### PR TITLE
fix-238-ci-ignore-bun-landing

### DIFF
--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -9,12 +9,14 @@ on:
       - "LICENSE"
       - ".vscode"
       - ".devcontainer"
+      - "packages/bun-landing/**"
   pull_request:
     branches: [main]
     paths-ignore:
       - "examples/**"
       - "bench/**"
       - README.*
+      - "packages/bun-landing/**"
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
fix: ignore bun-landing when running ci.

fixes #238 