### PR TITLE
fix(fetch): stop `new Response(null)` from segfaulting

### DIFF
--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -4673,7 +4673,7 @@ pub const Body = struct {
         pub fn fromJS(globalThis: *JSGlobalObject, value: JSValue) ?Value {
             value.ensureStillAlive();
 
-            if (value.isEmpty() or value.isUndefined() or value.isNull()) {
+            if (value.isEmptyOrUndefinedOrNull()) {
                 return Body.Value{
                     .Empty = void{},
                 };

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -4673,17 +4673,10 @@ pub const Body = struct {
         pub fn fromJS(globalThis: *JSGlobalObject, value: JSValue) ?Value {
             value.ensureStillAlive();
 
-            if (value.isEmpty() or value.isUndefined()) {
+            if (value.isEmpty() or value.isUndefined() or value.isNull()) {
                 return Body.Value{
                     .Empty = void{},
                 };
-            }
-
-            if (value.isNull()) {
-                var null_str: [4]u8 = "null".*;
-
-                // this looks like a pointer to stack memory, but it will be copied
-                return Body.Value.createBlobValue(&null_str, undefined, true);
             }
 
             const js_type = value.jsType();


### PR DESCRIPTION
Fixes #1379 

Not sure why the previous code was there as it seems to try to pass `"null"` as the body passed into the `Response` which does not match the spec.  Simply check the behavior from the Chrome Dev tools:

```js
const res = new Response(null);
console.log(await res.text()); // ""
```