### PR TITLE
fix(zig-build): disable stack probing on x86_64 so no `compiler_rt` needed

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -600,6 +600,9 @@ pub fn configureObjectStep(b: *std.build.Builder, obj: *CompileStep, comptime Ta
     if (target.getOsTag() != .freestanding) obj.linkLibC();
     if (target.getOsTag() != .freestanding) obj.bundle_compiler_rt = false;
 
+    // Disable staack probing on x86 so we don't need to include compiler_rt
+    if (target.getCpuArch().isX86()) obj.disable_stack_probing = true;
+
     if (target.getOsTag() == .linux) {
         // obj.want_lto = tar;
         obj.link_emit_relocs = true;


### PR DESCRIPTION
Alternative to #2155, disables stack probing on x86 so we don't need to bundle `compiler_rt`