### PR TITLE
Add missing JSON API to Web APIs page

### DIFF
--- a/docs/api/globals.md
+++ b/docs/api/globals.md
@@ -194,6 +194,12 @@ Bun implements the following globals.
 
 ---
 
+- [`JSON`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON)
+- Web
+- &nbsp;
+
+---
+
 - [`MessageEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent)
 - Web
 - &nbsp;

--- a/docs/runtime/web-apis.md
+++ b/docs/runtime/web-apis.md
@@ -36,6 +36,11 @@ The following Web APIs are partially or completely supported.
 
 ---
 
+- JSON
+- [`JSON`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON)
+
+---
+
 - Timeouts
 - [`setTimeout`](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout) [`clearTimeout`](https://developer.mozilla.org/en-US/docs/Web/API/clearTimeout)
 


### PR DESCRIPTION
Unless I'm missing something obvious, it appears that Bun has the JSON API (`stringify`/`parse`) but is not listed anywhere in the documentation.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON