### PR TITLE
Reduce size of the `dockerhub/Dockerfile` image

### DIFF
--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=get /tmp/sgerrand.rsa.pub /etc/apk/keys
 COPY --from=get /tmp/glibc-${GLIBC_RELEASE}.apk /tmp
 
 # install glibc
-RUN apk --no-cache add /tmp/glibc-${GLIBC_RELEASE}.apk && \
+RUN apk --no-cache add --force-overwrite /tmp/glibc-${GLIBC_RELEASE}.apk && \
 
 # cleanup
     rm /etc/apk/keys/sgerrand.rsa.pub && \

--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -14,8 +14,8 @@ RUN unzip bun-linux-x64.zip
 
 # get glibc
 ARG GLIBC_RELEASE
-RUN wget https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_RELEASE}/glibc-${GLIBC_RELEASE}.apk
+ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub sgerrand.rsa.pub
+ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_RELEASE}/glibc-${GLIBC_RELEASE}.apk glibc-${GLIBC_RELEASE}.apk
 
 
 ### IMAGE ###

--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -7,7 +7,6 @@ FROM alpine:latest as get
 
 # prepare environment
 WORKDIR /tmp
-RUN apk --no-cache add unzip
 
 # get bun
 ADD https://github.com/oven-sh/bun/releases/latest/download/bun-linux-x64.zip bun-linux-x64.zip

--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -1,40 +1,41 @@
-### GLOBALS ###
 ARG GLIBC_RELEASE=2.34-r0
 
 
-### GET ###
-FROM alpine:latest as get
+FROM alpine:latest AS base
+
+ARG GLIBC_RELEASE
 
 # prepare environment
 WORKDIR /tmp
 
+
+FROM base AS bun
+
 # get bun
 ADD https://github.com/oven-sh/bun/releases/latest/download/bun-linux-x64.zip bun-linux-x64.zip
-RUN unzip bun-linux-x64.zip
+# install bun
+RUN unzip bun-linux-x64.zip && \
+    mv /tmp/bun-linux-x64/bun /usr/local/bin && \
+    rm bun-linux-x64.zip
+
+
+FROM base AS glibc
 
 # get glibc
-ARG GLIBC_RELEASE
-ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub sgerrand.rsa.pub
-ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_RELEASE}/glibc-${GLIBC_RELEASE}.apk glibc-${GLIBC_RELEASE}.apk
-
-
-### IMAGE ###
-FROM alpine:latest
-
-# install bun
-COPY --from=get /tmp/bun-linux-x64/bun /usr/local/bin
-
-# prepare glibc
-ARG GLIBC_RELEASE
-COPY --from=get /tmp/sgerrand.rsa.pub /etc/apk/keys
-COPY --from=get /tmp/glibc-${GLIBC_RELEASE}.apk /tmp
+ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
+ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_RELEASE}/glibc-${GLIBC_RELEASE}.apk /tmp/glibc-${GLIBC_RELEASE}.apk
 
 # install glibc
-RUN apk --no-cache add --force-overwrite /tmp/glibc-${GLIBC_RELEASE}.apk && \
-
-# cleanup
+RUN apk add --no-cache --force-overwrite /tmp/glibc-${GLIBC_RELEASE}.apk && \
+    # cleanup
     rm /etc/apk/keys/sgerrand.rsa.pub && \
-    rm /tmp/glibc-${GLIBC_RELEASE}.apk && \
+    rm /tmp/glibc-${GLIBC_RELEASE}.apk
+
+
+FROM scratch AS image
+
+COPY --from=glibc . .
+COPY --from=bun /usr/local/bin/bun /usr/local/bin
 
 # smoke test
-    bun --version
+RUN bun --version


### PR DESCRIPTION
Hello, @Jarred-Sumner.

I rewrote `dockerhub/Dockerfile`:

* Fixed: `ERROR: glibc-2.34-r0: overwriting etc/nsswitch.conf owned by alpine-baselayout-data-3.4.0-r0`.
* Removed adding of the `unzip` package, because it's bundled.
* Using `ADD` instruction instead of `wget` command to enable Docker built-in caching and reduce network usage.
* Created stages: `base`, `bun`, `glibc` and `image` and removed `get` stage to make build parallel.

## Difference

Note a difference in the `/lib` directory, because old Alpine GNU/Linux is using the OpenSSL 1.1.1, and newest is using the OpenSSL 3.

### Before

![image](https://user-images.githubusercontent.com/2821574/214376041-ca2dbb56-a8b5-424e-bd06-7de5b7780e53.png)

### After

![image](https://user-images.githubusercontent.com/2821574/214376069-87d68679-7abc-4b84-b244-80e83dcb886b.png)

Best wishes,
Sergey.