### PR TITLE
[jest] fix and improve hooks

### DIFF
--- a/packages/bun-types/bun-test.d.ts
+++ b/packages/bun-types/bun-test.d.ts
@@ -26,11 +26,11 @@ declare module "bun:test" {
   export { test as it };
 
   export function expect(value: any): Expect;
-  export function afterAll(fn: () => void): void;
-  export function beforeAll(fn: () => void): void;
+  export function afterAll(fn: (done: (err?: any) => void) => void | Promise<any>): void;
+  export function beforeAll(fn: (done: (err?: any) => void) => void | Promise<any>): void;
 
-  export function afterEach(fn: () => void): void;
-  export function beforeEach(fn: () => void): void;
+  export function afterEach(fn: (done: (err?: any) => void) => void | Promise<any>): void;
+  export function beforeEach(fn: (done: (err?: any) => void) => void | Promise<any>): void;
 
   interface Expect {
     not: Expect;

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1281,6 +1281,14 @@ declare function queueMicrotask(callback: (...args: any[]) => void): void;
  */
 declare function reportError(error: any): void;
 /**
+ * Run a function immediately after main event loop is vacant
+ * @param handler function to call
+ */
+declare function setImmediate(
+  handler: TimerHandler,
+  ...arguments: any[]
+): number;
+/**
  * Run a function every `interval` milliseconds
  * @param handler function to call
  * @param interval milliseconds to wait between calls
@@ -2277,7 +2285,7 @@ declare function alert(message?: string): void;
 declare function confirm(message?: string): boolean;
 declare function prompt(message?: string, _default?: string): string | null;
 
-/* 
+/*
 
  Web Crypto API
 

--- a/test/bun.js/bun-test/jest-hooks.test.ts
+++ b/test/bun.js/bun-test/jest-hooks.test.ts
@@ -73,4 +73,131 @@ describe("test jest hooks in bun-test", () => {
       expect(animal).toEqual("lion");
     });
   });
+
+  describe("test async hooks", async () => {
+    let beforeAllCalled = 0;
+    let beforeEachCalled = 0;
+    let afterAllCalled = 0;
+    let afterEachCalled = 0;
+
+    beforeAll(async () => {
+      beforeAllCalled += await 1;
+    });
+
+    beforeEach(async () => {
+      beforeEachCalled += await 1;
+    });
+
+    afterAll(async () => {
+      afterAllCalled += await 1;
+    });
+
+    afterEach(async () => {
+      afterEachCalled += await 1;
+    });
+
+    it("should run after beforeAll()", () => {
+      expect(beforeAllCalled).toBe(1);
+      expect(beforeEachCalled).toBe(1);
+      expect(afterAllCalled).toBe(0);
+      expect(afterEachCalled).toBe(0);
+    });
+
+    it("should run after beforeEach()", () => {
+      expect(beforeAllCalled).toBe(1);
+      expect(beforeEachCalled).toBe(2);
+      expect(afterAllCalled).toBe(0);
+      expect(afterEachCalled).toBe(1);
+    });
+  });
+
+  describe("test done callback in hooks", () => {
+    let beforeAllCalled = 0;
+    let beforeEachCalled = 0;
+    let afterAllCalled = 0;
+    let afterEachCalled = 0;
+
+    beforeAll(done => {
+      setImmediate(() => {
+        beforeAllCalled++;
+        done();
+      });
+    });
+
+    beforeEach(done => {
+      setImmediate(() => {
+        beforeEachCalled++;
+        done();
+      });
+    });
+
+    afterAll(done => {
+      setImmediate(() => {
+        afterAllCalled++;
+        done();
+      });
+    });
+
+    afterEach(done => {
+      setImmediate(() => {
+        afterEachCalled++;
+        done();
+      });
+    });
+
+    it("should run after beforeAll()", () => {
+      expect(beforeAllCalled).toBe(1);
+      expect(beforeEachCalled).toBe(1);
+      expect(afterAllCalled).toBe(0);
+      expect(afterEachCalled).toBe(0);
+    });
+
+    it("should run after beforeEach()", () => {
+      expect(beforeAllCalled).toBe(1);
+      expect(beforeEachCalled).toBe(2);
+      expect(afterAllCalled).toBe(0);
+      expect(afterEachCalled).toBe(1);
+    });
+  });
+
+  describe("test async hooks with done()", () => {
+    let beforeAllCalled = 0;
+    let beforeEachCalled = 0;
+    let afterAllCalled = 0;
+    let afterEachCalled = 0;
+
+    beforeAll(async done => {
+      beforeAllCalled += await 1;
+      setTimeout(done, 1);
+    });
+
+    beforeEach(async done => {
+      beforeEachCalled += await 1;
+      setTimeout(done, 1);
+    });
+
+    afterAll(async done => {
+      afterAllCalled += await 1;
+      setTimeout(done, 1);
+    });
+
+    afterEach(async done => {
+      afterEachCalled += await 1;
+      setTimeout(done, 1);
+    });
+
+    it("should run after beforeAll()", () => {
+      expect(beforeAllCalled).toBe(1);
+      expect(beforeEachCalled).toBe(1);
+      expect(afterAllCalled).toBe(0);
+      expect(afterEachCalled).toBe(0);
+    });
+
+    it("should run after beforeEach()", () => {
+      expect(beforeAllCalled).toBe(1);
+      expect(beforeEachCalled).toBe(2);
+      expect(afterAllCalled).toBe(0);
+      expect(afterEachCalled).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
- wait for async hooks to complete before running tests
- add support for `done(err)` callbacks in hooks

fixes #1688