### PR TITLE
Class constructors are created when needed

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -17159,7 +17159,7 @@ fn NewParser_(
 
                     class.properties = class_properties.items;
 
-                    if (instance_members.items.len > 0 or class.extends != null) {
+                    if (instance_members.items.len > 0) {
                         if (constructor_function == null) {
                             var properties = ListManaged(Property).fromOwnedSlice(p.allocator, class.properties);
                             var constructor_stmts = ListManaged(Stmt).init(p.allocator);


### PR DESCRIPTION
Inspired by output from #2060 (doesn't fix issue).
Build output before change:
```js
class Base {
  constructor(data) {
    Object.assign(this, data);
  }
}

class Outer extends Base {
  constructor() {
    super(...arguments);
  }
  stuff;
  things;
  extra;
}

class Inner extends Base {
  constructor() {
    super(...arguments);
  }
  more;
  greatness;
}
let outer = new Outer({
  stuff: "Hello World",
  things: 42,
  extra: new Inner({
    more: "Bun is becoming great!",
    greatness: true
  })
});
```
After this change:
```js
class Base {
  constructor(data) {
    Object.assign(this, data);
  }
}

class Outer extends Base {
  stuff;
  things;
  extra;
}

class Inner extends Base {
  more;
  greatness;
}
let outer = new Outer({
  stuff: "Hello World",
  things: 42,
  extra: new Inner({
    more: "Bun is becoming great!",
    greatness: true
  })
});
```
Something like this will still create a constructor
```ts
function d1() {}

class A {
  @d1 data: number = 0;
}
```

Build output:
```js
import {
__decorateClass as __decorateClass_4b4920c627822e1f
} from "bun:wrap";
function d1() {
}

class A {
  constructor() {
    this.data = 0;
  }
}
__decorateClass_4b4920c627822e1f([
  d1
], A.prototype, "data", 2);
```