### PR TITLE
Fix checking for dynamic exports

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -9893,6 +9893,9 @@ const LinkerContext = struct {
             for (this.export_star_records[source_index]) |id| {
                 const record = records[id];
                 if (record.source_index.isValid()) {
+                    // This file has dynamic exports if the exported imports are from a file
+                    // that either has dynamic exports directly or transitively by itself
+                    // having an export star from a file with dynamic exports.
                     const kind = this.entry_point_kinds[record.source_index.get()];
                     if ((record.source_index.isInvalid() and (!kind.isEntryPoint() or !this.output_format.keepES6ImportExportSyntax())) or
                         (record.source_index.isValid() and record.source_index.get() != source_index and this.hasDynamicExportsDueToExportStar(record.source_index.get())))

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -9889,19 +9889,17 @@ const LinkerContext = struct {
                 return false;
             }
 
-            for (this.export_star_records[source_index]) |id| {
-                const records: []const ImportRecord = this.import_records[id].slice();
-                for (records) |record| {
-                    // This file has dynamic exports if the exported imports are from a file
-                    // that either has dynamic exports directly or transitively by itself
-                    // having an export star from a file with dynamic exports.
-                    const kind = this.entry_point_kinds[record.source_index.get()];
-                    if ((record.source_index.get() >= this.import_records.len and (!kind.isEntryPoint() or !this.output_format.keepES6ImportExportSyntax())) or
-                        (record.source_index.get() < this.import_records.len and record.source_index.get() != source_index and this.hasDynamicExportsDueToExportStar(record.source_index.get())))
-                    {
-                        this.exports_kind[source_index] = .esm_with_dynamic_fallback;
-                        return true;
-                    }
+            const records: []const ImportRecord = this.import_records[source_index].slice();
+            for (records) |record| {
+                // This file has dynamic exports if the exported imports are from a file
+                // that either has dynamic exports directly or transitively by itself
+                // having an export star from a file with dynamic exports.
+                const kind = this.entry_point_kinds[record.source_index.get()];
+                if ((record.source_index.get() >= this.import_records.len and (!kind.isEntryPoint() or !this.output_format.keepES6ImportExportSyntax())) or
+                    (record.source_index.get() < this.import_records.len and record.source_index.get() != source_index and this.hasDynamicExportsDueToExportStar(record.source_index.get())))
+                {
+                    this.exports_kind[source_index] = .esm_with_dynamic_fallback;
+                    return true;
                 }
             }
 

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -9889,15 +9889,13 @@ const LinkerContext = struct {
                 return false;
             }
 
-            const records: []const ImportRecord = this.import_records[source_index].slice();
-            for (records) |record| {
-                // This file has dynamic exports if the exported imports are from a file
-                // that either has dynamic exports directly or transitively by itself
-                // having an export star from a file with dynamic exports.
+            const records = this.import_records[source_index].slice();
+            for (this.export_star_records[source_index]) |id| {
+                const record = records[id];
                 if (record.source_index.isValid()) {
                     const kind = this.entry_point_kinds[record.source_index.get()];
-                    if ((record.source_index.get() >= this.import_records.len and (!kind.isEntryPoint() or !this.output_format.keepES6ImportExportSyntax())) or
-                        (record.source_index.get() < this.import_records.len and record.source_index.get() != source_index and this.hasDynamicExportsDueToExportStar(record.source_index.get())))
+                    if ((record.source_index.isInvalid() and (!kind.isEntryPoint() or !this.output_format.keepES6ImportExportSyntax())) or
+                        (record.source_index.isValid() and record.source_index.get() != source_index and this.hasDynamicExportsDueToExportStar(record.source_index.get())))
                     {
                         this.exports_kind[source_index] = .esm_with_dynamic_fallback;
                         return true;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -9894,12 +9894,14 @@ const LinkerContext = struct {
                 // This file has dynamic exports if the exported imports are from a file
                 // that either has dynamic exports directly or transitively by itself
                 // having an export star from a file with dynamic exports.
-                const kind = this.entry_point_kinds[record.source_index.get()];
-                if ((record.source_index.get() >= this.import_records.len and (!kind.isEntryPoint() or !this.output_format.keepES6ImportExportSyntax())) or
-                    (record.source_index.get() < this.import_records.len and record.source_index.get() != source_index and this.hasDynamicExportsDueToExportStar(record.source_index.get())))
-                {
-                    this.exports_kind[source_index] = .esm_with_dynamic_fallback;
-                    return true;
+                if (record.source_index.isValid()) {
+                    const kind = this.entry_point_kinds[record.source_index.get()];
+                    if ((record.source_index.get() >= this.import_records.len and (!kind.isEntryPoint() or !this.output_format.keepES6ImportExportSyntax())) or
+                        (record.source_index.get() < this.import_records.len and record.source_index.get() != source_index and this.hasDynamicExportsDueToExportStar(record.source_index.get())))
+                    {
+                        this.exports_kind[source_index] = .esm_with_dynamic_fallback;
+                        return true;
+                    }
                 }
             }
 


### PR DESCRIPTION
This fixes bundling in situations when the entry point imports a `cjs` file and also imports files with `export * from ...`.