### PR TITLE
docs: add callout for typedefs with TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If using Linux, kernel version 5.6 or higher is strongly recommended, but the mi
   - [Using bun with Create React App](#using-bun-with-create-react-app)
 - [Using bun with TypeScript](#using-bun-with-typescript)
   - [Transpiling TypeScript with Bun](#transpiling-typescript-with-bun)
+  - [Adding Type Definitions](#adding-type-definitions)
 - [Not implemented yet](#not-implemented-yet)
   - [Limitations & intended usage](#limitations--intended-usage)
 - [Benchmarks](#benchmarks)
@@ -485,11 +486,29 @@ If no directory is specified and `./public/` doesn’t exist, bun will try `./st
 
 ## Using bun with TypeScript
 
-#### Transpiling TypeScript with Bun
+### Transpiling TypeScript with Bun
 
 TypeScript just works. There’s nothing to configure and nothing extra to install. If you import a `.ts` or `.tsx` file, bun will transpile it into JavaScript. bun also transpiles `node_modules` containing `.ts` or `.tsx` files. This is powered by bun’s TypeScript transpiler, so it’s fast.
 
 bun also reads `tsconfig.json`, including `baseUrl` and `paths`.
+
+### Adding Type Definitions
+
+To get TypeScript working with the global API, add `bun-types` to your project:
+
+```sh
+bun add -d bun-types
+```
+
+And to the `types` field in your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["bun-types"]
+  }
+}
+```
 
 ## Not implemented yet
 


### PR DESCRIPTION
- adds callout for adding `bun-types` to the project
- adds callout for adding `bun-types` to the project's `tsconfig.json`
- adds link in TOC

````md
### Adding Type Definitions

To get TypeScript working with the global API, add `bun-types` to your project:

```sh
bun add -d bun-types
```

And to the `types` field in your `tsconfig.json`:

```json
{
  "compilerOptions": {
    "types": ["bun-types"]
  }
}
```
````

Would it almost be better to ship `bun-types` as `@types/bun` as to not clash with manually specifying `compilerOptions.types` and `@types/*` packages? https://www.typescriptlang.org/tsconfig#types

OR push folks into creating a `global.d.ts` file with:

```ts
/// <reference types="bun-types" />
```