### PR TITLE
fix(bun-test): test title in results

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1549,7 +1549,7 @@ pub const DescribeScope = struct {
         var scope = allocator.create(DescribeScope) catch unreachable;
         scope.* = .{
             .label = (label.toSlice(allocator).cloneIfNeeded(allocator) catch unreachable).slice(),
-            .parent = this,
+            .parent = active,
             .file_id = this.file_id,
         };
         var new_this = DescribeScope.Class.make(ctx, scope);

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1549,7 +1549,7 @@ pub const DescribeScope = struct {
         var scope = allocator.create(DescribeScope) catch unreachable;
         scope.* = .{
             .label = (label.toSlice(allocator).cloneIfNeeded(allocator) catch unreachable).slice(),
-            .parent = active,
+            .parent = active orelse this,
             .file_id = this.file_id,
         };
         var new_this = DescribeScope.Class.make(ctx, scope);

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -90,7 +90,9 @@ pub const CommandLineReporter = struct {
         const display_label = if (label.len > 0) label else "test";
 
         if (Output.enable_ansi_colors_stderr) {
-            for (scopes) |scope| {
+            for (scopes) |_, i| {
+                const index = (scopes.len - 1) - i;
+                const scope = scopes[index];
                 if (scope.label.len == 0) continue;
                 writer.writeAll(" ") catch unreachable;
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -102,7 +102,9 @@ pub const CommandLineReporter = struct {
                 writer.writeAll(" >") catch unreachable;
             }
         } else {
-            for (scopes) |scope| {
+            for (scopes) |_, i| {
+                const index = (scopes.len - 1) - i;
+                const scope = scopes[index];
                 if (scope.label.len == 0) continue;
                 writer.writeAll(" ") catch unreachable;
                 writer.writeAll(scope.label) catch unreachable;

--- a/test/bun.js/bun-test/nested-describes.test.ts
+++ b/test/bun.js/bun-test/nested-describes.test.ts
@@ -1,0 +1,41 @@
+import {
+    afterAll,
+    beforeAll,
+describe,
+expect,
+it,
+test,
+} from "bun:test";
+
+/*
+In this test we want the tests to print out the following on a success.
+Each success / fail should show the path of describe and test scopes
+
+✓ outer most describe > mid describe 1 > inner most describe 1 > first
+✓ outer most describe > mid describe 1 > inner most describe 2 > second
+✓ outer most describe > mid describe 2 > inner most describe 3 > first
+
+@TODO add testing for this, would require to read the test console output
+*/
+
+describe("outer most describe", () => {
+    describe("mid describe 1", () => {
+        describe("inner most describe 1", () => {
+            test("first", () => {
+                expect(5).toEqual(5);
+            })
+        })
+        describe("inner most describe 2", () => {
+            test("second", () => {
+                expect(5).toEqual(5);
+            })
+        })
+    })
+    describe("mid describe 2", () => {
+        describe("inner most describe 3", () => {
+            test("third", () => {
+                expect(5).toEqual(5);
+            })
+        })
+    })
+})

--- a/test/bun.js/bun-test/nested-describes.test.ts
+++ b/test/bun.js/bun-test/nested-describes.test.ts
@@ -1,9 +1,6 @@
 import {
-    afterAll,
-    beforeAll,
 describe,
 expect,
-it,
 test,
 } from "bun:test";
 


### PR DESCRIPTION
This PR fixes #1533.

Instead of printing just the test name in a test success or failure, bun-test will now print the full path of scopes for the test.

Previously:
```
✓ inner most describe 1 > first
```

Now:
```
✓ outer most describe > mid describe 1 > inner most describe 1 > first
```