### PR TITLE
Fix CLI regressions

### DIFF
--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -87,7 +87,7 @@ pub const PackageManagerCommand = struct {
         var args = try std.process.argsAlloc(ctx.allocator);
         args = args[1..];
 
-        var pm = PackageManager.init(ctx, null, &PackageManager.install_params) catch |err| {
+        var pm = PackageManager.init(ctx, null, &PackageManager.pm_params) catch |err| {
             // TODO: error messages here
             // if (err == error.MissingPackageJSON) {
             //     // TODO: error messages

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5324,6 +5324,11 @@ pub const PackageManager = struct {
         \\<STR> ...                         "name" uninstall package as a link
     );
 
+    pub const pm_params = install_params ++ clap.parseParamsComptime(
+        \\-a, --all                         List all dependencies, including aliased (bun pm ls only)
+        \\-A, --ALL                         List all dependencies, including aliased (bun pm ls only)
+    );
+
     pub const CommandLineArguments = struct {
         registry: string = "",
         cache_dir: string = "",


### PR DESCRIPTION
Restores the `--all` flag in `bun pm ls`.