### PR TITLE
Support importing `.txt` files as strings

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -3168,3 +3168,8 @@ declare var module: NodeModule;
 // Same as module.exports
 declare var exports: any;
 declare var global: typeof globalThis;
+
+declare module "*.txt" {
+  var text: string;
+  export = text;
+}

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -879,7 +879,7 @@ pub const ModuleLoader = struct {
         const disable_transpilying = comptime flags.disableTranspiling();
 
         switch (loader) {
-            .js, .jsx, .ts, .tsx, .json, .toml => {
+            .js, .jsx, .ts, .tsx, .json, .toml, .text => {
                 jsc_vm.transpiled_count += 1;
                 jsc_vm.bundler.resetStore();
                 const hash = http.Watcher.getHash(path.text);

--- a/test/js/bun/util/text-loader-fixture-dynamic-import.ts
+++ b/test/js/bun/util/text-loader-fixture-dynamic-import.ts
@@ -1,0 +1,3 @@
+const { default: text } = await import("./text-loader-fixture-text-file.txt");
+
+console.write(text);

--- a/test/js/bun/util/text-loader-fixture-import.ts
+++ b/test/js/bun/util/text-loader-fixture-import.ts
@@ -1,0 +1,3 @@
+import text from "./text-loader-fixture-text-file.txt";
+
+console.write(text);

--- a/test/js/bun/util/text-loader-fixture-require.ts
+++ b/test/js/bun/util/text-loader-fixture-require.ts
@@ -1,0 +1,3 @@
+// TODO: should .default really be necessary here?
+const { default: text } = require("./text-loader-fixture-text-file.txt");
+console.write(text);

--- a/test/js/bun/util/text-loader-fixture-text-file.txt
+++ b/test/js/bun/util/text-loader-fixture-text-file.txt
@@ -1,0 +1,1 @@
+These are words!

--- a/test/js/bun/util/text-loader.test.ts
+++ b/test/js/bun/util/text-loader.test.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from "bun";
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+describe("text-loader", () => {
+  const fixtures = [
+    ["dynamic-import", "text-loader-fixture-dynamic-import.ts"],
+    ["import", "text-loader-fixture-import.ts"],
+    ["require", "text-loader-fixture-require.ts"],
+  ] as const;
+  for (let [kind, path] of fixtures) {
+    describe("should load text", () => {
+      it(`using ${kind}`, () => {
+        const result = spawnSync({
+          cmd: [bunExe(), join(import.meta.dir, path)],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "inherit",
+          stdin: "ignore",
+        });
+
+        expect(result.stdout.toString()).toBe("These are words!");
+        expect(result.exitCode).toBe(0);
+      });
+    });
+  }
+});


### PR DESCRIPTION
This adds runtime support for importing .txt files as strings

```js
import foo from './hello-world.txt';

console.log(foo) // Hello!!!
```

`hello-world.txt`:

```txt
Hello!!!
```
