### PR TITLE
fix devcontainer starship installation

### DIFF
--- a/.devcontainer/scripts/nice.sh
+++ b/.devcontainer/scripts/nice.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 chsh -s $(which zsh)
-sh -c "$(curl -fsSL https://starship.rs/install.sh) -- --platform linux_musl"
+sh -c "$(curl -fsSL https://starship.rs/install.sh) -- --platform linux_musl" -- --yes
 echo "eval \"$(starship init zsh)\"" >>~/.zshrc
 
 curl https://github.com/Jarred-Sumner/vscode-zig/releases/download/fork-v1/zig-0.2.5.vsix >/home/ubuntu/vscode-zig.vsix


### PR DESCRIPTION
To install starship, we need to provide `--yes` or it gives the following error:

Error reading from prompt (please re-run with the '--yes' option) 