### PR TITLE
init command configures & creates package.json

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -51,6 +51,7 @@ const RunCommand = @import("./cli/run_command.zig").RunCommand;
 const ShellCompletions = @import("./cli/shell_completions.zig");
 const TestCommand = @import("./cli/test_command.zig").TestCommand;
 const UpgradeCommand = @import("./cli/upgrade_command.zig").UpgradeCommand;
+const InitCommand = @import("./cli/init_command.zig").InitCommand;
 
 const MacroMap = @import("./resolver/package_json.zig").MacroMap;
 
@@ -644,9 +645,6 @@ const AutoCommand = struct {
     pub fn exec(allocator: std.mem.Allocator) !void {
         try HelpCommand.execWithReason(allocator, .invalid_command);
     }
-};
-const InitCommand = struct {
-    pub fn exec(_: std.mem.Allocator) !void {}
 };
 pub const HelpCommand = struct {
     pub fn exec(allocator: std.mem.Allocator) !void {

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -72,7 +72,6 @@ pub const InitCommand = struct {
         // json object to string
         var string = std.ArrayList(u8).init(alloc);
         try std.json.stringify(content, .{ .whitespace = .{ .indent = .{ .Space = 4 } } }, string.writer());
-        defer string.deinit();
 
         // write json object to file
         try package_json.writeAll(string.items);

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -40,7 +40,7 @@ pub const InitCommand = struct {
         const fs = std.fs;
         const cwd = fs.cwd();
 
-        const package_json = cwd.createFile("package.json", .{ .exclusive = true }) catch |err| {
+        const package_json = try cwd.createFile("package.json", .{ .exclusive = true });
             std.debug.print("{any}", .{err});
             return;
         };

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -71,7 +71,7 @@ pub const InitCommand = struct {
 
         // json object to string
         var string = std.ArrayList(u8).init(alloc);
-        try std.json.stringify(content, .{}, string.writer());
+        try std.json.stringify(content, .{ .whitespace = .{ .indent = .{ .Space = 4 } } }, string.writer());
         defer string.deinit();
 
         // write json object to file

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -1,0 +1,80 @@
+const Command = @import("../cli.zig").Command;
+const std = @import("std");
+
+pub const InitCommand = struct {
+    fn getUserInput(alloc: std.mem.Allocator, default: []const u8) []const u8 {
+        const stdin = std.io.getStdIn().reader();
+
+        const buffer = stdin.readUntilDelimiterOrEofAlloc(alloc, '\n', 100) catch {
+            return default;
+        };
+    
+        const buf = buffer orelse "";
+        if (buf.len == 0) {
+            return default;
+        }  
+        else {
+            return buf;
+        }
+    }
+
+    pub fn exec(alloc: std.mem.Allocator) !void {
+        const stdout = std.io.getStdOut().writer();
+
+        // get package info from user
+        try stdout.print("package name: (project)", .{});
+        const project_name = getUserInput(alloc, "project");
+
+        try stdout.print("description: ", .{});
+        const desc = getUserInput(alloc, "");
+
+        try stdout.print("entry point: (index.ts)", .{});
+        const entry_point = getUserInput(alloc, "index.ts");
+
+        try stdout.print("author: ", .{});
+        const author = getUserInput(alloc, "");
+
+        try stdout.print("license: (ISC)", .{});
+        const license = getUserInput(alloc, "ISC");
+
+        const fs = std.fs;
+        const cwd = fs.cwd();
+
+        const package_json = cwd.createFile("package.json", .{ .exclusive = true }) catch |err| {
+            std.debug.print("{any}", .{err});
+            return;
+        };
+        defer package_json.close();
+
+        // build json object
+        const Scripts = struct {
+            tests: []const u8
+        };
+
+        const Package = struct {
+            name: []const u8,
+            description: []const u8,
+            main: []const u8,
+            scripts: Scripts,
+            author: []const u8,
+            license: []const u8
+        };
+
+        const content = Package {
+            .name = project_name,
+            .description = desc,
+            .main = entry_point,
+            .scripts = Scripts { .tests = "echo \"Error: no test specified\" && exit 1" },
+            .author = author,
+            .license = license
+        };
+
+        // json object to string
+        var string = std.ArrayList(u8).init(alloc);
+        try std.json.stringify(content, .{}, string.writer());
+        defer string.deinit();
+
+        // write json object to file
+        try package_json.writeAll(string.items);
+    }
+}


### PR DESCRIPTION
#381 This is a starting point for the init command. The main code is found inside src/cli/init_command.zig.

There are issues that needs to be address with the code in this pull request.

**Issues**
- Will not work on Windows because it doesn't recognize '\r\n' line break. It's not an issue now, but keep it in mind.
- Maybe some options are missing like package version or adding script command.
- Haven't been able to test it with bun (can't compile bun as of now).