### PR TITLE
Add RSC to list of unsupported Next.js features in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Here’s what doesn’t work yet:
 - `proxy` and anything else in `next.config.js`
 - API routes, middleware (middleware is easier to support though! similar SSR API)
 - styled-jsx (technically not Next.js but often used with it)
+- React Server Components
 
 When using Next.js, bun automatically reads configuration from `.env.local`, `.env.development` and `.env` (in that order). `process.env.NEXT_PUBLIC_` and `process.env.NEXT_` automatically are replaced via `--define`.
 


### PR DESCRIPTION
I tried out React Server Components by following the instructions in the Next.js docs [here](https://nextjs.org/docs/advanced-features/react-18/server-components) and it did not work for a bun Next.js app. I've confirmed they're working on regular Next.js apps made with `create-next-app`.