### PR TITLE
workflows/bun: add cache step before compiling c++ dependencies

### DIFF
--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -174,6 +174,13 @@ jobs:
         run: |
           mkdir -p $BUN_DEPS_OUT_DIR
           make vendor-without-check
+      - name: Cache C++
+        if: matrix.compile_obj
+        id: cache-cpp
+        uses: actions/cache@v3
+        with:
+          path: ${{ runner.temp }}/bun-cpp-obj
+          key: ${{ runner.os }}-${{ matrix.cpu }}-${{ matrix.arch }}-cpp
       - name: Compile C++
         if: matrix.compile_obj
         env:


### PR DESCRIPTION
Adding a cache step. Not sure if I have the right folder for this, would appreciate pointers.

Also, we'll need to run this at least 2 times to see if caching it does anything.