### PR TITLE
docs(configuration): update misleading comment

### DIFF
--- a/docs/project/configuration.md
+++ b/docs/project/configuration.md
@@ -32,7 +32,7 @@ optional = true
 # whether to install devDependencies
 dev = true
 
-# whether to install devDependencies
+# whether to install peerDependencies
 peer = false
 
 # equivalent to `--production` flag


### PR DESCRIPTION
The comment was for peer dependencies and not dev dependencies.