### PR TITLE
Automatically install npm packages when running a script in Bun's runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -4513,7 +4513,8 @@ It will check the lockfile for the version. If the lockfile doesn't have a versi
 
 Lowlights:
 
-- TypeScript type support is not implmented yet.
+- TypeScript type support isn't implmented yet
+- patch package support isn't implemented yet
 
 #### Resolving packages
 
@@ -4575,14 +4576,14 @@ This only activates for "package paths". That is, paths that start with a packag
 
 Per-project `node_modules` folders are not necessary when using Bun. This saves you disk space and time spent copying/linking dependencies into `node_modules` folders for every project.
 
-| Runtime | require/import | in package | resolution                                               |
-| ------- | -------------- | ---------- | -------------------------------------------------------- |
-| Node.js | "react-dom"    | "react"    | `./node_modules/react-dom/index.js`                      |
-| Bun     | "react-dom"    | "react"    | `$BUN_INSTALL_CACHE/react-dom@${REACT_VERSION}/index.js` |
+| Runtime | require/import | in package | resolution                                             |
+| ------- | -------------- | ---------- | ------------------------------------------------------ |
+| Node.js | "react-dom"    | "react"    | `./node_modules/react-dom/index.js`                    |
+| Bun     | "react-dom"    | "react"    | `$BUN_INSTALL_CACHE_DIR/react-dom@${version}/index.js` |
 
 When multiple versions of a package are installed, Node.js relies on the directory tree structure to resolve the correct version.
 
-Bun uses bun's lockfile to figure out what the version SHOULD be and then installs it into the global cache if that version is not already installed.
+Bun uses bun's lockfile to figure out what the version SHOULD be and then installs it into the global cache (if that version is not already installed).
 
 With a dependency tree like this:
 

--- a/README.md
+++ b/README.md
@@ -4551,7 +4551,7 @@ This only activates for "package paths". That is, paths that start with a packag
 
 Do not rely on this particular directory structure to exist, it may change in the future and also using folders like this may change in the future too. Eventually, Bun will likely move to a binary archive format which will allow us to efficiently load dependencies from disk.
 
-#### FAQ
+#### Frequently asked questions
 
 **How is this different than what Node.js does?**
 
@@ -4567,7 +4567,7 @@ You can continue to use node_modules when vendoring dependencies for your projec
 
 **How is this different than what pnpm does?**
 
-You have to run `pnpm install`, which creates a `node_modules` folder of symlinks for the runtime to resolve.
+With pnpm, you have to run `pnpm install`, which creates a `node_modules` folder of symlinks for the runtime to resolve.
 
 With Bun, you don't have to run any commands to install dependencies. Bun doesn't create a `node_modules` folder.
 
@@ -4578,7 +4578,7 @@ Just run `bun run foo.js` and it will automatically install the dependencies for
 Two things:
 
 1. With yarn, you have to run `yarn install`. With Bun, you don't have to run any extra commands to install dependencies &amp; run them.
-2. Yarn Plug'N'Play [makes loading dependencies slower](https://twitter.com/jarredsumner/status/1458207919636287490) at runtime because under the hood, it uses zip files to store dependencies. zip files are not performant for random access reads. Today, Bun uses an ordinary folder so there is no performance hit. In the future, Bun will likely move to a [binary archive format](https://github.com/jarred-sumner/hop) designed for fast random access reads.
+2. Yarn Plug'N'Play [makes loading dependencies slower](https://twitter.com/jarredsumner/status/1458207919636287490) at runtime because under the hood, it uses zip files to store dependencies. zip files are not performant for random access reads. Today, Bun uses an ordinary folder so there is no performance hit. In the future, Bun will likely move to a [binary archive format](https://github.com/jarred-sumner/hop) designed for fast random access reads (which will likely make it faster than the filesystem)
 
 **How is this different than what Deno does?**
 

--- a/README.md
+++ b/README.md
@@ -4598,7 +4598,7 @@ With a dependency tree like this:
 
 To satisfy the Node.js Module Resolution algorithm, npm clients are forced to install the same version of `dep2` **multiple times for the same project**. This is because `dep2` is a dependency of `dep1` and `dep3`, and `dep3` depends on a different version of `dep2` than `dep1`.
 
-With Bun, the lockfile is used to resolve the correct version of `dep2` to use. This means that `dep2` only needs to be installed once and it will be reused for every project that depends on it.
+With Bun, the lockfile is used to resolve the correct version of `dep2` to use. This means that `dep2` only needs to be installed once and it will be reused for all projects on your computer that depend on it.
 
 ![image](https://user-images.githubusercontent.com/709451/198907459-710d5299-bac0-40d8-b630-8112d42900e1.png)
 

--- a/README.md
+++ b/README.md
@@ -4424,11 +4424,7 @@ If the library strictly uses ESM (excluding dependencies), specify `"type": "mod
 ```json
 {
   "name": "foo",
-  "type": "module",
-  "exports": {
-    "bun": "./index.bun.js",
-    "default": "./index.js"
-  }
+  "type": "module"
 }
 ```
 

--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -52,6 +52,7 @@ pub const Features = struct {
     pub var external = false;
     pub var fetch = false;
     pub var bunfig = false;
+    pub var extracted_packages = false;
 
     pub fn formatter() Formatter {
         return Formatter{};
@@ -79,6 +80,7 @@ pub const Features = struct {
                 "external",
                 "fetch",
                 "bunfig",
+                "extracted_packages",
             };
             inline for (fields) |field| {
                 if (@field(Features, field)) {

--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -325,7 +325,7 @@ static JSValue handleVirtualModuleResult(
     }
 }
 
-extern "C" void Bun__onFulfillPendingModule(
+extern "C" void Bun__onFulfillAsyncModule(
     EncodedJSValue promiseValue,
     ErrorableResolvedSource* res,
     ZigString* specifier,

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2419,12 +2419,22 @@ static void fromErrorInstance(ZigException* except, JSC::JSGlobalObject* global,
         if (JSC::JSValue sourceURL = obj->getIfPropertyExists(global, global->vm().propertyNames->sourceURL)) {
             except->stack.frames_ptr[0].source_url = Zig::toZigString(sourceURL, global);
 
-            if (JSC::JSValue line = obj->getIfPropertyExists(global, global->vm().propertyNames->line)) {
-                except->stack.frames_ptr[0].position.line = line.toInt32(global);
-            }
-
             if (JSC::JSValue column = obj->getIfPropertyExists(global, global->vm().propertyNames->column)) {
                 except->stack.frames_ptr[0].position.column_start = column.toInt32(global);
+            }
+
+            if (JSC::JSValue line = obj->getIfPropertyExists(global, global->vm().propertyNames->line)) {
+                except->stack.frames_ptr[0].position.line = line.toInt32(global);
+
+                if (JSC::JSValue lineText = obj->getIfPropertyExists(global, JSC::Identifier::fromString(global->vm(), "lineText"_s))) {
+                    if (JSC::JSString* jsStr = lineText.toStringOrNull(global)) {
+                        auto str = jsStr->value(global);
+                        except->stack.source_lines_ptr[0] = Zig::toZigString(str);
+                        except->stack.source_lines_numbers[0] = except->stack.frames_ptr[0].position.line;
+                        except->stack.source_lines_len = 1;
+                        except->remapped = true;
+                    }
+                }
             }
             except->stack.frames_len = 1;
         }

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2555,7 +2555,9 @@ pub const ZigConsoleClient = struct {
         _: usize,
         // args
         _: *ScriptArguments,
-    ) callconv(.C) void {}
+    ) callconv(.C) void {
+        
+    }
     pub fn profile(
         // console
         _: ZigConsoleClient.Type,

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -229,7 +229,7 @@ extern "C" JSC::EncodedJSValue Bun__runVirtualModule(
     JSC::JSGlobalObject* global,
     ZigString* specifier);
 
-extern "C" bool Bun__transpileFile(
+extern "C" void* Bun__transpileFile(
     void* bunVM,
     JSC::JSGlobalObject* global,
     ZigString* specifier,

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -234,7 +234,7 @@ extern "C" void* Bun__transpileFile(
     JSC::JSGlobalObject* global,
     ZigString* specifier,
     ZigString* referrer,
-    ErrorableResolvedSource* result);
+    ErrorableResolvedSource* result, bool allowPromise);
 
 extern "C" JSC::EncodedJSValue CallbackJob__onResolve(JSC::JSGlobalObject*, JSC::CallFrame*);
 extern "C" JSC::EncodedJSValue CallbackJob__onReject(JSC::JSGlobalObject*, JSC::CallFrame*);

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -183,6 +183,7 @@ pub const CppTask = opaque {
 const ThreadSafeFunction = JSC.napi.ThreadSafeFunction;
 const MicrotaskForDefaultGlobalObject = JSC.MicrotaskForDefaultGlobalObject;
 const HotReloadTask = JSC.HotReloader.HotReloadTask;
+const PollPendingModulesTask = JSC.ModuleLoader.PendingModule.Queue;
 // const PromiseTask = JSInternalPromise.Completion.PromiseTask;
 pub const Task = TaggedPointerUnion(.{
     FetchTasklet,
@@ -197,6 +198,7 @@ pub const Task = TaggedPointerUnion(.{
     ThreadSafeFunction,
     CppTask,
     HotReloadTask,
+    PollPendingModulesTask,
     // PromiseTask,
     // TimeoutTasklet,
 });

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -3343,13 +3343,7 @@ pub const ModuleLoader = struct {
         defer _specifier.deinit();
         var specifier = normalizeSpecifier(jsc_vm, _specifier.slice());
         const path = Fs.Path.init(specifier);
-        const loader = jsc_vm.bundler.options.loaders.get(path.name.ext) orelse brk: {
-            if (strings.eqlLong(specifier, jsc_vm.main, true)) {
-                break :brk options.Loader.js;
-            }
-
-            break :brk options.Loader.file;
-        };
+        const loader = jsc_vm.bundler.options.loaders.get(path.name.ext) orelse options.Loader.js;
         ret.* = ErrorableResolvedSource.ok(
             ModuleLoader.transpileSourceCode(
                 jsc_vm,

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -861,6 +861,7 @@ pub const VirtualMachine = struct {
             .success => |r| r,
             .failure => |e| e,
             .not_found => error.ModuleNotFound,
+            .pending => unreachable,
         };
 
         if (!jsc_vm.macro_mode) {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1969,7 +1969,7 @@ pub const ResolveError = struct {
     pub fn fmt(allocator: std.mem.Allocator, specifier: string, referrer: string, err: anyerror) !string {
         switch (err) {
             error.ModuleNotFound => {
-                if (Resolver.isPackagePath(specifier)) {
+                if (Resolver.isPackagePath(specifier) and !strings.containsChar(specifier, '/')) {
                     return try std.fmt.allocPrint(allocator, "Cannot find package \"{s}\" from \"{s}\"", .{ specifier, referrer });
                 } else {
                     return try std.fmt.allocPrint(allocator, "Cannot find module \"{s}\" from \"{s}\"", .{ specifier, referrer });

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -415,7 +415,7 @@ pub const VirtualMachine = struct {
 
     pub threadlocal var is_main_thread_vm: bool = false;
 
-    pub fn packageManager(this: *VirtualMachine) *PackageManager {
+    pub inline fn packageManager(this: *VirtualMachine) *PackageManager {
         return this.bundler.getPackageManager();
     }
 
@@ -639,7 +639,7 @@ pub const VirtualMachine = struct {
 
         vm.bundler.macro_context = null;
 
-        VirtualMachine.vm.bundler.onWakePackageManager = .{
+        VirtualMachine.vm.bundler.resolver.onWakePackageManager = .{
             .context = &VirtualMachine.vm.modules,
             .handler = ModuleLoader.AsyncModule.Queue.onWakeHandler,
         };
@@ -856,7 +856,7 @@ pub const VirtualMachine = struct {
             // TODO: do we need to handle things like query string params?
             if (strings.hasPrefixComptime(specifier, "file://")) specifier["file://".len..] else specifier,
             .stmt,
-            .enable_but_no_install,
+            .read_only,
         )) {
             .success => |r| r,
             .failure => |e| e,

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -621,8 +621,8 @@ pub const ModuleLoader = struct {
             const name: []const u8 = switch (result.err) {
                 error.NoMatchingVersion => "PackageVersionNotFound",
                 error.DistTagNotFound => "PackageTagNotFound",
-                error.PackageManifestHTTP403 => "PackageForbiddenError",
-                error.PackageManifestHTTP404 => "PackageNotFoundError",
+                error.PackageManifestHTTP403 => "PackageForbidden",
+                error.PackageManifestHTTP404 => "PackageNotFound",
                 else => "PackageResolveError",
             };
 

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -1,0 +1,1699 @@
+const std = @import("std");
+const is_bindgen: bool = std.meta.globalOption("bindgen", bool) orelse false;
+const StaticExport = @import("./bindings/static_export.zig");
+const c_char = StaticExport.c_char;
+const bun = @import("../global.zig");
+const string = bun.string;
+const Output = bun.Output;
+const Global = bun.Global;
+const Environment = bun.Environment;
+const strings = bun.strings;
+const MutableString = bun.MutableString;
+const stringZ = bun.stringZ;
+const default_allocator = bun.default_allocator;
+const StoredFileDescriptorType = bun.StoredFileDescriptorType;
+const Arena = @import("../mimalloc_arena.zig").Arena;
+const C = bun.C;
+const NetworkThread = @import("http").NetworkThread;
+const IO = @import("io");
+const Allocator = std.mem.Allocator;
+const IdentityContext = @import("../identity_context.zig").IdentityContext;
+const Fs = @import("../fs.zig");
+const Resolver = @import("../resolver/resolver.zig");
+const ast = @import("../import_record.zig");
+const NodeModuleBundle = @import("../node_module_bundle.zig").NodeModuleBundle;
+const MacroEntryPoint = @import("../bundler.zig").MacroEntryPoint;
+const ParseResult = @import("../bundler.zig").ParseResult;
+const logger = @import("../logger.zig");
+const Api = @import("../api/schema.zig").Api;
+const options = @import("../options.zig");
+const Bundler = @import("../bundler.zig").Bundler;
+const PluginRunner = @import("../bundler.zig").PluginRunner;
+const ServerEntryPoint = @import("../bundler.zig").ServerEntryPoint;
+const js_printer = @import("../js_printer.zig");
+const js_parser = @import("../js_parser.zig");
+const js_ast = @import("../js_ast.zig");
+const hash_map = @import("../hash_map.zig");
+const http = @import("../http.zig");
+const NodeFallbackModules = @import("../node_fallbacks.zig");
+const ImportKind = ast.ImportKind;
+const Analytics = @import("../analytics/analytics_thread.zig");
+const ZigString = @import("../jsc.zig").ZigString;
+const Runtime = @import("../runtime.zig");
+const Router = @import("./api/router.zig");
+const ImportRecord = ast.ImportRecord;
+const DotEnv = @import("../env_loader.zig");
+const PackageJSON = @import("../resolver/package_json.zig").PackageJSON;
+const MacroRemap = @import("../resolver/package_json.zig").MacroMap;
+const WebCore = @import("../jsc.zig").WebCore;
+const Request = WebCore.Request;
+const Response = WebCore.Response;
+const Headers = WebCore.Headers;
+const Fetch = WebCore.Fetch;
+const FetchEvent = WebCore.FetchEvent;
+const js = @import("../jsc.zig").C;
+const JSC = @import("../jsc.zig");
+const JSError = @import("./base.zig").JSError;
+const d = @import("./base.zig").d;
+const MarkedArrayBuffer = @import("./base.zig").MarkedArrayBuffer;
+const getAllocator = @import("./base.zig").getAllocator;
+const JSValue = @import("../jsc.zig").JSValue;
+const NewClass = @import("./base.zig").NewClass;
+const Microtask = @import("../jsc.zig").Microtask;
+const JSGlobalObject = @import("../jsc.zig").JSGlobalObject;
+const ExceptionValueRef = @import("../jsc.zig").ExceptionValueRef;
+const JSPrivateDataPtr = @import("../jsc.zig").JSPrivateDataPtr;
+const ZigConsoleClient = @import("../jsc.zig").ZigConsoleClient;
+const Node = @import("../jsc.zig").Node;
+const ZigException = @import("../jsc.zig").ZigException;
+const ZigStackTrace = @import("../jsc.zig").ZigStackTrace;
+const ErrorableResolvedSource = @import("../jsc.zig").ErrorableResolvedSource;
+const ResolvedSource = @import("../jsc.zig").ResolvedSource;
+const JSPromise = @import("../jsc.zig").JSPromise;
+const JSInternalPromise = @import("../jsc.zig").JSInternalPromise;
+const JSModuleLoader = @import("../jsc.zig").JSModuleLoader;
+const JSPromiseRejectionOperation = @import("../jsc.zig").JSPromiseRejectionOperation;
+const Exception = @import("../jsc.zig").Exception;
+const ErrorableZigString = @import("../jsc.zig").ErrorableZigString;
+const ZigGlobalObject = @import("../jsc.zig").ZigGlobalObject;
+const VM = @import("../jsc.zig").VM;
+const JSFunction = @import("../jsc.zig").JSFunction;
+const Config = @import("./config.zig");
+const URL = @import("../url.zig").URL;
+const Transpiler = @import("./api/transpiler.zig");
+const Bun = JSC.API.Bun;
+const EventLoop = JSC.EventLoop;
+const PendingResolution = @import("../resolver/resolver.zig").PendingResolution;
+const ThreadSafeFunction = JSC.napi.ThreadSafeFunction;
+const PackageManager = @import("../install/install.zig").PackageManager;
+const Install = @import("../install/install.zig");
+const VirtualMachine = JSC.VirtualMachine;
+const Dependency = @import("../install/dependency.zig").Dependency;
+
+// This exists to make it so we can reload these quicker in development
+fn jsModuleFromFile(from_path: string, comptime input: string) string {
+    const absolute_path = comptime std.fs.path.dirname(@src().file).? ++ "/" ++ input;
+    const Holder = struct {
+        pub const file = @embedFile(absolute_path);
+    };
+
+    if (comptime !Environment.allow_assert) {
+        if (from_path.len == 0) {
+            return Holder.file;
+        }
+    }
+
+    var file: std.fs.File = undefined;
+
+    if (comptime Environment.allow_assert) {
+        file = std.fs.openFileAbsoluteZ(absolute_path, .{ .mode = .read_only }) catch {
+            const WarnOnce = struct {
+                pub var warned = false;
+            };
+            if (!WarnOnce.warned) {
+                WarnOnce.warned = true;
+                Output.prettyErrorln("Could not find file: " ++ absolute_path ++ " - using embedded version", .{});
+            }
+            return Holder.file;
+        };
+    } else {
+        var parts = [_]string{ from_path, input };
+        var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+        var absolute_path_to_use = Fs.FileSystem.instance.absBuf(&parts, &buf);
+        buf[absolute_path_to_use.len] = 0;
+        file = std.fs.openFileAbsoluteZ(std.meta.assumeSentinel(absolute_path_to_use.ptr, 0), .{ .mode = .read_only }) catch {
+            const WarnOnce = struct {
+                pub var warned = false;
+            };
+            if (!WarnOnce.warned) {
+                WarnOnce.warned = true;
+                Output.prettyErrorln("Could not find file: {s}, so using embedded version", .{absolute_path_to_use});
+            }
+            return Holder.file;
+        };
+    }
+
+    var contents = file.readToEndAlloc(bun.default_allocator, std.math.maxInt(usize)) catch @panic("Cannot read file: " ++ absolute_path);
+    if (comptime !Environment.allow_assert) {
+        file.close();
+    }
+    return contents;
+}
+
+inline fn jsSyntheticModule(comptime name: ResolvedSource.Tag) ResolvedSource {
+    return ResolvedSource{
+        .allocator = null,
+        .source_code = ZigString.init(""),
+        .specifier = ZigString.init(@tagName(name)),
+        .source_url = ZigString.init(@tagName(name)),
+        .hash = 0,
+        .tag = name,
+    };
+}
+
+fn dumpSource(specifier: string, printer: anytype) !void {
+    const BunDebugHolder = struct {
+        pub var dir: ?std.fs.Dir = null;
+    };
+    if (BunDebugHolder.dir == null) {
+        BunDebugHolder.dir = try std.fs.cwd().makeOpenPath("/tmp/bun-debug-src/", .{ .iterate = true });
+    }
+
+    if (std.fs.path.dirname(specifier)) |dir_path| {
+        var parent = try BunDebugHolder.dir.?.makeOpenPath(dir_path[1..], .{ .iterate = true });
+        defer parent.close();
+        try parent.writeFile(std.fs.path.basename(specifier), printer.ctx.getWritten());
+    } else {
+        try BunDebugHolder.dir.?.writeFile(std.fs.path.basename(specifier), printer.ctx.getWritten());
+    }
+}
+
+pub const ModuleLoader = struct {
+    pub const AsyncModule = struct {
+
+        // This is all the state used by the printer to print the module
+        parse_result: ParseResult,
+        stmt_blocks: []*js_ast.Stmt.Data.Store.All.Block = &[_]*js_ast.Stmt.Data.Store.All.Block{},
+        expr_blocks: []*js_ast.Expr.Data.Store.All.Block = &[_]*js_ast.Expr.Data.Store.All.Block{},
+        promise: JSC.Strong = .{},
+        path: Fs.Path,
+        specifier: string = "",
+        referrer: string = "",
+        string_buf: []u8 = &[_]u8{},
+        fd: ?StoredFileDescriptorType = null,
+        package_json: ?*PackageJSON = null,
+        loader: Api.Loader,
+        hash: u32 = std.math.maxInt(u32),
+
+        // This is the specific state for making it async
+        poll_ref: JSC.PollRef = .{},
+
+        pub const Id = u32;
+        const debug = Output.scoped(.ModuleLoader, false);
+        pub const Queue = struct {
+            map: Map = .{},
+            concurrent_task_count: std.atomic.Atomic(u32) = std.atomic.Atomic(u32).init(0),
+
+            pub const Map = std.ArrayListUnmanaged(AsyncModule);
+
+            pub fn enqueue(this: *Queue, globalObject: *JSC.JSGlobalObject, opts: anytype) void {
+                debug("enqueue: {s}", .{opts.specifier});
+                var module = AsyncModule.init(opts, globalObject) catch unreachable;
+                module.poll_ref.ref(this.vm());
+
+                this.map.append(this.vm().allocator, module) catch unreachable;
+                this.vm().packageManager().flushDependencyQueue();
+                _ = this.vm().packageManager().scheduleNetworkTasks();
+            }
+
+            pub fn onWakeHandler(ctx: *anyopaque, _: *PackageManager) void {
+                debug("onWake", .{});
+                var this = bun.cast(*Queue, ctx);
+                var concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch @panic("OOM");
+                concurrent_task.* = .{
+                    .task = JSC.Task.init(this),
+                    .auto_delete = true,
+                };
+                this.vm().enqueueTaskConcurrent(concurrent_task);
+            }
+
+            pub fn onPoll(this: *Queue) void {
+                debug("onPoll", .{});
+                var pm = this.vm().packageManager();
+
+                this.runTasks();
+                this.pollModules();
+                _ = pm.flushDependencyQueue();
+                _ = pm.scheduleNetworkTasks();
+            }
+
+            pub fn runTasks(this: *Queue) void {
+                var pm = this.vm().packageManager();
+                pm.runTasks(
+                    *Queue,
+                    this,
+                    .{
+                        .onExtract = onExtract,
+                        .onResolve = onResolve,
+                        .onPackageManifestError = onPackageManifestError,
+                    },
+                    PackageManager.Options.LogLevel.default_no_progress,
+                ) catch unreachable;
+            }
+
+            pub fn onResolve(_: *Queue) void {
+                debug("onResolve", .{});
+            }
+
+            pub fn onPackageManifestError(this: *Queue, name: []const u8) void {
+                debug("onPackageManifestError: {s}", .{name});
+                _ = this;
+                _ = name;
+            }
+
+            pub fn onExtract(this: *Queue, package_id: u32, comptime _: PackageManager.Options.LogLevel) void {
+                if (comptime Environment.allow_assert)
+                    debug("onExtract: {s} ({d})", .{
+                        this.vm().packageManager().lockfile.str(this.vm().packageManager().lockfile.packages.get(package_id).name),
+                        package_id,
+                    });
+                this.onPackageID(package_id);
+            }
+
+            pub fn onPackageID(this: *Queue, package_id: u32) void {
+                var values = this.map.items;
+                for (values) |value| {
+                    var package_ids = value.parse_result.pending_imports.items(.resolution_id);
+
+                    _ = package_id;
+                    _ = package_ids;
+                }
+            }
+
+            pub fn pollModules(this: *Queue) void {
+                var pm = this.vm().packageManager();
+                var modules = this.map.items;
+                var i: usize = 0;
+                for (modules) |mod| {
+                    var module = mod;
+                    var tags = module.parse_result.pending_imports.items(.tag);
+                    var resolution_ids = module.parse_result.pending_imports.items(.resolution_id);
+                    // var esms = module.parse_result.pending_imports.items(.esm);
+                    // var versions = module.parse_result.pending_imports.items(.dependency);
+                    var done_count: usize = 0;
+                    for (tags) |tag, tag_i| {
+                        const resolution_id = resolution_ids[tag_i];
+
+                        switch (tag) {
+                            .resolve => {
+                                if (resolution_id == Install.invalid_package_id) {
+                                    continue;
+                                }
+
+                                // if we get here, the package has already been resolved.
+                                tags[tag_i] = .download;
+                            },
+                            .download => {
+                                if (resolution_id == Install.invalid_package_id) {
+                                    unreachable;
+                                }
+                            },
+                            .done => {
+                                done_count += 1;
+                                continue;
+                            },
+                        }
+
+                        // we might have finished loading the dependency into the lockfile
+                        var package_id = pm.dynamicRootDependencies().items[resolution_id].resolution_id;
+
+                        if (package_id == Install.invalid_package_id) {
+                            continue;
+                        }
+
+                        const package = pm.lockfile.packages.get(package_id);
+                        std.debug.assert(package.resolution.tag != .root);
+
+                        switch (pm.determinePreinstallState(package, pm.lockfile)) {
+                            .done => {
+                                done_count += 1;
+                                tags[tag_i] = .done;
+                            },
+                            .extracting => {
+                                // we are extracting the package
+                                // we need to wait for the next poll
+                                continue;
+                            },
+                            .extract => {},
+                            else => {},
+                        }
+                    }
+
+                    if (done_count == tags.len) {
+                        module.done(this.vm());
+                    } else {
+                        modules[i] = module;
+                        i += 1;
+                    }
+                }
+                this.map.items.len = i;
+            }
+
+            pub fn vm(this: *Queue) *VirtualMachine {
+                return @fieldParentPtr(VirtualMachine, "modules", this);
+            }
+        };
+
+        pub fn init(opts: anytype, globalObject: *JSC.JSGlobalObject) !AsyncModule {
+            var promise = JSC.Strong{};
+            var stmt_blocks = js_ast.Stmt.Data.Store.toOwnedSlice();
+            var expr_blocks = js_ast.Expr.Data.Store.toOwnedSlice();
+            const this_promise = JSValue.createInternalPromise(globalObject);
+            promise.set(globalObject, this_promise);
+
+            var buf = bun.StringBuilder{};
+            buf.count(opts.referrer);
+            buf.count(opts.specifier);
+            buf.count(opts.path.text);
+
+            try buf.allocate(bun.default_allocator);
+            opts.promise_ptr.?.* = this_promise.asInternalPromise().?;
+            const referrer = buf.append(opts.referrer);
+            const specifier = buf.append(opts.specifier);
+            const path = Fs.Path.init(buf.append(opts.path.text));
+
+            return AsyncModule{
+                .parse_result = opts.parse_result,
+                .promise = promise,
+                .path = path,
+                .specifier = specifier,
+                .referrer = referrer,
+                .fd = opts.fd,
+                .package_json = opts.package_json,
+                .loader = opts.loader.toAPI(),
+                .string_buf = buf.allocatedSlice(),
+                .stmt_blocks = stmt_blocks,
+                .expr_blocks = expr_blocks,
+            };
+        }
+
+        pub fn done(this: *AsyncModule, jsc_vm: *JSC.VirtualMachine) void {
+            var log = logger.Log.init(jsc_vm.allocator);
+            defer log.deinit();
+            var errorable: ErrorableResolvedSource = undefined;
+            this.poll_ref.unref(jsc_vm);
+            outer: {
+                errorable = ErrorableResolvedSource.ok(this.resumeLoadingModule(&log) catch |err| {
+                    JSC.VirtualMachine.processFetchLog(
+                        jsc_vm.global, // TODO: shadowrealm
+                        ZigString.init(this.specifier),
+                        ZigString.init(this.referrer),
+                        &log,
+                        &errorable,
+                        err,
+                    );
+                    break :outer;
+                });
+            }
+
+            var spec = ZigString.init(this.specifier).withEncoding();
+            var ref = ZigString.init(this.referrer).withEncoding();
+            Bun__onFulfillAsyncModule(
+                this.promise.get().?,
+                &errorable,
+                &spec,
+                &ref,
+            );
+            this.deinit();
+        }
+
+        pub fn resumeLoadingModule(this: *AsyncModule, log: *logger.Log) !ResolvedSource {
+            debug("resumeLoadingModule: {s}", .{this.specifier});
+            var parse_result = this.parse_result;
+            var path = this.path;
+            var jsc_vm = JSC.VirtualMachine.vm;
+            var specifier = this.specifier;
+            var old_log = jsc_vm.log;
+
+            jsc_vm.bundler.linker.log = log;
+            jsc_vm.bundler.log = log;
+            jsc_vm.bundler.resolver.log = log;
+            defer {
+                jsc_vm.bundler.linker.log = old_log;
+                jsc_vm.bundler.log = old_log;
+                jsc_vm.bundler.resolver.log = old_log;
+            }
+            // We _must_ link because:
+            // - node_modules bundle won't be properly
+            try jsc_vm.bundler.linker.link(
+                path,
+                &parse_result,
+                jsc_vm.origin,
+                .absolute_path,
+                false,
+                true,
+            );
+            this.parse_result = parse_result;
+
+            var printer = VirtualMachine.source_code_printer.?.*;
+            printer.ctx.reset();
+
+            const written = brk: {
+                defer VirtualMachine.source_code_printer.?.* = printer;
+                break :brk try jsc_vm.bundler.printWithSourceMap(
+                    parse_result,
+                    @TypeOf(&printer),
+                    &printer,
+                    .esm_ascii,
+                    SavedSourceMap.SourceMapHandler.init(&jsc_vm.source_mappings),
+                );
+            };
+
+            if (written == 0) {
+                return error.PrintingErrorWriteFailed;
+            }
+
+            if (comptime Environment.dump_source) {
+                try dumpSource(specifier, &printer);
+            }
+
+            if (jsc_vm.isWatcherEnabled()) {
+                const resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, specifier, path.text, null);
+
+                if (parse_result.input_fd) |fd_| {
+                    if (jsc_vm.bun_watcher != null and std.fs.path.isAbsolute(path.text) and !strings.contains(path.text, "node_modules")) {
+                        jsc_vm.bun_watcher.?.addFile(
+                            fd_,
+                            path.text,
+                            this.hash,
+                            options.Loader.fromAPI(this.loader),
+                            0,
+                            this.package_json,
+                            true,
+                        ) catch {};
+                    }
+                }
+
+                return resolved_source;
+            }
+
+            return ResolvedSource{
+                .allocator = null,
+                .source_code = ZigString.init(try default_allocator.dupe(u8, printer.ctx.getWritten())),
+                .specifier = ZigString.init(specifier),
+                .source_url = ZigString.init(path.text),
+                // // TODO: change hash to a bitfield
+                // .hash = 1,
+
+                // having JSC own the memory causes crashes
+                .hash = 0,
+            };
+        }
+
+        pub fn deinit(this: *AsyncModule) void {
+            this.parse_result.deinit();
+            bun.default_allocator.free(this.stmt_blocks);
+            bun.default_allocator.free(this.expr_blocks);
+            this.promise.deinit();
+            bun.default_allocator.free(this.string_buf);
+        }
+
+        extern "C" fn Bun__onFulfillAsyncModule(
+            promiseValue: JSC.JSValue,
+            res: *JSC.ErrorableResolvedSource,
+            specifier: *ZigString,
+            referrer: *ZigString,
+        ) void;
+    };
+
+    pub export fn Bun__getDefaultLoader(global: *JSC.JSGlobalObject, str: *ZigString) Api.Loader {
+        var jsc_vm = global.bunVM();
+        const filename = str.toSlice(jsc_vm.allocator);
+        defer filename.deinit();
+        const loader = jsc_vm.bundler.options.loader(Fs.PathName.init(filename.slice()).ext).toAPI();
+        if (loader == .file) {
+            return Api.Loader.js;
+        }
+
+        return loader;
+    }
+
+    pub fn transpileSourceCode(
+        jsc_vm: *VirtualMachine,
+        specifier: string,
+        referrer: string,
+        path: Fs.Path,
+        loader: options.Loader,
+        log: *logger.Log,
+        virtual_source: ?*const logger.Source,
+        ret: *ErrorableResolvedSource,
+        promise_ptr: ?*?*JSC.JSInternalPromise,
+        source_code_printer: *js_printer.BufferPrinter,
+        globalObject: ?*JSC.JSGlobalObject,
+        comptime flags: FetchFlags,
+    ) !ResolvedSource {
+        const disable_transpilying = comptime flags.disableTranspiling();
+
+        switch (loader) {
+            .js, .jsx, .ts, .tsx, .json, .toml => {
+                jsc_vm.transpiled_count += 1;
+                jsc_vm.bundler.resetStore();
+                const hash = http.Watcher.getHash(path.text);
+
+                var allocator = if (jsc_vm.has_loaded) jsc_vm.arena.allocator() else jsc_vm.allocator;
+
+                var fd: ?StoredFileDescriptorType = null;
+                var package_json: ?*PackageJSON = null;
+
+                if (jsc_vm.bun_dev_watcher) |watcher| {
+                    if (watcher.indexOf(hash)) |index| {
+                        const _fd = watcher.watchlist.items(.fd)[index];
+                        fd = if (_fd > 0) _fd else null;
+                        package_json = watcher.watchlist.items(.package_json)[index];
+                    }
+                } else if (jsc_vm.bun_watcher) |watcher| {
+                    if (watcher.indexOf(hash)) |index| {
+                        const _fd = watcher.watchlist.items(.fd)[index];
+                        fd = if (_fd > 0) _fd else null;
+                        package_json = watcher.watchlist.items(.package_json)[index];
+                    }
+                }
+
+                var old = jsc_vm.bundler.log;
+                jsc_vm.bundler.log = log;
+                jsc_vm.bundler.linker.log = log;
+                jsc_vm.bundler.resolver.log = log;
+
+                defer {
+                    jsc_vm.bundler.log = old;
+                    jsc_vm.bundler.linker.log = old;
+                    jsc_vm.bundler.resolver.log = old;
+                }
+
+                // this should be a cheap lookup because 24 bytes == 8 * 3 so it's read 3 machine words
+                const is_node_override = specifier.len > "/bun-vfs/node_modules/".len and strings.eqlComptimeIgnoreLen(specifier[0.."/bun-vfs/node_modules/".len], "/bun-vfs/node_modules/");
+
+                const macro_remappings = if (jsc_vm.macro_mode or !jsc_vm.has_any_macro_remappings or is_node_override)
+                    MacroRemap{}
+                else
+                    jsc_vm.bundler.options.macro_remap;
+
+                var fallback_source: logger.Source = undefined;
+
+                var parse_options = Bundler.ParseOptions{
+                    .allocator = allocator,
+                    .path = path,
+                    .loader = loader,
+                    .dirname_fd = 0,
+                    .file_descriptor = fd,
+                    .file_hash = hash,
+                    .macro_remappings = macro_remappings,
+                    .jsx = jsc_vm.bundler.options.jsx,
+                    .virtual_source = virtual_source,
+                    .hoist_bun_plugin = true,
+                };
+
+                if (is_node_override) {
+                    if (NodeFallbackModules.contentsFromPath(specifier)) |code| {
+                        const fallback_path = Fs.Path.initWithNamespace(specifier, "node");
+                        fallback_source = logger.Source{ .path = fallback_path, .contents = code, .key_path = fallback_path };
+                        parse_options.virtual_source = &fallback_source;
+                    }
+                }
+
+                var parse_result = jsc_vm.bundler.parseMaybeReturnFileOnly(
+                    parse_options,
+                    null,
+                    disable_transpilying,
+                ) orelse {
+                    return error.ParseError;
+                };
+
+                if (jsc_vm.bundler.log.errors > 0) {
+                    return error.ParseError;
+                }
+
+                if (comptime disable_transpilying) {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = switch (comptime flags) {
+                            .print_source_and_clone => ZigString.init(jsc_vm.allocator.dupe(u8, parse_result.source.contents) catch unreachable),
+                            .print_source => ZigString.init(parse_result.source.contents),
+                            else => unreachable,
+                        },
+                        .specifier = ZigString.init(specifier),
+                        .source_url = ZigString.init(path.text),
+                        .hash = 0,
+                    };
+                }
+
+                const has_bun_plugin = parse_result.ast.bun_plugin.hoisted_stmts.items.len > 0;
+
+                if (has_bun_plugin) {
+                    try ModuleLoader.runBunPlugin(jsc_vm, JSC.VirtualMachine.source_code_printer.?, &parse_result, ret);
+                }
+
+                const start_count = jsc_vm.bundler.linker.import_counter;
+
+                // We _must_ link because:
+                // - node_modules bundle won't be properly
+                try jsc_vm.bundler.linker.link(
+                    path,
+                    &parse_result,
+                    jsc_vm.origin,
+                    .absolute_path,
+                    false,
+                    true,
+                );
+
+                if (parse_result.pending_imports.len > 0) {
+                    if (promise_ptr == null) {
+                        return error.UnexpectedPendingResolution;
+                    }
+
+                    if (jsc_vm.isWatcherEnabled()) {
+                        if (parse_result.input_fd) |fd_| {
+                            if (jsc_vm.bun_watcher != null and !is_node_override and std.fs.path.isAbsolute(path.text) and !strings.contains(path.text, "node_modules")) {
+                                jsc_vm.bun_watcher.?.addFile(
+                                    fd_,
+                                    path.text,
+                                    hash,
+                                    loader,
+                                    0,
+                                    package_json,
+                                    true,
+                                ) catch {};
+                            }
+                        }
+                    }
+
+                    jsc_vm.modules.enqueue(
+                        globalObject.?,
+                        .{
+                            .parse_result = parse_result,
+                            .path = path,
+                            .loader = loader,
+                            .fd = fd,
+                            .package_json = package_json,
+                            .hash = hash,
+                            .promise_ptr = promise_ptr,
+                            .specifier = specifier,
+                            .referrer = referrer,
+                        },
+                    );
+                    return error.AsyncModule;
+                }
+
+                if (!jsc_vm.macro_mode)
+                    jsc_vm.resolved_count += jsc_vm.bundler.linker.import_counter - start_count;
+                jsc_vm.bundler.linker.import_counter = 0;
+
+                var printer = source_code_printer.*;
+                printer.ctx.reset();
+
+                const written = brk: {
+                    defer source_code_printer.* = printer;
+                    break :brk try jsc_vm.bundler.printWithSourceMap(
+                        parse_result,
+                        @TypeOf(&printer),
+                        &printer,
+                        .esm_ascii,
+                        SavedSourceMap.SourceMapHandler.init(&jsc_vm.source_mappings),
+                    );
+                };
+
+                if (written == 0) {
+                    // if it's an empty file but there were plugins
+                    // we don't want it to break if you try to import from it
+                    if (has_bun_plugin) {
+                        return ResolvedSource{
+                            .allocator = null,
+                            .source_code = ZigString.init("// auto-generated plugin stub\nexport default undefined\n"),
+                            .specifier = ZigString.init(specifier),
+                            .source_url = ZigString.init(path.text),
+                            // // TODO: change hash to a bitfield
+                            // .hash = 1,
+
+                            // having JSC own the memory causes crashes
+                            .hash = 0,
+                        };
+                    }
+                    return error.PrintingErrorWriteFailed;
+                }
+
+                if (comptime Environment.dump_source) {
+                    try dumpSource(specifier, &printer);
+                }
+
+                if (jsc_vm.isWatcherEnabled()) {
+                    const resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, specifier, path.text, null);
+
+                    if (parse_result.input_fd) |fd_| {
+                        if (jsc_vm.bun_watcher != null and !is_node_override and std.fs.path.isAbsolute(path.text) and !strings.contains(path.text, "node_modules")) {
+                            jsc_vm.bun_watcher.?.addFile(
+                                fd_,
+                                path.text,
+                                hash,
+                                loader,
+                                0,
+                                package_json,
+                                true,
+                            ) catch {};
+                        }
+                    }
+
+                    return resolved_source;
+                }
+
+                return ResolvedSource{
+                    .allocator = null,
+                    .source_code = ZigString.init(try default_allocator.dupe(u8, printer.ctx.getWritten())),
+                    .specifier = ZigString.init(specifier),
+                    .source_url = ZigString.init(path.text),
+                    // // TODO: change hash to a bitfield
+                    // .hash = 1,
+
+                    // having JSC own the memory causes crashes
+                    .hash = 0,
+                };
+            },
+            // provideFetch() should be called
+            .napi => unreachable,
+            // .wasm => {
+            //     jsc_vm.transpiled_count += 1;
+            //     var fd: ?StoredFileDescriptorType = null;
+
+            //     var allocator = if (jsc_vm.has_loaded) jsc_vm.arena.allocator() else jsc_vm.allocator;
+
+            //     const hash = http.Watcher.getHash(path.text);
+            //     if (jsc_vm.watcher) |watcher| {
+            //         if (watcher.indexOf(hash)) |index| {
+            //             const _fd = watcher.watchlist.items(.fd)[index];
+            //             fd = if (_fd > 0) _fd else null;
+            //         }
+            //     }
+
+            //     var parse_options = Bundler.ParseOptions{
+            //         .allocator = allocator,
+            //         .path = path,
+            //         .loader = loader,
+            //         .dirname_fd = 0,
+            //         .file_descriptor = fd,
+            //         .file_hash = hash,
+            //         .macro_remappings = MacroRemap{},
+            //         .jsx = jsc_vm.bundler.options.jsx,
+            //     };
+
+            //     var parse_result = jsc_vm.bundler.parse(
+            //         parse_options,
+            //         null,
+            //     ) orelse {
+            //         return error.ParseError;
+            //     };
+
+            //     return ResolvedSource{
+            //         .allocator = if (jsc_vm.has_loaded) &jsc_vm.allocator else null,
+            //         .source_code = ZigString.init(jsc_vm.allocator.dupe(u8, parse_result.source.contents) catch unreachable),
+            //         .specifier = ZigString.init(specifier),
+            //         .source_url = ZigString.init(path.text),
+            //         .hash = 0,
+            //         .tag = ResolvedSource.Tag.wasm,
+            //     };
+            // },
+            else => {
+                return ResolvedSource{
+                    .allocator = &jsc_vm.allocator,
+                    .source_code = ZigString.init(try strings.quotedAlloc(jsc_vm.allocator, path.pretty)),
+                    .specifier = ZigString.init(path.text),
+                    .source_url = ZigString.init(path.text),
+                    .hash = 0,
+                };
+            },
+        }
+    }
+
+    pub fn runBunPlugin(
+        jsc_vm: *VirtualMachine,
+        source_code_printer: *js_printer.BufferPrinter,
+        parse_result: *ParseResult,
+        ret: *ErrorableResolvedSource,
+    ) !void {
+        var printer = source_code_printer.*;
+        printer.ctx.reset();
+
+        defer printer.ctx.reset();
+        // If we start transpiling in the middle of an existing transpilation session
+        // we will hit undefined memory bugs
+        // unless we disable resetting the store until we are done transpiling
+        const prev_disable_reset = js_ast.Stmt.Data.Store.disable_reset;
+        js_ast.Stmt.Data.Store.disable_reset = true;
+        js_ast.Expr.Data.Store.disable_reset = true;
+
+        // flip the source code we use
+        // unless we're already transpiling a plugin
+        // that case could happen when
+        const was_printing_plugin = jsc_vm.is_printing_plugin;
+        const prev = jsc_vm.bundler.resolver.caches.fs.use_alternate_source_cache;
+        jsc_vm.is_printing_plugin = true;
+        defer {
+            js_ast.Stmt.Data.Store.disable_reset = prev_disable_reset;
+            js_ast.Expr.Data.Store.disable_reset = prev_disable_reset;
+            if (!was_printing_plugin) jsc_vm.bundler.resolver.caches.fs.use_alternate_source_cache = prev;
+            jsc_vm.is_printing_plugin = was_printing_plugin;
+        }
+        // we flip use_alternate_source_cache
+        if (!was_printing_plugin) jsc_vm.bundler.resolver.caches.fs.use_alternate_source_cache = !prev;
+
+        // this is a bad idea, but it should work for now.
+        const original_name = parse_result.ast.symbols[parse_result.ast.bun_plugin.ref.innerIndex()].original_name;
+        parse_result.ast.symbols[parse_result.ast.bun_plugin.ref.innerIndex()].original_name = "globalThis.Bun.plugin";
+        defer {
+            parse_result.ast.symbols[parse_result.ast.bun_plugin.ref.innerIndex()].original_name = original_name;
+        }
+        const hoisted_stmts = parse_result.ast.bun_plugin.hoisted_stmts.items;
+
+        var parts = [1]js_ast.Part{
+            js_ast.Part{
+                .stmts = hoisted_stmts,
+            },
+        };
+        var ast_copy = parse_result.ast;
+        ast_copy.import_records = try jsc_vm.allocator.dupe(ImportRecord, ast_copy.import_records);
+        defer jsc_vm.allocator.free(ast_copy.import_records);
+        ast_copy.parts = &parts;
+        ast_copy.prepend_part = null;
+        var temporary_source = parse_result.source;
+        var source_name = try std.fmt.allocPrint(jsc_vm.allocator, "{s}.plugin.{s}", .{ temporary_source.path.text, temporary_source.path.name.ext[1..] });
+        temporary_source.path = Fs.Path.init(source_name);
+
+        var temp_parse_result = parse_result.*;
+        temp_parse_result.ast = ast_copy;
+
+        try jsc_vm.bundler.linker.link(
+            temporary_source.path,
+            &temp_parse_result,
+            jsc_vm.origin,
+            .absolute_path,
+            false,
+            true,
+        );
+
+        _ = brk: {
+            defer source_code_printer.* = printer;
+            break :brk try jsc_vm.bundler.printWithSourceMapMaybe(
+                temp_parse_result.ast,
+                &temporary_source,
+                @TypeOf(&printer),
+                &printer,
+                .esm_ascii,
+                true,
+                SavedSourceMap.SourceMapHandler.init(&jsc_vm.source_mappings),
+            );
+        };
+        const wrote = printer.ctx.getWritten();
+
+        if (wrote.len > 0) {
+            if (comptime Environment.dump_source)
+                try dumpSource(temporary_source.path.text, &printer);
+
+            var exception = [1]JSC.JSValue{JSC.JSValue.zero};
+            const promise = JSC.JSModuleLoader.evaluate(
+                jsc_vm.global,
+                wrote.ptr,
+                wrote.len,
+                temporary_source.path.text.ptr,
+                temporary_source.path.text.len,
+                parse_result.source.path.text.ptr,
+                parse_result.source.path.text.len,
+                JSC.JSValue.jsUndefined(),
+                &exception,
+            );
+            if (!exception[0].isEmpty()) {
+                ret.* = JSC.ErrorableResolvedSource.err(
+                    error.JSErrorObject,
+                    exception[0].asVoid(),
+                );
+                return error.PluginError;
+            }
+
+            if (!promise.isEmptyOrUndefinedOrNull()) {
+                if (promise.asInternalPromise()) |promise_value| {
+                    jsc_vm.waitForPromise(promise_value);
+
+                    if (promise_value.status(jsc_vm.global.vm()) == .Rejected) {
+                        ret.* = JSC.ErrorableResolvedSource.err(
+                            error.JSErrorObject,
+                            promise_value.result(jsc_vm.global.vm()).asVoid(),
+                        );
+                        return error.PluginError;
+                    }
+                }
+            }
+        }
+    }
+    pub fn normalizeSpecifier(jsc_vm: *VirtualMachine, slice_: string) string {
+        var slice = slice_;
+        if (slice.len == 0) return slice;
+        var was_http = false;
+        if (strings.hasPrefixComptime(slice, "https://")) {
+            slice = slice["https://".len..];
+            was_http = true;
+        } else if (strings.hasPrefixComptime(slice, "http://")) {
+            slice = slice["http://".len..];
+            was_http = true;
+        }
+
+        if (strings.hasPrefix(slice, jsc_vm.origin.host)) {
+            slice = slice[jsc_vm.origin.host.len..];
+        } else if (was_http) {
+            if (strings.indexOfChar(slice, '/')) |i| {
+                slice = slice[i..];
+            }
+        }
+
+        if (jsc_vm.origin.path.len > 1) {
+            if (strings.hasPrefix(slice, jsc_vm.origin.path)) {
+                slice = slice[jsc_vm.origin.path.len..];
+            }
+        }
+
+        if (jsc_vm.bundler.options.routes.asset_prefix_path.len > 0) {
+            if (strings.hasPrefix(slice, jsc_vm.bundler.options.routes.asset_prefix_path)) {
+                slice = slice[jsc_vm.bundler.options.routes.asset_prefix_path.len..];
+            }
+        }
+
+        return slice;
+    }
+
+    pub export fn Bun__fetchBuiltinModule(
+        jsc_vm: *VirtualMachine,
+        globalObject: *JSC.JSGlobalObject,
+        specifier: *ZigString,
+        referrer: *ZigString,
+        ret: *ErrorableResolvedSource,
+    ) bool {
+        JSC.markBinding(@src());
+        var log = logger.Log.init(jsc_vm.bundler.allocator);
+        defer log.deinit();
+        if (ModuleLoader.fetchBuiltinModule(jsc_vm, specifier.slice(), &log, false) catch |err| {
+            if (err == error.AsyncModule) {
+                unreachable;
+            }
+            VirtualMachine.processFetchLog(globalObject, specifier.*, referrer.*, &log, ret, err);
+            return true;
+        }) |builtin| {
+            ret.* = ErrorableResolvedSource.ok(builtin);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    pub export fn Bun__transpileFile(
+        jsc_vm: *VirtualMachine,
+        globalObject: *JSC.JSGlobalObject,
+        specifier_ptr: *ZigString,
+        referrer: *ZigString,
+        ret: *ErrorableResolvedSource,
+        allow_promise: bool,
+    ) ?*anyopaque {
+        JSC.markBinding(@src());
+        var log = logger.Log.init(jsc_vm.bundler.allocator);
+        defer log.deinit();
+        var _specifier = specifier_ptr.toSlice(jsc_vm.allocator);
+        var referrer_slice = referrer.toSlice(jsc_vm.allocator);
+        defer _specifier.deinit();
+        defer referrer_slice.deinit();
+        var specifier = normalizeSpecifier(jsc_vm, _specifier.slice());
+        const path = Fs.Path.init(specifier);
+        const loader = jsc_vm.bundler.options.loaders.get(path.name.ext) orelse options.Loader.js;
+        var promise: ?*JSC.JSInternalPromise = null;
+        ret.* = ErrorableResolvedSource.ok(
+            ModuleLoader.transpileSourceCode(
+                jsc_vm,
+                specifier,
+                referrer_slice.slice(),
+                path,
+                loader,
+                &log,
+                null,
+                ret,
+                if (allow_promise) &promise else null,
+                VirtualMachine.source_code_printer.?,
+                globalObject,
+                FetchFlags.transpile,
+            ) catch |err| {
+                if (err == error.AsyncModule) {
+                    std.debug.assert(promise != null);
+                    return promise;
+                }
+
+                if (err == error.PluginError) {
+                    return null;
+                }
+                VirtualMachine.processFetchLog(globalObject, specifier_ptr.*, referrer.*, &log, ret, err);
+                return null;
+            },
+        );
+        return promise;
+    }
+
+    export fn Bun__runVirtualModule(globalObject: *JSC.JSGlobalObject, specifier_ptr: *ZigString) JSValue {
+        JSC.markBinding(@src());
+        if (globalObject.bunVM().plugin_runner == null) return JSValue.zero;
+
+        const specifier = specifier_ptr.slice();
+
+        if (!PluginRunner.couldBePlugin(specifier)) {
+            return JSValue.zero;
+        }
+
+        const namespace = PluginRunner.extractNamespace(specifier);
+        const after_namespace = if (namespace.len == 0)
+            specifier
+        else
+            specifier[@minimum(namespace.len + 1, specifier.len)..];
+
+        return globalObject.runOnLoadPlugins(ZigString.init(namespace), ZigString.init(after_namespace), .bun) orelse return JSValue.zero;
+    }
+
+    const shared_library_suffix = if (Environment.isMac) "dylib" else if (Environment.isLinux) "so" else "";
+
+    pub fn fetchBuiltinModule(jsc_vm: *VirtualMachine, specifier: string, log: *logger.Log, comptime disable_transpilying: bool) !?ResolvedSource {
+        if (jsc_vm.node_modules != null and strings.eqlComptime(specifier, JSC.bun_file_import_path)) {
+            // We kind of need an abstraction around this.
+            // Basically we should subclass JSC::SourceCode with:
+            // - hash
+            // - file descriptor for source input
+            // - file path + file descriptor for bytecode caching
+            // - separate bundles for server build vs browser build OR at least separate sections
+            const code = try jsc_vm.node_modules.?.readCodeAsStringSlow(jsc_vm.allocator);
+
+            return ResolvedSource{
+                .allocator = null,
+                .source_code = ZigString.init(code),
+                .specifier = ZigString.init(JSC.bun_file_import_path),
+                .source_url = ZigString.init(JSC.bun_file_import_path[1..]),
+                .hash = 0, // TODO
+            };
+        } else if (jsc_vm.node_modules == null and strings.eqlComptime(specifier, Runtime.Runtime.Imports.Name)) {
+            return ResolvedSource{
+                .allocator = null,
+                .source_code = ZigString.init(Runtime.Runtime.sourceContentBun()),
+                .specifier = ZigString.init(Runtime.Runtime.Imports.Name),
+                .source_url = ZigString.init(Runtime.Runtime.Imports.Name),
+                .hash = Runtime.Runtime.versionHash(),
+            };
+        } else if (HardcodedModule.Map.get(specifier)) |hardcoded| {
+            switch (hardcoded) {
+                // This is all complicated because the imports have to be linked and we want to run the printer on it
+                // so it consistently handles bundled imports
+                // we can't take the shortcut of just directly importing the file, sadly.
+                .@"bun:main" => {
+                    if (comptime disable_transpilying) {
+                        return ResolvedSource{
+                            .allocator = null,
+                            .source_code = ZigString.init(jsc_vm.entry_point.source.contents),
+                            .specifier = ZigString.init(std.mem.span(JSC.VirtualMachine.main_file_name)),
+                            .source_url = ZigString.init(std.mem.span(JSC.VirtualMachine.main_file_name)),
+                            .hash = 0,
+                        };
+                    }
+                    defer jsc_vm.transpiled_count += 1;
+
+                    var bundler = &jsc_vm.bundler;
+                    var old = jsc_vm.bundler.log;
+                    jsc_vm.bundler.log = log;
+                    jsc_vm.bundler.linker.log = log;
+                    jsc_vm.bundler.resolver.log = log;
+                    defer {
+                        jsc_vm.bundler.log = old;
+                        jsc_vm.bundler.linker.log = old;
+                        jsc_vm.bundler.resolver.log = old;
+                    }
+
+                    var jsx = bundler.options.jsx;
+                    jsx.parse = false;
+                    var opts = js_parser.Parser.Options.init(jsx, .js);
+                    opts.enable_bundling = false;
+                    opts.transform_require_to_import = false;
+                    opts.features.dynamic_require = true;
+                    opts.can_import_from_bundle = bundler.options.node_modules_bundle != null;
+                    opts.features.hot_module_reloading = false;
+                    opts.features.react_fast_refresh = false;
+                    opts.filepath_hash_for_hmr = 0;
+                    opts.warn_about_unbundled_modules = false;
+                    opts.macro_context = &jsc_vm.bundler.macro_context.?;
+                    const main_ast = (bundler.resolver.caches.js.parse(jsc_vm.allocator, opts, bundler.options.define, bundler.log, &jsc_vm.entry_point.source) catch null) orelse {
+                        return error.ParseError;
+                    };
+                    var parse_result = ParseResult{ .source = jsc_vm.entry_point.source, .ast = main_ast, .loader = .js, .input_fd = null };
+                    var file_path = Fs.Path.init(bundler.fs.top_level_dir);
+                    file_path.name.dir = bundler.fs.top_level_dir;
+                    file_path.name.base = "bun:main";
+                    try bundler.linker.link(
+                        file_path,
+                        &parse_result,
+                        jsc_vm.origin,
+                        .absolute_path,
+                        false,
+                        true,
+                    );
+                    var printer = JSC.VirtualMachine.source_code_printer.?.*;
+                    var written: usize = undefined;
+                    printer.ctx.reset();
+                    {
+                        defer JSC.VirtualMachine.source_code_printer.?.* = printer;
+                        written = try jsc_vm.bundler.printWithSourceMap(
+                            parse_result,
+                            @TypeOf(&printer),
+                            &printer,
+                            .esm_ascii,
+                            SavedSourceMap.SourceMapHandler.init(&jsc_vm.source_mappings),
+                        );
+                    }
+
+                    if (comptime Environment.dump_source)
+                        try dumpSource(JSC.VirtualMachine.main_file_name, &printer);
+
+                    if (written == 0) {
+                        return error.PrintingErrorWriteFailed;
+                    }
+
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(jsc_vm.allocator.dupe(u8, printer.ctx.written) catch unreachable),
+                        .specifier = ZigString.init(std.mem.span(JSC.VirtualMachine.main_file_name)),
+                        .source_url = ZigString.init(std.mem.span(JSC.VirtualMachine.main_file_name)),
+                        .hash = 0,
+                    };
+                },
+                .@"bun:jsc" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(jsModuleFromFile(jsc_vm.load_builtins_from_path, "bun-jsc.exports.js")),
+                        .specifier = ZigString.init("bun:jsc"),
+                        .source_url = ZigString.init("bun:jsc"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:child_process" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(jsModuleFromFile(jsc_vm.load_builtins_from_path, "child_process.exports.js")),
+                        .specifier = ZigString.init("node:child_process"),
+                        .source_url = ZigString.init("node:child_process"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:net" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(jsModuleFromFile(jsc_vm.load_builtins_from_path, "net.exports.js")),
+                        .specifier = ZigString.init("node:net"),
+                        .source_url = ZigString.init("node:net"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:fs" => {
+                    if (comptime Environment.isDebug) {
+                        return ResolvedSource{
+                            .allocator = null,
+                            .source_code = ZigString.init(strings.append(bun.default_allocator, jsModuleFromFile(jsc_vm.load_builtins_from_path, "fs.exports.js"), JSC.Node.fs.constants_string) catch unreachable),
+                            .specifier = ZigString.init("node:fs"),
+                            .source_url = ZigString.init("node:fs"),
+                            .hash = 0,
+                        };
+                    }
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(@embedFile("fs.exports.js") ++ JSC.Node.fs.constants_string),
+                        .specifier = ZigString.init("node:fs"),
+                        .source_url = ZigString.init("node:fs"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:buffer" => return jsSyntheticModule(.@"node:buffer"),
+                .@"node:string_decoder" => return jsSyntheticModule(.@"node:string_decoder"),
+                .@"node:module" => return jsSyntheticModule(.@"node:module"),
+                .@"node:events" => return jsSyntheticModule(.@"node:events"),
+                .@"node:process" => return jsSyntheticModule(.@"node:process"),
+                .@"node:tty" => return jsSyntheticModule(.@"node:tty"),
+                .@"node:stream" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(jsModuleFromFile(jsc_vm.load_builtins_from_path, "streams.exports.js")),
+                        .specifier = ZigString.init("node:stream"),
+                        .source_url = ZigString.init("node:stream"),
+                        .hash = 0,
+                    };
+                },
+
+                .@"node:fs/promises" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(@embedFile("fs_promises.exports.js") ++ JSC.Node.fs.constants_string),
+                        .specifier = ZigString.init("node:fs/promises"),
+                        .source_url = ZigString.init("node:fs/promises"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:path" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(jsModuleFromFile(jsc_vm.load_builtins_from_path, "path.exports.js")),
+                        .specifier = ZigString.init("node:path"),
+                        .source_url = ZigString.init("node:path"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:path/win32" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(jsModuleFromFile(jsc_vm.load_builtins_from_path, "path-win32.exports.js")),
+                        .specifier = ZigString.init("node:path/win32"),
+                        .source_url = ZigString.init("node:path/win32"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:path/posix" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(jsModuleFromFile(jsc_vm.load_builtins_from_path, "path-posix.exports.js")),
+                        .specifier = ZigString.init("node:path/posix"),
+                        .source_url = ZigString.init("node:path/posix"),
+                        .hash = 0,
+                    };
+                },
+
+                .@"node:os" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(jsModuleFromFile(jsc_vm.load_builtins_from_path, "os.exports.js")),
+                        .specifier = ZigString.init("node:os"),
+                        .source_url = ZigString.init("node:os"),
+                        .hash = 0,
+                    };
+                },
+                .@"bun:ffi" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            "export const FFIType = " ++
+                                JSC.FFI.ABIType.map_to_js_object ++
+                                ";\n\n" ++
+                                "export const suffix = '" ++ shared_library_suffix ++ "';\n\n" ++
+                                @embedFile("ffi.exports.js") ++
+                                "\n",
+                        ),
+                        .specifier = ZigString.init("bun:ffi"),
+                        .source_url = ZigString.init("bun:ffi"),
+                        .hash = 0,
+                    };
+                },
+                .@"detect-libc" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, @embedFile(if (Environment.isLinux) "detect-libc.linux.js" else "detect-libc.js")),
+                        ),
+                        .specifier = ZigString.init("detect-libc"),
+                        .source_url = ZigString.init("detect-libc"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:url" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "url.exports.js")),
+                        ),
+                        .specifier = ZigString.init("node:url"),
+                        .source_url = ZigString.init("node:url"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:assert" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "assert.exports.js")),
+                        ),
+                        .specifier = ZigString.init("node:assert"),
+                        .source_url = ZigString.init("node:assert"),
+                        .hash = 0,
+                    };
+                },
+                .@"bun:sqlite" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "./bindings/sqlite/sqlite.exports.js")),
+                        ),
+                        .specifier = ZigString.init("bun:sqlite"),
+                        .source_url = ZigString.init("bun:sqlite"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:perf_hooks" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "./perf_hooks.exports.js")),
+                        ),
+                        .specifier = ZigString.init("node:perf_hooks"),
+                        .source_url = ZigString.init("node:perf_hooks"),
+                        .hash = 0,
+                    };
+                },
+                .@"ws" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "./ws.exports.js")),
+                        ),
+                        .specifier = ZigString.init("ws"),
+                        .source_url = ZigString.init("ws"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:timers" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "./node_timers.exports.js")),
+                        ),
+                        .specifier = ZigString.init("node:timers"),
+                        .source_url = ZigString.init("node:timers"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:timers/promises" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "./node_timers_promises.exports.js")),
+                        ),
+                        .specifier = ZigString.init("node:timers/promises"),
+                        .source_url = ZigString.init("node:timers/promises"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:stream/web" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "./node_streams_web.exports.js")),
+                        ),
+                        .specifier = ZigString.init("node:stream/web"),
+                        .source_url = ZigString.init("node:stream/web"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:stream/consumer" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "./node_streams_consumer.exports.js")),
+                        ),
+                        .specifier = ZigString.init("node:stream/consumer"),
+                        .source_url = ZigString.init("node:stream/consumer"),
+                        .hash = 0,
+                    };
+                },
+                .@"undici" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "./undici.exports.js")),
+                        ),
+                        .specifier = ZigString.init("undici"),
+                        .source_url = ZigString.init("undici"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:http" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "./http.exports.js")),
+                        ),
+                        .specifier = ZigString.init("node:http"),
+                        .source_url = ZigString.init("node:http"),
+                        .hash = 0,
+                    };
+                },
+                .@"node:https" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "./https.exports.js")),
+                        ),
+                        .specifier = ZigString.init("node:https"),
+                        .source_url = ZigString.init("node:https"),
+                        .hash = 0,
+                    };
+                },
+                .@"depd" => {
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = ZigString.init(
+                            @as(string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "./depd.exports.js")),
+                        ),
+                        .specifier = ZigString.init("depd"),
+                        .source_url = ZigString.init("depd"),
+                        .hash = 0,
+                    };
+                },
+            }
+        } else if (specifier.len > js_ast.Macro.namespaceWithColon.len and
+            strings.eqlComptimeIgnoreLen(specifier[0..js_ast.Macro.namespaceWithColon.len], js_ast.Macro.namespaceWithColon))
+        {
+            if (jsc_vm.macro_entry_points.get(MacroEntryPoint.generateIDFromSpecifier(specifier))) |entry| {
+                return ResolvedSource{
+                    .allocator = null,
+                    .source_code = ZigString.init(entry.source.contents),
+                    .specifier = ZigString.init(specifier),
+                    .source_url = ZigString.init(specifier),
+                    .hash = 0,
+                };
+            }
+        }
+
+        return null;
+    }
+
+    export fn Bun__transpileVirtualModule(
+        globalObject: *JSC.JSGlobalObject,
+        specifier_ptr: *ZigString,
+        referrer_ptr: *ZigString,
+        source_code: *ZigString,
+        loader_: Api.Loader,
+        ret: *ErrorableResolvedSource,
+    ) bool {
+        JSC.markBinding(@src());
+        const jsc_vm = globalObject.bunVM();
+        std.debug.assert(jsc_vm.plugin_runner != null);
+
+        var specifier_slice = specifier_ptr.toSlice(jsc_vm.allocator);
+        const specifier = specifier_slice.slice();
+        defer specifier_slice.deinit();
+        var source_code_slice = source_code.toSlice(jsc_vm.allocator);
+        defer source_code_slice.deinit();
+        var referrer_slice = referrer_ptr.toSlice(jsc_vm.allocator);
+        defer referrer_slice.deinit();
+
+        var virtual_source = logger.Source.initPathString(specifier, source_code_slice.slice());
+        var log = logger.Log.init(jsc_vm.allocator);
+        const path = Fs.Path.init(specifier);
+
+        const loader = if (loader_ != ._none)
+            options.Loader.fromString(@tagName(loader_)).?
+        else
+            jsc_vm.bundler.options.loaders.get(path.name.ext) orelse brk: {
+                if (strings.eqlLong(specifier, jsc_vm.main, true)) {
+                    break :brk options.Loader.js;
+                }
+
+                break :brk options.Loader.file;
+            };
+
+        defer log.deinit();
+        ret.* = ErrorableResolvedSource.ok(
+            ModuleLoader.transpileSourceCode(
+                jsc_vm,
+                specifier,
+                referrer_slice.slice(),
+                path,
+                options.Loader.fromString(@tagName(loader)).?,
+                &log,
+                &virtual_source,
+                ret,
+                null,
+                VirtualMachine.source_code_printer.?,
+                globalObject,
+                FetchFlags.transpile,
+            ) catch |err| {
+                if (err == error.PluginError) {
+                    return true;
+                }
+                VirtualMachine.processFetchLog(globalObject, specifier_ptr.*, referrer_ptr.*, &log, ret, err);
+                return true;
+            },
+        );
+        return true;
+    }
+
+    comptime {
+        _ = Bun__transpileVirtualModule;
+        _ = Bun__runVirtualModule;
+        _ = Bun__transpileFile;
+        _ = Bun__fetchBuiltinModule;
+        _ = Bun__getDefaultLoader;
+    }
+};
+
+pub const FetchFlags = enum {
+    transpile,
+    print_source,
+    print_source_and_clone,
+
+    pub fn disableTranspiling(this: FetchFlags) bool {
+        return this != .transpile;
+    }
+};
+
+const SavedSourceMap = JSC.SavedSourceMap;
+
+pub const HardcodedModule = enum {
+    @"bun:ffi",
+    @"bun:jsc",
+    @"bun:main",
+    @"bun:sqlite",
+    @"depd",
+    @"detect-libc",
+    @"node:assert",
+    @"node:buffer",
+    @"node:child_process",
+    @"node:events",
+    @"node:fs",
+    @"node:fs/promises",
+    @"node:http",
+    @"node:https",
+    @"node:module",
+    @"node:net",
+    @"node:os",
+    @"node:path",
+    @"node:path/posix",
+    @"node:path/win32",
+    @"node:perf_hooks",
+    @"node:process",
+    @"node:stream",
+    @"node:stream/consumer",
+    @"node:stream/web",
+    @"node:string_decoder",
+    @"node:timers",
+    @"node:timers/promises",
+    @"node:tty",
+    @"node:url",
+    @"undici",
+    @"ws",
+    /// Already resolved modules go in here.
+    /// This does not remap the module name, it is just a hash table.
+    /// Do not put modules that have aliases in here
+    /// Put those in Aliases
+    pub const Map = bun.ComptimeStringMap(
+        HardcodedModule,
+        .{
+            .{ "buffer", HardcodedModule.@"node:buffer" },
+            .{ "bun:ffi", HardcodedModule.@"bun:ffi" },
+            .{ "bun:jsc", HardcodedModule.@"bun:jsc" },
+            .{ "bun:main", HardcodedModule.@"bun:main" },
+            .{ "bun:sqlite", HardcodedModule.@"bun:sqlite" },
+            .{ "depd", HardcodedModule.@"depd" },
+            .{ "detect-libc", HardcodedModule.@"detect-libc" },
+            .{ "node:assert", HardcodedModule.@"node:assert" },
+            .{ "node:buffer", HardcodedModule.@"node:buffer" },
+            .{ "node:child_process", HardcodedModule.@"node:child_process" },
+            .{ "node:events", HardcodedModule.@"node:events" },
+            .{ "node:fs", HardcodedModule.@"node:fs" },
+            .{ "node:fs/promises", HardcodedModule.@"node:fs/promises" },
+            .{ "node:http", HardcodedModule.@"node:http" },
+            .{ "node:https", HardcodedModule.@"node:https" },
+            .{ "node:module", HardcodedModule.@"node:module" },
+            .{ "node:net", HardcodedModule.@"node:net" },
+            .{ "node:os", HardcodedModule.@"node:os" },
+            .{ "node:path", HardcodedModule.@"node:path" },
+            .{ "node:path/posix", HardcodedModule.@"node:path/posix" },
+            .{ "node:path/win32", HardcodedModule.@"node:path/win32" },
+            .{ "node:perf_hooks", HardcodedModule.@"node:perf_hooks" },
+            .{ "node:process", HardcodedModule.@"node:process" },
+            .{ "node:stream", HardcodedModule.@"node:stream" },
+            .{ "node:stream/consumer", HardcodedModule.@"node:stream/consumer" },
+            .{ "node:stream/web", HardcodedModule.@"node:stream/web" },
+            .{ "node:string_decoder", HardcodedModule.@"node:string_decoder" },
+            .{ "node:timers", HardcodedModule.@"node:timers" },
+            .{ "node:timers/promises", HardcodedModule.@"node:timers/promises" },
+            .{ "node:tty", HardcodedModule.@"node:tty" },
+            .{ "node:url", HardcodedModule.@"node:url" },
+            .{ "undici", HardcodedModule.@"undici" },
+            .{ "ws", HardcodedModule.@"ws" },
+        },
+    );
+    pub const Aliases = bun.ComptimeStringMap(
+        string,
+        .{
+            .{ "assert", "node:assert" },
+            .{ "buffer", "node:buffer" },
+            .{ "bun", "bun" },
+            .{ "bun:ffi", "bun:ffi" },
+            .{ "bun:jsc", "bun:jsc" },
+            .{ "bun:sqlite", "bun:sqlite" },
+            .{ "bun:wrap", "bun:wrap" },
+            .{ "child_process", "node:child_process" },
+            .{ "depd", "depd" },
+            .{ "detect-libc", "detect-libc" },
+            .{ "detect-libc/lib/detect-libc.js", "detect-libc" },
+            .{ "events", "node:events" },
+            .{ "ffi", "bun:ffi" },
+            .{ "fs", "node:fs" },
+            .{ "fs/promises", "node:fs/promises" },
+            .{ "http", "node:http" },
+            .{ "https", "node:https" },
+            .{ "module", "node:module" },
+            .{ "net", "node:net" },
+            .{ "node:assert", "node:assert" },
+            .{ "node:buffer", "node:buffer" },
+            .{ "node:child_process", "node:child_process" },
+            .{ "node:events", "node:events" },
+            .{ "node:fs", "node:fs" },
+            .{ "node:fs/promises", "node:fs/promises" },
+            .{ "node:http", "node:http" },
+            .{ "node:https", "node:https" },
+            .{ "node:module", "node:module" },
+            .{ "node:net", "node:net" },
+            .{ "node:os", "node:os" },
+            .{ "node:path", "node:path" },
+            .{ "node:path/posix", "node:path/posix" },
+            .{ "node:path/win32", "node:path/win32" },
+            .{ "node:perf_hooks", "node:perf_hooks" },
+            .{ "node:process", "node:process" },
+            .{ "node:stream", "node:stream" },
+            .{ "node:stream/consumer", "node:stream/consumer" },
+            .{ "node:stream/web", "node:stream/web" },
+            .{ "node:string_decoder", "node:string_decoder" },
+            .{ "node:timers", "node:timers" },
+            .{ "node:timers/promises", "node:timers/promises" },
+            .{ "node:tty", "node:tty" },
+            .{ "node:url", "node:url" },
+            .{ "os", "node:os" },
+            .{ "path", "node:path" },
+            .{ "path/posix", "node:path/posix" },
+            .{ "path/win32", "node:path/win32" },
+            .{ "perf_hooks", "node:perf_hooks" },
+            .{ "process", "node:process" },
+            .{ "stream", "node:stream" },
+            .{ "stream/consumer", "node:stream/consumer" },
+            .{ "stream/web", "node:stream/web" },
+            .{ "string_decoder", "node:string_decoder" },
+            .{ "timers", "node:timers" },
+            .{ "timers/promises", "node:timers/promises" },
+            .{ "tty", "node:tty" },
+            .{ "undici", "undici" },
+            .{ "url", "node:url" },
+            .{ "ws", "ws" },
+            .{ "ws/lib/websocket", "ws" },
+        },
+    );
+};
+
+pub const DisabledModule = bun.ComptimeStringMap(
+    void,
+    .{
+        .{"node:tls"},
+        .{"node:worker_threads"},
+        .{"tls"},
+        .{"worker_threads"},
+    },
+);

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -424,7 +424,11 @@ pub const ModuleLoader = struct {
                     // var versions = module.parse_result.pending_imports.items(.dependency);
                     var done_count: usize = 0;
                     for (tags) |tag, tag_i| {
-                        const package_id = pm.dynamicRootDependencies().items[root_dependency_ids[tag_i]].resolution_id;
+                        const root_id = root_dependency_ids[tag_i];
+                        if (root_id == Install.invalid_package_id) continue;
+                        const root_items = pm.dynamicRootDependencies().items;
+                        if (root_items.len <= root_id) continue;
+                        const package_id = root_items[root_id].resolution_id;
 
                         switch (tag) {
                             .resolve => {

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -667,6 +667,13 @@ pub const ModuleLoader = struct {
                         }
                     }
 
+                    if (parse_result.source.contents_is_recycled) {
+                        // this shared buffer is about to become owned by the AsyncModule struct
+                        jsc_vm.bundler.resolver.caches.fs.resetSharedBuffer(
+                            jsc_vm.bundler.resolver.caches.fs.sharedBuffer(),
+                        );
+                    }
+
                     jsc_vm.modules.enqueue(
                         globalObject.?,
                         .{

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -293,16 +293,16 @@ pub const ModuleLoader = struct {
                 for (modules) |mod| {
                     var module = mod;
                     var tags = module.parse_result.pending_imports.items(.tag);
-                    var resolution_ids = module.parse_result.pending_imports.items(.resolution_id);
+                    var root_dependency_ids = module.parse_result.pending_imports.items(.root_dependency_id);
                     // var esms = module.parse_result.pending_imports.items(.esm);
                     // var versions = module.parse_result.pending_imports.items(.dependency);
                     var done_count: usize = 0;
                     for (tags) |tag, tag_i| {
-                        const resolution_id = resolution_ids[tag_i];
+                        const package_id = pm.dynamicRootDependencies().items[root_dependency_ids[tag_i]].resolution_id;
 
                         switch (tag) {
                             .resolve => {
-                                if (resolution_id == Install.invalid_package_id) {
+                                if (package_id == Install.invalid_package_id) {
                                     continue;
                                 }
 
@@ -310,7 +310,7 @@ pub const ModuleLoader = struct {
                                 tags[tag_i] = .download;
                             },
                             .download => {
-                                if (resolution_id == Install.invalid_package_id) {
+                                if (package_id == Install.invalid_package_id) {
                                     unreachable;
                                 }
                             },

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -59,6 +59,9 @@ pub const Run = struct {
         };
         run.vm.argv = ctx.passthrough;
         run.vm.arena = &run.arena;
+        run.vm.bundler.options.enable_auto_install = true;
+        run.vm.bundler.resolver.opts.enable_auto_install = true;
+        run.vm.bundler.main_file_for_package_manager = entry_path;
 
         if (ctx.debug.macros) |macros| {
             run.vm.bundler.options.macro_remap = macros;
@@ -115,6 +118,9 @@ pub const Run = struct {
                 run.vm.load_builtins_from_path = override_path;
             }
         }
+
+        run.vm.is_main_thread = true;
+        JSC.VirtualMachine.is_main_thread_vm = true;
 
         var callback = OpaqueWrap(Run, Run.start);
         run.vm.global.vm().holdAPILock(&run, callback);

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -59,8 +59,15 @@ pub const Run = struct {
         };
         run.vm.argv = ctx.passthrough;
         run.vm.arena = &run.arena;
-        run.vm.bundler.options.enable_auto_install = true;
-        run.vm.bundler.resolver.opts.enable_auto_install = true;
+
+        run.vm.bundler.options.install = ctx.install;
+        run.vm.bundler.options.enable_auto_install = ctx.debug.auto_install_setting orelse true;
+        run.vm.bundler.options.prefer_offline_install = (ctx.debug.offline_mode_setting orelse bun.Bunfig.OfflineMode.online) == .offline;
+
+        run.vm.bundler.options.install = ctx.install;
+        run.vm.bundler.resolver.opts.enable_auto_install = run.vm.bundler.options.enable_auto_install;
+
+        run.vm.bundler.resolver.opts.prefer_offline_install = run.vm.bundler.options.prefer_offline_install;
         run.vm.bundler.main_file_for_package_manager = entry_path;
 
         if (ctx.debug.macros) |macros| {

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -65,7 +65,6 @@ pub const Run = struct {
         run.vm.bundler.resolver.opts.global_cache = ctx.debug.global_cache;
         run.vm.bundler.resolver.opts.prefer_offline_install = (ctx.debug.offline_mode_setting orelse .online) == .offline;
         run.vm.bundler.resolver.opts.prefer_latest_install = (ctx.debug.offline_mode_setting orelse .online) == .latest;
-        run.vm.bundler.resolver.main_file_for_package_manager = entry_path;
         run.vm.bundler.options.global_cache = run.vm.bundler.resolver.opts.global_cache;
         run.vm.bundler.options.prefer_offline_install = run.vm.bundler.resolver.opts.prefer_offline_install;
         run.vm.bundler.options.prefer_latest_install = run.vm.bundler.resolver.opts.prefer_latest_install;

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -28,12 +28,12 @@ const bundler = @import("bundler.zig");
 const NodeModuleBundle = @import("node_module_bundle.zig").NodeModuleBundle;
 const DotEnv = @import("env_loader.zig");
 const which = @import("which.zig").which;
-const VirtualMachine = @import("javascript_core").VirtualMachine;
 const JSC = @import("javascript_core");
 const AsyncHTTP = @import("http").AsyncHTTP;
 const Arena = @import("./mimalloc_arena.zig").Arena;
 
 const OpaqueWrap = JSC.OpaqueWrap;
+const VirtualMachine = JSC.VirtualMachine;
 
 pub const Run = struct {
     file: std.fs.File,
@@ -61,14 +61,15 @@ pub const Run = struct {
         run.vm.arena = &run.arena;
 
         run.vm.bundler.options.install = ctx.install;
-        run.vm.bundler.options.enable_auto_install = ctx.debug.auto_install_setting orelse true;
-        run.vm.bundler.options.prefer_offline_install = (ctx.debug.offline_mode_setting orelse bun.Bunfig.OfflineMode.online) == .offline;
-
-        run.vm.bundler.options.install = ctx.install;
-        run.vm.bundler.resolver.opts.enable_auto_install = run.vm.bundler.options.enable_auto_install;
-
-        run.vm.bundler.resolver.opts.prefer_offline_install = run.vm.bundler.options.prefer_offline_install;
-        run.vm.bundler.main_file_for_package_manager = entry_path;
+        run.vm.bundler.resolver.opts.install = ctx.install;
+        run.vm.bundler.resolver.opts.global_cache = ctx.debug.global_cache;
+        run.vm.bundler.resolver.opts.prefer_offline_install = (ctx.debug.offline_mode_setting orelse .online) == .offline;
+        run.vm.bundler.resolver.opts.prefer_latest_install = (ctx.debug.offline_mode_setting orelse .online) == .latest;
+        run.vm.bundler.resolver.main_file_for_package_manager = entry_path;
+        run.vm.bundler.options.global_cache = run.vm.bundler.resolver.opts.global_cache;
+        run.vm.bundler.options.prefer_offline_install = run.vm.bundler.resolver.opts.prefer_offline_install;
+        run.vm.bundler.options.prefer_latest_install = run.vm.bundler.resolver.opts.prefer_latest_install;
+        run.vm.bundler.resolver.env_loader = run.vm.bundler.env;
 
         if (ctx.debug.macros) |macros| {
             run.vm.bundler.options.macro_remap = macros;

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -368,6 +368,7 @@ pub const Bundler = struct {
 
         this.package_manager = PackageManager.initWithRuntime(
             this.log,
+            this.options.install,
             this.allocator,
             .{},
             this.env,

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -337,8 +337,6 @@ pub const PluginRunner = struct {
 };
 
 pub const Bundler = struct {
-    const ThisBundler = @This();
-
     options: options.BundleOptions,
     log: *logger.Log,
     allocator: std.mem.Allocator,

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -124,6 +124,18 @@ pub const ParseResult = struct {
     ast: js_ast.Ast,
     input_fd: ?StoredFileDescriptorType = null,
     empty: bool = false,
+    pending_imports: std.ArrayListUnmanaged(_resolver.Pending) = .{},
+
+    pub fn isPendingImport(this: *const ParseResult, id: u32) bool {
+        for (this.pending_imports.items) |pending| {
+            if (switch (pending) {
+                .resolve => |res| res.import_record_id == id,
+                .download => |dl| dl.import_record_id == id,
+            }) return true;
+        }
+
+        return false;
+    }
 };
 
 const cache_files = false;

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -356,6 +356,7 @@ pub const PluginRunner = struct {
 
 pub const Bundler = struct {
     package_manager: ?*PackageManager = null,
+    onWakePackageManager: PackageManager.WakeHandler = .{},
     options: options.BundleOptions,
     log: *logger.Log,
     allocator: std.mem.Allocator,
@@ -383,6 +384,7 @@ pub const Bundler = struct {
             return this.package_manager.?;
         }
 
+        bun.HTTPThead.init() catch unreachable;
         this.package_manager = PackageManager.initWithRuntime(
             this.log,
             this.options.install,
@@ -391,7 +393,7 @@ pub const Bundler = struct {
             this.env,
             this.main_file_for_package_manager,
         ) catch @panic("Failed to initialize package manager");
-
+        this.package_manager.?.onWake = this.onWakePackageManager;
         this.resolver.package_manager = this.package_manager;
 
         return this.package_manager.?;

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -476,6 +476,11 @@ pub const Bunfig = struct {
                 jsx.development = jsx_dev;
             }
 
+            if (json.get("autoInstall")) |auto_install_expr| {
+                try this.expect(auto_install_expr, .e_boolean);
+                this.ctx.debug.auto_install_setting = auto_install_expr.asBool();
+            }
+
             switch (comptime cmd) {
                 .AutoCommand, .DevCommand, .BuildCommand, .BunCommand => {
                     if (json.get("publicDir")) |public_dir| {

--- a/src/c.zig
+++ b/src/c.zig
@@ -396,3 +396,26 @@ pub fn getRelease(buf: []u8) []const u8 {
         return "unknown";
     }
 }
+
+// we only want these two symbols from this
+const WaitH = struct {
+    pub usingnamespace @cImport("sys/wait.h");
+};
+
+/// Return exit status.
+pub const WEXITSTATUS = WaitH.WEXITSTATUS;
+
+/// True if child exited normally.
+pub const WIFEXITED = WaitH.WIFEXITED;
+
+/// True if child exited due to uncaught signal.
+pub const WIFSIGNALED = WaitH.WIFSIGNALED;
+
+/// True if child is currently stopped.
+pub const WIFSTOPPED = WaitH.WIFSTOPPED;
+
+/// Return signal number that caused process to stop.
+pub const WSTOPSIG = WaitH.WSTOPSIG;
+
+/// Return signal number that caused process to terminate.
+pub const WTERMSIG = WaitH.WTERMSIG;

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -72,6 +72,19 @@ pub const Fs = struct {
             &this.macro_shared_buffer;
     }
 
+    /// When we need to suspend/resume something that has pointers into the shared buffer, we need to
+    /// switch out the shared buffer so that it is not in use
+    /// The caller must
+    pub fn resetSharedBuffer(this: *Fs, buffer: *MutableString) void {
+        if (buffer == &this.shared_buffer) {
+            this.shared_buffer = MutableString.initEmpty(bun.default_allocator);
+        } else if (buffer == &this.macro_shared_buffer) {
+            this.macro_shared_buffer = MutableString.initEmpty(bun.default_allocator);
+        } else {
+            bun.unreachablePanic("resetSharedBuffer: invalid buffer", .{});
+        }
+    }
+
     pub fn deinit(c: *Fs) void {
         var iter = c.entries.iterator();
         while (iter.next()) |entry| {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -190,6 +190,8 @@ pub const Arguments = struct {
         clap.parseParam("-u, --origin <STR>                Rewrite import URLs to start with --origin. Default: \"\"") catch unreachable,
         clap.parseParam("-p, --port <STR>                  Port to serve bun's dev server on. Default: \"3000\"") catch unreachable,
         clap.parseParam("--hot                             Enable auto reload in bun's JavaScript runtime") catch unreachable,
+        clap.parseParam("--no-auto-install                 Disable auto install in bun's JavaScript runtime") catch unreachable,
+        clap.parseParam("--prefer-offline                  Skip staleness checks for packages in bun's JavaScript runtime") catch unreachable,
         clap.parseParam("--silent                          Don't repeat the command for bun run") catch unreachable,
         clap.parseParam("<POS>...                          ") catch unreachable,
     };
@@ -428,6 +430,9 @@ pub const Arguments = struct {
         ctx.debug.dump_environment_variables = args.flag("--dump-environment-variables");
         ctx.debug.fallback_only = ctx.debug.fallback_only or args.flag("--disable-bun.js");
         ctx.debug.dump_limits = args.flag("--dump-limits");
+
+        ctx.debug.offline_mode_setting = if (args.flag("--prefer-offline")) Bunfig.OfflineMode.offline else Bunfig.OfflineMode.online;
+        ctx.debug.auto_install_setting = !args.flag("--no-auto-install");
 
         // var output_dir = args.option("--outdir");
         var output_dir: ?string = null;
@@ -785,6 +790,7 @@ pub const Command = struct {
         silent: bool = false,
         hot_reload: bool = false,
         auto_install_setting: ?bool = null,
+        offline_mode_setting: ?Bunfig.OfflineMode = null,
 
         // technical debt
         macros: ?MacroMap = null,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -312,7 +312,7 @@ pub const Arguments = struct {
         try loadConfigPath(allocator, auto_loaded, config_path, ctx, comptime cmd);
     }
 
-    fn loadConfigWithCmdArgs(
+    pub fn loadConfigWithCmdArgs(
         comptime cmd: Command.Tag,
         allocator: std.mem.Allocator,
         args: clap.Args(clap.Help, cmd.params()),
@@ -784,6 +784,7 @@ pub const Command = struct {
         fallback_only: bool = false,
         silent: bool = false,
         hot_reload: bool = false,
+        auto_install_setting: ?bool = null,
 
         // technical debt
         macros: ?MacroMap = null,

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -338,6 +338,9 @@ pub const TestCommand = struct {
             }
         }
 
+        vm.is_main_thread = true;
+        JSC.VirtualMachine.is_main_thread_vm = true;
+
         var scanner = Scanner{
             .dirs_to_scan = Scanner.Fifo.init(ctx.allocator),
             .options = &vm.bundler.options,

--- a/src/css_scanner.zig
+++ b/src/css_scanner.zig
@@ -1023,6 +1023,7 @@ pub fn NewWriter(
                                     "Not Found - \"{s}\"",
                                     .{import.text.utf8},
                                     import_record.ImportKind.at,
+                                    err,
                                 ) catch {};
                             },
                             else => {},

--- a/src/global.zig
+++ b/src/global.zig
@@ -368,3 +368,9 @@ pub inline fn unreachablePanic(comptime fmts: []const u8, args: anytype) noretur
     if (comptime !Environment.allow_assert) unreachable;
     std.debug.panic(fmts, args);
 }
+
+pub fn StringEnum(comptime Type: type, comptime Map: anytype, value: []const u8) ?Type {
+    return ComptimeStringMap(Type, Map).get(value);
+}
+
+pub const Bunfig = @import("./bunfig.zig").Bunfig;

--- a/src/global.zig
+++ b/src/global.zig
@@ -363,3 +363,8 @@ pub fn isWritable(fd: std.os.fd_t) bool {
 
     return (std.os.poll(polls, 0) catch 0) != 0;
 }
+
+pub inline fn unreachablePanic(comptime fmts: []const u8, args: anytype) noreturn {
+    if (comptime !Environment.allow_assert) unreachable;
+    std.debug.panic(fmts, args);
+}

--- a/src/global.zig
+++ b/src/global.zig
@@ -376,3 +376,5 @@ pub fn StringEnum(comptime Type: type, comptime Map: anytype, value: []const u8)
 pub const Bunfig = @import("./bunfig.zig").Bunfig;
 
 pub const HTTPThead = @import("./http_client_async.zig").HTTPThread;
+
+pub const Analytics = @import("./analytics/analytics_thread.zig");

--- a/src/global.zig
+++ b/src/global.zig
@@ -374,3 +374,5 @@ pub fn StringEnum(comptime Type: type, comptime Map: anytype, value: []const u8)
 }
 
 pub const Bunfig = @import("./bunfig.zig").Bunfig;
+
+pub const HTTPThead = @import("./http_client_async.zig").HTTPThread;

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -6,10 +6,17 @@ const std = @import("std");
 const SlicedString = Semver.SlicedString;
 const PackageNameHash = @import("./install.zig").PackageNameHash;
 const Features = @import("./install.zig").Features;
+const Install = @import("./install.zig");
 const logger = @import("../logger.zig");
 const Dependency = @This();
 const string = @import("../string_types.zig").string;
 const strings = @import("../string_immutable.zig");
+const bun = @import("../global.zig");
+
+pub const Pair = struct {
+    resolution_id: Install.PackageID = Install.invalid_package_id,
+    dependency: Dependency = .{},
+};
 
 pub const URI = union(Tag) {
     local: String,
@@ -127,6 +134,25 @@ pub const Version = struct {
     tag: Dependency.Version.Tag = Dependency.Version.Tag.uninitialized,
     literal: String = String{},
     value: Value = Value{ .uninitialized = void{} },
+
+    pub const @"0.0.0" = Version{
+        .tag = Dependency.Version.Tag.npm,
+        .literal = String.init("0.0.0", "0.0.0"),
+        .value = Value{
+            .npm = Semver.Query.Group{
+                .allocator = bun.default_allocator,
+                .head = .{
+                    .head = .{
+                        .range = .{
+                            .left = .{
+                                .op = .gte,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
 
     pub const zeroed = Version{};
 

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -135,6 +135,15 @@ pub const Version = struct {
     literal: String = String{},
     value: Value = Value{ .uninitialized = void{} },
 
+    pub fn deinit(this: *Version) void {
+        switch (this.tag) {
+            .npm => {
+                this.value.npm.deinit();
+            },
+            else => {},
+        }
+    }
+
     pub const @"0.0.0" = Version{
         .tag = Dependency.Version.Tag.npm,
         .literal = String.init("0.0.0", "0.0.0"),

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -16,6 +16,7 @@ const bun = @import("../global.zig");
 pub const Pair = struct {
     resolution_id: Install.PackageID = Install.invalid_package_id,
     dependency: Dependency = .{},
+    failed: ?anyerror = null,
 };
 
 pub const URI = union(Tag) {

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -70,19 +70,27 @@ pub fn isLessThan(string_buf: []const u8, lhs: Dependency, rhs: Dependency) bool
     return strings.cmpStringsAsc(void{}, lhs_name, rhs_name);
 }
 
+pub fn countWithDifferentBuffers(this: Dependency, name_buf: []const u8, version_buf: []const u8, comptime StringBuilder: type, builder: StringBuilder) void {
+    builder.count(this.name.slice(name_buf));
+    builder.count(this.version.literal.slice(version_buf));
+}
+
 pub fn count(this: Dependency, buf: []const u8, comptime StringBuilder: type, builder: StringBuilder) void {
-    builder.count(this.name.slice(buf));
-    builder.count(this.version.literal.slice(buf));
+    this.countWithDifferentBuffers(buf, buf, StringBuilder, builder);
 }
 
 pub fn clone(this: Dependency, buf: []const u8, comptime StringBuilder: type, builder: StringBuilder) !Dependency {
+    return this.cloneWithDifferentBuffers(buf, buf, StringBuilder, builder);
+}
+
+pub fn cloneWithDifferentBuffers(this: Dependency, name_buf: []const u8, version_buf: []const u8, comptime StringBuilder: type, builder: StringBuilder) !Dependency {
     const out_slice = builder.lockfile.buffers.string_bytes.items;
-    const new_literal = builder.append(String, this.version.literal.slice(buf));
+    const new_literal = builder.append(String, this.version.literal.slice(version_buf));
     const sliced = new_literal.sliced(out_slice);
 
     return Dependency{
         .name_hash = this.name_hash,
-        .name = builder.append(String, this.name.slice(buf)),
+        .name = builder.append(String, this.name.slice(name_buf)),
         .version = Dependency.parseWithTag(
             builder.lockfile.allocator,
             new_literal.slice(out_slice),

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -22,6 +22,7 @@ package_id: PackageID,
 skip_verify: bool = false,
 integrity: Integrity = Integrity{},
 url: string = "",
+package_manager: *PackageManager = &PackageManager.instance,
 
 pub inline fn run(this: ExtractTarball, bytes: []const u8) !string {
     if (!this.skip_verify and this.integrity.tag.isSupported()) {
@@ -220,7 +221,7 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !string {
             Output.flush();
         }
     }
-    var folder_name = PackageManager.instance.cachedNPMPackageFolderNamePrint(&abs_buf2, name, this.resolution.value.npm.version);
+    var folder_name = this.package_manager.cachedNPMPackageFolderNamePrint(&abs_buf2, name, this.resolution.value.npm.version);
     if (folder_name.len == 0 or (folder_name.len == 1 and folder_name[0] == '/')) @panic("Tried to delete root and stopped it");
     var cache_dir = this.cache_dir;
     cache_dir.deleteTree(folder_name) catch {};

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -4095,6 +4095,7 @@ pub const PackageManager = struct {
 
     pub fn initWithRuntime(
         log: *logger.Log,
+        bun_install: ?*Api.BunInstall,
         allocator: std.mem.Allocator,
         cli: CommandLineArguments,
         env_loader: *DotEnv.Loader,
@@ -4162,7 +4163,7 @@ pub const PackageManager = struct {
             log,
             env_loader,
             cli,
-            null,
+            bun_install,
         );
 
         manager.timestamp = @truncate(u32, @intCast(u64, @maximum(std.time.timestamp(), 0)));

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2851,7 +2851,6 @@ pub const PackageManager = struct {
                         const new_resolution_id = this.dynamicRootDependencies().items[dependency_id].resolution_id;
                         if (new_resolution_id != pair.resolution_id) {
                             any_root = true;
-                            Output.debug("Resolved root dependency", .{});
                         }
                     },
                     else => unreachable,

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -4326,7 +4326,6 @@ pub const PackageManager = struct {
         allocator: std.mem.Allocator,
         cli: CommandLineArguments,
         env_loader: *DotEnv.Loader,
-        main_file_name: []const u8,
     ) !*PackageManager {
         if (env_loader.map.get("BUN_INSTALL_VERBOSE") != null) {
             PackageManager.verbose_install = true;
@@ -4415,15 +4414,9 @@ pub const PackageManager = struct {
         manager.lockfile = brk: {
             var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
 
-            {
-                var basedir = if (main_file_name.len > 0)
-                    std.fs.path.dirname(main_file_name) orelse "/"
-                else
-                    FileSystem.instance.top_level_dir;
-
+            if (root_dir.entries.hasComptimeQuery("bun.lockb")) {
                 var parts = [_]string{
-                    basedir,
-                    "bun.lockb",
+                    "./bun.lockb",
                 };
                 var lockfile_path = Path.joinAbsStringBuf(
                     Fs.FileSystem.instance.top_level_dir,

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1499,7 +1499,7 @@ pub const PackageManager = struct {
     const PreallocatedNetworkTasks = std.BoundedArray(NetworkTask, 1024);
     const NetworkTaskQueue = std.HashMapUnmanaged(u64, void, IdentityContext(u64), 80);
     const PackageIndex = std.AutoHashMapUnmanaged(u64, *Package);
-    pub var verbose_install = true;
+    pub var verbose_install = false;
 
     const PackageDedupeList = std.HashMapUnmanaged(
         u32,
@@ -1568,6 +1568,8 @@ pub const PackageManager = struct {
             .behavior = behavior,
         };
         dependency.countWithDifferentBuffers(name, version_buf, @TypeOf(&builder), &builder);
+
+        try builder.allocate();
 
         const cloned_dependency = dependency.cloneWithDifferentBuffers(name, version_buf, @TypeOf(&builder), &builder) catch unreachable;
         builder.clamp();

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1984,11 +1984,12 @@ pub const Package = extern struct {
             package.name_hash = package_name.hash;
             package.name = package_name.value;
             var package_version = string_builder.append(String, package_json.version);
+            var buf = string_builder.allocatedSlice();
 
             const version: Dependency.Version = brk: {
                 if (package_json.version.len > 0) {
-                    const sliced = package_version.sliced(string_builder.allocatedSlice());
-                    const name = package.name.slice(string_builder.allocatedSlice());
+                    const sliced = package_version.sliced(buf);
+                    const name = package.name.slice(buf);
                     if (Dependency.parse(allocator, name, &sliced, log)) |dep| {
                         break :brk dep;
                     }

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -163,6 +163,7 @@ pub const Registry = struct {
         log: *logger.Log,
         package_name: string,
         loaded_manifest: ?PackageManifest,
+        package_manager: *PackageManager,
     ) !PackageVersionResponse {
         switch (response.status_code) {
             400 => return error.BadRequest,
@@ -210,8 +211,8 @@ pub const Registry = struct {
             new_etag,
             @truncate(u32, @intCast(u64, @maximum(0, std.time.timestamp()))) + 300,
         )) |package| {
-            if (PackageManager.instance.options.enable.manifest_cache) {
-                PackageManifest.Serializer.save(&package, PackageManager.instance.getTemporaryDirectory(), PackageManager.instance.getCacheDirectory()) catch {};
+            if (package_manager.options.enable.manifest_cache) {
+                PackageManifest.Serializer.save(&package, package_manager.getTemporaryDirectory(), package_manager.getCacheDirectory()) catch {};
             }
 
             return PackageVersionResponse{ .fresh = package };

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -194,7 +194,6 @@ pub const Registry = struct {
             }
         }
 
-        initializeStore();
         var new_etag_buf: [64]u8 = undefined;
 
         if (new_etag.len < new_etag_buf.len) {

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -1273,6 +1273,21 @@ pub const Query = struct {
             pub const build = 0;
         };
 
+        pub fn deinit(this: *Group) void {
+            var list = this.head;
+            var allocator = this.allocator;
+
+            while (list.next) |next| {
+                var query = list.head;
+                while (query.next) |next_query| {
+                    allocator.destroy(next_query);
+                    query = next_query.*;
+                }
+                allocator.destroy(next);
+                list = next.*;
+            }
+        }
+
         pub fn from(version: Version) Group {
             return .{
                 .allocator = bun.default_allocator,

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -296,7 +296,7 @@ pub const String = extern struct {
         }
 
         pub fn appendUTF8WithoutPool(this: *Builder, comptime Type: type, slice_: string, hash: u64) Type {
-            if (slice_.len < String.max_inline_len) {
+            if (slice_.len <= String.max_inline_len) {
                 if (strings.isAllASCII(slice_)) {
                     switch (Type) {
                         String => {
@@ -309,6 +309,7 @@ pub const String = extern struct {
                     }
                 }
             }
+
             assert(this.len <= this.cap); // didn't count everything
             assert(this.ptr != null); // must call allocate first
 
@@ -331,7 +332,7 @@ pub const String = extern struct {
 
         // SlicedString is not supported due to inline strings.
         pub fn appendWithoutPool(this: *Builder, comptime Type: type, slice_: string, hash: u64) Type {
-            if (slice_.len < String.max_inline_len) {
+            if (slice_.len <= String.max_inline_len) {
                 switch (Type) {
                     String => {
                         return String.init(this.allocatedSlice(), slice_);
@@ -363,7 +364,7 @@ pub const String = extern struct {
         }
 
         pub fn appendWithHash(this: *Builder, comptime Type: type, slice_: string, hash: u64) Type {
-            if (slice_.len < String.max_inline_len) {
+            if (slice_.len <= String.max_inline_len) {
                 switch (Type) {
                     String => {
                         return String.init(this.allocatedSlice(), slice_);

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -4450,6 +4450,15 @@ pub const Ast = struct {
         } };
         try std.json.stringify(self.parts, opts, stream);
     }
+
+    /// Do not call this if it wasn't globally allocated!
+    pub fn deinit(this: *Ast) void {
+        // TODO: assert mimalloc-owned memory
+        if (this.parts.len > 0) bun.default_allocator.free(this.parts);
+        if (this.externals.len > 0) bun.default_allocator.free(this.externals);
+        if (this.symbols.len > 0) bun.default_allocator.free(this.symbols);
+        if (this.import_records.len > 0) bun.default_allocator.free(this.import_records);
+    }
 };
 
 pub const Span = struct {

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -48,7 +48,7 @@ pub fn NewBaseStore(comptime Union: anytype, comptime count: usize) type {
             store: Self,
         };
 
-        const Block = struct {
+        pub const Block = struct {
             used: SizeType = 0,
             items: [count]UnionValueType align(MaxAlign) = undefined,
 

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -4875,6 +4875,7 @@ pub const Macro = struct {
                             "Macro \"{s}\" not found",
                             .{import_record_path},
                             .stmt,
+                            err,
                         ) catch unreachable;
                         return error.MacroNotFound;
                     },

--- a/src/jsc.zig
+++ b/src/jsc.zig
@@ -9,6 +9,7 @@ pub usingnamespace @import("./bun.js/base.zig");
 pub const RareData = @import("./bun.js/rare_data.zig");
 pub const Shimmer = @import("./bun.js/bindings/shimmer.zig").Shimmer;
 pub usingnamespace @import("./bun.js/javascript.zig");
+pub usingnamespace @import("./bun.js/module_loader.zig");
 pub const C = @import("./bun.js/javascript_core_c_api.zig");
 pub const WebCore = @import("./bun.js/webcore.zig");
 pub const Cloudflare = struct {

--- a/src/linker.zig
+++ b/src/linker.zig
@@ -34,6 +34,7 @@ const _bundler = @import("./bundler.zig");
 const Bundler = _bundler.Bundler;
 const ResolveQueue = _bundler.ResolveQueue;
 const ResolverType = Resolver.Resolver;
+const ESModule = @import("./resolver/package_json.zig").ESModule;
 const Runtime = @import("./runtime.zig").Runtime;
 const URL = @import("url.zig").URL;
 const JSC = @import("javascript_core");
@@ -570,6 +571,111 @@ pub const Linker = struct {
                         }
                     } else |err| {
                         switch (err) {
+                            error.NoMatchingVersion => {
+                                if (import_record.handles_import_errors) {
+                                    import_record.path.is_disabled = true;
+                                    continue;
+                                }
+
+                                had_resolve_errors = true;
+
+                                var package_name = import_record.path.text;
+                                var subpath_buf: [512]u8 = undefined;
+                                if (ESModule.Package.parse(import_record.path.text, &subpath_buf)) |pkg| {
+                                    package_name = pkg.name;
+                                    linker.log.addResolveError(
+                                        &result.source,
+                                        import_record.range,
+                                        linker.allocator,
+                                        "Version \"{s}\" not found for package \"{s}\" (while resolving \"{s}\")",
+                                        .{ pkg.version, package_name, import_record.path.text },
+                                        import_record.kind,
+                                        err,
+                                    ) catch {};
+                                } else {
+                                    linker.log.addResolveError(
+                                        &result.source,
+                                        import_record.range,
+                                        linker.allocator,
+                                        "Package version not found: \"{s}\"",
+                                        .{import_record.path.text},
+                                        import_record.kind,
+                                        err,
+                                    ) catch {};
+                                }
+                                continue;
+                            },
+
+                            error.DistTagNotFound => {
+                                if (import_record.handles_import_errors) {
+                                    import_record.path.is_disabled = true;
+                                    continue;
+                                }
+
+                                had_resolve_errors = true;
+
+                                var package_name = import_record.path.text;
+                                var subpath_buf: [512]u8 = undefined;
+                                if (ESModule.Package.parse(import_record.path.text, &subpath_buf)) |pkg| {
+                                    package_name = pkg.name;
+                                    linker.log.addResolveError(
+                                        &result.source,
+                                        import_record.range,
+                                        linker.allocator,
+                                        "Version \"{s}\" not found for package \"{s}\" (while resolving \"{s}\")",
+                                        .{ pkg.version, package_name, import_record.path.text },
+                                        import_record.kind,
+                                        err,
+                                    ) catch {};
+                                } else {
+                                    linker.log.addResolveError(
+                                        &result.source,
+                                        import_record.range,
+                                        linker.allocator,
+                                        "Package tag not found: \"{s}\"",
+                                        .{import_record.path.text},
+                                        import_record.kind,
+                                        err,
+                                    ) catch {};
+                                }
+
+                                continue;
+                            },
+
+                            error.PackageManifestHTTP404 => {
+                                if (import_record.handles_import_errors) {
+                                    import_record.path.is_disabled = true;
+                                    continue;
+                                }
+
+                                had_resolve_errors = true;
+
+                                var package_name = import_record.path.text;
+                                var subpath_buf: [512]u8 = undefined;
+                                if (ESModule.Package.parse(import_record.path.text, &subpath_buf)) |pkg| {
+                                    package_name = pkg.name;
+                                    linker.log.addResolveError(
+                                        &result.source,
+                                        import_record.range,
+                                        linker.allocator,
+                                        "Package not found: \"{s}\" (while resolving \"{s}\")",
+                                        .{ package_name, import_record.path.text },
+                                        import_record.kind,
+                                        err,
+                                    ) catch {};
+                                } else {
+                                    linker.log.addResolveError(
+                                        &result.source,
+                                        import_record.range,
+                                        linker.allocator,
+                                        "Package not found: \"{s}\"",
+                                        .{package_name},
+                                        import_record.kind,
+                                        err,
+                                    ) catch {};
+                                }
+                                continue;
+                            },
                             error.ModuleNotFound => {
                                 if (import_record.handles_import_errors) {
                                     import_record.path.is_disabled = true;
@@ -594,6 +700,7 @@ pub const Linker = struct {
                                             "Could not resolve: \"{s}\". Try setting --platform=\"node\" (after bun build exists)",
                                             .{import_record.path.text},
                                             import_record.kind,
+                                            err,
                                         );
                                         continue;
                                     } else {
@@ -604,6 +711,7 @@ pub const Linker = struct {
                                             "Could not resolve: \"{s}\". Maybe you need to \"bun install\"?",
                                             .{import_record.path.text},
                                             import_record.kind,
+                                            err,
                                         );
                                         continue;
                                     }
@@ -617,6 +725,7 @@ pub const Linker = struct {
                                             import_record.path.text,
                                         },
                                         import_record.kind,
+                                        err,
                                     );
                                     continue;
                                 }
@@ -634,6 +743,7 @@ pub const Linker = struct {
                                         import_record.path.text,
                                     },
                                     import_record.kind,
+                                    err,
                                 );
                                 continue;
                             },

--- a/src/linker.zig
+++ b/src/linker.zig
@@ -220,7 +220,7 @@ pub const Linker = struct {
         var needs_require = false;
         var node_module_bundle_import_path: ?string = null;
 
-        const is_deferred = result.pending_imports.items.len > 0;
+        const is_deferred = result.pending_imports.len > 0;
 
         var import_records = result.ast.import_records;
         defer {
@@ -234,7 +234,7 @@ pub const Linker = struct {
 
                 outer: while (record_i < record_count) : (record_i += 1) {
                     var import_record = &import_records[record_i];
-                    if (import_record.is_unused or (is_bun and is_deferred and result.isPendingImport(record_i))) continue;
+                    if (import_record.is_unused or (is_bun and is_deferred and !result.isPendingImport(record_i))) continue;
 
                     const record_index = record_i;
                     if (comptime !ignore_runtime) {

--- a/src/linker.zig
+++ b/src/linker.zig
@@ -431,7 +431,7 @@ pub const Linker = struct {
                                 source_dir,
                                 import_record.path.text,
                                 import_record.kind,
-                                bundler.options.enable_auto_install,
+                                if (bundler.options.enable_auto_install) Resolver.GlobalCache.auto_install else Resolver.GlobalCache.disable,
                             )) {
                                 .success => |_resolved_import| {
                                     switch (import_record.tag) {

--- a/src/linker.zig
+++ b/src/linker.zig
@@ -452,17 +452,8 @@ pub const Linker = struct {
                                         break :brk error.InstallationPending;
                                     }
 
-                                    switch (pending.*) {
-                                        .resolve => {
-                                            pending.resolve.import_record_id = record_i;
-                                        },
-                                        .download => {
-                                            pending.download.import_record_id = record_i;
-                                        },
-                                    }
-
-                                    result.pending_imports.append(linker.allocator, pending.*) catch unreachable;
-                                    std.debug.assert(!is_deferred);
+                                    pending.import_record_id = record_i;
+                                    try result.pending_imports.append(linker.allocator, pending.*);
                                     continue;
                                 },
                                 .not_found => break :brk error.ModuleNotFound,

--- a/src/options.zig
+++ b/src/options.zig
@@ -1226,6 +1226,8 @@ pub const BundleOptions = struct {
     disable_transpilation: bool = false,
 
     enable_auto_install: bool = false,
+    prefer_offline_install: bool = false,
+    install: ?*Api.BunInstall = null,
 
     pub inline fn cssImportBehavior(this: *const BundleOptions) Api.CssInJsBehavior {
         switch (this.platform) {

--- a/src/options.zig
+++ b/src/options.zig
@@ -1225,6 +1225,8 @@ pub const BundleOptions = struct {
 
     disable_transpilation: bool = false,
 
+    enable_auto_install: bool = false,
+
     pub inline fn cssImportBehavior(this: *const BundleOptions) Api.CssInJsBehavior {
         switch (this.platform) {
             .neutral, .browser => {

--- a/src/options.zig
+++ b/src/options.zig
@@ -716,6 +716,21 @@ pub const Loader = enum(u4) {
         };
     }
 
+    pub fn fromAPI(loader: Api.Loader) Loader {
+        return switch (loader) {
+            .jsx => .jsx,
+            .js => .js,
+            .ts => .ts,
+            .tsx => .tsx,
+            .css => .css,
+            .json => .json,
+            .toml => .toml,
+            .wasm => .wasm,
+            .napi => .napi,
+            else => .file,
+        };
+    }
+
     pub fn isJSX(loader: Loader) bool {
         return loader == .jsx or loader == .tsx;
     }

--- a/src/options.zig
+++ b/src/options.zig
@@ -1240,8 +1240,9 @@ pub const BundleOptions = struct {
 
     disable_transpilation: bool = false,
 
-    enable_auto_install: bool = false,
+    global_cache: GlobalCache = .disable,
     prefer_offline_install: bool = false,
+    prefer_latest_install: bool = false,
     install: ?*Api.BunInstall = null,
 
     pub inline fn cssImportBehavior(this: *const BundleOptions) Api.CssInJsBehavior {
@@ -2335,3 +2336,5 @@ pub const RouteConfig = struct {
         return router;
     }
 };
+
+pub const GlobalCache = @import("./resolver/resolver.zig").GlobalCache;

--- a/src/output.zig
+++ b/src/output.zig
@@ -376,6 +376,8 @@ pub fn scoped(comptime tag: @Type(.EnumLiteral), comptime disabled: bool) _log_f
                     std.os.getenv("BUN_DEBUG_" ++ @tagName(tag)) != null)
                 {
                     really_disable = false;
+                } else if (std.os.getenv("BUN_DEBUG_QUIET_LOGS") != null) {
+                    really_disable = true;
                 }
             }
 

--- a/src/resolver/dir_info.zig
+++ b/src/resolver/dir_info.zig
@@ -35,6 +35,8 @@ enclosing_tsconfig_json: ?*const TSConfigJSON = null,
 /// https://github.com/oven-sh/bun/issues/229
 enclosing_package_json: ?*PackageJSON = null,
 
+package_json_for_dependencies: ?*const PackageJSON = null,
+
 abs_path: string = "",
 entries: Index = undefined,
 has_node_modules: bool = false, // Is there a "node_modules" subdirectory?

--- a/src/resolver/dir_info.zig
+++ b/src/resolver/dir_info.zig
@@ -35,7 +35,7 @@ enclosing_tsconfig_json: ?*const TSConfigJSON = null,
 /// https://github.com/oven-sh/bun/issues/229
 enclosing_package_json: ?*PackageJSON = null,
 
-package_json_for_dependencies: ?*const PackageJSON = null,
+package_json_for_dependencies: ?*PackageJSON = null,
 
 abs_path: string = "",
 entries: Index = undefined,

--- a/src/resolver/dir_info.zig
+++ b/src/resolver/dir_info.zig
@@ -1,4 +1,5 @@
 const bun = @import("../global.zig");
+const std = @import("std");
 const string = bun.string;
 const Output = bun.Output;
 const Global = bun.Global;
@@ -39,15 +40,33 @@ package_json_for_dependencies: ?*PackageJSON = null,
 
 abs_path: string = "",
 entries: Index = undefined,
-has_node_modules: bool = false, // Is there a "node_modules" subdirectory?
-is_node_modules: bool = false, // Is this a "node_modules" directory?
 package_json: ?*PackageJSON = null, // Is there a "package.json" file?
 tsconfig_json: ?*TSConfigJSON = null, // Is there a "tsconfig.json" file in this directory or a parent directory?
 abs_real_path: string = "", // If non-empty, this is the real absolute path resolving any symlinks
 
+flags: Flags.Set = Flags.Set{},
+
+/// Is there a "node_modules" subdirectory?
+pub inline fn hasNodeModules(this: *const DirInfo) bool {
+    return this.flags.contains(.has_node_modules);
+}
+/// Is this a "node_modules" directory?
+pub inline fn isNodeModules(this: *const DirInfo) bool {
+    return this.flags.contains(.is_node_modules);
+}
+
+pub const Flags = enum {
+    /// This directory is a node_modules directory
+    is_node_modules,
+    /// This directory has a node_modules subdirectory
+    has_node_modules,
+
+    pub const Set = std.enums.EnumSet(Flags);
+};
+
 pub fn hasParentPackage(this: *const DirInfo) bool {
     const parent = this.getParent() orelse return false;
-    return !parent.is_node_modules;
+    return !parent.isNodeModules();
 }
 
 pub fn getFileDescriptor(dirinfo: *const DirInfo) StoredFileDescriptorType {

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -567,6 +567,7 @@ pub const PackageJSON = struct {
         r: *resolver.Resolver,
         input_path: string,
         dirname_fd: StoredFileDescriptorType,
+        package_id: ?Install.PackageID,
         comptime include_scripts: bool,
         comptime include_dependencies: @Type(.EnumLiteral),
         comptime generate_hash: bool,
@@ -744,6 +745,11 @@ pub const PackageJSON = struct {
 
         if (comptime include_dependencies == .main or include_dependencies == .local) {
             update_dependencies: {
+                if (package_id) |pkg| {
+                    package_json.package_manager_package_id = pkg;
+                    break :update_dependencies;
+                }
+
                 // // if there is a name & version, check if the lockfile has the package
                 if (package_json.name.len > 0 and package_json.version.len > 0) {
                     if (r.package_manager) |pm| {

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -1291,7 +1291,12 @@ pub const ESModule = struct {
                 //      ^^^^^^^^^^^^^^
                 //    this is the version
 
-                return specifier_after_name[0..slash];
+                const remainder = specifier_after_name[0..slash];
+                if (remainder.len > 0 and remainder[0] == '@') {
+                    return remainder[1..];
+                }
+
+                return remainder;
             }
 
             return null;

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -474,7 +474,7 @@ pub const Resolver = struct {
     dir_cache: *DirInfo.HashMap,
 
     pub inline fn usePackageManager(self: *const ThisResolver) bool {
-        return self.opts.enable_global_cache == true;
+        return self.opts.enable_auto_install == true;
     }
 
     pub fn init1(
@@ -904,7 +904,13 @@ pub const Resolver = struct {
         result.module_type = module_type;
     }
 
-    pub fn resolveWithoutSymlinks(r: *ThisResolver, source_dir: string, import_path_: string, kind: ast.ImportKind, global_cache: bool) Result.Union {
+    pub fn resolveWithoutSymlinks(
+        r: *ThisResolver,
+        source_dir: string,
+        import_path_: string,
+        kind: ast.ImportKind,
+        global_cache: GlobalCache,
+    ) Result.Union {
         var import_path = import_path_;
 
         // This implements the module resolution algorithm from node.js, which is

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1811,9 +1811,7 @@ pub const Resolver = struct {
             debug.addNoteFmt("Enqueueing pending dependency \"{s}@{s}\"", .{ esm.name, esm.version });
         }
 
-        _ = esm;
         const input_package_id = input_package_id_.*;
-        _ = version;
         var pm = r.package_manager.?;
         if (comptime Environment.allow_assert) {
             // we should never be trying to resolve a dependency that is already resolved

--- a/src/string_builder.zig
+++ b/src/string_builder.zig
@@ -77,3 +77,10 @@ pub fn fmt(this: *StringBuilder, comptime str: string, args: anytype) string {
 pub fn fmtCount(this: *StringBuilder, comptime str: string, args: anytype) void {
     this.cap += std.fmt.count(str, args);
 }
+
+pub fn allocatedSlice(this: *StringBuilder) []u8 {
+    var ptr = this.ptr orelse return &[_]u8{};
+    std.debug.assert(this.cap > 0);
+    std.debug.assert(this.len > 0);
+    return ptr[0..this.cap];
+}


### PR DESCRIPTION
This enables automatically installing npm packages used in a script and resolving from a global shared cache when no node_modules folder is present. 

It works:
- with and without package.json
- with and without lockfiles
 
package.json can be used the same as with `node_modules`. The version ranges specified in the package.json for dependencies become the default used in the runtime. This makes it so you don't have to run `npm install` or `bun install` to install dependencies in Bun's runtime. There is no special syntax.

![image](https://user-images.githubusercontent.com/709451/200111081-72781311-fe14-4527-a967-6f78119f199c.png)



TODO:
- [ ] Tests
- [x] Error handling
- [x] Disable version specifier support when a package.json is present
- [x] Update README for changes
- [x] Load lockfile from nearest package.json
- [x] Enable progress bar
- [ ] Save lockfile
- [x] Add a flag that enables it even if a node_modules folder is present. Useful for monorepos with a `<workspace>/scripts` folder. Thinking something like: (cc @colinhacks), though they might actually put it in `"scripts"` within package.json
```bash
bun -i scripts/extract-tps-reports.js
```

Out of scope for this first release:
- [ ] TypeScript support (generate .d.ts)
- [ ] Nested lockfiles