### PR TITLE
feat(docker): replace alpine/glibc with distroless

### DIFF
--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -1,41 +1,19 @@
-### GLOBALS ###
-ARG GLIBC_RELEASE=2.34-r0
-
-
-### GET ###
-FROM alpine:latest as get
+FROM debian:bullseye-slim as base
 
 # prepare environment
 WORKDIR /tmp
-RUN apk --no-cache add unzip
+RUN apt-get update && \
+    apt-get install -y unzip && \
+    rm -rf /var/lib/apt/lists/*
 
 # get bun
 ADD https://github.com/oven-sh/bun/releases/latest/download/bun-linux-x64.zip bun-linux-x64.zip
 RUN unzip bun-linux-x64.zip
 
-# get glibc
-ARG GLIBC_RELEASE
-RUN wget https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_RELEASE}/glibc-${GLIBC_RELEASE}.apk
-
-
-### IMAGE ###
-FROM alpine:latest
+FROM gcr.io/distroless/base-nossl-debian11
 
 # install bun
-COPY --from=get /tmp/bun-linux-x64/bun /usr/local/bin
+COPY --from=base /tmp/bun-linux-x64/bun /usr/bin/bun
 
-# prepare glibc
-ARG GLIBC_RELEASE
-COPY --from=get /tmp/sgerrand.rsa.pub /etc/apk/keys
-COPY --from=get /tmp/glibc-${GLIBC_RELEASE}.apk /tmp
-
-# install glibc
-RUN apk --no-cache --force-overwrite add /tmp/glibc-${GLIBC_RELEASE}.apk && \
-
-# cleanup
-    rm /etc/apk/keys/sgerrand.rsa.pub && \
-    rm /tmp/glibc-${GLIBC_RELEASE}.apk && \
-
-# smoke test
-    bun --version
+# default entrypoint
+ENTRYPOINT ["/usr/bin/bun"]


### PR DESCRIPTION
The current Dockerfile uses Alpine with a set of glibc libraries. This is not sustainable for a few reasons (see #1567). Since container size is important, we switch to distroless which allows a minimal host but based on debian 11.

Additionally, add an entrypoint that points to bun.

This PR increases the uncompressed container size by ~2MB.

Sidenote: google has aarch64 versions which makes it possible to release this for additional architectures.

---

Todo

- [ ] more testing, I don't use bun much in images
- [ ] fix CI build/label error
- [ ] add opencontainer labels
- [ ] explore more architectures than amd64