### PR TITLE
bundler tests!

### DIFF
--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -168,4 +168,53 @@ describe("bundler", () => {
       ARBITRARY: "secret environment stuff!",
     },
   });
+  itBundled("edgecase/StarExternal", {
+    files: {
+      "/entry.js": /* js */ `
+        import { foo } from './foo';
+        import { bar } from './bar';
+        console.log(foo);
+      `,
+    },
+    external: ["*"],
+  });
+  itBundled("edgecase/ImportNamespaceAndDefault", {
+    files: {
+      "/entry.js": /* js */ `
+        import def2, * as ns2 from './c'
+        console.log(def2, JSON.stringify(ns2))
+      `,
+    },
+    external: ["*"],
+    runtimeFiles: {
+      "/c.js": /* js */ `
+        export default 1
+        export const ns = 2
+        export const def2 = 3
+      `,
+    },
+    run: {
+      stdout: '1 {"def2":3,"default":1,"ns":2}',
+    },
+  });
+  itBundled("edgecase/ExternalES6ConvertedToCommonJSSimplified", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(JSON.stringify(require('./e')));
+      `,
+      "/e.js": `export * from 'x'`,
+    },
+    external: ["x"],
+    runtimeFiles: {
+      "/node_modules/x/index.js": /* js */ `
+        export const ns = 123
+        export const ns2 = 456
+      `,
+    },
+    run: {
+      stdout: `
+        {"ns":123,"ns2":456}
+      `,
+    },
+  });
 });

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -217,4 +217,15 @@ describe("bundler", () => {
       `,
     },
   });
+  itBundled("edgecase/ImportTrailingSlash", {
+    files: {
+      "/entry.js": /* js */ `
+        import "slash/"
+      `,
+      "/node_modules/slash/index.js": /* js */ `console.log(1)`,
+    },
+    run: {
+      stdout: "1",
+    },
+  });
 });

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import dedent from "dedent";
-import { itBundled, testForFile } from "../expectBundled";
+import { ESBUILD, itBundled, testForFile } from "../expectBundled";
 var { describe, test, expect } = testForFile(import.meta.path);
 
 // Tests ported from:
@@ -88,7 +88,7 @@ describe("bundler", () => {
       `,
     },
     run: {
-      stdout: 'hello\n{"default":{"foo":123},"foo":123}',
+      stdout: 'hello\n{"foo":123}',
     },
   });
   itBundled("dce/PackageJsonSideEffectsTrueKeepES6", {
@@ -704,7 +704,6 @@ describe("bundler", () => {
     },
   });
   itBundled("dce/PackageJsonSideEffectsFalseIntermediateFilesChainAll", {
-    // GENERATED
     files: {
       "/Users/user/project/src/entry.js": /* js */ `
         import {foo} from "a"
@@ -1038,35 +1037,6 @@ describe("bundler", () => {
       stdout: `["F",{"children":[null,{"children":["div",{}]}]}]`,
     },
   });
-  // TODO: Unsure how to port this: https://github.com/evanw/esbuild/blob/main/internal/bundler_tests/bundler_dce_test.go#L1249
-  itBundled("dce/DisableTreeShaking", {
-    notImplemented: true,
-    // GENERATED
-    files: {
-      "/entry.jsx": /* jsx */ `
-        import './remove-me'
-        function RemoveMe1() {}
-        let removeMe2 = 0
-        class RemoveMe3 {}
-
-        import './keep-me'
-        function KeepMe1() {}
-        let keepMe2 = <KeepMe1/>
-        function keepMe3() { console.log('side effects') }
-        let keepMe4 = /* @__PURE__ */ keepMe3()
-        let keepMe5 = pure()
-        let keepMe6 = some.fn()
-      `,
-      "/remove-me.js": `export default 'unused'`,
-      "/keep-me/index.js": `console.log('side effects')`,
-      "/keep-me/package.json": `{ "sideEffects": false }`,
-    },
-    ignoreDCEAnnotations: true,
-    define: {
-      pure: "???",
-      "some.fn": "???",
-    },
-  });
   itBundled("dce/DeadCodeFollowingJump", {
     notImplemented: true,
     files: {
@@ -1308,6 +1278,7 @@ describe("bundler", () => {
     dce: true,
   });
   itBundled("dce/TreeShakingClassStaticProperty", {
+    notImplemented: true,
     files: {
       "/entry.js": /* js */ `
         let remove1 = class { static x }
@@ -1421,6 +1392,7 @@ describe("bundler", () => {
     format: "iife",
   });
   itBundled("dce/TreeShakingNoBundleESM", {
+    notImplemented: true,
     files: {
       "/entry.js": /* js */ `
         function keep() {}
@@ -1434,7 +1406,6 @@ describe("bundler", () => {
     dce: true,
   });
   itBundled("dce/TreeShakingNoBundleCJS", {
-    // GENERATED
     files: {
       "/entry.js": /* js */ `
         function keep() {}
@@ -1442,12 +1413,12 @@ describe("bundler", () => {
         keep()
       `,
     },
+    dce: true,
     format: "cjs",
     treeShaking: true,
     mode: "transform",
   });
   itBundled("dce/TreeShakingNoBundleIIFE", {
-    // GENERATED
     files: {
       "/entry.js": /* js */ `
         function keep() {}
@@ -1455,6 +1426,7 @@ describe("bundler", () => {
         keep()
       `,
     },
+    dce: true,
     format: "iife",
     treeShaking: true,
     mode: "transform",
@@ -1483,7 +1455,6 @@ describe("bundler", () => {
     },
   });
   itBundled("dce/DCETypeOf", {
-    // GENERATED
     files: {
       "/entry.js": /* js */ `
         // These should be removed because they have no side effects
@@ -1690,6 +1661,7 @@ describe("bundler", () => {
     dce: true,
   });
   itBundled("dce/RemoveUnusedImports", {
+    notImplemented: true,
     files: {
       "/entry.js": /* js */ `
         import REMOVE1 from 'a'
@@ -1698,8 +1670,8 @@ describe("bundler", () => {
       `,
     },
     minifySyntax: true,
-    mode: "transform",
     dce: true,
+    external: ["a", "b", "c"],
     onAfterBundle(api) {
       api.expectFile("/out.js").toBe(
         dedent`
@@ -1721,6 +1693,7 @@ describe("bundler", () => {
     },
     minifySyntax: true,
     mode: "transform",
+    external: ["a", "b", "c"],
     dce: true,
   });
   itBundled("dce/RemoveUnusedImportsEvalTS", {
@@ -2157,6 +2130,7 @@ describe("bundler", () => {
     },
   });
   itBundled("dce/InlineFunctionCallBehaviorChanges", {
+    notImplemented: true,
     files: {
       // At the time of writing, using a template string here triggered a bug in bun's transpiler
       // making it impossible to run the test.
@@ -2238,6 +2212,7 @@ describe("bundler", () => {
     dce: true,
   });
   itBundled("dce/ConstValueInliningNoBundle", {
+    notImplemented: true,
     files: {
       "/top-level.js": /* js */ `
         // These should be kept because they are top-level and tree shaking is not enabled
@@ -2290,6 +2265,7 @@ describe("bundler", () => {
             s_keep, s_keep,
           )
         }
+        console.log(nested())
       `,
       "/namespace-export.ts": /* ts */ `
         namespace ns {
@@ -2343,10 +2319,12 @@ describe("bundler", () => {
           function foo() {
             return y_REMOVE
           }
+          console.log(foo)
         }
+        console.log(nested());
       `,
       "/disabled-tdz.js": /* js */ `
-        foo()
+        console.log(foo())
         const x_keep = 1
         function foo() {
           return x_keep
@@ -2369,6 +2347,7 @@ describe("bundler", () => {
             y, y,
           )
         }
+        console.log(foo())
       `,
     },
     entryPoints: [
@@ -2386,11 +2365,11 @@ describe("bundler", () => {
       "/backwards-reference-top-level.js",
       "/backwards-reference-nested-function.js",
     ],
-    mode: "transform",
     minifySyntax: true,
     dce: true,
     dceKeepMarkerCount: {
-      "/out/top-level.js": 7,
+      "/out/top-level.js": 5,
+      "/out/nested-function.js": 3,
       "/out/namespace-export.js": 1,
     },
   });
@@ -2539,6 +2518,7 @@ describe("bundler", () => {
     },
   });
   itBundled("dce/ConstValueInliningDirectEval", {
+    notImplemented: true,
     files: {
       "/top-level-no-eval.js": /* js */ `
         const keep = 1
@@ -2873,7 +2853,6 @@ describe("bundler", () => {
     },
   });
   itBundled("dce/NestedFunctionInliningWithSpread", {
-    // GENERATED
     files: {
       "/entry.js": /* js */ `
         function empty1() {}

--- a/test/bundler/esbuild/lower.test.ts
+++ b/test/bundler/esbuild/lower.test.ts
@@ -1,4 +1,4 @@
-import { RUN_UNCHECKED_TESTS, itBundled, testForFile } from "../expectBundled";
+import { itBundled, testForFile } from "../expectBundled";
 var { describe, test, expect } = testForFile(import.meta.path);
 
 // Tests ported from:
@@ -7,7 +7,7 @@ var { describe, test, expect } = testForFile(import.meta.path);
 // For debug, all files are written to $TEMP/bun-bundle-tests/lower
 
 describe("bundler", () => {
-  if (!RUN_UNCHECKED_TESTS) return;
+  return;
   itBundled("lower/LowerOptionalCatchNameCollisionNoBundle", {
     // GENERATED
     files: {

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -1470,7 +1470,6 @@ describe("bundler", () => {
     },
   });
   itBundled("ts/ThisInsideFunctionTSNoBundleUseDefineForClassFields", {
-    // GENERATED
     files: {
       "/entry.ts": /* ts */ `
         function foo(x = this) { return [x, this]; }

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -95,6 +95,7 @@ export interface BundlerTestInput {
     fragment?: string;
     automaticRuntime?: boolean;
     development?: boolean;
+    preserve?: boolean;
   };
   outbase?: string;
   /** Defaults to `/out.js` */
@@ -475,6 +476,7 @@ function expectBundled(
               minifyWhitespace && `--minify-whitespace`,
               globalName && `--global-name=${globalName}`,
               // inject && inject.map(x => ["--inject", path.join(root, x)]),
+              jsx.preserve && "--jsx=preserve",
               jsx.automaticRuntime === false && "--jsx=classic",
               jsx.factory && `--jsx-factory=${jsx.factory}`,
               jsx.fragment && `--jsx-fragment=${jsx.fragment}`,
@@ -508,6 +510,7 @@ function expectBundled(
               inject && inject.map(x => `--inject:${path.join(root, x)}`),
               define && Object.entries(define).map(([k, v]) => `--define:${k}=${v}`),
               jsx.automaticRuntime && "--jsx=automatic",
+              jsx.preserve && "--jsx=preserve",
               jsx.factory && `--jsx-factory=${jsx.factory}`,
               jsx.fragment && `--jsx-fragment=${jsx.fragment}`,
               jsx.development && `--jsx-dev`,


### PR DESCRIPTION
# what i think is important
- 17 splitting tests, mostly due to missing variables / imports.
	- `default/TopLevelAwaitAllowedImportWithSplitting` also affected
- `import def2, * as ns2 from './c'` in test `edgecase/ImportNamespaceAndDefault`
- `require` inside of trycatch is inlined with an error. `default/RequireWithCallInsideTry` ![Pasted image 20230425233834](https://user-images.githubusercontent.com/24465214/234470357-32aa6cf3-c914-4838-b72a-29e9c2063f64.png)
- `default/HashbangBundle` we do not add hashbangs like `#!/usr/bin/env bun`
- top level await in ES modules breaks `default/TopLevelAwaitAllowedImportWithoutSplitting` as the `__esm` is not given an async function
- `define` does not work with optional chaining `default/DefineOptionalChain`
- require a module that export * from external.`edgecase/ExternalES6ConvertedToCommonJSSimplified`. complex case `default/ExternalES6ConvertedToCommonJS`

## less important. skipped

- top level await in a commonjs module does not error. `default/TopLevelAwaitForbiddenRequire`
- identifier minification does not ignore comments
