### PR TITLE
Fix #2005

### DIFF
--- a/test/bun.js/repro_2005.test.js
+++ b/test/bun.js/repro_2005.test.js
@@ -1,0 +1,12 @@
+import { it, expect } from "bun:test";
+
+it("regex literal with non-Latin1 should work", () => {
+  const text = "这是一段要替换的文字";
+
+  //Correct results: 这是一段的文字
+  expect(text.replace(new RegExp("要替换"), "")).toBe("这是一段的文字");
+
+  //Incorrect result: 这是一段要替换的文字
+  expect(text.replace(/要替换/, "")).toBe("这是一段的文字");
+
+});


### PR DESCRIPTION
Resolves #2005 

When platform is bun, regexp literals with non-Latin1 characters need to be printed with unicode escape sequences.  The implementation was lifted wholesale from `printQuotedIdentifier`.  I could abstract the logic to something like `printUTF8AsEscapedSequences`--just wanted to make sure that I didn't simply reuse a function which could drift away from its current implementation.

When platform is not bun, the old implementation (simply printing the UTF8 sequence as-is) is used.