### PR TITLE
chore(bench): add unsafeConcurrency flag for deno x/sqlite3 bench

### DIFF
--- a/bench/sqlite/deno.js
+++ b/bench/sqlite/deno.js
@@ -1,7 +1,7 @@
 import { Database } from "https://deno.land/x/sqlite3@0.8.0/mod.ts";
 import { run, bench } from "../node_modules/mitata/src/cli.mjs";
 
-const db = new Database("./src/northwind.sqlite");
+const db = new Database("./src/northwind.sqlite", { unsafeConcurrency: true });
 
 {
   const sql = db.prepare(`SELECT * FROM "Order"`);


### PR DESCRIPTION
This adds the `unsafeConcurrency` flag to Deno `x/sqlite3` benchmark. I think this was previously mentioned somewhere but got lost in the weeds. Thank you @mlafeldt for reminding me to take a look at updating benchmarks to more accurately represent the current state of affairs benchmark-wise.