### PR TITLE
add `npm install` command before running bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ To create a new Next.js app with Bun:
 ```bash
 bun create next ./app
 cd app
+npm install
 bun
 ```
 


### PR DESCRIPTION
I think this will be required to install dependencies. Unless the `bun` command does that?