### PR TITLE
fix jest hooks in bun-test

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1431,18 +1431,19 @@ pub const DescribeScope = struct {
     pub threadlocal var module: *DescribeScope = undefined;
 
     const CallbackFn = fn (
-        this: *DescribeScope,
+        _: void,
         ctx: js.JSContextRef,
         _: js.JSObjectRef,
         _: js.JSObjectRef,
         arguments: []const js.JSValueRef,
         exception: js.ExceptionRef,
     ) js.JSObjectRef;
+
     fn createCallback(comptime hook: LifecycleHook) CallbackFn {
         return struct {
             const this_hook = hook;
             pub fn run(
-                _: *DescribeScope,
+                _: void,
                 ctx: js.JSContextRef,
                 _: js.JSObjectRef,
                 _: js.JSObjectRef,

--- a/test/bun.js/bun-test/jest-hooks.test.ts
+++ b/test/bun.js/bun-test/jest-hooks.test.ts
@@ -1,0 +1,76 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+describe("test jest hooks in bun-test", () => {
+  describe("test beforeAll hook", () => {
+    let animal = "tiger";
+
+    beforeAll(() => {
+      animal = "lion";
+    });
+
+    it("string should be set by hook", () => {
+      expect(animal).toEqual("lion");
+    });
+  });
+
+  describe("test beforeEach hook", () => {
+    let animal = "tiger";
+
+    beforeEach(() => {
+      animal = "lion";
+    });
+
+    it("string should be set by hook", () => {
+      expect(animal).toEqual("lion");
+      animal = "dog";
+    });
+
+    it("string should be re-set by hook", () => {
+      expect(animal).toEqual("lion");
+    });
+  });
+
+  describe("test afterEach hook", () => {
+    let animal = "tiger";
+
+    afterEach(() => {
+      animal = "lion";
+    });
+
+    it("string should not be set by hook", () => {
+      expect(animal).toEqual("tiger");
+      animal = "dog";
+    });
+
+    it("string should be set by hook", () => {
+      expect(animal).toEqual("lion");
+    });
+  });
+
+  describe("test afterAll hook", () => {
+    let animal = "tiger";
+
+    describe("test afterAll hook", () => {
+      afterAll(() => {
+        animal = "lion";
+      });
+
+      it("string should not be set by hook", () => {
+        expect(animal).toEqual("tiger");
+        animal = "dog";
+      });
+    });
+
+    it("string should be set by hook", () => {
+      expect(animal).toEqual("lion");
+    });
+  });
+});


### PR DESCRIPTION
### Description

PR fixes the problem mentioned in #1280 where jest hooks `beforeAll`, `beforeEach`, `afterAll`, and `afterEach` were not working. 


#### Questions for reviewer:

Should the type change be to `_: void,` or to type `anyopaque` or `anytype`. I've seen both used throughout the repo. (zig newbie here) 