### PR TITLE
ci: push images to ghcr to prevent rate limit and sync dockerhub description

### DIFF
--- a/.github/workflows/bun-dockerhub.yml
+++ b/.github/workflows/bun-dockerhub.yml
@@ -69,3 +69,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        if: github.event_name == 'release'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: jarredsumner/bun
+          short-description: ${{ github.event.repository.description }}

--- a/.github/workflows/bun-dockerhub.yml
+++ b/.github/workflows/bun-dockerhub.yml
@@ -1,4 +1,5 @@
 name: bun-dockerhub
+
 on:
   push:
     paths:
@@ -13,6 +14,12 @@ on:
   release:
     types:
       - published
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -20,24 +27,39 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Collect metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: |
             ${{ secrets.DOCKERHUB_USERNAME }}/bun
+            ghcr.io/oven-sh/bun
           tags: |
             type=match,pattern=bun-v(\d.\d.\d),group=1
             type=match,pattern=bun-v(\d.\d),group=1
             type=match,pattern=bun-v(\d),group=1
             type=ref,event=branch
             type=ref,event=pr
+
       - name: Login to DockerHub
         if: github.event_name == 'release'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'release'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build image
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
## Description

DockerHub has imposed a rate limits of 100 container image requests per six hours for anonymous usage, and 200 container image requests per six hours. Reference: https://www.docker.com/increase-rate-limits/

This PR allows to publish parallel images to GitHub Container registry which is tightly integrated with the Bun's GitHub repository and is free of rate limiting, hence giving more flexibility to end users using Bun in CI environments. 

This PR also adds another step to sync the repository's `README.md` file with the DockerHub description which is currently empty.