### PR TITLE
docs: add a section on uninstalling bun

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -99,6 +99,14 @@ $ docker run --rm --init --ulimit memlock=-1:-1 oven/bun:edge
 this is some output
 ``` -->
 
+## Uninstalling
+
+Bun's binary and install cache is located in `~/.bun` by default. To uninstall bun, delete this directory and edit your shell config (`.bashrc`, `.zshrc`, or similar) to remove `~/.bun/bin` from the `$PATH` variable.
+
+```sh
+$ rm -rf ~/.bun # make sure to remove ~/.bun/bin from $PATH
+```
+
 ## TypeScript
 
 To install TypeScript definitions for Bun's built-in APIs in your project, install `bun-types`.


### PR DESCRIPTION
i dont think this is a true fix for #2438, but adding this info informs how to uninstall bun before some "uninstall the runtime" command is added.

i think bun should have some command to remove itself. maybe something like `bun remove -g bun` or some top level command name i cant think of (uninstall is already a command), and what this would do on top of `rm ~/.bun` is do the reverse of the install script messing with your shell configurations, or printing a message if it couldn't remove (nonexistent) bun from your `$PATH`