### PR TITLE
Fix "operations" word spelling

### DIFF
--- a/types/bun/fs.d.ts
+++ b/types/bun/fs.d.ts
@@ -1263,7 +1263,7 @@ declare module "fs" {
      * Use `fs.rm(path, { recursive: true, force: true })` instead.
      *
      * If `true`, perform a recursive directory removal. In
-     * recursive mode soperations are retried on failure.
+     * recursive mode operations are retried on failure.
      * @default false
      */
     recursive?: boolean | undefined;


### PR DESCRIPTION
As the title, this pull just fixes a comment word misspelling ("soperations => "operations"):
https://github.com/oven-sh/bun/blob/c3bf97002d6f0b117060dabf2aa281eedd85b7fd/types/bun/fs.d.ts#L1266