### PR TITLE
nextjs >= 12.2.2 dev update (new middleware and their router changes)

### DIFF
--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@bun-examples/next",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "dependencies": {
-    "next": "^12.1.0",
+    "next": "^12.2.2",
     "react": "^18",
     "react-dom": "^18",
     "react-is": "^17.0.2"
   },
   "devDependencies": {
     "@types/react": "^18",
-    "bun-framework-next": "^12",
+    "bun-framework-next": "^12.2.2",
     "typescript": "latest"
   },
   "bun-create": {

--- a/packages/bun-framework-next/client.development.tsx
+++ b/packages/bun-framework-next/client.development.tsx
@@ -20,8 +20,6 @@ import { RouterContext } from "next/dist/shared/lib/router-context";
 import Router, {
   AppComponent,
   AppProps,
-  delBasePath,
-  hasBasePath,
   PrivateRouteInfo,
 } from "next/dist/shared/lib/router/router";
 
@@ -136,9 +134,31 @@ setConfig({
 });
 
 let asPath: string = getURL();
+const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
+
+function pathNoQueryHash(path: string) {
+  const queryIndex = path.indexOf('?')
+  const hashIndex = path.indexOf('#')
+
+  if (queryIndex > -1 || hashIndex > -1) {
+    path = path.substring(0, queryIndex > -1 ? queryIndex : hashIndex)
+  }
+  return path
+}
+
+function hasBasePath(path: string): boolean {
+  path = pathNoQueryHash(path)
+  return path === prefix || path.startsWith(prefix + '/')
+}
+
+function delBasePath(path: string): string {
+  path = path.slice(basePath.length)
+  if (!path.startsWith('/')) path = `/${path}`
+  return path
+}
 
 // make sure not to attempt stripping basePath for 404s
-if (hasBasePath(asPath)) {
+if (hasBasePath(asPath)) { 
   asPath = delBasePath(asPath);
 }
 

--- a/packages/bun-framework-next/package.json
+++ b/packages/bun-framework-next/package.json
@@ -1,9 +1,9 @@
 {
   "name": "bun-framework-next",
-  "version": "12.1.5",
+  "version": "12.2.2",
   "main": "empty.js",
   "module": "empty.js",
-  "description": "bun compatibility layer for Next.js v12.x.x",
+  "description": "bun compatibility layer for Next.js >= v12.2.2",
   "scripts": {
     "check": "tsc --noEmit"
   },
@@ -13,12 +13,12 @@
     "react-is": "^17.0.2"
   },
   "peerDependencies": {
-    "next": "^12"
+    "next": "^12.2.2"
   },
   "devDependencies": {
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "next": "^12.1.0",
+    "next": "^12.2.2",
     "react": "^18",
     "react-dom": "^18",
     "typescript": "^4"


### PR DESCRIPTION
Hi team, I will need your assistance, what's the best way to test this without publishing to npm. Does bun package.json supports local / workspace dependencies? i.e. 

`"devDependencies": {
    "@types/react": "^18",
    "bun-framework-next": "file:../foo/bar",
    "typescript": "latest"
  },`