### PR TITLE
chore: improve css styling and readability on performance claims on landing page (closes #2468)

### DIFF
--- a/test/js/web/fetch/fixture.html
+++ b/test/js/web/fetch/fixture.html
@@ -652,8 +652,9 @@
         text-decoration: none !important;
       }
       .PerformanceClaim {
-        text-decoration: dashed underline 2px #000 !important;
+        text-decoration: underline 2px #000 !important;
         text-decoration-skip-ink: auto !important;
+        text-underline-offset: 0.20rem !important;
       }
       .BarGraph--react,
       .BarGraph--websocket,


### PR DESCRIPTION

- dashed underline makes text difficult to read so made it a solid line
- applied an offset to the underline so that it doesn't touch the bottom part of text