### PR TITLE
Fix running commonjs modules as entry point

### DIFF
--- a/src/bundler/entry_points.zig
+++ b/src/bundler/entry_points.zig
@@ -192,7 +192,7 @@ pub const ServerEntryPoint = struct {
                     \\var cjs = start?.default;
                     \\if (cjs && typeof cjs ===  'function' && cjsSymbol in cjs) {{
                     \\  // if you module.exports = (class {{}}), don't call it
-                    \\  entryNamespace = import.meta.primordials.isConstructor(cjs.constructor) ? cjs : cjs();
+                    \\  entryNamespace = cjs.constructor === Function ? cjs() : cjs;
                     \\}}
                     \\if (typeof entryNamespace?.then === 'function') {{
                     \\   entryNamespace = entryNamespace.then((entryNamespace) => {{
@@ -235,7 +235,7 @@ pub const ServerEntryPoint = struct {
                 \\var cjs = start?.default;
                 \\if (cjs && typeof cjs ===  'function' && cjsSymbol in cjs) {{
                 \\  // if you module.exports = (class {{}}), don't call it
-                \\  entryNamespace = import.meta.primordials.isConstructor(cjs.constructor) ? cjs : cjs();
+                \\  entryNamespace = cjs.constructor === Function ? cjs() : cjs;
                 \\}}
                 \\if (typeof entryNamespace?.then === 'function') {{
                 \\   entryNamespace = entryNamespace.then((entryNamespace) => {{

--- a/src/bundler/entry_points.zig
+++ b/src/bundler/entry_points.zig
@@ -190,9 +190,9 @@ pub const ServerEntryPoint = struct {
                     \\export * from '{s}{s}';
                     \\var entryNamespace = start;
                     \\var cjs = start?.default;
-                    \\if (cjs && typeof cjs ===  'function' && cjsSymbol in cjs) {{
+                    \\if (cjs && cjsSymbol in cjs) {{
                     \\  // if you module.exports = (class {{}}), don't call it
-                    \\  entryNamespace = cjs.constructor === Function ? cjs() : cjs;
+                    \\  entryNamespace = import.meta.primordials.isCallable(cjs) ? cjs() : cjs;
                     \\}}
                     \\if (typeof entryNamespace?.then === 'function') {{
                     \\   entryNamespace = entryNamespace.then((entryNamespace) => {{
@@ -233,9 +233,9 @@ pub const ServerEntryPoint = struct {
                 \\export * from '{s}{s}';
                 \\var entryNamespace = start;
                 \\var cjs = start?.default;
-                \\if (cjs && typeof cjs ===  'function' && cjsSymbol in cjs) {{
+                \\if (cjs && cjsSymbol in cjs) {{
                 \\  // if you module.exports = (class {{}}), don't call it
-                \\  entryNamespace = cjs.constructor === Function ? cjs() : cjs;
+                \\  entryNamespace = import.meta.primordials.isCallable(cjs) ? cjs() : cjs;
                 \\}}
                 \\if (typeof entryNamespace?.then === 'function') {{
                 \\   entryNamespace = entryNamespace.then((entryNamespace) => {{

--- a/src/bundler/entry_points.zig
+++ b/src/bundler/entry_points.zig
@@ -192,7 +192,7 @@ pub const ServerEntryPoint = struct {
                     \\var cjs = start?.default;
                     \\if (cjs && typeof cjs ===  'function' && cjsSymbol in cjs) {{
                     \\  // if you module.exports = (class {{}}), don't call it
-                    \\  entryNamespace = ("prototype" in cjs) ? cjs : cjs();
+                    \\  entryNamespace = cjs.constructor === Function ? cjs() : cjs;
                     \\}}
                     \\if (typeof entryNamespace?.then === 'function') {{
                     \\   entryNamespace = entryNamespace.then((entryNamespace) => {{
@@ -235,7 +235,7 @@ pub const ServerEntryPoint = struct {
                 \\var cjs = start?.default;
                 \\if (cjs && typeof cjs ===  'function' && cjsSymbol in cjs) {{
                 \\  // if you module.exports = (class {{}}), don't call it
-                \\  entryNamespace = ("prototype" in cjs) ? cjs : cjs();
+                \\  entryNamespace = cjs.constructor === Function ? cjs() : cjs;
                 \\}}
                 \\if (typeof entryNamespace?.then === 'function') {{
                 \\   entryNamespace = entryNamespace.then((entryNamespace) => {{

--- a/src/bundler/entry_points.zig
+++ b/src/bundler/entry_points.zig
@@ -192,7 +192,7 @@ pub const ServerEntryPoint = struct {
                     \\var cjs = start?.default;
                     \\if (cjs && typeof cjs ===  'function' && cjsSymbol in cjs) {{
                     \\  // if you module.exports = (class {{}}), don't call it
-                    \\  entryNamespace = cjs.constructor === Function ? cjs() : cjs;
+                    \\  entryNamespace = import.meta.primordials.isConstructor(cjs.constructor) ? cjs : cjs();
                     \\}}
                     \\if (typeof entryNamespace?.then === 'function') {{
                     \\   entryNamespace = entryNamespace.then((entryNamespace) => {{
@@ -235,7 +235,7 @@ pub const ServerEntryPoint = struct {
                 \\var cjs = start?.default;
                 \\if (cjs && typeof cjs ===  'function' && cjsSymbol in cjs) {{
                 \\  // if you module.exports = (class {{}}), don't call it
-                \\  entryNamespace = cjs.constructor === Function ? cjs() : cjs;
+                \\  entryNamespace = import.meta.primordials.isConstructor(cjs.constructor) ? cjs : cjs();
                 \\}}
                 \\if (typeof entryNamespace?.then === 'function') {{
                 \\   entryNamespace = entryNamespace.then((entryNamespace) => {{

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -34,3 +34,27 @@ export default fn;
   });
   expect(stdout.toString("utf8")).toEqual("hello world\n");
 });
+
+
+test("not running with export default class", async () => {
+  const dir = join(realpathSync(tmpdir()), "bun-run-test2");
+  mkdirSync(dir, { recursive: true });
+  await Bun.write(
+    join(dir, "index1.js"),
+    `// @bun
+class Foo {
+  constructor() {
+    console.log('hello world');
+  }
+};
+Foo[Symbol.for("CommonJS")] = true;
+export default Foo
+`,
+  );
+  let { stdout } = Bun.spawnSync({
+    cmd: [bunExe(), join(dir, "index1.js")],
+    cwd: dir,
+    env: bunEnv,
+  });
+  expect(stdout.toString("utf8")).toEqual("");
+});

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -56,5 +56,5 @@ export default Foo
     cwd: dir,
     env: bunEnv,
   });
-  expect(stdout.toString("utf8")).toEqual("");
+  expect(stdout.toString("utf8")).toEqual("hello world\n");
 });

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -56,5 +56,5 @@ export default Foo
     cwd: dir,
     env: bunEnv,
   });
-  expect(stdout.toString("utf8")).toEqual("hello world\n");
+  expect(stdout.toString("utf8")).toEqual("");
 });

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, realpathSync } from "fs";
+import { bunEnv, bunExe } from "harness";
+import { tmpdir } from "os";
+import { join } from "path";
+
+test("running a commonjs module works", async () => {
+  const dir = join(realpathSync(tmpdir()), "bun-run-test1");
+  mkdirSync(dir, { recursive: true });
+  await Bun.write(join(dir, "index1.js"), "module.exports = 1; console.log('hello world');");
+  let { stdout } = Bun.spawnSync({
+    cmd: [bunExe(), join(dir, "index1.js")],
+    cwd: dir,
+    env: bunEnv,
+  });
+  expect(stdout.toString("utf8")).toEqual("hello world\n");
+});
+
+test("running with Symbol.for(CommonJS)", async () => {
+  const dir = join(realpathSync(tmpdir()), "bun-run-test2");
+  mkdirSync(dir, { recursive: true });
+  await Bun.write(
+    join(dir, "index1.js"),
+    `// @bun
+const fn = () => console.log('hello world');
+fn[Symbol.for("CommonJS")] = true;
+export default fn;
+`,
+  );
+  let { stdout } = Bun.spawnSync({
+    cmd: [bunExe(), join(dir, "index1.js")],
+    cwd: dir,
+    env: bunEnv,
+  });
+  expect(stdout.toString("utf8")).toEqual("hello world\n");
+});


### PR DESCRIPTION
fixes `bun run` with the following
```ts
this;
console.log("Hello World");
```
or more specifically this generated snippet
```ts
export default __cJS2ESM(() => console.log("Hello World"))
```