### PR TITLE
Publish bun-types@canary

### DIFF
--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -1,4 +1,4 @@
-name: Publish canary types
+name: Release bun-types@canary
 on:
   push:
     branches: [main, canary-types]

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -4,7 +4,7 @@ on:
     branches: [main, canary-types]
 jobs:
   tests:
-    name: Build and Test
+    name: Build, test, publish canary
     runs-on: ubuntu-latest
     if: github.repository_owner == 'oven-sh'
     defaults:
@@ -30,9 +30,6 @@ jobs:
 
       - name: Generate package
         run: bun run build
-        
-      - name: ESLint
-        run: bun run lint
 
       - name: Tests
         run: bun run test
@@ -40,7 +37,6 @@ jobs:
       - name: Set temp version
         working-directory: packages/bun-types/dist
         run: |
-          cd dist
           npm version --json
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           new_pkg_version="$(bun --version)-canary.${git_hash}"

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: latest
       
       - name: Install Bun
-        uses: xhyrom/setup-bun@v0.1.8
+        uses: oven-sh/setup-bun@v0.1.8
         with:
           bun-version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -1,0 +1,59 @@
+name: Publish canary types
+on:
+  push:
+    branches: [main, canary-types]
+jobs:
+  tests:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'oven-sh'
+    defaults:
+      run:
+        working-directory: packages/bun-types
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: latest
+      
+      - name: Install Bun
+        uses: xhyrom/setup-bun@v0.1.8
+        with:
+          bun-version: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Install dependencies
+        run: bun install
+
+      - name: Generate package
+        run: bun run build
+        
+      - name: ESLint
+        run: bun run lint
+
+      - name: Tests
+        run: bun run test
+
+      - name: Get package.json version
+        working-directory: packages/bun-types/dist
+        id: pkg
+        uses: martinbeentjes/npm-get-version-action@main
+
+      - name: Set temp version
+        working-directory: packages/bun-types/dist
+        run: |
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          new_pkg_version="${{ steps.pkg.outputs.current-version}}-canary.${git_hash}"
+          echo "new_pkg_version"
+          echo "${new_pkg_version}"
+          npm version ${new_pkg_version} --no-git-tag-version
+
+      - uses: JS-DevTools/npm-publish@v1
+        working-directory: packages/bun-types/dist
+        with:
+          tag: canary
+          dry-run: true
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -1,7 +1,7 @@
 name: Release bun-types@canary
 on:
   push:
-    branches: [main, canary-types]
+    branches: [main]
 jobs:
   tests:
     name: Build, test, publish canary

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -43,10 +43,16 @@ jobs:
           echo "new_pkg_version"
           echo "${new_pkg_version}"
           npm version ${new_pkg_version} --no-git-tag-version
-
-      - name: Publish on NPM
-        working-directory: packages/bun-types/dist
-        run: npm publish --access public --tag canary # --dry-run
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to NPM
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          package: packages/bun-types/dist/package.json
+          token: ${{ secrets.NPM_BUN_TYPES_TOKEN }}
+          dry-run: true
+          tag: canary
+      # - name: Publish on NPM
+      #   working-directory: packages/bun-types/dist
+      #   run: npm publish --access public --tag canary # --dry-run
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_BUN_TYPES_TOKEN }}

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -44,9 +44,9 @@ jobs:
           echo "${new_pkg_version}"
           npm version ${new_pkg_version} --no-git-tag-version
 
-      - uses: JS-DevTools/npm-publish@v1
-        with:
-          tag: canary
-          dry-run: true
-          package: packages/bun-types/dist/package.json
-          token: ${{ secrets.NPM_TOKEN }}
+      - name: Publish on NPM
+        working-directory: packages/bun-types/dist
+        run: npm publish --access public --tag canary --dry-run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Set temp version
         working-directory: packages/bun-types/dist
         run: |
+          cd dist
+          npm version --json
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           new_pkg_version="$(bun --version)-canary.${git_hash}"
           echo "new_pkg_version"
@@ -47,8 +49,8 @@ jobs:
           npm version ${new_pkg_version} --no-git-tag-version
 
       - uses: JS-DevTools/npm-publish@v1
-        working-directory: packages/bun-types/dist
         with:
           tag: canary
           dry-run: true
+          package: packages/bun-types/dist/package.json
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -37,16 +37,11 @@ jobs:
       - name: Tests
         run: bun run test
 
-      - name: Get package.json version
-        working-directory: packages/bun-types/dist
-        id: pkg
-        uses: martinbeentjes/npm-get-version-action@main
-
       - name: Set temp version
         working-directory: packages/bun-types/dist
         run: |
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
-          new_pkg_version="${{ steps.pkg.outputs.current-version}}-canary.${git_hash}"
+          new_pkg_version="${{ bun --version }}-canary.${git_hash}"
           echo "new_pkg_version"
           echo "${new_pkg_version}"
           npm version ${new_pkg_version} --no-git-tag-version

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: packages/bun-types/dist
         run: |
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
-          new_pkg_version="${{ bun --version }}-canary.${git_hash}"
+          new_pkg_version="$(bun --version)-canary.${git_hash}"
           echo "new_pkg_version"
           echo "${new_pkg_version}"
           npm version ${new_pkg_version} --no-git-tag-version

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Publish on NPM
         working-directory: packages/bun-types/dist
-        run: npm publish --access public --tag canary --dry-run
+        run: npm publish --access public --tag canary # --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Set temp version
         working-directory: packages/bun-types/dist
         run: |
-          npm version --json
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           new_pkg_version="$(bun --version)-canary.${git_hash}"
           echo "new_pkg_version"
@@ -50,6 +49,7 @@ jobs:
           token: ${{ secrets.NPM_BUN_TYPES_TOKEN }}
           # dry-run: true
           tag: canary
+      
       # - name: Publish on NPM
       #   working-directory: packages/bun-types/dist
       #   run: npm publish --access public --tag canary # --dry-run

--- a/.github/workflows/bun-types-release-canary.yml
+++ b/.github/workflows/bun-types-release-canary.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           package: packages/bun-types/dist/package.json
           token: ${{ secrets.NPM_BUN_TYPES_TOKEN }}
-          dry-run: true
+          # dry-run: true
           tag: canary
       # - name: Publish on NPM
       #   working-directory: packages/bun-types/dist

--- a/.github/workflows/bun-types-release.yml
+++ b/.github/workflows/bun-types-release.yml
@@ -1,6 +1,8 @@
 name: Release bun-types
 on:
   workflow_dispatch:
+  push:
+    branches: [canary-types]
 
 jobs:
   test-build:

--- a/.github/workflows/bun-types-release.yml
+++ b/.github/workflows/bun-types-release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v0.1.8
         with:
-          bun-version: canary
+          bun-version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install node
@@ -28,9 +28,6 @@ jobs:
 
       - name: Install dependencies
         run: bun install
-
-      - name: ESLint
-        run: bun run lint
 
       - name: Build package
         run: bun run build
@@ -93,7 +90,7 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v0.1.8
         with:
-          bun-version: canary
+          bun-version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all artifacts

--- a/.github/workflows/bun-types-release.yml
+++ b/.github/workflows/bun-types-release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install bun
-        uses: xhyrom/setup-bun@v0.1.8
+        uses: oven-sh/setup-bun@v0.1.8
         with:
           bun-version: canary
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
           scope: '@oven-sh'
 
       - name: Install bun
-        uses: xhyrom/setup-bun@v0.1.8
+        uses: oven-sh/setup-bun@v0.1.8
         with:
           bun-version: canary
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -104,7 +104,7 @@ jobs:
         run: bun scripts/gpr.ts
 
       - name: Publish on GPR
-        run: cd dist/ && npm publish --access public
+        run: cd dist/ && npm publish --dry-run --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/bun-types-release.yml
+++ b/.github/workflows/bun-types-release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Publish to NPM
         working-directory: packages/bun-types/dist
-        run: npm publish --dry-run
+        run: npm publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -101,7 +101,7 @@ jobs:
         run: bun scripts/gpr.ts
 
       - name: Publish on GPR
-        run: cd dist/ && npm publish --dry-run --access public
+        run: cd dist/ && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/bun-types-release.yml
+++ b/.github/workflows/bun-types-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release bun-types
 on:
   workflow_dispatch:
 

--- a/.github/workflows/bun-types-release.yml
+++ b/.github/workflows/bun-types-release.yml
@@ -1,8 +1,6 @@
 name: Release bun-types
 on:
   workflow_dispatch:
-  push:
-    branches: [canary-types]
 
 jobs:
   test-build:

--- a/.github/workflows/bun-types-release.yml
+++ b/.github/workflows/bun-types-release.yml
@@ -41,7 +41,7 @@ jobs:
           if-no-files-found: error
 
   publish-npm:
-    name: Publish on NPM
+    name: Publish to NPM
     runs-on: ubuntu-latest
     needs: [test-build]
     if: github.repository_owner == 'oven-sh'
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install node
+      - name: Install Node
         uses: actions/setup-node@v3
         with:
           node-version: latest
@@ -63,8 +63,9 @@ jobs:
           name: bun-types
           path: packages/bun-types/dist
 
-      - name: Publish on NPM
-        run: cd packages/bun-types/dist/ && npm publish --access public
+      - name: Publish to NPM
+        working-directory: packages/bun-types/dist
+        run: npm publish --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/bun-types-release.yml
+++ b/.github/workflows/bun-types-release.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: bun-types
-          path: dist
+          path: packages/bun-types/dist
 
       - name: Add scope to name
         run: bun scripts/gpr.ts

--- a/.github/workflows/bun-types-tests.yml
+++ b/.github/workflows/bun-types-tests.yml
@@ -37,8 +37,5 @@ jobs:
       - name: Generate package
         run: bun run build
 
-      - name: ESLint
-        run: bun run lint
-
       - name: Tests
         run: bun run test

--- a/.github/workflows/bun-types-tests.yml
+++ b/.github/workflows/bun-types-tests.yml
@@ -30,11 +30,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: latest
+
       - name: Install dependencies
         run: bun install
-        working-directory: '.'
-      - name: Install dependencies
-        run: bun install --force
 
       - name: Generate package
         run: bun run build

--- a/.github/workflows/bun-types-tests.yml
+++ b/.github/workflows/bun-types-tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install bun
-        uses: xhyrom/setup-bun@v0.1.8
+        uses: oven-sh/setup-bun@v0.1.8
         with:
           bun-version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bun-types-tests.yml
+++ b/.github/workflows/bun-types-tests.yml
@@ -2,11 +2,11 @@ name: Test bun-types
 on:
   push:
     paths:
-      - packages/bun-types
+      - 'packages/bun-types/**'
     branches: [main]
   pull_request:
     paths:
-      - packages/bun-types
+      - 'packages/bun-types/**'
 
 jobs:
   tests:

--- a/.github/workflows/bun-types-tests.yml
+++ b/.github/workflows/bun-types-tests.yml
@@ -30,7 +30,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: latest
-
+      - name: Install dependencies
+        run: bun install
+        working-directory: '.'
       - name: Install dependencies
         run: bun install --force
 

--- a/.github/workflows/bun-types-tests.yml
+++ b/.github/workflows/bun-types-tests.yml
@@ -1,4 +1,4 @@
-name: TypeScript Types
+name: Test bun-types
 on:
   push:
     paths:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tests:
-    name: Build and Test
+    name: Build and test
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install bun
         uses: xhyrom/setup-bun@v0.1.8

--- a/.github/workflows/bun-types-tests.yml
+++ b/.github/workflows/bun-types-tests.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --verbose
 
       - name: Generate package
         run: bun run build

--- a/.github/workflows/bun-types-tests.yml
+++ b/.github/workflows/bun-types-tests.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: latest
 
       - name: Install dependencies
-        run: bun install --verbose
+        run: bun install --force
 
       - name: Generate package
         run: bun run build

--- a/.github/workflows/bun-types-tests.yml
+++ b/.github/workflows/bun-types-tests.yml
@@ -2,11 +2,11 @@ name: Test bun-types
 on:
   push:
     paths:
-      - packages/bun-types/**/*
+      - packages/bun-types
     branches: [main]
   pull_request:
     paths:
-      - packages/bun-types/**/*
+      - packages/bun-types
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -2591,7 +2591,7 @@ If you need to read from `stdout` or `stderr` synchronously, you should use `Bun
 
 `Bun.spawn` returns a `Subprocess` object.
 
-More complete types are available in [`bun-types`](https://github.com/oven-sh/bun-types).
+More complete types are available in [`bun-types`](https://github.com/oven-sh/bun/tree/main/packages/bun-types).
 
 ```ts
 interface Subprocess {

--- a/packages/bun-types/package.json
+++ b/packages/bun-types/package.json
@@ -2,7 +2,7 @@
   "name": "bun-types",
   "types": "index.d.ts",
   "private": true,
-  "repository": "https://github.com/oven-sh/bun-types",
+  "repository": "https://github.com/oven-sh/bun",
   "scripts": {
     "build": "rm -rf ./dist && bun run bundle && bun run fmt",
     "bundle": "bun scripts/bundle.ts ./dist",

--- a/packages/bun-types/scripts/bundle.ts
+++ b/packages/bun-types/scripts/bundle.ts
@@ -53,7 +53,7 @@ const packageJSON = {
   files: ["types.d.ts", "README.md"],
   private: false,
   keywords: ["bun", "bun.js", "types"],
-  repository: "https://github.com/oven-sh/bun-types",
+  repository: "https://github.com/oven-sh/bun",
   homepage: "https://bun.sh",
 };
 


### PR DESCRIPTION
Publishes `bun-types@canary` on each push to `main`. The actual package.json version is in the form `<bun-version>-canary.<commit>`, e.g. `0.4.0-canary.348e091`.