### PR TITLE
Allow setting LLVM_PREFIX and MIN_MACOS_VERSION as environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,22 @@ ifeq ($(ARCH_NAME_RAW),aarch64)
 ARCH_NAME_RAW = arm64
 endif
 
-MIN_MACOS_VERSION = 10.14
-
-
 MARCH_NATIVE = -mtune=native
 
 ARCH_NAME :=
 DOCKER_BUILDARCH =
 ifeq ($(ARCH_NAME_RAW),arm64)
-   ARCH_NAME = aarch64
-   DOCKER_BUILDARCH = arm64
-   BREW_PREFIX_PATH = /opt/homebrew
-   MIN_MACOS_VERSION = 11.0
-   MARCH_NATIVE = -mtune=native
+	ARCH_NAME = aarch64
+	DOCKER_BUILDARCH = arm64
+	BREW_PREFIX_PATH = /opt/homebrew
+	MIN_MACOS_VERSION ?= 11.0
+	MARCH_NATIVE = -mtune=native
 else
-   ARCH_NAME = x64
-   DOCKER_BUILDARCH = amd64
-   BREW_PREFIX_PATH = /usr/local
-   MARCH_NATIVE = -march=native -mtune=native
+	ARCH_NAME = x64
+	DOCKER_BUILDARCH = amd64
+	BREW_PREFIX_PATH = /usr/local
+	MIN_MACOS_VERSION ?= 10.14
+	MARCH_NATIVE = -march=native -mtune=native
 endif
 
 AR=

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ CC = $(shell which clang-13 || which clang)
 CXX = $(shell which clang++-13 || which clang++)
 
 ifeq ($(OS_NAME),darwin)
-LLVM_PREFIX = $(shell brew --prefix llvm)
+LLVM_PREFIX ?= $(shell brew --prefix llvm)
 LDFLAGS += " -L$(LLVM_PREFIX)/lib"
 CPPFLAGS += " -I$(LLVM_PREFIX)/include"
 CC = $(LLVM_PREFIX)/bin/clang


### PR DESCRIPTION
I spent the evening working on trying to make a Homebrew formula for bun, and ended up needing the ability to customize these values to get things working. Figured I'd upstream the changes. :)

(I also tweaked the indentation for the `ifeq` that I touched, to better match the rest of the file)

Congrats on 0.1 btw!