### PR TITLE
Fix 2063

### DIFF
--- a/src/base64/base64.zig
+++ b/src/base64/base64.zig
@@ -49,8 +49,9 @@ pub fn decodeLenUpperBound(len: usize) usize {
 
 pub fn decodeLen(source: anytype) usize {
     return zig_base64.standard.Decoder.calcSizeForSlice(source) catch {
-        //fallback
-        return source.len / 4 * 3;
+
+        //fallback; add 2 to allow for potentially missing padding
+        return source.len / 4 * 3 + 2;
     };
 }
 

--- a/test/bun.js/buffer.test.js
+++ b/test/bun.js/buffer.test.js
@@ -2555,6 +2555,6 @@ it("repro #2063", () => {
   const buf = Buffer.from("eyJlbWFpbCI6Ijg3MTg4NDYxN0BxcS5jb20iLCJpZCI6OCwicm9sZSI6Im5vcm1hbCIsImlhdCI6MTY3NjI4NDQyMSwiZXhwIjoxNjc2ODg5MjIxfQ", 'base64');
   expect(buf.length).toBe(85);
   expect(buf[82]).toBe(50);
-  expect(buf[82]).toBe(49);
-  expect(buf[82]).toBe(125);
+  expect(buf[83]).toBe(49);
+  expect(buf[84]).toBe(125);
 });

--- a/test/bun.js/buffer.test.js
+++ b/test/bun.js/buffer.test.js
@@ -2550,3 +2550,11 @@ it("should not perform out-of-bound access on invalid UTF-8 byte sequence", () =
   expect(str.length).toBe(6);
   expect(str).toBe("\uFFFD\x13\x12\x11\x10\x09");
 });
+
+it("repro #2063", () => {
+  const buf = Buffer.from("eyJlbWFpbCI6Ijg3MTg4NDYxN0BxcS5jb20iLCJpZCI6OCwicm9sZSI6Im5vcm1hbCIsImlhdCI6MTY3NjI4NDQyMSwiZXhwIjoxNjc2ODg5MjIxfQ", 'base64');
+  expect(buf.length).toBe(85);
+  expect(buf[82]).toBe(50);
+  expect(buf[82]).toBe(49);
+  expect(buf[82]).toBe(125);
+});


### PR DESCRIPTION
Resolves #2063.

When padding is missing, the `calcSizeForSlice` function returns a InvalidPadding error.  When we catch this we need to allow for up to 2 more bytes of decoded output.  It's OK to overestimate because this length should only be used to allocate a buffer and the actual decoded length will be used to slice once decoded.