### PR TITLE
Use Ninja to build mimalloc and gitignore test/bun.lockb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1320,8 +1320,9 @@ mimalloc-debug:
 			-DMI_OVERRIDE=OFF \
 			-DCMAKE_C_FLAGS="$(CFLAGS)" \
 			-DCMAKE_CXX_FLAGS="$(CFLAGS)" \
+			-GNinja
 			. \
-			&& make -j $(CPUS);
+			&& ninja;
 	cp $(BUN_DEPS_DIR)/mimalloc/$(_MIMALLOC_DEBUG_FILE) $(BUN_DEPS_OUT_DIR)/$(MIMALLOC_FILE)
 
 
@@ -1343,8 +1344,9 @@ mimalloc:
 			-DMI_OVERRIDE=OFF \
 			-DMI_OSX_ZONE=OFF \
 			-DCMAKE_C_FLAGS="$(CFLAGS)" \
+			-GNinja \
 			 .\
-			&& make -j $(CPUS);
+			&& ninja;
 	cp $(BUN_DEPS_DIR)/mimalloc/$(MIMALLOC_INPUT_PATH) $(BUN_DEPS_OUT_DIR)/$(MIMALLOC_FILE)
 
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+bun.lockb


### PR DESCRIPTION
Fixes a few little issues I had while setting up bun development.

Ninja is faster than make at building, and explicitly setting which generator to use avoids issues when someone (like me) has `CMAKE_GENERATOR` set in their envvars.

I'm not sure whether `test/bun.lockb` should be ignored or committed, but given it's not been committed thus far I assume it should be ignored :)