### PR TITLE
Update bun-framework-next for Compatibility with Next 12.2+

### DIFF
--- a/packages/bun-framework-next/client.development.tsx
+++ b/packages/bun-framework-next/client.development.tsx
@@ -20,8 +20,6 @@ import { RouterContext } from "next/dist/shared/lib/router-context";
 import Router, {
   AppComponent,
   AppProps,
-  delBasePath,
-  hasBasePath,
   PrivateRouteInfo,
 } from "next/dist/shared/lib/router/router";
 
@@ -136,9 +134,31 @@ setConfig({
 });
 
 let asPath: string = getURL();
+const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
+
+function pathNoQueryHash(path: string) {
+  const queryIndex = path.indexOf('?')
+  const hashIndex = path.indexOf('#')
+
+  if (queryIndex > -1 || hashIndex > -1) {
+    path = path.substring(0, queryIndex > -1 ? queryIndex : hashIndex)
+  }
+  return path
+}
+
+function hasBasePath(path: string): boolean {
+  path = pathNoQueryHash(path)
+  return path === prefix || path.startsWith(prefix + '/')
+}
+
+function delBasePath(path: string): string {
+  path = path.slice(basePath.length)
+  if (!path.startsWith('/')) path = `/${path}`
+  return path
+}
 
 // make sure not to attempt stripping basePath for 404s
-if (hasBasePath(asPath)) {
+if (hasBasePath(asPath)) { 
   asPath = delBasePath(asPath);
 }
 

--- a/packages/bun-framework-next/package.json
+++ b/packages/bun-framework-next/package.json
@@ -1,9 +1,9 @@
 {
   "name": "bun-framework-next",
-  "version": "12.1.5",
+  "version": "12.2.3",
   "main": "empty.js",
   "module": "empty.js",
-  "description": "bun compatibility layer for Next.js v12.x.x",
+  "description": "bun compatibility layer for Next.js >= v12.2.3",
   "scripts": {
     "check": "tsc --noEmit"
   },
@@ -13,12 +13,12 @@
     "react-is": "^17.0.2"
   },
   "peerDependencies": {
-    "next": "^12"
+    "next": "^12.2.3"
   },
   "devDependencies": {
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "next": "^12.1.0",
+    "next": "^12.2.3",
     "react": "^18",
     "react-dom": "^18",
     "typescript": "^4"

--- a/packages/bun-framework-next/package.json
+++ b/packages/bun-framework-next/package.json
@@ -13,7 +13,7 @@
     "react-is": "^17.0.2"
   },
   "peerDependencies": {
-    "next": "^12.2.3"
+    "next": "~12.2.3"
   },
   "devDependencies": {
     "@types/react": "^18",

--- a/packages/bun-framework-next/renderDocument.tsx
+++ b/packages/bun-framework-next/renderDocument.tsx
@@ -17,7 +17,7 @@ import {
   type RenderPage,
   type RenderPageResult,
 } from "next/dist/shared/lib/utils";
-import * as NextUtils from "next/dist/shared/lib/utils";
+import { HtmlContext } from "next/dist/shared/lib/html-context";
 import type { RenderOpts } from "next/dist/server/render";
 import * as NextDocument from "next/document";
 import * as ReactDOMServer from "react-dom/server.browser";
@@ -26,18 +26,6 @@ import * as ReactIs from "react-is";
 import packageJson from "next/package.json";
 
 const nextVersion = packageJson.version;
-
-var HtmlContext;
-// HtmlContext is in different places depending on the next version
-if ("HtmlContext" in NextUtils) {
-  HtmlContext = NextUtils.HtmlContext;
-} else {
-  try {
-    HtmlContext = require("next/dist/shared/lib/html-context").HtmlContext;
-  } catch (err) {
-    throw err;
-  }
-}
 
 function appendNextBody(documentHTML: string, pageContent: string) {
   if (nextVersion.startsWith("12.0")) {


### PR DESCRIPTION
Thanks to nodexchange for starting this work in #789

Confirmed working locally, required another adjustment for a path change to the HtmlContext library.

Adjusted the peerDependency to match our reliance on minor versions for compatibility