### PR TITLE
docs(cli/bunx): add notice

### DIFF
--- a/docs/cli/bunx.md
+++ b/docs/cli/bunx.md
@@ -1,3 +1,7 @@
+{% callout %}
+**Note** — `bunx` is just alias of `bun x`
+{% /callout %}
+
 Use `bunx` to auto-install and run packages from `npm`. The `bunx` CLI will be auto-installed when you install `bun`.
 
 ```bash

--- a/docs/cli/bunx.md
+++ b/docs/cli/bunx.md
@@ -1,5 +1,5 @@
 {% callout %}
-**Note** — `bunx` is just alias of `bun x`
+**Note** — `bunx` is an alias for `bun x`
 {% /callout %}
 
 Use `bunx` to auto-install and run packages from `npm`. The `bunx` CLI will be auto-installed when you install `bun`.


### PR DESCRIPTION
Added notice that tells `bunx` is an alias for `bun x`

I think it fits, for example, as we have seen with https://github.com/oven-sh/setup-bun/issues/9#issuecomment-1489426974

