### PR TITLE
fix(release): Remove the `${{}}` from the `if` block in GHA

### DIFF
--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -161,7 +161,7 @@ jobs:
     name: release
     runs-on: ubuntu-18.04
     timeout-minutes: 90
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged) || github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged) || github.event_name == 'workflow_dispatch'
     needs:
       - linux-x64
       - linux-aarch64


### PR DESCRIPTION
See - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif
```
When you use expressions in an if conditional, you may omit the expression syntax (${{ }}) because GitHub automatically evaluates the if conditional as an expression.

```