### PR TITLE
fix: modules to have null prototype

### DIFF
--- a/src/bun.js/path.exports.js
+++ b/src/bun.js/path.exports.js
@@ -1,5 +1,8 @@
+// Utils to extract later
+const createModule = (obj) => Object.assign(Object.create(null), obj);
+
 function bound(obj) {
-  var result = {
+  var result = createModule({
     basename: obj.basename.bind(obj),
     dirname: obj.dirname.bind(obj),
     extname: obj.extname.bind(obj),
@@ -13,7 +16,7 @@ function bound(obj) {
     toNamespacedPath: obj.toNamespacedPath.bind(obj),
     sep: obj.sep,
     delimiter: obj.delimiter,
-  };
+  });
   result.default = result;
   return result;
 }

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -9,6 +9,10 @@ const strictEqual = (...args) => {
   expect(true).toBe(true);
 };
 
+it('should not inherit Object.prototype', () => {
+  expect(path).not.toHaveProperty('toString');
+});
+
 it("path.basename", () => {
   strictEqual(path.basename(file), "path.test.js");
   strictEqual(path.basename(file, ".js"), "path.test");


### PR DESCRIPTION
## Problem

In Bun, you can import Object prototype methods because modules inherit the Object prototype:

```js
import { toString } from 'path';
console.log(toString);
```

```
$ bun index.mjs
[Function: toString]
```

## Changes

Create a `createModule` util that creates a null prototype object.

So far I only did it in `path.exports.js`, but if it's good, I can add it to every one.

## Other info
- Before moving on with creating utils for `*.exports.js` files, we need to setup a bundler so we can import util files
- Is there a better place to test core modules in general? It's probably unnecessary to test it for each module.