### PR TITLE
Small change to `bun link` docs

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -185,7 +185,7 @@ $ cd /path/to/my-app
 $ bun link cool-pkg
 ```
 
-This will add `cool-pkg` to the `dependencies` field of your app's package.json with a special version specifier that tells Bun to load from the registered local directory instead of installing from `npm`.
+Alternatively you can add `cool-pkg` to the `dependencies` field of your app's package.json with a special version specifier that tells Bun to load from the registered local directory instead of installing from `npm`.
 
 ```json-diff
   {


### PR DESCRIPTION
From my testing, `bun link <package>` only does symlinking in `node_modules` and doesn't modify the `package.json`, whereas the docs make it sound like it does both.  I presume the docs mean to say that editing the `package.json` is an alternative way to use a linked package ... ?