### PR TITLE
fix: export `constants` from `fs/promises`

### DIFF
--- a/docs/ecosystem/nodejs.md
+++ b/docs/ecosystem/nodejs.md
@@ -87,7 +87,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 - {% anchor id="node_fs" %} [`node:fs`](https://nodejs.org/api/fs.html) {% /anchor %}
 - 🟡
-- Missing `fs.constants` `fs.fdatasync{Sync}` `fs.opendir{Sync}` `fs.readv{Sync}` `fs.{watch|watchFile|unwatchFile}` `fs.writev{Sync}`.
+- Missing `fs.fdatasync{Sync}` `fs.opendir{Sync}` `fs.readv{Sync}` `fs.{watch|watchFile|unwatchFile}` `fs.writev{Sync}`.
 
 ---
 

--- a/packages/bun-types/fs/promises.d.ts
+++ b/packages/bun-types/fs/promises.d.ts
@@ -28,8 +28,7 @@ declare module "fs/promises" {
     RmDirOptions,
   } from "node:fs";
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  import { constants } from "node:fs";
+  const constants: typeof import("node:fs")["constants"];
 
   interface FlagAndOpenMode {
     mode?: Mode | undefined;

--- a/packages/bun-types/fs/promises.d.ts
+++ b/packages/bun-types/fs/promises.d.ts
@@ -28,6 +28,8 @@ declare module "fs/promises" {
     RmDirOptions,
   } from "node:fs";
 
+  export { constants } from "node:fs";
+
   interface FlagAndOpenMode {
     mode?: Mode | undefined;
     flag?: OpenMode | undefined;

--- a/packages/bun-types/fs/promises.d.ts
+++ b/packages/bun-types/fs/promises.d.ts
@@ -28,7 +28,8 @@ declare module "fs/promises" {
     RmDirOptions,
   } from "node:fs";
 
-  export { constants } from "node:fs";
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  import { constants } from "node:fs";
 
   interface FlagAndOpenMode {
     mode?: Mode | undefined;

--- a/src/bun.js/fs.exports.js
+++ b/src/bun.js/fs.exports.js
@@ -925,7 +925,7 @@ export default {
   chownSync,
   close,
   closeSync,
-  constants,
+  constants: promises.constants,
   copyFile,
   copyFileSync,
   createReadStream,

--- a/src/bun.js/fs_promises.exports.js
+++ b/src/bun.js/fs_promises.exports.js
@@ -110,5 +110,6 @@ export default {
   lutimes,
   rm,
   rmdir,
+  constants,
   [Symbol.for("CommonJS")]: 0,
 };

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -1672,7 +1672,7 @@ pub const ModuleLoader = struct {
                     if (comptime Environment.isDebug) {
                         return ResolvedSource{
                             .allocator = null,
-                            .source_code = ZigString.init(strings.append(bun.default_allocator, JSC.Node.fs.constants_string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "fs.exports.js")) catch unreachable),
+                            .source_code = ZigString.init(jsModuleFromFile(jsc_vm.load_builtins_from_path, "fs.exports.js")),
                             .specifier = ZigString.init("node:fs"),
                             .source_url = ZigString.init("node:fs"),
                             .hash = 0,
@@ -1680,7 +1680,7 @@ pub const ModuleLoader = struct {
                     } else if (jsc_vm.load_builtins_from_path.len != 0) {
                         return ResolvedSource{
                             .allocator = null,
-                            .source_code = ZigString.init(strings.append(bun.default_allocator, JSC.Node.fs.constants_string, jsModuleFromFile(jsc_vm.load_builtins_from_path, "fs.exports.js")) catch unreachable),
+                            .source_code = ZigString.init(jsModuleFromFile(jsc_vm.load_builtins_from_path, "fs.exports.js")),
                             .specifier = ZigString.init("node:fs"),
                             .source_url = ZigString.init("node:fs"),
                             .hash = 0,
@@ -1689,7 +1689,7 @@ pub const ModuleLoader = struct {
 
                     return ResolvedSource{
                         .allocator = null,
-                        .source_code = ZigString.init(JSC.Node.fs.constants_string ++ @embedFile("fs.exports.js")),
+                        .source_code = ZigString.init(@embedFile("fs.exports.js")),
                         .specifier = ZigString.init("node:fs"),
                         .source_url = ZigString.init("node:fs"),
                         .hash = 0,
@@ -1733,7 +1733,7 @@ pub const ModuleLoader = struct {
                 .@"node:fs/promises" => {
                     return ResolvedSource{
                         .allocator = null,
-                        .source_code = ZigString.init(@embedFile("fs_promises.exports.js") ++ JSC.Node.fs.constants_string),
+                        .source_code = ZigString.init(JSC.Node.fs.constants_string ++ @embedFile("fs_promises.exports.js")),
                         .specifier = ZigString.init("node:fs/promises"),
                         .source_url = ZigString.init("node:fs/promises"),
                         .hash = 0,

--- a/src/bun.js/path.exports.js
+++ b/src/bun.js/path.exports.js
@@ -1,5 +1,5 @@
 // Utils to extract later
-const createModule = (obj) => Object.assign(Object.create(null), obj);
+const createModule = obj => Object.assign(Object.create(null), obj);
 
 function bound(obj) {
   var result = createModule({

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1095,45 +1095,7 @@ it("fs.constants", () => {
 
 it("fs.promises.constants", () => {
   expect(promises.constants).toBeDefined();
-  expect(promises.constants.F_OK).toBeDefined();
-  expect(promises.constants.R_OK).toBeDefined();
-  expect(promises.constants.W_OK).toBeDefined();
-  expect(promises.constants.X_OK).toBeDefined();
-  expect(promises.constants.O_RDONLY).toBeDefined();
-  expect(promises.constants.O_WRONLY).toBeDefined();
-  expect(promises.constants.O_RDWR).toBeDefined();
-  expect(promises.constants.O_CREAT).toBeDefined();
-  expect(promises.constants.O_EXCL).toBeDefined();
-  expect(promises.constants.O_NOCTTY).toBeDefined();
-  expect(promises.constants.O_TRUNC).toBeDefined();
-  expect(promises.constants.O_APPEND).toBeDefined();
-  expect(promises.constants.O_DIRECTORY).toBeDefined();
-  expect(promises.constants.O_NOATIME).toBeDefined();
-  expect(promises.constants.O_NOFOLLOW).toBeDefined();
-  expect(promises.constants.O_SYNC).toBeDefined();
-  expect(promises.constants.O_DSYNC).toBeDefined();
-  expect(promises.constants.O_SYMLINK).toBeDefined();
-  expect(promises.constants.O_DIRECT).toBeDefined();
-  expect(promises.constants.O_NONBLOCK).toBeDefined();
-  expect(promises.constants.S_IFMT).toBeDefined();
-  expect(promises.constants.S_IFREG).toBeDefined();
-  expect(promises.constants.S_IFDIR).toBeDefined();
-  expect(promises.constants.S_IFCHR).toBeDefined();
-  expect(promises.constants.S_IFBLK).toBeDefined();
-  expect(promises.constants.S_IFIFO).toBeDefined();
-  expect(promises.constants.S_IFLNK).toBeDefined();
-  expect(promises.constants.S_IFSOCK).toBeDefined();
-  expect(promises.constants.S_IRWXU).toBeDefined();
-  expect(promises.constants.S_IRUSR).toBeDefined();
-  expect(promises.constants.S_IWUSR).toBeDefined();
-  expect(promises.constants.S_IXUSR).toBeDefined();
-  expect(promises.constants.S_IRWXG).toBeDefined();
-  expect(promises.constants.S_IRGRP).toBeDefined();
-  expect(promises.constants.S_IWGRP).toBeDefined();
-  expect(promises.constants.S_IXGRP).toBeDefined();
-  expect(promises.constants.S_IRWXO).toBeDefined();
-  expect(promises.constants.S_IROTH).toBeDefined();
-  expect(promises.constants.S_IWOTH).toBeDefined();
+  expect(promises.constants).toBe(fs.constants);
 });
 
 it("fs.Dirent", () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1093,6 +1093,49 @@ it("fs.constants", () => {
   expect(constants.S_IWOTH).toBeDefined();
 });
 
+it("fs.promises.constants", () => {
+  expect(promises.constants).toBeDefined();
+  expect(promises.constants.F_OK).toBeDefined();
+  expect(promises.constants.R_OK).toBeDefined();
+  expect(promises.constants.W_OK).toBeDefined();
+  expect(promises.constants.X_OK).toBeDefined();
+  expect(promises.constants.O_RDONLY).toBeDefined();
+  expect(promises.constants.O_WRONLY).toBeDefined();
+  expect(promises.constants.O_RDWR).toBeDefined();
+  expect(promises.constants.O_CREAT).toBeDefined();
+  expect(promises.constants.O_EXCL).toBeDefined();
+  expect(promises.constants.O_NOCTTY).toBeDefined();
+  expect(promises.constants.O_TRUNC).toBeDefined();
+  expect(promises.constants.O_APPEND).toBeDefined();
+  expect(promises.constants.O_DIRECTORY).toBeDefined();
+  expect(promises.constants.O_NOATIME).toBeDefined();
+  expect(promises.constants.O_NOFOLLOW).toBeDefined();
+  expect(promises.constants.O_SYNC).toBeDefined();
+  expect(promises.constants.O_DSYNC).toBeDefined();
+  expect(promises.constants.O_SYMLINK).toBeDefined();
+  expect(promises.constants.O_DIRECT).toBeDefined();
+  expect(promises.constants.O_NONBLOCK).toBeDefined();
+  expect(promises.constants.S_IFMT).toBeDefined();
+  expect(promises.constants.S_IFREG).toBeDefined();
+  expect(promises.constants.S_IFDIR).toBeDefined();
+  expect(promises.constants.S_IFCHR).toBeDefined();
+  expect(promises.constants.S_IFBLK).toBeDefined();
+  expect(promises.constants.S_IFIFO).toBeDefined();
+  expect(promises.constants.S_IFLNK).toBeDefined();
+  expect(promises.constants.S_IFSOCK).toBeDefined();
+  expect(promises.constants.S_IRWXU).toBeDefined();
+  expect(promises.constants.S_IRUSR).toBeDefined();
+  expect(promises.constants.S_IWUSR).toBeDefined();
+  expect(promises.constants.S_IXUSR).toBeDefined();
+  expect(promises.constants.S_IRWXG).toBeDefined();
+  expect(promises.constants.S_IRGRP).toBeDefined();
+  expect(promises.constants.S_IWGRP).toBeDefined();
+  expect(promises.constants.S_IXGRP).toBeDefined();
+  expect(promises.constants.S_IRWXO).toBeDefined();
+  expect(promises.constants.S_IROTH).toBeDefined();
+  expect(promises.constants.S_IWOTH).toBeDefined();
+});
+
 it("fs.Dirent", () => {
   expect(Dirent).toBeDefined();
 });

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -9,8 +9,8 @@ const strictEqual = (...args) => {
   expect(true).toBe(true);
 };
 
-it('should not inherit Object.prototype', () => {
-  expect(path).not.toHaveProperty('toString');
+it("should not inherit Object.prototype", () => {
+  expect(path).not.toHaveProperty("toString");
 });
 
 it("path.basename", () => {


### PR DESCRIPTION
Docs claim fs.constants is missing. in actuality it is `fs.promises.constants` that is missing (which is in node)

This PR:
- fixes the missing export
- adds unit test
- fixes docs
- typedefs