### PR TITLE
Online embedded demo [need suggestions on how we can do this]

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,12 @@ $ bunx cowsay "Hello, world!"   # execute a package
 {% arrowbutton href="/docs/cli/test" text="Write and run tests" /%}
 {% /block %}
 
+### Online Demo
+
+Try bun runtime in your browser without installing anything:
+
+<iframe src="https://codedamn.com/playground/QfdYRxSPrQscm9SKKmm2b?embed=1&ctl=1" width="1280" height="720></iframe>
+
 ## What is a runtime?
 
 JavaScript (or, more formally, ECMAScript) is just a _specification_ for a programming language. Anyone can write a JavaScript _engine_ that ingests a valid JavaScript program and executes it. The two most popular engines in use today are V8 (developed by Google) and JavaScriptCore (developed by Apple). Both are open source.


### PR DESCRIPTION
First of all, congrats to @Jarred-Sumner and the whole team for building such a fast runtime. At @codedamn, we were some of the first to try to implement bun runtime in our development (and soon production) flows.

We released bun playground as soon as it was released publicly last year, and we've been keeping it up-to-date since then (we also have bun.new domain to boot a fast and free bun playground without downloading/installing/signing up anywhere).

I'm the founder of codedamn - and we would love to contribute to bun docs to make them richer and more interactive with live playground examples laid througout. This PR is a proof-of-concept.

For initial few playgrounds, we can work together. Once we have 3-5 playgrounds in the docs, we will be happy to shift the ownership of these playgrounds under a codedamn account owned by someone from the bun team (in case you want to update playgrounds later).

Here are our docs (relatively simple) on how to embed codedamn playgrounds and meaning of each parameter: https://teach.codedamn.com/docs/instructor-guides/playground-in-article

And here's how you can create a playground: https://codedamn.com/playgrounds

Some things I'd like to list down:

- We don't plan to charge/ask to create codedamn accounts from anyone when they're using these embeds
- They'll always be free.
- We have internal systems that detect compute abuse and rate limit people/ban people on IP address level. This shouldn't affect most legit users.
- Our bun playground usually is up to date with current stable bun binary (1-2 days delay maximum).

Here's the direct URL for you to visit to see how the embed would look like: https://codedamn.com/playground/QfdYRxSPrQscm9SKKmm2b?embed=1&ctl=1