### PR TITLE
Clarify and clean up macOS build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1083,7 +1083,7 @@ dev-obj-linux:
 	$(ZIG) build obj -Dtarget=x86_64-linux-gnu
 
 .PHONY: dev
-dev: mkdir-dev dev-obj bun-link-lld-debug bun-codesign-debug
+dev: mkdir-dev dev-obj bun-link-lld-debug
 
 mkdir-dev:
 	mkdir -p $(DEBUG_PACKAGE_DIR)/bin

--- a/README.md
+++ b/README.md
@@ -5142,10 +5142,9 @@ On fish that looks like `fish_add_path (brew --prefix llvm@15)/bin`
 
 #### Install Zig (macOS)
 
-Install the latest version of Zig via Homebrew:
-
+Install the version of Zig referenced in the [`Dockerfile`](./Dockerfile) using [zigup](https://github.com/marler8997/zigup). For example:
 ```bash
-brew install zig --head
+zigup 0.11.0-dev.1393+38eebf3c4
 ```
 
 #### Build bun (macOS)
@@ -5155,6 +5154,7 @@ One-off command to run:
 ```bash
 # If you omit --depth=1, `git submodule update` will take 17.5 minutes on 1gbps internet, mostly due to WebKit.
 git submodule update --init --recursive --progress --depth=1 --checkout
+bun install
 make vendor identifier-cache webcrypto-debug
 ```
 


### PR DESCRIPTION
Updating a few steps that tripped me up while getting set up to build on macOS:
- Specify to run `bun install` before `make vendor` [[1]](https://discord.com/channels/876711213126520882/888839314056839309/1075674284023881750)
- Specify to use zigup to install specific zig version rather than using `--head` [[2]](https://discord.com/channels/876711213126520882/888839314056839309/1075678278137946173)
- Skip codesigning for `make dev` [[3]](https://discord.com/channels/876711213126520882/888839314056839309/1075681626127872030)