### PR TITLE
fix(body) Make Request/Reponse empty body to be null

### DIFF
--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -529,7 +529,7 @@ pub const Body = struct {
 
                     if (bytes.len == 0) {
                         return Body.Value{
-                            .Used = {},
+                            .Empty = {},
                         };
                     }
 

--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -363,7 +363,10 @@ pub const Body = struct {
             JSC.markBinding(@src());
 
             switch (this.*) {
-                .Used, .Empty => {
+                .Empty => {
+                    return JSValue.jsNull();
+                },
+                .Used => {
                     return JSC.WebCore.ReadableStream.empty(globalThis);
                 },
                 .InternalBlob,
@@ -435,7 +438,7 @@ pub const Body = struct {
 
         pub fn fromJS(
             globalThis: *JSGlobalObject,
-            value: JSValue,
+            value: JSValue
         ) ?Value {
             value.ensureStillAlive();
 
@@ -526,7 +529,7 @@ pub const Body = struct {
 
                     if (bytes.len == 0) {
                         return Body.Value{
-                            .Empty = {},
+                            .Used = {},
                         };
                     }
 
@@ -972,6 +975,10 @@ pub fn BodyMixin(comptime Type: type) type {
         ) callconv(.C) JSValue {
             var body: *Body.Value = this.getBodyValue();
 
+            if (body.* == .Empty) {
+                return JSValue.jsNull();
+            }
+
             if (body.* == .Used) {
                 // TODO: make this closed
                 return JSC.WebCore.ReadableStream.empty(globalThis);
@@ -993,6 +1000,7 @@ pub fn BodyMixin(comptime Type: type) type {
             _: *JSC.CallFrame,
         ) callconv(.C) JSC.JSValue {
             var value: *Body.Value = this.getBodyValue();
+
             if (value.* == .Used) {
                 return handleBodyAlreadyUsed(globalObject);
             }

--- a/test/bun.js/fetch.test.js
+++ b/test/bun.js/fetch.test.js
@@ -523,33 +523,31 @@ function testBlobInterface(blobbyConstructor, hasBlobFn) {
         if (withGC) gc();
       });
 
-      it(`${jsonObject.hello === true ? "latin1" : "utf16"} arrayBuffer -> json${
-        withGC ? " (with gc) " : ""
-      }`, async () => {
-        if (withGC) gc();
-        var response = blobbyConstructor(new TextEncoder().encode(JSON.stringify(jsonObject)));
-        if (withGC) gc();
-        expect(JSON.stringify(await response.json())).toBe(JSON.stringify(jsonObject));
-        if (withGC) gc();
-      });
+      it(`${jsonObject.hello === true ? "latin1" : "utf16"} arrayBuffer -> json${withGC ? " (with gc) " : ""
+        }`, async () => {
+          if (withGC) gc();
+          var response = blobbyConstructor(new TextEncoder().encode(JSON.stringify(jsonObject)));
+          if (withGC) gc();
+          expect(JSON.stringify(await response.json())).toBe(JSON.stringify(jsonObject));
+          if (withGC) gc();
+        });
 
-      it(`${jsonObject.hello === true ? "latin1" : "utf16"} arrayBuffer -> invalid json${
-        withGC ? " (with gc) " : ""
-      }`, async () => {
-        if (withGC) gc();
-        var response = blobbyConstructor(
-          new TextEncoder().encode(JSON.stringify(jsonObject) + " NOW WE ARE INVALID JSON"),
-        );
-        if (withGC) gc();
-        var failed = false;
-        try {
-          await response.json();
-        } catch (e) {
-          failed = true;
-        }
-        expect(failed).toBe(true);
-        if (withGC) gc();
-      });
+      it(`${jsonObject.hello === true ? "latin1" : "utf16"} arrayBuffer -> invalid json${withGC ? " (with gc) " : ""
+        }`, async () => {
+          if (withGC) gc();
+          var response = blobbyConstructor(
+            new TextEncoder().encode(JSON.stringify(jsonObject) + " NOW WE ARE INVALID JSON"),
+          );
+          if (withGC) gc();
+          var failed = false;
+          try {
+            await response.json();
+          } catch (e) {
+            failed = true;
+          }
+          expect(failed).toBe(true);
+          if (withGC) gc();
+        });
 
       it(`${jsonObject.hello === true ? "latin1" : "utf16"} text${withGC ? " (with gc) " : ""}`, async () => {
         if (withGC) gc();
@@ -559,15 +557,14 @@ function testBlobInterface(blobbyConstructor, hasBlobFn) {
         if (withGC) gc();
       });
 
-      it(`${jsonObject.hello === true ? "latin1" : "utf16"} arrayBuffer -> text${
-        withGC ? " (with gc) " : ""
-      }`, async () => {
-        if (withGC) gc();
-        var response = blobbyConstructor(new TextEncoder().encode(JSON.stringify(jsonObject)));
-        if (withGC) gc();
-        expect(await response.text()).toBe(JSON.stringify(jsonObject));
-        if (withGC) gc();
-      });
+      it(`${jsonObject.hello === true ? "latin1" : "utf16"} arrayBuffer -> text${withGC ? " (with gc) " : ""
+        }`, async () => {
+          if (withGC) gc();
+          var response = blobbyConstructor(new TextEncoder().encode(JSON.stringify(jsonObject)));
+          if (withGC) gc();
+          expect(await response.text()).toBe(JSON.stringify(jsonObject));
+          if (withGC) gc();
+        });
 
       it(`${jsonObject.hello === true ? "latin1" : "utf16"} arrayBuffer${withGC ? " (with gc) " : ""}`, async () => {
         if (withGC) gc();
@@ -592,30 +589,29 @@ function testBlobInterface(blobbyConstructor, hasBlobFn) {
         if (withGC) gc();
       });
 
-      it(`${jsonObject.hello === true ? "latin1" : "utf16"} arrayBuffer -> arrayBuffer${
-        withGC ? " (with gc) " : ""
-      }`, async () => {
-        if (withGC) gc();
+      it(`${jsonObject.hello === true ? "latin1" : "utf16"} arrayBuffer -> arrayBuffer${withGC ? " (with gc) " : ""
+        }`, async () => {
+          if (withGC) gc();
 
-        var response = blobbyConstructor(new TextEncoder().encode(JSON.stringify(jsonObject)));
-        if (withGC) gc();
+          var response = blobbyConstructor(new TextEncoder().encode(JSON.stringify(jsonObject)));
+          if (withGC) gc();
 
-        const bytes = new TextEncoder().encode(JSON.stringify(jsonObject));
-        if (withGC) gc();
+          const bytes = new TextEncoder().encode(JSON.stringify(jsonObject));
+          if (withGC) gc();
 
-        const compare = new Uint8Array(await response.arrayBuffer());
-        if (withGC) gc();
+          const compare = new Uint8Array(await response.arrayBuffer());
+          if (withGC) gc();
 
-        withoutAggressiveGC(() => {
-          for (let i = 0; i < compare.length; i++) {
-            if (withGC) gc();
+          withoutAggressiveGC(() => {
+            for (let i = 0; i < compare.length; i++) {
+              if (withGC) gc();
 
-            expect(compare[i]).toBe(bytes[i]);
-            if (withGC) gc();
-          }
+              expect(compare[i]).toBe(bytes[i]);
+              if (withGC) gc();
+            }
+          });
+          if (withGC) gc();
         });
-        if (withGC) gc();
-      });
 
       hasBlobFn &&
         it(`${jsonObject.hello === true ? "latin1" : "utf16"} blob${withGC ? " (with gc) " : ""}`, async () => {
@@ -672,7 +668,7 @@ describe("Bun.file", () => {
   it("size is Infinity on a fifo", () => {
     try {
       unlinkSync("/tmp/test-fifo");
-    } catch (e) {}
+    } catch (e) { }
     mkfifo("/tmp/test-fifo");
 
     const { size } = Bun.file("/tmp/test-fifo");
@@ -690,14 +686,14 @@ describe("Bun.file", () => {
     beforeAll(async () => {
       try {
         unlinkSync("/tmp/my-new-file");
-      } catch {}
+      } catch { }
       await Bun.write("/tmp/my-new-file", "hey");
       chmodSync("/tmp/my-new-file", 0o000);
     });
     afterAll(() => {
       try {
         unlinkSync("/tmp/my-new-file");
-      } catch {}
+      } catch { }
     });
 
     forEachMethod(m => () => {
@@ -710,7 +706,7 @@ describe("Bun.file", () => {
     beforeAll(() => {
       try {
         unlinkSync("/tmp/does-not-exist");
-      } catch {}
+      } catch { }
     });
 
     forEachMethod(m => async () => {
@@ -861,6 +857,12 @@ describe("Response", () => {
       expect(response.status).toBe(407);
     });
 
+    it("body nullable", () => {
+      expect(new Response(null).body).toBeNull();
+      expect(new Response(undefined).body).toBeNull();
+      expect(new Response().body).toBeNull();
+    });
+
     it("supports headers", () => {
       var response = Response.json("hello", {
         headers: {
@@ -974,6 +976,29 @@ describe("Request", () => {
     expect(body.headers.get("content-type")).toBe("text/plain");
     gc();
     expect(await clone.text()).toBe("<div>hello</div>");
+  });
+
+  it("body nullable", async () => {
+    gc();
+    {
+      const req = new Request("https://hello.com", { body: null });
+      expect(req.body).toBeNull();
+    }
+    gc();
+    {
+      const req = new Request("https://hello.com", { body: undefined });
+      expect(req.body).toBeNull();
+    }
+    gc();
+    {
+      const req = new Request("https://hello.com");
+      expect(req.body).toBeNull();
+    }
+    gc();
+    {
+      const req = new Request("https://hello.com", { body: "" });
+      expect(req.body).toBeNull();
+    }
   });
 
   it("signal", async () => {


### PR DESCRIPTION
fixes partially https://github.com/oven-sh/bun/issues/1752
but do not cover this weird case:

```javascript
expect(new Response("").body instanceof ReadableStream).toBe(true)
```