### PR TITLE
fix(examples/bun-bakery): Create gitignore

### DIFF
--- a/examples/bun-bakery/gitignore
+++ b/examples/bun-bakery/gitignore
@@ -1,0 +1,42 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel
+
+**/*.trace
+**/*.zip
+**/*.tar.gz
+**/*.tgz
+**/*.log
+package-lock.json
+**/*.bun


### PR DESCRIPTION
We are using ``gitignore`` instead of ``.gitignore`` as a workaround for npm not publishing ``.gitignore`` files.