### PR TITLE
fix package json exports visit

### DIFF
--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -1068,7 +1068,7 @@ pub const ExportsMap = struct {
                 .e_object => |e_obj| {
                     var map_data = Entry.Data.Map.List{};
                     map_data.ensureTotalCapacity(this.allocator, e_obj.*.properties.len) catch unreachable;
-                    map_data.len = map_data.capacity;
+                    map_data.len = e_obj.*.properties.len;
                     var expansion_keys = this.allocator.alloc(Entry.Data.Map.MapEntry, e_obj.*.properties.len) catch unreachable;
                     var expansion_key_i: usize = 0;
                     var map_data_slices = map_data.slice();


### PR DESCRIPTION
fixes
```
packagejson/PackageJsonExportsRequireOverImport
packagejson/PackageJsonExportsImportOverRequire
packagejson/PackageJsonExportsDefaultOverImportAndRequire
packagejson/PackageJsonExportsBrowser
packagejson/PackageJsonExportsNode
packagejson/PackageJsonExportsNeutral
packagejson/PackageJsonExportsOrderIndependent
packagejson/PackageJsonExportsWildcard
packagejson/PackageJsonExportsNotExactMissingExtension
packagejson/PackageJsonExportsPatternTrailers
packagejson/PackageJsonImports
packagejson/PackageJsonImportsRemapToOtherPackage
```