### PR TITLE
Fix for bearer tokens missing from request headers on bun install step

### DIFF
--- a/src/http/header_builder.zig
+++ b/src/http/header_builder.zig
@@ -47,7 +47,7 @@ pub fn appendFmt(this: *HeaderBuilder, name: string, comptime fmt: string, args:
     const value = this.content.fmt(fmt, args);
 
     const value_ptr = Api.StringPointer{
-        .offset = @truncate(u32, this.content.len),
+        .offset = @truncate(u32, this.content.len - value.len),
         .length = @truncate(u32, value.len),
     };
 

--- a/test/bun.js/util.test.js
+++ b/test/bun.js/util.test.js
@@ -1,3 +1,26 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Tests adapted from https://github.com/nodejs/node/blob/main/test/parallel/test-util.js
+
 import { expect, describe, it } from "bun:test";
 import util from "util";
 import assert from "assert";


### PR DESCRIPTION
Fix for https://github.com/oven-sh/bun/issues/190#issuecomment-1203249140 in #190 