### PR TITLE
Link Github pages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3128,7 +3128,7 @@ export const loader = () => import('./loader');
 
 ## Credits
 
-- While written in Zig instead of Go, bun’s JS transpiler, CSS lexer, and node module resolver source code is based on @evanw’s esbuild project. @evanw did a fantastic job with esbuild.
+- While written in Zig instead of Go, bun’s JS transpiler, CSS lexer, and node module resolver source code is based on [@evanw](https://github.com/evanw)’s [esbuild](https://github.com/evanw/esbuild) project. Evan did a fantastic job with esbuild.
 - The idea for the name "bun" came from [@kipply](https://github.com/kipply)
 
 ## License


### PR DESCRIPTION
Tiny detail: Evan's profile and `esbuild` project where not linked.