### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,5 +1,6 @@
 name: 🐛 Bug report
 description: Create a report to help us improve
+labels: [bug, need repro]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,6 +1,6 @@
 name: 🚀 Feature request
 description: Suggest an idea for this project
-labels: [feature request]
+labels: [enhancement]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/3-api-ref-docs-problem.yml
+++ b/.github/ISSUE_TEMPLATE/3-api-ref-docs-problem.yml
@@ -1,6 +1,6 @@
 name: 📗 Open an issue regarding the bun docs
 description: Let us know about any problematic documentations
-labels: [doc]
+labels: [documentation]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord server
+    url: https://discord.com/invite/CXdq2DP29u
+    about: Please visit our Discord server for questions and support requests.


### PR DESCRIPTION
- Disable blank issues
- Add contact link
- Add bug & need repro label to bug report template

Please, create tag `need repro`
The `need repro` tag is used for when the bug is not yet confirmed.