### PR TITLE
Improve websocket chat server benchmark

### DIFF
--- a/bench/websocket-server/README.md
+++ b/bench/websocket-server/README.md
@@ -28,6 +28,19 @@ Then, run the client script. By default, it will connect 16 clients. This client
 node ./chat-client.mjs
 ```
 
+Example for running clients in multiple processes. (6 \* 32 = 192)
+First start the server:
+
+```bash
+CLIENTS_COUNT=192 node ./chat-server.uws.mjs
+```
+
+Then run 6 of these:
+
+```bash
+WORKERS=6 CLIENTS_COUNT=32 node ./chat-client.mjs
+```
+
 The client script loops through a list of messages for each connected client and sends a message.
 
 For example, when the client sends `"foo"`, the server sends back `"John: foo"` so that all members of the chatroom receive the message.

--- a/bench/websocket-server/chat-server.uws.mjs
+++ b/bench/websocket-server/chat-server.uws.mjs
@@ -1,0 +1,69 @@
+// See ./README.md for instructions on how to run this benchmark.
+const port = process.env.PORT || 4001;
+const CLIENTS_TO_WAIT_FOR = parseInt(process.env.CLIENTS_COUNT || "", 10) || 16;
+var remainingClients = CLIENTS_TO_WAIT_FOR;
+
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const uWS = require("uWebSockets.js");
+
+var clients = [];
+const decoder = new TextDecoder("utf-8");
+
+/* Non-SSL is simply App() */
+const app = uWS
+  .App()
+  .ws("/*", {
+    /* There are many common helper features */
+    idleTimeout: 32,
+    maxPayloadLength: 16 * 1024,
+    maxBackpressure: 4 * 1024,
+    compression: uWS.DISABLED,
+    upgrade: (res, req, context) => {
+      const url = req.getUrl();
+      const query = req.getQuery();
+      const name =
+        new URL(new URL(`${url}?${query}`, "http://localhost:3000")).searchParams.get("name") ||
+        "Client #" + (CLIENTS_TO_WAIT_FOR - remainingClients);
+      /* This immediately calls open handler, you must not use res after this call */
+      res.upgrade(
+        {
+          name /* First argument is UserData (see WebSocket.getUserData()) */,
+        },
+        /* Spell these correctly */
+        req.getHeader("sec-websocket-key"),
+        req.getHeader("sec-websocket-protocol"),
+        req.getHeader("sec-websocket-extensions"),
+        context,
+      );
+    },
+    open: ws => {
+      clients.push(ws);
+      remainingClients--;
+      console.log(`${ws.getUserData().name} connected (${remainingClients} remain)`);
+
+      ws.subscribe("room");
+
+      if (remainingClients === 0) {
+        console.log("All clients connected");
+        setTimeout(() => {
+          console.log('Starting benchmark by sending "ready" message');
+          app.publish("room", `ready`);
+        }, 100);
+      }
+    },
+
+    message: (ws, message, isBinary) => {
+      const msg = decoder.decode(message);
+      const out = `${ws.getUserData().name}: ${msg}`;
+      app.publish("room", out, false);
+    },
+    close: ws => {
+      remainingClients++;
+    },
+  })
+  .listen(port, listenSocket => {
+    if (listenSocket) {
+      console.log(`Waiting for ${remainingClients} clients to connect...\n`, `  http://localhost:${port}/`);
+    }
+  });

--- a/bench/websocket-server/package.json
+++ b/bench/websocket-server/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "bufferutil": "^4.0.7",
     "utf-8-validate": "^5.0.10",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.20.0",
     "ws": "^8.9.0"
   }
 }


### PR DESCRIPTION
Issues:
1) The way the results are reported, it implies that each run is N clients X M messages however this is not the case.
2) Only bun benchmark uses pub/sub.

Suggested fixes:
1) For each run, client measures time taken from sending first message to server and receiving last response.
2) Implement pub/sub benchmark for node using uWebSockets.js

Both fixes are implemented in this PR. 

On my ROG Strix G513QM (Ryzen 9 5900HX, 32GB RAM) running Fedora 37 kernel 6.2.8 NodeJS 19.18.1 I can consistently get 1.2-1.3 million messages per second. Bun 0.5.8 can also get to 1.3 million but it is not consistent - average is about 830k per second.
