### PR TITLE
Add 'scripts/nproc' helper script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,16 @@ SED = $(shell which gsed || which sed)
 BUN_DIR ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BUN_DEPS_DIR ?= $(shell pwd)/src/deps
 BUN_DEPS_OUT_DIR ?= $(BUN_DEPS_DIR)
-CPUS ?= $(shell ./scripts/nproc)
+CPU_COUNT = 2
+ifeq ($(OS_NAME),darwin)
+CPU_COUNT = $(shell sysctl -n hw.logicalcpu)
+endif
+
+ifeq ($(OS_NAME),linux)
+CPU_COUNT = $(shell nproc)
+endif
+
+CPUS ?= $(CPU_COUNT)
 USER ?= $(echo $USER)
 
 BUN_RELEASE_DIR ?= $(shell pwd)/../bun-release

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ SED = $(shell which gsed || which sed)
 BUN_DIR ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BUN_DEPS_DIR ?= $(shell pwd)/src/deps
 BUN_DEPS_OUT_DIR ?= $(BUN_DEPS_DIR)
-CPUS ?= $(shell nproc)
+CPUS ?= $(shell ./scripts/nproc)
 USER ?= $(echo $USER)
 
 BUN_RELEASE_DIR ?= $(shell pwd)/../bun-release

--- a/scripts/nproc
+++ b/scripts/nproc
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [[ $OSTYPE == 'darwin'* ]]; then
+  sysctl -n hw.logicalcpu
+else
+  nproc
+fi

--- a/scripts/nproc
+++ b/scripts/nproc
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-if [[ $OSTYPE == 'darwin'* ]]; then
-  sysctl -n hw.logicalcpu
-else
-  nproc
-fi


### PR DESCRIPTION
There's no 'nproc' on macOS by default so add a helper script that uses
sysctl instead. Simplifies build environment setup on macOS.