### PR TITLE
Fix rebuilds in `Bun.build()`

### DIFF
--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -93,6 +93,8 @@ pub const Run = struct {
             b.options.macro_remap = macros;
         }
 
+        b.resolver.store_fd = ctx.debug.hot_reload != .none;
+
         b.configureRouter(false) catch {
             if (Output.enable_ansi_colors_stderr) {
                 vm.log.printForLogLevelWithEnableAnsiColors(Output.errorWriter(), true) catch {};

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -505,7 +505,7 @@ pub const Bundler = struct {
         switch (this.options.env.behavior) {
             .prefix, .load_all => {
                 // Step 1. Load the project root.
-                var dir: *Fs.FileSystem.DirEntry = ((this.resolver.readDirInfo(this.fs.top_level_dir) catch return) orelse return).getEntries() orelse return;
+                var dir: *Fs.FileSystem.DirEntry = ((this.resolver.readDirInfo(this.fs.top_level_dir) catch return) orelse return).getEntries(this.resolver.generation) orelse return;
 
                 // Process always has highest priority.
                 const was_production = this.options.production;

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -503,7 +503,7 @@ pub const RunCommand = struct {
             //   This would cause potentially a different .env file to be loaded
             this_bundler.runEnvLoader() catch {};
 
-            if (root_dir_info.getEntries()) |dir| {
+            if (root_dir_info.getEntries(0)) |dir| {
                 // Run .env again if it exists in a parent dir
                 if (this_bundler.options.production) {
                     this_bundler.env.load(&this_bundler.fs.fs, dir, false) catch {};
@@ -654,6 +654,7 @@ pub const RunCommand = struct {
 
         this_bundler.resolver.care_about_bin_folder = true;
         this_bundler.resolver.care_about_scripts = true;
+        this_bundler.resolver.store_fd = true;
         defer {
             this_bundler.resolver.care_about_bin_folder = false;
             this_bundler.resolver.care_about_scripts = false;
@@ -699,7 +700,7 @@ pub const RunCommand = struct {
                         var dir_slice: string = "";
                         while (iter.next()) |entry| {
                             const value = entry.value_ptr.*;
-                            if (value.kind(&this_bundler.fs.fs) == .file) {
+                            if (value.kind(&this_bundler.fs.fs, true) == .file) {
                                 if (!has_copied) {
                                     bun.copy(u8, &path_buf, value.dir);
                                     dir_slice = path_buf[0..value.dir.len];
@@ -736,7 +737,7 @@ pub const RunCommand = struct {
                             !strings.contains(name, ".d.ts") and
                             !strings.contains(name, ".d.mts") and
                             !strings.contains(name, ".d.cts") and
-                            value.kind(&this_bundler.fs.fs) == .file)
+                            value.kind(&this_bundler.fs.fs, true) == .file)
                         {
                             _ = try results.getOrPut(this_bundler.fs.filename_store.append(@TypeOf(name), name) catch continue);
                         }

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -230,7 +230,7 @@ const Scanner = struct {
     };
 
     fn readDirWithName(this: *Scanner, name: string, handle: ?std.fs.Dir) !*FileSystem.RealFS.EntriesOption {
-        return try this.fs.fs.readDirectoryWithIterator(name, handle, *Scanner, this);
+        return try this.fs.fs.readDirectoryWithIterator(name, handle, 0, true, *Scanner, this);
     }
 
     pub fn scan(this: *Scanner, path_literal: string) void {
@@ -306,7 +306,7 @@ const Scanner = struct {
     pub fn next(this: *Scanner, entry: *FileSystem.Entry, fd: bun.StoredFileDescriptorType) void {
         const name = entry.base_lowercase();
         this.has_iterated = true;
-        switch (entry.kind(&this.fs.fs)) {
+        switch (entry.kind(&this.fs.fs, true)) {
             .dir => {
                 if ((name.len > 0 and name[0] == '.') or strings.eqlComptime(name, "node_modules")) {
                     return;
@@ -403,6 +403,7 @@ pub const TestCommand = struct {
         var vm = try JSC.VirtualMachine.init(ctx.allocator, ctx.args, null, ctx.log, env_loader);
         vm.argv = ctx.passthrough;
         vm.preload = ctx.preloads;
+        vm.bundler.resolver.store_fd = true;
 
         try vm.bundler.configureDefines();
         vm.bundler.options.rewrite_jest_for_tests = true;

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -22,7 +22,7 @@ const allocators = @import("./allocators.zig");
 
 pub const MAX_PATH_BYTES = bun.MAX_PATH_BYTES;
 pub const PathBuffer = [bun.MAX_PATH_BYTES]u8;
-const debug = Output.scoped(.fs, false);
+pub const debug = Output.scoped(.fs, false);
 
 // pub const FilesystemImplementation = @import("fs_impl.zig");
 
@@ -193,13 +193,14 @@ pub const FileSystem = struct {
         pub const EntryStore = allocators.BSSList(Entry, Preallocate.Counts.files);
         dir: string,
         fd: StoredFileDescriptorType = 0,
+        generation: bun.Generation = 0,
         data: EntryMap,
 
         // pub fn removeEntry(dir: *DirEntry, name: string) !void {
         //     // dir.data.remove(name);
         // }
 
-        pub fn addEntry(dir: *DirEntry, entry: std.fs.IterableDir.Entry, allocator: std.mem.Allocator, comptime Iterator: type, iterator: Iterator) !void {
+        pub fn addEntry(dir: *DirEntry, prev_map: ?*EntryMap, entry: std.fs.IterableDir.Entry, allocator: std.mem.Allocator, comptime Iterator: type, iterator: Iterator) !void {
             const _kind: Entry.Kind = switch (entry.kind) {
                 .Directory => .dir,
                 // This might be wrong!
@@ -207,34 +208,57 @@ pub const FileSystem = struct {
                 .File => .file,
                 else => return,
             };
-            // entry.name only lives for the duration of the iteration
 
-            const name = try strings.StringOrTinyString.initAppendIfNeeded(
-                entry.name,
-                *FileSystem.FilenameStore,
-                &FileSystem.FilenameStore.instance,
-            );
+            const stored = try brk: {
+                if (prev_map) |map| {
+                    var stack_fallback = std.heap.stackFallback(512, allocator);
+                    const stack = stack_fallback.get();
+                    const prehashed = bun.StringHashMapContext.PrehashedCaseInsensitive.init(stack, entry.name);
+                    defer prehashed.deinit(stack);
+                    if (map.getAdapted(entry.name, prehashed)) |existing| {
+                        existing.mutex.lock();
+                        defer existing.mutex.unlock();
+                        existing.dir = dir.dir;
 
-            const name_lowercased = try strings.StringOrTinyString.initLowerCaseAppendIfNeeded(
-                entry.name,
-                *FileSystem.FilenameStore,
-                &FileSystem.FilenameStore.instance,
-            );
+                        existing.need_stat = existing.need_stat or existing.cache.kind != _kind;
+                        // TODO: is this right?
+                        if (existing.cache.kind != _kind) {
+                            existing.cache.kind = _kind;
 
-            const stored = try EntryStore.instance.append(.{
-                .base_ = name,
-                .base_lowercase_ = name_lowercased,
-                .dir = dir.dir,
-                .mutex = Mutex.init(),
-                // Call "stat" lazily for performance. The "@material-ui/icons" package
-                // contains a directory with over 11,000 entries in it and running "stat"
-                // for each entry was a big performance issue for that package.
-                .need_stat = entry.kind == .SymLink,
-                .cache = .{
-                    .symlink = PathString.empty,
-                    .kind = _kind,
-                },
-            });
+                            existing.cache.symlink = PathString.empty;
+                        }
+                        break :brk existing;
+                    }
+                }
+
+                // entry.name only lives for the duration of the iteration
+                const name = try strings.StringOrTinyString.initAppendIfNeeded(
+                    entry.name,
+                    *FileSystem.FilenameStore,
+                    &FileSystem.FilenameStore.instance,
+                );
+
+                const name_lowercased = try strings.StringOrTinyString.initLowerCaseAppendIfNeeded(
+                    entry.name,
+                    *FileSystem.FilenameStore,
+                    &FileSystem.FilenameStore.instance,
+                );
+
+                break :brk EntryStore.instance.append(.{
+                    .base_ = name,
+                    .base_lowercase_ = name_lowercased,
+                    .dir = dir.dir,
+                    .mutex = Mutex.init(),
+                    // Call "stat" lazily for performance. The "@material-ui/icons" package
+                    // contains a directory with over 11,000 entries in it and running "stat"
+                    // for each entry was a big performance issue for that package.
+                    .need_stat = entry.kind == .SymLink,
+                    .cache = .{
+                        .symlink = PathString.empty,
+                        .kind = _kind,
+                    },
+                });
+            };
 
             const stored_name = stored.base();
 
@@ -253,12 +277,16 @@ pub const FileSystem = struct {
             }
         }
 
-        pub fn init(dir: string) DirEntry {
+        pub fn init(dir: string, generation: bun.Generation) DirEntry {
             if (comptime FeatureFlags.verbose_fs) {
                 Output.prettyln("\n  {s}", .{dir});
             }
 
-            return .{ .dir = dir, .data = .{} };
+            return .{
+                .dir = dir,
+                .data = .{},
+                .generation = generation,
+            };
         }
 
         pub const Err = struct {
@@ -402,21 +430,21 @@ pub const FileSystem = struct {
             file,
         };
 
-        pub fn kind(entry: *Entry, fs: *Implementation) Kind {
+        pub fn kind(entry: *Entry, fs: *Implementation, store_fd: bool) Kind {
             if (entry.need_stat) {
                 entry.need_stat = false;
                 // This is technically incorrect, but we are choosing not to handle errors here
-                entry.cache = fs.kind(entry.dir, entry.base(), entry.cache.fd) catch return entry.cache.kind;
+                entry.cache = fs.kind(entry.dir, entry.base(), entry.cache.fd, store_fd) catch return entry.cache.kind;
             }
             return entry.cache.kind;
         }
 
-        pub fn symlink(entry: *Entry, fs: *Implementation) string {
+        pub fn symlink(entry: *Entry, fs: *Implementation, store_fd: bool) string {
             if (entry.need_stat) {
                 entry.need_stat = false;
                 // This is technically incorrect, but we are choosing not to handle errors here
                 // This error can happen if the file was deleted between the time the directory was scanned and the time it was read
-                entry.cache = fs.kind(entry.dir, entry.base(), entry.cache.fd) catch return "";
+                entry.cache = fs.kind(entry.dir, entry.base(), entry.cache.fd, store_fd) catch return "";
             }
             return entry.cache.symlink.slice();
         }
@@ -559,6 +587,38 @@ pub const FileSystem = struct {
             return (try std.fs.cwd().openIterableDir(tmpdir_path, .{
                 .access_sub_paths = true,
             })).dir;
+        }
+
+        pub fn entriesAt(this: *RealFS, index: allocators.IndexType, generation: bun.Generation) ?*EntriesOption {
+            var existing = this.entries.atIndex(index) orelse return null;
+            if (existing.* == .entries) {
+                if (existing.entries.generation < generation) {
+                    var handle = std.fs.Dir.openIterableDir(std.fs.cwd(), existing.entries.dir, .{}) catch |err| {
+                        existing.entries.data.clearAndFree(bun.fs_allocator);
+
+                        return this.readDirectoryError(existing.entries.dir, err) catch unreachable;
+                    };
+                    defer handle.close();
+
+                    const new_entry = this.readdir(
+                        false,
+                        &existing.entries.data,
+                        existing.entries.dir,
+                        generation,
+                        handle.dir,
+
+                        void,
+                        void{},
+                    ) catch |err| {
+                        existing.entries.data.clearAndFree(bun.fs_allocator);
+                        return this.readDirectoryError(existing.entries.dir, err) catch unreachable;
+                    };
+                    existing.entries.data.clearAndFree(bun.fs_allocator);
+                    existing.entries.* = new_entry;
+                }
+            }
+
+            return existing;
         }
 
         pub fn getDefaultTempDir() string {
@@ -813,25 +873,31 @@ pub const FileSystem = struct {
 
         fn readdir(
             fs: *RealFS,
+            store_fd: bool,
+            prev_map: ?*DirEntry.EntryMap,
             _dir: string,
+            generation: bun.Generation,
             handle: std.fs.Dir,
             comptime Iterator: type,
             iterator: Iterator,
         ) !DirEntry {
             _ = fs;
+
             var iter = (std.fs.IterableDir{ .dir = handle }).iterate();
-            var dir = DirEntry.init(_dir);
+            var dir = DirEntry.init(_dir, generation);
             const allocator = bun.fs_allocator;
             errdefer dir.deinit(allocator);
 
-            if (FeatureFlags.store_file_descriptors) {
+            if (store_fd) {
                 FileSystem.setMaxFd(handle.fd);
                 dir.fd = handle.fd;
             }
 
             while (try iter.next()) |_entry| {
-                try dir.addEntry(_entry, allocator, Iterator, iterator);
+                try dir.addEntry(prev_map, _entry, allocator, Iterator, iterator);
             }
+
+            debug("readdir({d}, {s}) = {d}", .{ handle.fd, _dir, dir.data.count() });
 
             return dir;
         }
@@ -854,11 +920,17 @@ pub const FileSystem = struct {
 
         threadlocal var temp_entries_option: EntriesOption = undefined;
 
-        pub fn readDirectory(fs: *RealFS, _dir: string, _handle: ?std.fs.Dir) !*EntriesOption {
-            return readDirectoryWithIterator(fs, _dir, _handle, void, {});
+        pub fn readDirectory(
+            fs: *RealFS,
+            _dir: string,
+            _handle: ?std.fs.Dir,
+            generation: bun.Generation,
+            store_fd: bool,
+        ) !*EntriesOption {
+            return readDirectoryWithIterator(fs, _dir, _handle, generation, store_fd, void, {});
         }
 
-        pub fn readDirectoryWithIterator(fs: *RealFS, _dir: string, _handle: ?std.fs.Dir, comptime Iterator: type, iterator: Iterator) !*EntriesOption {
+        pub fn readDirectoryWithIterator(fs: *RealFS, _dir: string, _handle: ?std.fs.Dir, generation: bun.Generation, store_fd: bool, comptime Iterator: type, iterator: Iterator) !*EntriesOption {
             var dir = _dir;
             var cache_result: ?allocators.Result = null;
             if (comptime FeatureFlags.enable_entry_cache) {
@@ -869,13 +941,18 @@ pub const FileSystem = struct {
                     fs.entries_mutex.unlock();
                 }
             }
+            var in_place: ?*DirEntry = null;
 
             if (comptime FeatureFlags.enable_entry_cache) {
                 cache_result = try fs.entries.getOrPut(dir);
 
                 if (cache_result.?.hasCheckedIfExists()) {
                     if (fs.entries.atIndex(cache_result.?.index)) |cached_result| {
-                        return cached_result;
+                        if (cached_result.* != .entries or (cached_result.* == .entries and cached_result.entries.generation >= generation)) {
+                            return cached_result;
+                        }
+
+                        in_place = cached_result.entries;
                     }
                 }
             }
@@ -883,28 +960,43 @@ pub const FileSystem = struct {
             var handle = _handle orelse try fs.openDir(dir);
 
             defer {
-                if (_handle == null and fs.needToCloseFiles()) {
+                if (_handle == null and (!store_fd or fs.needToCloseFiles())) {
                     handle.close();
                 }
             }
 
             // if we get this far, it's a real directory, so we can just store the dir name.
             if (_handle == null) {
-                dir = try DirnameStore.instance.append(string, _dir);
+                dir = try if (in_place) |existing|
+                    existing.dir
+                else
+                    DirnameStore.instance.append(string, _dir);
             }
 
             // Cache miss: read the directory entries
             var entries = fs.readdir(
+                store_fd,
+                if (in_place) |existing| &existing.data else null,
                 dir,
+                generation,
                 handle,
+
                 Iterator,
                 iterator,
             ) catch |err| {
+                if (in_place) |existing| existing.data.clearAndFree(bun.fs_allocator);
+
                 return fs.readDirectoryError(dir, err) catch unreachable;
             };
 
             if (comptime FeatureFlags.enable_entry_cache) {
-                var entries_ptr = bun.fs_allocator.create(DirEntry) catch unreachable;
+                var entries_ptr = in_place orelse bun.fs_allocator.create(DirEntry) catch unreachable;
+                if (in_place) |original| {
+                    original.data.clearAndFree(bun.fs_allocator);
+                }
+                if (store_fd and entries.fd == 0)
+                    entries.fd = handle.fd;
+
                 entries_ptr.* = entries;
                 const result = EntriesOption{
                     .entries = entries_ptr,
@@ -1041,7 +1133,13 @@ pub const FileSystem = struct {
             return File{ .path = Path.init(path), .contents = file_contents };
         }
 
-        pub fn kind(fs: *RealFS, _dir: string, base: string, existing_fd: StoredFileDescriptorType) !Entry.Cache {
+        pub fn kind(
+            fs: *RealFS,
+            _dir: string,
+            base: string,
+            existing_fd: StoredFileDescriptorType,
+            store_fd: bool,
+        ) !Entry.Cache {
             var dir = _dir;
             var combo = [2]string{ dir, base };
             var outpath: [bun.MAX_PATH_BYTES]u8 = undefined;
@@ -1062,11 +1160,16 @@ pub const FileSystem = struct {
             var symlink: []const u8 = "";
 
             if (is_symlink) {
-                var file = if (existing_fd != 0) std.fs.File{ .handle = existing_fd } else try std.fs.openFileAbsoluteZ(absolute_path_c, .{ .mode = .read_only });
+                var file = try if (existing_fd != 0)
+                    std.fs.File{ .handle = existing_fd }
+                else if (store_fd)
+                    std.fs.openFileAbsoluteZ(absolute_path_c, .{ .mode = .read_only })
+                else
+                    bun.openFileForPath(absolute_path_c);
                 setMaxFd(file.handle);
 
                 defer {
-                    if (fs.needToCloseFiles() and existing_fd == 0) {
+                    if ((!store_fd or fs.needToCloseFiles()) and existing_fd == 0) {
                         file.close();
                     } else if (comptime FeatureFlags.store_file_descriptors) {
                         cache.fd = file.handle;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5019,7 +5019,7 @@ pub const PackageManager = struct {
         bun.copy(u8, &package_json_cwd_buf, fs.top_level_dir);
         bun.copy(u8, package_json_cwd_buf[fs.top_level_dir.len..], "package.json");
 
-        var entries_option = try fs.fs.readDirectory(fs.top_level_dir, null);
+        var entries_option = try fs.fs.readDirectory(fs.top_level_dir, null, 0, true);
         var options = Options{
             .global = cli.global,
         };
@@ -5128,6 +5128,8 @@ pub const PackageManager = struct {
         var root_dir = try Fs.FileSystem.instance.fs.readDirectory(
             Fs.FileSystem.instance.top_level_dir,
             null,
+            0,
+            true,
         );
         // var progress = Progress{};
         // var node = progress.start(name: []const u8, estimated_total_items: usize)

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -906,7 +906,7 @@ pub const Printer = struct {
         var fs = &FileSystem.instance;
         var options = PackageManager.Options{};
 
-        var entries_option = try fs.fs.readDirectory(fs.top_level_dir, null);
+        var entries_option = try fs.fs.readDirectory(fs.top_level_dir, null, 0, true);
 
         var env_loader: *DotEnv.Loader = brk: {
             var map = try allocator.create(DotEnv.Map);
@@ -2592,6 +2592,8 @@ pub const Package = extern struct {
                 const entries_option = FileSystem.instance.fs.readDirectory(
                     dir_prefix,
                     null,
+                    0,
+                    true,
                 ) catch |err| switch (err) {
                     error.FileNotFound => {
                         log.addWarningFmt(
@@ -2624,7 +2626,7 @@ pub const Package = extern struct {
                     if (strings.eqlAnyComptime(name, skipped_names))
                         continue;
                     var entry: *FileSystem.Entry = entry_iter.value_ptr.*;
-                    if (entry.kind(&Fs.FileSystem.instance.fs) != .dir) continue;
+                    if (entry.kind(&Fs.FileSystem.instance.fs, true) != .dir) continue;
 
                     var parts = [2]string{ entry.dir, entry.base() };
                     var entry_path = Path.joinAbsStringBufZ(

--- a/src/options.zig
+++ b/src/options.zig
@@ -1681,18 +1681,18 @@ pub const BundleOptions = struct {
 
             if (!static_dir_set) {
                 chosen_dir = choice: {
-                    if (fs.fs.readDirectory(fs.top_level_dir, null)) |dir_| {
+                    if (fs.fs.readDirectory(fs.top_level_dir, null, 0, false)) |dir_| {
                         const dir: *const Fs.FileSystem.RealFS.EntriesOption = dir_;
                         switch (dir.*) {
                             .entries => {
                                 if (dir.entries.getComptimeQuery("public")) |q| {
-                                    if (q.entry.kind(&fs.fs) == .dir) {
+                                    if (q.entry.kind(&fs.fs, true) == .dir) {
                                         break :choice "public";
                                     }
                                 }
 
                                 if (dir.entries.getComptimeQuery("static")) |q| {
-                                    if (q.entry.kind(&fs.fs) == .dir) {
+                                    if (q.entry.kind(&fs.fs, true) == .dir) {
                                         break :choice "static";
                                     }
                                 }

--- a/src/resolver/dir_info.zig
+++ b/src/resolver/dir_info.zig
@@ -74,15 +74,15 @@ pub fn getFileDescriptor(dirinfo: *const DirInfo) StoredFileDescriptorType {
         return 0;
     }
 
-    if (dirinfo.getEntries()) |entries| {
+    if (dirinfo.getEntries(0)) |entries| {
         return entries.fd;
     } else {
         return 0;
     }
 }
 
-pub fn getEntries(dirinfo: *const DirInfo) ?*Fs.FileSystem.DirEntry {
-    var entries_ptr = Fs.FileSystem.instance.fs.entries.atIndex(dirinfo.entries) orelse return null;
+pub fn getEntries(dirinfo: *const DirInfo, generation: bun.Generation) ?*Fs.FileSystem.DirEntry {
+    var entries_ptr = Fs.FileSystem.instance.fs.entriesAt(dirinfo.entries, generation) orelse return null;
     switch (entries_ptr.*) {
         .entries => {
             return entries_ptr.entries;

--- a/src/router.zig
+++ b/src/router.zig
@@ -431,7 +431,7 @@ const RouteLoader = struct {
                     continue :outer;
                 }
 
-                switch (entry.kind(&fs.fs)) {
+                switch (entry.kind(&fs.fs, false)) {
                     .dir => {
                         inline for (banned_dirs) |banned_dir| {
                             if (strings.eqlComptime(entry.base(), comptime banned_dir)) {

--- a/test/bundler/bundler-reloader-script.ts
+++ b/test/bundler/bundler-reloader-script.ts
@@ -1,0 +1,41 @@
+// This test serves two purposes:
+// 1. If previously seen files are rebuilt, the second time it is rebuilt, we
+//    read the directory entries from the filesystem again.
+//
+//    That way, if the developer changes a file, we will see the change.
+//
+// 2. Checks the file descriptor count to make sure we're not leaking any files between re-builds.
+import { tmpdir } from "os";
+import { realpathSync, unlinkSync } from "fs";
+import { join } from "path";
+import { openSync, closeSync } from "fs";
+const tmp = realpathSync(tmpdir());
+const input = join(tmp, "input.js");
+const mutate = join(tmp, "mutate.js");
+try {
+  unlinkSync(mutate);
+} catch (e) {}
+await Bun.write(input, "import value from './mutate.js';\n" + `export default value;` + "\n");
+
+await Bun.build({
+  entrypoints: [input],
+});
+await Bun.write(mutate, "export default 1;\n");
+
+const maxfd = openSync(process.execPath, 0);
+closeSync(maxfd);
+const { outputs: second } = await Bun.build({
+  entrypoints: [input],
+});
+const text = await second?.[0]?.result?.text();
+
+if (!text?.includes?.(" = 1")) {
+  throw new Error("Expected text to include ' = 1', but received\n\n" + text);
+}
+
+const newMax = openSync(process.execPath, 0);
+if (newMax !== maxfd) {
+  throw new Error("File descriptors leaked! Expected " + maxfd + " but got " + newMax + "");
+}
+
+process.exit(0);

--- a/test/bundler/bundler_reloadable.test.ts
+++ b/test/bundler/bundler_reloadable.test.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+test("rebuilding busts the directory entries cache", () => {
+  const { exitCode, stderr } = Bun.spawnSync({
+    cmd: [bunExe(), join(import.meta.dir, "bundler-reloader-script.ts")],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "inherit",
+  });
+  if (stderr.byteLength > 0) {
+    throw new Error(stderr.toString());
+  }
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
This introduces a `generation` number to Bun's filesystem cache. This generation number is incremented on every call to `Bun.build()` which we then will lazily re-scan the files. This doesn't account for changes to `package.json`, `tsconfig.json`,  currently.

This also fixes a file descriptor leak in tsconfig.json and when reading directory entries. We continue the existing behavior for keeping file descriptors open in `--hot` or `--watch` mode so that the filesystem watcher continues to work