### PR TITLE
[install] link network-delayed `.bin` scripts correctly

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5708,7 +5708,6 @@ pub const PackageManager = struct {
         manager: *PackageManager,
         lockfile: *Lockfile,
         progress: *std.Progress,
-        node_modules_path: stringZ,
         node_modules_folder: std.fs.IterableDir,
         skip_verify_installed_version_number: bool,
         skip_delete: bool,
@@ -5928,7 +5927,6 @@ pub const PackageManager = struct {
 
                                     var bin_linker = Bin.Linker{
                                         .bin = bin,
-                                        .package_installed_path = this.node_modules_path["node_modules".len..],
                                         .package_installed_node_modules = this.node_modules_folder.dir.fd,
                                         .global_bin_path = this.options.bin_path,
                                         .global_bin_dir = this.options.global_bin_dir.dir,
@@ -6186,7 +6184,6 @@ pub const PackageManager = struct {
                 .resolutions = resolutions,
                 .lockfile = lockfile,
                 .node = &install_node,
-                .node_modules_path = "node_modules",
                 .node_modules_folder = node_modules_folder,
                 .progress = progress,
                 .skip_verify_installed_version_number = skip_verify_installed_version_number,
@@ -6208,7 +6205,6 @@ pub const PackageManager = struct {
                 // We deliberately do not close this folder.
                 // If the package hasn't been downloaded, we will need to install it later
                 // We use this file descriptor to know where to put it.
-                installer.node_modules_path = node_modules.relative_path;
                 installer.node_modules_folder = try cwd.openIterableDir(node_modules.relative_path, .{});
 
                 var remaining = node_modules.dependencies;

--- a/test/bun.js/install/bun-install.test.ts
+++ b/test/bun.js/install/bun-install.test.ts
@@ -1764,7 +1764,7 @@ it("should consider peerDependencies during hoisting", async () => {
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["baz-exec", "baz-run"]);
   expect(await readlink(join(package_dir, "node_modules", ".bin", "baz-exec"))).toBe(join("..", "baz", "index.js"));
   expect(await readlink(join(package_dir, "node_modules", ".bin", "baz-run"))).toBe(
-    join("..", "bar", "node_modules", "baz", "index.js"),
+    join("..", "..", "bar", "node_modules", "baz", "index.js"),
   );
   expect(await readlink(join(package_dir, "node_modules", "bar"))).toBe(join("..", "bar"));
   expect(await readdirSorted(join(package_dir, "bar"))).toEqual(["node_modules", "package.json"]);


### PR DESCRIPTION
Previously we cached the "current" `node_modules` folder which we are iterating through, which is not necessarily the folder we are in during `PackageInstaller.installEnqueuedPackages()`, e.g. when package installation is delayed by tarball download.

Hard to create a reliably failing test (and technically covered by existing ones). This can be observed with `bun install` under `/bun` and without caching, after which all symlinks under `node_modules/.bin` will point to the same wrong sub-directory.