### PR TITLE
Fix Deno SQLite benchmark

### DIFF
--- a/bench/sqlite/deno.js
+++ b/bench/sqlite/deno.js
@@ -1,4 +1,4 @@
-import { Database } from "https://deno.land/x/sqlite3@0.7.2/mod.ts";
+import { Database } from "https://deno.land/x/sqlite3@0.8.0/mod.ts";
 import { run, bench } from "../node_modules/mitata/src/cli.mjs";
 
 const db = new Database("./src/northwind.sqlite");


### PR DESCRIPTION
Deno has removed direct access to Deno.core:

https://deno.com/blog/v1.30#removal-of-internal-denocore

```
❯ bun run bench:deno
$ $DENO run -A --unstable deno.js
error: Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'ops')
const { op_ffi_cstr_read, op_ffi_get_buf } = (Deno as any).core.ops;
                                                                ^
    at https://deno.land/x/sqlite3@0.7.2/src/util.ts:19:65
error: script "bench:deno" exited with code 1 (SIGHUP)
```

As a result, a newer version of sqlite3 is required:

https://deno.land/x/sqlite3@0.8.0/src/util.ts?source#L19

```
❯ bun run bench:deno
$ $DENO run -A --unstable deno.js
cpu: unknown
runtime: deno 1.30.3 (aarch64-apple-darwin)

benchmark                        time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------------- -----------------------------
SELECT * FROM "Order"         27.49 ms/iter   (26.56 ms … 28.74 ms)  28.03 ms  28.74 ms  28.74 ms
SELECT * FROM "Product"       63.81 µs/iter  (57.04 µs … 346.67 µs)  66.92 µs  76.42 µs  84.54 µs
SELECT * FROM "OrderDetail"  292.21 ms/iter (263.01 ms … 326.35 ms) 305.96 ms 326.35 ms 326.35 ms
```