### PR TITLE
add tests for `process.stdin`

### DIFF
--- a/src/bun.js/builtins/js/ProcessObjectInternals.js
+++ b/src/bun.js/builtins/js/ProcessObjectInternals.js
@@ -515,7 +515,7 @@ function getStdinStream(fd, rawRequire, Bun) {
     }
 
     resume() {
-      this.#reader = Bun.stdin.stream().getReader();
+      this.#reader ??= Bun.stdin.stream().getReader();
       this.ref();
       return super.resume();
     }

--- a/test/bun.js/process-stdin-echo.js
+++ b/test/bun.js/process-stdin-echo.js
@@ -1,0 +1,11 @@
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (data) => {
+  process.stdout.write(data);
+});
+process.stdin.once("end", () => {
+    process.stdout.write("ENDED");
+});
+if (process.argv[2] == "resume") {
+  process.stdout.write("RESUMED");
+  process.stdin.resume();
+}

--- a/test/bun.js/process-stdio.test.ts
+++ b/test/bun.js/process-stdio.test.ts
@@ -1,12 +1,81 @@
-import { spawnSync } from "bun";
+import { spawn, spawnSync } from "bun";
 import { describe, expect, it, test } from "bun:test";
 import { bunExe } from "bunExe";
 import { isatty } from "tty";
 
 test("process.stdin", () => {
   expect(process.stdin).toBeDefined();
+  expect(process.stdout.isTTY).toBe(isatty(0));
   expect(process.stdin.on("close", function() {})).toBe(process.stdin);
   expect(process.stdin.once("end", function() {})).toBe(process.stdin);
+});
+
+test("process.stdin - read", async () => {
+  const { stdin, stdout } = spawn({
+    cmd: [bunExe(), import.meta.dir + "/process-stdin-echo.js"],
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: null,
+    env: {
+      ...process.env,
+      BUN_DEBUG_QUIET_LOGS: "1",
+    },
+  });
+  expect(stdin).toBeDefined();
+  expect(stdout).toBeDefined();
+  var lines = [
+    "Get Emoji",
+    "— All Emojis to ✂️ Copy and 📋 Paste",
+    "👌",
+    "",
+  ];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    setTimeout(() => {
+      if (line) {
+        stdin?.write(line + "\n");
+        stdin?.flush();
+      } else {
+        stdin?.end();
+      }
+    }, i * 200);
+  }
+  var text = await new Response(stdout).text();
+  expect(text).toBe(lines.join("\n") + "ENDED");
+});
+
+test("process.stdin - resume", async () => {
+  const { stdin, stdout } = spawn({
+    cmd: [bunExe(), import.meta.dir + "/process-stdin-echo.js", "resume"],
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: null,
+    env: {
+      ...process.env,
+      BUN_DEBUG_QUIET_LOGS: "1",
+    },
+  });
+  expect(stdin).toBeDefined();
+  expect(stdout).toBeDefined();
+  var lines = [
+    "Get Emoji",
+    "— All Emojis to ✂️ Copy and 📋 Paste",
+    "👌",
+    "",
+  ];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    setTimeout(() => {
+      if (line) {
+        stdin?.write(line + "\n");
+        stdin?.flush();
+      } else {
+        stdin?.end();
+      }
+    }, i * 200);
+  }
+  var text = await new Response(stdout).text();
+  expect(text).toBe("RESUMED" + lines.join("\n") + "ENDED");
 });
 
 test("process.stdout", () => {


### PR DESCRIPTION
- fix issue with repeated `.resume()` calls