### PR TITLE
Add start dev server step in next.js example in cli comment

### DIFF
--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1636,7 +1636,7 @@ pub const CreateCommand = struct {
             \\<d>#<r><b> To get started, run:<r>
             \\
             \\  <b><cyan>cd {s}<r>
-            \\  <b><cyan>bun<r>
+            \\  <b><cyan>bun dev<r>
             \\
             \\
         , .{


### PR DESCRIPTION
This commit adds the bun dev step in creating a new Next.js app example in cli comment

fixes: https://github.com/Jarred-Sumner/bun/issues/200