### PR TITLE
Fix date format (#2422)

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2304,7 +2304,10 @@ pub const ZigConsoleClient = struct {
                         // in the code for printing dates, it never exceeds this amount
                         var iso_string_buf: [36]u8 = undefined;
                         var out_buf: []const u8 = std.fmt.bufPrint(&iso_string_buf, "{}", .{str}) catch "";
-                        if (out_buf.len > 2) {
+
+                        if (strings.eql(out_buf, "null")) {
+                            out_buf = "Invalid Date";
+                        } else if (out_buf.len > 2) {
                             // trim the quotes
                             out_buf = out_buf[1 .. out_buf.len - 1];
                         }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -337,3 +337,15 @@ describe("crash testing", () => {
 it("possibly formatted emojis log", () => {
   expect(Bun.inspect("✔", "hey")).toBe("✔ hey");
 });
+
+it("new Date(..)", () => {
+  expect(Bun.inspect(new Date(1679911059000))).toBe("2023-03-27T09:54:00.000Z");
+  expect(Bun.inspect(new Date("March 27, 2023 09:54:00"))).toBe("2023-03-27T09:54:00.000Z");
+  expect(Bun.inspect(new Date("2023-03-27T09:54:00"))).toBe("2023-03-27T09:54:00.000Z");
+  expect(Bun.inspect(new Date(2023, 02, 27))).toBe("2023-03-27T00:00:00.000Z");
+  expect(Bun.inspect(new Date(2023, 02, 27, 09, 54, 0))).toBe("2023-03-27T09:54:00.000Z");
+
+  expect(Bun.inspect(new Date("1679911059000"))).toBe("Invalid Date");
+  expect(Bun.inspect(new Date("hello world"))).toBe("Invalid Date");
+  expect(Bun.inspect(new Date("Invalid Date"))).toBe("Invalid Date");
+});


### PR DESCRIPTION
Hi!

That PR provide a quick fix to the bug #2422. If the parsing of the date is null, write `Invalid Date` instead. Maybe it could be fixed earlier inside `jsonStringify` ?
