### PR TITLE
Make `node-fetch` polyfill better

### DIFF
--- a/src/node-fallbacks/node-fetch.js
+++ b/src/node-fallbacks/node-fetch.js
@@ -1,8 +1,88 @@
-var fetchHandler = globalThis.fetch;
+var { Headers, Request, Response, Blob, File = Blob, FormData, fetch: realFetch } = globalThis;
 
 if ("Bun" in globalThis) {
-  fetchHandler = Bun.fetch;
+  realFetch = Bun.fetch;
 }
 
-export default fetchHandler;
-export { fetchHandler as fetch };
+function fetch(url, opts) {
+  return realFetch(url, opts);
+}
+
+class AbortError extends DOMException {
+  constructor(message) {
+    super(message, "AbortError");
+  }
+}
+
+class FetchBaseError extends Error {
+  constructor(message, type) {
+    super(message);
+    this.type = type;
+  }
+}
+
+class FetchError extends FetchBaseError {
+  constructor(message, type, systemError) {
+    super(message, type);
+    this.code = systemError?.code;
+  }
+}
+
+function blobFrom(path, options) {
+  if ("Bun" in globalThis) {
+    return Promise.resolve(Bun.file(data));
+  }
+
+  return fetch(path, options).then(response => response.blob());
+}
+
+function blobFromSync(path, options) {
+  if ("Bun" in globalThis) {
+    return Bun.file(data);
+  }
+
+  return fetch(path, options).then(response => response.blob());
+}
+
+var fileFrom = blobFrom;
+var fileFromSync = blobFromSync;
+
+function isRedirect(code) {
+  return code === 301 || code === 302 || code === 303 || code === 307 || code === 308;
+}
+
+export default Object.assign(fetch, {
+  AbortError,
+  Blob,
+  FetchBaseError,
+  FetchError,
+  File,
+  FormData,
+  Headers,
+  Request,
+  Response,
+  blobFrom,
+  blobFromSync,
+  fileFrom,
+  fileFromSync,
+  isRedirect,
+  [Symbol.for("CommonJS")]: 0,
+});
+
+export {
+  AbortError,
+  Blob,
+  FetchBaseError,
+  FetchError,
+  File,
+  FormData,
+  Headers,
+  Request,
+  Response,
+  blobFrom,
+  blobFromSync,
+  fileFrom,
+  fileFromSync,
+  isRedirect,
+  fetch,
+};

--- a/src/node-fallbacks/node-fetch.js
+++ b/src/node-fallbacks/node-fetch.js
@@ -5,6 +5,10 @@ if ("Bun" in globalThis) {
 }
 
 function fetch(...args) {
+  // require("node-fetch") returns the default export which means we need to
+  // repeat the ESM exports onto it.
+  //
+  // We don't want to copy that onto the global fetch object, so we wrap it.
   return realFetch(...args);
 }
 

--- a/src/node-fallbacks/node-fetch.js
+++ b/src/node-fallbacks/node-fetch.js
@@ -4,8 +4,8 @@ if ("Bun" in globalThis) {
   realFetch = Bun.fetch;
 }
 
-function fetch(url, opts) {
-  return realFetch(url, opts);
+function fetch(...args) {
+  return realFetch(...args);
 }
 
 class AbortError extends DOMException {

--- a/test/js/node/fs/node-fetch.test.js
+++ b/test/js/node/fs/node-fetch.test.js
@@ -1,0 +1,10 @@
+import { fetch, Response, Request, Headers } from "node-fetch";
+
+import { test, expect } from "bun:test";
+
+test("node-fetch", () => {
+  expect(Response).toBe(globalThis.Response);
+  expect(Request).toBe(globalThis.Request);
+  expect(Headers).toBe(globalThis.Headers);
+  expect(fetch).toBe(Bun.fetch);
+});

--- a/test/js/node/fs/node-fetch.test.js
+++ b/test/js/node/fs/node-fetch.test.js
@@ -9,5 +9,13 @@ test("node-fetch", () => {
 });
 
 test("node-fetch fetches", async () => {
-  expect(await fetch("http://example.com")).toBeInstanceOf(Response);
+  const server = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      server.stop();
+      return new Response();
+    },
+  });
+  expect(await fetch("http://" + server.hostname + ":" + server.port)).toBeInstanceOf(Response);
+  server.stop(true);
 });

--- a/test/js/node/fs/node-fetch.test.js
+++ b/test/js/node/fs/node-fetch.test.js
@@ -6,5 +6,8 @@ test("node-fetch", () => {
   expect(Response).toBe(globalThis.Response);
   expect(Request).toBe(globalThis.Request);
   expect(Headers).toBe(globalThis.Headers);
-  expect(fetch).toBe(Bun.fetch);
+});
+
+test("node-fetch fetches", async () => {
+  expect(await fetch("http://example.com")).toBeInstanceOf(Response);
 });


### PR DESCRIPTION
`node-fetch` has the following exports:
```js
  AbortError: [class AbortError extends FetchBaseError],
  Blob: [class Blob],
  FetchError: [class FetchError extends FetchBaseError],
  File: [class File extends Blob],
  FormData: [class FormData],
  Headers: [class Headers extends URLSearchParams],
  Request: [class Request extends Body],
  Response: [class Response extends Body],
  blobFrom: [Function: blobFrom],
  blobFromSync: [Function: blobFromSync],
  default: [AsyncFunction: fetch],
  fileFrom: [Function: fileFrom],
  fileFromSync: [Function: fileFromSync],
  isRedirect: [Function: isRedirect]
```

We were only exporting `fetch`. note that this polyfill is also run in browsers which is why it has the `in` checks.