### PR TITLE
Add start dev server step in next.js example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,8 @@ To create a new Next.js app with bun:
 ```bash
 bun create next ./app
 cd app
-bun
+bun # bundle dependencies
+bun dev # start dev server
 ```
 
 To use an existing Next.js app with bun:


### PR DESCRIPTION
This commit adds the `bun dev` step in creating a new Next.js app example in the README

fixes: #183