### PR TITLE
fix(makefile) fix devcontainer rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -791,7 +791,7 @@ clone-submodules:
 	git -c submodule."src/bun.js/WebKit".update=none submodule update --init --recursive --depth=1 --progress
 
 .PHONY: devcontainer
-devcontainer: clone-submodules libbacktrace mimalloc zlib libarchive boringssl picohttp identifier-cache node-fallbacks api analytics bun_error fallback_decoder bindings uws lolhtml usockets base64 tinycc dev runtime_js_dev
+devcontainer: clone-submodules libbacktrace mimalloc zlib libarchive boringssl picohttp identifier-cache node-fallbacks npm-install api analytics bun_error fallback_decoder bindings uws lolhtml usockets base64 tinycc runtime_js_dev sqlite dev
 
 .PHONY: devcontainer-build
 devcontainer-build:


### PR DESCRIPTION
This PR adds npm-install and sqlite to devcontainer rule and move runtime_js_dev to the front of dev in makefile, because:

- api rule will need `./node_modules/.bin/peechy` which is downloaded from npm-install;
- dev need `sqlite3.o` which is compiled by sqlite rule;
- dev needs files like `src/runtime.node.out.js`, which is generated from runtime_js_dev.

After these 3 changes we could build the develop container in the readme.

Thank you for your time on this PR:)