### PR TITLE
fix bugs

### DIFF
--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -2028,20 +2028,29 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
             const args_list = callframe.arguments(4);
             const args = args_list.ptr[0..args_list.len];
 
-            if (args.len == 0 or args[0].isEmptyOrUndefinedOrNull() or args[0].isNumber()) {
-                const err = JSC.toTypeError(
-                    if (args.len == 0) JSC.Node.ErrorCode.ERR_MISSING_ARGS else JSC.Node.ErrorCode.ERR_INVALID_ARG_TYPE,
+            if (args.len == 0) {
+                globalThis.vm().throwError(globalThis, JSC.toTypeError(
+                    JSC.Node.ErrorCode.ERR_MISSING_ARGS,
                     "write() expects a string, ArrayBufferView, or ArrayBuffer",
                     .{},
                     globalThis,
-                );
-                globalThis.vm().throwError(globalThis, err);
+                ));
                 return JSC.JSValue.jsUndefined();
             }
 
             const arg = args[0];
             arg.ensureStillAlive();
             defer arg.ensureStillAlive();
+
+            if (arg.isEmptyOrUndefinedOrNull()) {
+                globalThis.vm().throwError(globalThis, JSC.toTypeError(
+                    JSC.Node.ErrorCode.ERR_STREAM_NULL_VALUES,
+                    "write() expects a string, ArrayBufferView, or ArrayBuffer",
+                    .{},
+                    globalThis,
+                ));
+                return JSC.JSValue.jsUndefined();
+            }
 
             if (arg.asArrayBuffer(globalThis)) |buffer| {
                 const slice = buffer.slice();
@@ -2050,6 +2059,16 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
                 }
 
                 return this.sink.writeBytes(.{ .temporary = bun.ByteList.init(slice) }).toJS(globalThis);
+            }
+
+            if (!arg.isString()) {
+                globalThis.vm().throwError(globalThis, JSC.toTypeError(
+                    JSC.Node.ErrorCode.ERR_INVALID_ARG_TYPE,
+                    "write() expects a string, ArrayBufferView, or ArrayBuffer",
+                    .{},
+                    globalThis,
+                ));
+                return JSC.JSValue.jsUndefined();
             }
 
             const str = arg.getZigString(globalThis);

--- a/test/bun.js/fs.test.js
+++ b/test/bun.js/fs.test.js
@@ -500,20 +500,20 @@ describe("createWriteStream", () => {
     const stream = createWriteStream(path);
     try {
       stream.write(null);
-      throw new Error("should not get here");
+      expect(() => {}).toThrow(Error);
     } catch (exception) {
       expect(exception.code).toBe("ERR_STREAM_NULL_VALUES");
     }
   });
 
-  it("writing null with objectMode: true throws ERR_STREAM_NULL_VALUES", async () => {
+  it("writing null throws ERR_STREAM_NULL_VALUES (objectMode: true)", async () => {
     const path = `/tmp/fs.test.js/${Date.now()}.createWriteStreamNulls.txt`;
     const stream = createWriteStream(path, {
       objectMode: true,
     });
     try {
       stream.write(null);
-      throw new Error("should not get here");
+      expect(() => {}).toThrow(Error);
     } catch (exception) {
       expect(exception.code).toBe("ERR_STREAM_NULL_VALUES");
     }
@@ -524,26 +524,32 @@ describe("createWriteStream", () => {
     const stream = createWriteStream(path);
     try {
       stream.write(false);
-      throw new Error("should not get here");
+      expect(() => {}).toThrow(Error);
     } catch (exception) {
       expect(exception.code).toBe("ERR_INVALID_ARG_TYPE");
     }
   });
 
-  it("writing false with objectMode: true should not throw", async () => {
+  it("writing false throws ERR_INVALID_ARG_TYPE (objectMode: true)", async () => {
     const path = `/tmp/fs.test.js/${Date.now()}.createWriteStreamFalse.txt`;
     const stream = createWriteStream(path, {
       objectMode: true,
     });
-    stream.write(false);
-    stream.on("error", () => {
-      throw new Error("should not get here");
-    });
+    try {
+      stream.write(false);
+      expect(() => {}).toThrow(Error);
+    } catch (exception) {
+      expect(exception.code).toBe("ERR_INVALID_ARG_TYPE");
+    }
   });
 });
 
 describe("fs/promises", () => {
-  const { readFile, writeFile } = promises;
+  const { readFile, stat, writeFile } = promises;
+
+  it("should not segfault on exception", async () => {
+    stat("foo/bar");
+  });
 
   it("readFile", async () => {
     const data = await readFile(import.meta.dir + "/readFileSync.txt", "utf8");


### PR DESCRIPTION
- segfault reading stacktrace from `fs/promises` rejections
- `Promise` rejection within `describe()` ends testing abruptly
- `FSSink.write()` incorrectly handles `objectMode`
- `FSSink.write()` throws wrong error codes