### PR TITLE
chore: Clean buffer C API

### DIFF
--- a/src/bun.js/bindings/Buffer.h
+++ b/src/bun.js/bindings/Buffer.h
@@ -13,13 +13,8 @@
 #include "headers-handwritten.h"
 
 extern "C" JSC::EncodedJSValue JSBuffer__bufferFromPointerAndLengthAndDeinit(JSC::JSGlobalObject* lexicalGlobalObject, char* ptr, unsigned int length, void* ctx, JSTypedArrayBytesDeallocator bytesDeallocator);
-extern "C" JSC::EncodedJSValue Bun__encoding__toStringUTF16(const uint8_t* input, size_t len, JSC::JSGlobalObject* globalObject);
+extern "C" JSC::EncodedJSValue Bun__encoding__toString(const uint8_t* input, size_t len, JSC::JSGlobalObject* globalObject, Encoding encoding);
 extern "C" JSC::EncodedJSValue Bun__encoding__toStringUTF8(const uint8_t* input, size_t len, JSC::JSGlobalObject* globalObject);
-extern "C" JSC::EncodedJSValue Bun__encoding__toStringASCII(const uint8_t* input, size_t len, JSC::JSGlobalObject* globalObject);
-extern "C" JSC::EncodedJSValue Bun__encoding__toStringLatin1(const uint8_t* input, size_t len, JSC::JSGlobalObject* globalObject);
-extern "C" JSC::EncodedJSValue Bun__encoding__toStringHex(const uint8_t* input, size_t len, JSC::JSGlobalObject* globalObject);
-extern "C" JSC::EncodedJSValue Bun__encoding__toStringBase64(const uint8_t* input, size_t len, JSC::JSGlobalObject* globalObject);
-extern "C" JSC::EncodedJSValue Bun__encoding__toStringURLSafeBase64(const uint8_t* input, size_t len, JSC::JSGlobalObject* globalObject);
 extern "C" void Bun__Buffer_fill(ZigString*, void*, size_t, WebCore::BufferEncodingType);
 
 namespace WebCore {

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -237,74 +237,43 @@ static EncodedJSValue constructFromEncoding(JSGlobalObject* lexicalGlobalObject,
     auto view = str->tryGetValue(lexicalGlobalObject);
     JSC::EncodedJSValue result;
 
-    switch (encoding) {
-    case WebCore::BufferEncodingType::utf8: {
-        if (view.is8Bit()) {
-            result = Bun__encoding__constructFromLatin1AsUTF8(lexicalGlobalObject, view.characters8(), view.length());
-        } else {
-            result = Bun__encoding__constructFromUTF16AsUTF8(lexicalGlobalObject, view.characters16(), view.length());
+    if (view.is8Bit()) {
+        switch (encoding) {
+        case WebCore::BufferEncodingType::utf8:
+        case WebCore::BufferEncodingType::ucs2:
+        case WebCore::BufferEncodingType::utf16le:
+        case WebCore::BufferEncodingType::base64:
+        case WebCore::BufferEncodingType::base64url:
+        case WebCore::BufferEncodingType::hex: {
+            result = Bun__encoding__constructFromLatin1(lexicalGlobalObject, view.characters8(), view.length(), static_cast<uint8_t>(encoding));
+            break;
         }
-        break;
-    }
-
-    case WebCore::BufferEncodingType::ascii: {
-        if (view.is8Bit()) {
-            // ascii is a noop for latin1
+        case WebCore::BufferEncodingType::ascii:     // ascii is a noop for latin1
+        case WebCore::BufferEncodingType::latin1: {  // The native encoding is latin1, so we don't need to do any conversion.
             result = JSBuffer__bufferFromPointerAndLength(lexicalGlobalObject, view.characters8(), view.length());
-        } else {
-            result = Bun__encoding__constructFromUTF16AsASCII(lexicalGlobalObject, view.characters16(), view.length());
+            break;
         }
-        break;
-    }
-    case WebCore::BufferEncodingType::latin1: {
-        if (view.is8Bit()) {
-            // The native encoding is latin1
-            // so we don't need to do any conversion.
-            result = JSBuffer__bufferFromPointerAndLength(lexicalGlobalObject, view.characters8(), view.length());
-        } else {
-            result = Bun__encoding__constructFromUTF16AsASCII(lexicalGlobalObject, view.characters16(), view.length());
         }
-        break;
-    }
-    case WebCore::BufferEncodingType::ucs2:
-    case WebCore::BufferEncodingType::utf16le: {
-        if (view.is8Bit()) {
-            result = Bun__encoding__constructFromLatin1AsUTF16(lexicalGlobalObject, view.characters8(), view.length());
-        } else {
+    } else {
+        switch (encoding) {
+        case WebCore::BufferEncodingType::utf8:
+        case WebCore::BufferEncodingType::base64:
+        case WebCore::BufferEncodingType::base64url:
+        case WebCore::BufferEncodingType::ascii:
+        case WebCore::BufferEncodingType::latin1: {
+            result = Bun__encoding__constructFromUTF16(lexicalGlobalObject, view.characters16(), view.length(), static_cast<uint8_t>(encoding));
+            break;
+        }
+        case WebCore::BufferEncodingType::ucs2:
+        case WebCore::BufferEncodingType::utf16le: {
             // The native encoding is UTF-16
             // so we don't need to do any conversion.
             result = JSBuffer__bufferFromPointerAndLength(lexicalGlobalObject, reinterpret_cast<const unsigned char*>(view.characters16()), view.length() * 2);
+            break;
         }
-        break;
+        }
     }
 
-    case WebCore::BufferEncodingType::base64: {
-        if (view.is8Bit()) {
-            result = Bun__encoding__constructFromLatin1AsBase64(lexicalGlobalObject, view.characters8(), view.length());
-        } else {
-            result = Bun__encoding__constructFromUTF16AsBase64(lexicalGlobalObject, view.characters16(), view.length());
-        }
-        break;
-    }
-
-    case WebCore::BufferEncodingType::base64url: {
-        if (view.is8Bit()) {
-            result = Bun__encoding__constructFromLatin1AsURLSafeBase64(lexicalGlobalObject, view.characters8(), view.length());
-        } else {
-            result = Bun__encoding__constructFromUTF16AsURLSafeBase64(lexicalGlobalObject, view.characters16(), view.length());
-        }
-        break;
-    }
-
-    case WebCore::BufferEncodingType::hex: {
-        if (view.is8Bit()) {
-            result = Bun__encoding__constructFromLatin1AsHex(lexicalGlobalObject, view.characters8(), view.length());
-        } else {
-            result = Bun__encoding__constructFromUTF16AsHex(lexicalGlobalObject, view.characters16(), view.length());
-        }
-        break;
-    }
-    }
     JSC::JSValue decoded = JSC::JSValue::decode(result);
     if (UNLIKELY(!result)) {
         throwTypeError(lexicalGlobalObject, scope, "An error occurred while decoding the string"_s);
@@ -430,57 +399,18 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_byteLengthBody(JSC
     int64_t written = 0;
 
     switch (encoding) {
-    case WebCore::BufferEncodingType::utf8: {
-        if (view.is8Bit()) {
-            written = Bun__encoding__byteLengthLatin1AsUTF8(view.characters8(), view.length());
-        } else {
-            written = Bun__encoding__byteLengthUTF16AsUTF8(view.characters16(), view.length());
-        }
-        break;
-    }
-
+    case WebCore::BufferEncodingType::utf8:
     case WebCore::BufferEncodingType::latin1:
-    case WebCore::BufferEncodingType::ascii: {
-        if (view.is8Bit()) {
-            written = Bun__encoding__byteLengthLatin1AsASCII(view.characters8(), view.length());
-        } else {
-            written = Bun__encoding__byteLengthUTF16AsASCII(view.characters16(), view.length());
-        }
-        break;
-    }
+    case WebCore::BufferEncodingType::ascii:
     case WebCore::BufferEncodingType::ucs2:
-    case WebCore::BufferEncodingType::utf16le: {
-        if (view.is8Bit()) {
-            written = Bun__encoding__byteLengthLatin1AsUTF16(view.characters8(), view.length());
-        } else {
-            written = Bun__encoding__byteLengthUTF16AsUTF16(view.characters16(), view.length());
-        }
-        break;
-    }
-
-    case WebCore::BufferEncodingType::base64: {
-        if (view.is8Bit()) {
-            written = Bun__encoding__byteLengthLatin1AsBase64(view.characters8(), view.length());
-        } else {
-            written = Bun__encoding__byteLengthUTF16AsBase64(view.characters16(), view.length());
-        }
-        break;
-    }
-
-    case WebCore::BufferEncodingType::base64url: {
-        if (view.is8Bit()) {
-            written = Bun__encoding__byteLengthLatin1AsURLSafeBase64(view.characters8(), view.length());
-        } else {
-            written = Bun__encoding__byteLengthUTF16AsURLSafeBase64(view.characters16(), view.length());
-        }
-        break;
-    }
-
+    case WebCore::BufferEncodingType::utf16le:
+    case WebCore::BufferEncodingType::base64:
+    case WebCore::BufferEncodingType::base64url:
     case WebCore::BufferEncodingType::hex: {
         if (view.is8Bit()) {
-            written = Bun__encoding__byteLengthLatin1AsHex(view.characters8(), view.length());
+            written = Bun__encoding__byteLengthLatin1(view.characters8(), view.length(), static_cast<uint8_t>(encoding));
         } else {
-            written = Bun__encoding__byteLengthUTF16AsHex(view.characters16(), view.length());
+            written = Bun__encoding__byteLengthUTF16(view.characters16(), view.length(), static_cast<uint8_t>(encoding));
         }
         break;
     }
@@ -1205,40 +1135,19 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JS
     JSC::EncodedJSValue ret = 0;
 
     switch (encoding) {
-    case WebCore::BufferEncodingType::buffer:
-    case WebCore::BufferEncodingType::utf8: {
-        ret = Bun__encoding__toStringUTF8(castedThis->typedVector() + offset, length, lexicalGlobalObject);
-        break;
-    }
-
-    case WebCore::BufferEncodingType::ascii: {
-        ret = Bun__encoding__toStringASCII(castedThis->typedVector() + offset, length, lexicalGlobalObject);
-        break;
-    }
-
     case WebCore::BufferEncodingType::latin1: {
         ret = JSC::JSValue::encode(JSC::jsString(vm, WTF::StringImpl::create(reinterpret_cast<const UChar*>(castedThis->typedVector() + offset), length)));
         break;
     }
-
+    case WebCore::BufferEncodingType::buffer:
+    case WebCore::BufferEncodingType::utf8:
+    case WebCore::BufferEncodingType::ascii:
     case WebCore::BufferEncodingType::ucs2:
-    case WebCore::BufferEncodingType::utf16le: {
-        ret = Bun__encoding__toStringUTF16(castedThis->typedVector() + offset, length, lexicalGlobalObject);
-        break;
-    }
-
-    case WebCore::BufferEncodingType::base64: {
-        ret = Bun__encoding__toStringBase64(castedThis->typedVector() + offset, length, lexicalGlobalObject);
-        break;
-    }
-
-    case WebCore::BufferEncodingType::base64url: {
-        ret = Bun__encoding__toStringURLSafeBase64(castedThis->typedVector() + offset, length, lexicalGlobalObject);
-        break;
-    }
-
+    case WebCore::BufferEncodingType::utf16le:
+    case WebCore::BufferEncodingType::base64:
+    case WebCore::BufferEncodingType::base64url:
     case WebCore::BufferEncodingType::hex: {
-        ret = Bun__encoding__toStringHex(castedThis->typedVector() + offset, length, lexicalGlobalObject);
+        ret = Bun__encoding__toString(castedThis->typedVector() + offset, length, lexicalGlobalObject, static_cast<uint8_t>(encoding));
         break;
     }
     default: {
@@ -1324,57 +1233,18 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlo
     int64_t written = 0;
 
     switch (encoding) {
-    case WebCore::BufferEncodingType::utf8: {
-        if (view.is8Bit()) {
-            written = Bun__encoding__writeLatin1AsUTF8(view.characters8(), view.length(), castedThis->typedVector() + offset, length);
-        } else {
-            written = Bun__encoding__writeUTF16AsUTF8(view.characters16(), view.length(), castedThis->typedVector() + offset, length);
-        }
-        break;
-    }
-
+    case WebCore::BufferEncodingType::utf8:
     case WebCore::BufferEncodingType::latin1:
-    case WebCore::BufferEncodingType::ascii: {
-        if (view.is8Bit()) {
-            written = Bun__encoding__writeLatin1AsASCII(view.characters8(), view.length(), castedThis->typedVector() + offset, length);
-        } else {
-            written = Bun__encoding__writeUTF16AsASCII(view.characters16(), view.length(), castedThis->typedVector() + offset, length);
-        }
-        break;
-    }
+    case WebCore::BufferEncodingType::ascii:
     case WebCore::BufferEncodingType::ucs2:
-    case WebCore::BufferEncodingType::utf16le: {
-        if (view.is8Bit()) {
-            written = Bun__encoding__writeLatin1AsUTF16(view.characters8(), view.length(), castedThis->typedVector() + offset, length);
-        } else {
-            written = Bun__encoding__writeUTF16AsUTF16(view.characters16(), view.length(), castedThis->typedVector() + offset, length);
-        }
-        break;
-    }
-
-    case WebCore::BufferEncodingType::base64: {
-        if (view.is8Bit()) {
-            written = Bun__encoding__writeLatin1AsBase64(view.characters8(), view.length(), castedThis->typedVector() + offset, length);
-        } else {
-            written = Bun__encoding__writeUTF16AsBase64(view.characters16(), view.length(), castedThis->typedVector() + offset, length);
-        }
-        break;
-    }
-
-    case WebCore::BufferEncodingType::base64url: {
-        if (view.is8Bit()) {
-            written = Bun__encoding__writeLatin1AsURLSafeBase64(view.characters8(), view.length(), castedThis->typedVector() + offset, length);
-        } else {
-            written = Bun__encoding__writeUTF16AsURLSafeBase64(view.characters16(), view.length(), castedThis->typedVector() + offset, length);
-        }
-        break;
-    }
-
+    case WebCore::BufferEncodingType::utf16le:
+    case WebCore::BufferEncodingType::base64:
+    case WebCore::BufferEncodingType::base64url:
     case WebCore::BufferEncodingType::hex: {
         if (view.is8Bit()) {
-            written = Bun__encoding__writeLatin1AsHex(view.characters8(), view.length(), castedThis->typedVector() + offset, length);
+            written = Bun__encoding__writeLatin1(view.characters8(), view.length(), castedThis->typedVector() + offset, length, static_cast<uint8_t>(encoding));
         } else {
-            written = Bun__encoding__writeUTF16AsHex(view.characters16(), view.length(), castedThis->typedVector() + offset, length);
+            written = Bun__encoding__writeUTF16(view.characters16(), view.length(), castedThis->typedVector() + offset, length, static_cast<uint8_t>(encoding));
         }
         break;
     }

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -205,43 +205,13 @@ extern "C" const char* Bun__versions_zig;
 
 extern "C" void ZigString__free_global(const unsigned char* ptr, size_t len);
 
-extern "C" int64_t Bun__encoding__writeLatin1AsHex(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len);
-extern "C" int64_t Bun__encoding__writeUTF16AsHex(const UChar* ptr, size_t len, unsigned char* to, size_t other_len);
-extern "C" int64_t Bun__encoding__writeLatin1AsURLSafeBase64(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len);
-extern "C" int64_t Bun__encoding__writeUTF16AsURLSafeBase64(const UChar* ptr, size_t len, unsigned char* to, size_t other_len);
-extern "C" int64_t Bun__encoding__writeLatin1AsBase64(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len);
-extern "C" int64_t Bun__encoding__writeUTF16AsBase64(const UChar* ptr, size_t len, unsigned char* to, size_t other_len);
-extern "C" int64_t Bun__encoding__writeLatin1AsUTF16(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len);
-extern "C" int64_t Bun__encoding__writeUTF16AsUTF16(const UChar* ptr, size_t len, unsigned char* to, size_t other_len);
-extern "C" int64_t Bun__encoding__writeLatin1AsUTF8(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len);
-extern "C" int64_t Bun__encoding__writeUTF16AsUTF8(const UChar* ptr, size_t len, unsigned char* to, size_t other_len);
-extern "C" int64_t Bun__encoding__writeLatin1AsASCII(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len);
-extern "C" int64_t Bun__encoding__writeUTF16AsASCII(const UChar* ptr, size_t len, unsigned char* to, size_t other_len);
+extern "C" int64_t Bun__encoding__writeLatin1(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
+extern "C" int64_t Bun__encoding__writeUTF16(const UChar* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
 
-extern "C" size_t Bun__encoding__byteLengthLatin1AsHex(const unsigned char* ptr, size_t len);
-extern "C" size_t Bun__encoding__byteLengthUTF16AsHex(const UChar* ptr, size_t len);
-extern "C" size_t Bun__encoding__byteLengthLatin1AsURLSafeBase64(const unsigned char* ptr, size_t len);
-extern "C" size_t Bun__encoding__byteLengthUTF16AsURLSafeBase64(const UChar* ptr, size_t len);
-extern "C" size_t Bun__encoding__byteLengthLatin1AsBase64(const unsigned char* ptr, size_t len);
-extern "C" size_t Bun__encoding__byteLengthUTF16AsBase64(const UChar* ptr, size_t len);
-extern "C" size_t Bun__encoding__byteLengthLatin1AsUTF16(const unsigned char* ptr, size_t len);
-extern "C" size_t Bun__encoding__byteLengthUTF16AsUTF16(const UChar* ptr, size_t len);
-extern "C" size_t Bun__encoding__byteLengthLatin1AsUTF8(const unsigned char* ptr, size_t len);
-extern "C" size_t Bun__encoding__byteLengthUTF16AsUTF8(const UChar* ptr, size_t len);
-extern "C" size_t Bun__encoding__byteLengthLatin1AsASCII(const unsigned char* ptr, size_t len);
-extern "C" size_t Bun__encoding__byteLengthUTF16AsASCII(const UChar* ptr, size_t len);
+extern "C" size_t Bun__encoding__byteLengthLatin1(const unsigned char* ptr, size_t len, Encoding encoding);
+extern "C" size_t Bun__encoding__byteLengthUTF16(const UChar* ptr, size_t len, Encoding encoding);
 
-extern "C" int64_t Bun__encoding__constructFromLatin1AsHex(void*, const unsigned char* ptr, size_t len);
-extern "C" int64_t Bun__encoding__constructFromUTF16AsHex(void*, const UChar* ptr, size_t len);
-extern "C" int64_t Bun__encoding__constructFromLatin1AsURLSafeBase64(void*, const unsigned char* ptr, size_t len);
-extern "C" int64_t Bun__encoding__constructFromUTF16AsURLSafeBase64(void*, const UChar* ptr, size_t len);
-extern "C" int64_t Bun__encoding__constructFromLatin1AsBase64(void*, const unsigned char* ptr, size_t len);
-extern "C" int64_t Bun__encoding__constructFromUTF16AsBase64(void*, const UChar* ptr, size_t len);
-extern "C" int64_t Bun__encoding__constructFromLatin1AsUTF16(void*, const unsigned char* ptr, size_t len);
-extern "C" int64_t Bun__encoding__constructFromUTF16AsUTF16(void*, const UChar* ptr, size_t len);
-extern "C" int64_t Bun__encoding__constructFromLatin1AsUTF8(void*, const unsigned char* ptr, size_t len);
-extern "C" int64_t Bun__encoding__constructFromUTF16AsUTF8(void*, const UChar* ptr, size_t len);
-extern "C" int64_t Bun__encoding__constructFromLatin1AsASCII(void*, const unsigned char* ptr, size_t len);
-extern "C" int64_t Bun__encoding__constructFromUTF16AsASCII(void*, const UChar* ptr, size_t len);
+extern "C" int64_t Bun__encoding__constructFromLatin1(void*, const unsigned char* ptr, size_t len, Encoding encoding);
+extern "C" int64_t Bun__encoding__constructFromUTF16(void*, const UChar* ptr, size_t len, Encoding encoding);
 
 #endif

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -678,154 +678,103 @@ pub const TextDecoder = struct {
     }
 };
 
-/// This code is incredibly redundant
-/// We have different paths for creaitng a new buffer versus writing into an existing one
-/// That's mostly why all the duplication
-/// The majority of the business logic here is just shooting it off to the optimized functions
 pub const Encoder = struct {
-    export fn Bun__encoding__writeLatin1AsHex(input: [*]const u8, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU8(input, len, to, to_len, .hex);
+    export fn Bun__encoding__writeLatin1(input: [*]const u8, len: usize, to: [*]u8, to_len: usize, encoding: u8) i64 {
+        return switch (@intToEnum(JSC.Node.Encoding, encoding)) {
+            .utf8 => writeU8(input, len, to, to_len, .utf8),
+            .latin1 => writeU8(input, len, to, to_len, .ascii),
+            .ascii => writeU8(input, len, to, to_len, .ascii),
+            .ucs2 => writeU8(input, len, to, to_len, .utf16le),
+            .utf16le => writeU8(input, len, to, to_len, .utf16le),
+            .base64 => writeU8(input, len, to, to_len, .base64),
+            .base64url => writeU8(input, len, to, to_len, .base64url),
+            .hex => writeU8(input, len, to, to_len, .hex),
+            else => unreachable,
+        };
     }
-    export fn Bun__encoding__writeLatin1AsASCII(input: [*]const u8, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU8(input, len, to, to_len, .ascii);
+    export fn Bun__encoding__writeUTF16(input: [*]const u16, len: usize, to: [*]u8, to_len: usize, encoding: u8) i64 {
+        return switch (@intToEnum(JSC.Node.Encoding, encoding)) {
+            .utf8 => writeU16(input, len, to, to_len, .utf8),
+            .latin1 => writeU16(input, len, to, to_len, .ascii),
+            .ascii => writeU16(input, len, to, to_len, .ascii),
+            .ucs2 => writeU16(input, len, to, to_len, .utf16le),
+            .utf16le => writeU16(input, len, to, to_len, .utf16le),
+            .base64 => writeU16(input, len, to, to_len, .base64),
+            .base64url => writeU16(input, len, to, to_len, .base64url),
+            .hex => writeU16(input, len, to, to_len, .hex),
+            else => unreachable,
+        };
     }
-    export fn Bun__encoding__writeLatin1AsURLSafeBase64(input: [*]const u8, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU8(input, len, to, to_len, .base64url);
+    export fn Bun__encoding__byteLengthLatin1(input: [*]const u8, len: usize, encoding: u8) usize {
+        return switch (@intToEnum(JSC.Node.Encoding, encoding)) {
+            .utf8 => byteLengthU8(input, len, .hex),
+            .latin1 =>byteLengthU8(input, len, .ascii),
+            .ascii => byteLengthU8(input, len, .ascii),
+            .ucs2 =>byteLengthU8(input, len, .utf16le),
+            .utf16le => byteLengthU8(input, len, .utf16le),
+            .base64 => byteLengthU8(input, len, .base64),
+            .base64url => byteLengthU8(input, len, .base64url),
+            .hex => byteLengthU8(input, len, .hex),
+            else => unreachable,
+        };
     }
-    export fn Bun__encoding__writeLatin1AsUTF16(input: [*]const u8, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU8(input, len, to, to_len, .utf16le);
+    export fn Bun__encoding__byteLengthUTF16(input: [*]const u16, len: usize, encoding: u8) usize {
+        return switch (@intToEnum(JSC.Node.Encoding, encoding)) {
+            .utf8 => byteLengthU16(input, len, .hex),
+            .latin1 =>byteLengthU16(input, len, .ascii),
+            .ascii => byteLengthU16(input, len, .ascii),
+            .ucs2 =>byteLengthU16(input, len, .utf16le),
+            .utf16le => byteLengthU16(input, len, .utf16le),
+            .base64 => byteLengthU16(input, len, .base64),
+            .base64url => byteLengthU16(input, len, .base64url),
+            .hex => byteLengthU16(input, len, .hex),
+            else => unreachable,
+        };
     }
-    export fn Bun__encoding__writeLatin1AsUTF8(input: [*]const u8, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU8(input, len, to, to_len, JSC.Node.Encoding.utf8);
-    }
-    export fn Bun__encoding__writeLatin1AsBase64(input: [*]const u8, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU8(input, len, to, to_len, .base64);
-    }
-    export fn Bun__encoding__writeUTF16AsBase64(input: [*]const u16, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU16(input, len, to, to_len, .base64);
-    }
-    export fn Bun__encoding__writeUTF16AsHex(input: [*]const u16, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU16(input, len, to, to_len, .hex);
-    }
-    export fn Bun__encoding__writeUTF16AsURLSafeBase64(input: [*]const u16, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU16(input, len, to, to_len, .base64url);
-    }
-    export fn Bun__encoding__writeUTF16AsUTF16(input: [*]const u16, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU16(input, len, to, to_len, JSC.Node.Encoding.utf16le);
-    }
-    export fn Bun__encoding__writeUTF16AsUTF8(input: [*]const u16, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU16(input, len, to, to_len, .utf8);
-    }
-    export fn Bun__encoding__writeUTF16AsASCII(input: [*]const u8, len: usize, to: [*]u8, to_len: usize) i64 {
-        return writeU8(input, len, to, to_len, .ascii);
-    }
-
-    export fn Bun__encoding__byteLengthLatin1AsHex(input: [*]const u8, len: usize) usize {
-        return byteLengthU8(input, len, .hex);
-    }
-    export fn Bun__encoding__byteLengthLatin1AsASCII(input: [*]const u8, len: usize) usize {
-        return byteLengthU8(input, len, .ascii);
-    }
-    export fn Bun__encoding__byteLengthLatin1AsURLSafeBase64(input: [*]const u8, len: usize) usize {
-        return byteLengthU8(input, len, .base64url);
-    }
-    export fn Bun__encoding__byteLengthLatin1AsUTF16(input: [*]const u8, len: usize) usize {
-        return byteLengthU8(input, len, .utf16le);
-    }
-    export fn Bun__encoding__byteLengthLatin1AsUTF8(input: [*]const u8, len: usize) usize {
-        return byteLengthU8(input, len, .utf8);
-    }
-    export fn Bun__encoding__byteLengthLatin1AsBase64(input: [*]const u8, len: usize) usize {
-        return byteLengthU8(input, len, .base64);
-    }
-    export fn Bun__encoding__byteLengthUTF16AsBase64(input: [*]const u16, len: usize) usize {
-        return byteLengthU16(input, len, .base64);
-    }
-    export fn Bun__encoding__byteLengthUTF16AsHex(input: [*]const u16, len: usize) usize {
-        return byteLengthU16(input, len, .hex);
-    }
-    export fn Bun__encoding__byteLengthUTF16AsURLSafeBase64(input: [*]const u16, len: usize) usize {
-        return byteLengthU16(input, len, .base64url);
-    }
-    export fn Bun__encoding__byteLengthUTF16AsUTF16(input: [*]const u16, len: usize) usize {
-        return byteLengthU16(input, len, .utf16le);
-    }
-    export fn Bun__encoding__byteLengthUTF16AsUTF8(input: [*]const u16, len: usize) usize {
-        return byteLengthU16(input, len, .utf8);
-    }
-    export fn Bun__encoding__byteLengthUTF16AsASCII(input: [*]const u8, len: usize) usize {
-        return byteLengthU8(input, len, .ascii);
-    }
-
-    export fn Bun__encoding__constructFromLatin1AsHex(globalObject: *JSGlobalObject, input: [*]const u8, len: usize) JSValue {
-        var slice = constructFromU8(input, len, .hex);
+    export fn Bun__encoding__constructFromLatin1(globalObject: *JSGlobalObject, input: [*]const u8, len: usize, encoding: u8) JSValue {
+        var slice = switch (@intToEnum(JSC.Node.Encoding, encoding)) {
+            .hex => constructFromU8(input, len, .hex),
+            .ascii => constructFromU8(input, len, .ascii),
+            .base64url => constructFromU8(input, len, .base64url),
+            .utf16le => constructFromU8(input, len, .utf16le),
+            .ucs2 => constructFromU8(input, len, .utf16le),
+            .utf8 => constructFromU8(input, len, .utf8),
+            .base64 => constructFromU8(input, len, .base64),
+            else => unreachable,
+        };
         return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
     }
-    export fn Bun__encoding__constructFromLatin1AsASCII(globalObject: *JSGlobalObject, input: [*]const u8, len: usize) JSValue {
-        var slice = constructFromU8(input, len, .ascii);
-        return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
-    }
-    export fn Bun__encoding__constructFromLatin1AsURLSafeBase64(globalObject: *JSGlobalObject, input: [*]const u8, len: usize) JSValue {
-        var slice = constructFromU8(input, len, .base64url);
-        return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
-    }
-    export fn Bun__encoding__constructFromLatin1AsUTF16(globalObject: *JSGlobalObject, input: [*]const u8, len: usize) JSValue {
-        var slice = constructFromU8(input, len, .utf16le);
-        return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
-    }
-    export fn Bun__encoding__constructFromLatin1AsUTF8(globalObject: *JSGlobalObject, input: [*]const u8, len: usize) JSValue {
-        var slice = constructFromU8(input, len, JSC.Node.Encoding.utf8);
-        return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
-    }
-    export fn Bun__encoding__constructFromLatin1AsBase64(globalObject: *JSGlobalObject, input: [*]const u8, len: usize) JSValue {
-        var slice = constructFromU8(input, len, .base64);
-        return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
-    }
-    export fn Bun__encoding__constructFromUTF16AsBase64(globalObject: *JSGlobalObject, input: [*]const u16, len: usize) JSValue {
-        var slice = constructFromU16(input, len, .base64);
-        return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
-    }
-    export fn Bun__encoding__constructFromUTF16AsHex(globalObject: *JSGlobalObject, input: [*]const u16, len: usize) JSValue {
-        var slice = constructFromU16(input, len, .hex);
-        return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
-    }
-    export fn Bun__encoding__constructFromUTF16AsURLSafeBase64(globalObject: *JSGlobalObject, input: [*]const u16, len: usize) JSValue {
-        var slice = constructFromU16(input, len, .base64url);
-        return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
-    }
-    export fn Bun__encoding__constructFromUTF16AsUTF16(globalObject: *JSGlobalObject, input: [*]const u16, len: usize) JSValue {
-        var slice = constructFromU16(input, len, JSC.Node.Encoding.utf16le);
-        return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
-    }
-    export fn Bun__encoding__constructFromUTF16AsUTF8(globalObject: *JSGlobalObject, input: [*]const u16, len: usize) JSValue {
-        var slice = constructFromU16(input, len, .utf8);
-        return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
-    }
-    export fn Bun__encoding__constructFromUTF16AsASCII(globalObject: *JSGlobalObject, input: [*]const u16, len: usize) JSValue {
-        var slice = constructFromU16(input, len, .utf8);
+    export fn Bun__encoding__constructFromUTF16(globalObject: *JSGlobalObject, input: [*]const u16, len: usize, encoding: u8) JSValue {
+        var slice = switch (@intToEnum(JSC.Node.Encoding, encoding)) {
+            .base64 => constructFromU16(input, len, .base64),
+            .hex => constructFromU16(input, len, .hex),
+            .base64url => constructFromU16(input, len, .base64url),
+            .utf16le => constructFromU16(input, len, .utf16le),
+            .ucs2 => constructFromU16(input, len, .utf16le),
+            .utf8 => constructFromU16(input, len, .utf8),
+            .ascii => constructFromU16(input, len, .utf8),
+            else => unreachable,
+        };
         return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
     }
 
-    export fn Bun__encoding__toStringUTF16(input: [*]const u8, len: usize, globalObject: *JSC.JSGlobalObject) JSValue {
-        return toString(input, len, globalObject, JSC.Node.Encoding.utf16le);
-    }
+    // for SQL statement
     export fn Bun__encoding__toStringUTF8(input: [*]const u8, len: usize, globalObject: *JSC.JSGlobalObject) JSValue {
         return toString(input, len, globalObject, .utf8);
     }
-    export fn Bun__encoding__toStringASCII(input: [*]const u8, len: usize, globalObject: *JSC.JSGlobalObject) JSValue {
-        return toString(input, len, globalObject, .ascii);
-    }
 
-    export fn Bun__encoding__toStringHex(input: [*]const u8, len: usize, globalObject: *JSC.JSGlobalObject) JSValue {
-        return toString(input, len, globalObject, .hex);
-    }
-
-    export fn Bun__encoding__toStringBase64(input: [*]const u8, len: usize, globalObject: *JSC.JSGlobalObject) JSValue {
-        return toString(input, len, globalObject, .base64);
-    }
-
-    export fn Bun__encoding__toStringURLSafeBase64(input: [*]const u8, len: usize, globalObject: *JSC.JSGlobalObject) JSValue {
-        return toString(input, len, globalObject, .base64url);
+    export fn Bun__encoding__toString(input: [*]const u8, len: usize, globalObject: *JSC.JSGlobalObject, encoding: u8) JSValue {
+        return switch (@intToEnum(JSC.Node.Encoding, encoding)) {
+            .ucs2 => toString(input, len, globalObject, .utf16le),
+            .utf16le => toString(input, len, globalObject, .utf16le),
+            .buffer => toString(input, len, globalObject, .utf8),
+            .utf8 => toString(input, len, globalObject, .utf8),
+            .ascii => toString(input, len, globalObject, .ascii),
+            .hex => toString(input, len, globalObject, .hex),
+            .base64 => toString(input, len, globalObject, .base64),
+            .base64url => toString(input, len, globalObject, .base64url),
+            else => unreachable,
+        };
     }
 
     // pub fn writeUTF16AsUTF8(utf16: [*]const u16, len: usize, to: [*]u8, to_len: usize) callconv(.C) i32 {
@@ -1205,51 +1154,17 @@ pub const Encoder = struct {
 
     comptime {
         if (!JSC.is_bindgen) {
-            _ = Bun__encoding__writeLatin1AsHex;
-            _ = Bun__encoding__writeLatin1AsURLSafeBase64;
-            _ = Bun__encoding__writeLatin1AsUTF16;
-            _ = Bun__encoding__writeLatin1AsUTF8;
-            _ = Bun__encoding__writeLatin1AsBase64;
-            _ = Bun__encoding__writeUTF16AsBase64;
-            _ = Bun__encoding__writeUTF16AsHex;
-            _ = Bun__encoding__writeUTF16AsURLSafeBase64;
-            _ = Bun__encoding__writeUTF16AsUTF16;
-            _ = Bun__encoding__writeUTF16AsUTF8;
-            _ = Bun__encoding__writeLatin1AsASCII;
-            _ = Bun__encoding__writeUTF16AsASCII;
+            _ = Bun__encoding__writeLatin1;
+            _ = Bun__encoding__writeUTF16;
 
-            _ = Bun__encoding__byteLengthLatin1AsHex;
-            _ = Bun__encoding__byteLengthLatin1AsURLSafeBase64;
-            _ = Bun__encoding__byteLengthLatin1AsUTF16;
-            _ = Bun__encoding__byteLengthLatin1AsUTF8;
-            _ = Bun__encoding__byteLengthLatin1AsBase64;
-            _ = Bun__encoding__byteLengthUTF16AsBase64;
-            _ = Bun__encoding__byteLengthUTF16AsHex;
-            _ = Bun__encoding__byteLengthUTF16AsURLSafeBase64;
-            _ = Bun__encoding__byteLengthUTF16AsUTF16;
-            _ = Bun__encoding__byteLengthUTF16AsUTF8;
-            _ = Bun__encoding__byteLengthLatin1AsASCII;
-            _ = Bun__encoding__byteLengthUTF16AsASCII;
+            _ = Bun__encoding__byteLengthLatin1;
+            _ = Bun__encoding__byteLengthUTF16;
 
-            _ = Bun__encoding__toStringUTF16;
+            _ = Bun__encoding__toString;
             _ = Bun__encoding__toStringUTF8;
-            _ = Bun__encoding__toStringASCII;
-            _ = Bun__encoding__toStringHex;
-            _ = Bun__encoding__toStringBase64;
-            _ = Bun__encoding__toStringURLSafeBase64;
 
-            _ = Bun__encoding__constructFromLatin1AsHex;
-            _ = Bun__encoding__constructFromLatin1AsASCII;
-            _ = Bun__encoding__constructFromLatin1AsURLSafeBase64;
-            _ = Bun__encoding__constructFromLatin1AsUTF16;
-            _ = Bun__encoding__constructFromLatin1AsUTF8;
-            _ = Bun__encoding__constructFromLatin1AsBase64;
-            _ = Bun__encoding__constructFromUTF16AsBase64;
-            _ = Bun__encoding__constructFromUTF16AsHex;
-            _ = Bun__encoding__constructFromUTF16AsURLSafeBase64;
-            _ = Bun__encoding__constructFromUTF16AsUTF16;
-            _ = Bun__encoding__constructFromUTF16AsUTF8;
-            _ = Bun__encoding__constructFromUTF16AsASCII;
+            _ = Bun__encoding__constructFromLatin1;
+            _ = Bun__encoding__constructFromUTF16;
         }
     }
 };


### PR DESCRIPTION
This PR is trying to reduce the number of exposed C API for buffer. This could make us implement other classes like `StringDecoder` in a much simpler way, as well as reduce the binary size.