### PR TITLE
feat(node/fs): implement more stat methods

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -797,7 +797,7 @@ pub const FileSystemFlags = enum(Mode) {
     }
 };
 
-/// Milliseconds precision 
+/// Milliseconds precision
 pub const Date = enum(u64) {
     _,
 
@@ -818,11 +818,26 @@ fn StatsLike(comptime name: [:0]const u8, comptime T: type) type {
             This,
             .{ .name = name },
             .{
-                .isFile = .{
-                    .rfn = JSC.wrap(This, "isFile", false),
+                .isBlockDevice = .{
+                    .rfn = JSC.wrap(This, "isBlockDevice", false),
+                },
+                .isCharacterDevice = .{
+                    .rfn = JSC.wrap(This, "isCharacterDevice", false),
                 },
                 .isDirectory = .{
                     .rfn = JSC.wrap(This, "isDirectory", false),
+                },
+                .isFIFO = .{
+                    .rfn = JSC.wrap(This, "isFIFO", false),
+                },
+                .isFile = .{
+                    .rfn = JSC.wrap(This, "isFile", false),
+                },
+                .isSocket = .{
+                    .rfn = JSC.wrap(This, "isSocket", false),
+                },
+                .isSymbolicLink = .{
+                    .rfn = JSC.wrap(This, "isSymbolicLink", false),
                 },
                 .finalize = finalize,
             },
@@ -957,11 +972,37 @@ fn StatsLike(comptime name: [:0]const u8, comptime T: type) type {
             };
         }
 
+        pub fn isBlockDevice(this: *Stats) JSC.JSValue {
+            return JSC.JSValue.jsBoolean(os.S.ISBLK(@intCast(Mode, this.mode)));
+        }
+
+        pub fn isCharacterDevice(this: *Stats) JSC.JSValue {
+            return JSC.JSValue.jsBoolean(os.S.ISCHR(@intCast(Mode, this.mode)));
+        }
+
+        pub fn isDirectory(this: *Stats) JSC.JSValue {
+            return JSC.JSValue.jsBoolean(os.S.ISDIR(@intCast(Mode, this.mode)));
+        }
+
+        pub fn isFIFO(this: *Stats) JSC.JSValue {
+            return JSC.JSValue.jsBoolean(os.S.ISFIFO(@intCast(Mode, this.mode)));
+        }
+
         pub fn isFile(this: *Stats) JSC.JSValue {
             return JSC.JSValue.jsBoolean(os.S.ISREG(@intCast(Mode, this.mode)));
         }
-        pub fn isDirectory(this: *Stats) JSC.JSValue {
-            return JSC.JSValue.jsBoolean(os.S.ISDIR(@intCast(Mode, this.mode)));
+
+        pub fn isSocket(this: *Stats) JSC.JSValue {
+            return JSC.JSValue.jsBoolean(os.S.ISSOCK(@intCast(Mode, this.mode)));
+        }
+
+        // Node.js says this method is only valid on the result of lstat()
+        // so it's fine if we just include it on stat() because it would
+        // still just return false.
+        //
+        // See https://nodejs.org/api/fs.html#statsissymboliclink
+        pub fn isSymbolicLink(this: *Stats) JSC.JSValue {
+            return JSC.JSValue.jsBoolean(os.S.ISLNK(@intCast(Mode, this.mode)));
         }
 
         pub fn toJS(this: Stats, ctx: JSC.C.JSContextRef, _: JSC.C.ExceptionRef) JSC.C.JSValueRef {

--- a/test/bun.js/fs-stream.link.js
+++ b/test/bun.js/fs-stream.link.js
@@ -1,0 +1,1 @@
+./test/bun.js/fs-stream.js

--- a/test/bun.js/fs.test.js
+++ b/test/bun.js/fs.test.js
@@ -11,6 +11,9 @@ import {
   readSync,
   writeFileSync,
   writeSync,
+  statSync,
+  lstatSync,
+  symlinkSync,
 } from "node:fs";
 
 const Buffer = globalThis.Buffer || Uint8Array;
@@ -240,5 +243,64 @@ describe("writeFileSync", () => {
     for (let i = 0; i < buffer.length; i++) {
       expect(buffer[i]).toBe(out[i]);
     }
+  });
+});
+
+describe("lstat", () => {
+  it("file metadata is correct", () => {
+    const fileStats = lstatSync(
+      new URL("./fs-stream.js", import.meta.url)
+        .toString()
+        .slice("file://".length - 1)
+    );
+    expect(fileStats.isSymbolicLink()).toBe(false);
+    expect(fileStats.isFile()).toBe(true);
+    expect(fileStats.isDirectory()).toBe(false);
+  });
+
+  it("folder metadata is correct", () => {
+    const fileStats = lstatSync(
+      new URL("../../test", import.meta.url)
+        .toString()
+        .slice("file://".length - 1)
+    );
+    expect(fileStats.isSymbolicLink()).toBe(false);
+    expect(fileStats.isFile()).toBe(false);
+    expect(fileStats.isDirectory()).toBe(true);
+  });
+
+  it("symlink metadata is correct", () => {
+    const linkStats = lstatSync(
+      new URL("./fs-stream.link.js", import.meta.url)
+        .toString()
+        .slice("file://".length - 1)
+    );
+    expect(linkStats.isSymbolicLink()).toBe(true);
+    expect(linkStats.isFile()).toBe(false);
+    expect(linkStats.isDirectory()).toBe(false);
+  });
+});
+
+describe("stat", () => {
+  it("file metadata is correct", () => {
+    const fileStats = statSync(
+      new URL("./fs-stream.js", import.meta.url)
+        .toString()
+        .slice("file://".length - 1)
+    );
+    expect(fileStats.isSymbolicLink()).toBe(false);
+    expect(fileStats.isFile()).toBe(true);
+    expect(fileStats.isDirectory()).toBe(false);
+  });
+
+  it("folder metadata is correct", () => {
+    const fileStats = statSync(
+      new URL("../../test", import.meta.url)
+        .toString()
+        .slice("file://".length - 1)
+    );
+    expect(fileStats.isSymbolicLink()).toBe(false);
+    expect(fileStats.isFile()).toBe(false);
+    expect(fileStats.isDirectory()).toBe(true);
   });
 });

--- a/test/bun.js/fs.test.js
+++ b/test/bun.js/fs.test.js
@@ -13,7 +13,6 @@ import {
   writeSync,
   statSync,
   lstatSync,
-  symlinkSync,
 } from "node:fs";
 
 const Buffer = globalThis.Buffer || Uint8Array;


### PR DESCRIPTION
Implements `Stat.isBlockDevice()`, `Stat.isCharacterDevice()`, `Stat.isFIFO()`, `Stat.isSocket()`, and `Stat.isSymbolicLink()` using the equivalent sys calls.

See https://nodejs.org/api/fs.html#class-fsstats for reference

Closes #797