### PR TITLE
export syntax error fix for exported enums and namespaces

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -17079,7 +17079,6 @@ fn NewParser_(
                             S.Local{
                                 .kind = .k_let,
                                 .decls = decls,
-                                .is_export = is_export,
                             },
                             stmt_loc,
                         ),


### PR DESCRIPTION
Removed setting `is_export` for variables used inside generated closures for enums and namespaces. Can be seen in esbuild as well: https://github.com/evanw/esbuild/blob/77194c8fd8026e8e9f09f4480d1be42aaa6fc09c/internal/js_parser/ts_parser.go#L1627

Fixes #1136 