### PR TITLE
fix(node:http): match Node headers casing (lowercase only)

### DIFF
--- a/src/bun.js/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/bun.js/bindings/webcore/JSFetchHeaders.cpp
@@ -450,7 +450,7 @@ static inline JSC::EncodedJSValue jsFetchHeadersPrototypeFunction_toJSONBody(JSC
         for (auto it = vec.begin(); it != vec.end(); ++it) {
             auto& name = it->key;
             auto& value = it->value;
-            obj->putDirect(vm, Identifier::fromString(vm, name), jsString(vm, value), 0);
+            obj->putDirect(vm, Identifier::fromString(vm, name.convertToASCIILowercase()), jsString(vm, value), 0);
         }
     }
 

--- a/src/bun.js/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/bun.js/bindings/webcore/JSFetchHeaders.cpp
@@ -450,7 +450,7 @@ static inline JSC::EncodedJSValue jsFetchHeadersPrototypeFunction_toJSONBody(JSC
         for (auto it = vec.begin(); it != vec.end(); ++it) {
             auto& name = it->key;
             auto& value = it->value;
-            obj->putDirect(vm, Identifier::fromString(vm, name.convertToASCIILowercase()), jsString(vm, value), 0);
+            obj->putDirect(vm, Identifier::fromString(vm, WTFMove(name.convertToASCIILowercase())), jsString(vm, value), 0);
         }
     }
 

--- a/test/bun.js/fetch_headers.test.js
+++ b/test/bun.js/fetch_headers.test.js
@@ -46,6 +46,18 @@ describe("Headers", async () => {
     // This would hang
     expect(await fetchContent({ "x-test": origString })).toBe(origString);
   });
+
+  describe("toJSON()", () => {
+    it("should provide lowercase header names", () => {
+      const headers1 = new Headers({ "X-Test": "yep", "Content-Type": "application/json" });
+      expect(headers1.toJSON()).toEqual({ "x-test": "yep", "content-type": "application/json" });
+
+      const headers2 = new Headers();
+      headers2.append("X-Test", "yep");
+      headers2.append("Content-Type", "application/json");
+      expect(headers2.toJSON()).toEqual({ "x-test": "yep", "content-type": "application/json" });
+    });
+  });
 });
 
 async function fetchContent(headers) {

--- a/test/bun.js/node-http.test.ts
+++ b/test/bun.js/node-http.test.ts
@@ -101,6 +101,11 @@ describe("node:http", () => {
             res.end("Not Found");
             return;
           }
+          if (reqUrl.pathname === "/lowerCaseHeaders") {
+            res.writeHead(200, { "content-type": "text/plain", "X-Custom-Header": "custom_value" });
+            res.end("Hello World");
+            return;
+          }
           if (reqUrl.pathname.includes("timeout")) {
             if (timer) clearTimeout(timer);
             timer = setTimeout(() => {
@@ -411,6 +416,16 @@ describe("node:http", () => {
         req.write("BODY");
         req.end();
       }
+    });
+
+    it("should return response with lowercase headers", done => {
+      const req = request(`http://localhost:${serverPort}/lowerCaseHeaders`, res => {
+        console.log(res.headers);
+        expect(res.headers["content-type"]).toBe("text/plain");
+        expect(res.headers["x-custom-header"]).toBe("custom_value");
+        done();
+      });
+      req.end();
     });
   });
 


### PR DESCRIPTION
Fixes #2273 