### PR TITLE
Support `@jsx`, `@jsxRuntime`, `@jsxImportSource`, and `@jsxFragment` pragmas

### DIFF
--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -564,6 +564,10 @@ pub const Bundler = struct {
 
         try this.runEnvLoader();
 
+        if (this.env.isProduction()) {
+            this.options.jsx.setProduction(this.allocator, true);
+        }
+
         js_ast.Expr.Data.Store.create(this.allocator);
         js_ast.Stmt.Data.Store.create(this.allocator);
 
@@ -583,15 +587,8 @@ pub const Bundler = struct {
         if (this.options.define.dots.get("NODE_ENV")) |NODE_ENV| {
             if (NODE_ENV.len > 0 and NODE_ENV[0].data.value == .e_string and NODE_ENV[0].data.value.e_string.eqlComptime("production")) {
                 this.options.production = true;
-                this.options.jsx.development = false;
 
-                if (this.options.jsx.import_source.ptr == options.JSX.Pragma.Defaults.ImportSourceDev) {
-                    this.options.jsx.import_source = options.JSX.Pragma.Defaults.ImportSource;
-                }
-
-                if (options.JSX.Pragma.Defaults.ImportSource == this.options.jsx.import_source.ptr or
-                    strings.eqlComptime(this.options.jsx.import_source, comptime options.JSX.Pragma.Defaults.ImportSource) or strings.eqlComptime(this.options.jsx.package_name, "react"))
-                {
+                if (strings.eqlComptime(this.options.jsx.package_name, "react")) {
                     if (this.options.jsx_optimization_inline == null) {
                         this.options.jsx_optimization_inline = true;
                     }

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -391,6 +391,8 @@ pub const BundleV2 = struct {
         bundler.options.mark_bun_builtins_as_external = bundler.options.platform.isBun();
         bundler.resolver.opts.mark_bun_builtins_as_external = bundler.options.platform.isBun();
 
+        var this = generator;
+
         defer allocator.destroy(generator);
         generator.* = BundleV2{
             .bundler = bundler,
@@ -428,18 +430,6 @@ pub const BundleV2 = struct {
         generator.graph.pool = pool;
 
         var batch = ThreadPoolLib.Batch{};
-
-        var this = generator;
-
-        if (this.bundler.env.isProduction()) {
-            this.bundler.options.jsx.development = false;
-        }
-
-        if (!this.bundler.options.jsx.development) {
-            this.bundler.options.jsx.import_source = std.fmt.allocPrint(allocator, "{s}/jsx-runtime", .{generator.bundler.options.jsx.classic_import_source}) catch unreachable;
-        }
-
-        this.bundler.resolver.opts.jsx = this.bundler.options.jsx;
 
         try pool.start(this);
 

--- a/src/options.zig
+++ b/src/options.zig
@@ -936,6 +936,36 @@ pub const JSX = struct {
             return strings.eqlComptime(pragma.package_name, "react") or strings.eqlComptime(pragma.package_name, "@emotion/jsx") or strings.eqlComptime(pragma.package_name, "@emotion/react");
         }
 
+        pub fn setImportSource(pragma: *Pragma, allocator: std.mem.Allocator, suffix: []const u8) void {
+            strings.concatIfNeeded(
+                allocator,
+                &pragma.import_source,
+                &[_]string{
+                    pragma.package_name,
+                    suffix,
+                },
+                &.{
+                    Defaults.ImportSource,
+                    Defaults.ImportSourceDev,
+                },
+            ) catch unreachable;
+        }
+
+        pub fn setProduction(pragma: *Pragma, allocator: std.mem.Allocator, is_production: bool) void {
+            pragma.development = !is_production;
+            const package_name = parsePackageName(pragma.import_source);
+            pragma.package_name = package_name;
+            pragma.classic_import_source = package_name;
+
+            if (is_production) {
+                pragma.setImportSource(allocator, "/jsx-runtime");
+                pragma.jsx = "jsx";
+            } else {
+                pragma.setImportSource(allocator, "/jsx-dev-runtime");
+                pragma.jsx = "jsxDEV";
+            }
+        }
+
         pub const Defaults = struct {
             pub const Factory = &[_]string{"createElement"};
             pub const Fragment = &[_]string{"Fragment"};
@@ -1069,6 +1099,7 @@ pub fn definesFromTransformOptions(
     platform: Platform,
     loader: ?*DotEnv.Loader,
     framework_env: ?*const Env,
+    NODE_ENV: ?string,
 ) !*defines.Define {
     var input_user_define = _input_define orelse std.mem.zeroes(Api.StringMap);
 
@@ -1108,8 +1139,35 @@ pub fn definesFromTransformOptions(
         }
     }
 
-    if (input_user_define.keys.len == 0) {
-        try user_defines.put(DefaultUserDefines.NodeEnv.Key, DefaultUserDefines.NodeEnv.Value);
+    if (NODE_ENV) |node_env| {
+        if (node_env.len > 0) {
+            var quoted_node_env: string = "";
+            if ((strings.startsWithChar(node_env, '"') and strings.endsWithChar(node_env, '"')) or
+                (strings.startsWithChar(node_env, '\'') and strings.endsWithChar(node_env, '\'')))
+            {
+                quoted_node_env = node_env;
+            } else {
+                // avoid allocating if we can
+                if (strings.eqlComptime(node_env, "production")) {
+                    quoted_node_env = "\"production\"";
+                } else if (strings.eqlComptime(node_env, "development")) {
+                    quoted_node_env = "\"development\"";
+                } else if (strings.eqlComptime(node_env, "test")) {
+                    quoted_node_env = "\"test\"";
+                } else {
+                    quoted_node_env = try std.fmt.allocPrint(allocator, "\"{s}\"", .{node_env});
+                }
+            }
+
+            _ = try user_defines.getOrPutValue(
+                "process.env.NODE_ENV",
+                quoted_node_env,
+            );
+            _ = try user_defines.getOrPutValue(
+                "process.env.BUN_ENV",
+                quoted_node_env,
+            );
+        }
     }
 
     if (hmr) {
@@ -1382,6 +1440,10 @@ pub const BundleOptions = struct {
             this.platform,
             loader_,
             env,
+            if (loader_) |e|
+                e.map.get("BUN_ENV") orelse e.map.get("NODE_ENV")
+            else
+                null,
         );
         this.defines_loaded = true;
     }

--- a/src/options.zig
+++ b/src/options.zig
@@ -884,6 +884,7 @@ pub const ESMConditions = struct {
 
 pub const JSX = struct {
     pub const RuntimeMap = bun.ComptimeStringMap(JSX.Runtime, .{
+        .{ "classic", JSX.Runtime.classic },
         .{ "react", JSX.Runtime.classic },
         .{ "react-jsx", JSX.Runtime.automatic },
         .{ "react-jsxDEV", JSX.Runtime.automatic },
@@ -950,36 +951,38 @@ pub const JSX = struct {
         // saves an allocation for the majority case
         pub fn memberListToComponentsIfDifferent(allocator: std.mem.Allocator, original: []const string, new: string) ![]const string {
             var splitter = std.mem.split(u8, new, ".");
+            const count = strings.countChar(new, '.') + 1;
 
             var needs_alloc = false;
-            var count: usize = 0;
+            var current_i: usize = 0;
             while (splitter.next()) |str| {
-                const i = (splitter.index orelse break);
-                count = i;
-                if (i > original.len) {
+                if (str.len == 0) continue;
+                if (current_i >= original.len) {
                     needs_alloc = true;
                     break;
                 }
 
-                if (!strings.eql(original[i], str)) {
+                if (!strings.eql(original[current_i], str)) {
                     needs_alloc = true;
                     break;
                 }
+                current_i += 1;
             }
 
             if (!needs_alloc) {
                 return original;
             }
 
-            var out = try allocator.alloc(string, count + 1);
+            var out = try allocator.alloc(string, count);
 
             splitter = std.mem.split(u8, new, ".");
             var i: usize = 0;
             while (splitter.next()) |str| {
+                if (str.len == 0) continue;
                 out[i] = str;
                 i += 1;
             }
-            return out;
+            return out[0..i];
         }
 
         pub fn fromApi(jsx: api.Api.Jsx, allocator: std.mem.Allocator) !Pragma {

--- a/src/resolver/tsconfig_json.zig
+++ b/src/resolver/tsconfig_json.zig
@@ -104,8 +104,9 @@ pub const TSConfigJSON = struct {
         log: *logger.Log,
         source: logger.Source,
         json_cache: *cache.Json,
-        is_jsx_development: bool,
+        is_jsx_development_: bool,
     ) anyerror!?*TSConfigJSON {
+        var is_jsx_development = is_jsx_development_;
         // Unfortunately "tsconfig.json" isn't actually JSON. It's some other
         // format that appears to be defined by the implementation details of the
         // TypeScript compiler.
@@ -160,7 +161,8 @@ pub const TSConfigJSON = struct {
                     if (options.JSX.RuntimeMap.get(str)) |runtime| {
                         result.jsx.runtime = runtime;
                         if (runtime == .automatic) {
-                            result.jsx.development = strings.eqlComptime(str, "react-jsxDEV");
+                            result.jsx.setProduction(allocator, strings.eqlComptime(str, "react-jsxDEV"));
+                            is_jsx_development = result.jsx.development;
                             result.jsx_flags.insert(.development);
                         }
 
@@ -178,9 +180,9 @@ pub const TSConfigJSON = struct {
                         result.jsx_flags.insert(.runtime);
                     } else {
                         if (is_jsx_development) {
-                            result.jsx.import_source = std.fmt.allocPrint(allocator, "{s}/jsx-dev-runtime", .{str}) catch unreachable;
+                            result.jsx.setImportSource(allocator, "{s}/jsx-dev-runtime");
                         } else {
-                            result.jsx.import_source = std.fmt.allocPrint(allocator, "{s}/jsx-runtime", .{str}) catch unreachable;
+                            result.jsx.setImportSource(allocator, "{s}/jsx-runtime");
                         }
                     }
 

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -4318,3 +4318,23 @@ pub fn leftHasAnyInRight(to_check: []const string, against: []const string) bool
     }
     return false;
 }
+
+pub fn hasPrefixWithWordBoundary(input: []const u8, comptime prefix: []const u8) bool {
+    if (hasPrefixComptime(input, prefix)) {
+        if (input.len == prefix.len) return true;
+
+        const next = input[prefix.len..];
+        var bytes: [4]u8 = .{
+            next[0],
+            if (next.len > 1) next[1] else 0,
+            if (next.len > 2) next[2] else 0,
+            if (next.len > 3) next[3] else 0,
+        };
+
+        if (!bun.js_lexer.isIdentifierContinue(decodeWTF8RuneT(&bytes, wtf8ByteSequenceLength(next[0]), i32, -1))) {
+            return true;
+        }
+    }
+
+    return false;
+}


### PR DESCRIPTION
This implements the following comment pragmas:
- `@jsx`
- `@jsxRuntime`
- `@jsxImportSource`
- `@jsxFragment`

This also parses `sourceMappingURL=` comments.