### PR TITLE
Report unhandled promise rejection on exit

### DIFF
--- a/test/bun.js/exit-code-0.js
+++ b/test/bun.js/exit-code-0.js
@@ -1,0 +1,1 @@
+process.exit(0);

--- a/test/bun.js/exit-code-1.js
+++ b/test/bun.js/exit-code-1.js
@@ -1,0 +1,1 @@
+process.exit(1);

--- a/test/bun.js/exit-code-await-throw-1.js
+++ b/test/bun.js/exit-code-await-throw-1.js
@@ -1,0 +1,3 @@
+await (async function () {
+  throw 42;
+})();

--- a/test/bun.js/exit-code-unhandled-throw.js
+++ b/test/bun.js/exit-code-unhandled-throw.js
@@ -1,0 +1,3 @@
+(async function () {
+  throw 42;
+})();

--- a/test/bun.js/exit-code.test.ts
+++ b/test/bun.js/exit-code.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, test } from "bun:test";
+import { bunExe } from "bunExe";
+import { spawnSync } from "bun";
+
+it("process.exit(1) works", () => {
+  const { exitCode } = spawnSync([
+    bunExe(),
+    import.meta.dir + "/exit-code-1.js",
+  ]);
+  expect(exitCode).toBe(1);
+});
+
+it("await on a thrown value reports exit code 1", () => {
+  const { exitCode } = spawnSync([
+    bunExe(),
+    import.meta.dir + "/exit-code-await-throw-1.js",
+  ]);
+  expect(exitCode).toBe(1);
+});
+
+it("unhandled promise rejection reports exit code 1", () => {
+  const { exitCode } = spawnSync([
+    bunExe(),
+    import.meta.dir + "/exit-code-unhandled-throw.js",
+  ]);
+  expect(exitCode).toBe(1);
+});
+
+it("process.exit(0) works", () => {
+  const { exitCode } = spawnSync([
+    bunExe(),
+    import.meta.dir + "/exit-code-0.js",
+  ]);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Previously, the following would:
1) never log the error
2) exit code would be 0 (success)

```js
(async function() {
  throw new Error("uh oh!");
})();
```

This happened because the promise was never awaited, so the exception never propagated to the top-level module.

Now any rejected promises that haven't been handed will be reported and the process exit code will be 1 instead of 0. This check only happens at the very end of the application's lifecycle to give scripts a chance to handle any pending promises.