### PR TITLE
Fix buffer.fill handle extended ascii

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2647,11 +2647,6 @@ pub const ZigConsoleClient = struct {
         }
 
         fn writeTypedArray(this: *ZigConsoleClient.Formatter, comptime Writer: type, writer: Writer, comptime Number: type, slice: []const Number, comptime enable_ansi_colors: bool) void {
-            writer.writeAll("\n  ");
-            defer {
-                writer.writeAll("\n");
-            }
-
             const fmt_ = if (Number == i64 or Number == u64)
                 "<r><yellow>{d}n<r>"
             else
@@ -2664,15 +2659,10 @@ pub const ZigConsoleClient = struct {
             writer.print(comptime Output.prettyFmt(fmt_, enable_ansi_colors), .{slice[0]});
             var leftover = slice[1..];
             const max = 512;
-            const max_length_in_line = 10;
             leftover = leftover[0..@min(leftover.len, max)];
-            for (leftover) |el, idx| {
+            for (leftover) |el| {
                 this.printComma(@TypeOf(&writer.ctx), &writer.ctx, enable_ansi_colors) catch return;
-                if ((idx + 1) % max_length_in_line == 0) {
-                    writer.writeAll("\n  ");
-                } else {
-                    writer.writeAll(" ");
-                }
+                writer.writeAll(" ");
 
                 writer.print(comptime Output.prettyFmt(fmt_, enable_ansi_colors), .{el});
             }

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2647,6 +2647,11 @@ pub const ZigConsoleClient = struct {
         }
 
         fn writeTypedArray(this: *ZigConsoleClient.Formatter, comptime Writer: type, writer: Writer, comptime Number: type, slice: []const Number, comptime enable_ansi_colors: bool) void {
+            writer.writeAll("\n  ");
+            defer {
+                writer.writeAll("\n");
+            }
+
             const fmt_ = if (Number == i64 or Number == u64)
                 "<r><yellow>{d}n<r>"
             else
@@ -2659,10 +2664,15 @@ pub const ZigConsoleClient = struct {
             writer.print(comptime Output.prettyFmt(fmt_, enable_ansi_colors), .{slice[0]});
             var leftover = slice[1..];
             const max = 512;
+            const max_length_in_line = 10;
             leftover = leftover[0..@min(leftover.len, max)];
-            for (leftover) |el| {
+            for (leftover) |el, idx| {
                 this.printComma(@TypeOf(&writer.ctx), &writer.ctx, enable_ansi_colors) catch return;
-                writer.writeAll(" ");
+                if ((idx + 1) % max_length_in_line == 0) {
+                    writer.writeAll("\n  ");
+                } else {
+                    writer.writeAll(" ");
+                }
 
                 writer.print(comptime Output.prettyFmt(fmt_, enable_ansi_colors), .{el});
             }

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -926,7 +926,7 @@ pub const Encoder = struct {
 
                 // Hoping this gets auto vectorized
                 for (to[0..written]) |c, i| {
-                    to[i] = @as(u8, @truncate(u7, c));
+                    to[i] = c;
                 }
 
                 return @intCast(i64, written);

--- a/test/bun.js/buffer.test.js
+++ b/test/bun.js/buffer.test.js
@@ -324,6 +324,22 @@ it("Buffer.fill 1 char string", () => {
   expect(input.join("")).toBe(demo.join(""));
 });
 
+it("Buffer.fill different arguments", () => {
+  var input = new Buffer(3);
+  input.fill("a", "ascii");
+  input.fill("b", 1, 2, "ascii");
+  input.fill("c", 2, "ascii");
+  expect(input[0]).toBe(97)
+  expect(input[1]).toBe(98)
+  expect(input[2]).toBe(99)
+});
+
+it("Buffer.fill extend ascii encoding", () => {
+  var input = new Buffer(1);
+  input.fill("\xc8", "ascii");
+  expect(input[0]).toBe(200);
+});
+
 it("Buffer.concat", () => {
   var array1 = new Uint8Array(128);
   array1.fill(100);


### PR DESCRIPTION
Fix https://github.com/oven-sh/bun/issues/1696
and 1. support Buffer.fill with different arguments like nodejs. 2. console.log format typedarray
<img width="421" alt="Screen Shot 2023-01-17 at 17 10 12" src="https://user-images.githubusercontent.com/32867472/212856441-fe43b96c-2869-46ef-b5b5-b37374f87b2f.png">
