### PR TITLE
docs: changes recommendation for typescript typedefs to use typedef file

### DIFF
--- a/docs/ecosystem/typescript.md
+++ b/docs/ecosystem/typescript.md
@@ -12,13 +12,17 @@ To install TypeScript definitions for Bun's built-in APIs, first install `bun-ty
 $ bun add -d bun-types # dev dependency
 ```
 
-Then include `"bun-types"` in the `compilerOptions.types` in your `tsconfig.json`:
+Then create a file in your project, `env.d.ts`, with a reference to this package using a [triple-slash directive](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html).
+
+```ts
+/// <reference types="bun-types" />
+```
+
+Lastly, in order for your TypeScript files to recognize the types referenced in the file created above, add this file to the `include` array.
 
 ```json-diff
   {
-    "compilerOptions": {
-+     "types": ["bun-types"]
-    }
++   "include": ["./env.d.ts"]
   }
 ```
 


### PR DESCRIPTION
Changes suggestion from modifying the `tsconfig.json`'s `compilerOptions.types` in favor of a typedef file with a reference to `bun-types`.

When manually supplying packages to `compilerOptions.types` it will disable auto-detection of `@types` packages https://www.typescriptlang.org/tsconfig#types

> By default all visible ”@types” packages are included in your compilation. Packages in node_modules/@types of any enclosing folder are considered visible. For example, that means packages within ./node_modules/@types/, ../node_modules/@types/, ../../node_modules/@types/, and so on.
If `types` is specified, only packages listed will be included in the global scope. For instance:

This change also adheres to community trends, such as Vite's suggestion for referencing its client types https://vitejs.dev/guide/env-and-mode.html#intellisense-for-typescript