### PR TITLE
Fix documentation of `atob` and `btoa`

### DIFF
--- a/types/bun/globals.d.ts
+++ b/types/bun/globals.d.ts
@@ -726,18 +726,18 @@ interface Crypto {
 declare var crypto: Crypto;
 
 /**
- * [`atob`](https://developer.mozilla.org/en-US/docs/Web/API/atob) converts ascii text into base64.
+ * [`atob`](https://developer.mozilla.org/en-US/docs/Web/API/atob) decodes base64 into ascii text.
  *
- * @param asciiText The ascii text to convert.
+ * @param asciiText The base64 string to decode.
  */
-declare function atob(asciiText: string): string;
+declare function atob(encodedData: string): string;
 
 /**
- * [`btoa`](https://developer.mozilla.org/en-US/docs/Web/API/btoa) decodes base64 into ascii text.
+ * [`btoa`](https://developer.mozilla.org/en-US/docs/Web/API/btoa) encodes ascii text into base64.
  *
- * @param base64Text The base64 text to convert.
+ * @param stringToEncode The ascii text to encode.
  */
-declare function btoa(base64Text: string): string;
+declare function btoa(stringToEncode: string): string;
 
 /**
  * An implementation of the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/) `TextEncoder` API. All


### PR DESCRIPTION
These function are confusingly named. `btoa` converts "Binary" to Ascii by encoding the input using base64. `atob` reverses that process by base64 decoding the Ascii input into a "Binary" output.

The names come from the Unix utilities with the same names, which "converts a binary file to ascii for transmission over a telephone line" (https://www.unix.com/man-page/minix/1/btoa/)

See:
- https://developer.mozilla.org/en-US/docs/Web/API/atob
- https://developer.mozilla.org/en-US/docs/Web/API/btoa
- https://html.spec.whatwg.org/multipage/webappapis.html#dom-btoa-dev

Note: the actual implementation of `btoa` and `atob` are correct, but the docs were backwards.