### PR TITLE
#609 Don't truncate ascii buffers to 7-bit

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -1094,9 +1094,13 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JS
         break;
     }
 
-    case WebCore::BufferEncodingType::latin1:
     case WebCore::BufferEncodingType::ascii: {
         ret = Bun__encoding__toStringASCII(castedThis->typedVector() + offset, length, lexicalGlobalObject);
+        break;
+    }
+
+    case WebCore::BufferEncodingType::latin1: {
+        ret = Bun__encoding__toStringLatin1(castedThis->typedVector() + offset, length, lexicalGlobalObject);
         break;
     }
 

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -28,6 +28,7 @@
 #include "wtf/GetPtr.h"
 #include "wtf/PointerPreparations.h"
 #include "wtf/URL.h"
+#include "wtf/text/WTFString.h"
 #include "JavaScriptCore/BuiltinNames.h"
 
 #include "JSBufferEncodingType.h"
@@ -270,8 +271,15 @@ static inline JSC::EncodedJSValue constructBufferFromStringAndEncoding(JSC::JSGl
         break;
     }
 
-    case WebCore::BufferEncodingType::latin1:
     case WebCore::BufferEncodingType::ascii: {
+        if (view.is8Bit()) {
+            result = Bun__encoding__constructFromLatin1AsASCII(lexicalGlobalObject, view.characters8(), view.length());
+        } else {
+            result = Bun__encoding__constructFromUTF16AsASCII(lexicalGlobalObject, view.characters16(), view.length());
+        }
+        break;
+    }
+    case WebCore::BufferEncodingType::latin1: {
         if (view.is8Bit()) {
             result = Bun__encoding__constructFromLatin1AsASCII(lexicalGlobalObject, view.characters8(), view.length());
         } else {
@@ -1100,7 +1108,7 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JS
     }
 
     case WebCore::BufferEncodingType::latin1: {
-        ret = Bun__encoding__toStringLatin1(castedThis->typedVector() + offset, length, lexicalGlobalObject);
+        ret = JSC::JSValue::encode(JSC::jsString(vm, WTF::StringImpl::create(reinterpret_cast<const UChar*>(castedThis->typedVector() + offset), length)));
         break;
     }
 

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -838,9 +838,6 @@ pub const Encoder = struct {
     export fn Bun__encoding__toStringASCII(input: [*]const u8, len: usize, globalObject: *JSC.JSGlobalObject) JSValue {
         return toString(input, len, globalObject, .ascii);
     }
-    export fn Bun__encoding__toStringLatin1(input: [*]const u8, len: usize, globalObject: *JSC.JSGlobalObject) JSValue {
-        return toString(input, len, globalObject, .latin1);
-    }
 
     export fn Bun__encoding__toStringHex(input: [*]const u8, len: usize, globalObject: *JSC.JSGlobalObject) JSValue {
         return toString(input, len, globalObject, .hex);
@@ -1116,12 +1113,8 @@ pub const Encoder = struct {
             },
             .latin1, .ascii => {
                 var to = allocator.alloc(u8, len) catch return &[_]u8{};
-                @memcpy(to.ptr, input, len);
 
-                // Hoping this gets auto vectorized
-                for (to[0..len]) |c, i| {
-                    to[i] = @truncate(u8, c);
-                }
+                @memcpy(to.ptr, input, len);
 
                 return to;
             },
@@ -1264,7 +1257,6 @@ pub const Encoder = struct {
             _ = Bun__encoding__toStringUTF16;
             _ = Bun__encoding__toStringUTF8;
             _ = Bun__encoding__toStringASCII;
-            _ = Bun__encoding__toStringLatin1;
             _ = Bun__encoding__toStringHex;
             _ = Bun__encoding__toStringBase64;
             _ = Bun__encoding__toStringURLSafeBase64;

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -866,7 +866,7 @@ pub const Encoder = struct {
         const allocator = VirtualMachine.vm.allocator;
 
         switch (comptime encoding) {
-            .latin1, .ascii => {
+            .ascii => {
                 var to = allocator.alloc(u8, len) catch return ZigString.init("Out of memory").toErrorInstance(global);
 
                 @memcpy(to.ptr, input_ptr, to.len);
@@ -875,6 +875,13 @@ pub const Encoder = struct {
                 for (to[0..to.len]) |c, i| {
                     to[i] = @as(u8, @truncate(u7, c));
                 }
+
+                return ZigString.init(to).toExternalValue(global);
+            },
+            .latin1 => {
+                var to = allocator.alloc(u8, len) catch return ZigString.init("Out of memory").toErrorInstance(global);
+
+                @memcpy(to.ptr, input_ptr, to.len);
 
                 return ZigString.init(to).toExternalValue(global);
             },
@@ -1113,7 +1120,7 @@ pub const Encoder = struct {
 
                 // Hoping this gets auto vectorized
                 for (to[0..len]) |c, i| {
-                    to[i] = @as(u8, @truncate(u7, c));
+                    to[i] = @truncate(u8, c);
                 }
 
                 return to;

--- a/test/bun.js/buffer.test.js
+++ b/test/bun.js/buffer.test.js
@@ -161,6 +161,17 @@ it("Buffer.from", () => {
   gc();
 });
 
+it("Buffer.from latin1 vs ascii", () => {
+  const simpleBuffer = Buffer.from('\xa4', 'binary');
+  expect(simpleBuffer.toString("latin1").toBe("¤"));
+  expect(simpleBuffer.toString('ascii').toBe("$"));
+
+  const asciiBuffer = Buffer.from('\xa4', 'ascii');
+  expect(asciiBuffer.toString("latin1").toBe("¤"));
+  expect(asciiBuffer.toString('ascii').toBe("$"));
+  gc();
+});
+
 it("Buffer.equals", () => {
   var a = new Uint8Array(10);
   a[2] = 1;


### PR DESCRIPTION
latin1, binary and ascii are now stored as full bytes. It's consistent with that Node.js does. The conversion of ascii buffers is only done in `toString`.