### PR TITLE
Hotfix potential memory leak

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5861,7 +5861,7 @@ pub const PackageManager = struct {
                 };
                 if (alias) |name| {
                     request.is_aliased = true;
-                    request.name = allocator.dupe(u8, name) catch unreachable;
+                    request.name = name;
                     request.name_hash = String.Builder.stringHash(name);
                 } else {
                     request.name_hash = String.Builder.stringHash(version.literal.slice(input));


### PR DESCRIPTION
I think I randomly spotted this memory leak. I think we do not need to allocate the `alias`/`name` into a separate buffer. It should sit comfortably in `version_buf`, although I am not sure where that is freed just yet (I am currently stepping through the code to read/learn how it works, haha). The version_buf was from `manager.options.positionals[1..]` though (`manager` was created [here](https://github.com/oven-sh/bun/blob/a744f5369d356424c3039f9dcf6d7f9412565ecf/src/install/install.zig#L5885)).

Here is the code which looks bad to me:

```zig
if (alias) |name| {
    request.is_aliased = true;
    // request owns this memory?
    request.name = allocator.dupe(u8, name) catch unreachable;
    request.name_hash = String.Builder.stringHash(name);
} else {
    request.name_hash = String.Builder.stringHash(version.literal.slice(input));
}

for (update_requests.constSlice()) |*prev| {
    // if we continue, `request` is never written to `update_requests`, therefore we leak `request.name` if it exists
    if (prev.name_hash == request.name_hash and request.name.len == prev.name.len) continue :outer;
}
// this append could fail and perform `catch break`, at which point we leak `request.name` if it exists?
update_requests.append(request) catch break;
```