### PR TITLE
support `expect().toThrow(/pattern/)`

### DIFF
--- a/packages/bun-types/bun-test.d.ts
+++ b/packages/bun-types/bun-test.d.ts
@@ -76,7 +76,7 @@ declare module "bun:test" {
     toBeGreaterThanOrEqual(value: number | bigint): void;
     toBeLessThan(value: number | bigint): void;
     toBeLessThanOrEqual(value: number | bigint): void;
-    toThrow(error?: string | Error | ErrorConstructor): void;
+    toThrow(error?: string | Error | ErrorConstructor | RegExp): void;
   }
 }
 

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1768,7 +1768,7 @@ pub const Expect = struct {
             if (expected_value.isString()) {
                 const received_message = result.getIfPropertyExistsImpl(globalObject, "message", 7);
 
-                // partial match (regex not supported)
+                // partial match
                 {
                     var expected_string = ZigString.Empty;
                     var received_string = ZigString.Empty;
@@ -1784,6 +1784,29 @@ pub const Expect = struct {
                 }
 
                 const fmt = signature ++ "\n\nExpected substring: not <green>{any}<r>\nReceived message: <red>{any}<r>\n";
+                if (Output.enable_ansi_colors) {
+                    globalObject.throw(Output.prettyFmt(fmt, true), .{
+                        expected_value.toFmt(globalObject, &formatter),
+                        received_message.toFmt(globalObject, &formatter),
+                    });
+                    return .zero;
+                }
+                globalObject.throw(Output.prettyFmt(fmt, false), .{
+                    expected_value.toFmt(globalObject, &formatter),
+                    received_message.toFmt(globalObject, &formatter),
+                });
+                return .zero;
+            }
+
+            if (expected_value.isRegExp()) {
+                const received_message = result.getIfPropertyExistsImpl(globalObject, "message", 7);
+
+                if (expected_value.get(globalObject, "test")) |test_fn| {
+                    const matches = test_fn.callWithThis(globalObject, expected_value, &.{received_message});
+                    if (!matches.toBooleanSlow(globalObject)) return thisValue;
+                }
+
+                const fmt = signature ++ "\n\nExpected pattern: not <green>{any}<r>\nReceived message: <red>{any}<r>\n";
                 if (Output.enable_ansi_colors) {
                     globalObject.throw(Output.prettyFmt(fmt, true), .{
                         expected_value.toFmt(globalObject, &formatter),
@@ -1835,7 +1858,7 @@ pub const Expect = struct {
 
             if (expected_value.isString()) {
                 if (_received_message) |received_message| {
-                    // partial match (regex not supported)
+                    // partial match
                     var expected_string = ZigString.Empty;
                     var received_string = ZigString.Empty;
                     expected_value.toZigString(&expected_string, globalObject);
@@ -1868,6 +1891,42 @@ pub const Expect = struct {
                 const expected_fmt = expected_value.toFmt(globalObject, &formatter);
                 const received_fmt = result.toFmt(globalObject, &formatter);
                 const fmt = signature ++ "\n\n" ++ "Expected substring: <green>{any}<r>\nReceived value: <red>{any}<r>";
+                if (Output.enable_ansi_colors) {
+                    globalObject.throw(Output.prettyFmt(fmt, true), .{ expected_fmt, received_fmt });
+                    return .zero;
+                }
+
+                globalObject.throw(Output.prettyFmt(fmt, false), .{ expected_fmt, received_fmt });
+                return .zero;
+            }
+
+            if (expected_value.isRegExp()) {
+                if (_received_message) |received_message| {
+                    if (expected_value.get(globalObject, "test")) |test_fn| {
+                        const matches = test_fn.callWithThis(globalObject, expected_value, &.{received_message});
+                        if (matches.toBooleanSlow(globalObject)) return thisValue;
+                    }
+                }
+
+                // error: message from received error does not match expected pattern
+                var formatter = JSC.ZigConsoleClient.Formatter{ .globalThis = globalObject, .quote_strings = true };
+
+                if (_received_message) |received_message| {
+                    const expected_value_fmt = expected_value.toFmt(globalObject, &formatter);
+                    const received_message_fmt = received_message.toFmt(globalObject, &formatter);
+                    const fmt = signature ++ "\n\n" ++ "Expected pattern: <green>{any}<r>\nReceived message: <red>{any}<r>\n";
+                    if (Output.enable_ansi_colors) {
+                        globalObject.throw(Output.prettyFmt(fmt, true), .{ expected_value_fmt, received_message_fmt });
+                        return .zero;
+                    }
+
+                    globalObject.throw(Output.prettyFmt(fmt, false), .{ expected_value_fmt, received_message_fmt });
+                    return .zero;
+                }
+
+                const expected_fmt = expected_value.toFmt(globalObject, &formatter);
+                const received_fmt = result.toFmt(globalObject, &formatter);
+                const fmt = signature ++ "\n\n" ++ "Expected pattern: <green>{any}<r>\nReceived value: <red>{any}<r>";
                 if (Output.enable_ansi_colors) {
                     globalObject.throw(Output.prettyFmt(fmt, true), .{ expected_fmt, received_fmt });
                     return .zero;
@@ -1975,6 +2034,18 @@ pub const Expect = struct {
 
         if (expected_value.isString()) {
             const expected_fmt = "\n\nExpected substring: <green>{any}<r>\n\n" ++ received_line;
+            const fmt = signature ++ expected_fmt;
+            if (Output.enable_ansi_colors) {
+                globalObject.throw(Output.prettyFmt(fmt, true), .{expected_value.toFmt(globalObject, &formatter)});
+                return .zero;
+            }
+
+            globalObject.throw(Output.prettyFmt(fmt, false), .{expected_value.toFmt(globalObject, &formatter)});
+            return .zero;
+        }
+
+        if (expected_value.isRegExp()) {
+            const expected_fmt = "\n\nExpected pattern: <green>{any}<r>\n\n" ++ received_line;
             const fmt = signature ++ expected_fmt;
             if (Output.enable_ansi_colors) {
                 globalObject.throw(Output.prettyFmt(fmt, true), .{expected_value.toFmt(globalObject, &formatter)});
@@ -2275,7 +2346,7 @@ pub const TestScope = struct {
                 task,
             );
             task.done_callback_state = .pending;
-            initial_value = JSValue.fromRef(callback.?).call(vm.global, &.{callback_func});
+            initial_value = JSValue.fromRef(callback).call(vm.global, &.{callback_func});
         } else {
             initial_value = js.JSObjectCallAsFunctionReturnValue(vm.global, callback, null, 0, null);
         }

--- a/test/bun.js/console/console-log.expected.txt
+++ b/test/bun.js/console/console-log.expected.txt
@@ -8,7 +8,7 @@ false
 null
 undefined
 Symbol(Symbol Description)
-2022-02-27T05:11:48.999Z
+2000-06-27T02:24:34.304Z
 [ 123, 456, 789 ]
 {
   name: "foo"

--- a/test/bun.js/console/console-log.js
+++ b/test/bun.js/console/console-log.js
@@ -8,7 +8,7 @@ console.log(false);
 console.log(null);
 console.log(undefined);
 console.log(Symbol("Symbol Description"));
-console.log(new Date(2021, 12, 30, 666, 777, 888, 999));
+console.log(new Date(Math.pow(2, 34) * 56));
 console.log([123, 456, 789]);
 console.log({ name: "foo" });
 console.log({ a: 123, b: 456, c: 789 });

--- a/test/bun.js/test-test.test.ts
+++ b/test/bun.js/test-test.test.ts
@@ -156,10 +156,19 @@ test("toThrow", () => {
     throw err;
   }).toThrow(err);
 
-  var err = new Error("good");
   expect(() => {
-    throw err;
+    throw new Error("good");
   }).toThrow();
+
+  expect(() => {
+    throw new Error("foo");
+  }).toThrow(/oo/);
+
+  expect(() =>
+    expect(() => {
+      throw new Error("bar");
+    }).toThrow(/baz/),
+  ).toThrow("/baz/");
 
   expect(() => {
     return true;


### PR DESCRIPTION
- fix time-zone-dependent test failure