### PR TITLE
Reduce friction for building with npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ dist
 *.log
 *.out.js
 *.out.refresh.js
-/package-lock.json
+**/package-lock.json
 build
 *.wat
 zig-out

--- a/test/package.json
+++ b/test/package.json
@@ -21,6 +21,6 @@
   "private": true,
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "postinstall": "cd node_modules/bktree-fast && bun x node-gyp configure build"
+    "postinstall": "cd node_modules/bktree-fast && npx node-gyp configure build"
   }
 }


### PR DESCRIPTION
This was the only dependency on bun that I encountered while building the project, and the change to the gitignore ensures that it's easy to make changes after an npm based build