### PR TITLE
:memo: npm is no longer *the* package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ bun is a new:
 - JavaScript/TypeScript/JSX transpiler
 - JavaScript & CSS bundler
 - Task runner for package.json scripts
-- npm-compatible package manager
+- package manager working on the `package.json` file, same as `npm` or other package managers.
 
 All in one fast &amp; easy-to-use tool. Instead of 1,000 node_modules for development, you only need bun.
 


### PR DESCRIPTION
And it works on the package.json file, which is the actual standard, same as yarn or pnpm.
I know, this is a nit, but still I guess the ground truth is `package.json`, not the fact that it's been used by `npm`