### PR TITLE
fix(stream): make Readable.read work w/o _construct implemented

### DIFF
--- a/src/bun.js/bindings/JSReadableState.cpp
+++ b/src/bun.js/bindings/JSReadableState.cpp
@@ -109,6 +109,10 @@ void JSReadableState::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObj
         }
     }
 
+    // ReadableState.constructed is set to false during construction when a _construct method is implemented
+    // this is here so that the ReadableState behavior tracks the behavior in node, and that calling Readable.read
+    // will work when we return early from construct because there is no Readable._construct implemented
+    // See: https://github.com/nodejs/node/blob/main/lib/internal/streams/readable.js
     setBool(JSReadableState::Mask::constructed, true);
 }
 

--- a/src/bun.js/bindings/JSReadableState.cpp
+++ b/src/bun.js/bindings/JSReadableState.cpp
@@ -108,6 +108,8 @@ void JSReadableState::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObj
             m_encoding.set(vm, this, JSC::jsNull());
         }
     }
+
+    setBool(JSReadableState::Mask::constructed, true);
 }
 
 const JSC::ClassInfo JSReadableState::s_info = { "ReadableState"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableState) };
@@ -305,9 +307,12 @@ JSReadableState_NULLABLE_BOOLEAN_GETTER_SETTER(paused)
 
 #undef JSReadableState_JSVALUE_GETTER_SETTER
 
-#define JSReadableState_GETTER_SETTER_HASH_TABLE_VALUE(NAME)                                                                                                                                                                                                          \
-    {                                                                                                                                                                                                                                                                 \
-#NAME ""_s, static_cast < unsigned>(JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsReadableState_##NAME, setJSReadableState_##NAME } \
+#define JSReadableState_GETTER_SETTER_HASH_TABLE_VALUE(NAME)                                                                                                                  \
+    {                                                                                                                                                                         \
+#NAME ""_s, static_cast < unsigned>(JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, \
+        {                                                                                                                                                                     \
+            HashTableValue::GetterSetterType, jsReadableState_##NAME, setJSReadableState_##NAME                                                                               \
+        }                                                                                                                                                                     \
     }
 
     /* Hash table for prototype */

--- a/src/bun.js/builtins/js/ProcessObjectInternals.js
+++ b/src/bun.js/builtins/js/ProcessObjectInternals.js
@@ -462,11 +462,6 @@ function getStdinStream(fd, rawRequire, Bun) {
       return fd_;
     }
 
-    // TODO: investigate https://github.com/oven-sh/bun/issues/1608
-    _construct(callback) {
-      callback();
-    }
-
     constructor() {
       super({ readable: true, writable: true });
     }

--- a/src/bun.js/streams.exports.js
+++ b/src/bun.js/streams.exports.js
@@ -2814,13 +2814,6 @@ var require_readable = __commonJS({
           globalThis.reportError(error);
         }
       }
-
-      // NOTE(Derrick): For whatever reason this seems to be necessary to make this work
-      // I couldn't find out why .constructed was getting set to false
-      // even though construct() was getting called
-      _construct() {
-        this._readableState.constructed = true;
-      }
     }
 
     /**
@@ -6080,10 +6073,6 @@ function createNativeStreamReadable(nativeType, Readable) {
       }
     }
 
-    _construct(cb) {
-      this._readableState.constructed = true;
-      cb();
-    }
     _destroy(error, callback) {
       var ptr = this.#ptr;
       if (ptr === 0) {

--- a/test/bun.js/node-stream.test.js
+++ b/test/bun.js/node-stream.test.js
@@ -8,18 +8,37 @@ import {
 } from "node:stream";
 
 describe("Readable", () => {
-  it("should be able to be piped via .pipe", () => {
+  it("should be able to be created without _construct method defined", (done) => {
     const readable = new Readable({
-      _read() {
+      read() {
+        this.push("Hello World!\n");
+        this.push(null);
+      },
+    });
+    expect(readable instanceof Readable).toBe(true);
+    let data = "";
+    readable.on("data", (chunk) => {
+      data += chunk.toString();
+    });
+    readable.on("end", () => {
+      expect(data).toBe("Hello World!\n");
+      done();
+    });
+  });
+
+  it("should be able to be piped via .pipe", (done) => {
+    const readable = new Readable({
+      read() {
         this.push("Hello World!");
         this.push(null);
       },
     });
 
     const writable = new Writable({
-      _write(chunk, encoding, callback) {
+      write(chunk, encoding, callback) {
         expect(chunk.toString()).toBe("Hello World!");
         callback();
+        done();
       },
     });
 


### PR DESCRIPTION
This fixes #1608

We needed `ReadableState.constructed` to default to `true` instead of `false` to match Node's behavior. This PR puts `ReadableState`'s behavior in spec.