### PR TITLE
Add tests for `bun test` with preload scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ bun run index.tsx             # TS and JSX supported out of the box
 bun test                      # run tests
 bun run start                 # run the `start` script in `package.json`
 bun install <pkg>​             # install a package
-bunx cowsay "Hello, world!"   # execute a package
+bunx cowsay 'Hello, world!'   # execute a package
 ```
 
 ## Install

--- a/test/js/bun/test/preload-test.test.js
+++ b/test/js/bun/test/preload-test.test.js
@@ -1,0 +1,106 @@
+import { spawnSync } from "bun";
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, realpathSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { bunEnv, bunExe } from "harness";
+
+const preloadModule = `
+import {plugin} from 'bun';
+
+plugin({
+    setup(build) {
+        build.onResolve({ filter: /.*\.txt$/, }, async (args) => {
+            return {
+                path: args.path,
+                namespace: 'boop'
+            }
+        });
+        build.onResolve({ namespace: "boop", filter: /.*/ }, async (args) => {
+            return {
+                path: args.path,
+                namespace: 'boop'
+            }
+        });
+        build.onLoad({ namespace: "boop", filter: /.*/ }, async (args) => {
+            return {
+                contents: '"hello world"',
+                loader: 'json'
+            }
+        });
+    }
+});
+`;
+
+const mainModule = `
+import { expect, test } from 'bun:test';
+import hey from './hey.txt';
+
+test('says hello world', () => {
+  expect(hey).toBe('hello world');
+});
+`;
+
+const bunfig = `preload = ["./preload.js"]`;
+
+describe("preload for bun:test", () => {
+  test("works with bunfig", async () => {
+    const preloadDir = join(realpathSync(tmpdir()), "bun-test-preload-test1");
+    mkdirSync(preloadDir, { recursive: true });
+    const preloadPath = join(preloadDir, "preload.js");
+    const mainPath = join(preloadDir, "main.test.js");
+    const bunfigPath = join(preloadDir, "bunfig.toml");
+    await Bun.write(preloadPath, preloadModule);
+    await Bun.write(mainPath, mainModule);
+    await Bun.write(bunfigPath, bunfig);
+
+    const cmds = [
+      [bunExe(), "test", mainPath],
+    ];
+
+    for (let cmd of cmds) {
+      const { stderr, exitCode, stdout } = spawnSync({
+        cmd,
+        cwd: preloadDir,
+        stderr: "pipe",
+        stdout: "pipe",
+        env: bunEnv,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(stderr.toString()).toBe("");
+      expect(stdout.toString()).toContain("✓ says hello world");
+      expect(stdout.toString()).toContain("1 pass");
+      expect(stdout.toString()).toContain("0 fail");
+    }
+  });
+
+  test("works from CLI", async () => {
+    const preloadDir = join(realpathSync(tmpdir()), "bun-test-preload-test2");
+    mkdirSync(preloadDir, { recursive: true });
+    const preloadPath = join(preloadDir, "preload.js");
+    const mainPath = join(preloadDir, "main.test.js");
+    await Bun.write(preloadPath, preloadModule);
+    await Bun.write(mainPath, mainModule);
+
+    const cmds = [
+      [bunExe(), `-r=${preloadPath}`, "test", mainPath],
+    ];
+
+    for (let cmd of cmds) {
+      const { stderr, exitCode, stdout } = spawnSync({
+        cmd,
+        cwd: preloadDir,
+        stderr: "pipe",
+        stdout: "pipe",
+        env: bunEnv,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(stderr.toString()).toBe("");
+      expect(stdout.toString()).toContain("✓ says hello world");
+      expect(stdout.toString()).toContain("1 pass");
+      expect(stdout.toString()).toContain("0 fail");
+    }
+  });
+});

--- a/test/js/bun/test/preload-test.test.js
+++ b/test/js/bun/test/preload-test.test.js
@@ -68,10 +68,10 @@ describe("preload for bun:test", () => {
       });
 
       expect(exitCode).toBe(0);
-      expect(stderr.toString()).toBe("");
-      expect(stdout.toString()).toContain("✓ says hello world");
-      expect(stdout.toString()).toContain("1 pass");
-      expect(stdout.toString()).toContain("0 fail");
+      const str = stderr.toString();
+      expect(str).toContain("✓ says hello world");
+      expect(str).toContain("1 pass");
+      expect(str).toContain("0 fail");
     }
   });
 
@@ -97,10 +97,10 @@ describe("preload for bun:test", () => {
       });
 
       expect(exitCode).toBe(0);
-      expect(stderr.toString()).toBe("");
-      expect(stdout.toString()).toContain("✓ says hello world");
-      expect(stdout.toString()).toContain("1 pass");
-      expect(stdout.toString()).toContain("0 fail");
+      const str = stderr.toString();
+      expect(str).toContain("✓ says hello world");
+      expect(str).toContain("1 pass");
+      expect(str).toContain("0 fail");
     }
   });
 });


### PR DESCRIPTION
Per @Jarred-Sumner [in this Discord chat](https://discord.com/channels/876711213126520882/1092938757428219934/1092942936469143552), tests exist for the `preload` config for `bun run` but not for `bun test`. This PR adds those missing tests. (It also updates the `cowsay` example on the README to be compatible with `zsh`.)