### PR TITLE
In Documentation, move --watch before the script name

### DIFF
--- a/docs/runtime/hot.md
+++ b/docs/runtime/hot.md
@@ -7,16 +7,17 @@ Bun supports two kinds of automatic reloading via CLI flags:
 
 Watch mode can be used with `bun test` or when running TypeScript, JSX, and JavaScript files.
 
+
 To run a file in `--watch` mode:
 
 ```bash
-$ bun index.tsx --watch
+$ bun --watch index.tsx
 ```
 
 To run your tests in `--watch` mode:
 
 ```bash
-$ bun test --watch
+$ bun --watch test 
 ```
 
 In `--watch` mode, Bun keeps track of all imported files and watches them for changes. When a change is detected, Bun restarts the process, preserving the same set of CLI arguments and environment variables used in the initial run. If Bun crashes, `--watch` will attempt to automatically restart the process.
@@ -34,7 +35,7 @@ The following examples show Bun live-reloading a file as it is edited, with VSCo
 {% codetabs %}
 
 ```bash
-$ bun run watchy.tsx --watch
+$ bun run --watch watchy.tsx
 ```
 
 ```tsx#watchy.tsx
@@ -57,7 +58,7 @@ serve({
 Running `bun test` in watch mode and `save-on-keypress` enabled:
 
 ```bash
-$ bun test --watch
+$ bun --watch test 
 ```
 
 ![bun test gif](https://user-images.githubusercontent.com/709451/228396976-38a23864-4a1d-4c96-87cc-04e5181bf459.gif)


### PR DESCRIPTION
Related message by Jarred: https://discord.com/channels/876711213126520882/876711213126520885/1093286199369682944 
If you put `--watch` after the script name, it will not work.