### PR TITLE
Use latest for building both zls and bun

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -47,6 +47,7 @@ RUN apt-get update && \
     cargo \
     unzip \
     tar \
+    xz-utils \
     golang-go ninja-build pkg-config automake autoconf libtool curl && \
     update-alternatives --install /usr/bin/cc cc /usr/bin/clang-13 90 && \
     update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-13 90 && \
@@ -90,9 +91,13 @@ ARG BUILDARCH=amd64
 WORKDIR $GITHUB_WORKSPACE
 
 RUN cd $GITHUB_WORKSPACE && \
-    curl -o zig-linux-$BUILDARCH.zip -L https://github.com/Jarred-Sumner/zig/releases/download/mar4/zig-linux-$BUILDARCH.zip && \
-    unzip -q zig-linux-$BUILDARCH.zip && \
-    rm zig-linux-$BUILDARCH.zip;
+    zig_tarball_url=$(curl -sS https://ziglang.org/download/ | grep -o -E 'https://ziglang\.org/builds/zig-linux-x86_64-[^>]+') && \
+    zig_master_version=$(echo "$zig_tarball_url" | grep -o -E '[0-9.]+-dev\.[0-9]+\+[0-9a-f]+') && \
+    echo zig_master_verion=$zig_master_version && \
+    curl -o zig-linux-$BUILDARCH.tar.xz -L https://ziglang.org/builds/zig-linux-x86_64-$zig_master_version.tar.xz && \
+    tar -xJf zig-linux-$BUILDARCH.tar.xz && \
+    mv zig-linux-x86_64-$zig_master_version zig && \
+    rm zig-linux-$BUILDARCH.tar.xz;
 
 RUN cd $GITHUB_WORKSPACE && \
     curl -o bun-webkit-linux-$BUILDARCH.tar.gz -L https://github.com/Jarred-Sumner/WebKit/releases/download/jul4/bun-webkit-linux-$BUILDARCH.tar.gz && \


### PR DESCRIPTION
Since [fix: update build files to latest Zig version by sno2 · Pull Request #522 · Jarred-Sumner/bun](https://github.com/Jarred-Sumner/bun/pull/522) and [Migrate to Zig v0.10.0 (HEAD) by alexkuz · Pull Request #491 · Jarred-Sumner/bun](https://github.com/Jarred-Sumner/bun/pull/491) are merged, we now need to use the latest zig for building both zls and bun.

So this pull request is needed instead of [Use the latest to build zls by hnakamur · Pull Request #265 · Jarred-Sumner/bun](https://github.com/Jarred-Sumner/bun/pull/265).


## The steps for local build

The following steps are needed until Docker image `bunbunbunbun/bun-base-with-zig-and-webkit` is updated after this pull request is merged.

### Steps on the host machine

Build local docker image.

```
DOCKER_BUILDARCH=amd64
BUILDKIT=1 docker build -f Dockerfile.base --build-arg GITHUB_WORKSPACE=/build --platform=linux/${DOCKER_BUILDARCH} --tag local/bun-base --target bun-base .
BUILDKIT=1 docker build -f Dockerfile.base --build-arg GITHUB_WORKSPACE=/build --platform=linux/${DOCKER_BUILDARCH} --tag local/bun-base-with-zig-and-webkit --target bun-base-with-zig-and-webkit .
```

Use node 18.x
```
sed -i 's|bunbunbunbun/bun-base|local/bun-base|' Dockerfile
```

Use latest zig 

```
sed -i 's|bunbunbunbun/bun-base-with-zig-and-webkit|local/bun-base-with-zig-and-webkit|' Dockerfile
```

Build the devcontainer

```
devcontainer build
```

### Steps in the devcontainer

Confirm commits of bun and submodules.

```
root in bun on  main [$!?] via  v18.5.0 via ↯ v0.10.0-dev.2882+13d58258a 
⬢ [Systemd] ❯ git git log -1 | cat

commit 0acf8a66181624e11ec83a0e4031eb8c2facc9d2
Author: Ryan Russell <git@ryanrussell.org>
Date:   Fri Jul 8 18:04:32 2022 -0500

    refactor(websockets): Rename `connectedWebSocketContext()`
    
    Signed-off-by: Ryan Russell <git@ryanrussell.org>

root in bun on  main [$!?] via  v18.5.0 via ↯ v0.10.0-dev.2882+13d58258a 
⬢ [Systemd] ❯ git submodule status
 7e7774dabf1c2d94fe3604defb3c54a4c989c3b7 src/bun.js/WebKit (jul4)
 fa3fbda07bbf70925453d6a3c25a7aa455aa1cef src/deps/boringssl (fa3fbda)
 dc321febde83dd0f31158e1be61a7aedda65e7a2 src/deps/libarchive (dc321fe)
 4d2dd0b172f2c9192f83ba93425f868f2a13c553 src/deps/libbacktrace (heads/master)
 2eed349dcdfa4ff5c19fe7c6e501cfd687601033 src/deps/lol-html (2eed349)
 6d07c0b9ba535617cf9665ea77d099dad265818a src/deps/mimalloc (6d07c0b)
 066d2b1e9ab820703db0837a7255d92d30f0c9f5 src/deps/picohttpparser (heads/master)
 2d3ad9e0d32194ad7fd867b66ebe218dcc8cb5cd src/deps/tinycc (heads/mob)
 1b46cf9ace5f55f713d55bb8c086f5878d132457 src/deps/uws (heads/master)
 959b4ea305821e753385e873ec4edfaa9a5d49b7 src/deps/zlib (959b4ea)
```

Also confirm node and zig version.

```
root in bun on  main [$!?] via  v18.5.0 via ↯ v0.10.0-dev.2882+13d58258a
⬢ [Systemd] ❯ node --version
v18.5.0
```

```
root in bun on  main [$!?] via  v18.5.0 via ↯ v0.10.0-dev.2882+13d58258a
⬢ [Systemd] ❯ zig version
0.10.0-dev.2882+13d58258a
```

Now run `make devcontainer`. It fails with missing dependencies.

```
root in bun on  main [$!?] via  v18.5.0 via ↯ v0.10.0-dev.2882+13d58258a
⬢ [Systemd] ❯ make devcontainer

...(snip)...

rm -f /tmp/build-jsc-headers src/bun.js/bindings/headers.zig
touch src/bun.js/bindings/headers.zig
mkdir -p src/bun.js/bindings-obj/
/build/zig/zig build headers-obj
/usr/bin/clang++-13  -march=native -mtune=native  -O3 -march=native -mtune=native -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -fuse-ld=lld -Wl,-z,now -Wl,--as-needed -Wl,--gc-sections -Wl,-z,stack-size=12800000 -static-libstdc++ -static-libgcc -fno-omit-frame-pointer -Wl,--compress-debug-sections,zlib  -Wl,-Bsymbolic-functions -fno-semantic-interposition -flto -Wl,--allow-multiple-definition -rdynamic /build/bun-webkit/lib/libJavaScriptCore.a /build/bun-webkit/lib/libWTF.a  /build/bun-webkit/lib/libbmalloc.a /build/bun-webkit/lib/libLowLevelInterpreterLib.a  /build/icu/source/lib/libicuuc.a /build/icu/source/lib/libicudata.a /build/icu/source/lib/libicui18n.a /build/bun-deps/picohttpparser.o -L/build/bun-deps -llolhtml -lz -larchive -lssl -lbase64 -ltcc /build/bun-deps/libmimalloc.o /build/bun-deps/libbacktrace.a -lcrypto -lusockets /build/bun-deps/libuwsockets.o  -I/build/bun/src/deps/uws/uSockets/src -I/build/bun/src/deps/uws/src -I/build/bun/src/deps -I/build/bun/src/deps/mimalloc/include -Isrc/napi -I/build/bun-webkit/include -Isrc/bun.js/builtins/ -Isrc/bun.js/bindings/ -Isrc/bun.js/bindings/webcore -Isrc/bun.js/bindings/sqlite -Isrc/bun.js/builtins/cpp -I/build/bun/src/deps/zlib -std=c++2a -DSTATICALLY_LINKED_WITH_JavaScriptCore=1 -DSTATICALLY_LINKED_WITH_WTF=1 -DSTATICALLY_LINKED_WITH_BMALLOC=1 -DBUILDING_WITH_CMAKE=1 -DBUN_SINGLE_THREADED_PER_VM_ENTRY_SCOPE=1 -DNDEBUG=1 -DNOMINMAX -DIS_BUILD -DENABLE_INSPECTOR_ALTERNATE_DISPATCHERS=1 -DBUILDING_JSCONLY__ -DASSERT_ENABLED=0 -fvisibility=hidden -fvisibility-inlines-hidden -pthread -ldl   -march=native -mtune=native  -O3 -march=native -mtune=native -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -fuse-ld=lld -Wl,-z,now -Wl,--as-needed -Wl,--gc-sections -Wl,-z,stack-size=12800000 -static-libstdc++ -static-libgcc -fno-omit-frame-pointer -Wl,--compress-debug-sections,zlib  -Wl,-Bsymbolic-functions -fno-semantic-interposition -flto -Wl,--allow-multiple-definition -rdynamic /build/bun-deps/sqlite3.o  /build/icu/source/lib/libicuuc.a /build/icu/source/lib/libicudata.a /build/icu/source/lib/libicui18n.a  -g /build/bun/packages/debug-bun-linux-x64//headers.o -W -o /tmp/build-jsc-headers -lc;
clang: error: no such file or directory: '/build/bun-deps/libbacktrace.a'
clang: error: no such file or directory: '/build/bun-deps/libuwsockets.o'
clang: error: no such file or directory: '/build/bun-deps/sqlite3.o'
make: *** [Makefile:723: jsc-bindings-headers] Error 1
```

Try again with dependencies.

```
root in bun on  main [$!?] via  v18.5.0 via ↯ v0.10.0-dev.2882+13d58258a
⬢ [Systemd] ❯ make libbacktrace uws sqlite devcontainer

...(snip)...

rm -f /tmp/build-jsc-headers src/bun.js/bindings/headers.zig
touch src/bun.js/bindings/headers.zig
mkdir -p src/bun.js/bindings-obj/
/build/zig/zig build headers-obj
/usr/bin/clang++-13  -march=native -mtune=native  -O3 -march=native -mtune=native -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -fuse-ld=lld -Wl,-z,now -Wl,--as-needed -Wl,--gc-sections -Wl,-z,stack-size=12800000 -static-libstdc++ -static-libgcc -fno-omit-frame-pointer -Wl,--compress-debug-sections,zlib  -Wl,-Bsymbolic-functions -fno-semantic-interposition -flto -Wl,--allow-multiple-definition -rdynamic /build/bun-webkit/lib/libJavaScriptCore.a /build/bun-webkit/lib/libWTF.a  /build/bun-webkit/lib/libbmalloc.a /build/bun-webkit/lib/libLowLevelInterpreterLib.a  /build/icu/source/lib/libicuuc.a /build/icu/source/lib/libicudata.a /build/icu/source/lib/libicui18n.a /build/bun-deps/picohttpparser.o -L/build/bun-deps -llolhtml -lz -larchive -lssl -lbase64 -ltcc /build/bun-deps/libmimalloc.o /build/bun-deps/libbacktrace.a -lcrypto -lusockets /build/bun-deps/libuwsockets.o  -I/build/bun/src/deps/uws/uSockets/src -I/build/bun/src/deps/uws/src -I/build/bun/src/deps -I/build/bun/src/deps/mimalloc/include -Isrc/napi -I/build/bun-webkit/include -Isrc/bun.js/builtins/ -Isrc/bun.js/bindings/ -Isrc/bun.js/bindings/webcore -Isrc/bun.js/bindings/sqlite -Isrc/bun.js/builtins/cpp -I/build/bun/src/deps/zlib -std=c++2a -DSTATICALLY_LINKED_WITH_JavaScriptCore=1 -DSTATICALLY_LINKED_WITH_WTF=1 -DSTATICALLY_LINKED_WITH_BMALLOC=1 -DBUILDING_WITH_CMAKE=1 -DBUN_SINGLE_THREADED_PER_VM_ENTRY_SCOPE=1 -DNDEBUG=1 -DNOMINMAX -DIS_BUILD -DENABLE_INSPECTOR_ALTERNATE_DISPATCHERS=1 -DBUILDING_JSCONLY__ -DASSERT_ENABLED=0 -fvisibility=hidden -fvisibility-inlines-hidden -pthread -ldl   -march=native -mtune=native  -O3 -march=native -mtune=native -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -fuse-ld=lld -Wl,-z,now -Wl,--as-needed -Wl,--gc-sections -Wl,-z,stack-size=12800000 -static-libstdc++ -static-libgcc -fno-omit-frame-pointer -Wl,--compress-debug-sections,zlib  -Wl,-Bsymbolic-functions -fno-semantic-interposition -flto -Wl,--allow-multiple-definition -rdynamic /build/bun-deps/sqlite3.o  /build/icu/source/lib/libicuuc.a /build/icu/source/lib/libicudata.a /build/icu/source/lib/libicui18n.a  -g /build/bun/packages/debug-bun-linux-x64//headers.o -W -o /tmp/build-jsc-headers -lc;
ld.lld: error: unable to find library -llolhtml
ld.lld: error: unable to find library -lbase64
ld.lld: error: unable to find library -ltcc
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:723: jsc-bindings-headers] Error 1
```

Try again with another dependencies.

```
root in bun on  main [$!?] via  v18.5.0 via ↯ v0.10.0-dev.2882+13d58258a
⬢ [Systemd] ❯ make lolhtml base64 tinycc devcontainer

...(snip)...

cd /build/bun/src/deps/uws/uSockets/ && llvm-ar-13 rcvs /build/bun-deps/libusockets.a *.bc
/usr/bin/clang++-13 -fdata-sections -ffunction-sections -emit-llvm -flto="full" -fPIC -I/build/bun/src/deps/uws/uSockets/src -I/build/bun/src/deps/uws/uSockets/src -I/build/bun/src/deps/uws/src -I/build/bun/src/deps -I/build/bun/src/deps/mimalloc/include -Isrc/napi -I/build/bun-webkit/include -Isrc/bun.js/builtins/ -Isrc/bun.js/bindings/ -Isrc/bun.js/bindings/webcore -Isrc/bun.js/bindings/sqlite -Isrc/bun.js/builtins/cpp -I/build/bun/src/deps/zlib -std=c++2a -DSTATICALLY_LINKED_WITH_JavaScriptCore=1 -DSTATICALLY_LINKED_WITH_WTF=1 -DSTATICALLY_LINKED_WITH_BMALLOC=1 -DBUILDING_WITH_CMAKE=1 -DBUN_SINGLE_THREADED_PER_VM_ENTRY_SCOPE=1 -DNDEBUG=1 -DNOMINMAX -DIS_BUILD -DENABLE_INSPECTOR_ALTERNATE_DISPATCHERS=1 -DBUILDING_JSCONLY__ -DASSERT_ENABLED=0 -fvisibility=hidden -fvisibility-inlines-hidden  -march=native -mtune=native -fdata-sections -ffunction-sections -O3 -march=native -mtune=native -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -pthread  -DLIBUS_USE_OPENSSL=1 -DUWS_HTTPRESPONSE_NO_WRITEMARK=1  -DLIBUS_USE_BORINGSSL=1 -DWITH_BORINGSSL=1 -Wpedantic -Wall -Wextra -Wsign-conversion -Wconversion  -DUWS_WITH_PROXY -std=c++2a -fno-exceptions -I/build/bun/src/deps/boringssl/include -I/build/bun/src/deps/zlib  -march=native -mtune=native  -O3 -march=native -mtune=native -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -fuse-ld=lld -Wl,-z,now -Wl,--as-needed -Wl,--gc-sections -Wl,-z,stack-size=12800000 -static-libstdc++ -static-libgcc -fno-omit-frame-pointer -Wl,--compress-debug-sections,zlib  -Wl,-Bsymbolic-functions -fno-semantic-interposition -flto -Wl,--allow-multiple-definition -rdynamic -c -I/build/bun/src/deps /build/bun-deps/libusockets.a /build/bun/src/deps/libuwsockets.cpp -o /build/bun-deps/libuwsockets.o
clang: warning: -Wl,-z,now: 'linker' input unused [-Wunused-command-line-argument]
clang: warning: -Wl,--as-needed: 'linker' input unused [-Wunused-command-line-argument]
clang: warning: -Wl,--gc-sections: 'linker' input unused [-Wunused-command-line-argument]
clang: warning: -Wl,-z,stack-size=12800000: 'linker' input unused [-Wunused-command-line-argument]
clang: warning: -Wl,--compress-debug-sections,zlib: 'linker' input unused [-Wunused-command-line-argument]
clang: warning: -Wl,-Bsymbolic-functions: 'linker' input unused [-Wunused-command-line-argument]
clang: warning: -Wl,--allow-multiple-definition: 'linker' input unused [-Wunused-command-line-argument]
clang: warning: /build/bun-deps/libusockets.a: 'linker' input unused [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-fuse-ld=lld' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-static-libstdc++' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-static-libgcc' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-rdynamic' [-Wunused-command-line-argument]
/build/bun/src/deps/libuwsockets.cpp:481:71: warning: unused parameter 'length' [-Wunused-parameter]
                                          const char *message, size_t length,
                                                                      ^
/build/bun/src/deps/libuwsockets.cpp:513:73: warning: unused parameter 'length' [-Wunused-parameter]
                                            const char *message, size_t length,
                                                                        ^
/build/bun/src/deps/libuwsockets.cpp:960:26: warning: unused parameter 'ssl' [-Wunused-parameter]
void uws_res_upgrade(int ssl, uws_res_t *res, void *data,
                         ^
In file included from /build/bun/src/deps/libuwsockets.cpp:3:
In file included from /build/bun/src/deps/uws/src/App.h:65:
In file included from /build/bun/src/deps/uws/src/HttpResponse.h:31:
/build/bun/src/deps/uws/src/WebSocket.h:216:18: warning: unused variable '[written, failed]' [-Wunused-variable]
            auto [written, failed] = Super::uncork();
                 ^
/build/bun/src/deps/libuwsockets.cpp:576:10: note: in instantiation of member function 'uWS::WebSocket<true, true, void *>::cork' requested here
    uws->cork([handler, user_data]() { handler(user_data); });
         ^
In file included from /build/bun/src/deps/libuwsockets.cpp:3:
In file included from /build/bun/src/deps/uws/src/App.h:65:
In file included from /build/bun/src/deps/uws/src/HttpResponse.h:31:
/build/bun/src/deps/uws/src/WebSocket.h:216:18: warning: unused variable '[written, failed]' [-Wunused-variable]
            auto [written, failed] = Super::uncork();
                 ^
/build/bun/src/deps/libuwsockets.cpp:581:10: note: in instantiation of member function 'uWS::WebSocket<false, true, void *>::cork' requested here
    uws->cork([handler, user_data]() { handler(user_data); });
         ^
5 warnings generated.
```

We got 5 warnings, but build succeeds.

```
root in bun on  main [$!?] via  v18.5.0 via ↯ v0.10.0-dev.2882+13d58258a took 4m15s
⬢ [Systemd] ❯ echo $?
0
```

Now run `make dev`.

```
root in bun on  main [$!?] via  v18.5.0 via ↯ v0.10.0-dev.2882+13d58258a
⬢ [Systemd] ❯ make dev
mkdir -p /build/bun/packages/debug-bun-linux-x64/bin
/build/zig/zig build obj --prominent-compile-errors
Build linux-x64 v5.15 - v5.15
/usr/bin/clang++-13 /build/bun-deps/picohttpparser.o -L/build/bun-deps -llolhtml -lz -larchive -lssl -lbase64 -ltcc /build/bun-deps/libmimalloc.o /build/bun-deps/libbacktrace.a -lcrypto -lusockets /build/bun-deps/libuwsockets.o  -I/build/bun/src/deps/uws/uSockets/src -I/build/bun/src/deps/uws/src -I/build/bun/src/deps -I/build/bun/src/deps/mimalloc/include -Isrc/napi -I/build/bun-webkit/include -Isrc/bun.js/builtins/ -Isrc/bun.js/bindings/ -Isrc/bun.js/bindings/webcore -Isrc/bun.js/bindings/sqlite -Isrc/bun.js/builtins/cpp -I/build/bun/src/deps/zlib -std=c++2a -DSTATICALLY_LINKED_WITH_JavaScriptCore=1 -DSTATICALLY_LINKED_WITH_WTF=1 -DSTATICALLY_LINKED_WITH_BMALLOC=1 -DBUILDING_WITH_CMAKE=1 -DBUN_SINGLE_THREADED_PER_VM_ENTRY_SCOPE=1 -DNDEBUG=1 -DNOMINMAX -DIS_BUILD -DENABLE_INSPECTOR_ALTERNATE_DISPATCHERS=1 -DBUILDING_JSCONLY__ -DASSERT_ENABLED=0 -fvisibility=hidden -fvisibility-inlines-hidden -pthread -ldl   -march=native -mtune=native  -O3 -march=native -mtune=native -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -fuse-ld=lld -Wl,-z,now -Wl,--as-needed -Wl,--gc-sections -Wl,-z,stack-size=12800000 -static-libstdc++ -static-libgcc -fno-omit-frame-pointer -Wl,--compress-debug-sections,zlib  -Wl,-Bsymbolic-functions -fno-semantic-interposition -flto -Wl,--allow-multiple-definition -rdynamic /build/bun-deps/sqlite3.o  /build/icu/source/lib/libicuuc.a /build/icu/source/lib/libicudata.a /build/icu/source/lib/libicui18n.a /build/bun-webkit/lib/libJavaScriptCore.a /build/bun-webkit/lib/libWTF.a  /build/bun-webkit/lib/libbmalloc.a /build/bun-webkit/lib/libLowLevelInterpreterLib.a src/bun.js/bindings-obj/JSDOMExceptionHandling.o src/bun.js/bindings-obj/URLSearchParams.o src/bun.js/bindings-obj/ImportMetaObject.o src/bun.js/bindings-obj/napi.o src/bun.js/bindings-obj/wtf-bindings.o src/bun.js/bindings-obj/DOMException.o src/bun.js/bindings-obj/ScriptExecutionContext.o src/bun.js/bindings-obj/URLDecomposition.o src/bun.js/bindings-obj/Path.o src/bun.js/bindings-obj/Process.o src/bun.js/bindings-obj/napi_external.o src/bun.js/bindings-obj/JSDOMGlobalObject.o src/bun.js/bindings-obj/JSDOMWrapperCache.o src/bun.js/bindings-obj/bindings.o src/bun.js/bindings-obj/BunGCOutputConstraint.o src/bun.js/bindings-obj/JSBuffer.o src/bun.js/bindings-obj/inlines.o src/bun.js/bindings-obj/ZigConsoleClient.o src/bun.js/bindings-obj/MarkingConstraint.o src/bun.js/bindings-obj/JSFFIFunction.o src/bun.js/bindings-obj/BunJSCModule.o src/bun.js/bindings-obj/JSBufferEncodingType.o src/bun.js/bindings-obj/DOMURL.o src/bun.js/bindings-obj/DOMWrapperWorld.o src/bun.js/bindings-obj/ActiveDOMCallback.o src/bun.js/bindings-obj/BunClientData.o src/bun.js/bindings-obj/JSSink.o src/bun.js/bindings-obj/ZigSourceProvider.o src/bun.js/bindings-obj/objects.o src/bun.js/bindings-obj/JSDOMWrapper.o src/bun.js/bindings-obj/Buffer.o src/bun.js/bindings-obj/ZigGlobalObject.o src/bun.js/bindings-obj/JSCustomEvent.o src/bun.js/bindings-obj/WebCoreTypedArrayController.o src/bun.js/bindings-obj/JSEventListenerOptions.o src/bun.js/bindings-obj/CustomEventCustom.o src/bun.js/bindings-obj/TextEncoder.o src/bun.js/bindings-obj/JSReadableByteStreamController.o src/bun.js/bindings-obj/EventTarget.o src/bun.js/bindings-obj/JSWritableStreamDefaultController.o src/bun.js/bindings-obj/JSMessageEvent.o src/bun.js/bindings-obj/JSDOMURL.o src/bun.js/bindings-obj/JSAbortSignalCustom.o src/bun.js/bindings-obj/JSEventCustom.o src/bun.js/bindings-obj/HTTPHeaderField.o src/bun.js/bindings-obj/EventContext.o src/bun.js/bindings-obj/EventNames.o src/bun.js/bindings-obj/CustomEvent.o src/bun.js/bindings-obj/JSReadableStreamSink.o src/bun.js/bindings-obj/JSCloseEvent.o src/bun.js/bindings-obj/JSFetchHeaders.o src/bun.js/bindings-obj/JSTransformStreamDefaultController.o src/bun.js/bindings-obj/JSAbortController.o src/bun.js/bindings-obj/JSEventModifierInit.o src/bun.js/bindings-obj/ErrorCallback.o src/bun.js/bindings-obj/EventTargetConcrete.o src/bun.js/bindings-obj/MessageEvent.o src/bun.js/bindings-obj/ReadableStreamDefaultController.o src/bun.js/bindings-obj/JSEventInit.o src/bun.js/bindings-obj/ReadableStream.o src/bun.js/bindings-obj/CommonAtomStrings.o src/bun.js/bindings-obj/JSErrorCallback.o src/bun.js/bindings-obj/JSAbortAlgorithm.o src/bun.js/bindings-obj/JSDOMConvertDate.o src/bun.js/bindings-obj/JSEventTargetCustom.o src/bun.js/bindings-obj/JSDOMBindingInternalsBuiltins.o src/bun.js/bindings-obj/EventDispatcher.o src/bun.js/bindings-obj/ScriptWrappable.o src/bun.js/bindings-obj/JSDOMConvertWebGL.o src/bun.js/bindings-obj/JSDOMConstructorBase.o src/bun.js/bindings-obj/InternalWritableStream.o src/bun.js/bindings-obj/JSEventListener.o src/bun.js/bindings-obj/weak_handle.o src/bun.js/bindings-obj/JSAbortSignal.o src/bun.js/bindings-obj/JSReadableStreamBYOBRequest.o src/bun.js/bindings-obj/JSErrorHandler.o src/bun.js/bindings-obj/ErrorEvent.o src/bun.js/bindings-obj/JSTransformStream.o src/bun.js/bindings-obj/JSReadableStream.o src/bun.js/bindings-obj/JSAddEventListenerOptions.o src/bun.js/bindings-obj/JSDOMException.o src/bun.js/bindings-obj/HTTPParsers.o src/bun.js/bindings-obj/StructuredClone.o src/bun.js/bindings-obj/EventListenerMap.o src/bun.js/bindings-obj/JSEvent.o src/bun.js/bindings-obj/JSDOMConvertNumbers.o src/bun.js/bindings-obj/ReadableStreamSink.o src/bun.js/bindings-obj/ParsedContentType.o src/bun.js/bindings-obj/JSTextEncoder.o src/bun.js/bindings-obj/JSDOMPromiseDeferred.o src/bun.js/bindings-obj/JSByteLengthQueuingStrategy.o src/bun.js/bindings-obj/EventFactory.o src/bun.js/bindings-obj/ActiveDOMObject.o src/bun.js/bindings-obj/JSReadableStreamDefaultController.o src/bun.js/bindings-obj/CloseEvent.o src/bun.js/bindings-obj/JSMessageEventCustom.o src/bun.js/bindings-obj/AbortController.o src/bun.js/bindings-obj/JSWebSocket.o src/bun.js/bindings-obj/JSErrorEventCustom.o src/bun.js/bindings-obj/JSDOMGuardedObject.o src/bun.js/bindings-obj/HTTPHeaderNames.o src/bun.js/bindings-obj/FetchHeaders.o src/bun.js/bindings-obj/JSEventTarget.o src/bun.js/bindings-obj/ReadableStreamSource.o src/bun.js/bindings-obj/JSReadableStreamSourceCustom.o src/bun.js/bindings-obj/JSDOMConvertStrings.o src/bun.js/bindings-obj/JSCountQueuingStrategy.o src/bun.js/bindings-obj/JSCallbackData.o src/bun.js/bindings-obj/JSWritableStreamDefaultWriter.o src/bun.js/bindings-obj/EventTargetFactory.o src/bun.js/bindings-obj/JSURLSearchParams.o src/bun.js/bindings-obj/WritableStream.o src/bun.js/bindings-obj/HTTPHeaderValues.o src/bun.js/bindings-obj/JSWritableStreamSink.o src/bun.js/bindings-obj/HTTPHeaderMap.o src/bun.js/bindings-obj/JSReadableStreamDefaultReader.o src/bun.js/bindings-obj/Event.o src/bun.js/bindings-obj/AbortSignal.o src/bun.js/bindings-obj/EventPath.o src/bun.js/bindings-obj/JSDOMIterator.o src/bun.js/bindings-obj/JSReadableStreamBYOBReader.o src/bun.js/bindings-obj/JSWritableStream.o src/bun.js/bindings-obj/JSErrorEvent.o src/bun.js/bindings-obj/JSReadableStreamSource.o src/bun.js/bindings-obj/JSDOMBuiltinConstructorBase.o src/bun.js/bindings-obj/JSDOMPromise.o src/bun.js/bindings-obj/WebSocket.o src/bun.js/bindings-obj/JSSQLStatement.o src/bun.js/bindings-obj/WebCoreJSBuiltinInternals.o src/bun.js/bindings-obj/WebCoreJSBuiltins.o  -Wl,--dynamic-list /build/bun/src/symbols.dyn \
        -g \
        /build/bun/packages/debug-bun-linux-x64//bun-debug.o \
        -W \
        -o /build/bun/packages/debug-bun-linux-x64//bun-debug
```

Check the version of built `bun-debug`.

```
root in bun on  main [$!?] via  v18.5.0 via ↯ v0.10.0-dev.2882+13d58258a
⬢ [Systemd] ❯ /build/bun/packages/debug-bun-linux-x64/bun-debug --version
0.1.2_debug
```

