### PR TITLE
Fix a rare crash in http server

### DIFF
--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -4163,11 +4163,14 @@ pub const FinalizationCallback = struct {
             this.ref_count -= 1;
         }
 
-        pub fn ptr(this: *Ptr) ?*anyopaque {
+        pub fn ptr(this: Ptr) ?*anyopaque {
             if (this.address == 0)
                 return null;
 
-            return @intToPtr(*anyopaque, @as(usize, this.addrress));
+            // zero the trailing little endian 4 bits from u64
+            // We want to make sure that the ref_count is not included in the pointer
+            const safe_addr = @as(usize, this.address) & @as(usize, 0xFFFFFFFFFFFFFFF0);
+            return @intToPtr(*anyopaque, safe_addr);
         }
 
         pub fn init(addr: *anyopaque) Ptr {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -361,6 +361,7 @@ pub const VirtualMachine = struct {
     pending_unref_counter: i32 = 0,
     preload: []const string = &[_][]const u8{},
     unhandled_pending_rejection_to_capture: ?*JSC.JSValue = null,
+    finalization_pool: ?*JSC.FinalizationCallback.Pool = null,
 
     hot_reload: bun.CLI.Command.HotReload = .none,
 
@@ -463,6 +464,16 @@ pub const VirtualMachine = struct {
     };
 
     pub threadlocal var is_main_thread_vm: bool = false;
+
+    pub fn finalizationPool(this: *VirtualMachine) *JSC.FinalizationCallback.Pool {
+        if (this.finalization_pool == null) {
+            var pool = this.allocator.create(JSC.FinalizationCallback.Pool) catch @panic("Failed to create finalization pool");
+            pool.* = JSC.FinalizationCallback.Pool.init(this.allocator);
+            this.finalization_pool = pool;
+        }
+
+        return this.finalization_pool.?;
+    }
 
     pub const UnhandledRejectionScope = struct {
         ctx: ?*anyopaque = null,

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -68,6 +68,8 @@ pub const Request = struct {
     // We must report a consistent value for this
     reported_estimated_size: ?u63 = null,
 
+    finalization_callback: ?*JSC.FinalizationCallback = null,
+
     const RequestMixin = BodyMixin(@This());
     pub usingnamespace JSC.Codegen.JSRequest;
 
@@ -279,6 +281,10 @@ pub const Request = struct {
 
     pub fn finalize(this: *Request) callconv(.C) void {
         this.finalizeWithoutDeinit();
+        if (this.finalization_callback) |finalizer| {
+            var pool = JSC.VirtualMachine.get().finalizationPool();
+            finalizer.call(pool);
+        }
         bun.default_allocator.destroy(this);
     }
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -123,11 +123,16 @@ it("request.signal works in trivial case", async () => {
 it("request.signal works in leaky case", async () => {
   var aborty = new AbortController();
   var didAbort = false;
-  var leaky: Request | undefined;
+  var onRequest = (req: Request) => {
+    req.signal.addEventListener("abort", () => {
+      didAbort = true;
+    });
+  };
+
   await runTest(
     {
       async fetch(req) {
-        leaky = req;
+        onRequest(req);
         expect(didAbort).toBe(false);
         aborty.abort();
         await Bun.sleep(2);
@@ -135,21 +140,9 @@ it("request.signal works in leaky case", async () => {
       },
     },
     async server => {
-      try {
-        const resp = fetch(`http://${server.hostname}:${server.port}`, { signal: aborty.signal });
-
-        await Bun.sleep(1);
-
-        leaky!.signal.addEventListener("abort", () => {
-          didAbort = true;
-        });
-
-        await resp;
-
-        throw new Error("Expected fetch to throw");
-      } catch (e: any) {
-        expect(e.name).toBe("AbortError");
-      }
+      expect(async () => {
+        await fetch(`http://${server.hostname}:${server.port}`, { signal: aborty.signal });
+      }).toThrow("The operation was aborted.");
 
       await Bun.sleep(1);
 


### PR DESCRIPTION
This introduces a `FinalizationCallback` which can be used when we don't want to keep a JS type alive but do potentially need to access it when it might've been freed. It's like WeakRef but cheaper and assumes there is only one user.