### PR TITLE
fix: missing space in docs on homepage

### DIFF
--- a/packages/bun-landing/page.tsx
+++ b/packages/bun-landing/page.tsx
@@ -539,7 +539,7 @@ export default ({ inlineCSS }) => (
               <NodeJS href="https://github.com/Jarred-Sumner/bun/issues/158">
                 Node-API
               </NodeJS>{" "}
-              bun.js implements most of
+              bun.js implements most of{' '}
               <a
                 href="https://nodejs.org/api/n-api.html#node-api"
                 target="_blank"


### PR DESCRIPTION
I noticed a missing space 

<img width="655" alt="image" src="https://user-images.githubusercontent.com/229881/177429282-14d74811-b743-4e8a-be9c-ae6abd803792.png">
