### PR TITLE
[Response] reject HTTP status code correctly

### DIFF
--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -171,7 +171,7 @@ pub const Body = struct {
 
             if (response_init.fastGet(ctx, .status)) |status_value| {
                 const number = status_value.to(i32);
-                if (number > 0)
+                if (100 <= number and number < 1000)
                     result.status_code = @truncate(u16, @intCast(u32, number));
             }
 
@@ -183,7 +183,6 @@ pub const Body = struct {
                 }
             }
 
-            if (result.headers == null and result.status_code < 200) return null;
             return result;
         }
     };


### PR DESCRIPTION
`picohttp` would flop for code above `999`, thus where we draw the line.

fixes #1768