### PR TITLE
Fix glibc error in latest alpine

### DIFF
--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=get /tmp/sgerrand.rsa.pub /etc/apk/keys
 COPY --from=get /tmp/glibc-${GLIBC_RELEASE}.apk /tmp
 
 # install glibc
-RUN apk --no-cache add /tmp/glibc-${GLIBC_RELEASE}.apk && \
+RUN apk --no-cache --force-overwrite add /tmp/glibc-${GLIBC_RELEASE}.apk && \
 
 # cleanup
     rm /etc/apk/keys/sgerrand.rsa.pub && \


### PR DESCRIPTION
There's an override error with latest alpine and various versions of glibc (including 2.35): https://github.com/sgerrand/alpine-pkg-glibc/issues/185

This MR proposes a workaround (tested on fly.io - it works) so that it's possible to have bun usable with minimal linux dependencies.