### PR TITLE
fix: broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1895,7 +1895,7 @@ db.query("SELECT * FROM foo WHERE greeting = $greeting").get({
 
 ### bun:sqlite Benchmark
 
-Database: [Northwind Traders](https://github.com/jpwhite3/northwind-SQLite3/blob/master/Northwind_large.sqlite.zip).
+Database: [Northwind Traders](https://github.com/jpwhite3/northwind-SQLite3/blob/46d5f8a64f396f87cd374d1600dbf521523980e8/Northwind_large.sqlite.zip).
 
 This benchmark can be run from [./bench/sqlite](./bench/sqlite).
 
@@ -2924,7 +2924,7 @@ const out = encode_png(
 );
 ```
 
-The [auto-generated wrapper](https://github.com/oven-sh/bun/blob/c6d732eee2721cd6191672cbe2c57fb17c3fffe4/src/bun.js/ffi.exports.js#L146-L148) converts the pointer to a TypedArray
+The [auto-generated wrapper](https://github.com/oven-sh/bun/blob/6a65631cbdcae75bfa1e64323a6ad613a922cd1a/src/bun.js/ffi.exports.js#L180-L182) converts the pointer to a TypedArray
 
 <details>
 
@@ -3023,7 +3023,7 @@ require("./my-node-module.node");
 import.meta.require("./my-node-module.node");
 ```
 
-Bun doesn't currently support dynamic requires, but `import.meta.require` is an escape hatch for that. It uses a [JavaScriptCore built-in function](https://github.com/oven-sh/bun/blob/aa87d40f4b7fdfb52575f44d151906ddba6a82d0/src/bun.js/bindings/builtins/js/JSZigGlobalObject.js#L26).
+Bun doesn't currently support dynamic requires, but `import.meta.require` is an escape hatch for that. It uses a [JavaScriptCore built-in function](https://github.com/oven-sh/bun/blob/aa87d40f4b7fdfb52575f44d151906ddba6a82d0/src/javascript/jsc/bindings/builtins/js/JSZigGlobalObject.js#L26).
 
 ### `Bun.Transpiler`
 


### PR DESCRIPTION
## Description
When viewing the DB benchmark, I noticed the link `404`'d. After running bun through [markdown-link-check](https://github.com/tcort/markdown-link-check), I found 3 dead links.

### DB Link
Found the commit SHA that the `curl` command downloads (in the [download.sh](https://github.com/oven-sh/bun/blob/main/bench/sqlite/src/download.sh#L8) file)

### Pointer Conversion
Used `git log -L '/val instanceof ArrayBuffer/,+1:src/bun.js/ffi.exports.js'` to find commit 98393ca to change the referenced lines

### Dynamic Requires
This one is just odd, not exactly sure what happened there. But the link now works (insert shrug emote here)?

----

**Let me know if any of these updated links are wrong and I'll take another pass at em!**