### PR TITLE
allow setting status code in Response.redirect

### DIFF
--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -510,12 +510,12 @@ pub const Response = struct {
             } else {
                 if (Body.Init.init(getAllocator(ctx), ctx, init.asObjectRef()) catch null) |_init| {
                     response.body.init = _init;
+                    response.body.init.status_code = 302;
                 }
             }
         }
 
         response.body.init.headers = response.getOrCreateHeaders();
-        response.body.init.status_code = 302;
         var headers_ref = response.body.init.headers.?;
         headers_ref.put("location", url_string_slice.slice());
         var ptr = response.allocator.create(Response) catch unreachable;


### PR DESCRIPTION
fix #976.

We should raise `RangeError` when the status code is not one of the redirect code, but it seems like RangeError is not exposed in zig yet.

Thank you for your time on this PR :)