### PR TITLE
fix(makefile): devcontainer install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 .swcrc
 yarn.lock
 dist
+*.tmp
 *.log
 *.out.js
 *.out.refresh.js

--- a/Makefile
+++ b/Makefile
@@ -791,7 +791,7 @@ clone-submodules:
 	git -c submodule."src/bun.js/WebKit".update=none submodule update --init --recursive --depth=1 --progress
 
 .PHONY: devcontainer
-devcontainer: clone-submodules libbacktrace mimalloc zlib libarchive boringssl picohttp identifier-cache node-fallbacks headers api analytics bun_error fallback_decoder bindings dev runtime_js_dev libarchive libbacktrace lolhtml usockets uws base64 tinycc
+devcontainer: clone-submodules libbacktrace mimalloc zlib libarchive boringssl picohttp identifier-cache node-fallbacks api analytics bun_error fallback_decoder bindings dev runtime_js_dev libarchive libbacktrace lolhtml usockets uws base64 tinycc
 
 .PHONY: devcontainer-build
 devcontainer-build:
@@ -807,7 +807,6 @@ CLANG_FORMAT := $(shell command -v clang-format 2> /dev/null)
 headers:
 	rm -f /tmp/build-jsc-headers src/bun.js/bindings/headers.zig
 	touch src/bun.js/bindings/headers.zig
-	mkdir -p src/bun.js/bindings-obj/
 	$(ZIG) build headers-obj
 	$(CXX) $(PLATFORM_LINKER_FLAGS) $(JSC_FILES_DEBUG) ${ICU_FLAGS} $(BUN_LLD_FLAGS_WITHOUT_JSC)  -g $(DEBUG_BIN)/headers.o -W -o /tmp/build-jsc-headers -lc;
 	/tmp/build-jsc-headers
@@ -1391,7 +1390,10 @@ EMIT_LLVM=$(EMIT_LLVM_FOR_RELEASE)
 
 # We do this outside of build.zig for performance reasons
 # The C compilation stuff with build.zig is really slow and we don't need to run this as often as the rest
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
+$(OBJ_DIR):
+	mkdir -p $(OBJ_DIR)
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp $(OBJ_DIR)
 	$(CXX) $(CLANG_FLAGS) $(UWS_INCLUDE) \
 		$(MACOS_MIN_FLAG) \
 		$(OPTIMIZATION_LEVEL) \
@@ -1401,7 +1403,7 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
 		$(EMIT_LLVM) \
 		-g3 -c -o $@ $<
 
-$(OBJ_DIR)/%.o: $(SRC_DIR)/webcore/%.cpp
+$(OBJ_DIR)/%.o: $(SRC_DIR)/webcore/%.cpp $(OBJ_DIR)
 	$(CXX) $(CLANG_FLAGS) \
 		$(MACOS_MIN_FLAG) \
 		$(OPTIMIZATION_LEVEL) \
@@ -1411,7 +1413,7 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/webcore/%.cpp
 		$(EMIT_LLVM) \
 		-g3 -c -o $@ $<
 
-$(OBJ_DIR)/%.o: $(SRC_DIR)/sqlite/%.cpp
+$(OBJ_DIR)/%.o: $(SRC_DIR)/sqlite/%.cpp $(OBJ_DIR)
 	$(CXX) $(CLANG_FLAGS) \
 		$(MACOS_MIN_FLAG) \
 		$(OPTIMIZATION_LEVEL) \
@@ -1421,7 +1423,7 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/sqlite/%.cpp
 		$(EMIT_LLVM) \
 		-g3 -c -o $@ $<
 
-$(OBJ_DIR)/%.o: src/bun.js/builtins/%.cpp
+$(OBJ_DIR)/%.o: src/bun.js/builtins/%.cpp $(OBJ_DIR)
 	$(CXX) $(CLANG_FLAGS) \
 		$(MACOS_MIN_FLAG) \
 		$(OPTIMIZATION_LEVEL) \

--- a/Makefile
+++ b/Makefile
@@ -791,7 +791,7 @@ clone-submodules:
 	git -c submodule."src/bun.js/WebKit".update=none submodule update --init --recursive --depth=1 --progress
 
 .PHONY: devcontainer
-devcontainer: clone-submodules libbacktrace mimalloc zlib libarchive boringssl picohttp identifier-cache node-fallbacks api analytics bun_error fallback_decoder bindings dev runtime_js_dev libarchive libbacktrace lolhtml usockets uws base64 tinycc
+devcontainer: clone-submodules libbacktrace mimalloc zlib libarchive boringssl picohttp identifier-cache node-fallbacks api analytics bun_error fallback_decoder bindings uws lolhtml usockets base64 tinycc dev runtime_js_dev
 
 .PHONY: devcontainer-build
 devcontainer-build:


### PR DESCRIPTION
I ran into these issues on a fresh ubuntu install with docker. this mainly alters the `devcontainer` script in the makefile.

- `make devcontainer` does not run `make headers`
- bindings directory is created when compiling bindings (like `make bindings`), instead of during `make headers`. as far as i can tell, the folder isn't needed for headers and was just a convenient location to put it at the time.
- add `*.tmp` to gitignore. there isn't a case this would be reasonably committed, but i did notice these files pop in and out of my git changes list while building bun
- sort the order of the `make devcontainer` dependencies, so that deps of bun are built before bun is built.

jarred mentioned having these all the libraries prebuilt, but if that isnt done i believe there should be some more work done on the makefile that makes things like `make uws` a proper dependency of `make dev` instead of relying on the fact that the `make devcontainer` just happens to cause the dependencies to be satisfied as a side effect. but i don't know if that causes more issues than it solves.

either way, others should be able to get a docker container going now, but the 16gb of ram that the dev container recommends is not enough; i left that as is just to keep it easy.