### PR TITLE
fix(string_immutable): fix `toUTF16Alloc` for bindgen

### DIFF
--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -1082,7 +1082,8 @@ pub fn toUTF16Alloc(allocator: std.mem.Allocator, bytes: []const u8, comptime fa
                 },
                 else => return out,
             }
-        };
+        } else null;
+
         var output = output_ orelse fallback: {
             var list = try std.ArrayList(u16).initCapacity(allocator, i + 2);
             list.items.len = i;


### PR DESCRIPTION
Fixes build error when calling `toUTF16Alloc` from bindgen, since branch where `FeatureFlags.use_simdutf = false` apparently returns `void` (at least in zig `v0.11.0-dev.1481+4c1168418`)