### PR TITLE
chore(prettier): simplify glob and enable cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-fallback": "esbuild --target=esnext  --bundle src/fallback.ts --format=iife --platform=browser --minify > src/fallback.out.js",
     "postinstall": "bash .scripts/postinstall.sh",
     "typecheck": "tsc --noEmit && cd test && bun run typecheck",
-    "fmt": "prettier --write  './test/**/*.{mjs,ts,tsx,js,jsx}' './src/*.{mjs,ts,tsx,js,jsx}' './src/*/*.{mjs,ts,tsx,js,jsx}' './src/*/*/*.{mjs,ts,tsx,js,jsx}' './bench/**/*.{mjs,ts,tsx,js,jsx}' --config .prettierrc.cjs",
+    "fmt": "prettier --write --cache './{src,test,bench}/**/*.{mjs,ts,tsx,js,jsx}'",
     "lint": "eslint './**/*.d.ts' --cache",
     "lint:fix": "eslint './**/*.d.ts' --cache --fix"
   },


### PR DESCRIPTION
## Changes

### Simplify the glob
I consolidated the globs so it's shorter. I also made sure I had the WebKit Git submodule pulled down, and compared the prettier outputs, and it added 9 additional files: https://www.diffchecker.com/CC91K1OX/

I think we actually want to lint these files but they were missed:
```
src/api/demo/lib/api.ts
src/api/demo/lib/run.ts
src/api/demo/lib/scan.ts
src/api/demo/pages/_app.js
src/api/demo/pages/api/hello.js
src/api/demo/pages/index.tsx
src/api/demo/pages/scan.tsx
src/api/demo/pages/two.tsx
src/bun.js/bindings/sqlite/sqlite.exports.js
```

### Enable caching

`--cache` flag stores local cache in `./node_modules/.cache/prettier/.prettier-cache`
https://prettier.io/docs/en/cli.html#--cache

Before:
```
bun fmt  41.85s user 2.21s system 175% cpu 25.066 total
```

After:
```
bun fmt  4.96s user 3.16s system 159% cpu 5.097 total
```