### PR TITLE
Fix: Handle filename with non-latin1 characters

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3829,7 +3829,7 @@ JSC::JSInternalPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalOb
         return rejectedInternalPromise(globalObject, createTypeError(globalObject, "To load Node-API modules, use require() or process.dlopen instead of import."_s));
     }
 
-    auto moduleKeyZig = toZigString(moduleKey);
+    auto moduleKeyZig = Zig::utf8ToZigString(moduleKey);
     auto source = Zig::toZigString(value1, globalObject);
     ErrorableResolvedSource res;
     res.success = false;

--- a/src/bun.js/bindings/helpers.h
+++ b/src/bun.js/bindings/helpers.h
@@ -251,6 +251,11 @@ static const unsigned char* taggedUTF16Ptr(const UChar* ptr)
     return reinterpret_cast<const unsigned char*>(reinterpret_cast<uintptr_t>(ptr) | (static_cast<uint64_t>(1) << 63));
 }
 
+static const unsigned char* taggedUTF8Ptr(const LChar* ptr)
+{
+    return reinterpret_cast<const unsigned char*>(reinterpret_cast<uintptr_t>(ptr) | (static_cast<uint64_t>(1) << 61));
+}
+
 static ZigString toZigString(WTF::String* str)
 {
     return str->isEmpty()
@@ -280,6 +285,16 @@ static ZigString toZigString(const WTF::StringView& str)
     return str.isEmpty()
         ? ZigStringEmpty
         : ZigString { str.is8Bit() ? str.characters8() : taggedUTF16Ptr(str.characters16()),
+              str.length() };
+}
+
+// Sometimes WTF::String has already encode by UTF8, but it regards as Latin-1. 
+// So we need to explicitly to set to UTF-8 when transfering to ZigString.
+static ZigString utf8ToZigString(const WTF::StringView& str)
+{
+    return str.isEmpty()
+        ? ZigStringEmpty
+        : ZigString { str.is8Bit() ? taggedUTF8Ptr(str.characters8()) : taggedUTF16Ptr(str.characters16()),
               str.length() };
 }
 

--- a/test/cli/run/tËst.test.ts
+++ b/test/cli/run/tËst.test.ts
@@ -1,0 +1,5 @@
+import { it, expect } from "bun:test";
+
+it("non-latin1 file name", () => {
+  expect(true).toEqual(true);
+});

--- a/test/cli/run/测试.test.ts
+++ b/test/cli/run/测试.test.ts
@@ -1,0 +1,5 @@
+import { it, expect } from "bun:test";
+
+it("non-latin1 file name(Chinese)", () => {
+  expect(true).toEqual(true);
+});


### PR DESCRIPTION
Sometimes WTF::String has already encode by UTF8, but it regards as Latin-1. 
So we need to explicitly to set to UTF-8 when transfering to ZigString.