### PR TITLE
Stop if we are current

### DIFF
--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -295,6 +295,10 @@ pub const UpgradeCommand = struct {
         if (expr.asProperty("tag_name")) |tag_name_| {
             if (tag_name_.expr.asString(allocator)) |tag_name| {
                 version.tag = tag_name;
+
+                if (version.isCurrent()) {
+                    return version;
+                }
             }
         }
 


### PR DESCRIPTION
https://github.com/oven-sh/bun/discussions/2436#discussioncomment-5396011 reported that they were running 0.5.8 when the update repository didn't list 0.5.8 for their platform.

If the version we have is current, there's no reason to do more work, so, try to return the version and let the flow continue.

(This is untested, I can't figure out how to convince my computer to build it.)