### PR TITLE
Add needed dependencies to Makefile devcontainer target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -706,7 +706,7 @@ jsc-bindings: jsc-bindings-headers jsc-bindings-mac
 clone-submodules:
 	git -c submodule."src/bun.js/WebKit".update=none submodule update --init --recursive --depth=1 --progress
 
-devcontainer: clone-submodules mimalloc zlib libarchive boringssl picohttp identifier-cache node-fallbacks jsc-bindings-headers api analytics bun_error fallback_decoder jsc-bindings-mac dev runtime_js_dev
+devcontainer: clone-submodules mimalloc zlib libarchive boringssl picohttp identifier-cache node-fallbacks jsc-bindings-headers api analytics bun_error fallback_decoder jsc-bindings-mac dev runtime_js_dev libarchive libbacktrace lolhtml usockets uws base64 tinycc
 
 CLANG_FORMAT := $(shell command -v clang-format 2> /dev/null)
 


### PR DESCRIPTION
Or if we do not want to add dependencies here, update the following line
https://github.com/Jarred-Sumner/bun/blob/f0c283c632816143d8eb3a9dc9ed41d326dcbde1/.devcontainer/scripts/getting-started.sh#L10
to
```
make devcontainer libarchive libbacktrace lolhtml usockets uws base64 tinycc
```
