### PR TITLE
Console log

### DIFF
--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -3072,7 +3072,7 @@ pub fn firstNonASCII16CheckMin_simd(comptime Slice: type, slice: Slice, comptime
     // here we handle what was left out
     if (remainder > 0) {
         i = slice.len - remainder;
-        while (i < remainder): (i += 1) {
+        while (i < slice.len): (i += 1) {
             const char = slice[i];
             if (char > max_u16_ascii[0] or char < min_u16_ascii[0]) {
                 return @intCast(u32, i);

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -3057,17 +3057,15 @@ pub fn firstNonASCII16CheckMin_simd(comptime Slice: type, slice: Slice, comptime
     var i: usize = 0;    
     while (i < remaining.len) : (i += ascii_u16_vector_size) {
         const mins: @Vector(ascii_u16_vector_size, u16) = remaining[i..][0..ascii_u16_vector_size].*;
-        // building a mask where @select works as an Or so we can check min and/or max
+        // building a mask where @select works as an OR so we can check min and/or max
         const mask: @Vector(ascii_u16_vector_size, bool) = if (comptime check_min) @select(bool, mins < min_u16_ascii, @splat(ascii_u16_vector_size, true), mins > max_u16_ascii) else mins > max_u16_ascii; 
-        // we keep all indices that the mask has True in it.
+        // we keep all indices that the mask has TRUE in it.
         const nonascii_indices  = @select(usize,  mask, indices, @splat(ascii_u16_vector_size, slice.len + 2));
-        // counting all tues to know if any isn't ascii
-        const trues = @reduce(.Add, @select(usize, mask, @splat(ascii_u16_vector_size, @as(usize, 1)), @splat(ascii_u16_vector_size, @as(usize, 0))));
 
-        if (trues > 0) {
-            // if any return the first index
+        // checking if any element on mask is TRUE
+        if (@reduce(.Or, mask)) {
             return @intCast(u32, @reduce(.Min, nonascii_indices));
-        }
+        } 
 
         indices += increment;
     }


### PR DESCRIPTION
Helps on this issue: https://github.com/oven-sh/bun/issues/188
One big difference with node is the amount of stuff printed out, bun prints what node would with JSON.stringify
Code snippet used to quickly compare
```zig
pub const max_u16_ascii = @splat(8, @as(u16, 127));
pub const min_u16_ascii = @splat(8, @as(u16, 0x20));

pub fn toUTF16Literal(comptime str: []const u8) []const u16 {
    comptime {
        comptime var output: [str.len]u16 = undefined;

        for (str) |c, i| {
            output[i] = c;
        }

        const Static = struct {
            pub const literal: []const u16 = output[0..];
        };

        return Static.literal;
    }
}

pub fn simd_double_loop(slice: []const u16) ?u32 {
    const VECTOR_SIZE:usize = 8;
    const remainder:usize = slice.len % VECTOR_SIZE;
    
    const remaining = if (remainder != 0) slice[0..slice.len - remainder] else slice;

    var indices: @Vector(VECTOR_SIZE, usize) = std.simd.iota(usize, VECTOR_SIZE);
    const increment:  @Vector(VECTOR_SIZE, usize) =  @splat(VECTOR_SIZE, VECTOR_SIZE);
    var i: usize = 0;
    while (i < remaining.len) : (i += VECTOR_SIZE) {
        const mins: @Vector(VECTOR_SIZE, u16) = remaining[i..][0..VECTOR_SIZE].*;
        const mask: @Vector(VECTOR_SIZE, bool) = @select(bool, mins < min_u16_ascii, @splat(VECTOR_SIZE, true), mins > max_u16_ascii); 
        const min_indices  = @select(usize,  mask, indices, @splat(VECTOR_SIZE, ~@as(usize, 0)));

        if (@reduce(.Or, mask)) {
            return @intCast(u32, @reduce(.Min, min_indices));
        }

        indices += increment;        
    }

    if (remainder > 0) {
        i = slice.len - remainder;
        while (i < remainder): (i += 1) {
            const char = slice[i];
            if (char > max_u16_ascii[0] or char < min_u16_ascii[0]) {
                return @intCast(u32, i);
            }
        }
    }
    return null;
}

pub fn simd_single_loop(slice: []const u16) ?u32 {
    var remaining = slice;
    const end_ptr = remaining.ptr + remaining.len - (remaining.len % 8);
    if (remaining.len > 8) {
        const remaining_start = remaining.ptr;
        while (remaining.ptr != end_ptr) {
            const vec: @Vector(8, u16) = remaining[0..8].*;
            const max_value = @reduce(.Max, vec);

            // by using @reduce here, we make it only do one comparison
            // @reduce doesn't tell us the index though
            const min_value = @reduce(.Min, vec);
            if (min_value < 0x20 or max_value > 127) {
                remaining.len -= (@ptrToInt(remaining.ptr) - @ptrToInt(remaining_start)) / 2;

                // this is really slow
                // it does it element-wise for every single u8 on the vector
                // instead of doing the SIMD instructions
                // it removes a loop, but probably is slower in the end
                const cmp = @bitCast(@Vector(8, u1), vec > max_u16_ascii) |
                    @bitCast(@Vector(8, u1), vec < min_u16_ascii);
                const bitmask: u16 = @ptrCast(*const u16, &cmp).*;
                const first = @ctz(u16, bitmask);

                return @intCast(u32, @as(u32, first) +
                    @intCast(u32, slice.len - remaining.len));
            }
            remaining.ptr += 8;
        }
        remaining.len -= (@ptrToInt(remaining.ptr) - @ptrToInt(remaining_start)) / 2;
    }
    return null;
}

const std = @import("std");
pub fn main() anyerror!void {
    @setEvalBranchQuota(99999);
    const input = std.mem.span(toUTF16Literal("aspdokasdpokasdpokasd aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasd  aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasd aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasd aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123"));

    var timer = std.time.Timer.start() catch unreachable;
    _ = simd_double_loop(input);
    std.debug.print("simd Double Loop took {}\n", .{std.fmt.fmtDuration(timer.lap())});

    _ = simd_single_loop(input);
    std.debug.print("simd Single Loop took {}\n", .{std.fmt.fmtDuration(timer.lap())});
}
```
