### PR TITLE
Fix missing c-ares dep in dev build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -897,7 +897,7 @@ clone-submodules:
 	git -c submodule."src/bun.js/WebKit".update=none submodule update --init --recursive --depth=1 --progress
 
 .PHONY: devcontainer
-devcontainer: $(OBJ_DIR) $(DEBUG_OBJ_DIR) clone-submodules mimalloc zlib libarchive boringssl picohttp identifier-cache node-fallbacks npm-install api analytics bun_error fallback_decoder bindings uws lolhtml usockets tinycc runtime_js_dev sqlite webcrypto-debug webcrypto
+devcontainer: $(OBJ_DIR) $(DEBUG_OBJ_DIR) clone-submodules mimalloc zlib libarchive boringssl picohttp identifier-cache node-fallbacks npm-install api analytics bun_error fallback_decoder bindings uws lolhtml usockets tinycc c-ares runtime_js_dev sqlite webcrypto-debug webcrypto
 
 .PHONY: devcontainer-build
 devcontainer-build:


### PR DESCRIPTION
The `make dev` command fails due to the newly added c-ares dependency.

This fix adds the missing dep to the `devcontainer` target so that the `c-ares`
dep is built when the devcontainer is built.
