### PR TITLE
Fix issue  #2338 about path.parse

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1775,17 +1775,16 @@ pub const Path = struct {
         var path_slice: JSC.ZigString.Slice = args_ptr[0].toSlice(globalThis, heap_allocator);
         defer path_slice.deinit();
         var path = path_slice.slice();
-        var path_name = if (isWindows) Fs.PathName.init_win32(path) else Fs.PathName.init(path);
+        var path_name = if (isWindows) Fs.PathName.initWindows(path) else Fs.PathName.init(path);
         var root = JSC.ZigString.init(path_name.dir);
         const is_absolute = (isWindows and isZigStringAbsoluteWindows(root)) or (!isWindows and path_name.dir.len > 0 and path_name.dir[0] == '/');
-    
         // Build root for windows in any case
         if (isWindows) {
             if (path.len > 1 and path[1] == ':') {
                 // Windows root can be like "C:", "C:/" and "C:\\", but only the last two patterns
                 // are for absolute paths.
                 if (path.len > 2 and (path[2] == '/' or path[2] == '\\')) {
-                    
+
                     // Fix the dir if the path is absolute.
                     if (is_absolute)
                         path_name.dir = path[0..3];

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1136,7 +1136,7 @@ pub const PathName = struct {
         var is_absolute = true;
 
         var _i = strings.lastIndexOfChar(path, '/');
-        
+
         while (_i) |i| {
             // Stop if we found a non-trailing slash
             if (i + 1 != path.len) {
@@ -1176,7 +1176,7 @@ pub const PathName = struct {
     }
 
     // Same as init but consider '\\' characters
-    pub fn init_win32(_path: string) PathName {
+    pub fn initWindows(_path: string) PathName {
         var path = _path;
         var base = path;
 
@@ -1190,7 +1190,7 @@ pub const PathName = struct {
         if (strings.lastIndexOfChar(path, '\\')) |win32_i| {
             _i = if (_i) |posix_i| @max(posix_i, win32_i) else win32_i;
         }
-        
+
         while (_i) |i| {
             // Stop if we found a non-trailing slash
             if (i + 1 != path.len) {

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -77,6 +77,61 @@ it("path.basename", () => {
   strictEqual(path.posix.basename(`/a/b/${controlCharFilename}`), controlCharFilename);
 });
 
+it("path.parse().name", () => {
+  strictEqual(path.parse(file).name, "path.test");
+  strictEqual(path.parse(".js").name, ".js");
+  strictEqual(path.parse("..js").name, ".");
+  strictEqual(path.parse("").name, "");
+  strictEqual(path.parse(".").name, ".");
+  strictEqual(path.parse("dir/name.ext").name, "name");
+  strictEqual(path.parse("/dir/name.ext").name, "name");
+  strictEqual(path.parse("/name.ext").name, "name");
+  strictEqual(path.parse("name.ext").name, "name");
+  strictEqual(path.parse("name.ext/").name, "name");
+  strictEqual(path.parse("name.ext//").name, "name");
+  strictEqual(path.parse("aaa/bbb").name, "bbb");
+  strictEqual(path.parse("aaa/bbb/").name, "bbb");
+  strictEqual(path.parse("aaa/bbb//").name, "bbb");
+  strictEqual(path.parse("/aaa/bbb").name, "bbb");
+  strictEqual(path.parse("/aaa/bbb/").name, "bbb");
+  strictEqual(path.parse("/aaa/bbb//").name, "bbb");
+  strictEqual(path.parse("//aaa/bbb").name, "bbb");
+  strictEqual(path.parse("//aaa/bbb/").name, "bbb");
+  strictEqual(path.parse("//aaa/bbb//").name, "bbb");
+  strictEqual(path.parse("///aaa").name, "aaa");
+  strictEqual(path.parse("//aaa").name, "aaa");
+  strictEqual(path.parse("/aaa").name, "aaa");
+  strictEqual(path.parse("aaa.").name, "aaa");
+
+  // On Windows a backslash acts as a path separator.
+  strictEqual(path.win32.parse("\\dir\\name.ext").name, "name");
+  strictEqual(path.win32.parse("\\name.ext").name, "name");
+  strictEqual(path.win32.parse("name.ext").name, "name");
+  strictEqual(path.win32.parse("name.ext\\").name, "name");
+  strictEqual(path.win32.parse("name.ext\\\\").name, "name");
+  strictEqual(path.win32.parse("name").name, "name");
+  strictEqual(path.win32.parse(".name").name, ".name");
+  strictEqual(path.win32.parse("C:").name, "");
+  strictEqual(path.win32.parse("C:.").name, ".");
+  strictEqual(path.win32.parse("C:\\").name, "");
+  strictEqual(path.win32.parse("C:\\.").name, ".");
+  strictEqual(path.win32.parse("C:\\.ext").name, ".ext");
+  strictEqual(path.win32.parse("C:\\dir\\name.ext").name, "name");
+  strictEqual(path.win32.parse("C:name.ext").name, "name");
+  strictEqual(path.win32.parse("C:name.ext\\").name, "name");
+  strictEqual(path.win32.parse("C:name.ext\\\\").name, "name");
+  strictEqual(path.win32.parse("C:foo").name, "foo");
+  strictEqual(path.win32.parse("C:.foo").name, ".foo");
+  strictEqual(path.win32.parse("file:stream").name, "file:stream");
+
+  // On unix a backslash is just treated as any other character.
+  strictEqual(path.posix.parse("\\dir\\name.ext").name, "\\dir\\name");
+  strictEqual(path.posix.parse("\\name.ext").name, "\\name");
+  strictEqual(path.posix.parse("name.ext").name, "name");
+  strictEqual(path.posix.parse("name.ext\\").name, "name");
+  strictEqual(path.posix.parse("name.ext\\\\").name, "name");
+});
+
 it("path.join", () => {
   const failures = [];
   const backslashRE = /\\/g;


### PR DESCRIPTION
Hi, I just looked at the issue #2338 and I managed to write a PR for it.

The issue is about a wrong behavior of the `path.parse` method:

```js
const path = require("path")
console.log(path.parse("foo.txt").name)
// Expect "foo", but actually "foo.txt"
```

My objective was to align the results as closely as possible with those of `nodejs`, so I wrote some relevant unit tests and fixed the most I could. I have made changes in the parse function in the `types.zig` file, and have also modified the `Fs.PathName.init` function (I have to check if I broke something here). While I am uncertain about the separation of concern between these two functions, I would prefer to modify only one of them at term.

During my the checks I noticed some differences with `nodejs` and I attempt to fix that too. A quick fix but incomplete would be to basically swap these following assignations. It looks like a naming issue at first look.

```zig
var base = JSC.ZigString.init(path_name.base);
var name_ = JSC.ZigString.init(path_name.filename);
// into
var base = JSC.ZigString.init(path_name.filename);
var name_ = JSC.ZigString.init(path_name.base);
```

However, I am not entirely satisfied with the `initWindows` function I have created. In the other hand, I am unsure about  a `isWindows` argument in `fs.zig` (does it make any sense?).  Any advice would be greatly appreciated!

Thank you for your time, :pray: 