### PR TITLE
Ignore browser disable paths to support more node packages

### DIFF
--- a/src/bun.js/config.zig
+++ b/src/bun.js/config.zig
@@ -43,6 +43,6 @@ pub fn configureTransformOptionsForBunVM(allocator: std.mem.Allocator, _args: Ap
 
 pub fn configureTransformOptionsForBun(_: std.mem.Allocator, _args: Api.TransformOptions) !Api.TransformOptions {
     var args = _args;
-    args.platform = Api.Platform.bun;
+    args.platform = args.platform orelse Api.Platform.bun;
     return args;
 }

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -435,7 +435,9 @@ pub const VirtualMachine = struct {
             this.macro_event_loop.concurrent_tasks = EventLoop.Queue.init(default_allocator);
         }
 
-        this.bundler.options.platform = .bun_macro;
+        if (this.bundler.options.platform == .bun) {
+            this.bundler.options.platform = .bun_macro;
+        }
         this.bundler.resolver.caches.fs.is_macro_mode = true;
         this.macro_mode = true;
         this.event_loop = &this.macro_event_loop;
@@ -443,7 +445,9 @@ pub const VirtualMachine = struct {
     }
 
     pub fn disableMacroMode(this: *VirtualMachine) void {
-        this.bundler.options.platform = .bun;
+        if (this.bundler.options.platform == .bun_macro) {
+            this.bundler.options.platform = .bun;
+        }
         this.bundler.resolver.caches.fs.is_macro_mode = false;
         this.macro_mode = false;
         this.event_loop = &this.regular_event_loop;
@@ -2828,3 +2832,4 @@ pub const DisabledModule = bun.ComptimeStringMap(
         .{"worker_threads"},
     },
 );
+


### PR DESCRIPTION
Bun used to disable paths in the `browser` field of package.json, however, this will disable many node packages, e.g. `object-inspect` and `iconv-lite` relied by express (#496). 

This PR is trying to make bun continue to resolve those disabled paths and allow user to pass the platform info from cli to resolver. After this PR, bun could start the basic express server:tada: (not able to send response back though...):

```js
const express = require('express')
const app = express()
const port = 8080

app.get('/', (req, res) => {
  console.log("receive req")
  res.send('Hello World!')
})

app.listen(port, () => {
  console.log(`Example app listening on port ${port}`)
})
```

Thank you for your time on reviewing this PR :)

gently ping @Jarred-Sumner @evanwashere 