### PR TITLE
Fix #1516

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -1027,14 +1027,14 @@ const Arguments = struct {
 
                 if (val.isObject()) {
                     if (val.getIfPropertyExists(ctx.ptr(), "flags")) |flags_| {
-                        flags = FileSystemFlags.fromJS(ctx, flags_, exception) orelse flags;
+                        flags = FileSystemFlags.fromJS(ctx, flags_, flags, exception) orelse flags;
                     }
 
                     if (val.getIfPropertyExists(ctx.ptr(), "mode")) |mode_| {
                         mode = JSC.Node.modeFromJS(ctx, mode_, exception) orelse mode;
                     }
                 } else if (!val.isEmpty()) {
-                    flags = FileSystemFlags.fromJS(ctx, val, exception) orelse flags;
+                    flags = FileSystemFlags.fromJS(ctx, val, flags, exception) orelse flags;
 
                     if (arguments.nextEat()) |next| {
                         mode = JSC.Node.modeFromJS(ctx, next, exception) orelse mode;
@@ -1508,7 +1508,7 @@ const Arguments = struct {
                     }
 
                     if (arg.getIfPropertyExists(ctx.ptr(), "flag")) |flag_| {
-                        flag = FileSystemFlags.fromJS(ctx, flag_, exception) orelse {
+                        flag = FileSystemFlags.fromJS(ctx, flag_, flag, exception) orelse {
                             if (exception.* == null) {
                                 JSC.throwInvalidArguments(
                                     "Invalid flag",
@@ -1615,7 +1615,7 @@ const Arguments = struct {
                     }
 
                     if (arg.getIfPropertyExists(ctx.ptr(), "flag")) |flag_| {
-                        flag = FileSystemFlags.fromJS(ctx, flag_, exception) orelse {
+                        flag = FileSystemFlags.fromJS(ctx, flag_, flag, exception) orelse {
                             if (exception.* == null) {
                                 JSC.throwInvalidArguments(
                                     "Invalid flag",
@@ -1785,7 +1785,7 @@ const Arguments = struct {
             if (arguments.next()) |arg| {
                 arguments.eat();
                 if (arg.isString()) {
-                    mode = FileSystemFlags.fromJS(ctx, arg, exception) orelse {
+                    mode = FileSystemFlags.fromJS(ctx, arg, mode, exception) orelse {
                         if (exception.* == null) {
                             JSC.throwInvalidArguments(
                                 "Invalid mode",

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -964,9 +964,9 @@ pub const FileSystemFlags = enum(Mode) {
     const O_SYNC: Mode = 0;
     const O_TRUNC: Mode = std.os.O.TRUNC;
 
-    pub fn fromJS(ctx: JSC.C.JSContextRef, val: JSC.JSValue, exception: JSC.C.ExceptionRef) ?FileSystemFlags {
+    pub fn fromJS(ctx: JSC.C.JSContextRef, val: JSC.JSValue, default: FileSystemFlags, exception: JSC.C.ExceptionRef) ?FileSystemFlags {
         if (val.isUndefinedOrNull()) {
-            return @intToEnum(FileSystemFlags, O_RDONLY);
+            return default;
         }
 
         if (val.isNumber()) {

--- a/test/bun.js/fs.test.js
+++ b/test/bun.js/fs.test.js
@@ -987,3 +987,10 @@ it("fs.Dirent", () => {
 it("fs.Stats", () => {
   expect(Stats).toBeDefined();
 });
+
+it("repro 1516: can use undefined/null to specify default flag", () => {
+  const path = "/tmp/repro_1516.txt";
+  writeFileSync(path, "b", { flag: undefined });
+  expect(readFileSync(path, { encoding: "utf8", flag: null })).toBe("b");
+  rmSync(path);
+});


### PR DESCRIPTION
Resolves #1516

`FileSystemFlags.fromJS` was hardcoded to return `O_RDONLY` when the flag value
 was null or undefined and this caused breakage when used with write functions.
Updated the function to take a `default` argument so that the caller can specify
 a sane default for their use.

In all usages the caller had already assigned the correct default to target variable, so the usages were easily patched.