### PR TITLE
Create github workflow to publish releases on dockerhub

### DIFF
--- a/.github/workflows/bun-dockerhub.yml
+++ b/.github/workflows/bun-dockerhub.yml
@@ -1,0 +1,46 @@
+name: bun-dockerhub
+on:
+  push:
+    paths:
+      - dockerhub/Dockerfile
+    branches:
+      - main
+  pull_request:
+    paths:
+      - dockerhub/Dockerfile
+    branches:
+      - main
+  release:
+    types:
+      - published
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Collect metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/bun
+          tags: |
+            type=match,pattern=bun-v(\d.\d.\d),group=1
+            type=match,pattern=bun-v(\d.\d),group=1
+            type=match,pattern=bun-v(\d),group=1
+            type=ref,event=branch
+            type=ref,event=pr
+      - name: Login to DockerHub
+        if: github.event_name == 'release'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          context: ./dockerhub
+          push: ${{ github.event_name == 'release' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -1,0 +1,36 @@
+### GLOBALS ###
+ARG GLIBC_RELEASE=2.34-r0
+
+
+### GET ###
+FROM alpine:latest as get
+
+# prepare environment
+WORKDIR /tmp
+RUN apk --update add unzip
+
+# get bun
+RUN wget https://github.com/oven-sh/bun/releases/latest/download/bun-linux-x64.zip && \
+    unzip bun-linux-x64.zip
+
+# get glibc
+ARG GLIBC_RELEASE
+RUN wget https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_RELEASE}/glibc-${GLIBC_RELEASE}.apk
+
+
+### IMAGE ###
+FROM alpine:latest
+
+# prepare bun
+COPY --from=get /tmp/bun-linux-x64/bun /usr/local/bin
+
+# prepare glibc
+ARG GLIBC_RELEASE
+COPY --from=get /tmp/sgerrand.rsa.pub /etc/apk/keys
+COPY --from=get /tmp/glibc-${GLIBC_RELEASE}.apk /tmp
+
+# install, clean up, and sanity check
+RUN apk --no-cache add /tmp/glibc-${GLIBC_RELEASE}.apk && \
+    rm -rf /tmp/* && \
+    bun

--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -7,7 +7,7 @@ FROM alpine:latest as get
 
 # prepare environment
 WORKDIR /tmp
-RUN apk --update add unzip
+RUN apk --no-cache add unzip
 
 # get bun
 RUN wget https://github.com/oven-sh/bun/releases/latest/download/bun-linux-x64.zip && \
@@ -22,7 +22,7 @@ RUN wget https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
 ### IMAGE ###
 FROM alpine:latest
 
-# prepare bun
+# install bun
 COPY --from=get /tmp/bun-linux-x64/bun /usr/local/bin
 
 # prepare glibc
@@ -30,7 +30,12 @@ ARG GLIBC_RELEASE
 COPY --from=get /tmp/sgerrand.rsa.pub /etc/apk/keys
 COPY --from=get /tmp/glibc-${GLIBC_RELEASE}.apk /tmp
 
-# install, clean up, and sanity check
+# install glibc
 RUN apk --no-cache add /tmp/glibc-${GLIBC_RELEASE}.apk && \
-    rm -rf /tmp/* && \
-    bun
+
+# cleanup
+    rm /etc/apk/keys/sgerrand.rsa.pub && \
+    rm /tmp/glibc-${GLIBC_RELEASE}.apk && \
+
+# smoke test
+    bun --version


### PR DESCRIPTION
This will automatically make sure that changes to `dockerhub/Dockerfile` build successfully as well as publish new bun releases to DockerHub with semantic versioning tags `X`, `X.Y`, `X.Y.Z`, and `latest`.

Requires action secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` to be set for the repo.