### PR TITLE
Add `bun docs`

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -82,7 +82,7 @@ _bun_completions() {
     declare -A PACKAGE_OPTIONS;
     declare -A PM_OPTIONS;
 
-    local SUBCOMMANDS="dev bun create run install add remove upgrade completions discord help init pm x";
+    local SUBCOMMANDS="dev bun create run install add remove upgrade completions discord docs help init pm x";
 
     GLOBAL_OPTIONS[LONG_OPTIONS]="--use --cwd --bunfile --server-bunfile --config --disable-react-fast-refresh --disable-hmr --extension-order --jsx-factory --jsx-fragment --extension-order --jsx-factory --jsx-fragment --jsx-import-source --jsx-production --jsx-runtime --main-fields --no-summary --version --platform --public-dir --tsconfig-override --define --external --help --inject --loader --origin --port --dump-environment-variables --dump-limits --disable-bun-js";
     GLOBAL_OPTIONS[SHORT_OPTIONS]="-c -v -d -e -h -i -l -u -p";

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -53,14 +53,14 @@ end
 set -l bun_install_boolean_flags yarn production optional development no-save dry-run force no-cache silent verbose global
 set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't install devDependencies" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependenices" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
 
-set -l bun_builtin_cmds dev create help bun upgrade discord run install remove add init link unlink pm x
-set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add init pm x
-set -l bun_builtin_cmds_without_bun dev create help upgrade run discord install remove add init pm x
-set -l bun_builtin_cmds_without_create dev help bun upgrade discord run install remove add init pm x
-set -l bun_builtin_cmds_without_install create dev help bun upgrade discord run remove add init pm x
-set -l bun_builtin_cmds_without_remove create dev help bun upgrade discord run install add init pm x
-set -l bun_builtin_cmds_without_add create dev help bun upgrade discord run remove install init pm x
-set -l bun_builtin_cmds_without_pm create dev help bun upgrade discord run init pm x
+set -l bun_builtin_cmds dev create help bun upgrade discord docs run install remove add init link unlink pm x
+set -l bun_builtin_cmds_without_run dev create help bun upgrade discord docs install remove add init pm x
+set -l bun_builtin_cmds_without_bun dev create help upgrade run discord docs install remove add init pm x
+set -l bun_builtin_cmds_without_create dev help bun upgrade discord docs run install remove add init pm x
+set -l bun_builtin_cmds_without_install create dev help bun upgrade discord docs run remove add init pm x
+set -l bun_builtin_cmds_without_remove create dev help bun upgrade discord docs run install add init pm x
+set -l bun_builtin_cmds_without_add create dev help bun upgrade discord docs run remove install init pm x
+set -l bun_builtin_cmds_without_pm create dev help bun upgrade discord docs run init pm x
 
 # clear
 complete -e -c bun
@@ -108,6 +108,8 @@ complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -l "version" -s "v"  -a '--version' -d 'Bun\'s version' -x
 complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'discord' -d 'Open bun\'s Discord server' -x 
+complete -c bun \
+	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'docs' -d 'Open bun\'s documentation' -x
 
 
 complete -c bun \

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -787,6 +787,7 @@ pub const HelpCommand = struct {
             \\>  <b><blue>upgrade<r>                         Get the latest version of bun
             \\>  <b><d>completions<r>                     Install shell completions for tab-completion
             \\>  <b><d>discord<r>                         Open bun's Discord server
+            \\>  <b><d>docs<r>                            Open bun's documentation
             \\>  <b><d>help<r>                            Print this help menu
             \\
         ;
@@ -979,6 +980,7 @@ pub const Command = struct {
             RootCommandMatcher.case("init") => .InitCommand,
             RootCommandMatcher.case("build"), RootCommandMatcher.case("bun") => .BuildCommand,
             RootCommandMatcher.case("discord") => .DiscordCommand,
+            RootCommandMatcher.case("docs") => .DocsCommand,
             RootCommandMatcher.case("upgrade") => .UpgradeCommand,
             RootCommandMatcher.case("completions") => .InstallCompletionsCommand,
             RootCommandMatcher.case("getcompletes") => .GetCompletionsCommand,
@@ -1026,6 +1028,7 @@ pub const Command = struct {
         "bun",
         "upgrade",
         "discord",
+        "docs",
         "pm",
         "x",
     };
@@ -1044,6 +1047,7 @@ pub const Command = struct {
         const CreateListExamplesCommand = @import("./cli/create_command.zig").CreateListExamplesCommand;
         const DevCommand = @import("./cli/dev_command.zig").DevCommand;
         const DiscordCommand = @import("./cli/discord_command.zig").DiscordCommand;
+        const DocsCommand = @import("./cli/docs_command.zig").DocsCommand;
         const InstallCommand = @import("./cli/install_command.zig").InstallCommand;
         const LinkCommand = @import("./cli/link_command.zig").LinkCommand;
         const UnlinkCommand = @import("./cli/unlink_command.zig").UnlinkCommand;
@@ -1079,6 +1083,7 @@ pub const Command = struct {
 
         switch (tag) {
             .DiscordCommand => return try DiscordCommand.exec(allocator),
+            .DocsCommand => return try DocsCommand.exec(allocator),
             .HelpCommand => return try HelpCommand.exec(allocator),
             .InitCommand => return try InitCommand.exec(allocator, std.os.argv),
             else => {},
@@ -1487,6 +1492,7 @@ pub const Command = struct {
         CreateCommand,
         DevCommand,
         DiscordCommand,
+        DocsCommand,
         GetCompletionsCommand,
         HelpCommand,
         InitCommand,

--- a/src/cli/docs_command.zig
+++ b/src/cli/docs_command.zig
@@ -1,0 +1,19 @@
+const bun = @import("bun");
+const string = bun.string;
+const Output = bun.Output;
+const Global = bun.Global;
+const Environment = bun.Environment;
+const strings = bun.strings;
+const MutableString = bun.MutableString;
+const stringZ = bun.stringZ;
+const default_allocator = bun.default_allocator;
+const C = bun.C;
+const std = @import("std");
+const open = @import("../open.zig");
+
+pub const DocsCommand = struct {
+    const docs_url: string = "https://bun.sh/docs";
+    pub fn exec(_: std.mem.Allocator) !void {
+        try open.openURL(docs_url);
+    }
+};


### PR DESCRIPTION
Adds `bun docs` which opens https://bun.sh/docs. 

Copied entirely from the implementation of `bun discord`