### PR TITLE
Add experimental nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ All in one fast &amp; easy-to-use tool. Instead of 1,000 node_modules for develo
 curl -fsSL https://bun.sh/install | bash
 ```
 
+### Nix
+
+There is a `default.nix` file bundled with Bun's source. This could eventually be brought to Nixpkgs, but for now, you can run and install it like any other nix package.
+
+Before using it, change `bun_install` on line 11 to wherever you'd like Bun to store it's cache.
+
 ## Benchmarks
 
 **CSS**: [Bun is 14x faster](./bench/hot-module-reloading/css-stress-test) than Next.js at hot reloading CSS. TODO: compare Vite

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, autoPatchelfHook
+, fetchurl
+, openssl
+, unzip
+, pkgs
+, ... }:
+let
+  version = "0.0.52";
+  checksum = "88k0RW6/X/CudqExRwnbfzpKcxHJ3BvtvX2dIudqU+A=";
+  bun_install = "/home/<whatever>/.bun"; # Set this to where you want bun's cache
+in stdenv.mkDerivation {
+    pname = "bun";
+    version = version;
+    src =  fetchurl {
+      url = "https://github.com/Jarred-Sumner/bun-releases-for-updater/releases/download/bun-v${version}/bun-linux-x64.zip";
+      sha256 = checksum;
+    };
+    sourceRoot = ".";
+    unpackCmd = "unzip bun-linux-x64.zip";
+    dontConfigure = true;
+    dontBuild = true;
+    nativeBuildInputs = [ pkgs.makeWrapper autoPatchelfHook ];
+    buildInputs = [ unzip openssl stdenv.cc.cc.lib ];
+      
+    installPhase = "install -D ./bun-linux-x64/bun $out/bin/bun";
+    postInstall = ''
+      wrapProgram "$out/bin/bun" \
+        --prefix BUN_INSTALL : ${bun_install}
+    '';
+}


### PR DESCRIPTION
As discussed in the discord, this PR adds experimental Nix support via a `default.nix` file and a small note in the README. While this is great and all, it still leaves many unanswered questions:

- Should we be building from source instead? (Currently unfeasible for multiple reasons, but good long term)
- How should we handle updating versions?
  - Should we just use the latest version at all times?
  - ~~Should use/update check-sums?~~ 
    As mentioned in the discord by @Jarred-Sumner 
    > There have been a couple cases where I had to re-upload the version after some build issue
    > so it might make sense to forgo the checksum for now
  - Should we dynamically update the `default.zig` file upon each new release with the `Makefile`?
- Should we provide more detailed instructions on how to install with Nix?
- When is the right time to submit to nixpkgs?
- How should we handle configuring Bun's cache directory?

*and the list goes on.*

There are definitely a few things that should be fixed here, this is a decent starting point to build upon.