### PR TITLE
toBeFalsy expect counter and test scope check

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1478,10 +1478,16 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
 
         const value: JSValue = Expect.capturedValueGetCached(thisValue) orelse {
-            globalObject.throw("internal consistency error: the expect(value) was garbage collected but it should not have been!", .{});
+            globalObject.throw("Internal consistency error: the expect(value) was garbage collected but it should not have been!", .{});
             return .zero;
         };
         value.ensureStillAlive();
+
+        if (this.scope.tests.items.len <= this.test_id) {
+            globalObject.throw("toBeFalsy() must be called in a test", .{});
+            return .zero;
+        }
+        active_test_expectation_counter.actual += 1;
 
         const not = this.op.contains(.not);
         var pass = false;


### PR DESCRIPTION
Noticed the expect counter for toBeFalsy wasn't updating.

- Added counter increment.
- Added test scope check
- Made capitalization of `Internal consistency error` message consistent with other errors in file