### PR TITLE
fix lingering process by dead sockets

### DIFF
--- a/test/bun.js/socket/echo.js
+++ b/test/bun.js/socket/echo.js
@@ -1,0 +1,70 @@
+function createOptions(type, message, closeOnDone) {
+  let buffers = [];
+  let report = function() {
+    report = function() {};
+    const data = new Uint8Array(buffers.reduce(function(sum, buffer) {
+      return sum + buffer.length;
+    }, 0));
+    buffers.reduce(function(offset, buffer) {
+      data.set(buffer, offset);
+      return offset + buffer.length;
+    }, 0);
+    console.log(type, "GOT", new TextDecoder().decode(data));
+  }
+
+  let done = closeOnDone ? function(socket, sent) {
+    socket.data[sent ? "sent" : "received"] = true;
+    if (socket.data.sent && socket.data.received) {
+      done = function() {};
+      closeOnDone(socket);
+    }
+  } : function() {};
+
+  function drain(socket) {
+    const message = socket.data.message;
+    const written = socket.write(message);
+    if (written < message.length) {
+      socket.data.message = message.slice(written);
+    } else {
+      done(socket, true);
+    }
+  }
+
+  return {
+    hostname: "localhost",
+    port: 12345,
+    socket: {
+      close() {
+        report();
+        console.log(type, "CLOSED");
+      },
+      data(socket, buffer) {
+        buffers.push(buffer);
+        done(socket);
+      },
+      drain: drain,
+      end() {
+        report();
+        console.log(type, "ENDED");
+      },
+      error(socket, err) {
+        console.log(type, "ERRED", err);
+      },
+      open(socket) {
+        console.log(type, "OPENED");
+        drain(socket);
+      },
+    },
+    data: {
+      sent: false,
+      received: false,
+      message: message,
+    },
+  };
+}
+
+const server = Bun.listen(createOptions("[Server]", "response", socket => {
+  server.stop();
+  socket.end();
+}));
+Bun.connect(createOptions("[Client]", "request"));

--- a/test/bun.js/socket/socket.test.ts
+++ b/test/bun.js/socket/socket.test.ts
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test";
+import { bunExe } from "../bunExe";
+import { spawn } from "bun";
+
+it("should keep process alive only when active", async () => {
+  const { exited, stdout, stderr } = spawn({
+    cmd: [ bunExe(), "echo.js" ],
+    cwd: import.meta.dir,
+    stdout: "pipe",
+    stdin: null,
+    stderr: "pipe",
+    env: {
+      BUN_DEBUG_QUIET_LOGS: 1,
+    },
+  });
+  expect(await exited).toBe(0);
+  expect(await new Response(stderr).text()).toBe("");
+  var lines = (await new Response(stdout).text()).split(/\r?\n/);
+  expect(lines.filter(function(line) {
+    return line.startsWith("[Server]");
+  })).toEqual([
+    "[Server] OPENED",
+    "[Server] GOT request",
+    "[Server] CLOSED",
+  ]);
+  expect(lines.filter(function(line) {
+    return line.startsWith("[Client]");
+  })).toEqual([
+    "[Client] OPENED",
+    "[Client] GOT response",
+    "[Client] ENDED",
+    "[Client] CLOSED",
+  ]);
+});


### PR DESCRIPTION
`Bun.listen()` and `Bun.connect()` would create sockets that under certain conditions with calls to `.end()` or `.stop`,  prevents the process from exiting gracefully.