### PR TITLE
Fix namespace import

### DIFF
--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1765,7 +1765,7 @@ pub fn NewPrinter(
                         flags,
                     );
 
-                    if (p.canPrintIdentifier(e.name)) {
+                    if (!strings.containsNonBmpCodePoint(e.name)) {
                         if (!isOptionalChain and p.prev_num_end == p.writer.written) {
                             // "1.toString" is a syntax error, so print "1 .toString" instead
                             p.print(" ");

--- a/test/bun.js/transpiler.test.js
+++ b/test/bun.js/transpiler.test.js
@@ -1755,6 +1755,16 @@ class Foo {
       expect(out).toBe("import {ɵtest} from \"foo\";\n");
     });
 
+    it("special identifier in namespace import", () => {
+        const out = transpiler.transformSync(`
+            import * as ɵi from 'foo'
+            ɵi.ɵtest()
+        `);
+
+        expect(out).toBe("import * as ɵi from \"foo\";\nɵi.ɵtest();\n");
+    });
+
+
     const importLines = [
       "import {createElement, bacon} from 'react';",
       "import {bacon, createElement} from 'react';",


### PR DESCRIPTION
See #1306

From the issue comments:

```
1 | import * as i from './export'
2 |
3 | console.log(i.ɵtest())
               ^
TypeError: i["Éµtest"] is not a function. (In 'i["Éµtest"]()', 'i["Éµtest"]' is undefined)
```
with export.js containing:
```ts
export function ɵtest() {
  return 1;
};
```