### PR TITLE
Update `bun init` and document partial support for `node:vm`

### DIFF
--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -236,8 +236,8 @@ This page is updated regularly to reflect compatibility status of the latest ver
 ---
 
 - {% anchor id="node_vm" %} [`node:vm`](https://nodejs.org/api/vm.html) {% /anchor %}
-- 🔴
-- Not implemented.
+- 🟡
+- Partially implemented.
 
 ---
 

--- a/src/__global.zig
+++ b/src/__global.zig
@@ -49,7 +49,7 @@ pub inline fn getStartTime() i128 {
 
 pub const version: @import("./install/semver.zig").Version = .{
     .major = 0,
-    .minor = 5,
+    .minor = 6,
     .patch = build_id,
 };
 

--- a/src/cli/tsconfig-for-init.json
+++ b/src/cli/tsconfig-for-init.json
@@ -1,8 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "ESNext"
-    ],
+    "lib": ["ESNext"],
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "bundler",
@@ -15,6 +13,7 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "allowJs": true,
+    "noEmit": true,
     "types": [
       "bun-types" // add Bun global
     ]


### PR DESCRIPTION
- Add noEmit to tsconfig.json
- Bump bun-types in bun init package.json to `^0.6.0`
- Add "partially implemented" to the documentation of `node:vm`
