### PR TITLE
updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3125,7 +3125,7 @@ export const loader = () => import('./loader');
 
 ## Credits
 
-- While written in Zig instead of Go, bun’s JS transpiler, CSS lexer, and node module resolver source code is based off of @evanw’s esbuild project. @evanw did a fantastic job with esbuild.
+- While written in Zig instead of Go, bun’s JS transpiler, CSS lexer, and node module resolver source code is based on @evanw’s esbuild project. @evanw did a fantastic job with esbuild.
 - The idea for the name "bun" came from [@kipply](https://github.com/kipply)
 
 ## License


### PR DESCRIPTION
### Affected URL(s)
https://bun-docs.vercel.app/#/?id=configuring-with-environment-variables

## Description of the problem
### Under the Credits section
- on line no. 2, it is mentioned as based off of whereas based on would be the correct choice of a word representing it as official documentation of Bun.
- I hope this would help to make the Bun Documentation more precise to the users.