### PR TITLE
fix express/send

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -5148,7 +5148,7 @@ fn NewParser_(
                         // require cannot return a promise.
                         !handles_import_errors)
                     {
-                        const import_record_index = p.addImportRecordByRangeAndPath(.stmt, p.source.rangeOfString(arg.loc), path);
+                        const import_record_index = p.addImportRecordByRangeAndPath(.require, p.source.rangeOfString(arg.loc), path);
                         p.import_records.items[import_record_index].handles_import_errors = handles_import_errors;
 
                         // Note that this symbol may be completely removed later.

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -854,4 +854,34 @@ describe("bundler", () => {
       "<bun>": ['Refusing to overwrite input file "/entry.js"'],
     },
   });
+  itBundled("edgecase/ModuleExportsFunctionIssue2911", {
+    files: {
+      "/entry.js": /* js */ `
+        const fn = require('fresh');
+        console.log(fn());
+
+        const fn2 = require('./not_in_node_modules');
+        console.log(fn2());
+
+        import fn3 from 'fresh';
+        console.log(fn());
+
+        import fn4 from './not_in_node_modules';
+        console.log(fn2());
+      `,
+      "/node_modules/fresh/index.js": /* js */ `
+        module.exports = function() {
+          return 'it worked';
+        }
+      `,
+      "/not_in_node_modules.js": /* js */ `
+        module.exports = function() {
+          return 'it worked';
+        }
+      `,
+    },
+    run: {
+      stdout: "it worked\nit worked\nit worked\nit worked",
+    },
+  });
 });


### PR DESCRIPTION
changing the import record kind to .require instead of .stmt, but that doesn't FEEL right to me since it's changed in a cjs2esm transform. however, it doesn't break any new tests.

fixes #2911