### PR TITLE
chore: fix bun-tools location in macOSx Zig instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3400,7 +3400,7 @@ To install the zig binary:
 
 ```bash
 # Custom path for the custom zig install
-mkdir -p ~/.bun-tools
+mkdir -p $HOME/.bun-tools
 
 # Requires jq & grab latest binary
 curl -o zig.tar.gz -sL https://github.com/oven-sh/zig/releases/download/jul1/zig-macos-$(uname -m).tar.gz
@@ -3409,7 +3409,7 @@ curl -o zig.tar.gz -sL https://github.com/oven-sh/zig/releases/download/jul1/zig
 tar -xvf zig.tar.gz -C $HOME/.bun-tools/
 
 # Make sure it gets trusted
-xattr -dr com.apple.quarantine .bun-tools/zig/zig
+xattr -dr com.apple.quarantine $HOME/.bun-tools/zig/zig
 ```
 
 Now you'll need to add Zig to your PATH.


### PR DESCRIPTION
- explicitly refer to `$HOME` bash variable in the examples. 
- Add missing `$HOME` reference