### PR TITLE
fix(examples): Add missing .gitignore

### DIFF
--- a/examples/blank/.gitignore
+++ b/examples/blank/.gitignore
@@ -1,0 +1,8 @@
+# Dependencies
+node_modules/
+
+# dotenv
+.env
+
+# misc
+.DS_Store

--- a/examples/hono/.gitignore
+++ b/examples/hono/.gitignore
@@ -1,0 +1,8 @@
+# Dependencies
+node_modules/
+
+# dotenv
+.env
+
+# misc
+.DS_Store

--- a/examples/macros/.gitignore
+++ b/examples/macros/.gitignore
@@ -1,0 +1,8 @@
+# Dependencies
+node_modules/
+
+# dotenv
+.env
+
+# misc
+.DS_Store

--- a/examples/react-fast-refresh-test/.gitignore
+++ b/examples/react-fast-refresh-test/.gitignore
@@ -1,0 +1,8 @@
+# Dependencies
+node_modules/
+
+# dotenv
+.env
+
+# misc
+.DS_Store


### PR DESCRIPTION
Prevent flooding github with `node_modules` since they are used in `bun create <package name>`