### PR TITLE
update example react-is to v18(#1155)

### DIFF
--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@bun-examples/next",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "dependencies": {
     "next": "^12.2.0",
     "react": "^18",
     "react-dom": "^18",
-    "react-is": "^17.0.2"
+    "react-is": "^18"
   },
   "devDependencies": {
     "@types/react": "^18",


### PR DESCRIPTION
Sorry if there are any errors in the manner in which this is my first PR.
The version of `react-is` did not match React, which was in issue (#1155), so I had to do a `bun create` and then separately install the latest version.
This fix raises `react-is` to v18. Please check.

Fixes: #1155 