### PR TITLE
chore: fix types release action

### DIFF
--- a/.github/workflows/bun-release.yml
+++ b/.github/workflows/bun-release.yml
@@ -99,11 +99,6 @@ jobs:
           TAG="${TAG:-"${{ github.event.release.tag_name }}"}"
           echo "Setup tag: ${TAG}"
           echo "TAG=${TAG}" >> ${GITHUB_ENV}
-      - id: setup-node
-        name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: latest
       - id: setup-bun
         name: Setup Bun
         uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
`bun-release` action is not executed: https://github.com/oven-sh/bun/actions/runs/4996129488/jobs/8948925147

Install dependencies step:
```sh
bun install v0.6.1 (78229da7)

 + conditional-type-checks@1.0.6
 + prettier@2.[8](https://github.com/oven-sh/bun/actions/runs/4996129488/jobs/8948925147#step:6:9).4
 + tsd@0.22.0
 + typescript@5.0.2

 11[9](https://github.com/oven-sh/bun/actions/runs/4996129488/jobs/8948925147#step:6:10) packages installed [592.00ms]
error: linking semver: FileNotFound

error: linking resolve: FileNotFound

error: linking tsd: FileNotFound

error: linking semver: FileNotFound

error: linking prettier: FileNotFound

error: linking typescript: FileNotFound

error: linking @tsd/typescript: FileNotFound
```

Build step:
```sh
$ echo $(which prettier) && prettier --write './**/*.{ts,tsx,js,jsx}'

/usr/bin/bash: line 1: prettier: command not found
```

The problem seems to be a conflict with the node.js installation step.

Closes https://github.com/oven-sh/bun/issues/2923