### PR TITLE
Add a space in page.tsx

### DIFF
--- a/packages/bun-landing/page.tsx
+++ b/packages/bun-landing/page.tsx
@@ -539,7 +539,7 @@ export default ({ inlineCSS }) => (
               <NodeJS href="https://github.com/Jarred-Sumner/bun/issues/158">
                 Node-API
               </NodeJS>{" "}
-              bun.js implements most of{' '}
+              bun.js implements most of{" "}
               <a
                 href="https://nodejs.org/api/n-api.html#node-api"
                 target="_blank"


### PR DESCRIPTION
Just a very simple fix for an issue I noticed on the landing page where a space was not applying to the text:

**Before**
<img width="704" alt="Screen Shot 2022-07-06 at 16 33 09" src="https://user-images.githubusercontent.com/16276358/177562837-9d6a5628-ee4d-4c94-ac62-5794852dc676.png">

**After** 
<img width="752" alt="Screen Shot 2022-07-06 at 16 34 34" src="https://user-images.githubusercontent.com/16276358/177562879-a1dfe750-9d5c-4225-9c2f-c78e33dff463.png">

