### PR TITLE
fix appendFile permission

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -682,7 +682,7 @@ pub const PathOrFileDescriptor = union(Tag) {
 
 pub const FileSystemFlags = enum(Mode) {
     /// Open file for appending. The file is created if it does not exist.
-    @"a" = std.os.O.APPEND,
+    @"a" = std.os.O.APPEND | std.os.O.WRONLY | std.os.O.CREAT,
     /// Like 'a' but fails if the path exists.
     // @"ax" = std.os.O.APPEND | std.os.O.EXCL,
     /// Open file for reading and appending. The file is created if it does not exist.


### PR DESCRIPTION
fix #1020

man of `open` says:
> The argument flags must include one of the following access
modes: O_RDONLY, O_WRONLY, or O_RDWR.  These request opening the
file read-only, write-only, or read/write, respectively.

And in node's doc:
> 'a': Open file for appending. The file is created if it does not exist.
-- https://nodejs.org/api/fs.html#file-system-flags