### PR TITLE
Fix update zls version in devcontainer

### DIFF
--- a/.devcontainer/scripts/zig-env.sh
+++ b/.devcontainer/scripts/zig-env.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-curl -L https://github.com/zigtools/zls-vscode/releases/download/1.1.6/zls-vscode-1.1.6.vsix >/home/ubuntu/vscode-zig.vsix
 git clone https://github.com/zigtools/zls /home/ubuntu/zls
 cd /home/ubuntu/zls
 git checkout 30869d7d8741656448e46fbf14f14da9ca7e5a21

--- a/.devcontainer/scripts/zig-env.sh
+++ b/.devcontainer/scripts/zig-env.sh
@@ -3,6 +3,6 @@
 curl -L https://github.com/zigtools/zls-vscode/releases/download/1.1.6/zls-vscode-1.1.6.vsix >/home/ubuntu/vscode-zig.vsix
 git clone https://github.com/zigtools/zls /home/ubuntu/zls
 cd /home/ubuntu/zls
-git checkout aabdb0c6ecb3c9a47feff2c2bfb9be4e95adf723
+git checkout 30869d7d8741656448e46fbf14f14da9ca7e5a21
 git submodule update --init --recursive --progress --depth=1
 zig build -Doptimize=ReleaseFast


### PR DESCRIPTION
Fix `make devcontainer-build` failed. Related issue https://github.com/zigtools/zls/issues/960

update `zls` to latest commit