### PR TITLE
docs hotfix

### DIFF
--- a/docs/cli/build.md
+++ b/docs/cli/build.md
@@ -122,9 +122,9 @@ Then paste the following contents into it:
 <html>
   <body>
     <div id="root"></div>
-    <script type="module" src="/index.js"></script>
+    < script type="module" src="/index.js"></ script>
   </body>
-</div>
+</html>
 ```
 
 Then spin up a static file server serving the `out` directory:


### PR DESCRIPTION
the codeblock says this now
```html
<html>
  <body>
    <div id="root"></div>
    < script type="module" src="/index.js"></ script>
  </body>
</html>
```
which we do have to fix this script tag thing, but right now the doc site prints this incorrectly so this output is more readable than a broken page