### PR TITLE
[install] use default URL when only auth token is specified

### DIFF
--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -35,12 +35,7 @@ const ComptimeStringMap = @import("../comptime_string_map.zig").ComptimeStringMa
 const Npm = @This();
 
 pub const Registry = struct {
-    url: URL = URL.parse("https://registry.npmjs.org/"),
-    scopes: Map = Map{},
-
-    token: string = "",
-    auth: string = "",
-
+    pub const DefaultURL = "https://registry.npmjs.org/";
     pub const BodyPool = ObjectPool(MutableString, MutableString.init2048, true, 8);
 
     pub const Scope = struct {
@@ -72,7 +67,7 @@ pub const Registry = struct {
 
         pub fn fromAPI(name: string, registry_: Api.NpmRegistry, allocator: std.mem.Allocator, env: *DotEnv.Loader) !Scope {
             var registry = registry_;
-            var url = URL.parse(registry.url);
+            var url = URL.parse(if (registry.url.len == 0) DefaultURL else registry.url);
             var auth: string = "";
 
             if (registry.token.len == 0) {
@@ -620,15 +615,15 @@ pub const PackageManifest = struct {
 
     pub fn reportSize(this: *const PackageManifest) void {
         Output.prettyErrorln(
-            \\ Versions count:            {d} 
-            \\ External Strings count:    {d} 
+            \\ Versions count:            {d}
+            \\ External Strings count:    {d}
             \\ Package Versions count:    {d}
-            \\ 
+            \\
             \\ Bytes:
             \\
-            \\  Versions:   {d} 
-            \\  External:   {d} 
-            \\  Packages:   {d} 
+            \\  Versions:   {d}
+            \\  External:   {d}
+            \\  Packages:   {d}
             \\  Strings:    {d}
             \\  Total:      {d}
         , .{

--- a/test/bun.js/bun-install.test.ts
+++ b/test/bun.js/bun-install.test.ts
@@ -1,0 +1,38 @@
+import { spawn, spawnSync } from "bun";
+import { describe, expect, it, test } from "bun:test";
+import { bunExe } from "bunExe";
+
+test("bun install", async () => {
+  const urls = [];
+  const server = Bun.serve({
+    async fetch(request) {
+      try {
+        expect(request.method).toBe("GET");
+        expect(request.headers.get("accept")).toBe("application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*");
+        expect(await request.text()).toBe("");
+        urls.push(request.url);
+        return new Response("bar", { status: 404 });
+      } finally {
+        server.stop();
+      }
+    },
+    port: 54321,
+  });
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "foo", "--config", import.meta.dir + "/bun-install.toml"],
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      BUN_DEBUG_QUIET_LOGS: "1",
+    },
+  });
+  expect(stdout).toBeDefined();
+  expect(stderr).toBeDefined();
+  expect(await new Response(stdout).text()).toBe("");
+  var err = await new Response(stderr).text();
+  expect(err.split(/\n/)).toContain('error: package "foo" not found localhost/foo 404');
+  expect(urls).toContain("http://localhost:54321/foo");
+  expect(await exited).toBe(1);
+});

--- a/test/bun.js/bun-install.toml
+++ b/test/bun.js/bun-install.toml
@@ -1,0 +1,2 @@
+[install]
+registry = "http://localhost:54321/"


### PR DESCRIPTION
Previously it would default to `http://localhost/` which was inconsistent with the case sans token.

Use official `npm` registry as fallback in both cases.