### PR TITLE
fix(api): stop double free of prop array

### DIFF
--- a/src/bun.js/api/transpiler.zig
+++ b/src/bun.js/api/transpiler.zig
@@ -374,11 +374,11 @@ fn transformOptionsFromJSC(ctx: JSC.C.JSContextRef, temp_allocator: std.mem.Allo
 
             var i: usize = 0;
             while (i < count) : (i += 1) {
+                // no need to free because we free the name array at once
                 var property_name_ref = JSC.C.JSPropertyNameArrayGetNameAtIndex(
                     array,
                     i,
                 );
-                defer JSC.C.JSStringRelease(property_name_ref);
                 const prop: []const u8 = JSC.C.JSStringGetCharacters8Ptr(property_name_ref)[0..JSC.C.JSStringGetLength(property_name_ref)];
                 const property_value: JSC.JSValue = JSC.JSValue.fromRef(
                     JSC.C.JSObjectGetProperty(
@@ -675,13 +675,14 @@ fn transformOptionsFromJSC(ctx: JSC.C.JSContextRef, temp_allocator: std.mem.Allo
                 }
 
                 while (iter.next()) |item| {
+                    // no need to free key because we free the name array at once
+
                     const start = total_name_buf.items.len;
                     total_name_buf.items.len += @maximum(
                         // this returns a null terminated string
                         JSC.C.JSStringGetUTF8CString(item, total_name_buf.items.ptr + start, total_name_buf.capacity - start),
                         1,
                     ) - 1;
-                    JSC.C.JSStringRelease(item);
                     const key = total_name_buf.items[start..total_name_buf.items.len];
                     // if somehow the string is empty, skip it
                     if (key.len == 0)

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -1934,16 +1934,14 @@ pub const ZigConsoleClient = struct {
                                 const count_without_children = count_ - @as(usize, @boolToInt(children_prop != null));
 
                                 while (i < count_) : (i += 1) {
+                                    // no need to free because we free the name array at once
                                     var property_name_ref = CAPI.JSPropertyNameArrayGetNameAtIndex(array, i);
+
                                     const prop_len = CAPI.JSStringGetLength(property_name_ref);
                                     if (prop_len == 0) continue;
                                     var prop = CAPI.JSStringGetCharacters8Ptr(property_name_ref)[0..prop_len];
-                                    if (strings.eqlComptime(prop, "children")) {
-                                        CAPI.JSStringRelease(property_name_ref);
+                                    if (strings.eqlComptime(prop, "children"))
                                         continue;
-                                    }
-
-                                    defer CAPI.JSStringRelease(property_name_ref);
 
                                     var property_value = CAPI.JSObjectGetProperty(this.globalThis.ref(), props.asObjectRef(), property_name_ref, null);
                                     const tag = Tag.get(JSValue.fromRef(property_value), this.globalThis);
@@ -2116,7 +2114,6 @@ pub const ZigConsoleClient = struct {
 
                         while (i < count_) : (i += 1) {
                             var property_name_ref = CAPI.JSPropertyNameArrayGetNameAtIndex(array, i);
-                            defer CAPI.JSStringRelease(property_name_ref);
                             const len = CAPI.JSStringGetLength(property_name_ref);
                             if (len == 0) continue;
                             const encoding = CAPI.JSStringEncoding(property_name_ref);


### PR DESCRIPTION
Closes #786 and also solves a segfault with the same cause which seems to not have been found yet when using the JSX prop array.

When you release the `JSPropertyNameArrayRef`, it actually deallocates the underlying names.  However, we were freeing the individual names and then the property name array ref was freeing them.  Jarred found the cause of the double free in the Discord.