### PR TITLE
Add subpath imports example

### DIFF
--- a/examples/subpath-imports/glob-ext.ts
+++ b/examples/subpath-imports/glob-ext.ts
@@ -1,0 +1,3 @@
+import { a, b, c } from "#glob-ext/mod.ts";
+
+console.log(a * b() * c());

--- a/examples/subpath-imports/glob.ts
+++ b/examples/subpath-imports/glob.ts
@@ -1,0 +1,3 @@
+import { a, b, c } from "#glob/mod";
+
+console.log(a * b() * c());

--- a/examples/subpath-imports/named-ext.ts
+++ b/examples/subpath-imports/named-ext.ts
@@ -1,0 +1,3 @@
+import { a, b, c } from "#named-ext/mod.ts";
+
+console.log(a * b() * c());

--- a/examples/subpath-imports/named.ts
+++ b/examples/subpath-imports/named.ts
@@ -1,0 +1,3 @@
+import { a, b, c } from "#named/mod";
+
+console.log(a * b() * c());

--- a/examples/subpath-imports/package.json
+++ b/examples/subpath-imports/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "basic",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "imports": {
+    "#glob-ext/*.ts": "./subpath/*.ts",
+    "#glob/*": "./subpath/*.ts",
+    "#named/mod": "./subpath/mod.ts",
+    "#named-ext/mod.ts": "./subpath/mod.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/subpath-imports/subpath/mod.ts
+++ b/examples/subpath-imports/subpath/mod.ts
@@ -1,0 +1,7 @@
+export const a = 2;
+
+export const b = () => 3;
+
+export function c() {
+  return 7;
+}


### PR DESCRIPTION
I've started working on some test cases for https://github.com/oven-sh/bun/pull/1483

Still need to get a grasp on how to fit these within the existing testing infrastructure, I was testing manually using `bun examples/subpath-imports/glob-ext.ts`, etc..