### PR TITLE
fix(webcrypto): fix ed25519 CryptoKey.algorithm

### DIFF
--- a/src/bun.js/bindings/webcrypto/CryptoKeyOKP.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoKeyOKP.cpp
@@ -232,17 +232,19 @@ bool CryptoKeyOKP::isValidOKPAlgorithm(CryptoAlgorithmIdentifier algorithm)
 
 auto CryptoKeyOKP::algorithm() const -> KeyAlgorithm
 {
-    CryptoEcKeyAlgorithm result;
+    CryptoKeyAlgorithm result;
+    // FIXME: This should be set to the actual algorithm name in the case of X25519
     result.name = CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier());
 
-    switch (m_curve) {
-    case NamedCurve::X25519:
-        result.namedCurve = X25519;
-        break;
-    case NamedCurve::Ed25519:
-        result.namedCurve = Ed25519;
-        break;
-    }
+    // This is commented out because the spec doesn't define the namedCurve field for OKP keys
+    // switch (m_curve) {
+    // case NamedCurve::X25519:
+    //     result.namedCurve = X25519;
+    //     break;
+    // case NamedCurve::Ed25519:
+    //     result.namedCurve = Ed25519;
+    //     break;
+    // }
 
     return result;
 }

--- a/test/bun.js/web-crypto.test.ts
+++ b/test/bun.js/web-crypto.test.ts
@@ -72,3 +72,20 @@ describe("Web Crypto", () => {
     expect(isSigValid).toBe(true);
   });
 });
+
+describe("Ed25519", () => {
+  describe("generateKey", () => {
+    it("should return CryptoKeys without namedCurve in algorithm field", async () => {
+      const { publicKey, privateKey } = (await crypto.subtle.generateKey("Ed25519", true, [
+        "sign",
+        "verify",
+      ])) as CryptoKeyPair;
+      expect(publicKey.algorithm!.name).toBe("Ed25519");
+      // @ts-ignore
+      expect(publicKey.algorithm!.namedCurve).toBe(undefined);
+      expect(privateKey.algorithm!.name).toBe("Ed25519");
+      // @ts-ignore
+      expect(privateKey.algorithm!.namedCurve).toBe(undefined);
+    });
+  });
+});


### PR DESCRIPTION
This fixes an incompatibility with the current draft spec for Ed25519. See [WICG draft spec](https://wicg.github.io/webcrypto-secure-curves/#ed25519-operations) under Key Generation for reference as 

Reported by: @panva