### PR TITLE
fix(node:http): match Node headers casing (lowercase only)

### DIFF
--- a/src/bun.js/http.exports.js
+++ b/src/bun.js/http.exports.js
@@ -308,13 +308,17 @@ export class Server extends EventEmitter {
 
 function assignHeaders(object, req) {
   var headers = req.headers.toJSON();
+  var lowerHeaders = {};
   const rawHeaders = newArrayWithSize(req.headers.count * 2);
   var i = 0;
   for (const key in headers) {
     rawHeaders[i++] = key;
-    rawHeaders[i++] = headers[key];
+    var header = headers[key];
+
+    rawHeaders[i++] = header;
+    lowerHeaders[key.toLowerCase()] = header;
   }
-  object.headers = headers;
+  object.headers = lowerHeaders;
   object.rawHeaders = rawHeaders;
 }
 function destroyBodyStreamNT(bodyStream) {

--- a/test/bun.js/node-http.test.ts
+++ b/test/bun.js/node-http.test.ts
@@ -411,6 +411,15 @@ describe("node:http", () => {
         req.end();
       }
     });
+
+    it("should allow us to access headers on response object in lower-case", done => {
+      const req = request(`http://localhost:${serverPort}`, { method: "POST" }, res => {
+        expect(res.rawHeaders.indexOf("Content-Type")).toBeTruthy();
+        expect(res.headers["content-type"]).toBe("text/plain");
+        done();
+      });
+      req.end();
+    });
   });
 
   describe("signal", () => {


### PR DESCRIPTION
Fixes #2273 