### PR TITLE
fix deinit behavior when connection is aborted using ResponseStream and abort event behavior

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1816,6 +1816,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
         pub fn handleResolveStream(req: *RequestContext) void {
             streamLog("handleResolveStream", .{});
+
             var wrote_anything = false;
             if (req.sink) |wrapper| {
                 wrapper.sink.pending_flush = null;
@@ -1845,7 +1846,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 req.resp.clearAborted();
                 req.resp.endStream(req.shouldCloseConnection());
             }
-
+            //aborted already called finalizeForAbort at this stage
+            if(req.aborted) return;
             req.finalize();
         }
 
@@ -1903,6 +1905,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                         req.server.vm.runErrorHandler(err, &exception_list);
                     }
                 }
+                //aborted already called finalizeForAbort at this stage
+                if(req.aborted) return;
                 req.finalize();
                 return;
             }

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -2760,9 +2760,9 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
 
         pub fn onAborted(this: *@This(), _: *UWSResponse) void {
             log("onAborted()", .{});
-            this.signal.close(null);
             this.done = true;
             this.aborted = true;
+            this.signal.close(null);
             this.flushPromise();
             this.finalize();
         }

--- a/test/bun.js/bun-server.test.ts
+++ b/test/bun.js/bun-server.test.ts
@@ -70,7 +70,7 @@ describe("Server", () => {
                 controller.write(buffer);
       
                 //wait to detect the connection abortion
-                await Bun.sleep(5);
+                await Bun.sleep(15);
                 
                 controller.close();
               },
@@ -91,6 +91,7 @@ describe("Server", () => {
         await fetch(`http://${server.hostname}:${server.port}`, { signal: abortController.signal });
       } catch {}
       expect(signalOnServer).toBe(true);
+      await Bun.sleep(5);
       server.stop(true);
     }
   });
@@ -114,7 +115,7 @@ describe("Server", () => {
                 controller.enqueue(buffer);
     
                 //wait to detect the connection abortion
-                await Bun.sleep(5);
+                await Bun.sleep(15);
 
                 controller.close();
               },
@@ -135,6 +136,7 @@ describe("Server", () => {
         await fetch(`http://${server.hostname}:${server.port}`, { signal: abortController.signal });
       } catch {}
       expect(signalOnServer).toBe(true);
+      await Bun.sleep(5);
       server.stop(true);
     }
   });

--- a/test/bun.js/bun-server.test.ts
+++ b/test/bun.js/bun-server.test.ts
@@ -90,8 +90,8 @@ describe("Server", () => {
       try {
         await fetch(`http://${server.hostname}:${server.port}`, { signal: abortController.signal });
       } catch {}
+      await Bun.sleep(10);
       expect(signalOnServer).toBe(true);
-      await Bun.sleep(5);
       server.stop(true);
     }
   });
@@ -135,8 +135,8 @@ describe("Server", () => {
       try {
         await fetch(`http://${server.hostname}:${server.port}`, { signal: abortController.signal });
       } catch {}
+      await Bun.sleep(10);
       expect(signalOnServer).toBe(true);
-      await Bun.sleep(5);
       server.stop(true);
     }
   });


### PR DESCRIPTION
fix Stream not deinit properly when connection is aborted
fix signal "abort" event always firing

Current behavior:
using `controller.write` after abortion it throws:
```
TypeError: Expected Sink
 code: "ERR_INVALID_THIS"

      at /home/cirospaciari/Repos/bun/tests.ts:156:12
 ```

If using `controller.enqueue` after abortion it throws:
```
TypeError: Cannot start stream with closed controller
```

The difference in behaviors:
`{type: "direct" }` after throw go to `onResolveStream` path
default type with enqueue go to `onRejectStream` path
default type uses TypeError but does not show the line of code that throws the error


