### PR TITLE
throw returned errors on `wrapWithHasContainer`

### DIFF
--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -616,3 +616,13 @@ if (ok) {
 } else {
   it.skip("run ffi", () => {});
 }
+
+it("dlopen throws an error instead of returning it", () => {
+  let err;
+  try {
+    dlopen("nonexistent", { x: {} });
+  } catch (error) {
+    err = error;
+  }
+  expect(err).toBeTruthy();
+});


### PR DESCRIPTION
if a function with `wrapWithHasContainer` does not get an error reference passed to it, then instead of checking that reference (would be always null), we check the result `.isError` and then properly throw that.

also refactored to use `defer` deinit of the iterator instead of how it was copy pasted throughout the function.

this is one of the first few times I've used comptime stuff, but I'm 99% sure i did it correctly. crazy cool stuff.

Fixes #2820 and some similar issues in other functions that use this wrapper