### PR TITLE
refactor(exports.zig): Fix WebSocketHTTPSClient var name

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -188,7 +188,7 @@ pub const JSHTTPResponseSink = JSC.WebCore.HTTPResponseSink.JSSink;
 
 // WebSocket
 pub const WebSocketHTTPClient = @import("../../http/websocket_http_client.zig").WebSocketHTTPClient;
-pub const WebSocketHTTSPClient = @import("../../http/websocket_http_client.zig").WebSocketHTTPSClient;
+pub const WebSocketHTTPSClient = @import("../../http/websocket_http_client.zig").WebSocketHTTPSClient;
 pub const WebSocketClient = @import("../../http/websocket_http_client.zig").WebSocketClient;
 pub const WebSocketClientTLS = @import("../../http/websocket_http_client.zig").WebSocketClientTLS;
 
@@ -2177,7 +2177,7 @@ pub const ZigConsoleClient = struct {
             defer this.globalThis = prevGlobalThis;
             this.globalThis = globalThis;
 
-            // This looks incredibly redudant. We make the ZigConsoleClient.Formatter.Tag a
+            // This looks incredibly redundant. We make the ZigConsoleClient.Formatter.Tag a
             // comptime var so we have to repeat it here. The rationale there is
             // it _should_ limit the stack usage because each version of the
             // function will be relatively small
@@ -2527,7 +2527,7 @@ pub const HTTPDebugSSLServerRequestContext = JSC.API.DebugSSLServer.RequestConte
 comptime {
     if (!is_bindgen) {
         WebSocketHTTPClient.shim.ref();
-        WebSocketHTTSPClient.shim.ref();
+        WebSocketHTTPSClient.shim.ref();
         WebSocketClient.shim.ref();
         WebSocketClientTLS.shim.ref();
 


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

Readability improvements to `src/bun.js/bindings/exports.zig`
- `WebSocketHTTSPClient` -> `WebSocketHTTPSClient`
- Fix typo in comment