### PR TITLE
update bash references to work in non-fhs compliant distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash # Use bash syntax to be consistent
+SHELL :=  $(shell which bash) # Use bash syntax to be consistent
 
 OS_NAME := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH_NAME_RAW := $(shell uname -m)

--- a/bench/ffi/plus100/download-napi-plus100.sh
+++ b/bench/ffi/plus100/download-napi-plus100.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -rf plus100-napi
 git clone https://github.com/Jarred-Sumner/napi-plus100 plus100-napi --depth=1

--- a/bench/hot-module-reloading/css-stress-test/run.sh
+++ b/bench/hot-module-reloading/css-stress-test/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Running next at 24ms"
 PROJECT=next SLEEP_INTERVAL=24 make generate &

--- a/bench/sqlite/download-northwind.sh
+++ b/bench/sqlite/download-northwind.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 rm -rf Northwind_large.sqlite.zip

--- a/misctools/find-unused-zig.sh
+++ b/misctools/find-unused-zig.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rg "@import\(\"(.*\.zig)\"\)" src -r "\$1" --only-matching  -I  | xargs basename | sort | uniq > /tmp/imported-names.txt
 find src -iname "*.zig" | xargs basename | sort | uniq > /tmp/all-names.txt

--- a/misctools/generate-tests-file.sh
+++ b/misctools/generate-tests-file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd src
 rg -l "^test " --type zig | sed  -e 's/\(.*\)/@import\(\".\/\1"\);/' | sed  '/schema/d' | sed '/deps/d' > /tmp/tests.zig

--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Reset
 Color_Off=''

--- a/test/apps/bun-create-next.sh
+++ b/test/apps/bun-create-next.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/test/apps/bun-create-react.sh
+++ b/test/apps/bun-create-react.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/test/apps/bun-dev-index-html.sh
+++ b/test/apps/bun-dev-index-html.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/test/apps/bun-dev.sh
+++ b/test/apps/bun-dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/test/apps/bun-install-lockfile-status.sh
+++ b/test/apps/bun-install-lockfile-status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/test/apps/bun-install-utf8.sh
+++ b/test/apps/bun-install-utf8.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/test/apps/bun-install.sh
+++ b/test/apps/bun-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/test/apps/bun-run-check.sh
+++ b/test/apps/bun-run-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/zig-build/release.sh
+++ b/zig-build/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 


### PR DESCRIPTION
# Commands for reference
- oneliner used to replace the shebangs treewide
```bash
for f in $(rg -l '#!/bin/bash'); do sed -i 's;#!/bin/bash;#!/usr/bin/env bash;' $f; done
```
