### PR TITLE
Update Dev Containers extension name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4419,7 +4419,7 @@ The VSCode Dev Container in this repository is the easiest way to get started. I
 To develop on Linux, the following is required:
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for Visual Studio Code
+- [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for Visual Studio Code
 - [Docker](https://www.docker.com). If using WSL on Windows, it is recommended to use [Docker Desktop](https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers) for its WSL2 integration.
 - [Dev Container CLI](https://www.npmjs.com/package/@devcontainers/cli): `npm install -g @devcontainers/cli`
 
@@ -4431,7 +4431,7 @@ make devcontainer-build
 ```
 
 Next, open VS Code in the `bun` repository.
-To open the dev container, open the command palette (Ctrl + Shift + P) and run: `Remote-Containers: Reopen in Container`.
+To open the dev container, open the command palette (Ctrl + Shift + P) and run: `Dev Containers: Reopen in Container`.
 
 You will then need to clone the GitHub repository inside that container.
 


### PR DESCRIPTION
It seems like the VS Code extension name has changed to Dev Containers, this updates the documentation to reflect that.