### PR TITLE
Support for NULL in ffi

### DIFF
--- a/src/bun.js/api/FFI.h
+++ b/src/bun.js/api/FFI.h
@@ -148,11 +148,17 @@ static bool JSVALUE_IS_NUMBER(EncodedJSValue val) {
 
 static void* JSVALUE_TO_PTR(EncodedJSValue val) {
   // must be a double
+  if (val.asInt64 == TagValueNull)
+    return 0;
   return (void*)(val.asInt64 - DoubleEncodeOffset);
 }
 
 static EncodedJSValue PTR_TO_JSVALUE(void* ptr) {
   EncodedJSValue val;
+  if (ptr == 0) {
+    val.asInt64 = TagValueNull;
+    return val;
+  }
   val.asInt64 = (int64_t)ptr + DoubleEncodeOffset;
   return val;
 }

--- a/src/bun.js/ffi.exports.js
+++ b/src/bun.js/ffi.exports.js
@@ -174,7 +174,7 @@ ffiWrappers[FFIType.cstring] = ffiWrappers[FFIType.pointer] = function pointer(
 ) {
   if (typeof val === "number") return val;
   if (!val) {
-    return 0;
+    return null;
   }
 
   if (ArrayBuffer.isView(val) || val instanceof ArrayBuffer) {

--- a/test/bun.js/ffi-test.c
+++ b/test/bun.js/ffi-test.c
@@ -118,6 +118,7 @@ void *getDeallocatorBuffer() {
 }
 int getDeallocatorCalledCount() { return deallocatorCalled; }
 
+bool is_null(int32_t *ptr) { return ptr == NULL; }
 bool does_pointer_equal_42_as_int32_t(int32_t *ptr);
 bool does_pointer_equal_42_as_int32_t(int32_t *ptr) { return *ptr == 42; }
 

--- a/test/bun.js/ffi.test.fixture.callback.c
+++ b/test/bun.js/ffi.test.fixture.callback.c
@@ -149,11 +149,17 @@ static bool JSVALUE_IS_NUMBER(EncodedJSValue val) {
 
 static void* JSVALUE_TO_PTR(EncodedJSValue val) {
   // must be a double
+  if (val.asInt64 == TagValueNull)
+    return 0;
   return (void*)(val.asInt64 - DoubleEncodeOffset);
 }
 
 static EncodedJSValue PTR_TO_JSVALUE(void* ptr) {
   EncodedJSValue val;
+  if (ptr == 0) {
+    val.asInt64 = TagValueNull;
+    return val;
+  }
   val.asInt64 = (int64_t)ptr + DoubleEncodeOffset;
   return val;
 }

--- a/test/bun.js/ffi.test.fixture.receiver.c
+++ b/test/bun.js/ffi.test.fixture.receiver.c
@@ -150,11 +150,17 @@ static bool JSVALUE_IS_NUMBER(EncodedJSValue val) {
 
 static void* JSVALUE_TO_PTR(EncodedJSValue val) {
   // must be a double
+  if (val.asInt64 == TagValueNull)
+    return 0;
   return (void*)(val.asInt64 - DoubleEncodeOffset);
 }
 
 static EncodedJSValue PTR_TO_JSVALUE(void* ptr) {
   EncodedJSValue val;
+  if (ptr == 0) {
+    val.asInt64 = TagValueNull;
+    return val;
+  }
   val.asInt64 = (int64_t)ptr + DoubleEncodeOffset;
   return val;
 }

--- a/test/bun.js/ffi.test.js
+++ b/test/bun.js/ffi.test.js
@@ -206,6 +206,11 @@ function getTypes(fast) {
       args: ["uint32_t", "uint32_t"],
     },
 
+    is_null: {
+      returns: "bool",
+      args: ["ptr"],
+    },
+
     does_pointer_equal_42_as_int32_t: {
       returns: "bool",
       args: ["ptr"],
@@ -338,6 +343,7 @@ function ffiRunner(types) {
       identity_ptr,
       add_uint32_t,
       add_uint64_t,
+      is_null,
       does_pointer_equal_42_as_int32_t,
       ptr_should_point_to_42_as_int32_t,
       cb_identity_true,
@@ -434,6 +440,7 @@ function ffiRunner(types) {
   expect(add_uint16_t(1, 1)).toBe(2);
   expect(add_uint32_t(1, 1)).toBe(2);
   Bun.gc(true);
+  expect(is_null(null)).toBe(true);
   const cptr = ptr_should_point_to_42_as_int32_t();
   expect(cptr != 0).toBe(true);
   expect(typeof cptr === "number").toBe(true);


### PR DESCRIPTION
A hacky way to support `NULL` in ffi. The origin problem is that we cannot have `(double)DoubleEncodeOffset` in js. Not sure if this is a good method...