### PR TITLE
Fix ffi uint64_t parameter

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2023,7 +2023,7 @@ JSC__JSValue JSC__JSValue__fromUInt64NoTruncate(JSC__JSGlobalObject* globalObjec
     return JSC::JSValue::encode(JSC::JSValue(JSC::JSBigInt::createFrom(globalObject, val)));
 }
 
-uint64_t JSC__JSValue__toUInt64NoTruncate(JSC__JSValue val)
+uint64_t JSC__JSValue__toUInt64NoTruncate(JSC__JSGlobalObject* arg0, JSC__JSValue val)
 {
     JSC::JSValue _val = JSC::JSValue::decode(val);
 

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -546,7 +546,7 @@ CPP_DECL JSC__JSValue JSC__JSValue__toPropertyKeyValue(JSC__JSValue JSValue0, JS
 CPP_DECL JSC__JSString* JSC__JSValue__toString(JSC__JSValue JSValue0, JSC__JSGlobalObject* arg1);
 CPP_DECL JSC__JSString* JSC__JSValue__toString(JSC__JSValue JSValue0, JSC__JSGlobalObject* arg1);
 CPP_DECL JSC__JSString* JSC__JSValue__toStringOrNull(JSC__JSValue JSValue0, JSC__JSGlobalObject* arg1);
-CPP_DECL uint64_t JSC__JSValue__toUInt64NoTruncate(JSC__JSValue JSValue0);
+CPP_DECL uint64_t JSC__JSValue__toUInt64NoTruncate(JSC__JSGlobalObject* arg0, JSC__JSValue JSValue0);
 CPP_DECL bWTF__String JSC__JSValue__toWTFString(JSC__JSValue JSValue0, JSC__JSGlobalObject* arg1);
 CPP_DECL void JSC__JSValue__toZigException(JSC__JSValue JSValue0, JSC__JSGlobalObject* arg1, ZigException* arg2);
 CPP_DECL void JSC__JSValue__toZigString(JSC__JSValue JSValue0, ZigString* arg1, JSC__JSGlobalObject* arg2);

--- a/src/bun.js/ffi.exports.js
+++ b/src/bun.js/ffi.exports.js
@@ -76,7 +76,7 @@ ffiWrappers[FFIType.uint32_t] = function uint32(val) {
 };
 ffiWrappers[FFIType.i64_fast] = function int64(val) {
   if (typeof val === "bigint") {
-    if (val < BigInt(Number.MAX_VALUE)) {
+    if (val <= BigInt(Number.MAX_SAFE_INTEGER) && val >= BigInt(-Number.MAX_SAFE_INTEGER)) {
       return Number(val).valueOf() || 0;
     }
 
@@ -88,7 +88,7 @@ ffiWrappers[FFIType.i64_fast] = function int64(val) {
 
 ffiWrappers[FFIType.u64_fast] = function u64_fast(val) {
   if (typeof val === "bigint") {
-    if (val < BigInt(Number.MAX_VALUE) && val > 0) {
+    if (val <= BigInt(Number.MAX_SAFE_INTEGER) && val >= 0) {
       return Number(val).valueOf() || 0;
     }
 
@@ -124,11 +124,9 @@ ffiWrappers[FFIType.uint64_t] = function uint64(val) {
 
 ffiWrappers[FFIType.u64_fast] = function u64_fast(val) {
   if (typeof val === "bigint") {
-    return val < BigInt(Number.MAX_VALUE)
-      ? val <= BigInt(0)
-        ? 0
-        : Number(val)
-      : val;
+    if (val <= BigInt(Number.MAX_SAFE_INTEGER) && val >= BigInt(0))
+      return Number(val);
+    return val;
   }
 
   return typeof val === "number" ? (val <= 0 ? 0 : +val || 0) : +val || 0;


### PR DESCRIPTION
There were 2 bugs:
- `JSC__JSValue__toUInt64NoTruncate` should have 2 arguments;
- should use `Number.MAX_SAFE_INTEGER` instead of `Number.MAX_VALUE` for upper bound of `int64_t` and `uint64_t`.