### PR TITLE
fix: remove unnecessary quotes in commit message

### DIFF
--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -2210,7 +2210,7 @@ const GitHandler = struct {
             const git_commands = .{
                 &[_]string{ std.mem.span(git), "init", "--quiet" },
                 &[_]string{ std.mem.span(git), "add", destination, "--ignore-errors" },
-                &[_]string{ std.mem.span(git), "commit", "-am", "\"Initial commit (via bun create)\"", "--quiet" },
+                &[_]string{ std.mem.span(git), "commit", "-am", "Initial commit (via bun create)", "--quiet" },
             };
 
             if (comptime verbose) {


### PR DESCRIPTION
The `bun create react ./app` command posts an initial commit when it is done, but that commit contains extra quotes that don't appear to be necessary.

![image](https://user-images.githubusercontent.com/551858/178082827-38c9a22f-582a-4275-a1ca-fd30a6abc201.png)
