### PR TITLE
"bun-create" example "postinstall"→"preinstall"

### DIFF
--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -129,7 +129,7 @@ Each of these can correspond to a string or array of strings. An array of comman
     "react-dom": "^17.0.2"
   },
   "bun-create": {
-    "postinstall": "echo 'Installing...'", // a single command
+    "preinstall": "echo 'Installing...'", // a single command
     "postinstall": ["echo 'Done!'"], // an array of commands
     "start": "bun run echo 'Hello world!'"
   }


### PR DESCRIPTION
"postinstall" is listed twice in the example for the "bun-create" section of package.json. Based on the context and content of the echo commands I believe the intent is that the first "postinstall" should be "preinstall".  This change corrects this.