### PR TITLE
fix dotenv config snippet

### DIFF
--- a/packages/bun-landing/page.tsx
+++ b/packages/bun-landing/page.tsx
@@ -539,7 +539,7 @@ export default ({ inlineCSS }) => (
             <li>
               bun.js automatically loads environment variables from{" "}
               <Bun>.env</Bun> files. No more{" "}
-              <code class="mono">require("dotenv").load()</code>
+              <code class="mono">require("dotenv").config()</code>
             </li>
             <li>
               bun ships with a fast SQLite3 client builtin <Bun>bun:sqlite</Bun>


### PR DESCRIPTION
The dotenv config snippet on the website isn't correct.

[dotenv package usage](https://github.com/motdotla/dotenv#usage)