### PR TITLE
fix: detect avx2 in base64

### DIFF
--- a/src/base64/bun-base64.c
+++ b/src/base64/bun-base64.c
@@ -1,4 +1,3 @@
-
 #include "bun-base64.h"
 
 #if defined(__GNUC__) && defined(__ARM_NEON__)
@@ -6,13 +5,6 @@
 int neon_base64_decode(char *out, const char *src, size_t srclen,
                        size_t *outlen);
 
-#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
-
-#include "fastavxbase64.h"
-
-#endif
-
-#if defined(__GNUC__) && defined(__ARM_NEON__)
 size_t bun_base64_decode(char *dest, const char *src, size_t len,
                          size_t *outlen) {
   // neon base64 is decode only
@@ -22,7 +14,9 @@ size_t bun_base64_encode(char *dest, const char *src, size_t len) {
   return chromium_base64_encode(dest, src, len);
 }
 
-#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__)) && defined(__AVX2__)
+
+#include "fastavxbase64.h"
 
 size_t bun_base64_decode(char *dest, const char *src, size_t len,
                          size_t *outlen) {

--- a/src/base64/bun-base64.h
+++ b/src/base64/bun-base64.h
@@ -1,6 +1,4 @@
-
 #include "chromiumbase64.h"
-#include "fastavxbase64.h"
 
 size_t bun_base64_decode(char *dest, const char *src, size_t len,
                          size_t *outlen);

--- a/src/base64/fastavxbase64.c
+++ b/src/base64/fastavxbase64.c
@@ -1,4 +1,4 @@
-#if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__)) && defined(__AVX2__)
 #include "fastavxbase64.h"
 
 #include <stdbool.h>

--- a/src/base64/fastavxbase64.h
+++ b/src/base64/fastavxbase64.h
@@ -1,4 +1,4 @@
-#if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__)) && defined(__AVX2__)
 
 #ifndef EXPAVX_B64
 #define EXPAVX_B64


### PR DESCRIPTION
Currently, bun doesn't even build on non-AVX2 environment.
[some package managers](https://github.com/Homebrew/homebrew-core/pull/105263#issuecomment-1185819052) intentionally disable AVX2 to support older systems.

This PR fixes the build on non-AVX2 env, though I don't assure bun runs properly.

Disclaimer: I have not tested this because I don't have a non-AVX2 machine.