### PR TITLE
Fix clearTimeout and linux timeout

### DIFF
--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -2188,8 +2188,6 @@ pub const Timer = struct {
                     this.io_task.?.deinit();
                     var task = Timeout.TimeoutTask.createOnJSThread(VirtualMachine.vm.allocator, global, this) catch unreachable;
                     VirtualMachine.vm.timer.timeouts.put(VirtualMachine.vm.allocator, this.id, this) catch unreachable;
-                    VirtualMachine.vm.timer.active +|= 1;
-                    VirtualMachine.vm.active_tasks +|= 1;
                     this.io_task = task;
                     task.schedule();
                 }
@@ -2198,6 +2196,13 @@ pub const Timer = struct {
 
                 if (this.repeat)
                     return;
+
+                VirtualMachine.vm.timer.active -|= 1;
+                VirtualMachine.vm.active_tasks -|= 1;
+            } else {
+                // the active tasks count is already cleared for canceled timeout,
+                // add one here to neutralize the `-|= 1` in event loop.
+                VirtualMachine.vm.active_tasks +|= 1;
             }
 
             this.clear(global);
@@ -2214,8 +2219,6 @@ pub const Timer = struct {
                 task.deinit();
             }
             VirtualMachine.vm.allocator.destroy(this);
-            VirtualMachine.vm.timer.active -|= 1;
-            VirtualMachine.vm.active_tasks -|= 1;
         }
     };
 
@@ -2270,6 +2273,9 @@ pub const Timer = struct {
         if (comptime is_bindgen) unreachable;
         var timer: *Timeout = VirtualMachine.vm.timer.timeouts.get(id.toInt32()) orelse return;
         timer.cancelled = true;
+        VirtualMachine.vm.timer.active -|= 1;
+        // here we also remove the active task count added in event_loop.
+        VirtualMachine.vm.active_tasks -|= 2;
     }
 
     pub fn clearTimeout(

--- a/src/io/io_linux.zig
+++ b/src/io/io_linux.zig
@@ -769,7 +769,7 @@ pub const Completion = struct {
             },
             .timeout => {
                 var op = &completion.operation.timeout;
-                linux.io_uring_prep_timeout(sqe, &op.timespec, 1, 0);
+                linux.io_uring_prep_timeout(sqe, &op.timespec, 0, 0);
             },
             .write => |op| {
                 linux.io_uring_prep_write(


### PR DESCRIPTION
fix #1135

It seems that there were lots of bugs for `setTimeout`/`setInterval`. So I'll try to clarify what I'm trying to do in this PR, in case it introduces some new bugs :p

The rationale is, for each timeout event, the `vm.active_tasks` will be added twice:
- one in event loop, just like any other `IOTask` (`IOTask.createOnJSThread`);
- the other in `Timer.set`, which is an additional count for timer.

`active_tasks` will prevent bun from exit: bun will loop to wait until `active_task` is zero.

And correpsond to the 2 add, there will be 2 minus:
- one in event loop, when a task is finished, event loop will minus 1 to `active_task`
- the other in `Timer`, when a timer is triggered, and it won't happen again, `active_task` need to be `-|= 1`ed.

The reason timer events need 2 adds instead of 1 is that, when a timer event  will repeat, we can just not do the second minus and keep bun alive.

There were several problem with the origin implementation.
- when clear the timeout (`clearTimer`), we should do `-|= 2`, so that bun could exit immediately. Instead, currently it only set `timer.cancelled` to `true`.
- no need to add to `active_task` when repeating, not minusing is good enough, otherwise, the `setInterval` cannot be cancelled.

And in this pr, I changed the code into:
- `active_tasks -|= 2` in `clearTimer`
- don't `active_tasks +|= 1` for repeat timer
- don't `active_tasks -|= 1` in `clear`, as the timer may be canceled already.

Also, for linux timeout, we should not set the count field in `io_uring_prep_timeout`, as it has a special function. For more information, please check: https://github.com/axboe/liburing/issues/232

Thank you for your time on this PR :)