### PR TITLE
fix(env_loader): Off by one error

### DIFF
--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -363,7 +363,7 @@ pub const Lexer = struct {
                             },
                             ' ' => {
                                 // Set key end to the last non space character
-                                key_end = this.current - 1;
+                                key_end = this.current;
                                 this.step();
                                 while (this.codepoint() == ' ') this.step();
                                 continue;


### PR DESCRIPTION
``WELCOME_MESSAGE     ="Hello, World"`` is currently parsed as ``WELCOME_MESSAG="Hello, World"``.