### PR TITLE
fix #640

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ JS Transpiler == JavaScript Transpiler
 <br/>
 TS Transpiler == TypeScript Transpiler
 <br/>
-Package manager == `bun install`
+Package manager == <code>bun install</code>
 <br/>
 bun.js == bun’s JavaScriptCore integration that executes JavaScript. Similar to how Node.js & Deno embed V8.
 </small>


### PR DESCRIPTION
Backticks cannot be used to quote codes within html. Replaced `` ` ` `` with `<code></code>`.