### PR TITLE
a few helpful links added to the install.sh and bun --help

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -690,7 +690,7 @@ pub const HelpCommand = struct {
             \\> <r> <b><green>dev     <r><d>  ./a.ts ./b.jsx<r>        Start a bun Dev Server
             \\> <r> <b><magenta>bun     <r><d>  ./a.ts ./b.jsx<r>        Bundle dependencies of input files into a <r><magenta>.bun<r>
             \\
-            \\> <r> <b><cyan>create    <r><d>next ./app<r>            Start a new project from a template <d>(bun c)<r>
+            \\> <r> <b><cyan>create    <r><d>next ./app<r>            Start a new project from a template (full list: https://github.com/oven-sh/bun/tree/main/examples) <d>(bun c)<r>
             \\> <r> <b><magenta>run     <r><d>  test        <r>          Run JavaScript with bun, a package.json script, or a bin<r>
             \\> <r> <b><green>install<r>                         Install dependencies for a package.json <d>(bun i)<r>
             \\> <r> <b><blue>add     <r><d>  {s:<16}<r>      Add a dependency to package.json <d>(bun a)<r>

--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -109,6 +109,7 @@ if command -v bun --version >/dev/null; then
     IS_BUN_AUTO_UPDATE="true" $exe completions >/dev/null 2>&1
 
     echo "Run 'bun --help' to get started"
+    echo "Here is the list of our examples: https://github.com/oven-sh/bun/tree/main/examples"
     exit 0
 fi
 
@@ -149,8 +150,12 @@ then
         echo ""
         echo -e "To get started, run"
         echo -e "$BWhite"
-        echo -e "   exec $SHELL"
-        echo -e "   bun --help$Color_Off"
+        echo -e "   'exec $SHELL' to restart the shell"
+        echo -e "   'bun --help' to get started"
+        echo -e "   -----"
+        echo -e "$Color_Off"
+        echo -e ""
+        echo "Here is the list of our examples: https://github.com/oven-sh/bun/tree/main/examples"
         echo ""
         exit 0
     else


### PR DESCRIPTION
Subjectively, I do find it useful to have either docs or examples folders added to the install script print out (we love to reverse-engineer things). 

Feel free to adjust or drop me a comment. 