### PR TITLE
feat: hack in support for tsconfig `extends`

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2698,7 +2698,7 @@ pub const Resolver = struct {
                     break :brk null;
                 };
                 if (info.tsconfig_json) |tsconfig_json| {
-                    var parentConfigs = std.ArrayList(*TSConfigJSON).init(r.allocator);
+var parent_configs = std.BoundedArray(*TSConfigJSON, 64);
                     defer parentConfigs.deinit();
                     try parentConfigs.append(tsconfig_json);
                     var current = tsconfig_json;

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2703,39 +2703,39 @@ pub const Resolver = struct {
                     try parent_configs.append(tsconfig_json);
                     var current = tsconfig_json;
                     while (current.extends.len > 0) {
-                        var tsDirName = Dirname.dirname(current.abs_path);
+                        var ts_dir_name = Dirname.dirname(current.abs_path);
                         // not sure why this needs cwd but we'll just pass in the dir of the tsconfig...
-                        var absPath = ResolvePath.joinAbsStringBuf(tsDirName, &tsconfig_path_abs_buf, &[_]string{ tsDirName, current.extends }, .auto);
-                        var parentConfigMaybe = try r.parseTSConfig(absPath, 0);
-                        if (parentConfigMaybe) |parentConfig| {
-                            try parentConfigs.append(parentConfig);
-                            current = parentConfig;
+                        var abs_path = ResolvePath.joinAbsStringBuf(ts_dir_name, &tsconfig_path_abs_buf, &[_]string{ ts_dir_name, current.extends }, .auto);
+                        var parent_config_maybe = try r.parseTSConfig(abs_path, 0);
+                        if (parent_config_maybe) |parent_config| {
+                            try parent_configs.append(parent_config);
+                            current = parent_config;
                         } else {
                             break;
                         }
                     }
 
-                    var mergedConfig = parentConfigs.pop();
+                    var merged_config = parent_configs.pop();
                     // starting from the base config (end of the list)
                     // successively apply the inheritable attributes to the next config
-                    while (parentConfigs.popOrNull()) |parentConfig| {
-                        if (parentConfig.base_url.len > 0) {
-                            mergedConfig.base_url = parentConfig.base_url;
-                            mergedConfig.base_url_for_paths = parentConfig.base_url_for_paths;
+                    while (parent_configs.popOrNull()) |parent_config| {
+                        if (parent_config.base_url.len > 0) {
+                            merged_config.base_url = parent_config.base_url;
+                            merged_config.base_url_for_paths = parent_config.base_url_for_paths;
                         }
-                        mergedConfig.jsx = parentConfig.mergeJSX(mergedConfig.jsx);
+                        merged_config.jsx = parent_config.mergeJSX(merged_config.jsx);
 
-                        if (parentConfig.preserve_imports_not_used_as_values) |value| {
-                            mergedConfig.preserve_imports_not_used_as_values = value;
+                        if (parent_config.preserve_imports_not_used_as_values) |value| {
+                            merged_config.preserve_imports_not_used_as_values = value;
                         }
 
-                        var iter = parentConfig.paths.iterator();
+                        var iter = parent_config.paths.iterator();
                         while (iter.next()) |c| {
-                            mergedConfig.paths.put(c.key_ptr.*, c.value_ptr.*) catch unreachable;
+                            merged_config.paths.put(c.key_ptr.*, c.value_ptr.*) catch unreachable;
                         }
                         // todo deinit these parent configs somehow?
                     }
-                    info.tsconfig_json = mergedConfig;
+                    info.tsconfig_json = merged_config;
                 }
                 info.enclosing_tsconfig_json = info.tsconfig_json;
             }

--- a/src/resolver/tsconfig_json.zig
+++ b/src/resolver/tsconfig_json.zig
@@ -33,6 +33,7 @@ pub const TSConfigJSON = struct {
     // More info: https://github.com/microsoft/TypeScript/issues/31869
     base_url_for_paths: string = "",
 
+    extends: ?string = null,
     // The verbatim values of "compilerOptions.paths". The keys are patterns to
     // match and the values are arrays of fallback paths to search. Each key and
     // each fallback path can optionally have a single "*" wildcard character.
@@ -49,7 +50,7 @@ pub const TSConfigJSON = struct {
 
     use_define_for_class_fields: ?bool = null,
 
-    preserve_imports_not_used_as_values: bool = false,
+    preserve_imports_not_used_as_values: ?bool = false,
 
     pub fn hasBaseURL(tsconfig: *const TSConfigJSON) bool {
         return tsconfig.base_url.len > 0;
@@ -108,18 +109,10 @@ pub const TSConfigJSON = struct {
         errdefer allocator.free(result.paths);
         if (json.asProperty("extends")) |extends_value| {
             if (!source.path.isNodeModule()) {
-                log.addWarning(&source, extends_value.loc, "\"extends\" is not implemented yet") catch unreachable;
+                if (extends_value.expr.asString(allocator) orelse null) |str| {
+                    result.extends = str;
+                }
             }
-            // if ((extends_value.expr.asString(allocator) catch null)) |str| {
-            //     if (extends(str, source.rangeOfString(extends_value.loc))) |base| {
-            //         result.jsx = base.jsx;
-            //         result.base_url_for_paths = base.base_url_for_paths;
-            //         result.use_define_for_class_fields = base.use_define_for_class_fields;
-            //         result.preserve_imports_not_used_as_values = base.preserve_imports_not_used_as_values;
-            //         //  https://github.com/microsoft/TypeScript/issues/14527#issuecomment-284948808
-            //         result.paths = base.paths;
-            //     }
-            // }
         }
         var has_base_url = false;
 

--- a/src/resolver/tsconfig_json.zig
+++ b/src/resolver/tsconfig_json.zig
@@ -33,7 +33,7 @@ pub const TSConfigJSON = struct {
     // More info: https://github.com/microsoft/TypeScript/issues/31869
     base_url_for_paths: string = "",
 
-    extends: ?string = null,
+    extends: string = "",
     // The verbatim values of "compilerOptions.paths". The keys are patterns to
     // match and the values are arrays of fallback paths to search. Each key and
     // each fallback path can optionally have a single "*" wildcard character.


### PR DESCRIPTION
https://github.com/oven-sh/bun/issues/72

I will preface this PR by saying this is my first time touching Zig, so this code needs some work, but it does two things:

- Fixes a bug with tsconfig `paths` that are purely a wildcard prefix (i.e, `'*': ["foo/*"]`), these previously caused a segfault while trying to slice the key.
- Handle `extends` when the property is encountered in a tsconfig. We look up all parent tsconfigs until we hit the base config, then apply the tsconfigs starting from the base to generate a merged tsconfig. 

The solution really needs some caching and memoization so that we don't keep reading and reparsing parent tsconfigs. But I think this is at odds with how Bun currently stores tsconfigs on DirEntry objects. I think there needs to be a dedicated cache of TsConfigJSONs, which includes both the DirEntry tsconfigs as well as ones referenced by `extends`.