### PR TITLE
Invalidate column name caches when the schema of table may change

### DIFF
--- a/src/bun.js/bindings/sqlite/JSSQLStatement.h
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.h
@@ -47,6 +47,13 @@
 
 namespace WebCore {
 
+class VersionSqlite3 {
+public:
+  explicit VersionSqlite3(sqlite3* db) : db(db), version(0) {}
+  sqlite3* db;
+  std::atomic<uint64_t> version;
+};
+
 class JSSQLStatementConstructor final : public JSC::JSFunction {
 public:
     using Base = JSC::JSFunction;
@@ -71,7 +78,8 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    Vector<sqlite3*> databases;
+    Vector<VersionSqlite3*> databases;
+    Vector<std::atomic<uint64_t>> schema_versions;
 
 private:
     JSSQLStatementConstructor(JSC::VM& vm, NativeExecutable* native, JSGlobalObject* globalObject, JSC::Structure* structure)


### PR DESCRIPTION
fix #921.

This won't affect the benchmark result. In my environment, the result of `bench/sqlite/bun.js` is:
before:
```
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
runtime: bun 0.1.8_debug (x64-linux)

benchmark                        time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------------- -----------------------------
SELECT * FROM "Order"         60.08 ms/iter    (55.76 ms … 62.9 ms)  61.04 ms   62.9 ms   62.9 ms
SELECT * FROM "Product"      139.96 µs/iter   (115.86 µs … 1.37 ms) 140.19 µs 210.96 µs 237.65 µs
SELECT * FROM "OrderDetail"  668.64 ms/iter (657.35 ms … 691.36 ms) 674.38 ms 691.36 ms 691.36 ms
```
after
```
benchmark                        time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------------- -----------------------------
SELECT * FROM "Order"         61.04 ms/iter   (57.15 ms … 62.79 ms)  61.53 ms  62.79 ms  62.79 ms
SELECT * FROM "Product"      142.77 µs/iter   (118.23 µs … 1.71 ms) 142.28 µs 216.04 µs 239.18 µs
SELECT * FROM "OrderDetail"  686.22 ms/iter (670.32 ms … 713.47 ms) 697.33 ms 713.47 ms 713.47 ms
```

Thank you for your time on this PR :)