### PR TITLE
override `process.stdin.on()` correctly

### DIFF
--- a/src/bun.js/builtins/js/ProcessObjectInternals.js
+++ b/src/bun.js/builtins/js/ProcessObjectInternals.js
@@ -511,10 +511,10 @@ function getStdinStream(fd, rawRequire, Bun) {
     }
 
     on(ev, cb) {
-      super.on(ev, cb);
       if (!this.#readStream && (ev === "readable" || ev === "data")) {
         this.#loadReadStream();
       }
+      return super.on(ev, cb);
     }
 
     #loadReadStream() {

--- a/test/bun.js/process-stdio.test.ts
+++ b/test/bun.js/process-stdio.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it, test } from "bun:test";
 import { bunExe } from "bunExe";
 import { isatty } from "tty";
 
+test("process.stdin", () => {
+  expect(process.stdin).toBeDefined();
+  expect(process.stdin.on("close", function() {})).toBe(process.stdin);
+  expect(process.stdin.once("end", function() {})).toBe(process.stdin);
+});
+
 test("process.stdout", () => {
   expect(process.stdout).toBeDefined();
   expect(process.stdout.isTTY).toBe(isatty(1));


### PR DESCRIPTION
fixes #1601