### PR TITLE
fix `require.resolve` with an empty options object #2370

### DIFF
--- a/src/bun.js/bindings/ImportMetaObject.cpp
+++ b/src/bun.js/bindings/ImportMetaObject.cpp
@@ -84,9 +84,11 @@ static EncodedJSValue functionRequireResolve(JSC::JSGlobalObject* globalObject, 
             // require.resolve also supports a paths array
             // we only support a single path
             if (!fromValue.isUndefinedOrNull() && fromValue.isObject()) {
-                if (JSC::JSArray* array = JSC::jsDynamicCast<JSC::JSArray*>(fromValue.getObject()->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, "paths"_s)))) {
-                    if (array->length() > 0) {
-                        fromValue = array->getIndex(globalObject, 0);
+                 if (JSValue pathsValue = fromValue.getObject()->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, "paths"_s))) {
+                    if (JSC::JSArray* array = JSC::jsDynamicCast<JSC::JSArray*>(pathsValue)) {
+                        if (array->length() > 0) {
+                            fromValue = array->getIndex(globalObject, 0);
+                        }
                     }
                 }
             }

--- a/test/js/bun/resolve/import-meta.test.js
+++ b/test/js/bun/resolve/import-meta.test.js
@@ -164,5 +164,5 @@ it('import("bun") works', async () => {
 });
 
 it("require.resolve with empty options object", () => {
-  expect(require.resolve("bun", {})).toBe("bun");
+  expect(require.resolve(import.meta.path + String(""), {})).toBe(import.meta.path);
 });

--- a/test/js/bun/resolve/import-meta.test.js
+++ b/test/js/bun/resolve/import-meta.test.js
@@ -1,7 +1,7 @@
 import { it, expect } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import * as Module from "node:module";
-import sync from "./require-json.json.js";
+import sync from "./require-json.json";
 
 const { path, dir } = import.meta;
 
@@ -50,7 +50,7 @@ it("require with a query string works on dynamically created content", () => {
 it("import.meta.require (json)", () => {
   expect(import.meta.require("./require-json.json").hello).toBe(sync.hello);
   const require = Module.createRequire(import.meta.path);
-  expect(require("./require-json.json.js").hello).toBe(sync.hello);
+  expect(require("./require-json").hello).toBe(sync.hello);
 });
 
 it("const f = require;require(json)", () => {
@@ -161,4 +161,8 @@ it('require("bun") works', () => {
 
 it('import("bun") works', async () => {
   expect(await import("bun")).toBe(Bun);
+});
+
+it("require.resolve with empty options object", () => {
+  expect(require.resolve("bun", {})).toBe("bun");
 });


### PR DESCRIPTION
this would segv `require.resolve("bun", {})`

this also fixes test in `import-meta.test.js`

fixes #2370 