### PR TITLE
Remove column name caches in js

### DIFF
--- a/src/bun.js/bindings/sqlite/sqlite.exports.js
+++ b/src/bun.js/bindings/sqlite/sqlite.exports.js
@@ -49,7 +49,6 @@ var controllers;
 export class Statement {
   constructor(raw) {
     this.#raw = raw;
-    this.#columns = undefined;
 
     switch (raw.paramsCount) {
       case 0: {
@@ -70,7 +69,6 @@ export class Statement {
   }
 
   #raw;
-  #columns;
 
   get;
   all;
@@ -164,7 +162,7 @@ export class Statement {
   }
 
   get columnNames() {
-    return (this.#columns ||= this.#raw.columns);
+    return this.#raw.columns;
   }
 
   get paramsCount() {


### PR DESCRIPTION
followup of #1056 . Forgot to check `stmt.columnNames`... Sorry about that...