### PR TITLE
fix: remove suffix arg for mktemp compatibility

### DIFF
--- a/test/apps/bun-dev-index-html.sh
+++ b/test/apps/bun-dev-index-html.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 killall -9 $(basename $BUN_BIN) || echo ""
 
-dir=$(mktemp -d --suffix=bun-dev-check)
+dir=$(mktemp -d)
 
 index_content="<html><body>index.html</body></html>"
 bacon_content="<html><body>bacon.html</body></html>"

--- a/test/apps/bun-dev.sh
+++ b/test/apps/bun-dev.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 killall -9 $(basename $BUN_BIN) || echo ""
 
-dir=$(mktemp -d --suffix=bun-dev-check)
+dir=$(mktemp -d)
 
 index_content="<html><body>index.html</body></html>"
 bacon_content="<html><body>bacon.html</body></html>"

--- a/test/apps/bun-install-lockfile-status.sh
+++ b/test/apps/bun-install-lockfile-status.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 killall -9 $(basename $BUN_BIN) || echo ""
 
-dir=$(mktemp -d --suffix=bun-lockfile)
+dir=$(mktemp -d)
 
 cd $dir
 

--- a/test/apps/bun-install-utf8.sh
+++ b/test/apps/bun-install-utf8.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 killall -9 $(basename $BUN_BIN) || echo ""
 
-dir=$(mktemp -d --suffix=bun-ADD)
+dir=$(mktemp -d)
 
 cd $dir
 

--- a/test/apps/bun-install.sh
+++ b/test/apps/bun-install.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-dir=$(mktemp -d --suffix=bun-install-test-1)
+dir=$(mktemp -d)
 
 cd $dir
 ${NPM_CLIENT:-$(which bun)} add react react-dom @types/react @babel/parser esbuild


### PR DESCRIPTION
The default macOS `mktemp` doesn't support the `--suffix` arg that is supported by the GNU version. This causes the tests to fail when running on macOS.

This PR removes the use of the `--suffix` arg in the test suite, allowing the tests to pass using the default macOS `mktemp`.