### PR TITLE
WIP: Fix timeouts for HTTPS handshakes

### DIFF
--- a/test/regression/issue/02489.test.ts
+++ b/test/regression/issue/02489.test.ts
@@ -1,0 +1,25 @@
+import { sleep, listen } from "bun";
+import { describe, expect, it } from "bun:test";
+
+describe("an https fetch to a silent TCP socket", () => {
+  const listener = listen({
+    port: 0,
+    hostname: "localhost",
+    socket: {
+      data() {},
+    },
+  });
+  it("should respond to abort signals", async () => {
+    const signal = AbortSignal.timeout(1);
+
+    // After 1ms, the signal should abort the fetch and reject its promise. (with an http URL, this behaviour is seen)
+    // As of this commit, however, the fetch will hang indefinitely.
+    // We detect this by requiring the rejection after waiting 250ms.
+    expect(() =>
+      Promise.race([
+        sleep(250),
+        fetch(`https://127.0.0.1:${listener.port}`, { signal: signal }).then(res => res.text()),
+      ]),
+    ).toThrow(new DOMException("The operation timed out."));
+  });
+});

--- a/test/regression/issue/02489.test.ts
+++ b/test/regression/issue/02489.test.ts
@@ -2,24 +2,28 @@ import { sleep, listen } from "bun";
 import { describe, expect, it } from "bun:test";
 
 describe("an https fetch to a silent TCP socket", () => {
-  const listener = listen({
-    port: 0,
-    hostname: "localhost",
-    socket: {
-      data() {},
-    },
-  });
   it("should respond to abort signals", async () => {
-    const signal = AbortSignal.timeout(1);
+    const listener = listen({
+      port: 0,
+      hostname: "localhost",
+      socket: {
+        data() {},
+      },
+    });
+    try {
+      const signal = AbortSignal.timeout(1);
+      const check_after = sleep(200);
 
-    // After 1ms, the signal should abort the fetch and reject its promise. (with an http URL, this behaviour is seen)
-    // As of this commit, however, the fetch will hang indefinitely.
-    // We detect this by requiring the rejection after waiting 250ms.
-    expect(() =>
-      Promise.race([
-        sleep(250),
-        fetch(`https://127.0.0.1:${listener.port}`, { signal: signal }).then(res => res.text()),
-      ]),
-    ).toThrow(new DOMException("The operation timed out."));
+      // After 1ms, the signal should abort the fetch and reject its promise. (with an http URL, this behaviour is seen)
+      // As of this commit, however, the fetch will hang indefinitely.
+      // We detect this by requiring the rejection after waiting 250ms.
+      expect(() =>
+        Promise.race([check_after, fetch(`https://127.0.0.1:${listener.port}`, { signal: signal })]),
+      ).toThrow(new DOMException("The operation timed out."));
+      await check_after;
+      await sleep(1);
+    } finally {
+      listener.stop(true);
+    }
   });
 });


### PR DESCRIPTION
To close #2489.

As far as I can tell, the runtime isn't capable of timing out https fetches before this handshake is complete.

Now that I've introduced a test, I'll need to dig into the HTTP implementation. It looks like the abort handler belongs here: https://github.com/oven-sh/bun/blob/98209b8e101c8c0199f1360f7c1781938f502ed8/src/http_client_async.zig#L2252

However I'm not entirely sure how the signalling works when an abort is fired. This is the callback used:

https://github.com/oven-sh/bun/blob/98209b8e101c8c0199f1360f7c1781938f502ed8/src/bun.js/webcore/response.zig#L870-L880

It shuts down the socket itself, which presumably makes it back to a callback in http_client_async. Any pointers here would be great :)

Also: With the broken `fetch` implementation, the new test will detect a failure, but can't actually complete. The `FetchTasklet` keeps the event loop alive indefinitely. Can I ask the test harness to forcefully `process.exit`?