### PR TITLE
Implement `Bun.serve({fd})` and `Bun.listen({fd})` for socket-activated deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -634,6 +634,9 @@ boringssl-debug: boringssl-build-debug boringssl-copy
 compile-ffi-test:
 	clang $(OPTIMIZATION_LEVEL) -shared -undefined dynamic_lookup -o /tmp/bun-ffi-test.dylib -fPIC ./test/js/bun/ffi/ffi-test.c
 
+.PHONY: compile-direct-fd-test
+compile-direct-fd-test:
+	zig build-lib ./test/js/bun/net/direct-fd-test.zig -dynamic -OReleaseFast -femit-bin=/tmp/libdirect-fd-test
 sqlite:
 
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1513,6 +1513,18 @@ declare module "bun" {
     hostname?: string;
 
     /**
+     * Instead of binding and listening to a hostname and port, the server
+     * can operate off a socket which has already been bound and listened
+     * by a separate process. This enables "socket activated" deployments.
+     *
+     * @example
+     * ```js
+     * process.env.LISTEN_FDS // Use fd passed by systemd socket activation
+     * ```
+     */
+     fd?: string | number;
+
+    /**
      * What URI should be used to make {@link Request.url} absolute?
      *
      * By default, looks at {@link hostname}, {@link port}, and whether or not SSL is enabled to generate one
@@ -3030,8 +3042,9 @@ declare module "bun" {
 
   interface TCPSocketListenOptions<Data = undefined>
     extends SocketOptions<Data> {
-    hostname: string;
-    port: number;
+    fd?: number;
+    hostname?: string;
+    port?: number;
     tls?: TLSOptions;
   }
 
@@ -3075,6 +3088,7 @@ declare module "bun" {
    * @param options.data The per-instance data context
    * @param options.hostname The hostname to connect to
    * @param options.port The port to connect to
+   * @param options.fd The bound socket to attach to
    * @param options.tls The TLS configuration object
    * @param options.unix The unix socket to connect to
    *

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -92,6 +92,7 @@ const DateTime = bun.DateTime;
 const linux = std.os.linux;
 
 pub const ServerConfig = struct {
+    fd: ?uws.socket_t = null,
     port: u16 = 0,
     hostname: [*:0]const u8 = "localhost",
 
@@ -554,6 +555,12 @@ pub const ServerConfig = struct {
                     }
                     return args;
                 }
+            }
+
+            if (arg.getTruthy(global, "fd")) |fd_| {
+                args.fd = @intCast(
+                    i32,
+                    fd_.coerce(i32, global));
             }
 
             if (arg.getTruthy(global, "port")) |port_| {
@@ -5206,6 +5213,7 @@ pub fn NewServer(comptime ssl_enabled_: bool, comptime debug_mode_: bool) type {
             }
 
             this.app.listenWithConfig(*ThisServer, this, onListen, .{
+                .fd = this.config.fd orelse 0,
                 .port = this.config.port,
                 .host = host,
                 .options = 0,

--- a/src/deps/_libusockets.h
+++ b/src/deps/_libusockets.h
@@ -15,6 +15,17 @@ typedef struct StringPointer {
 } StringPointer;
 #endif
 
+/* Define what a socket descriptor is based on platform */
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <winsock2.h>
+#define LIBUS_SOCKET_DESCRIPTOR SOCKET
+#else
+#define LIBUS_SOCKET_DESCRIPTOR int
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -63,7 +74,7 @@ enum uws_opcode_t : int32_t {
 enum uws_sendstatus_t : uint32_t { BACKPRESSURE, SUCCESS, DROPPED };
 
 typedef struct {
-
+  LIBUS_SOCKET_DESCRIPTOR fd;
   int port;
   const char *host;
   int options;
@@ -167,8 +178,9 @@ void uws_app_run(int ssl, uws_app_t *);
 
 void uws_app_listen(int ssl, uws_app_t *app, int port,
                     uws_listen_handler handler, void *user_data);
-void uws_app_listen_with_config(int ssl, uws_app_t *app, const char *host,
-                                uint16_t port, int32_t options,
+void uws_app_listen_with_config(int ssl, uws_app_t *app,
+                                LIBUS_SOCKET_DESCRIPTOR fd, uint16_t port,
+                                const char *host, int32_t options,
                                 uws_listen_handler handler, void *user_data);
 void uws_app_listen_domain(int ssl, uws_app_t *app, const char *domain, 
                            uws_listen_domain_handler handler, void *user_data);

--- a/test/js/bun/net/direct-fd-test.zig
+++ b/test/js/bun/net/direct-fd-test.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const os = std.os;
+
+pub export fn bind_listen(port: u16) os.socket_t {
+  const fd = _bind_listen(port) catch {
+    return -1;
+  };
+  return fd;
+}
+
+pub fn _bind_listen(port: u16) !os.socket_t {
+  const address = try std.net.Address.resolveIp("127.0.0.1", port);
+  const fd = try std.os.socket(
+    address.any.family,
+    os.SOCK.STREAM | os.SOCK.CLOEXEC | os.SOCK.NONBLOCK,
+    os.IPPROTO.TCP);
+  var socklen = address.getOsSockLen();
+  try os.bind(fd, &address.any, socklen);
+  try os.listen(fd, 128);
+  return fd;
+}
+
+pub export fn close(fd: os.socket_t) void {
+  os.closeSocket(fd);
+}

--- a/test/js/bun/net/direct-fd.test.js
+++ b/test/js/bun/net/direct-fd.test.js
@@ -1,0 +1,103 @@
+import { expect, it } from "bun:test";
+import { dlopen, FFIType, suffix } from "bun:ffi";
+
+const hostname = '127.0.0.1';
+const fdTest = async (lib, name, test) => {
+  if (lib) {
+    it(name, async () => {
+      let port = 2000 + Math.floor(Math.random() * 30000);
+      let fd = lib.symbols.bind_listen(port);
+      if (fd < 0) throw "Couldn't get socket";
+      try {
+        await test(fd, port);
+      } catch (e) {
+        throw e;
+      } finally {
+        lib.symbols.close(fd);
+      }
+    });
+  } else {
+    it.skip(name, () => {});
+  }
+}
+
+let lib;
+try {
+  const path = '/tmp/libdirect-fd-test';
+  lib = dlopen(path, {
+    bind_listen: {
+      args: [FFIType.u16],
+      returns: FFIType.i32,
+    },
+
+    close: {
+      args: [FFIType.i32]
+    }
+  });
+} catch {
+  console.log("To enable this test, run `make compile-direct-fd-test`.");
+}
+
+await fdTest(lib, "directly listen on fd", async (fd, port) => {
+  let serverResolve, serverReject, clientResolve, clientReject;
+  const serverPromise = new Promise((resolve, reject) => {
+    serverResolve = resolve;
+    serverReject = reject;
+  });
+  const clientPromise = new Promise((resolve, reject) => {
+    clientResolve = resolve;
+    clientReject = reject;
+  });
+
+  const hello = new Uint8Array([ 72, 101, 108, 108, 111 ]);
+  const server = Bun.listen({
+    fd,
+    socket: {
+      data(socket, data) {
+        socket.write(hello);
+        setTimeout(() => {
+          socket.end();
+          serverResolve();
+        });
+      },
+      error(socket, error) {
+        serverReject(error);
+      }
+    }
+  });
+  const client = Bun.connect({
+    hostname,
+    port,
+    socket: {
+      open(socket) {
+        socket.write("Hi");
+      },
+      data(socket, data) {
+        expect(data).toEqual(hello);
+        setTimeout(() => {
+          socket.end();
+          clientResolve();
+        });
+      },
+      error(socket, error) {
+        clientReject(error);
+      }
+    }
+  });
+
+  await Promise.all([serverPromise, clientPromise]);
+  server.stop(true);
+  server.unref();
+});
+
+await fdTest(lib, "directly serve on fd", async (fd, port) => {
+  const server = Bun.serve({
+    fd,
+    fetch() {
+      return new Response("Hello");
+    }
+  });
+  const response = await fetch(`http://${hostname}:${port}`);
+  expect(await response.text()).toBe("Hello");
+  server.stop(true);
+});


### PR DESCRIPTION
**Overview**. This PR implements `Bun.serve({fd})` and `Bun.listen({fd})`, which runs the HTTP (or TCP) server on a socket that has are already been bound and listened. The overall idea is to have a separate process `bind()` and `listen()` to a socket, and pass it to the Bun process. This is used in production deployments for:
- efficiency: servers can be started on demand in, e.g., large multi-tenant edge setups ☺
- security: a privileged process can bind port < 1024 and then pass the socket to an unprivileged server. Also, the socket can be passed into a restricted network namespace wherein the server is run. This allows the server to respond to requests, but blocks all other network activity.
- reliability: socket activation can implement failover.

This feature is available in Go, Node, etc but not Deno (https://github.com/denoland/deno/issues/6529). Here, it's mildly tricky to implement, since it involves changes to two layers of low-level platform bindings - see the companion PRs at the bottom.

**Usage**. Typical users (on Linux/systemd) would call `Bun.serve({fd: process.env.LISTEN_FDS})`. On Mac/launchd, the fd is obtained from [launch_activate_socket](https://www.manpagez.com/man/3/launch_activate_socket/). On Windows, it could ostensibly be transferred by [WSADuplicateSocket](https://learn.microsoft.com/en-us/windows/win32/winsock/shared-sockets-2).

**Workaround**. socat or systemd-socket-proxyd. These aren't ideal for efficiency, security, or reliability.

**Notes**.
1. The Zig and C++ code correctly handle the socket type, which is usually just an fd, but isn't on Windows. The Javascript API is simple and oblivious, expecting positive ints to be passed.

2. This introduces an asymmetry between `listen()` and `connect()`, since now you can `listen()` to an fd, but you cannot `connect()` to one. Hence the somewhat awkward `FdOrUnixOrHost` type, which I don't think is worth fretting over.

3. Testing requires some Zig code to perform the `bind()` and `listen()` typically done out-of-process.

4. I copied the library changes to `_libusockets.h` and `libuwsockets.cpp`. These seem to differ in minor (unnecessary?) ways from the underlying libraries, for reasons I don't currently understand.

5. I haven't tried running this on Windows. Also, as @Jarred-Sumner [mentioned](https://github.com/uNetworking/uSockets/pull/192), some sanitization of fd might be useful. Also, I've never actually written any Zig code, so maybe double-check things.

**Building**. For politeness, I didn't redirect any submodules. Wait for the following PRs to be merged, or use my feature branches.
* https://github.com/Jarred-Sumner/uSockets/pull/3
* https://github.com/Jarred-Sumner/uWebSockets/pull/10
