### PR TITLE
Fix 'make jsc' sed failure on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1124,9 +1124,9 @@ jsc-copy-headers:
 # on macOS, it never requests JIT permissions
 .PHONY: jsc-force-fastjit
 jsc-force-fastjit:
-	$(SED) -i "s/USE(PTHREAD_JIT_PERMISSIONS_API)/CPU(ARM64)/g" $(WEBKIT_DIR)/Source/JavaScriptCore/jit/ExecutableAllocator.h
-	$(SED) -i "s/USE(PTHREAD_JIT_PERMISSIONS_API)/CPU(ARM64)/g" $(WEBKIT_DIR)/Source/JavaScriptCore/assembler/FastJITPermissions.h
-	$(SED) -i "s/USE(PTHREAD_JIT_PERMISSIONS_API)/CPU(ARM64)/g" $(WEBKIT_DIR)/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+	$(SED) -i -e "s/USE(PTHREAD_JIT_PERMISSIONS_API)/CPU(ARM64)/g" $(WEBKIT_DIR)/Source/JavaScriptCore/jit/ExecutableAllocator.h
+	$(SED) -i -e "s/USE(PTHREAD_JIT_PERMISSIONS_API)/CPU(ARM64)/g" $(WEBKIT_DIR)/Source/JavaScriptCore/assembler/FastJITPermissions.h
+	$(SED) -i -e "s/USE(PTHREAD_JIT_PERMISSIONS_API)/CPU(ARM64)/g" $(WEBKIT_DIR)/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
 
 .PHONY: jsc-build-mac-compile
 jsc-build-mac-compile:


### PR DESCRIPTION
The 'make jsc' target fails as follows on macOS:

  /usr/bin/sed -i "s/USE(PTHREAD_JIT_PERMISSIONS_API)/CPU(ARM64)/g" /Users/penberg/src/bun/bun/src/bun.js/WebKit/Source/JavaScriptCore/jit/ExecutableAllocator.h
  sed: 1: "/Users/penberg/src/bun/ ...": extra characters at the end of p command

Fix it up.