### PR TITLE
fix/clean-up-bun-error

### DIFF
--- a/packages/bun-error/index.tsx
+++ b/packages/bun-error/index.tsx
@@ -345,7 +345,6 @@ const AsyncSourceLines = ({
   highlightColumnEnd = Infinity,
   children,
   buildURL,
-  isClient,
   sourceLines,
   setSourceLines,
 }: {
@@ -354,7 +353,6 @@ const AsyncSourceLines = ({
   highlightColumnEnd: number;
   children?: React.ReactNode;
   buildURL: (line?: number, column?: number) => string;
-  isClient: boolean
   sourceLines: SourceLine[];
   setSourceLines: (lines: SourceLine[]) => void;
 }) => {
@@ -797,7 +795,6 @@ const NativeStackTrace = ({
           highlightColumnStart={position.column_start}
           buildURL={buildURL}
           highlightColumnEnd={position.column_stop}
-          isClient={isClient}
         >
           {children}
         </AsyncSourceLines>

--- a/packages/bun-error/index.tsx
+++ b/packages/bun-error/index.tsx
@@ -255,7 +255,7 @@ class FancyTypeError {
   constructor(exception: JSException) {
     this.runtimeType = exception.runtime_type || 0;
     this.runtimeTypeName = RuntimeType[this.runtimeType] || "undefined";
-    this.message = exception.message ?? '';
+    this.message = exception.message || '';
     this.explain = "";
 
     this.normalize(exception);
@@ -1387,12 +1387,7 @@ export function dismissError() {
       runtimeErrorController = null;
     }
 
-    while (pending.length > 0) {
-      const pendingFrame = pending.shift();
-      if (pendingFrame) {
-        pendingFrame.stopped = true;
-      }
-    }
+    while (pending.length > 0) pending.shift().stopped = true;
   }
 }
 

--- a/packages/bun-error/markdown.ts
+++ b/packages/bun-error/markdown.ts
@@ -5,15 +5,10 @@ import {
   StackFrameScope,
 } from "./index";
 import type {
-  FallbackMessageContainer,
   JSException,
   JSException as JSExceptionType,
-  Location,
   Message,
   Problems,
-  SourceLine,
-  StackFrame,
-  WebsocketMessageBuildFailure,
 } from "../../src/api/schema";
 
 export function problemsToMarkdown(problems: Problems) {
@@ -87,7 +82,7 @@ function exceptionToMarkdown(exception: JSException): string {
           column_start: -1,
           column_stop: -1,
         },
-        scope = 0,
+        scope = 0 as any,
       } = stack.frames[0];
       const file = normalizedFilename(_file, thisCwd);
 
@@ -156,7 +151,7 @@ function exceptionToMarkdown(exception: JSException): string {
             line: -1,
             column_start: -1,
           },
-          scope = 0,
+          scope = 0 as any,
         } = frame;
         padding = Math.max(
           padding,
@@ -178,7 +173,7 @@ function exceptionToMarkdown(exception: JSException): string {
             line: -1,
             column_start: -1,
           },
-          scope = 0,
+          scope = 0 as any,
         } = frame;
 
         markdown += `

--- a/packages/bun-error/runtime-error.ts
+++ b/packages/bun-error/runtime-error.ts
@@ -4,7 +4,7 @@ import type {
   StackFrame as StackFrameType,
   StackFramePosition,
   StackFrameScope,
-} from "../../../src/api/schema";
+} from "../../src/api/schema";
 
 export class StackFrame implements StackFrameType {
   function_name: string;

--- a/packages/bun-error/tsconfig.json
+++ b/packages/bun-error/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "lib": ["ESNext", "DOM"],
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "node",
+    "types": ["bun-types"],
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/packages/bun-error/tsconfig.json
+++ b/packages/bun-error/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "node",
-    "types": ["bun-types"],
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
   }
 }


### PR DESCRIPTION
Updates to the `bun-error` package to remove unused code and fix TypeScript errors.

There are quite a few changes, but this is the general breakdown:
1. Removing unused imports
2. Adding missing prop types to components
3. Removing unused props from components
4. Fixing bugs caught by TypeScript