### PR TITLE
Cache dir loader: Prefer `$BUN_INSTALL` and `$XDG_CACHE_HOME` to `$HOME`.

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2482,17 +2482,17 @@ pub const PackageManager = struct {
             return CacheDir{ .path = dir, .is_node_modules = false };
         }
 
-        if (env_loader.map.get("HOME")) |dir| {
-            var parts = [_]string{ dir, ".bun/", "install/", "cache/" };
-            return CacheDir{ .path = Fs.FileSystem.instance.abs(&parts), .is_node_modules = false };
-        }
-
         if (env_loader.map.get("BUN_INSTALL")) |dir| {
             var parts = [_]string{ dir, "install/", "cache/" };
             return CacheDir{ .path = Fs.FileSystem.instance.abs(&parts), .is_node_modules = false };
         }
 
         if (env_loader.map.get("XDG_CACHE_HOME")) |dir| {
+            var parts = [_]string{ dir, ".bun/", "install/", "cache/" };
+            return CacheDir{ .path = Fs.FileSystem.instance.abs(&parts), .is_node_modules = false };
+        }
+
+        if (env_loader.map.get("HOME")) |dir| {
             var parts = [_]string{ dir, ".bun/", "install/", "cache/" };
             return CacheDir{ .path = Fs.FileSystem.instance.abs(&parts), .is_node_modules = false };
         }


### PR DESCRIPTION
This partially addresses https://github.com/oven-sh/bun/issues/696 , by using `$XDG_CACHE_HOME` for those of us who already have that env var set.
