### PR TITLE
Add module condition to the node platform

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -520,7 +520,10 @@ pub const Platform = enum {
     pub const DefaultConditions: std.EnumArray(Platform, []const string) = brk: {
         var array = std.EnumArray(Platform, []const string).initUndefined();
 
-        array.set(Platform.node, &[_]string{default_conditions_strings.node});
+        array.set(Platform.node, &[_]string{
+            default_conditions_strings.node,
+            default_conditions_strings.module,
+        });
 
         var listc = [_]string{
             default_conditions_strings.browser,


### PR DESCRIPTION
the "module" condition doesn't prescribe the target environment anyhow but rather it ensures that a particular file can be reused regardless of the used loader - the same file (the module condition file) should be loaded both when requesting using require and when requesting with an import statement (or a dynamic import etc)