### PR TITLE
docs: remove emulating cpu section

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,28 +903,6 @@ If you’re interested in adding a framework integration, please reach out. Ther
 
 ## Troubleshooting
 
-### Illegal Instruction (Core Dumped)
-Bun currently only works on CPUs supporting the AVX2 instruction set. To run on older CPUs this can be emulated using Intel SDE, however bun won't be as fast as it would be when running on CPUs with AVX2 support.
-If you get this error while bun is initializing, You probably need to wrap the bun executable with intel-sde
-  1. Install intel-sde
-    - Arch Linux: `yay -S intel-sde`
-    - Other Distros:
-```
-# wget https://downloadmirror.intel.com/732268/sde-external-9.7.0-2022-05-09-lin.tar.xz -O /tmp/intel-sde.tar.xz
-# cd /tmp
-# tar -xf intel-sde.tar.xz
-# cd sde-external*
-# mkdir /usr/local/bin -p
-# cp sde64 /usr/local/bin/sde
-# cp -r intel64 /usr/local/bin/
-# cp -r misc /usr/local/bin/
-```
-  2. Add alias to bashrc
-```
-$ echo "alias bun='sde -chip-check-disable -- bun'" >> ~/.bashrc
-```
-You can replace `.bashrc` with `.zshrc` if you use zsh instead of bash
-
 ### bun not running on an M1 (or Apple Silicon)
 
 If you see a message like this


### PR DESCRIPTION
Removes the section for emulating CPU using Intel SDE for now.

Related: 
- https://www.reddit.com/r/sveltejs/comments/vyryhb/comment/ig4qv3u/
- https://discord.com/channels/876711213126520882/903845031230713857/997183368938655885