### PR TITLE
feat(bun-landing): add cloudflare worker to rewrite install url

### DIFF
--- a/packages/bun-landing/README.md
+++ b/packages/bun-landing/README.md
@@ -23,3 +23,10 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 ```bash
 bun run build
 ```
+
+## Publishing `install-worker`
+
+```sh
+cd install-worker/
+npx --yes wrangler publish
+```

--- a/packages/bun-landing/install-worker/index.js
+++ b/packages/bun-landing/install-worker/index.js
@@ -1,0 +1,7 @@
+export default {
+  async fetch() {
+    return fetch(
+      "https://raw.githubusercontent.com/oven-sh/bun/HEAD/src/cli/install.sh"
+    );
+  },
+};

--- a/packages/bun-landing/install-worker/wrangler.toml
+++ b/packages/bun-landing/install-worker/wrangler.toml
@@ -1,0 +1,4 @@
+name = "bun-install"
+main = "index.js"
+route = "bun.sh/install"
+compatibility_date = "2022-09-19"


### PR DESCRIPTION
I'm assuming that the bun.sh domain is managed via Cloudflare

This is a Cloudflare worker that fetches the contents of `src/cli/install.sh` from GitHub when a request is sent to https://bun.sh/install

See the README in bun-landing for publishing the worker

Closes #1128

(This also means that changes to the install script update on the bun website immediately)