### PR TITLE
test default condition

### DIFF
--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -378,4 +378,54 @@ describe("bundler", () => {
       "/x.aaaa": `x`,
     },
   });
+  itBundled("edgecase/PackageJSONDefaultConditionRequire", {
+    files: {
+      "/entry.js": /* js */ `
+        const react = require('react')
+        console.log(react)
+      `,
+      "/node_modules/react/package.json": /* json */ `
+        {
+          "name": "react",
+          "exports": {
+            ".": {
+              "react-server": "./ignore.js",
+              "default": "./react.js",
+            }
+          }
+        }
+      `,
+      "/node_modules/react/react.js": /* js */ `
+        module.exports = 123
+      `,
+    },
+    run: {
+      stdout: "123",
+    },
+  });
+  itBundled("edgecase/PackageJSONDefaultConditionImport", {
+    files: {
+      "/entry.js": /* js */ `
+        import React from 'react'
+        console.log(React)
+      `,
+      "/node_modules/react/package.json": /* json */ `
+        {
+          "name": "react",
+          "exports": {
+            ".": {
+              "react-server": "./ignore.js",
+              "default": "./react.js",
+            }
+          }
+        }
+      `,
+      "/node_modules/react/react.js": /* js */ `
+        export default 123
+      `,
+    },
+    run: {
+      stdout: "123",
+    },
+  });
 });

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -34,8 +34,8 @@ const DEBUG = process.env.BUN_BUNDLER_TEST_DEBUG;
 const FILTER = process.env.BUN_BUNDLER_TEST_FILTER;
 /** Set this to hide skips */
 const HIDE_SKIP = process.env.BUN_BUNDLER_TEST_HIDE_SKIP;
-/** Path to the bun. TODO: Once bundler is merged, we should remove the `bun-debug` fallback. */
-const BUN_EXE = (process.env.BUN_EXE && Bun.which(process.env.BUN_EXE)) ?? Bun.which("bun-debug") ?? bunExe();
+/** Path to the bun. */
+const BUN_EXE = (process.env.BUN_EXE && Bun.which(process.env.BUN_EXE)) ?? bunExe();
 export const RUN_UNCHECKED_TESTS = false;
 
 const outBaseTemplate = path.join(tmpdir(), "bun-build-tests", `${ESBUILD ? "esbuild" : "bun"}-`);


### PR DESCRIPTION
1. changes bundle test runner to not seek out `bun-debug`, instead just uses the active bun. this is because back before you couldnt run the test runner on bun-debug since we didnt compile it, etc etc etc.
2. two default export condition test. these are breaking react and vue from being bundled.