### PR TITLE
docs: consistent indentation for post install commands

### DIFF
--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -295,7 +295,7 @@ info "To get started, run:"
 echo
 
 if [[ $refresh_command ]]; then
-    info_bold " $refresh_command"
+    info_bold "  $refresh_command"
 fi
 
 info_bold "  bun --help"


### PR DESCRIPTION
Heya!

I just installed bun for the first time - it's very exciting!

My install (on Ubuntu) looked like this:

```bash
curl -fsSL https://bun.sh/install | bash
######################################################################## 100.0%
bun was installed successfully to ~/.bun/bin/bun 

Added "~/.bun/bin" to $PATH in "~/.zshrc" 

To get started, run: 

 exec /usr/bin/zsh 
  bun --help
```

![screenshot illustrating the above text](https://user-images.githubusercontent.com/1010525/221345990-e35d124f-dd7e-4d35-ac2c-b966b9517c1d.png)

Note the difference in indentation between `exec /usr/bin/zsh` and `bun --help`.  This seemed likely to be unintentional.  This PR makes it consistent.

Yes - it's a 1 char whitespace PR :wink: 
