### PR TITLE
Add linker script to remove unwanted exports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,7 @@ PLATFORM_LINKER_FLAGS += -DDU_DISABLE_RENAMING=1 \
 endif
 
 ifeq ($(OS_NAME),linux)
-SYMBOLS=-Wl,--dynamic-list $(realpath src/symbols.dyn)
+SYMBOLS=-Wl,--dynamic-list $(realpath src/symbols.dyn) -Wl,--version-script=$(realpath src/linker.lds)
 endif
 
 SHARED_LIB_EXTENSION = .so

--- a/src/linker.lds
+++ b/src/linker.lds
@@ -1,0 +1,8 @@
+VERS_1.0 {
+    global:
+	napi*;
+	__cxa_atexit;
+	__cxa_thread_atexit_impl;
+    local:
+	*;
+};


### PR DESCRIPTION
fixes crashes when handling c++ exceptions in a shared library loaded by bunffi