### PR TITLE
Fix mistake in Next.js Example README.

### DIFF
--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -33,4 +33,4 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+Check out the [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.


### PR DESCRIPTION
Changed the 'our' in "Check out **our** [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details." to 'the'.