### PR TITLE
Return server on listen (node:http)

### DIFF
--- a/src/bun.js/http.exports.js
+++ b/src/bun.js/http.exports.js
@@ -289,6 +289,8 @@ export class Server extends EventEmitter {
       }
       this.emit("error", err);
     }
+
+    return this;
   }
 }
 

--- a/test/bun.js/node-http.test.ts
+++ b/test/bun.js/node-http.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll, afterAll } from "bun:test";
-import { createServer, request, get, Agent, globalAgent } from "node:http";
+import { createServer, request, get, Agent, globalAgent, Server } from "node:http";
 import { createDoneDotAll } from "node-test-helpers";
 
 describe("node:http", () => {
@@ -68,6 +68,13 @@ describe("node:http", () => {
       const out = await res.text();
       expect(out).toBe(input);
       server.close();
+    });
+
+    it("listen should return server", async () => {
+      const server = createServer();
+      const listenResponse = server.listen(8129);
+      expect(listenResponse instanceof Server).toBe(true);
+      expect(listenResponse).toBe(server);
     });
   });
 


### PR DESCRIPTION
This fixes #1541 .

Currently `.listen` does not return value like it does in https://nodejs.org/api/net.html#serverlisten . This PR fixes this