### PR TITLE
Implement os.cpus() for Linux

### DIFF
--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -73,14 +73,14 @@ pub const Os = struct {
         const cpus_or_error = if (comptime Environment.isLinux)
                                 cpusImplLinux(&cpu_buffer)
                               else
-                                cpu_buffer[0..0];  // unsupported platform -> empty array
+                                @as(anyerror![]CPU, cpu_buffer[0..0]);  // unsupported platform -> empty array
 
         if (cpus_or_error) |list| {
             // Convert the CPU list to a JS Array
             const values = JSC.JSValue.createEmptyArray(globalThis, list.len);
             for (list) |cpu, cpu_index| {
                 const obj = JSC.JSValue.createEmptyObject(globalThis, 3);
-                obj.put(globalThis, JSC.ZigString.static("model"), cpu.model.withEncoding().toValue(globalThis));
+                obj.put(globalThis, JSC.ZigString.static("model"), cpu.model.withEncoding().toValueGC(globalThis));
                 obj.put(globalThis, JSC.ZigString.static("speed"), JSC.JSValue.jsNumberFromUint64(cpu.speed));
 
                 const timesFields = comptime std.meta.fieldNames(@TypeOf(cpu.times));


### PR DESCRIPTION
Partially fixes #1888 

`os.cpus()` currently returns an empty array for all platforms.  This PR implements full functionality for Linux and has been tested on x86-64.  Other OSes will continue to return an empty array.

Note that Linux on Arm64 may report the CPU model differently; if this is the case the CPU model will currently be reported as "unknown".  As I do not have Arm64 hardware to verify and develop against, a todo has been left in the code.