### PR TITLE
chore(vscode): set tab size and tab format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,8 @@
   "search.useIgnoreFiles": true,
   "zig.buildOnSave": false,
   "[zig]": {
+	  "editor.tabSize": 4,
+	  "editor.useTabStops": false,
     "editor.defaultFormatter": "AugusteRame.zls-vscode",
     "editor.formatOnSave": true
   },
@@ -164,6 +166,5 @@
     "__memory": "cpp",
     "memory_resource": "cpp"
   },
-  "go.logging.level": "off",
   "cmake.configureOnOpen": false
 }


### PR DESCRIPTION
I have different global settings than the default formatter so it always does one actual tab character which is only shown as 2 spaces when I tab.  This normalizes the settings to match the formatter's style for tabs.