### PR TITLE
refactor(installer): renovate install script

### DIFF
--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -46,23 +46,23 @@ fi
 
 case $(uname -ms) in
 'Darwin x86_64')
-    target='darwin-x64'
+    target=darwin-x64
     ;;
 'Darwin arm64')
-    target='darwin-aarch64'
+    target=darwin-aarch64
     ;;
 'Linux aarch64' | 'Linux arm64')
-    target='linux-aarch64'
+    target=linux-aarch64
     ;;
 'Linux x86_64' | *)
-    target='linux-x64'
+    target=linux-x64
     ;;
 esac
 
 if [[ $target = darwin-x64 ]]; then
     # Is this process running in Rosetta?
     if [[ $(sysctl -n sysctl.proc_translated) = 1 ]]; then
-        target='darwin-aarch64'
+        target=darwin-aarch64
         echo -e "${Dim}Your shell is running in Rosetta 2. Downloading bun for $target instead$Color_Off"
     fi
 fi
@@ -70,9 +70,9 @@ fi
 github_repo=https://github.com/Jarred-Sumner/bun-releases-for-updater
 
 if [[ $# = 0 ]]; then
-    bun_uri="$github_repo/releases/latest/download/bun-$target.zip"
+    bun_uri=$github_repo/releases/latest/download/bun-$target.zip
 else
-    bun_uri="$github_repo/releases/download/$1/bun-$target.zip"
+    bun_uri=$github_repo/releases/download/$1/bun-$target.zip
 fi
 
 install_env=BUN_INSTALL
@@ -111,7 +111,7 @@ tildify() {
             echo "'$escaped'"
         fi
     else
-        echo "${1//"$HOME/"/'~/'}"
+        echo "${1/"$HOME/"/'~/'}"
     fi
 }
 

--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${OS:-} = Windows_NT ]]; then
+    echo 'error: Please install bun using Windows Subsystem for Linux'
+    exit 1
+fi
 
 # Reset
 Color_Off=''
@@ -6,169 +12,200 @@ Color_Off=''
 # Regular Colors
 Red=''
 Green=''
-
-# Bold
-BWhite=''
-BGreen=''
-
 Dim='' # White
 
-if test -t 1; then
+# Bold
+Bold_White=''
+Bold_Green=''
+
+if [[ -t 1 ]]; then
     # Reset
     Color_Off='\033[0m' # Text Reset
 
     # Regular Colors
     Red='\033[0;31m'   # Red
     Green='\033[0;32m' # Green
-    White='\033[0;37m' # White
-
-    Dim='\033[0;2m' # White
+    Dim='\033[0;2m'    # White
 
     # Bold
-    BGreen='\033[1;32m' # Green
-    BWhite='\033[1;37m' # White
+    Bold_Green='\033[1;32m' # Bold Green
+    Bold_White='\033[1;37m' # Bold White
 fi
 
-if ! command -v unzip >/dev/null; then
-    echo -e "\n${Red}error${Color_Off}: unzip is required to install bun (see: https://github.com/oven-sh/bun#unzip-is-required)." 1>&2
+error() {
+    echo -e "${Red}error${Color_Off}:" "$@" >&2
     exit 1
+}
+
+command -v unzip >/dev/null ||
+    error 'unzip is required to install bun (see: https://github.com/oven-sh/bun#unzip-is-required)'
+
+if [[ $# -gt 1 ]]; then
+    error 'Too many arguments, only 1 is allowed, which can be a specific tag of bun to install (e.g. "bun-v0.1.4")'
 fi
 
-if [ "$OS" = "Windows_NT" ]; then
-    echo "error: Please install bun using Windows Subsystem for Linux."
-    exit 1
-else
-    case $(uname -sm) in
-    "Darwin x86_64") target="darwin-x64" ;;
-    "Darwin arm64") target="darwin-aarch64" ;;
-    "Linux aarch64") target="linux-aarch64" ;;
-    "Linux arm64") target="linux-aarch64" ;;
-    "Linux x86_64") target="linux-x64" ;;
-    *) target="linux-x64" ;;
-    esac
-fi
+case $(uname -ms) in
+'Darwin x86_64')
+    target='darwin-x64'
+    ;;
+'Darwin arm64')
+    target='darwin-aarch64'
+    ;;
+'Linux aarch64' | 'Linux arm64')
+    target='linux-aarch64'
+    ;;
+'Linux x86_64' | *)
+    target='linux-x64'
+    ;;
+esac
 
-if [ "$target" = "darwin-x64" ]; then
-    # Is it rosetta
-    sysctl sysctl.proc_translated >/dev/null 2>&1
-    if [ $? -eq 0 ]; then
-        target="darwin-aarch64"
-        echo -e "$Dim Your shell is running in Rosetta 2. Downloading bun for $target instead. $Color_Off"
+if [[ $target = darwin-x64 ]]; then
+    # Is this process running in Rosetta?
+    if [[ $(sysctl -n sysctl.proc_translated) = 1 ]]; then
+        target='darwin-aarch64'
+        echo -e "${Dim}Your shell is running in Rosetta 2. Downloading bun for $target instead$Color_Off"
     fi
 fi
 
-github_repo="https://github.com/Jarred-Sumner/bun-releases-for-updater"
+github_repo='https://github.com/Jarred-Sumner/bun-releases-for-updater'
 
-if [ $# -eq 0 ]; then
-    bun_uri="$github_repo/releases/latest/download/bun-${target}.zip"
+if [[ $# = 0 ]]; then
+    bun_uri="$github_repo/releases/latest/download/bun-$target.zip"
 else
-    bun_uri="$github_repo/releases/download/${1}/bun-${target}.zip"
+    bun_uri="$github_repo/releases/download/$1/bun-$target.zip"
 fi
 
-bun_install="${BUN_INSTALL:-$HOME/.bun}"
-bin_dir="$bun_install/bin"
-exe="$bin_dir/bun"
+install_env=BUN_INSTALL
+bin_env=\$$install_env/bin
 
-if [ ! -d "$bin_dir" ]; then
-    mkdir -p "$bin_dir"
+install_dir=${!install_env:-$HOME/.bun}
+bin_dir=$install_dir/bin
+exe=$bin_dir/bun
 
-    if (($?)); then
-        echo -e "${Red}error${Color_Off}: Failed to create install directory $bin_dir" 1>&2
-        exit 1
+if [[ ! -d $bin_dir ]]; then
+    mkdir -p "$bin_dir" ||
+        error "Failed to create install directory \"$bin_dir\""
+fi
+
+curl --fail --location --progress-bar --output "$exe.zip" "$bun_uri" ||
+    error "Failed to download bun from \"$bun_uri\""
+
+unzip -oqd "$bin_dir" "$exe.zip" ||
+    error 'Failed to extract bun'
+
+mv "$bin_dir/bun-$target/bun" "$exe" ||
+    error 'Failed to move extracted bun to destination'
+
+chmod +x "$exe" ||
+    error 'Failed to set permissions on bun executable'
+
+rm -r "$bin_dir/bun-$target" "$exe.zip"
+
+tildify() {
+    if [[ ${2:-} = safe ]]; then
+        echo "${1//"$HOME/"/"~/'"}'"
+    else
+        echo "${1//"$HOME/"/'~/'}"
     fi
-fi
+}
 
-curl --fail --location --progress-bar --output "$exe.zip" "$bun_uri"
+echo -e "${Green}bun was installed successfully to $Bold_Green$(tildify "$exe")$Color_Off"
 
-if (($?)); then
-    echo -e "${Red}error${Color_Off}: Failed to download bun from $bun_uri" 1>&2
-    exit 1
-fi
-unzip -d "$bin_dir" -q -o "$exe.zip"
-if (($?)); then
-    echo -e "${Red}error${Color_Off}: Failed to extract bun" 1>&2
-    exit 1
-fi
-mv "$bin_dir/bun-${target}/bun" "$exe"
-if (($?)); then
-    echo -e "${Red}error${Color_Off}: Failed to extract bun" 1>&2
-    exit 1
-fi
-chmod +x "$exe"
-if (($?)); then
-    echo -e "${Red}error${Color_Off}: Failed to set permissions on bun executable." 1>&2
-    exit 1
-fi
-rmdir $bin_dir/bun-${target}
-rm "$exe.zip"
-
-echo -e "${Green}bun was installed successfully to ${BGreen}$exe$Color_Off"
-
-if command -v bun --version >/dev/null; then
+if command -v bun >/dev/null; then
     # Install completions, but we don't care if it fails
-    IS_BUN_AUTO_UPDATE="true" $exe completions >/dev/null 2>&1
+    IS_BUN_AUTO_UPDATE=true $exe completions &>/dev/null || :
 
     echo "Run 'bun --help' to get started"
-    exit 0
+    exit
 fi
 
-if test $(basename $SHELL) == "fish"; then
+refresh_command=''
+
+tilde_bin_dir=$(tildify "$bin_dir")
+safe_tilde_install_dir=$(tildify "$install_dir" safe)
+
+echo
+
+case $(basename "$SHELL") in
+fish)
     # Install completions, but we don't care if it fails
-    IS_BUN_AUTO_UPDATE="true" SHELL="fish" $exe completions >/dev/null 2>&1
-    if test -f $HOME/.config/fish/config.fish; then
-        echo -e "\n# bun\nset -Ux BUN_INSTALL \"$bun_install\"" >>"$HOME/.config/fish/config.fish"
-        echo -e "fish_add_path \"$bin_dir\"\n" >>"$HOME/.config/fish/config.fish"
-        echo ""
-        echo -e "$Dim Added \"$bin_dir\" to \$PATH in \"\~/.config/fish/config.fish\"$Color_Off"
-        echo ""
-        echo -e "To get started, run"
-        echo -e "$BWhite"
-        echo -e "   source ~/.config/fish/config.fish"
-        echo -e "   bun --help$Color_Off"
-        exit 0
+    IS_BUN_AUTO_UPDATE=true SHELL=fish $exe completions &>/dev/null || :
+
+    commands=(
+        "set --export $install_env $safe_tilde_install_dir"
+        "set --export PATH $bin_env \$PATH"
+    )
+
+    fish_config=$HOME/.config/fish/config.fish
+    tilde_fish_config=$(tildify "$fish_config")
+
+    if [[ -w $fish_config ]]; then
+        {
+            echo -e '\n# bun'
+
+            for command in "${commands[@]}"; do
+                echo "$command"
+            done
+        } >>"$fish_config"
+
+        echo -e "${Dim}Added \"$tilde_bin_dir\" to \$PATH in \"$tilde_fish_config\"$Color_Off"
+
+        refresh_command="source $tilde_fish_config"
     else
-        echo ""
-        echo "Manually add the directory to your \$HOME/.config/fish/config.fish (or similar)"
-        echo ""
-        echo -e "  $BWhite set -Ux BUN_INSTALL \"$bun_install\"$Color_Off"
-        echo -e "  $BWhite fish_add_path \"$bin_dir\"$Color_Off"
-        echo ""
+        echo "Manually add the directory to $tilde_fish_config (or similar):"
+        echo
+
+        for command in "${commands[@]}"; do
+            echo -e "  $Bold_White $command$Color_Off"
+        done
     fi
-elif
-    test $(basename $SHELL) == "zsh"
-then
+    ;;
+zsh)
     # Install completions, but we don't care if it fails
-    IS_BUN_AUTO_UPDATE="true" SHELL="zsh" $exe completions >/dev/null 2>&1
+    IS_BUN_AUTO_UPDATE=true SHELL=zsh $exe completions &>/dev/null || :
 
-    if test -f $HOME/.zshrc; then
-        echo -e "\n# bun\nexport BUN_INSTALL=\"$bun_install\"" >>"$HOME/.zshrc"
-        echo -e "export PATH=\"\$BUN_INSTALL/bin:\$PATH\"" >>"$HOME/.zshrc"
-        echo ""
-        echo -e "$Dim Added \"$bin_dir\" to \$PATH in \"~/.zshrc\"$Color_Off"
+    commands=(
+        "export $install_env=$safe_tilde_install_dir"
+        "export PATH=\"$bin_env:\$PATH\""
+    )
 
-        echo ""
-        echo -e "To get started, run"
-        echo -e "$BWhite"
-        echo -e "   exec $SHELL"
-        echo -e "   bun --help$Color_Off"
-        echo ""
-        exit 0
+    zsh_config=$HOME/.zshrc
+    tilde_zsh_config=$(tildify "$zsh_config")
+
+    if [[ -w $zsh_config ]]; then
+        {
+            echo -e '\n# bun'
+
+            for command in "${commands[@]}"; do
+                echo "$command"
+            done
+        } >>"$zsh_config"
+
+        echo -e "${Dim}Added \"$tilde_bin_dir\" to \$PATH in \"$tilde_zsh_config\"$Color_Off"
+
+        refresh_command="exec $SHELL"
     else
-        echo ""
-        echo "Manually add the directory to your \$HOME/.zshrc (or similar)"
-        echo ""
-        echo -e "  $BWhite export BUN_INSTALL=\"$bun_install\"$Color_Off"
-        echo -e "  $BWhite export PATH=\"\$BUN_INSTALL/bin:\$PATH\"$Color_Off"
-    fi
+        echo "Manually add the directory to $tilde_zsh_config (or similar):"
+        echo
 
-else
-    echo ""
-    echo "Manually add the directory to your \$HOME/.bashrc (or similar)"
-    echo ""
-    echo -e "  $BWhiteexport export BUN_INSTALL=\"$bun_install\"$Color_Off"
-    echo -e "  $BWhiteexport export PATH=\"\$BUN_INSTALL/bin:\$PATH\"$Color_Off"
+        for command in "${commands[@]}"; do
+            echo -e "  $Bold_White $command$Color_Off"
+        done
+    fi
+    ;;
+*)
+    echo "Manually add the directory to ~/.bashrc (or similar):"
+    echo
+    echo -e "  $Bold_White export $install_env=$safe_tilde_install_dir$Color_Off"
+    echo -e "  $Bold_White export PATH=\"$bin_env:\$PATH\"$Color_Off"
+    ;;
+esac
+
+echo
+echo -e "To get started, run:$Bold_White"
+
+if [[ $refresh_command ]]; then
+    echo -e "   $refresh_command"
 fi
-echo ""
-echo -e "To get started, run"
-echo -e "$BWhite"
+
 echo -e "   bun --help$Color_Off"

--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -67,7 +67,7 @@ if [[ $target = darwin-x64 ]]; then
     fi
 fi
 
-github_repo='https://github.com/Jarred-Sumner/bun-releases-for-updater'
+github_repo=https://github.com/Jarred-Sumner/bun-releases-for-updater
 
 if [[ $# = 0 ]]; then
     bun_uri="$github_repo/releases/latest/download/bun-$target.zip"
@@ -103,7 +103,13 @@ rm -r "$bin_dir/bun-$target" "$exe.zip"
 
 tildify() {
     if [[ ${2:-} = safe ]]; then
-        echo "${1//"$HOME/"/"~/'"}'"
+        local escaped=${1//"'"/"\\'"}
+
+        if [[ $1 = $HOME/* ]]; then
+            echo "${escaped/"$HOME/"/"~/'"}'"
+        else
+            echo "'$escaped'"
+        fi
     else
         echo "${1//"$HOME/"/'~/'}"
     fi

--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -103,15 +103,17 @@ rm -r "$bin_dir/bun-$target" "$exe.zip"
 
 tildify() {
     if [[ ${2:-} = safe ]]; then
-        local escaped=${1//"'"/"\\'"}
+        local escaped=${1//\'/\\\'}
 
         if [[ $1 = $HOME/* ]]; then
-            echo "${escaped/"$HOME/"/"~/'"}'"
+            local replacement=\~/\'
+
+            echo "${escaped/$HOME\//$replacement}'"
         else
             echo "'$escaped'"
         fi
     else
-        echo "${1/"$HOME/"/'~/'}"
+        echo "${1/$HOME\//~/}"
     fi
 }
 


### PR DESCRIPTION
Did a little overhaul of the install script

Some notable changes:
- Added `set -euo pipefail` to make the script fail on errors & undefined variables
- Corrected bad practices, like using double square brackets for if conditions for better performance & syntax
- Fixed various dangerous statements with the help of the [ShellCheck linter](https://www.shellcheck.net/)
- Removed a lot of duplicate code
- Changed the fish config to use `set --export PATH` instead of `fish_add_path`, since the latter modifies `$PATH` permanently with `$fish_user_paths` 