### PR TITLE
Bundler uses incorrect port when dev server is listening on non-default port #1885

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -3505,9 +3505,8 @@ pub const Server = struct {
         }
 
         const addr = listener.listen_address;
-
-        if (port != addr.getPort()) {
-            server.bundler.options.origin.port = try std.fmt.allocPrint(server.allocator, "{d}", .{addr.getPort()});
+        if (server.bundler.options.origin.getPort() != addr.getPort()) {
+            server.bundler.options.origin = ZigURL.parse(try std.fmt.allocPrint(server.allocator, "{s}://{s}:{d}", .{server.bundler.options.origin.displayProtocol(), server.bundler.options.origin.displayHostname(), addr.getPort()}));
         }
 
         const start_time = Global.getStartTime();


### PR DESCRIPTION
When starting the dev server,  there is a logic bug when the default / user provided port is already in use and it tries to pick a new random port. In this case although, the server will listen on the new correct port, the bundler's origin is not updated correctly.