### PR TITLE
bun-framework-next README.md clarification

### DIFF
--- a/packages/bun-framework-next/README.md
+++ b/packages/bun-framework-next/README.md
@@ -15,8 +15,10 @@ npm install bun-framework-next
 bun bun --use next
 ```
 
-Launch bun:
+Launch the development server:
 
 ```bash
-bun
+bun dev
 ```
+
+Open http://localhost:3000 with your browser to see the result.


### PR DESCRIPTION
the last step in this README instructs the client to run `bun` to 'launch bun', but this would just lead the client to receive the command's usage, which I imagine is not the intent.

i added some clarifications that instead instruct the client to launch bun's dev server as well as where to reach that server, which seemed like a more logical next step. If this was an incorrect assumption, lmk and I'll close this PR 🙂