### PR TITLE
Fix: NotSameFileSystem at clonefile

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1061,7 +1061,7 @@ const PackageInstall = struct {
                         return result;
                     } else |err| {
                         switch (err) {
-                            error.NotSupported => {
+                            error.NotSameFileSystem, error.NotSupported => {
                                 supported_method = .copyfile;
                             },
                             error.FileNotFound => return Result{


### PR DESCRIPTION
Fixes #531

Before this, using 'bun install' on a directory in different filesystem
such as tmpfs (/tmp) would have caused "Error: NotSameFileSystem".

This commit fixes that by handling this error, and at end of function it
will fall back to use copyfile (same as --backend=copyfile).

The discussion is in https://github.com/oven-sh/bun/issues/531#issuecomment-1179732743.

Credit due to [@Beamnawap](https://github.com/BeamNawapat), who suggested me about --backend=copyfile as a fix.

> Note: **I think** this error (NotSameFileSystem) may occur in case of `clonefile_each_dir` too, and should be handled there similarly:
>
> https://github.com/oven-sh/bun/blob/f5d896542ae5a9e0b62c73d386727392d32489e0/src/install/install.zig#L1085-L1087
>
> changed to:
> 
> ```diff
> -error.NotSupported => {
> +error.NotSameFileSystem, error.NotSupported => {
>      supported_method = .copyfile;
> },
> ```
>
> Does it seem okay, should I add that in this PR?