### PR TITLE
Remove compinit call in zsh completion script

### DIFF
--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -1,10 +1,10 @@
 _bun() {
     zstyle ':completion:*:*:bun:*' group-name ''
     zstyle ':completion:*:*:bun-grouped:*' group-name ''
-    
+
     zstyle ':completion:*:*:bun::descriptions' format '%F{green}-- %d --%f'
     zstyle ':completion:*:*:bun-grouped:*' format '%F{green}-- %d --%f'
-    
+
     local program=bun
     typeset -A opt_args
     local curcontext="$curcontext" state line context
@@ -546,5 +546,4 @@ __bun_dynamic_comp() {
     return $comp
 }
 
-autoload -U compinit && compinit
 compdef _bun bun


### PR DESCRIPTION
After installing Bun I noticed a slight slowdown in terminal start-up. Profiling ZSH startup showed me that the completion system was initialized twice (see 2nd row):

```
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    4          58.92    14.73   61.96%     58.92    14.73   61.96%  compaudit
 2)    2          93.94    46.97   98.79%     35.02    17.51   36.83%  compinit
 3)    4           0.33     0.08    0.35%      0.33     0.08    0.35%  compdef
...
```

Checking out the changes in `.zshrc` I followed the rabbit to Bun's completion scripts.

The [ZSH manual](https://zsh-manual.netlify.app/completion-system) says that `compinit` should be called in the initialization file of your shell. I think it's implied that it should be called once in shell start-up.