### PR TITLE
Add dynamic port assigning to Bun.serve

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -408,10 +408,6 @@ pub const ServerConfig = struct {
             }
         }
 
-        if (args.port == 0) {
-            JSC.throwInvalidArguments("Invalid port: must be > 0", .{}, global, exception);
-        }
-
         if (args.base_uri.len > 0) {
             args.base_url = URL.parse(args.base_uri);
             if (args.base_url.hostname.len == 0) {
@@ -4308,7 +4304,8 @@ pub fn NewServer(comptime ssl_enabled_: bool, comptime debug_mode_: bool) type {
         }
 
         pub fn getPort(this: *ThisServer) JSC.JSValue {
-            return JSC.JSValue.jsNumber(this.config.port);
+            var listener = this.listener orelse return JSC.JSValue.jsNumber(this.config.port);
+            return JSC.JSValue.jsNumber(listener.getLocalPort());
         }
 
         pub fn getPendingRequests(this: *ThisServer) JSC.JSValue {

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -987,6 +987,9 @@ pub const ListenSocket = opaque {
     pub fn close(this: *ListenSocket, ssl: bool) void {
         us_listen_socket_close(@boolToInt(ssl), this);
     }
+    pub fn getLocalPort(this: *ListenSocket, ssl: bool) i32 {
+        return us_socket_local_port(@boolToInt(ssl), this);
+    }
 };
 extern fn us_listen_socket_close(ssl: i32, ls: *ListenSocket) void;
 extern fn uws_app_close(ssl: i32, app: *uws_app_s) void;
@@ -1057,6 +1060,12 @@ pub fn NewApp(comptime ssl: bool) type {
                     unreachable;
                 }
                 return us_listen_socket_close(ssl_flag, @ptrCast(*uws.ListenSocket, this));
+            }
+            pub inline fn getLocalPort(this: *ThisApp.ListenSocket) i32 {
+                if (comptime is_bindgen) {
+                    unreachable;
+                }
+                return us_socket_local_port(ssl_flag, @ptrCast(*uws.Socket, this));
             }
         };
 

--- a/test/bun.js/bun-server.test.ts
+++ b/test/bun.js/bun-server.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Server", () => {
+  test("returns active port when initializing server with 0 port", () => {
+    const server = Bun.serve({
+      fetch() {
+        return new Response("Hello");
+      },
+      port: 0,
+    });
+
+    expect(server.port).not.toBe(0);
+    expect(server.port).toBeDefined();
+    server.stop();
+  });
+
+  test("allows connecting to server", async () => {
+    const server = Bun.serve({
+      fetch() {
+        return new Response("Hello");
+      },
+      port: 0,
+    });
+
+    const response = await fetch(`http://${server.hostname}:${server.port}`);
+    expect(await response.text()).toBe("Hello");
+    server.stop();
+  });
+});


### PR DESCRIPTION
Servers on unix systems when binding to port 0 get a unique free port assigned dynamically. 

This simplifies the need for coming up with unique ports ie. across app tests.

Node already supports that and there are libraries using that ie. `supertest`. This PR adds this feature.

It's my first time writing `zig` code so if anything is not ok, I'll be happy to fix that :).

This fixes #1544 