### PR TITLE
Fix #2024

### DIFF
--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -162,6 +162,7 @@ pub const HTMLRewriter = struct {
         var handler = getAllocator(global).create(DocumentHandler) catch unreachable;
         handler.* = handler_;
 
+        // If this fails, subsequent calls to write or end should throw
         this.builder.addDocumentContentHandlers(
             DocumentHandler,
             DocumentHandler.onDocType,
@@ -190,9 +191,7 @@ pub const HTMLRewriter = struct {
                 handler
             else
                 null,
-        ) catch {
-            return throwLOLHTMLError(global);
-        };
+        );
 
         this.context.document_handlers.append(bun.default_allocator, handler) catch unreachable;
         return JSValue.fromRef(thisObject);

--- a/src/deps/lol-html.zig
+++ b/src/deps/lol-html.zig
@@ -83,7 +83,7 @@ pub const HTMLRewriter = opaque {
             text_handler_user_data: ?*anyopaque,
             doc_end_handler: ?lol_html_doc_end_handler_t,
             doc_end_user_data: ?*anyopaque,
-        ) c_int;
+        ) void;
 
         pub fn init() *HTMLRewriter.Builder {
             auto_disable();
@@ -121,10 +121,10 @@ pub const HTMLRewriter = opaque {
             comptime DocEndHandler: type,
             comptime end_tag_handler: ?DirectiveFunctionTypeForHandler(DocEnd, DocEndHandler),
             end_tag_handler_data: ?*DocEndHandler,
-        ) Error!void {
+        ) void {
             auto_disable();
 
-            return switch (builder.lol_html_rewriter_builder_add_document_content_handlers(
+            builder.lol_html_rewriter_builder_add_document_content_handlers(
                 if (doctype_handler_data != null)
                     DirectiveHandler(DocType, DocTypeHandler, doctype_handler.?)
                 else
@@ -145,11 +145,7 @@ pub const HTMLRewriter = opaque {
                 else
                     null,
                 end_tag_handler_data,
-            )) {
-                0 => void{},
-                -1 => error.Fail,
-                else => unreachable,
-            };
+            );
         }
 
         /// Adds element content handlers to the builder for the


### PR DESCRIPTION
The `lol_html_rewriter_builder_add_document_content_handlers` function does not return a status code and always succeeds; errors are reported on subsequent calls to `write` or `end`.

Relevant line in header file: https://github.com/cloudflare/lol-html/blob/2eed349dcdfa4ff5c19fe7c6e501cfd687601033/c-api/include/lol_html.h#L172

Fixes #2024