### PR TITLE
Use PATH instead of sudo to install bun for testing

### DIFF
--- a/.github/workflows/bun-linux-build.yml
+++ b/.github/workflows/bun-linux-build.yml
@@ -174,6 +174,12 @@ jobs:
         with:
           name: bun-${{matrix.tag}}
           path: ${{runner.temp}}/release
+      - id: shim-path
+        name: set path
+        run: |
+          stage_bin=$(mktemp -d)
+          echo "stage_bin=$stage_bin"
+          echo $stage_bin >> $GITHUB_PATH
       - id: install
         name: Install
         run: |
@@ -181,7 +187,7 @@ jobs:
           unzip bun-${{matrix.tag}}.zip
           cd bun-${{matrix.tag}}
           chmod +x bun
-          sudo mv bun /usr/local/bin/bun
+          mv bun $stage_bin/bun
           bun --version
       - id: test
         name: Test (node runner)

--- a/.github/workflows/bun-mac-aarch64.yml
+++ b/.github/workflows/bun-mac-aarch64.yml
@@ -411,6 +411,12 @@ jobs:
         with:
           name: ${{matrix.tag}}
           path: ${{runner.temp}}/release
+      - id: shim-path
+        name: set path
+        run: |
+          stage_bin=$(mktemp -d)
+          echo "stage_bin=$stage_bin"
+          echo $stage_bin >> $GITHUB_PATH
       - id: install
         name: Install
         run: |
@@ -418,7 +424,7 @@ jobs:
           unzip ${{matrix.tag}}.zip
           cd ${{matrix.tag}}
           chmod +x bun
-          sudo mv bun /usr/local/bin/bun
+          mv bun $stage_bin/bun
           bun --version
       - id: test
         name: Test (node runner)

--- a/.github/workflows/bun-mac-x64-baseline.yml
+++ b/.github/workflows/bun-mac-x64-baseline.yml
@@ -415,6 +415,12 @@ jobs:
         with:
           name: ${{matrix.tag}}
           path: ${{runner.temp}}/release
+      - id: shim-path
+        name: set path
+        run: |
+          stage_bin=$(mktemp -d)
+          echo "stage_bin=$stage_bin"
+          echo $stage_bin >> $GITHUB_PATH
       - id: install
         name: Install
         run: |
@@ -422,7 +428,7 @@ jobs:
           unzip ${{matrix.tag}}.zip
           cd ${{matrix.tag}}
           chmod +x bun
-          sudo mv bun /usr/local/bin/bun
+          mv bun $stage_bin/bun
           bun --version
       - id: test
         name: Test (node runner)

--- a/.github/workflows/bun-mac-x64.yml
+++ b/.github/workflows/bun-mac-x64.yml
@@ -417,6 +417,12 @@ jobs:
         with:
           name: ${{matrix.tag}}
           path: ${{runner.temp}}/release
+      - id: shim-path
+        name: set path
+        run: |
+          stage_bin=$(mktemp -d)
+          echo "stage_bin=$stage_bin"
+          echo $stage_bin >> $GITHUB_PATH
       - id: install
         name: Install
         run: |
@@ -424,7 +430,7 @@ jobs:
           unzip ${{matrix.tag}}.zip
           cd ${{matrix.tag}}
           chmod +x bun
-          sudo mv bun /usr/local/bin/bun
+          mv bun $stage_bin/bun
           bun --version
       - id: test
         name: Test (node runner)


### PR DESCRIPTION
I made a pr and the CI failed when it tried to use `sudo` on the self-hosted arm runner:

https://github.com/oven-sh/bun/actions/runs/4495384541/jobs/7909151739#step:4:17

Using `sudo` to install `bun` for testing PRs isn't a great idea...

Here, I offer a way to create a temporary directory (`$stage_bin`) and add it to the path (via [`$GITHUB_PATH`](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path)) for the rest of a specific github workflow `job`. macOS will delete temp files periodically (see `/etc/defaults/periodic.conf`), but roughly:
```
# 110.clean-tmps
daily_clean_tmps_enable="YES"                           # Delete stuff daily
daily_clean_tmps_dirs="/tmp"                            # Delete under here
daily_clean_tmps_days="3"                               # If not accessed for
```

This avoids installing things into the system's normal path and scopes it for roughly the lifespan of the single workflow job.