### PR TITLE
add spread operator case in `skipTypeScriptBinding()`

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -5851,6 +5851,18 @@ fn NewParser_(
                                 try p.lexer.next();
                             },
 
+                            // "{...x}"
+                            .t_dot_dot_dot => {
+                                try p.lexer.next();
+
+                                if (p.lexer.token != .t_identifier) {
+                                    try p.lexer.unexpected();
+                                }
+
+                                found_identifier = true;
+                                try p.lexer.next();
+                            },
+
                             // "{1: y}"
                             // "{'x': y}"
                             .t_string_literal, .t_numeric_literal => {


### PR DESCRIPTION
fixes #1481 
seen in [esbuild](https://cs.github.com/evanw/esbuild/blob/c6e880adf148e5d00eddc655038bf9e53b20015c/internal/js_parser/ts_parser.go#L49) 