### PR TITLE
Use Node.js v18.x from NodeSource to use string.replaceAll method

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -19,6 +19,7 @@ RUN apt-get update && \
     wget https://apt.llvm.org/llvm.sh --no-check-certificate && \
     chmod +x llvm.sh && \
     ./llvm.sh 13 && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
     ca-certificates \
@@ -35,7 +36,6 @@ RUN apt-get update && \
     nodejs \
     gcc \
     g++ \
-    npm \
     clang-13 \
     clang-format-13 \
     libc++-13-dev \


### PR DESCRIPTION
Node.js in Ubuntu focal does not have string.replaceAll method.
```
root@focal:~# node --version
v10.19.0
root@focal:~# echo "console.log(''.replace)" | node
[Function: replace]
root@focal:~# echo "console.log(''.replaceAll)" | node
undefined
```

And it gives the following error at
https://github.com/Jarred-Sumner/bun/blob/f0c283c632816143d8eb3a9dc9ed41d326dcbde1/Makefile#L722

```
/build/bun/misctools/headers-cleaner.js:33
input = input.replaceAll("*WebCore__", "*bindings.");
              ^

TypeError: input.replaceAll is not a function
    at Object.<anonymous>
(/build/bun/misctools/headers-cleaner.js:33:15)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js
(internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
make: *** [Makefile:722: jsc-bindings-headers] Error 1
```