### PR TITLE
fix: added shell function to STRIP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ STRIP=/usr/bin/strip
 endif
 
 ifeq ($(OS_NAME),linux)
-STRIP=$(which llvm-strip || which llvm-strip-13 || which strip || echo "Missing strip")
+STRIP=$(shell which llvm-strip || which llvm-strip-13 || which strip || echo "Missing strip")
 endif
 
 


### PR DESCRIPTION
Without shell this error will occur:
```
s /build/bun/packages/bun-linux-x64/bun --wildcard -K _napi\*
/usr/bin/bash: s: command not found
```
With shell:
```
/usr/bin/llvm-strip-13 -s /build/bun/packages/bun-linux-x64/bun --wildcard -K _napi\*
```