### PR TITLE
Bugfixes to install

### DIFF
--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -424,9 +424,6 @@ pub const Version = struct {
                         var remain = dependency[i..];
                         for (remain) |c, j| {
                             if (c == '@') {
-                                remain = remain[j + 1 ..];
-                                if (remain.len == 0) return .npm;
-
                                 return infer(remain[j + 1 ..]);
                             }
                         }

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -420,11 +420,10 @@ pub const Version = struct {
                 // npm:package@1.2.3
                 'n' => {
                     if (strings.hasPrefixComptime(dependency, "npm:") and dependency.len > "npm:".len) {
-                        var i: usize = "npm:".len + @boolToInt(dependency["npm:".len] == '@');
-                        var remain = dependency[i..];
-                        for (remain) |c, j| {
+                        const remain = dependency["npm:".len + @boolToInt(dependency["npm:".len] == '@') ..];
+                        for (remain) |c, i| {
                             if (c == '@') {
-                                return infer(remain[j + 1 ..]);
+                                return infer(remain[i + 1 ..]);
                             }
                         }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2092,8 +2092,7 @@ pub const PackageManager = struct {
                     package.resolution.value.npm.version,
                 );
 
-                var is_first_time: bool = true;
-                if (try this.generateNetworkTaskForTarballTrackExisting(task_id, manifest.str(find_result.package.tarball_url), package, &is_first_time)) |network_task| {
+                if (try this.generateNetworkTaskForTarball(task_id, manifest.str(find_result.package.tarball_url), package)) |network_task| {
                     return ResolvedPackageResult{
                         .package = package,
                         .is_first_time = true,
@@ -2111,15 +2110,8 @@ pub const PackageManager = struct {
     }
 
     pub fn generateNetworkTaskForTarball(this: *PackageManager, task_id: u64, url: string, package: Lockfile.Package) !?*NetworkTask {
-        return this.generateNetworkTaskForTarballTrackExisting(task_id, url, package, null);
-    }
-
-    pub fn generateNetworkTaskForTarballTrackExisting(this: *PackageManager, task_id: u64, url: string, package: Lockfile.Package, existing: ?*bool) !?*NetworkTask {
         const dedupe_entry = try this.network_dedupe_map.getOrPut(this.allocator, task_id);
         if (dedupe_entry.found_existing) {
-            if (existing) |exist| {
-                exist.* = true;
-            }
             return null;
         }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2092,13 +2092,17 @@ pub const PackageManager = struct {
                     package.resolution.value.npm.version,
                 );
 
-                var network_task = (try this.generateNetworkTaskForTarball(task_id, manifest.str(find_result.package.tarball_url), package)).?;
+                var is_first_time: bool = true;
+                if (try this.generateNetworkTaskForTarballTrackExisting(task_id, manifest.str(find_result.package.tarball_url), package, &is_first_time)) |network_task| {
+                    return ResolvedPackageResult{
+                        .package = package,
+                        .is_first_time = true,
+                        .network_task = network_task,
+                    };
+                }
 
-                return ResolvedPackageResult{
-                    .package = package,
-                    .is_first_time = true,
-                    .network_task = network_task,
-                };
+                // if we are in the middle of extracting this package, we should wait for it to finish
+                return ResolvedPackageResult{ .package = package };
             },
             else => unreachable,
         }
@@ -2107,8 +2111,17 @@ pub const PackageManager = struct {
     }
 
     pub fn generateNetworkTaskForTarball(this: *PackageManager, task_id: u64, url: string, package: Lockfile.Package) !?*NetworkTask {
+        return this.generateNetworkTaskForTarballTrackExisting(task_id, url, package, null);
+    }
+
+    pub fn generateNetworkTaskForTarballTrackExisting(this: *PackageManager, task_id: u64, url: string, package: Lockfile.Package, existing: ?*bool) !?*NetworkTask {
         const dedupe_entry = try this.network_dedupe_map.getOrPut(this.allocator, task_id);
-        if (dedupe_entry.found_existing) return null;
+        if (dedupe_entry.found_existing) {
+            if (existing) |exist| {
+                exist.* = true;
+            }
+            return null;
+        }
 
         var network_task = this.getNetworkTask();
 
@@ -2196,7 +2209,7 @@ pub const PackageManager = struct {
                 // Resolve the version from the loaded NPM manifest
                 const manifest = this.manifests.getPtr(name_hash) orelse return null; // manifest might still be downloading. This feels unreliable.
                 const find_result: Npm.PackageManifest.FindResult = switch (version.tag) {
-                    .dist_tag => manifest.findByDistTag(this.lockfile.str(version.value.dist_tag)),
+                    .dist_tag => manifest.findByDistTag(this.lockfile.str(version.value.dist_tag.tag)),
                     .npm => manifest.findBestVersion(version.value.npm.version),
                     else => unreachable,
                 } orelse return switch (version.tag) {
@@ -2417,10 +2430,11 @@ pub const PackageManager = struct {
         const alias = dependency.name;
         const name = switch (dependency.version.tag) {
             .npm => dependency.version.value.npm.name,
+            .dist_tag => dependency.version.value.dist_tag.name,
             else => alias,
         };
         const name_hash = switch (dependency.version.tag) {
-            .npm => Lockfile.stringHash(this.lockfile.str(name)),
+            .dist_tag, .npm => Lockfile.stringHash(this.lockfile.str(name)),
             else => dependency.name_hash,
         };
         const version = dependency.version;
@@ -2470,7 +2484,7 @@ pub const PackageManager = struct {
                                                 "package \"{s}\" with tag \"{s}\" not found, but package exists",
                                                 .{
                                                     this.lockfile.str(name),
-                                                    this.lockfile.str(version.value.dist_tag),
+                                                    this.lockfile.str(version.value.dist_tag.tag),
                                                 },
                                             ) catch unreachable;
                                         }

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -577,7 +577,13 @@ pub const PackageManifest = struct {
                 timer = std.time.Timer.start() catch @panic("timer fail");
             }
             defer cache_file.close();
-            var bytes = try cache_file.readToEndAlloc(allocator, std.math.maxInt(u32));
+            var bytes = try cache_file.readToEndAllocOptions(
+                allocator,
+                std.math.maxInt(u32),
+                cache_file.getEndPos() catch null,
+                @alignOf(u8),
+                null,
+            );
             errdefer allocator.free(bytes);
             if (bytes.len < header_bytes.len) return null;
             const result = try readAll(bytes);

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -1791,6 +1791,9 @@ pub const Query = struct {
                         },
                     }
                 } else if (count == 0) {
+                    // From a semver perspective, treat "--foo" the same as "-foo"
+                    // example: foo/bar@1.2.3@--canary.24
+                    //                         ^
                     if (token.tag == .none) {
                         is_or = false;
                         token.wildcard = .none;


### PR DESCRIPTION
- Support `npm:` with dist tags such as `npm:@foo/bar@latest`
- Handle race condition when the preinstall state for a package is `extract` and another dependency depends on it while it is still being extracted. I'm surprised this wasn't noticed earlier.
- Use an exactly-sized buffer when reading the manifest from disk to minimize reallocations (the change to readToEnd)
- Fix out of range buffer in getPackageID