### PR TITLE
allow set proxy for github

### DIFF
--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -80,7 +80,9 @@ if [[ $target = darwin-x64 ]]; then
     fi
 fi
 
-github_repo="https://github.com/oven-sh/bun"
+GITHUB=${GITHUB-"https://github.com"}
+
+github_repo="$GITHUB/oven-sh/bun"
 
 if [[ $target = darwin-x64 ]]; then
     # If AVX2 isn't supported, use the -baseline build


### PR DESCRIPTION
in  china , github is blocked, we use https://ghproxy.com/ for proxy

for example
use
`wget https://ghproxy.com/https://github.com/stilleshan/ServerStatus/archive/master.zip`
instead of 
`wget https://github.com/stilleshan/ServerStatus/archive/master.zip`