### PR TITLE
switch http server default encoding order

### DIFF
--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -826,7 +826,7 @@ const accept_header = picohttp.Header{ .name = "Accept", .value = "*/*" };
 const accept_header_hash = hashHeaderName("Accept");
 
 const accept_encoding_no_compression = "identity";
-const accept_encoding_compression = "deflate, gzip";
+const accept_encoding_compression = "gzip, deflate";
 const accept_encoding_header_compression = picohttp.Header{ .name = "Accept-Encoding", .value = accept_encoding_compression };
 const accept_encoding_header_no_compression = picohttp.Header{ .name = "Accept-Encoding", .value = accept_encoding_no_compression };
 


### PR DESCRIPTION
Roblox is responding with bad data when encoding is set to deflate. This gives a zlib error with Node, Deno, and Bun:
```js
async function getInfo(rId) {
  var res = await fetch(`https://users.roblox.com/v1/users/${rId}`, {
    method: "GET",
    headers: {
      "Content-Type": "application/json",
      "Accept-Encoding": "deflate",
    },
  }).catch((err) => console.log(err));

  var data = res.json();

  return data;
}

async function printInfo(rId) {
  var info = await getInfo(rId);
  console.log(info);
}

printInfo(520887847);
```
Bun defaults to deflate first. Switched the default encoding order to start with gzip.
#686 