### PR TITLE
fix expectBundled precheck

### DIFF
--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -885,7 +885,7 @@ export function itBundled(id: string, opts: BundlerTestInput): BundlerTestRef {
     return ref;
   } else if (!FILTER) {
     try {
-      expectBundled(id, opts);
+      expectBundled(id, opts, true);
     } catch (error) {
       it.skip(id, () => {});
       return ref;


### PR DESCRIPTION
it calls expectBundled in "dry run" mode to check if options are supported, skips if an error happens. i wasn't passing the dry run flag