### PR TITLE
fix(Express.js) Express.js try to use function as hostname

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -340,16 +340,13 @@ pub const ServerConfig = struct {
             }
 
             if (arg.getTruthy(global, "hostname") orelse arg.getTruthy(global, "host")) |host| {
-                // Express.js will attempt to pass the function as host or hostname
-                if (!host.jsType().isFunction()) {
-                    const host_str = host.toSlice(
-                        global,
-                        bun.default_allocator,
-                    );
-                    if (host_str.len > 0) {
-                        args.hostname = bun.default_allocator.dupeZ(u8, host_str.slice()) catch unreachable;
-                        has_hostname = true;
-                    }
+                const host_str = host.toSlice(
+                    global,
+                    bun.default_allocator,
+                );
+                if (host_str.len > 0) {
+                    args.hostname = bun.default_allocator.dupeZ(u8, host_str.slice()) catch unreachable;
+                    has_hostname = true;
                 }
             }
 

--- a/src/bun.js/http.exports.js
+++ b/src/bun.js/http.exports.js
@@ -43,13 +43,12 @@ export class Server extends EventEmitter {
     const server = this;
     if (typeof host === "function") {
       onListen = host;
+      host = undefined;
     }
 
     if (typeof port === "function") {
       onListen = port;
-    }
-
-    if (typeof port === "object") {
+    } else if (typeof port === "object") {
       host = port?.host;
       port = port?.port;
       if (typeof port?.callback === "function") onListen = port?.callback;


### PR DESCRIPTION
In canary Express.js stop working because it passes a function as host/hostname and we use toString on it, with gives onListenFailed, this check prevents functions to be used as host/hostname and makes Express.js work again