### PR TITLE
fix: Print URL as object in

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -1373,10 +1373,6 @@ pub const ZigConsoleClient = struct {
                             return .{ .tag = .JSX, .cell = js_type };
                         }
                     }
-
-                    if (value.as(JSC.DOMURL) != null) {
-                        return .{ .tag = .String, .cell = js_type };
-                    }
                 }
 
                 return .{

--- a/test/bun.js/url.test.ts
+++ b/test/bun.js/url.test.ts
@@ -2,13 +2,71 @@ import { describe, it, expect } from "bun:test";
 
 describe("url", () => {
   it("prints", () => {
-    expect(Bun.inspect(new URL("https://example.com"))).toBe("https://example.com/");
+    expect(Bun.inspect(new URL("https://example.com"))).toBe(`URL {
+  href: "https://example.com/",
+  origin: "https://example.com",
+  protocol: "https:",
+  username: "",
+  password: "",
+  host: "example.com",
+  hostname: "example.com",
+  port: "",
+  pathname: "/",
+  hash: "",
+  search: "",
+  searchParams: URLSearchParams {
+    append: [Function: append],
+    delete: [Function: delete],
+    get: [Function: get],
+    getAll: [Function: getAll],
+    has: [Function: has],
+    set: [Function: set],
+    sort: [Function: sort],
+    entries: [Function: entries],
+    keys: [Function: keys],
+    values: [Function: values],
+    forEach: [Function: forEach],
+    toString: [Function: toString],
+    [Symbol(Symbol.iterator)]: [Function: entries]
+  },
+  toJSON: [Function: toJSON],
+  toString: [Function: toString]
+}`);
 
     expect(
       Bun.inspect(
         new URL("https://github.com/oven-sh/bun/issues/135?hello%20i%20have%20spaces%20thank%20you%20good%20night"),
       ),
-    ).toBe("https://github.com/oven-sh/bun/issues/135?hello%20i%20have%20spaces%20thank%20you%20good%20night");
+    ).toBe(`URL {
+  href: "https://github.com/oven-sh/bun/issues/135?hello%20i%20have%20spaces%20thank%20you%20good%20night",
+  origin: "https://github.com",
+  protocol: "https:",
+  username: "",
+  password: "",
+  host: "github.com",
+  hostname: "github.com",
+  port: "",
+  pathname: "/oven-sh/bun/issues/135",
+  hash: "",
+  search: "?hello%20i%20have%20spaces%20thank%20you%20good%20night",
+  searchParams: URLSearchParams {
+    append: [Function: append],
+    delete: [Function: delete],
+    get: [Function: get],
+    getAll: [Function: getAll],
+    has: [Function: has],
+    set: [Function: set],
+    sort: [Function: sort],
+    entries: [Function: entries],
+    keys: [Function: keys],
+    values: [Function: values],
+    forEach: [Function: forEach],
+    toString: [Function: toString],
+    [Symbol(Symbol.iterator)]: [Function: entries]
+  },
+  toJSON: [Function: toJSON],
+  toString: [Function: toString]
+}`);
   });
   it("works", () => {
     const inputs = [


### PR DESCRIPTION
This is my first contribution to bun, and I don't really know what I'm doing ;)

This PR closes #2006

It's unclear to me why the particular casing was necessary. It was added in 30542225c6e140c900078538a6a563561005411b but I wasn't able to deduce the reason from the commit message. @Jarred-Sumner do you remember why it was added? 

I updated the expected output for `Bun.inspect(URL)` because it's documentation says that it returns the output of `console.log(URL)` as a string. 