### PR TITLE
cleanup/fix(stdio,child_process): bug fixes, refactoring, etc.

### DIFF
--- a/src/bun.js/child_process.exports.js
+++ b/src/bun.js/child_process.exports.js
@@ -8,6 +8,7 @@ const {
 } = import.meta.require("node:os");
 
 const { ArrayBuffer } = import.meta.primordials;
+var runOnNextTick = (fn, ...args) => setImmediate(() => fn(...args));
 
 const MAX_BUFFER = 1024 * 1024;
 
@@ -159,7 +160,7 @@ export function spawn(file, args, options) {
   if (options.signal) {
     const signal = options.signal;
     if (signal.aborted) {
-      process.nextTick(onAbortListener);
+      runOnNextTick(onAbortListener);
     } else {
       signal.addEventListener("abort", onAbortListener, { once: true });
       child.once("exit", () =>
@@ -925,7 +926,7 @@ export class ChildProcess extends EventEmitter {
     // Do it on nextTick so that the user has one last chance
     // to consume the output, if for example they only want to
     // start reading the data once the process exits.
-    process.nextTick(flushStdio, this);
+    runOnNextTick(flushStdio, this);
 
     this.#maybeClose();
     this.#exited = true;

--- a/src/bun.js/child_process.exports.js
+++ b/src/bun.js/child_process.exports.js
@@ -8,7 +8,6 @@ const {
 } = import.meta.require("node:os");
 
 const { ArrayBuffer } = import.meta.primordials;
-var runOnNextTick = (fn, ...args) => setImmediate(() => fn(...args));
 
 const MAX_BUFFER = 1024 * 1024;
 
@@ -160,7 +159,7 @@ export function spawn(file, args, options) {
   if (options.signal) {
     const signal = options.signal;
     if (signal.aborted) {
-      runOnNextTick(onAbortListener);
+      process.nextTick(onAbortListener);
     } else {
       signal.addEventListener("abort", onAbortListener, { once: true });
       child.once("exit", () =>
@@ -926,7 +925,7 @@ export class ChildProcess extends EventEmitter {
     // Do it on nextTick so that the user has one last chance
     // to consume the output, if for example they only want to
     // start reading the data once the process exits.
-    runOnNextTick(flushStdio, this);
+    process.nextTick(flushStdio, this);
 
     this.#maybeClose();
     this.#exited = true;

--- a/src/bun.js/child_process.exports.js
+++ b/src/bun.js/child_process.exports.js
@@ -1819,7 +1819,6 @@ function ERR_INVALID_ARG_VALUE(name, value, reason) {
   );
 }
 
-// TODO: Add actual proper error implementation here
 class SystemError extends Error {
   path;
   syscall;

--- a/src/bun.js/child_process.exports.js
+++ b/src/bun.js/child_process.exports.js
@@ -947,9 +947,7 @@ export class ChildProcess extends EventEmitter {
       case 0: {
         switch (io) {
           case "pipe":
-            return new NativeWritable(this.#handle.stdin, {
-              __id: `child-stdin-1`,
-            });
+            return new NativeWritable(this.#handle.stdin);
           case "inherit":
             return process.stdin || null;
           case "destroyed":

--- a/src/bun.js/streams.exports.js
+++ b/src/bun.js/streams.exports.js
@@ -6803,7 +6803,7 @@ var NativeWritable = class NativeWritable extends Writable {
     var result = fileSink.write(chunk);
 
     var then = result?.then;
-    if (isPromise(result) && then && isCallable(then)) {
+    if (isPromise(result)) {
       var writePromises = this.#writePromises;
       var i = writePromises.length;
       writePromises[i] = result;

--- a/src/bun.js/streams.exports.js
+++ b/src/bun.js/streams.exports.js
@@ -4158,7 +4158,7 @@ var require_writable_readable = __commonJS({
       state.length -= state.writelen;
       state.writelen = 0;
       if (er) {
-        er.stack;
+        Error.captureStackTrace(er);
         if (!state.errored) {
           state.errored = er;
         }


### PR DESCRIPTION
Doing some fixes for stdio/child_process. Currently fixes ChildProcess.stdin to be `NativeWritable` stream, and fixes a bug with process.nextTick silently failing to queue a stdio flush which caused a very frequent race condition where a child's stdout was never read.

Also reverts streams back to function/prototype-based construction rather than classes because of the reliance of being able to derive classes with `.call()` in so many node_modules, which you cannot do with classes in JSC.