### PR TITLE
fix: add missing quotation in sample zsh config

### DIFF
--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -99,7 +99,7 @@ elif test $(basename $SHELL) == "zsh"; then
     echo ""
     echo "Manually add the directory to your \$HOME/.zshrc (or similar)"
     echo ""
-    echo -e "  $BWhite export BUN_INSTALL=\"$bun_install$Color_Off"
+    echo -e "  $BWhite export BUN_INSTALL=\"$bun_install\"$Color_Off"
     echo -e "  $BWhite export PATH=\"\$BUN_INSTALL/bin:\$PATH\"$Color_Off"
 else
     echo ""


### PR DESCRIPTION
Before:
```bash
export BUN_INSTALL="/Users/mike/.bun
```

After:
```bash
export BUN_INSTALL="/Users/mike/.bun"
```

P.s. Thank you for bun, I'm PSYCHED! 🚀 