### PR TITLE
Fix(env_loader): Ignore spaces before equals sign

### DIFF
--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -268,7 +268,11 @@ pub const Lexer = struct {
                     this.has_newline_before = true;
                     continue;
                 },
-
+                ' ' => {
+                    this.step();
+                    while (this.codepoint() == ' ') this.step();
+                    continue;
+                },
                 // Valid keys:
                 'a'...'z', 'A'...'Z', '0'...'9', '_', '-', '.' => {
                     this.start = this.current;


### PR DESCRIPTION
Closes #519. Before this PR, ``.env`` files like ``PORT =8080`` wouldn't get parsed.