### PR TITLE
Fetch WebKit submodule via https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	ignore = dirty
 [submodule "src/javascript/jsc/WebKit"]
 	path = src/javascript/jsc/WebKit
-	url = git@github.com:/Jarred-Sumner/WebKit
+	url = https://github.com/Jarred-Sumner/WebKit.git
 	ignore = dirty
 [submodule "src/deps/mimalloc"]
 	path = src/deps/mimalloc


### PR DESCRIPTION
Fetching submodule via ssh leads to auth error if SSH key is not provided in GitHub settings; all submodules left uninitialized as a result.