### PR TITLE
copy: replace Bun with bun

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/docker-existing-dockerfile
 {
-  "name": "Bun (Ubuntu)",
+  "name": "bun (Ubuntu)",
 
   // Sets the run context to one level up instead of the .devcontainer folder.
   "context": "..",

--- a/.devcontainer/scripts/getting-started.sh
+++ b/.devcontainer/scripts/getting-started.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "To get started, login to GitHub and clone Bun's GitHub repo into /workspaces/bun"
+echo "To get started, login to GitHub and clone bun's GitHub repo into /workspaces/bun"
 echo "Make sure to login with a Personal Access Token"
 echo "# First time setup"
 echo "gh auth login"
@@ -9,7 +9,7 @@ echo ""
 echo "# Compile bun dependencies (zig is already compiled)"
 echo "make devcontainer"
 echo ""
-echo "# Build Bun for development"
+echo "# Build bun for development"
 echo "make dev"
 echo ""
 echo "# Run bun"

--- a/.devcontainer/workspace.code-workspace
+++ b/.devcontainer/workspace.code-workspace
@@ -2,7 +2,7 @@
   "folders": [
     {
       // Source code
-      "name": "Bun",
+      "name": "bun",
       "path": "bun"
     },
   ]

--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -158,9 +158,9 @@ jobs:
           platforms: |
             linux/amd64
           labels: |
-            org.opencontainers.image.title=Bun
-            org.opencontainers.image.description=Bun is a fast bundler, transpiler, JavaScript Runtime environment and package manager for web software. The image is an Ubuntu 20.04 image with bun preinstalled into /opt/bun.
-            org.opencontainers.image.vendor=Bun
+            org.opencontainers.image.title=bun
+            org.opencontainers.image.description=bun is a fast bundler, transpiler, JavaScript Runtime environment and package manager for web software. The image is an Ubuntu 20.04 image with bun preinstalled into /opt/bun.
+            org.opencontainers.image.vendor=bun
             org.opencontainers.image.source=https://github.com/Jarred-Sumner/bun
             org.opencontainers.image.url=https://bun.sh
           builder: ${{ steps.buildx.outputs.name }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -238,7 +238,7 @@
     {
       "type": "lldb",
       "request": "launch",
-      "name": "Bun",
+      "name": "bun",
       "program": "bun-debug",
       "args": ["bun", "--use=next"],
       "cwd": "/Users/jarred/Build/lattice/apps/dazzle",
@@ -327,7 +327,7 @@
     {
       "type": "lldb",
       "request": "launch",
-      "name": "Context Bun Bug",
+      "name": "Context bun Bug",
       "program": "bun-debug",
       "args": ["bun", "./code.js"],
       "cwd": "/Users/jarred/Build/context/www",
@@ -336,7 +336,7 @@
     {
       "type": "lldb",
       "request": "launch",
-      "name": "Context Bun",
+      "name": "Context bun",
       "program": "bun-debug",
       "args": ["bun", "--use=next"],
       "cwd": "/Users/jarred/Build/context/www",
@@ -345,7 +345,7 @@
     {
       "type": "lldb",
       "request": "launch",
-      "name": "Bun-hello",
+      "name": "bun-hello",
       "program": "bun-debug",
       "args": [],
       "cwd": "${workspaceFolder}/packages/bun-hello",

--- a/Dockerfile
+++ b/Dockerfile
@@ -267,7 +267,7 @@ COPY .devcontainer/limits.conf /etc/security/limits.conf
 ENV BUN_INSTALL /opt/bun
 ENV PATH "/opt/bun/bin:$PATH"
 ARG BUILDARCH=amd64
-LABEL org.opencontainers.image.title="Bun ${BUILDARCH} (glibc)"
+LABEL org.opencontainers.image.title="bun ${BUILDARCH} (glibc)"
 LABEL org.opencontainers.image.source=https://github.com/jarred-sumner/bun
 COPY --from=build_release ${BUN_RELEASE_DIR}/bun /opt/bun/bin/bun
 WORKDIR /opt/bun

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -69,7 +69,7 @@ ENV BUN_DEPS_OUT_DIR ${BUN_DEPS_OUT_DIR}
 
 RUN cd / && mkdir -p $BUN_RELEASE_DIR $BUN_DEPS_OUT_DIR ${BUN_DIR} ${BUN_DEPS_OUT_DIR}
 
-LABEL org.opencontainers.image.title="Bun base image ${BUILDARCH} (glibc)"
+LABEL org.opencontainers.image.title="bun base image ${BUILDARCH} (glibc)"
 LABEL org.opencontainers.image.source=https://github.com/jarred-sumner/bun
 
 
@@ -108,7 +108,7 @@ RUN  cd $GITHUB_WORKSPACE && \
 
 ENV ZIG "${ZIG_PATH}/zig"
 
-LABEL org.opencontainers.image.title="Bun base image with zig & webkit ${BUILDARCH} (glibc)"
+LABEL org.opencontainers.image.title="bun base image with zig & webkit ${BUILDARCH} (glibc)"
 LABEL org.opencontainers.image.source=https://github.com/jarred-sumner/bun
 
 

--- a/Dockerfile.musl
+++ b/Dockerfile.musl
@@ -119,7 +119,7 @@
 # ENV BUN_INSTALL /opt/bun
 # ENV PATH /opt/bun/bin:$PATH
 
-# LABEL org.opencontainers.image.title="Bun - Linux ${BUILDARCH} (musl)"
+# LABEL org.opencontainers.image.title="bun - Linux ${BUILDARCH} (musl)"
 # LABEL org.opencontainers.image.source=https://github.com/jarred-sumner/bun
 
 # FROM release as test

--- a/Makefile
+++ b/Makefile
@@ -468,8 +468,8 @@ prepare-release: tag release-create
 release-create-auto-updater:
 
 release-create:
-	gh release create --title "Bun v$(PACKAGE_JSON_VERSION)" "$(BUN_BUILD_TAG)"
-	gh release create --repo=$(BUN_AUTO_UPDATER_REPO) --title "Bun v$(PACKAGE_JSON_VERSION)" "$(BUN_BUILD_TAG)" -n "See https://github.com/Jarred-Sumner/bun/releases/tag/$(BUN_BUILD_TAG) for release notes. Using the install script or bun upgrade is the recommended way to install Bun. Join Bun's Discord to get access https://bun.sh/discord"
+	gh release create --title "bun v$(PACKAGE_JSON_VERSION)" "$(BUN_BUILD_TAG)"
+	gh release create --repo=$(BUN_AUTO_UPDATER_REPO) --title "bun v$(PACKAGE_JSON_VERSION)" "$(BUN_BUILD_TAG)" -n "See https://github.com/Jarred-Sumner/bun/releases/tag/$(BUN_BUILD_TAG) for release notes. Using the install script or bun upgrade is the recommended way to install bun. Join bun's Discord to get access https://bun.sh/discord"
 
 release-bin-entitlements:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Bun
+# bun
 
-Bun is a new:
+bun is a new:
 
 - JavaScript/TypeScript/JSX transpiler
 - JavaScript & CSS bundler
@@ -9,9 +9,9 @@ Bun is a new:
 - Task runner for package.json scripts
 - npm-compatible package manager
 
-All in one fast &amp; easy-to-use tool. Instead of 1,000 node_modules for development, you only need Bun.
+All in one fast &amp; easy-to-use tool. Instead of 1,000 node_modules for development, you only need bun.
 
-**Bun is experimental software**. Join [Bun’s Discord](https://bun.sh/discord) for help and have a look at [things that don’t work yet](#things-that-dont-work-yet).
+**bun is experimental software**. Join [bun’s Discord](https://bun.sh/discord) for help and have a look at [things that don’t work yet](#things-that-dont-work-yet).
 
 ## Install
 
@@ -32,13 +32,13 @@ docker run --rm --init --ulimit memlock=-1:-1 jarredsumner/bun:edge
 
 - [Install](#install)
 - [Benchmarks](#benchmarks)
-- [Using Bun as a package manager](#using-bun-as-a-package-manager)
-- [Using Bun as a task runner](#using-bun-as-a-task-runner)
-- [Using Bun with Next.js](#using-bun-with-nextjs)
-- [Using Bun with single page apps](#using-bun-with-single-page-apps)
-  - [Using Bun with Create React App](#using-bun-with-create-react-app)
-- [Using Bun with TypeScript](#using-bun-with-typescript)
-- [Using Tailwind with Bun](#using-tailwind-with-bun)
+- [Using bun as a package manager](#using-bun-as-a-package-manager)
+- [Using bun as a task runner](#using-bun-as-a-task-runner)
+- [Using bun with Next.js](#using-bun-with-nextjs)
+- [Using bun with single page apps](#using-bun-with-single-page-apps)
+  - [Using bun with Create React App](#using-bun-with-create-react-app)
+- [Using bun with TypeScript](#using-bun-with-typescript)
+- [Using Tailwind with bun](#using-tailwind-with-bun)
 - [Things that don’t work yet](#things-that-dont-work-yet)
   - [Limitations & intended usage](#limitations--intended-usage)
 - [Configuration](#configuration)
@@ -57,18 +57,18 @@ docker run --rm --init --ulimit memlock=-1:-1 jarredsumner/bun:edge
 - [Environment variables](#environment-variables)
 - [Credits](#credits)
 - [License](#license)
-- [Developing Bun](#developing-bun)
+- [Developing bun](#developing-bun)
   - [VSCode Dev Container](#vscode-dev-container-linux)
   - [MacOS](#macos)
 - [vscode-zig](#vscode-zig)
 
 ## Benchmarks
 
-**CSS**: [Bun is 14x faster](./bench/hot-module-reloading/css-stress-test) than Next.js at hot reloading CSS. TODO: compare Vite
+**CSS**: [bun is 14x faster](./bench/hot-module-reloading/css-stress-test) than Next.js at hot reloading CSS. TODO: compare Vite
 
 **JavaScript**: TODO
 
-## Using Bun as a package manager
+## Using bun as a package manager
 
 On Linux, `bun install` tends to install packages 20x - 100x faster than `npm install`. On macOS, it’s more like 4x - 80x.
 
@@ -87,9 +87,9 @@ bun remove react
 bun add preact
 ```
 
-## Using Bun as a task runner
+## Using bun as a task runner
 
-Instead of waiting 170ms for your npm client to start for each task, you wait 6ms for Bun.
+Instead of waiting 170ms for your npm client to start for each task, you wait 6ms for bun.
 
 To use bun as a task runner, run `bun run` instead of `npm run`.
 
@@ -112,9 +112,9 @@ Assuming a package.json with a `"clean"` command in `"scripts"`:
 }
 ```
 
-## Using Bun with Next.js
+## Using bun with Next.js
 
-To create a new Next.js app with Bun:
+To create a new Next.js app with bun:
 
 ```bash
 bun create next ./app
@@ -122,7 +122,7 @@ cd app
 bun
 ```
 
-To use an existing Next.js app with Bun:
+To use an existing Next.js app with bun:
 
 ```bash
 npm install bun-framework-next
@@ -142,11 +142,11 @@ Here’s what doesn’t work yet:
 - API routes, middleware (middleware is easier to support though! similar SSR API)
 - styled-jsx (technically not Next.js but often used with it)
 
-When using Next.js, Bun automatically reads configuration from `.env.local`, `.env.development` and `.env` (in that order). `process.env.NEXT_PUBLIC_` and `process.env.NEXT_` automatically are replaced via `--define`.
+When using Next.js, bun automatically reads configuration from `.env.local`, `.env.development` and `.env` (in that order). `process.env.NEXT_PUBLIC_` and `process.env.NEXT_` automatically are replaced via `--define`.
 
 Currently, any time you import new dependencies from `node_modules`, you will need to re-run `bun bun --use next`. This will eventually be automatic.
 
-## Using Bun with single page apps
+## Using bun with single page apps
 
 In your project folder root (where `package.json` is):
 
@@ -170,7 +170,7 @@ Here are examples of routing from `public/` and how they’re matched:
 
 If `public/index.html` exists, it becomes the default page instead of a 404 page, unless that pathname has a file extension.
 
-### Using Bun with Create React App
+### Using bun with Create React App
 
 To create new a React app:
 
@@ -193,7 +193,7 @@ bun bun ./src/index.js # jsx, tsx, ts also work. can be multiple files
 bun
 ```
 
-From there, Bun relies on the filesystem for mapping dev server paths to source files. All URL paths are relative to the project root (where `package.json` is located).
+From there, bun relies on the filesystem for mapping dev server paths to source files. All URL paths are relative to the project root (where `package.json` is located).
 
 Here are examples of routing source code file paths:
 
@@ -207,17 +207,17 @@ You do not need to include file extensions in `import` paths. CommonJS-style imp
 
 You can override the public directory by passing `--public-dir="path-to-folder"`.
 
-If no directory is specified and `./public/` doesn’t exist, Bun will try `./static/`. If `./static/` does not exist, but won’t serve from a public directory. If you pass `--public-dir=./` Bun will serve from the current directory, but it will check the current directory last instead of first.
+If no directory is specified and `./public/` doesn’t exist, bun will try `./static/`. If `./static/` does not exist, but won’t serve from a public directory. If you pass `--public-dir=./` bun will serve from the current directory, but it will check the current directory last instead of first.
 
-## Using Bun with TypeScript
+## Using bun with TypeScript
 
-TypeScript just works. There’s nothing to configure and nothing extra to install. If you import a `.ts` or `.tsx` file, Bun will transpile it into JavaScript. Bun also transpiles `node_modules` containing `.ts` or `.tsx` files. This is powered by Bun’s TypeScript transpiler, so it’s fast.
+TypeScript just works. There’s nothing to configure and nothing extra to install. If you import a `.ts` or `.tsx` file, bun will transpile it into JavaScript. bun also transpiles `node_modules` containing `.ts` or `.tsx` files. This is powered by bun’s TypeScript transpiler, so it’s fast.
 
-Bun also reads `tsconfig.json`, including `baseUrl` and `paths`.
+bun also reads `tsconfig.json`, including `baseUrl` and `paths`.
 
-## Using Tailwind with Bun
+## Using Tailwind with bun
 
-[Tailwind](https://tailwindcss.com/) is a popular CSS utility framework. Currently, the easiest way to use Tailwind with Bun is through Tailwind’s CLI. That means running both `bun` and `tailwind`, and importing the file `tailwind`’s CLI outputs.
+[Tailwind](https://tailwindcss.com/) is a popular CSS utility framework. Currently, the easiest way to use Tailwind with bun is through Tailwind’s CLI. That means running both `bun` and `tailwind`, and importing the file `tailwind`’s CLI outputs.
 
 Tailwind’s docs talk more about [Tailwind’s CLI usage](https://tailwindcss.com/docs/installation#watching-for-changes), but the gist is you’ll want to run this:
 
@@ -229,7 +229,7 @@ From there, make sure to import the `dist/tailwind.css` file (or what you chose 
 
 ## Things that don’t work yet
 
-Bun is a project with incredibly large scope, and it’s early days.
+bun is a project with incredibly large scope, and it’s early days.
 
 | Feature                                                                                                                | In              |
 | ---------------------------------------------------------------------------------------------------------------------- | --------------- |
@@ -244,9 +244,9 @@ Bun is a project with incredibly large scope, and it’s early days.
 | [TypeScript Decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)                                  | TS Transpiler   |
 | `@jsxPragma` comments                                                                                                  | JS Transpiler   |
 | JSX source file name                                                                                                   | JS Transpiler   |
-| Sharing `.bun` files                                                                                                   | Bun             |
-| [Finish fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)                                             | Bun.js          |
-| [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout)                                              | Bun.js          |
+| Sharing `.bun` files                                                                                                   | bun             |
+| [Finish fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)                                             | bun.js          |
+| [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout)                                              | bun.js          |
 | [workspace: dependencies](https://github.com/Jarred-Sumner/bun/issues/83)                                              | Package manager |
 | [git: dependencies](https://github.com/Jarred-Sumner/bun/issues/82)                                                    | Package manager |
 | [github: dependencies](https://github.com/Jarred-Sumner/bun/issues/81)                                                 | Package manager |
@@ -260,21 +260,21 @@ TS Transpiler == TypeScript Transpiler
 <br/>
 Package manager == `bun install`
 <br/>
-Bun.js == Bun’s JavaScriptCore integration that executes JavaScript. Similar to how Node.js & Deno embed V8.
+bun.js == bun’s JavaScriptCore integration that executes JavaScript. Similar to how Node.js & Deno embed V8.
 </small>
 
 ### Limitations & intended usage
 
-Bun is great for building websites &amp; webapps. For libraries, consider using Rollup or esbuild instead. Bun currently doesn’t minify code and Bun’s dead code elimination doesn’t look beyond the current file.
+bun is great for building websites &amp; webapps. For libraries, consider using Rollup or esbuild instead. bun currently doesn’t minify code and bun’s dead code elimination doesn’t look beyond the current file.
 
-Today, Bun is focused on:
+Today, bun is focused on:
 
 - Development, not production
 - Compatibility with existing frameworks & tooling
 
-Ideally, most projects can use Bun with their existing tooling while making few changes to their codebase. That means using Bun in development, and continuing to use Webpack, esbuild, or another bundler in production. Using two bundlers might sound strange at first, but after all the production-only AST transforms, minification, and special development/production-only imported files...it’s not far from the status quo.
+Ideally, most projects can use bun with their existing tooling while making few changes to their codebase. That means using bun in development, and continuing to use Webpack, esbuild, or another bundler in production. Using two bundlers might sound strange at first, but after all the production-only AST transforms, minification, and special development/production-only imported files...it’s not far from the status quo.
 
-Longer-term, Bun intends to replace Node.js, Webpack, Babel, and PostCSS (in production).
+Longer-term, bun intends to replace Node.js, Webpack, Babel, and PostCSS (in production).
 
 ## Configuration
 
@@ -282,7 +282,7 @@ Longer-term, Bun intends to replace Node.js, Webpack, Babel, and PostCSS (in pro
 
 A loader determines how to map imports &amp; file extensions to transforms and output.
 
-Currently, Bun implements the following loaders:
+Currently, bun implements the following loaders:
 
 | Input | Loader                        | Output |
 | ----- | ----------------------------- | ------ |
@@ -312,7 +312,7 @@ This will disable JSX transforms for `.js` files.
 
 When importing CSS in JavaScript-like loaders, CSS is treated special.
 
-By default, Bun will transform a statement like this:
+By default, bun will transform a statement like this:
 
 ```js
 import "../styles/global.css";
@@ -336,16 +336,16 @@ An event handler for turning that into a `<link>` is automatically registered wh
 //@import url("http://localhost:3000/styles/globals.css");
 ```
 
-Additionally, Bun exposes an API for SSR/SSG that returns a flat list of URLs to css files imported. That function is `Bun.getImportedStyles()`.
+Additionally, bun exposes an API for SSR/SSG that returns a flat list of URLs to css files imported. That function is `bun.getImportedStyles()`.
 
 ```ts
 addEventListener("fetch", async (event: FetchEvent) => {
-  var route = Bun.match(event);
+  var route = bun.match(event);
   const App = await import("pages/_app");
 
   // This returns all .css files that were imported in the line above.
   // It’s recursive, so any file that imports a CSS file will be included.
-  const appStylesheets = Bun.getImportedStyles();
+  const appStylesheets = bun.getImportedStyles();
 
   // ...rest of code
 });
@@ -355,7 +355,7 @@ This is useful for preventing flash of unstyled content.
 
 ### CSS Loader
 
-Bun bundles `.css` files imported via `@import` into a single file. It doesn’t autoprefix or minify CSS today. Multiple `.css` files imported in one JavaScript file will _not_ be bundled into one file. You’ll have to import those from a `.css` file.
+bun bundles `.css` files imported via `@import` into a single file. It doesn’t autoprefix or minify CSS today. Multiple `.css` files imported in one JavaScript file will _not_ be bundled into one file. You’ll have to import those from a `.css` file.
 
 This input:
 
@@ -378,13 +378,13 @@ Becomes:
 
 ### CSS runtime
 
-To support hot CSS reloading, Bun inserts `@supports` annotations into CSS that tag which files a stylesheet is composed of. Browsers ignore this, so it doesn’t impact styles.
+To support hot CSS reloading, bun inserts `@supports` annotations into CSS that tag which files a stylesheet is composed of. Browsers ignore this, so it doesn’t impact styles.
 
-By default, Bun’s runtime code automatically listens to `onimportcss` and will insert the `event.detail` into a `<link rel="stylesheet" href={${event.detail}}>` if there is no existing `link` tag with that stylesheet. That’s how Bun’s equivalent of `style-loader` works.
+By default, bun’s runtime code automatically listens to `onimportcss` and will insert the `event.detail` into a `<link rel="stylesheet" href={${event.detail}}>` if there is no existing `link` tag with that stylesheet. That’s how bun’s equivalent of `style-loader` works.
 
 ### Frameworks
 
-Frameworks preconfigure Bun to enable developers to use Bun with their existing tooling.
+Frameworks preconfigure bun to enable developers to use bun with their existing tooling.
 
 Frameworks are configured via the `framework` object in the `package.json` of the framework (not in the application’s `package.json`):
 
@@ -477,12 +477,12 @@ type Framework = Environment & {
   //    and replaces an imported object with a proxy that mimics CSS module support without doing any class renaming.
   css?: "onimportcss" | "facade";
 
-  // Bun’s filesystem router
+  // bun’s filesystem router
   router?: Router;
 };
 
 type Define = {
-  // By passing ".env", Bun will automatically load .env.local, .env.development, and .env if exists in the project root
+  // By passing ".env", bun will automatically load .env.local, .env.development, and .env if exists in the project root
   //    (in addition to the processes’ environment variables)
   // When "*", all environment variables will be automatically injected into the JavaScript loader
   // When a string like "NEXT_PUBLIC_", only environment variables starting with that prefix will be injected
@@ -510,8 +510,8 @@ type Environment = {
   define?: Define;
 };
 
-// Bun’s filesystem router
-// Currently, Bun supports pages by either an absolute match or a parameter match.
+// bun’s filesystem router
+// Currently, bun supports pages by either an absolute match or a parameter match.
 // pages/index.tsx will be executed on navigation to "/" and "/index"
 // pages/posts/[id].tsx will be executed on navigation to "/posts/123"
 // Routes & parameters are automatically passed to `fallback` and `server`.
@@ -534,15 +534,15 @@ If you’re interested in adding a framework integration, please reach out. Ther
 
 ## Troubleshooting
 
-### Bun not running on an M1 (or Apple Silicon)
+### bun not running on an M1 (or Apple Silicon)
 
 If you see a message like this
 
 > [1] 28447 killed bun create next ./test
 
-It most likely means you’re running bun’s x64 version on Apple Silicon. This happens if bun is running via Rosetta. Rosetta is unable to emulate AVX2 instructions, which Bun indirectly uses.
+It most likely means you’re running bun’s x64 version on Apple Silicon. This happens if bun is running via Rosetta. Rosetta is unable to emulate AVX2 instructions, which bun indirectly uses.
 
-The fix is to ensure you installed a version of Bun built for Apple Silicon.
+The fix is to ensure you installed a version of bun built for Apple Silicon.
 
 ### error: Unexpected
 
@@ -550,7 +550,7 @@ If you see an error like this:
 
 ![image](https://user-images.githubusercontent.com/709451/141210854-89434678-d21b-42f4-b65a-7df3b785f7b9.png)
 
-It usually means the max number of open file descriptors is being explicitly set to a low number. By default, Bun requests the max number of file descriptors available (which on macOS, is something like 32,000). But, if you previously ran into ulimit issues with e.g. Chokidar, someone on The Internet may have advised you to run `ulimit -n 8096`.
+It usually means the max number of open file descriptors is being explicitly set to a low number. By default, bun requests the max number of file descriptors available (which on macOS, is something like 32,000). But, if you previously ran into ulimit issues with e.g. Chokidar, someone on The Internet may have advised you to run `ulimit -n 8096`.
 
 That advice unfortunately **lowers** the hard limit to `8096`. This can be a problem in large repositories or projects with lots of dependencies. Chokidar (and other watchers) don’t seem to call `setrlimit`, which means they’re reliant on the (much lower) soft limit.
 
@@ -579,19 +579,19 @@ Environment variables
 | BUN_CONFIG_SKIP_LOAD_LOCKFILE    | Don’t load a lockfile                                         |
 | BUN_CONFIG_SKIP_INSTALL_PACKAGES | Don’t install any packages                                    |
 
-Bun always tries to use the fastest available installation method for the target platform. On macOS, that’s `clonefile` and on Linux, that’s `hardlink`. You can change which installation method is used with the `--backend` flag. When unavailable or on error, `clonefile` and `hardlink` fallsback to a platform-specific implementation of copying files.
+bun always tries to use the fastest available installation method for the target platform. On macOS, that’s `clonefile` and on Linux, that’s `hardlink`. You can change which installation method is used with the `--backend` flag. When unavailable or on error, `clonefile` and `hardlink` fallsback to a platform-specific implementation of copying files.
 
-Bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}`. Note that if the semver version has a `build` or a `pre` tag, it is replaced with a hash of that value instead. This is to reduce chances of errors from long file paths, but unfortunately complicates figuring out where a package was installed on disk.
+bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}`. Note that if the semver version has a `build` or a `pre` tag, it is replaced with a hash of that value instead. This is to reduce chances of errors from long file paths, but unfortunately complicates figuring out where a package was installed on disk.
 
-When the `node_modules` folder exists, before installing, Bun checks if the `"name"` and `"version"` in `package/package.json` in the expected node_modules folder matches the expected `name` and `version`. This is how it determines whether or not it should install. It uses a custom JSON parser which stops parsing as soon as it finds `"name"` and `"version"`.
+When the `node_modules` folder exists, before installing, bun checks if the `"name"` and `"version"` in `package/package.json` in the expected node_modules folder matches the expected `name` and `version`. This is how it determines whether or not it should install. It uses a custom JSON parser which stops parsing as soon as it finds `"name"` and `"version"`.
 
 When a `bun.lockb` doesn’t exist or `package.json` has changed dependencies, tarballs are downloaded & extracted eagerly while resolving.
 
-When a `bun.lockb` exists and `package.json` hasn’t changed, Bun downloads missing dependencies lazily. If the package with a matching `name` & `version` already exists in the expected location within `node_modules`, Bun won’t attempt to download the tarball.
+When a `bun.lockb` exists and `package.json` hasn’t changed, bun downloads missing dependencies lazily. If the package with a matching `name` & `version` already exists in the expected location within `node_modules`, bun won’t attempt to download the tarball.
 
 #### Platform-specific dependencies?
 
-Bun stores normalized `cpu` and `os` values from npm in the lockfile, along with the resolved packages. It skips downloading, extracting, and installing packages disabled for the current target at runtime. This means the lockfile won’t change between platforms/architectures even if the packages ultimately installed do change.
+bun stores normalized `cpu` and `os` values from npm in the lockfile, along with the resolved packages. It skips downloading, extracting, and installing packages disabled for the current target at runtime. This means the lockfile won’t change between platforms/architectures even if the packages ultimately installed do change.
 
 #### Peer dependencies?
 
@@ -599,11 +599,11 @@ Peer dependencies are handled similarly to yarn. `bun install` does not automati
 
 #### Lockfile
 
-`bun.lockb` is Bun’s binary lockfile format.
+`bun.lockb` is bun’s binary lockfile format.
 
 #### Why is it binary?
 
-In a word: Performance. Bun’s lockfile saves & loads incredibly quickly, and saves a lot more data than what is typically inside lockfiles.
+In a word: Performance. bun’s lockfile saves & loads incredibly quickly, and saves a lot more data than what is typically inside lockfiles.
 
 #### How do I inspect it?
 
@@ -627,14 +627,14 @@ rm -rf ~/.bun/install/cache
 
 #### npm registry metadata
 
-Bun uses a binary format for caching NPM registry responses. This loads much faster than JSON and tends to be smaller on disk.
+bun uses a binary format for caching NPM registry responses. This loads much faster than JSON and tends to be smaller on disk.
 You will see these files in `~/.bun/install/cache/*.npm`. The filename pattern is `${hash(packageName)}.npm`. It’s a hash so that extra directories don’t need to be created for scoped packages
 
-Bun’s usage of `Cache-Control` ignores `Age`. This improves performance, but means Bun may be about 5 minutes out of date to receive the the latest package version metadata from npm.
+bun’s usage of `Cache-Control` ignores `Age`. This improves performance, but means bun may be about 5 minutes out of date to receive the the latest package version metadata from npm.
 
 ### `bun run`
 
-`bun run` is a fast `package.json` scripts runner. Instead of waiting 170ms for your npm client to start every time, you wait 6ms for Bun.
+`bun run` is a fast `package.json` scripts runner. Instead of waiting 170ms for your npm client to start every time, you wait 6ms for bun.
 
 By default, `bun run` prints the script that will be invoked:
 
@@ -673,7 +673,7 @@ react-scripts eject
 4 scripts
 ```
 
-`bun run` automatically loads environment variables from `.env` into the shell/task. `.env` files are loaded with the same priority as the rest of Bun, so that means:
+`bun run` automatically loads environment variables from `.env` into the shell/task. `.env` files are loaded with the same priority as the rest of bun, so that means:
 
 1. `.env.local` is first
 2. if (`$NODE_ENV` === `"production"`) `.env.production` else `.env.development`
@@ -691,7 +691,7 @@ bun run relay-compiler
 
 # You can also do this, but:
 # - It will only lookup packages in `node_modules/.bin` instead of `$PATH`
-# - It will start Bun’s dev server if the script name doesn’t exist (`bun` starts the dev server by default)
+# - It will start bun’s dev server if the script name doesn’t exist (`bun` starts the dev server by default)
 bun relay-compiler
 ```
 
@@ -702,7 +702,7 @@ To pass additional flags through to the task or executable, there are two ways:
 bun run relay-compiler -- -–help
 
 # Implicit: if you do not include "--", anything *after* the script name will be passed through
-# Bun flags are parsed first, which means e.g. `bun run relay-compiler --help` will print Bun’s help instead of relay-compiler’s help.
+# bun flags are parsed first, which means e.g. `bun run relay-compiler --help` will print bun’s help instead of relay-compiler’s help.
 bun run relay-compiler --schema foo.graphql
 ```
 
@@ -750,13 +750,13 @@ bun create https://github.com/github-user/repo-name destination
 bun create github.com/github-user/repo-name destination
 ```
 
-Note: you don’t need `bun create` to use Bun. You don’t need any configuration at all. This command exists to make it a little easier.
+Note: you don’t need `bun create` to use bun. You don’t need any configuration at all. This command exists to make it a little easier.
 
 #### Local templates
 
 If you have your own boilerplate you prefer using, copy it into `$HOME/.bun-create/my-boilerplate-name`.
 
-Before checking Bun’s examples folder, `bun create` checks for a local folder matching the input in:
+Before checking bun’s examples folder, `bun create` checks for a local folder matching the input in:
 
 - `$BUN_CREATE_DIR/`
 - `$HOME/.bun-create/`
@@ -946,7 +946,7 @@ export var $eb6819b = $$m({
     // ... rest of code
 ```
 
-This makes bundled modules [position-independent](https://en.wikipedia.org/wiki/Position-independent_code). In theory, one could import only the exact modules in-use without reparsing code and without generating a new bundle. One bundle can dynamically become many bundles comprising only the modules in use on the webpage. Thanks to the metadata with the byte offsets, a web server can send each module to browsers [zero-copy](https://en.wikipedia.org/wiki/Zero-copy) using [sendfile](https://man7.org/linux/man-pages/man2/sendfile.2.html). Bun itself is not quite this smart yet, but these optimizations would be useful in production and potentially very useful for React Server Components.
+This makes bundled modules [position-independent](https://en.wikipedia.org/wiki/Position-independent_code). In theory, one could import only the exact modules in-use without reparsing code and without generating a new bundle. One bundle can dynamically become many bundles comprising only the modules in use on the webpage. Thanks to the metadata with the byte offsets, a web server can send each module to browsers [zero-copy](https://en.wikipedia.org/wiki/Zero-copy) using [sendfile](https://man7.org/linux/man-pages/man2/sendfile.2.html). bun itself is not quite this smart yet, but these optimizations would be useful in production and potentially very useful for React Server Components.
 
 To see the schema inside, have a look at [`JavascriptBundleContainer`](./src/api/schema.d.ts#:~:text=export%20interface-,JavascriptBundleContainer,-%7B). You can find JavaScript bindings to read the metadata in [src/api/schema.js](./src/api/schema.js). This is not really an API yet. It’s missing the part where it gets the binary data from the bottom of the file. Someday, I want this to be usable by other tools too.
 
@@ -968,7 +968,7 @@ This works because every `.bun` file starts with this:
 #!/usr/bin/env bun
 ```
 
-To deploy to production with Bun, you’ll want to get the code from the `.bun` file and stick that somewhere your web server can find it (or if you’re using Vercel or a Rails app, in a `public` folder).
+To deploy to production with bun, you’ll want to get the code from the `.bun` file and stick that somewhere your web server can find it (or if you’re using Vercel or a Rails app, in a `public` folder).
 
 Note that `.bun` is a binary file format, so just opening it in VSCode or vim might render strangely.
 
@@ -987,7 +987,7 @@ To force bun to bundle packages which are not located in a `node_modules` folder
 }
 ```
 
-Bundled dependencies are not eligible for Hot Module Reloading. The code is served to browsers & Bun.js verbatim. But, in the future, it may be sectioned off into only parts of the bundle being used. That’s possible in the current version of the `.bun` file (so long as you know which files are necessary), but it’s not implemented yet. Longer-term, it will include all `import` and `export` of each module inside.
+Bundled dependencies are not eligible for Hot Module Reloading. The code is served to browsers & bun.js verbatim. But, in the future, it may be sectioned off into only parts of the bundle being used. That’s possible in the current version of the `.bun` file (so long as you know which files are necessary), but it’s not implemented yet. Longer-term, it will include all `import` and `export` of each module inside.
 
 #### What is the module ID hash?
 
@@ -1003,7 +1003,7 @@ Is generated like this:
 2. Wyhash 64 of the `package.hash` + `package_path`. `package_path` means "relative to the root of the npm package, where is the module imported?". For example, if you imported `react/jsx-dev-runtime.js`, the `package_path` is `jsx-dev-runtime.js`. `react-dom/cjs/react-dom.development.js` would be `cjs/react-dom.development.js`
 3. Truncate the hash generated above to a `u32`
 
-The implementation details of this module ID hash will vary between versions of Bun. The important part is the metadata contains the module IDs, the package paths, and the package hashes so it shouldn’t really matter in practice if other tooling wants to make use of any of this.
+The implementation details of this module ID hash will vary between versions of bun. The important part is the metadata contains the module IDs, the package paths, and the package hashes so it shouldn’t really matter in practice if other tooling wants to make use of any of this.
 
 ### `bun completions`
 
@@ -1014,33 +1014,33 @@ If you want to copy the completions manually, run `bun completions > path-to-fil
 ## Environment variables
 
 - `GOMAXPROCS`: For `bun bun`, this sets the maximum number of threads to use. If you’re experiencing an issue with `bun bun`, try setting `GOMAXPROCS=1` to force bun to run single-threaded
-- `DISABLE_BUN_ANALYTICS=1` this disables Bun’s analytics. Bun records bundle timings (so we can answer with data, "is bun getting faster?") and feature usage (e.g. "are people actually using macros?"). The request body size is about 60 bytes, so it’s not a lot of data
+- `DISABLE_BUN_ANALYTICS=1` this disables bun’s analytics. bun records bundle timings (so we can answer with data, "is bun getting faster?") and feature usage (e.g. "are people actually using macros?"). The request body size is about 60 bytes, so it’s not a lot of data
 - `TMPDIR`: Before `bun bun` completes, it stores the new `.bun` in `$TMPDIR`. If unset, `TMPDIR` defaults to the platform-specific temporary directory (on Linux, `/tmp` and on macOS `/private/tmp`)
 
 ## Credits
 
-- While written in Zig instead of Go, Bun’s JS transpiler, CSS lexer, and node module resolver source code is based off of @evanw’s esbuild project. @evanw did a fantastic job with esbuild.
-- The idea for the name "Bun" came from [@kipply](https://github.com/kipply)
+- While written in Zig instead of Go, bun’s JS transpiler, CSS lexer, and node module resolver source code is based off of @evanw’s esbuild project. @evanw did a fantastic job with esbuild.
+- The idea for the name "bun" came from [@kipply](https://github.com/kipply)
 
 ## License
 
-Bun itself is MIT-licensed.
+bun itself is MIT-licensed.
 
-However, JavaScriptCore (and WebKit) is LGPL-2 and Bun statically links it.
+However, JavaScriptCore (and WebKit) is LGPL-2 and bun statically links it.
 
 Per LGPL2:
 
 > (1) If you statically link against an LGPL’d library, you must also provide your application in an object (not necessarily source) format, so that a user has the opportunity to modify the library and relink the application.
 
-You can find the patched version of WebKit used by Bun here: <https://github.com/jarred-sumner/webkit>. If you would like to relink Bun with changes:
+You can find the patched version of WebKit used by bun here: <https://github.com/jarred-sumner/webkit>. If you would like to relink bun with changes:
 
 - `git submodule update --init --recursive`
 - `make jsc`
 - `zig build`
 
-This compiles JavaScriptCore, compiles Bun’s `.cpp` bindings for JavaScriptCore (which are the object files using JavaScriptCore) and outputs a new `bun` binary with your changes.
+This compiles JavaScriptCore, compiles bun’s `.cpp` bindings for JavaScriptCore (which are the object files using JavaScriptCore) and outputs a new `bun` binary with your changes.
 
-Bun also statically links these libraries:
+bun also statically links these libraries:
 
 - `libicu` 66.1, which can be found here: <https://github.com/unicode-org/icu/blob/main/icu4c/LICENSE>
 - [`picohttp`](https://github.com/h2o/picohttpparser), which is dual-licensed under the Perl License or the MIT License
@@ -1050,7 +1050,7 @@ Bun also statically links these libraries:
 - [`libarchive`](https://github.com/libarchive/libarchive), which has [several licenses](https://github.com/libarchive/libarchive/blob/master/COPYING)
 - [`libiconv`](https://www.gnu.org/software/libiconv/), which is LGPL2. It’s a dependency of libarchive.
 
-For compatibiltiy reasons, these NPM packages are embedded into Bun’s binary and injected if imported.
+For compatibiltiy reasons, these NPM packages are embedded into bun’s binary and injected if imported.
 
 - [`assert`](https://npmjs.com/package/assert) (MIT license)
 - [`browserify-zlib`](https://npmjs.com/package/browserify-zlib) (MIT license)
@@ -1074,7 +1074,7 @@ For compatibiltiy reasons, these NPM packages are embedded into Bun’s binary a
 - [`util`](https://npmjs.com/package/util) (MIT license)
 - [`vm-browserify`](https://npmjs.com/package/vm-browserify) (MIT license)
 
-## Developing Bun
+## Developing bun
 
 Estimated: 30-90 minutes :(
 
@@ -1097,7 +1097,7 @@ devcontainer build
 devcontainer open
 ```
 
-You will need to clone the GitHub repository inside that container, which also requires authenticating with GitHub (until Bun's repository is public). Make sure to login with a Personal Access Token rather than a web browser.
+You will need to clone the GitHub repository inside that container, which also requires authenticating with GitHub (until bun's repository is public). Make sure to login with a Personal Access Token rather than a web browser.
 
 Inside the container, run this:
 
@@ -1112,7 +1112,7 @@ git -c submodule."src/javascript/jsc/WebKit".update=none submodule update --init
 # Compile bun dependencies (zig is already compiled)
 make devcontainer
 
-# Build Bun for development
+# Build bun for development
 make dev
 
 # Run bun
@@ -1129,7 +1129,7 @@ Install LLVM 13 and homebrew dependencies:
 brew install llvm@13 coreutils libtool cmake libiconv automake openssl@1.1 ninja gnu-sed pkg-config
 ```
 
-Bun (& the version of Zig) need LLVM 13 and Clang 13 (clang is part of LLVM). Weird build & runtime errors will happen otherwise.
+bun (& the version of Zig) need LLVM 13 and Clang 13 (clang is part of LLVM). Weird build & runtime errors will happen otherwise.
 
 Make sure LLVM 13 is in your `$PATH`:
 

--- a/bench/hot-module-reloading/css-stress-test/README.md
+++ b/bench/hot-module-reloading/css-stress-test/README.md
@@ -4,10 +4,10 @@ This benchmarks bundler performance for CSS hot reloading.
 
 ## Results
 
-Bun is 14x faster than Next.js at hot reloading CSS.
+bun is 14x faster than Next.js at hot reloading CSS.
 
 ```
- Bun v0.0.34
+ bun v0.0.34
  Saving every 16ms
 
  Frame time:
@@ -40,7 +40,7 @@ The intent is to be as accurate as possible. Measuring times reported client-sid
 
 It works like this:
 
-1. `browser.js` loads either Bun or Next.js and a Chromium instance opened to the correct webpage
+1. `browser.js` loads either bun or Next.js and a Chromium instance opened to the correct webpage
 2. `color-looper.zig` updates [`./src/colors.css`](./src/colors.css) in a loop up to `1024` times (1024 is arbitrary), sleeping every `16`ms or `32`ms (a CLI arg you can pass it). The `var(--timestamp)` CSS variable contains the UTC timestamp with precision of milliseconds and one extra decimal point
 3. `color-looper.zig` automatically records the screen via `screencapture` (builtin on macOS) and saves it, along with a `BigUint64Array` containing all the expected timestamps. When it's done, it writes to a designated file on disk which `browser.js` picks up as the signal to close the browser.
 4. `ffmpeg` converts each frame into a black and white `.tif` file, which `tesseract` then OCRs

--- a/build.zig
+++ b/build.zig
@@ -233,7 +233,7 @@ pub fn build(b: *std.build.Builder) !void {
         },
     ).step);
 
-    var obj_step = b.step("obj", "Build Bun as a .o file");
+    var obj_step = b.step("obj", "Build bun as a .o file");
     var obj = b.addObject(bun_executable_name, exe.root_src.?.path);
 
     {

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -94,14 +94,14 @@ complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_create next react; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from create;" -a 'react' -d 'new React project'
 
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'upgrade' -d 'Upgrade Bun to the latest version' -x 
+	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'upgrade' -d 'Upgrade bun to the latest version' -x 
 complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand"  -a '--help' -d 'See all commands and flags' -x
 
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -l "version" -s "v"  -a '--version' -d 'Bun\'s version' -x
+	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -l "version" -s "v"  -a '--version' -d 'bun\'s version' -x
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'discord' -d 'Open Bun\'s Discord server' -x 
+	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'discord' -d 'Open bun\'s Discord server' -x 
 
 
 complete -c bun \

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -15,9 +15,9 @@ _bun() {
         IFS=$'\n' scripts_list=($(SHELL=zsh bun getcompletes i))
         compadd $scripts_list && ret=0
 
-        main_commands=('add\:"Add a dependency to package.json" bun\:"Generate a bundle" create\:"Create a new project" dev\:"Start a dev server" help\:"Show command help" install\:"Install packages from package.json" remove\:"Remove a dependency from package.json" run\:"Run a script or package bin" upgrade\:"Upgrade to the latest version of Bun"')
+        main_commands=('add\:"Add a dependency to package.json" bun\:"Generate a bundle" create\:"Create a new project" dev\:"Start a dev server" help\:"Show command help" install\:"Install packages from package.json" remove\:"Remove a dependency from package.json" run\:"Run a script or package bin" upgrade\:"Upgrade to the latest version of bun"')
         main_commands=($main_commands)
-        _alternative "args:Bun:(($main_commands))"
+        _alternative "args:bun:(($main_commands))"
         ;;
     args)
         case $line[1] in

--- a/completions/spec.yaml
+++ b/completions/spec.yaml
@@ -58,7 +58,7 @@ subcommands:
         summary: Use a framework, e.g. "next"
 
   upgrade:
-    summary: Upgrade to the latest version of Bun
+    summary: Upgrade to the latest version of bun
 
   dev:
     summary: Start a dev server

--- a/integration/apps/bun-create-next.sh
+++ b/integration/apps/bun-create-next.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# The important part of this test: make sure that Bun.js successfully loads
-# The most likely reason for this test to fail is that something broke in the JavaScriptCore <> Bun integration
+# The important part of this test: make sure that bun.js successfully loads
+# The most likely reason for this test to fail is that something broke in the JavaScriptCore <> bun integration
 killall -9 $(basename $BUN_BIN) || echo ""
 
 rm -rf /tmp/next-app

--- a/integration/snippets/public/index.html
+++ b/integration/snippets/public/index.html
@@ -3,7 +3,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Bun Test</title>
+    <title>bun Test</title>
   </head>
   <body>
     <script type="module">

--- a/packages/bun-framework-next/README.md
+++ b/packages/bun-framework-next/README.md
@@ -1,6 +1,6 @@
 # bun-framework-next
 
-This package lets you use Next.js 12 with Bun. This readme assumes you already installed Bun.
+This package lets you use Next.js 12 with bun. This readme assumes you already installed bun.
 
 To start a new project:
 

--- a/packages/bun-framework-next/package.json
+++ b/packages/bun-framework-next/package.json
@@ -3,7 +3,7 @@
   "version": "12.0.7",
   "main": "empty.js",
   "module": "empty.js",
-  "description": "Bun compatibility layer for Next.js v12.0.x",
+  "description": "bun compatibility layer for Next.js v12.0.x",
   "scripts": {
     "test": "echo Worked",
     "check": "tsc --noEmit"

--- a/packages/bun-macro-relay/README.md
+++ b/packages/bun-macro-relay/README.md
@@ -1,8 +1,8 @@
 # bun-macro-relay
 
-This lets you use Faceook's [Relay](https://github.com/facebook/relay) framework (GraphQL) with Bun.
+This lets you use Faceook's [Relay](https://github.com/facebook/relay) framework (GraphQL) with bun.
 
-Specifically, this implements the Bun equivalent of [`babel-plugin-relay`](https://github.com/facebook/relay/tree/main/packages/babel-plugin-relay). It parses `graphql` queries, but does not compile/save them to your artifacts directory, you still need [`relay-compiler`](https://github.com/facebook/relay/tree/main/packages/relay-compiler) for that.
+Specifically, this implements the bun equivalent of [`babel-plugin-relay`](https://github.com/facebook/relay/tree/main/packages/babel-plugin-relay). It parses `graphql` queries, but does not compile/save them to your artifacts directory, you still need [`relay-compiler`](https://github.com/facebook/relay/tree/main/packages/relay-compiler) for that.
 
 ## Installation
 
@@ -12,7 +12,7 @@ npm install -D bun-macro-relay
 
 ## Usage
 
-With one tweak to your project's `package.json`, `react-relay` works automatically with Bun.
+With one tweak to your project's `package.json`, `react-relay` works automatically with bun.
 
 Add this to your `package.json`:
 
@@ -26,12 +26,12 @@ Add this to your `package.json`:
   },
 ```
 
-This tells Bun to automatically pretend every import statement to `react-relay` with a `graphql` import came from `macro:bun-macro-relay/bun-macro-relay.tsx`.
+This tells bun to automatically pretend every import statement to `react-relay` with a `graphql` import came from `macro:bun-macro-relay/bun-macro-relay.tsx`.
 
 Effectively, it applies this diff in-memory so you can use `bun-macro-relay` without making other changes to your code:
 
 ```js
-// Bun will remap this import:
+// bun will remap this import:
 import { graphql } from "react-relay";
 
 // To this:
@@ -41,7 +41,7 @@ import { graphql } from "macro:bun-macro-relay/bun-macro-relay.tsx";
 You can still use the other imports from `react-relay`. It only affects the `graphql` export from `react-relay`.
 
 ```js
-// Bun will remap this import:
+// bun will remap this import:
 import { graphql, useFragment } from "react-relay";
 
 // To this:
@@ -119,9 +119,9 @@ const Tweet = () => {
 };
 ```
 
-Bun automatically transpiles JSX & TypeScript, but that's not relevant to this example.
+bun automatically transpiles JSX & TypeScript, but that's not relevant to this example.
 
 ### What does `bun-macro-relay` not do?
 
-1. This first version doesn't hash the contents of the `graphql` query, so it won't detect when the GraphQL query is out of sync with the compiled `.graphql` file in development. However, if you're running Relay's CLI, Bun's hot module reloading will automatically update. As long as you run Relay's CLI, it shouldn't matter. This will be fixed eventually (have to expose a native MD5 hashing function)
+1. This first version doesn't hash the contents of the `graphql` query, so it won't detect when the GraphQL query is out of sync with the compiled `.graphql` file in development. However, if you're running Relay's CLI, bun's hot module reloading will automatically update. As long as you run Relay's CLI, it shouldn't matter. This will be fixed eventually (have to expose a native MD5 hashing function)
 2. Compile GraphQL. You still need to use `relay-compiler` for that.

--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -29,7 +29,7 @@ fn NewUint64(val: u64) Analytics.Uint64 {
     };
 }
 
-// This answers, "What parts of Bun are people actually using?"
+// This answers, "What parts of bun are people actually using?"
 pub const Features = struct {
     pub var single_page_app_routing = false;
     pub var tsconfig_paths = false;

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -97,7 +97,7 @@ const Resolver = _resolver.Resolver;
 //     - on macOS, ensure it does an APFS shallow clone so that doesn't use disk space (only possible if file doesn't already exist)
 //          fclonefile
 // IF serving via HTTP AND it's a file-like loader:
-// 4. Use os.sendfile so copying/reading the file happens in the kernel instead of in Bun.
+// 4. Use os.sendfile so copying/reading the file happens in the kernel instead of in bun.
 //      This unfortunately means content hashing for HTTP server is unsupported, but metadata etags work
 // For each imported file, GOTO 1.
 
@@ -710,7 +710,7 @@ pub const Bundler = struct {
             }
         }
 
-        // The Bun Bundle Format
+        // The bun Bundle Format
         // All the node_modules your app uses in a single compact file with metadata
         // A binary JavaScript bundle format prioritizing generation time and deserialization time
         pub const magic_bytes = "#!/usr/bin/env bun\n\n";

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -161,7 +161,7 @@ pub const Arguments = struct {
         clap.parseParam("-i, --inject <STR>...             Inject module at the top of every file") catch unreachable,
         clap.parseParam("-l, --loader <STR>...             Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: jsx, js, json, tsx, ts, css") catch unreachable,
         clap.parseParam("-u, --origin <STR>                Rewrite import URLs to start with --origin. Default: \"\"") catch unreachable,
-        clap.parseParam("-p, --port <STR>                      Port to serve Bun's dev server on. Default: \"3000\"") catch unreachable,
+        clap.parseParam("-p, --port <STR>                      Port to serve bun's dev server on. Default: \"3000\"") catch unreachable,
         clap.parseParam("--silent                          Don't repeat the command for bun run") catch unreachable,
         clap.parseParam("<POS>...                          ") catch unreachable,
     };
@@ -169,7 +169,7 @@ pub const Arguments = struct {
     const debug_params = [_]ParamType{
         clap.parseParam("--dump-environment-variables    Dump environment variables from .env and process as JSON and quit. Useful for debugging") catch unreachable,
         clap.parseParam("--dump-limits                   Dump system limits. Useful for debugging") catch unreachable,
-        clap.parseParam("--disable-bun.js                Disable Bun.js from loading in the dev server") catch unreachable,
+        clap.parseParam("--disable-bun.js                Disable bun.js from loading in the dev server") catch unreachable,
     };
 
     const params = public_params ++ debug_params;
@@ -488,7 +488,7 @@ pub const HelpCommand = struct {
 
     pub fn printWithReason(comptime reason: Reason) void {
         const fmt =
-            \\> <r> <b><green>dev     <r><d>  ./a.ts ./b.jsx<r>        Start a Bun Dev Server
+            \\> <r> <b><green>dev     <r><d>  ./a.ts ./b.jsx<r>        Start a bun Dev Server
             \\> <r> <b><magenta>bun     <r><d>  ./a.ts ./b.jsx<r>        Bundle dependencies of input files into a <r><magenta>.bun<r>
             \\
             \\> <r> <b><cyan>create    <r><d>next ./app<r>            Start a new project from a template <d>(bun c)<r>
@@ -497,9 +497,9 @@ pub const HelpCommand = struct {
             \\> <r> <b><blue>add     <r><d>  {s:<16}<r>      Add a dependency to package.json <d>(bun a)<r>
             \\> <r> remove  <r><d>  {s:<16}<r>      Remove a dependency from package.json <d>(bun rm)<r>
             \\
-            \\> <r> <b><blue>upgrade <r>                        Get the latest version of Bun
+            \\> <r> <b><blue>upgrade <r>                        Get the latest version of bun
             \\> <r> <b><d>completions<r>                     Install shell completions for tab-completion
-            \\> <r> <b><d>discord <r>                        Open Bun's Discord server
+            \\> <r> <b><d>discord <r>                        Open bun's Discord server
             \\> <r> <b><d>help      <r>                      Print this help menu
             \\
         ;
@@ -515,7 +515,7 @@ pub const HelpCommand = struct {
 
         switch (reason) {
             .explicit => Output.pretty(
-                "<r><b><magenta>Bun<r>: a fast bundler, transpiler, JavaScript Runtime and package manager for web software.\n\n" ++ fmt,
+                "<r><b><magenta>bun<r>: a fast bundler, transpiler, JavaScript Runtime and package manager for web software.\n\n" ++ fmt,
                 args,
             ),
             .invalid_command => Output.prettyError(

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -86,7 +86,7 @@ const UnsupportedPackages = struct {
     pub fn print(this: UnsupportedPackages) void {
         inline for (comptime std.meta.fieldNames(UnsupportedPackages)) |field_name| {
             if (@field(this, field_name)) {
-                Output.prettyErrorln("<r><yellow>warn<r><d>:<r> <b>\"{s}\"<r> won't work in Bun yet\n", .{field_name});
+                Output.prettyErrorln("<r><yellow>warn<r><d>:<r> <b>\"{s}\"<r> won't work in bun yet\n", .{field_name});
             }
         }
     }
@@ -434,7 +434,7 @@ pub const CreateCommand = struct {
                                 node.end();
                                 progress.refresh();
 
-                                Output.prettyError("\n<r><red>error:<r> GitHub returned 403. This usually means GitHub is rate limiting your requests.\nTo fix this, either:<r>  <b>A) pass a <r><cyan>GITHUB_ACCESS_TOKEN<r> environment variable to Bun<r>\n  <b>B)Wait a little and try again<r>\n", .{});
+                                Output.prettyError("\n<r><red>error:<r> GitHub returned 403. This usually means GitHub is rate limiting your requests.\nTo fix this, either:<r>  <b>A) pass a <r><cyan>GITHUB_ACCESS_TOKEN<r> environment variable to bun<r>\n  <b>B)Wait a little and try again<r>\n", .{});
                                 Global.crash();
                             },
 
@@ -1548,7 +1548,7 @@ pub const CreateCommand = struct {
 
         Output.pretty(
             \\
-            \\<d>Come hang out in Bun's Discord: https://bun.sh/discord<r>
+            \\<d>Come hang out in bun's Discord: https://bun.sh/discord<r>
             \\
         , .{});
 
@@ -2118,7 +2118,7 @@ pub const CreateListExamplesCommand = struct {
         const examples = try Example.fetchAllLocalAndRemote(ctx, node, &env_loader, filesystem);
         Output.printStartEnd(time, std.time.nanoTimestamp());
         Output.prettyln(" <d>Fetched manifest<r>", .{});
-        Output.prettyln("Welcome to Bun! Create a new project by pasting any of the following:\n\n", .{});
+        Output.prettyln("Welcome to bun! Create a new project by pasting any of the following:\n\n", .{});
         Output.flush();
 
         Example.print(examples.items, null);

--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -30,12 +30,12 @@ if test -t 1; then
 fi
 
 if ! command -v unzip >/dev/null; then
-    echo -e "\n${Red}error${Color_Off}: unzip is required to install Bun (see: https://github.com/Jarred-Sumner/bun#unzip-is-required)." 1>&2
+    echo -e "\n${Red}error${Color_Off}: unzip is required to install bun (see: https://github.com/Jarred-Sumner/bun#unzip-is-required)." 1>&2
     exit 1
 fi
 
 if [ "$OS" = "Windows_NT" ]; then
-    echo "error: Please install Bun using Windows Subsystem for Linux."
+    echo "error: Please install bun using Windows Subsystem for Linux."
     exit 1
 else
     case $(uname -sm) in
@@ -53,7 +53,7 @@ if [ "$target" = "darwin-x64" ]; then
     sysctl sysctl.proc_translated >/dev/null 2>&1
     if [ $? -eq 0 ]; then
         target="darwin-aarch64"
-        echo -e "$Dim Your shell is running in Rosetta 2. Downloading Bun for $target instead. $Color_Off"
+        echo -e "$Dim Your shell is running in Rosetta 2. Downloading bun for $target instead. $Color_Off"
     fi
 fi
 
@@ -81,17 +81,17 @@ fi
 curl --fail --location --progress-bar --output "$exe.zip" "$bun_uri"
 
 if (($?)); then
-    echo -e "${Red}error${Color_Off}: Failed to download Bun from $bun_uri" 1>&2
+    echo -e "${Red}error${Color_Off}: Failed to download bun from $bun_uri" 1>&2
     exit 1
 fi
 unzip -d "$bin_dir" -q -o "$exe.zip"
 if (($?)); then
-    echo -e "${Red}error${Color_Off}: Failed to extract Bun" 1>&2
+    echo -e "${Red}error${Color_Off}: Failed to extract bun" 1>&2
     exit 1
 fi
 mv "$bin_dir/bun-${target}/bun" "$exe"
 if (($?)); then
-    echo -e "${Red}error${Color_Off}: Failed to extract Bun" 1>&2
+    echo -e "${Red}error${Color_Off}: Failed to extract bun" 1>&2
     exit 1
 fi
 chmod +x "$exe"
@@ -102,7 +102,7 @@ fi
 rmdir $bin_dir/bun-${target}
 rm "$exe.zip"
 
-echo -e "${Green}Bun was installed successfully to ${BGreen}$exe$Color_Off"
+echo -e "${Green}bun was installed successfully to ${BGreen}$exe$Color_Off"
 
 if command -v bun --version >/dev/null; then
     # Install completions, but we don't care if it fails
@@ -116,7 +116,7 @@ if test $(basename $SHELL) == "fish"; then
     # Install completions, but we don't care if it fails
     IS_BUN_AUTO_UPDATE="true" SHELL="fish" $exe completions >/dev/null 2>&1
     if test -f $HOME/.config/fish/config.fish; then
-        echo -e "\n# Bun\nset -Ux BUN_INSTALL \"$bun_install\"" >>"$HOME/.config/fish/config.fish"
+        echo -e "\n# bun\nset -Ux BUN_INSTALL \"$bun_install\"" >>"$HOME/.config/fish/config.fish"
         echo -e "set -px --path PATH \"$bin_dir\"\n" >>"$HOME/.config/fish/config.fish"
         echo ""
         echo -e "$Dim Added \"$bin_dir\" to \$PATH in \"\~/.config/fish/config.fish\"$Color_Off"
@@ -141,7 +141,7 @@ then
     IS_BUN_AUTO_UPDATE="true" SHELL="zsh" $exe completions >/dev/null 2>&1
 
     if test -f $HOME/.zshrc; then
-        echo -e "\n# Bun\nexport BUN_INSTALL=\"$bun_install\"" >>"$HOME/.zshrc"
+        echo -e "\n# bun\nexport BUN_INSTALL=\"$bun_install\"" >>"$HOME/.zshrc"
         echo -e "export PATH=\"\$BUN_INSTALL/bin:\$PATH\"" >>"$HOME/.zshrc"
         echo ""
         echo -e "$Dim Added \"$bin_dir\" to \$PATH in \"~/.zshrc\"$Color_Off"

--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -356,14 +356,14 @@ pub const InstallCompletionsCommand = struct {
 
                 // We need to add it to the end of the file
                 var remaining = buf[read..];
-                var extra = std.fmt.bufPrint(remaining, "\n# Bun completions\n[ -s \"{s}\" ] && source \"{s}\"\n", .{
+                var extra = std.fmt.bufPrint(remaining, "\n# bun completions\n[ -s \"{s}\" ] && source \"{s}\"\n", .{
                     completions_path,
                     completions_path,
                 }) catch unreachable;
 
                 dot_zshrc.pwriteAll(extra, read) catch break :brk true;
 
-                Output.prettyErrorln("<r><d>Enabled loading Bun's completions in .zshrc<r>", .{});
+                Output.prettyErrorln("<r><d>Enabled loading bun's completions in .zshrc<r>", .{});
                 break :brk false;
             };
 

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -645,7 +645,7 @@ pub const RunCommand = struct {
 
                             return true;
 
-                            // If we get here, then we run it with Bun.js
+                            // If we get here, then we run it with bun.js
 
                         }
                     }

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -96,7 +96,7 @@ pub const UpgradeCheckerThread = struct {
 
         if (!version.isCurrent()) {
             if (version.name()) |name| {
-                Output.prettyErrorln("\n<r><d>Bun v{s} is out. Run <b><cyan>bun upgrade<r> to upgrade.\n", .{name});
+                Output.prettyErrorln("\n<r><d>bun v{s} is out. Run <b><cyan>bun upgrade<r> to upgrade.\n", .{name});
                 Output.flush();
             }
         }
@@ -312,7 +312,7 @@ pub const UpgradeCommand = struct {
             progress.end();
             refresher.refresh();
             if (version.name()) |name| {
-                Output.prettyErrorln("Bun v{s} is out, but not for this platform ({s}) yet.", .{
+                Output.prettyErrorln("bun v{s} is out, but not for this platform ({s}) yet.", .{
                     name, Version.triplet,
                 });
             }
@@ -353,7 +353,7 @@ pub const UpgradeCommand = struct {
 
             if (version.name() != null and version.isCurrent()) {
                 Output.prettyErrorln(
-                    "<r><green>Congrats!<r> You're already on the latest version of Bun <d>(which is v{s})<r>",
+                    "<r><green>Congrats!<r> You're already on the latest version of bun <d>(which is v{s})<r>",
                     .{
                         version.name().?,
                     },
@@ -364,7 +364,7 @@ pub const UpgradeCommand = struct {
 
             if (version.name() == null) {
                 Output.prettyErrorln(
-                    "<r><red>error:<r> Bun versions are currently unavailable (the latest version name didn't match the expeccted format)",
+                    "<r><red>error:<r> bun versions are currently unavailable (the latest version name didn't match the expeccted format)",
                     .{},
                 );
                 Output.flush();
@@ -373,7 +373,7 @@ pub const UpgradeCommand = struct {
         }
 
         {
-            Output.prettyErrorln("<r><b>Bun <cyan>v{s}<r> is out<r>! You're on <blue>{s}<r>\n", .{ version.name().?, Global.package_json_version });
+            Output.prettyErrorln("<r><b>bun <cyan>v{s}<r> is out<r>! You're on <blue>{s}<r>\n", .{ version.name().?, Global.package_json_version });
             Output.flush();
 
             var refresher = std.Progress{};
@@ -413,7 +413,7 @@ pub const UpgradeCommand = struct {
             refresher.refresh();
 
             if (bytes.len == 0) {
-                Output.prettyErrorln("<r><red>error:<r> Failed to download the latest version of Bun. Received empty content", .{});
+                Output.prettyErrorln("<r><red>error:<r> Failed to download the latest version of bun. Received empty content", .{});
                 Output.flush();
                 std.os.exit(1);
             }
@@ -512,14 +512,14 @@ pub const UpgradeCommand = struct {
                     .max_output_bytes = 128,
                 }) catch |err| {
                     save_dir_.deleteTree(version_name) catch {};
-                    Output.prettyErrorln("<r><red>error<r> Failed to verify Bun {s}<r>)", .{@errorName(err)});
+                    Output.prettyErrorln("<r><red>error<r> Failed to verify bun {s}<r>)", .{@errorName(err)});
                     Output.flush();
                     std.os.exit(1);
                 };
 
                 if (result.term.Exited != 0) {
                     save_dir_.deleteTree(version_name) catch {};
-                    Output.prettyErrorln("<r><red>error<r> failed to verify Bun<r> (exit code: {d})", .{result.term.Exited});
+                    Output.prettyErrorln("<r><red>error<r> failed to verify bun<r> (exit code: {d})", .{result.term.Exited});
                     Output.flush();
                     std.os.exit(1);
                 }
@@ -528,7 +528,7 @@ pub const UpgradeCommand = struct {
                     save_dir_.deleteTree(version_name) catch {};
 
                     Output.prettyErrorln(
-                        "<r><red>error<r>: The downloaded version of Bun (<red>{s}<r>) doesn't match the expected version (<b>{s}<r>)<r>. Cancelled upgrade",
+                        "<r><red>error<r>: The downloaded version of bun (<red>{s}<r>) doesn't match the expected version (<b>{s}<r>)<r>. Cancelled upgrade",
                         .{
                             result.stdout[0..@minimum(result.stdout.len, 128)],
                             version_name,
@@ -550,7 +550,7 @@ pub const UpgradeCommand = struct {
             var target_dirname = current_executable_buf[0..target_dir_.len :0];
             var target_dir = std.fs.openDirAbsoluteZ(target_dirname, .{ .iterate = true }) catch |err| {
                 save_dir_.deleteTree(version_name) catch {};
-                Output.prettyErrorln("<r><red>error:<r> Failed to open Bun's install directory {s}", .{@errorName(err)});
+                Output.prettyErrorln("<r><red>error:<r> Failed to open bun's install directory {s}", .{@errorName(err)});
                 Output.flush();
                 std.os.exit(1);
             };
@@ -558,7 +558,7 @@ pub const UpgradeCommand = struct {
             if (env_loader.map.get("BUN_DRY_RUN") == null) {
                 C.moveFileZ(save_dir.fd, exe_subpath, target_dir.fd, target_filename) catch |err| {
                     save_dir_.deleteTree(version_name) catch {};
-                    Output.prettyErrorln("<r><red>error:<r> Failed to move new version of Bun due to {s}. You could try the install script instead:\n   curl -L https://bun.sh/install | bash", .{@errorName(err)});
+                    Output.prettyErrorln("<r><red>error:<r> Failed to move new version of bun due to {s}. You could try the install script instead:\n   curl -L https://bun.sh/install | bash", .{@errorName(err)});
                     Output.flush();
                     std.os.exit(1);
                 };
@@ -584,7 +584,7 @@ pub const UpgradeCommand = struct {
 
             Output.printStartEnd(ctx.start_time, std.time.nanoTimestamp());
 
-            Output.prettyErrorln("<r> Upgraded.\n\n<b><green>Welcome to Bun v{s}!<r>\n\n  Report any bugs:\n    https://github.com/Jarred-Sumner/bun/issues\n\n  What's new:\n    https://github.com/Jarred-Sumner/bun/releases/tag/{s}<r>", .{ version_name, version.tag });
+            Output.prettyErrorln("<r> Upgraded.\n\n<b><green>Welcome to bun v{s}!<r>\n\n  Report any bugs:\n    https://github.com/Jarred-Sumner/bun/issues\n\n  What's new:\n    https://github.com/Jarred-Sumner/bun/releases/tag/{s}<r>", .{ version_name, version.tag });
             Output.flush();
             return;
         }

--- a/src/css_scanner.zig
+++ b/src/css_scanner.zig
@@ -337,7 +337,7 @@ pub const Scanner = struct {
             scanner.source,
             logger.usize2Loc(start),
             scanner.allocator,
-            "To use Tailwind with Bun, use the Tailwind CLI and import the processed .css file.\nLearn more: https://tailwindcss.com/docs/installation#watching-for-changes",
+            "To use Tailwind with bun, use the Tailwind CLI and import the processed .css file.\nLearn more: https://tailwindcss.com/docs/installation#watching-for-changes",
             .{},
         ) catch {};
     }

--- a/src/global.zig
+++ b/src/global.zig
@@ -505,7 +505,7 @@ pub const Global = struct {
         }
     }
 
-    // Enabling huge pages slows down Bun by 8x or so
+    // Enabling huge pages slows down bun by 8x or so
     // Keeping this code for:
     // 1. documentation that an attempt was made
     // 2. if I want to configure allocator later

--- a/src/http.zig
+++ b/src/http.zig
@@ -1334,14 +1334,14 @@ pub const RequestContext = struct {
 
             if (vm.bundler.options.framework.?.display_name.len > 0) {
                 Output.prettyError(
-                    " {s} ready<d>! (powered by Bun)\n<r>",
+                    " {s} ready<d>! (powered by bun)\n<r>",
                     .{
                         vm.bundler.options.framework.?.display_name,
                     },
                 );
             } else {
                 Output.prettyError(
-                    " Bun.js started\n<r>",
+                    " bun.js started\n<r>",
                     .{},
                 );
             }
@@ -1359,7 +1359,7 @@ pub const RequestContext = struct {
             var module_map = JavaScript.ZigGlobalObject.getModuleRegistryMap(vm.global);
 
             if (!JavaScript.VM.isJITEnabled()) {
-                Output.prettyErrorln("<red><r>warn:<r> JIT is disabled,,,this is a bug in Bun and/or a permissions problem. JS will run slower.", .{});
+                Output.prettyErrorln("<red><r>warn:<r> JIT is disabled,,,this is a bug in bun and/or a permissions problem. JS will run slower.", .{});
                 if (vm.bundler.env.map.get("BUN_CRASH_WITHOUT_JIT") != null) {
                     Global.crash();
                 }
@@ -2911,7 +2911,7 @@ pub const Server = struct {
                 var random_number = std.rand.DefaultPrng.init(@intCast(u64, std.time.milliTimestamp()));
                 const default_port = @intCast(u16, server.bundler.options.origin.getPort() orelse 3000);
                 Output.prettyErrorln(
-                    "<r><red>error<r>: Bun can't start because <b>port {d} is already in use<r>. Tried {d} - {d}. Try closing the other apps or manually passing Bun a port\n\n  <r><cyan><b>bun --origin http://localhost:{d}/<r>\n",
+                    "<r><red>error<r>: bun can't start because <b>port {d} is already in use<r>. Tried {d} - {d}. Try closing the other apps or manually passing bun a port\n\n  <r><cyan><b>bun --origin http://localhost:{d}/<r>\n",
                     .{
                         default_port,
                         default_port,
@@ -2940,7 +2940,7 @@ pub const Server = struct {
         if (std.mem.readIntNative(u32, &addr.ipv4.host.octets) == 0 or std.mem.readIntNative(u128, &addr.ipv6.host.octets) == 0) {
             if (server.bundler.options.routes.single_page_app_routing) {
                 Output.prettyError(
-                    " Bun!! <d>v{s}<r>\n\n\n  Link:<r> <b><cyan>http://localhost:{d}<r>\n        <d>./{s}/index.html<r> \n\n\n",
+                    " bun!! <d>v{s}<r>\n\n\n  Link:<r> <b><cyan>http://localhost:{d}<r>\n        <d>./{s}/index.html<r> \n\n\n",
                     .{
                         Global.package_json_version,
                         addr.ipv4.port,
@@ -2948,20 +2948,20 @@ pub const Server = struct {
                     },
                 );
             } else {
-                Output.prettyError(" Bun!! <d>v{s}<r>\n\n\n<d>  Link:<r> <b><cyan>http://localhost:{d}<r>\n\n\n", .{
+                Output.prettyError(" bun!! <d>v{s}<r>\n\n\n<d>  Link:<r> <b><cyan>http://localhost:{d}<r>\n\n\n", .{
                     Global.package_json_version,
                     addr.ipv4.port,
                 });
             }
         } else {
             if (server.bundler.options.routes.single_page_app_routing) {
-                Output.prettyError(" Bun!! <d>v{s}<r>\n\n\n<d>  Link:<r> <b><cyan>http://{s}<r>\n       <d>./{s}/index.html<r> \n\n\n", .{
+                Output.prettyError(" bun!! <d>v{s}<r>\n\n\n<d>  Link:<r> <b><cyan>http://{s}<r>\n       <d>./{s}/index.html<r> \n\n\n", .{
                     Global.package_json_version,
                     addr,
                     resolve_path.relative(server.bundler.fs.top_level_dir, server.bundler.options.routes.static_dir),
                 });
             } else {
-                Output.prettyError(" Bun!! <d>v{s}\n\n\n<d>  Link:<r> <b><cyan>http://{s}<r>\n\n\n", .{
+                Output.prettyError(" bun!! <d>v{s}\n\n\n<d>  Link:<r> <b><cyan>http://{s}<r>\n\n\n", .{
                     Global.package_json_version,
                     addr,
                 });

--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -176,7 +176,7 @@ else
 
 const accept_encoding_header_hash = hashHeaderName("Accept-Encoding");
 
-const user_agent_header = picohttp.Header{ .name = "User-Agent", .value = "Bun.js " ++ Global.package_json_version };
+const user_agent_header = picohttp.Header{ .name = "User-Agent", .value = "bun.js " ++ Global.package_json_version };
 const user_agent_header_hash = hashHeaderName("User-Agent");
 const location_header_hash = hashHeaderName("Location");
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -3694,7 +3694,7 @@ pub const PackageManager = struct {
             }
 
             return std.fs.cwd().makeOpenPath("node_modules/.cache", .{ .iterate = true }) catch |err| {
-                Output.prettyErrorln("<r><red>error<r>: Bun is unable to write files: {s}", .{@errorName(err)});
+                Output.prettyErrorln("<r><red>error<r>: bun is unable to write files: {s}", .{@errorName(err)});
                 Output.flush();
                 Global.crash();
             };
@@ -3716,7 +3716,7 @@ pub const PackageManager = struct {
         var tempdir: std.fs.Dir = std.fs.cwd().makeOpenPath(default_tempdir, .{ .iterate = true }) catch brk: {
             tried_dot_tmp = true;
             break :brk cache_directory.makeOpenPath(".tmp", .{ .iterate = true }) catch |err| {
-                Output.prettyErrorln("<r><red>error<r>: Bun is unable to access tempdir: {s}", .{@errorName(err)});
+                Output.prettyErrorln("<r><red>error<r>: bun is unable to access tempdir: {s}", .{@errorName(err)});
                 Output.flush();
                 Global.crash();
             };
@@ -3730,7 +3730,7 @@ pub const PackageManager = struct {
                     tried_dot_tmp = true;
 
                     tempdir = cache_directory.makeOpenPath(".tmp", .{ .iterate = true }) catch |err| {
-                        Output.prettyErrorln("<r><red>error<r>: Bun is unable to access tempdir: {s}", .{@errorName(err)});
+                        Output.prettyErrorln("<r><red>error<r>: bun is unable to access tempdir: {s}", .{@errorName(err)});
                         Output.flush();
                         Global.crash();
                     };
@@ -3747,7 +3747,7 @@ pub const PackageManager = struct {
                 if (!tried_dot_tmp) {
                     tried_dot_tmp = true;
                     tempdir = cache_directory.makeOpenPath(".tmp", .{ .iterate = true }) catch |err2| {
-                        Output.prettyErrorln("<r><red>error<r>: Bun is unable to write files to tempdir: {s}", .{@errorName(err2)});
+                        Output.prettyErrorln("<r><red>error<r>: bun is unable to write files to tempdir: {s}", .{@errorName(err2)});
                         Output.flush();
                         Global.crash();
                     };

--- a/src/install/resolution.zig
+++ b/src/install/resolution.zig
@@ -280,7 +280,7 @@ pub const Resolution = extern struct {
         //
         // There are many ways to do it, but perhaps one way to be maximally compatible is just removing the protocol part of the URL.
         //
-        // For example, Bun would transform this input:
+        // For example, bun would transform this input:
         //
         //   import _ from "https://github.com/lodash/lodash/lodash.min.js";
         //

--- a/src/javascript/jsc/bindings/exports.zig
+++ b/src/javascript/jsc/bindings/exports.zig
@@ -36,10 +36,10 @@ const Handler = struct {
         Output.Source.set(&source);
 
         if (Output.isEmojiEnabled()) {
-            Output.prettyErrorln("<r><red>Bun will crash now<r> 😭😭😭\n", .{});
+            Output.prettyErrorln("<r><red>bun will crash now<r> 😭😭😭\n", .{});
             Output.flush();
         } else {
-            stderr.writeAll("Bun has crashed :'(\n") catch {};
+            stderr.writeAll("bun has crashed :'(\n") catch {};
         }
         std.mem.doNotOptimizeAway(source);
 

--- a/src/javascript/jsc/typescript.zig
+++ b/src/javascript/jsc/typescript.zig
@@ -49,7 +49,7 @@ pub fn main() anyerror!void {
 
     var global_file = try dir.createFile("globals.d.ts", .{});
     try global_file.writeAll(
-        \\// Bun.js v
+        \\// bun.js v
         \\
         \\
     );
@@ -57,7 +57,7 @@ pub fn main() anyerror!void {
 
     var module_file = try dir.createFile("modules.d.ts", .{});
     try module_file.writeAll(
-        \\// Bun.js v
+        \\// bun.js v
         \\
         \\
     );

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -5856,7 +5856,7 @@ pub const Macro = struct {
                             return TagOrJSNode{ .invalid = .{} };
                         },
                         else => {
-                            throwTypeError(writer.ctx, "Invalid Bun AST", writer.exception);
+                            throwTypeError(writer.ctx, "Invalid bun AST", writer.exception);
                             return TagOrJSNode{ .invalid = .{} };
                         },
                     }

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -4299,7 +4299,7 @@ pub const Format = enum {
     esm,
     cjs,
 
-    // Bun.js must escape non-latin1 identifiers in the output This is because
+    // bun.js must escape non-latin1 identifiers in the output This is because
     // we load JavaScript as a UTF-8 buffer instead of a UTF-16 buffer
     // JavaScriptCore does not support UTF-8 identifiers when the source code
     // string is loaded as const char* We don't want to double the size of code

--- a/src/options.zig
+++ b/src/options.zig
@@ -1332,7 +1332,7 @@ pub const BundleOptions = struct {
                         },
                         error.AccessDenied => {
                             Output.prettyErrorln(
-                                "error: access denied when trying to open directory for static files: \"{s}\".\nPlease re-open Bun with access to this folder or pass a different folder via \"--public-dir\". Note: --public-dir is relative to --cwd (or the process' current working directory).\n\nThe public folder is where static assets such as images, fonts, and .html files go.",
+                                "error: access denied when trying to open directory for static files: \"{s}\".\nPlease re-open bun with access to this folder or pass a different folder via \"--public-dir\". Note: --public-dir is relative to --cwd (or the process' current working directory).\n\nThe public folder is where static assets such as images, fonts, and .html files go.",
                                 .{opts.routes.static_dir},
                             );
                             std.process.exit(1);

--- a/src/panic_handler.zig
+++ b/src/panic_handler.zig
@@ -32,17 +32,17 @@ pub fn NewPanicHandler(comptime panic_func: fn handle_panic(msg: []const u8, err
 
             if (msg.len > 0) {
                 if (Output.isEmojiEnabled()) {
-                    Output.prettyErrorln("<r><red>Bun crashed 😭😭😭<r><d>: <r><b>{s}<r>\n", .{msg});
+                    Output.prettyErrorln("<r><red>bun crashed 😭😭😭<r><d>: <r><b>{s}<r>\n", .{msg});
                 } else {
                     Output.prettyErrorln("<r><red>Crash<r><d>:<r> <b>{s}<r>", .{msg});
                 }
                 Output.flush();
             } else {
                 if (Output.isEmojiEnabled()) {
-                    Output.prettyErrorln("<r><red>Bun will crash now<r> 😭😭😭<r>\n", .{});
+                    Output.prettyErrorln("<r><red>bun will crash now<r> 😭😭😭<r>\n", .{});
                     Output.flush();
                 } else {
-                    Output.printError("Bun has crashed :'(\n", .{});
+                    Output.printError("bun has crashed :'(\n", .{});
                 }
                 Output.flush();
             }

--- a/src/runtime.footer.js
+++ b/src/runtime.footer.js
@@ -1,6 +1,6 @@
 // ---
 // Public exports from runtime
-// Compatible with Bun's Runtime Environment and web browsers.
+// Compatible with bun's Runtime Environment and web browsers.
 export var $$m =
   "$primordials" in globalThis ? $primordials.require : BUN_RUNTIME.$$m;
 export var __HMRModule = BUN_RUNTIME.__HMRModule;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,4 +1,4 @@
-// Bun.js v
+// bun.js v
 
 declare global {
   function addEventListener(

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -1,6 +1,6 @@
-// Bun.js v
+// bun.js v
 
-/**  Filesystem Router supporting dynamic routes, exact routes, catch-all routes, and optional catch-all routes. Implemented in native code and only available with Bun.js.  */
+/**  Filesystem Router supporting dynamic routes, exact routes, catch-all routes, and optional catch-all routes. Implemented in native code and only available with bun.js.  */
 declare module "bun.js/router" {
   /**  Match a {@link https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent FetchEvent} to a `Route` from the local filesystem. Returns `null` if there is no match.  */
   function match(event: FetchEvent): Route | null;

--- a/zig-build/Dockerfile
+++ b/zig-build/Dockerfile
@@ -1,5 +1,5 @@
 
-# This builds the specifc version of Zig used by Bun
+# This builds the specifc version of Zig used by bun
 # It outputs a zig.zip file
 FROM ubuntu:20.04
 


### PR DESCRIPTION
Most CLI tools have the style convention of referring to themselves in
lowercase. It is, after all, the name that users type in when using
the tool. This PR maintains that convention in bun.

"Drop the uppercase B, it's cleaner"