### PR TITLE
docs: Buchta Docs Page

### DIFF
--- a/docs/ecosystem/buchta.md
+++ b/docs/ecosystem/buchta.md
@@ -1,0 +1,24 @@
+[Buchta](https://buchtajs.com) is a Full-Stack framework powered by Bun that takes most features from Bun as its advantages
+
+```ts#server.ts
+import { Buchta, BuchtaRequest, BuchtaResponse } from "buchta";
+
+const app = new Buchta();
+
+app.get("/api/hello/", (req: BuchtaRequest, res: BuchtaResponse) => {
+    res.send("Hello, World!");
+});
+
+app.run();
+```
+
+Get started with `bun x buchta init`.
+
+```bash
+$ bun x buchta init myapp # configure it to your likings
+$ cd myapp
+$ bun install
+$ bun run buchta serve
+```
+
+For more information on how to write your own plugins, how to use FS router, etc. Follow buchta's [documentation](https://buchtajs.com/docs/)

--- a/docs/ecosystem/buchta.md
+++ b/docs/ecosystem/buchta.md
@@ -1,24 +1,36 @@
-[Buchta](https://buchtajs.com) is a Full-Stack framework powered by Bun that takes most features from Bun as its advantages
+[Buchta](https://buchtajs.com) is a fullstack framework designed to take full advantage of Bun's strengths. It currently supports Preact and Svelte.
+
+To get started:
+
+```bash
+$ bunx buchta init myapp
+Project templates: 
+- svelte
+- default
+- preact
+Name of template: preact  
+Do you want TSX? y  
+Do you want SSR? y
+Enable livereload? y
+Buchta Preact project was setup successfully!
+$ cd myapp
+$ bun install
+$ bunx buchta serve
+```
+
+To implement a simple HTTP server with Buchta:
 
 ```ts#server.ts
-import { Buchta, BuchtaRequest, BuchtaResponse } from "buchta";
+import { Buchta, type BuchtaRequest, type BuchtaResponse } from "buchta";
 
 const app = new Buchta();
 
 app.get("/api/hello/", (req: BuchtaRequest, res: BuchtaResponse) => {
-    res.send("Hello, World!");
+  res.send("Hello, World!");
 });
 
 app.run();
 ```
 
-Get started with `bun x buchta init`.
 
-```bash
-$ bun x buchta init myapp # configure it to your likings
-$ cd myapp
-$ bun install
-$ bun run buchta serve
-```
-
-For more information on how to write your own plugins, how to use FS router, etc. Follow buchta's [documentation](https://buchtajs.com/docs/)
+For more information, refer to Buchta's [documentation](https://buchtajs.com/docs/).

--- a/docs/nav.ts
+++ b/docs/nav.ts
@@ -108,6 +108,9 @@ export default {
     page("ecosystem/hono", "Hono", {
       description: `Hono is an ultra-fast, Bun-friendly web framework designed for edge environments.`,
     }),
+    page("ecosystem/buchta", "Buchta", {
+      description: `Buchta is a Bun-native fullstack framework for Svelte and Preact apps.`,
+    }),
     page("ecosystem/express", "Express", {
       description: `Servers built with Express and other major Node.js HTTP libraries work out of the box.`,
     }),


### PR DESCRIPTION
I'd like to know if I could add my project as part of the ecosystem into docs. `Buchta` is a web framework that currently uses "legacy" bun's bundler ( the old one + I don't know if I can call the old bundler "legacy" ). It currently supports Svelte and Preact. It's not the fastest framework but has something to it. It allows you to create web applications that can be SSR'd with the ability to export your project. I would be happy if the project could appear in the docs section.

Official website: https://buchtajs.com/
Documentation page: https://buchtajs.com/docs/
Project's repository: https://github.com/Fire-The-Fox/buchta
Source code of the website: https://github.com/Fire-The-Fox/buchtajs.com
* The exported page is located in `dist` directory / `gh-pages` branch