### PR TITLE
Fix check for ninja on Debian/Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -611,7 +611,7 @@ require:
 	@go version >/dev/null 2>&1 || (echo -e "ERROR: go is required."; exit 1)
 	@which aclocal > /dev/null || (echo -e  "ERROR: automake is required. Install with:\n\n    $(POSIX_PKG_MANAGER) install automake"; exit 1)
 	@which $(LIBTOOL) > /dev/null || (echo -e "ERROR: libtool is required. Install with:\n\n    $(POSIX_PKG_MANAGER) install libtool"; exit 1)
-	@which $(PKGNAME_NINJA) > /dev/null || (echo -e "ERROR: Ninja is required. Install with:\n\n    $(POSIX_PKG_MANAGER) install $(PKGNAME_NINJA)"; exit 1)
+	@which ninja > /dev/null || (echo -e "ERROR: Ninja is required. Install with:\n\n    $(POSIX_PKG_MANAGER) install $(PKGNAME_NINJA)"; exit 1)
 	@echo "You have the dependencies installed! Woo"
 
 init-submodules:


### PR DESCRIPTION
Even though the package is named ninja-build, the ninja binary is still named ninja, so use `which ninja` to check for it