### PR TITLE
Update NodeJS LTS version in run_command.zig

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -605,7 +605,7 @@ pub const RunCommand = struct {
             // the use of npm/? is copying yarn
             // e.g.
             // > "yarn/1.22.4 npm/? node/v12.16.3 darwin x64",
-            "bun/" ++ Global.package_json_version ++ " npm/? node/v16.14.0 " ++ Global.os_name ++ " " ++ Global.arch_name,
+            "bun/" ++ Global.package_json_version ++ " npm/? node/v18.15.0 " ++ Global.os_name ++ " " ++ Global.arch_name,
         ) catch unreachable;
 
         if (this_bundler.env.get("npm_execpath") == null) {


### PR DESCRIPTION
This is probably a very inconsequential change, but I thought it might be worth keeping the NodeJS LTS version up to date in the `npm_config_user_agent` string.

This PR updates it to "v18.15.0". v20.x isn't scheduled to be LTS until October of this year.