### PR TITLE
Implement Buffer swap16, swap32, swap64

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -1070,19 +1070,26 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_swap16Body(JSC::JSGl
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    const int size = 2;
+    constexpr int elemSize = 2;
     int64_t length = static_cast<int64_t>(castedThis->byteLength());
-    if (length % size != 0) {
-        throwRangeError(lexicalGlobalObject, scope, "Invalid buffer length"_s);
+    if (length % elemSize != 0) {
+        throwRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 16-bits"_s);
         return JSC::JSValue::encode(jsUndefined());
+    }
+
+    if (UNLIKELY(castedThis->isDetached())) {
+        throwVMTypeError(lexicalGlobalObject, scope, "Buffer is detached"_s);
+        return JSValue::encode(jsUndefined());
     }
 
     uint8_t* typedVector = castedThis->typedVector();
 
-    for (size_t i = 0; i < length/size; i++) {
-        uint8_t temp = typedVector[size*i];
-        typedVector[size*i] = typedVector[size*i+1];
-        typedVector[size*i+1] = temp;
+    for (size_t elem = 0; elem < length; elem += elemSize) {
+        const size_t right = elem + 1;
+
+        uint8_t temp = typedVector[elem];
+        typedVector[elem] = typedVector[right];
+        typedVector[right] = temp;
     }
 
     return JSC::JSValue::encode(castedThis);
@@ -1092,20 +1099,30 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_swap32Body(JSC::JSGl
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    const int size = 4;
+    constexpr int elemSize = 4;
     int64_t length = static_cast<int64_t>(castedThis->byteLength());
-    if (length % size != 0) {
-        throwRangeError(lexicalGlobalObject, scope, "Invalid buffer length"_s);
+    if (length % elemSize != 0) {
+        throwRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 32-bits"_s);
         return JSC::JSValue::encode(jsUndefined());
+    }
+
+    if (UNLIKELY(castedThis->isDetached())) {
+        throwVMTypeError(lexicalGlobalObject, scope, "Buffer is detached"_s);
+        return JSValue::encode(jsUndefined());
     }
 
     uint8_t* typedVector = castedThis->typedVector();
 
-    for (size_t i = 0; i < length/size; i++) {
-        for (size_t j = 0; j < size/2; j++) {
-            uint8_t temp = typedVector[size*i+j];
-            typedVector[size*i+j] = typedVector[size*i+(size-1)-j];
-            typedVector[size*i+(size-1)-j] = temp;
+    constexpr size_t swaps = elemSize/2;
+    for (size_t elem = 0; elem < length; elem += elemSize) {
+        const size_t right = elem + elemSize - 1;
+        for (size_t k = 0; k < swaps; k++) {
+            const size_t i = right - k;
+            const size_t j = elem + k;
+
+            uint8_t temp = typedVector[i];
+            typedVector[i] = typedVector[j];
+            typedVector[j] = temp;
         }
     }
 
@@ -1116,20 +1133,30 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_swap64Body(JSC::JSGl
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    const int size = 8;
+    constexpr size_t elemSize = 8;
     int64_t length = static_cast<int64_t>(castedThis->byteLength());
-    if (length % size != 0) {
-        throwRangeError(lexicalGlobalObject, scope, "Invalid buffer length"_s);
+    if (length % elemSize != 0) {
+        throwRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 64-bits"_s);
         return JSC::JSValue::encode(jsUndefined());
+    }
+
+    if (UNLIKELY(castedThis->isDetached())) {
+        throwVMTypeError(lexicalGlobalObject, scope, "Buffer is detached"_s);
+        return JSValue::encode(jsUndefined());
     }
 
     uint8_t* typedVector = castedThis->typedVector();
 
-    for (size_t i = 0; i < length/size; i++) {
-        for (size_t j = 0; j < size/2; j++) {
-            uint8_t temp = typedVector[size*i+j];
-            typedVector[size*i+j] = typedVector[size*i+(size-1)-j];
-            typedVector[size*i+(size-1)-j] = temp;
+    constexpr size_t swaps = elemSize/2;
+    for (size_t elem = 0; elem < length; elem += elemSize) {
+        const size_t right = elem + elemSize - 1;
+        for (size_t k = 0; k < swaps; k++) {
+            const size_t i = right - k;
+            const size_t j = elem + k;
+
+            uint8_t temp = typedVector[i];
+            typedVector[i] = typedVector[j];
+            typedVector[j] = temp;
         }
     }
 

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -1068,17 +1068,72 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_lastIndexOfBody(JSC:
 static inline JSC::EncodedJSValue jsBufferPrototypeFunction_swap16Body(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSBuffer>::ClassParameter castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
-    return JSC::JSValue::encode(jsUndefined());
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    const int size = 2;
+    int64_t length = static_cast<int64_t>(castedThis->byteLength());
+    if (length % size != 0) {
+        throwRangeError(lexicalGlobalObject, scope, "Invalid buffer length"_s);
+        return JSC::JSValue::encode(jsUndefined());
+    }
+
+    uint8_t* typedVector = castedThis->typedVector();
+
+    for (size_t i = 0; i < length/size; i++) {
+        uint8_t temp = typedVector[size*i];
+        typedVector[size*i] = typedVector[size*i+1];
+        typedVector[size*i+1] = temp;
+    }
+
+    return JSC::JSValue::encode(castedThis);
 }
 static inline JSC::EncodedJSValue jsBufferPrototypeFunction_swap32Body(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSBuffer>::ClassParameter castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
-    return JSC::JSValue::encode(jsUndefined());
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    const int size = 4;
+    int64_t length = static_cast<int64_t>(castedThis->byteLength());
+    if (length % size != 0) {
+        throwRangeError(lexicalGlobalObject, scope, "Invalid buffer length"_s);
+        return JSC::JSValue::encode(jsUndefined());
+    }
+
+    uint8_t* typedVector = castedThis->typedVector();
+
+    for (size_t i = 0; i < length/size; i++) {
+        for (size_t j = 0; j < size/2; j++) {
+            uint8_t temp = typedVector[size*i+j];
+            typedVector[size*i+j] = typedVector[size*i+(size-1)-j];
+            typedVector[size*i+(size-1)-j] = temp;
+        }
+    }
+
+    return JSC::JSValue::encode(castedThis);
 }
 static inline JSC::EncodedJSValue jsBufferPrototypeFunction_swap64Body(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSBuffer>::ClassParameter castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
-    return JSC::JSValue::encode(jsUndefined());
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    const int size = 8;
+    int64_t length = static_cast<int64_t>(castedThis->byteLength());
+    if (length % size != 0) {
+        throwRangeError(lexicalGlobalObject, scope, "Invalid buffer length"_s);
+        return JSC::JSValue::encode(jsUndefined());
+    }
+
+    uint8_t* typedVector = castedThis->typedVector();
+
+    for (size_t i = 0; i < length/size; i++) {
+        for (size_t j = 0; j < size/2; j++) {
+            uint8_t temp = typedVector[size*i+j];
+            typedVector[size*i+j] = typedVector[size*i+(size-1)-j];
+            typedVector[size*i+(size-1)-j] = temp;
+        }
+    }
+
+    return JSC::JSValue::encode(castedThis);
 }
 
 static inline JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSBuffer>::ClassParameter castedThis)

--- a/test/bun.js/buffer.test.js
+++ b/test/bun.js/buffer.test.js
@@ -622,7 +622,7 @@ it("Buffer.swap16", () => {
     buf.swap16();
     expect(false).toBe(true);
   } catch (exception) {
-    expect(exception.message).toBe("Invalid buffer length");
+    expect(exception.message).toBe("Buffer size must be a multiple of 16-bits");
   }
 });
 
@@ -648,7 +648,7 @@ it("Buffer.swap32", () => {
     buf.swap32();
     expect(false).toBe(true);
   } catch (exception) {
-    expect(exception.message).toBe("Invalid buffer length");
+    expect(exception.message).toBe("Buffer size must be a multiple of 32-bits");
   }
 });
 
@@ -674,7 +674,7 @@ it("Buffer.swap64", () => {
     buf.swap64();
     expect(false).toBe(true);
   } catch (exception) {
-    expect(exception.message).toBe("Invalid buffer length");
+    expect(exception.message).toBe("Buffer size must be a multiple of 64-bits");
   }
 });
 

--- a/test/bun.js/buffer.test.js
+++ b/test/bun.js/buffer.test.js
@@ -600,6 +600,84 @@ it("Buffer.from(base64)", () => {
   ).toBe('console.log("hello world")\n');
 });
 
+it("Buffer.swap16", () => {
+  const examples = [
+    ["", ""],
+    ["a1", "1a"],
+    ["a1b2", "1a2b"]
+  ];
+
+  for (let i = 0; i < examples.length; i++) {
+    const input = examples[i][0];
+    const output = examples[i][1];
+    const buf = Buffer.from(input, "utf-8");
+
+    const ref = buf.swap16();
+    expect(ref instanceof Buffer).toBe(true);
+    expect(buf.toString()).toBe(output);
+  }
+
+  const buf = Buffer.from("123", "utf-8");
+  try {
+    buf.swap16();
+    expect(false).toBe(true);
+  } catch (exception) {
+    expect(exception.message).toBe("Invalid buffer length");
+  }
+});
+
+it("Buffer.swap32", () => {
+  const examples = [
+    ["", ""],
+    ["a1b2", "2b1a"],
+    ["a1b2c3d4", "2b1a4d3c"]
+  ];
+
+  for (let i = 0; i < examples.length; i++) {
+    const input = examples[i][0];
+    const output = examples[i][1];
+    const buf = Buffer.from(input, "utf-8");
+
+    const ref = buf.swap32();
+    expect(ref instanceof Buffer).toBe(true);
+    expect(buf.toString()).toBe(output);
+  }
+
+  const buf = Buffer.from("12345", "utf-8");
+  try {
+    buf.swap32();
+    expect(false).toBe(true);
+  } catch (exception) {
+    expect(exception.message).toBe("Invalid buffer length");
+  }
+});
+
+it("Buffer.swap64", () => {
+  const examples = [
+    ["", ""],
+    ["a1b2c3d4", "4d3c2b1a"],
+    ["a1b2c3d4e5f6g7h8", "4d3c2b1a8h7g6f5e"],
+  ];
+
+  for (let i = 0; i < examples.length; i++) {
+    const input = examples[i][0];
+    const output = examples[i][1];
+    const buf = Buffer.from(input, "utf-8");
+
+    const ref = buf.swap64();
+    expect(ref instanceof Buffer).toBe(true);
+    expect(buf.toString()).toBe(output);
+  }
+
+  const buf = Buffer.from("123456789", "utf-8");
+  try {
+    buf.swap64();
+    expect(false).toBe(true);
+  } catch (exception) {
+    expect(exception.message).toBe("Invalid buffer length");
+  }
+});
+
 it("Buffer.toString regessions", () => {
   expect(
     Buffer.from([65, 0])


### PR DESCRIPTION
The `Buffer` api is not complete as detailed in https://github.com/oven-sh/bun/issues/155.

Specifically `swap16`, `swap32` and `swap64` are unimplemented.

This PR:
- Implements `swap16`, `swap32` and `swap64` in `src/bun.js/bindings/JSBuffer.cpp`
- Adds supporting tests to `test/bun.js/buffer.test.js`, testing:
    -  Correct swapping behaviour for several examples
    - An error is thrown if the buffers are not appropriately sized (not multiples of the swap byte size, i.e. 2, 4, or 8 bytes for `swap16`, `swap32` and `swap64` respectively)

To do:
- [ ] Port node tests