### PR TITLE
Use the latest to build zls

### DIFF
--- a/.devcontainer/scripts/zig-env.sh
+++ b/.devcontainer/scripts/zig-env.sh
@@ -4,4 +4,4 @@ curl -L https://github.com/Jarred-Sumner/vscode-zig/releases/download/fork-v1/zi
 git clone https://github.com/zigtools/zls /home/ubuntu/zls
 cd /home/ubuntu/zls
 git submodule update --init --recursive --progress --depth=1
-zig build -Drelease-fast
+/build/zig-latest/zig build -Drelease-fast

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -47,6 +47,7 @@ RUN apt-get update && \
     cargo \
     unzip \
     tar \
+    xz-utils \
     golang-go ninja-build pkg-config automake autoconf libtool curl && \
     update-alternatives --install /usr/bin/cc cc /usr/bin/clang-13 90 && \
     update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-13 90 && \
@@ -93,6 +94,15 @@ RUN cd $GITHUB_WORKSPACE && \
     curl -o zig-linux-$BUILDARCH.zip -L https://github.com/Jarred-Sumner/zig/releases/download/mar4/zig-linux-$BUILDARCH.zip && \
     unzip -q zig-linux-$BUILDARCH.zip && \
     rm zig-linux-$BUILDARCH.zip;
+
+RUN cd $GITHUB_WORKSPACE && \
+    zig_tarball_url=$(curl -sS https://ziglang.org/download/ | grep -o -E 'https://ziglang\.org/builds/zig-linux-x86_64-[^>]+') && \
+    zig_master_version=$(echo "$zig_tarball_url" | grep -o -E '[0-9.]+-dev\.[0-9]+\+[0-9a-f]+') && \
+    echo zig_master_verion=$zig_master_version && \
+    curl -o zig-linux-$BUILDARCH.tar.xz -L https://ziglang.org/builds/zig-linux-x86_64-$zig_master_version.tar.xz && \
+    tar -xJf zig-linux-$BUILDARCH.tar.xz && \
+    mv zig-linux-x86_64-$zig_master_version zig-latest && \
+    rm zig-linux-$BUILDARCH.tar.xz;
 
 RUN cd $GITHUB_WORKSPACE && \
     curl -o bun-webkit-linux-$BUILDARCH.tar.gz -L https://github.com/Jarred-Sumner/WebKit/releases/download/jul4/bun-webkit-linux-$BUILDARCH.tar.gz && \


### PR DESCRIPTION
The latest Zig is needed according to https://github.com/zigtools/zls#from-source

With an old version of zig, building zls gives the following error:

  #0 44.55 Submodule path 'src/known-folders': checked out '9db1b99219c767d5e24994b1525273fe4031e464'
  #0 46.23 From https://github.com/wolfpld/tracy
  #0 46.23  * branch            2d8723b69b39721eadcc296451012828899c0f17 -> FETCH_HEAD
  #0 46.34 Submodule path 'src/tracy': checked out '2d8723b69b39721eadcc296451012828899c0f17'
  #0 48.85 ./build.zig:45:48: error: no member named 'source' in struct 'std.build.Pkg'
  #0 48.85     exe.addPackage(.{ .name = "known-folders", .source = .{ .path = "src/known-folders/known-folders.zig" } });
  #0 48.85                                                ^