### PR TITLE
[WIP] fix Fetch and WebSocket handshake

### DIFF
--- a/src/bun.js/bindings/ScriptExecutionContext.cpp
+++ b/src/bun.js/bindings/ScriptExecutionContext.cpp
@@ -38,9 +38,9 @@ us_socket_context_t* ScriptExecutionContext::webSocketContextSSL()
 {
     if (!m_ssl_client_websockets_ctx) {
         us_loop_t* loop = (us_loop_t*)uws_get_loop();
-        us_socket_context_options_t opts;
-        memset(&opts, 0, sizeof(us_socket_context_options_t));
-        this->m_ssl_client_websockets_ctx = us_create_socket_context(1, loop, sizeof(size_t), opts);
+        us_bun_socket_context_options_t opts;
+        memset(&opts, 0, sizeof(us_bun_socket_context_options_t));
+        this->m_ssl_client_websockets_ctx = us_create_bun_socket_context(1, loop, sizeof(size_t), opts);
         void** ptr = reinterpret_cast<void**>(us_socket_context_ext(1, m_ssl_client_websockets_ctx));
         *ptr = this;
         registerHTTPContextForWebSocket<true, false>(this, m_ssl_client_websockets_ctx, loop);
@@ -65,9 +65,9 @@ us_socket_context_t* ScriptExecutionContext::webSocketContextNoSSL()
 {
     if (!m_client_websockets_ctx) {
         us_loop_t* loop = (us_loop_t*)uws_get_loop();
-        us_socket_context_options_t opts;
-        memset(&opts, 0, sizeof(us_socket_context_options_t));
-        this->m_client_websockets_ctx = us_create_socket_context(0, loop, sizeof(size_t), opts);
+        us_bun_socket_context_options_t opts;
+        memset(&opts, 0, sizeof(us_bun_socket_context_options_t));
+        this->m_client_websockets_ctx = us_create_bun_socket_context(0, loop, sizeof(size_t), opts);
         void** ptr = reinterpret_cast<void**>(us_socket_context_ext(0, m_client_websockets_ctx));
         *ptr = this;
         registerHTTPContextForWebSocket<false, false>(this, m_client_websockets_ctx, loop);


### PR DESCRIPTION
Today we do not wait until the handshake is properly done on fetch and do not wait on WebSocket before call open event.

List of pending things:

- [ ] Expose the true handshake error message like nodejs in fetch and reject if we have SSL errors when rejectUnauthorized == true (default: true)
- [ ] Add global config for rejectUnauthorized aka https://nodejs.org/api/https.html#httpsglobalagent
- [ ] fix fetch test failing website with tlsextname
- [ ] fix fetch test failing simultaneous HTTPS fetch
- [ ] proper signalize WebSocket open event on TLS
 - [ ] proper signalize WebSocket error event on TLS error matching fetch behavior and browser behavior.
- [ ] add tests to check TLS behavior 
- [ ] add https://github.com/oven-sh/bun/blob/main/src/deps/boringssl.translated.zig#L18819-L18837 in bun_context_options_t so no need to use it onOpen anymore.