### PR TITLE
Raise error on unhandled rejected promises

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -201,6 +201,8 @@ public:
         return m_processEnvObject.getInitializedOnMainThread(this);
     }
 
+    void handleRejectedPromises();
+
     void* bunVM() { return m_bunVM; }
     bool isThreadLocalDefaultGlobalObject = false;
 
@@ -242,6 +244,7 @@ private:
 
     DOMGuardedObjectSet m_guardedObjects WTF_GUARDED_BY_LOCK(m_gcLock);
     void* m_bunVM;
+    WTF::Vector<JSC::Strong<JSC::JSPromise>> m_aboutToBeNotifiedRejectedPromises;
 };
 
 class JSMicrotaskCallbackDefaultGlobal final : public RefCounted<JSMicrotaskCallbackDefaultGlobal> {

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -1702,6 +1702,11 @@ JSC__VM* JSC__JSGlobalObject__vm(JSC__JSGlobalObject* arg0) { return &arg0->vm()
     // JSC__JSGlobalObject__throwError(JSC__JSGlobalObject* arg0, JSC__JSObject*
     // arg1) {};
 
+void JSC__JSGlobalObject__handleRejectedPromises(JSC__JSGlobalObject* arg0)
+{
+    return static_cast<Zig::GlobalObject*>(arg0)->handleRejectedPromises();
+}
+
 #pragma mark - JSC::JSValue
 
 JSC__JSCell* JSC__JSValue__asCell(JSC__JSValue JSValue0)

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -1693,6 +1693,10 @@ pub const JSGlobalObject = extern struct {
         return @ptrCast(*JSC.VirtualMachine, @alignCast(std.meta.alignment(JSC.VirtualMachine), this.bunVM_()));
     }
 
+    pub fn handleRejectedPromises(this: *JSGlobalObject) void {
+        return cppFn("handleRejectedPromises", .{this});
+    }
+
     pub fn startRemoteInspector(this: *JSGlobalObject, host: [:0]const u8, port: u16) bool {
         return cppFn("startRemoteInspector", .{ this, host, port });
     }
@@ -1755,6 +1759,7 @@ pub const JSGlobalObject = extern struct {
         "vm",
         "generateHeapSnapshot",
         "startRemoteInspector",
+        "handleRejectedPromises",
         // "createError",
         // "throwError",
     };

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -407,6 +407,7 @@ CPP_DECL bool JSC__JSGlobalObject__startRemoteInspector(JSC__JSGlobalObject* arg
 CPP_DECL JSC__StringPrototype* JSC__JSGlobalObject__stringPrototype(JSC__JSGlobalObject* arg0);
 CPP_DECL JSC__JSObject* JSC__JSGlobalObject__symbolPrototype(JSC__JSGlobalObject* arg0);
 CPP_DECL JSC__VM* JSC__JSGlobalObject__vm(JSC__JSGlobalObject* arg0);
+CPP_DECL void JSC__JSGlobalObject__handleRejectedPromises(JSC__JSGlobalObject* arg0);
 
 #pragma mark - WTF::URL
 

--- a/src/bun.js/bindings/headers.zig
+++ b/src/bun.js/bindings/headers.zig
@@ -212,6 +212,7 @@ pub extern fn JSC__JSGlobalObject__startRemoteInspector(arg0: ?*JSC__JSGlobalObj
 pub extern fn JSC__JSGlobalObject__stringPrototype(arg0: ?*JSC__JSGlobalObject) ?*bindings.StringPrototype;
 pub extern fn JSC__JSGlobalObject__symbolPrototype(arg0: ?*JSC__JSGlobalObject) [*c]JSC__JSObject;
 pub extern fn JSC__JSGlobalObject__vm(arg0: ?*JSC__JSGlobalObject) [*c]JSC__VM;
+pub extern fn JSC__JSGlobalObject__handleRejectedPromises(arg0: ?*JSC__JSGlobalObject) void;
 pub extern fn WTF__URL__encodedPassword(arg0: [*c]WTF__URL) bWTF__StringView;
 pub extern fn WTF__URL__encodedUser(arg0: [*c]WTF__URL) bWTF__StringView;
 pub extern fn WTF__URL__fileSystemPath(arg0: [*c]WTF__URL) bWTF__String;

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -437,16 +437,7 @@ pub const EventLoop = struct {
             ctx.is_us_loop_entered = false;
         }
 
-        // Deal with unhandled rejected promises.
-        var i: usize = 0;
-        while (i < ctx.unhandled_rejected_promises.items.len) : (i += 1) {
-            var promise = ctx.unhandled_rejected_promises.items[i];
-            if (promise.isHandled(this.global.vm())) {
-                continue;
-            }
-            const result = promise.result(this.global.vm());
-            ctx.runErrorHandler(result, null);
-        }
+        this.global.handleRejectedPromises();
     }
 
     // TODO: fix this technical debt

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -436,6 +436,17 @@ pub const EventLoop = struct {
             ctx.enterUWSLoop();
             ctx.is_us_loop_entered = false;
         }
+
+        // Deal with unhandled rejected promises.
+        var i: usize = 0;
+        while (i < ctx.unhandled_rejected_promises.items.len) : (i += 1) {
+            var promise = ctx.unhandled_rejected_promises.items[i];
+            if (promise.isHandled(this.global.vm())) {
+                continue;
+            }
+            const result = promise.result(this.global.vm());
+            ctx.runErrorHandler(result, null);
+        }
     }
 
     // TODO: fix this technical debt


### PR DESCRIPTION
fix #970, #953

This is a simpler version of `RejectedPromiseTracker` in WebKit, which will save the unhandled promises in a vector.

Thank you for your time on this PR :)
