### PR TITLE
feat: create --disable-ts flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -934,6 +934,14 @@ test-dev-no-hmr: copy-test-node-modules
 	-killall bun-debug -9;
 	DISABLE_HMR="DISABLE_HMR" BUN_BIN=$(DEBUG_BUN) node test/scripts/browser.js
 
+test-disable-ts: kill-bun copy-test-node-modules
+	-killall bun -9;
+	DISABLE_TS="DISABLE_TS" BUN_BIN=$(RELEASE_BUN) node test/scripts/browser.js
+
+test-disable-ts: copy-test-node-modules
+	-killall bun-debug -9;
+	DISABLE_TS="DISABLE_TS" BUN_BIN=$(DEBUG_BUN) node test/scripts/browser.js
+
 test-dev-bun-run:
 	cd test/apps && BUN_BIN=$(DEBUG_BUN) bash bun-run-check.sh
 

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -173,6 +173,7 @@ _bun() {
                 '--main-fields[Main fields to lookup in package.json. Defaults to --platform dependent]:main-fields' \
                 '--disable-react-fast-refresh[Disable React Fast Refresh]' \
                 '--disable-hmr[Disable Hot Module Reloading]' \
+                '--disable-ts[Disable Typescript processing]' \
                 '--jsx-factory[Changes the function called when compiling JSX elements using the classic JSX runtime]:jsx-factory' \
                 '--jsx-fragment[Changes the function called when compiling JSX fragments]:jsx-fragment' \
                 '--jsx-import-source[Declares the module specifier to be used for importing the jsx and jsxs factory functions. Default: "react"]:jsx-import-source' \

--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -535,6 +535,7 @@ export interface TransformOptions {
   router?: RouteConfig;
   no_summary?: boolean;
   disable_hmr?: boolean;
+  disable_ts?:boolean;
   port?: uint16;
   logLevel?: MessageLevel;
   source_map?: SourceMapMode;

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -1729,6 +1729,10 @@ function decodeTransformOptions(bb) {
       case 27:
         result["source_map"] = SourceMapMode[bb.readByte()];
         break;
+      
+      case 28:
+        result["disable_ts"] = !!bb.readByte();
+        break;
 
       default:
         throw new Error("Attempted to parse invalid message");
@@ -1948,6 +1952,13 @@ function encodeTransformOptions(message, bb) {
       );
     bb.writeByte(encoded);
   }
+
+  var value = message["disable_ts"];
+  if (value != null) {
+    bb.writeByte(28);
+    bb.writeByte(value);
+  }
+
   bb.writeByte(0);
 }
 const SourceMapMode = {

--- a/src/api/schema.peechy
+++ b/src/api/schema.peechy
@@ -348,6 +348,8 @@ message TransformOptions {
   uint16 port = 25;
   MessageLevel logLevel = 26;
   SourceMapMode source_map = 27;
+
+  bool disable_ts = 28;
 }
 
 smol SourceMapMode {

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -1744,6 +1744,9 @@ pub const Api = struct {
         /// disable_hmr
         disable_hmr: ?bool = null,
 
+        ///disable_ts
+        disable_ts: ?bool = null,
+
         /// port
         port: ?u16 = null,
 
@@ -1842,6 +1845,9 @@ pub const Api = struct {
                     },
                     27 => {
                         this.source_map = try reader.readValue(SourceMapMode);
+                    },
+                    28 => {
+                        this.disable_ts = try reader.readValue(bool);
                     },
                     else => {
                         return error.InvalidMessage;
@@ -1959,6 +1965,10 @@ pub const Api = struct {
             if (this.source_map) |source_map| {
                 try writer.writeFieldID(27);
                 try writer.writeEnum(source_map);
+            }
+            if (this.disable_ts) |disable_ts| {
+                try writer.writeFieldID(28);
+                try writer.writeInt(@as(u8, @boolToInt(disable_ts)));
             }
             try writer.endMessage();
         }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -167,6 +167,7 @@ pub const Arguments = struct {
         clap.parseParam("-c, --config <PATH>?               Config file to load bun from (e.g. -c bunfig.toml") catch unreachable,
         clap.parseParam("--disable-react-fast-refresh      Disable React Fast Refresh") catch unreachable,
         clap.parseParam("--disable-hmr                     Disable Hot Module Reloading (disables fast refresh too)") catch unreachable,
+        clap.parseParam("--disable-ts                     Disable Typescript processing") catch unreachable,
         clap.parseParam("--extension-order <STR>...        defaults to: .tsx,.ts,.jsx,.js,.json ") catch unreachable,
         clap.parseParam("--jsx-factory <STR>               Changes the function called when compiling JSX elements using the classic JSX runtime") catch unreachable,
         clap.parseParam("--jsx-fragment <STR>              Changes the function called when compiling JSX fragments") catch unreachable,
@@ -400,6 +401,7 @@ pub const Arguments = struct {
 
         opts.no_summary = args.flag("--no-summary");
         opts.disable_hmr = args.flag("--disable-hmr");
+        opts.disable_ts = args.flag("--disable-ts");
 
         ctx.debug.silent = args.flag("--silent");
         if (opts.port != null and opts.origin == null) {

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -447,7 +447,7 @@ pub const ImportScanner = struct {
         var scanner = ImportScanner{};
         var stmts_end: usize = 0;
         const allocator = p.allocator;
-        const is_typescript_enabled: bool = comptime P.parser_features.typescript;
+        const is_typescript_enabled: bool = comptime if (P.options.disable_ts) false else P.parser_features.typescript;
 
         for (stmts) |_stmt| {
             // zls needs the hint, it seems.
@@ -3852,7 +3852,7 @@ fn NewParser_(
     // P is for Parser!
     return struct {
         const js_parser_jsx = if (FeatureFlags.force_macro) JSXTransformType.macro else js_parser_features.jsx;
-        const is_typescript_enabled = js_parser_features.typescript;
+        const is_typescript_enabled = if (options.disable_ts) false else js_parser_features.typescript;
         const is_jsx_enabled = js_parser_jsx != .none;
         const only_scan_imports_and_do_not_visit = js_parser_features.scan_only;
         const ImportRecordList = if (only_scan_imports_and_do_not_visit) *std.ArrayList(ImportRecord) else std.ArrayList(ImportRecord);

--- a/test/scripts/browser.js
+++ b/test/scripts/browser.js
@@ -8,10 +8,12 @@ const snippetsDir = path.resolve(__dirname, "../snippets");
 const serverURL = process.env.TEST_SERVER_URL || "http://localhost:8080";
 const USE_EXISTING_PROCESS = process.env.USE_EXISTING_PROCESS || false;
 const DISABLE_HMR = !!process.env.DISABLE_HMR;
+const DISABLE_TS = !!process.env.DISABLE_TS;
 const bunFlags = [
   "dev",
   `--origin=${serverURL}`,
   DISABLE_HMR && "--disable-hmr",
+  DISABLE_TS && "--disable-ts",
 ].filter(Boolean);
 const bunExec = process.env.BUN_BIN || "bun";
 


### PR DESCRIPTION
## What is the problem this feature will solve?
whenever bun reads a tsconfig it doesn't understand a warning is presented, I guess that's ok if the intention is to use bun for compilation but it isn't very nice if I am simply using bun as a JS runtime.

## feature you are proposing to solve the problem?
A flag to disable ts processing, something like --disable-ts

closes #615 