### PR TITLE
Add pkg-config as a build requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -666,6 +666,7 @@ require:
 	@which aclocal > /dev/null || (echo -e  "ERROR: automake is required. Install with:\n\n    $(POSIX_PKG_MANAGER) install automake"; exit 1)
 	@which $(LIBTOOL) > /dev/null || (echo -e "ERROR: libtool is required. Install with:\n\n    $(POSIX_PKG_MANAGER) install libtool"; exit 1)
 	@which ninja > /dev/null || (echo -e "ERROR: Ninja is required. Install with:\n\n    $(POSIX_PKG_MANAGER) install $(PKGNAME_NINJA)"; exit 1)
+	@which pkg-config > /dev/null || (echo -e "ERROR: pkg-config is required. Install with:\n\n    $(POSIX_PKG_MANAGER) install pkg-config"; exit 1)
 	@echo "You have the dependencies installed! Woo"
 
 init-submodules:


### PR DESCRIPTION
Without pkg-config, the libarchive build fails in autogen.sh[1]

1: https://github.com/libarchive/libarchive/issues/742

<details>
<summary>error details when you try to build without pkg-config</summary>

```
cd /Users/llimllib/readme/tmp/bun/src/deps/libarchive; \
	(make clean || echo ""); \
	(./build/clean.sh || echo ""); \
	./build/autogen.sh; \
	CFLAGS="-mmacosx-version-min=11.0 -O3 -mtune=native -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -mtune=native" CC=" /usr/bin/clang" CCACHE_COMPILER=/usr/bin/clang ./configure --disable-shared --enable-static  --with-pic  --disable-bsdtar   --disable-bsdcat --disable-rpath --enable-posix-regex-lib  --without-xml2  --without-expat --without-openssl  --without-iconv --without-zlib; \
	make -j12; \
	cp ./.libs/libarchive.a /Users/llimllib/readme/tmp/bun/src/deps/libarchive.a;
make[1]: *** No rule to make target `clean'.  Stop.

+ aclocal -I build/autoconf
+ case `uname` in
++ uname
+ glibtoolize --automake -c
+ autoconf
configure.ac:108: warning: The macro `AC_PROG_CC_C99' is obsolete.
configure.ac:108: You should run autoupdate.
./lib/autoconf/c.m4:1659: AC_PROG_CC_C99 is expanded from...
configure.ac:108: the top level
configure.ac:112: warning: The macro `AC_LIBTOOL_WIN32_DLL' is obsolete.
configure.ac:112: You should run autoupdate.
aclocal.m4:8546: AC_LIBTOOL_WIN32_DLL is expanded from...
configure.ac:112: the top level
configure.ac:112: warning: AC_LIBTOOL_WIN32_DLL: Remove this warning and the call to _LT_SET_OPTION when you
configure.ac:112: put the 'win32-dll' option into LT_INIT's first parameter.
./lib/autoconf/general.m4:2434: AC_DIAGNOSE is expanded from...
aclocal.m4:8546: AC_LIBTOOL_WIN32_DLL is expanded from...
configure.ac:112: the top level
configure.ac:113: warning: The macro `AC_PROG_LIBTOOL' is obsolete.
configure.ac:113: You should run autoupdate.
aclocal.m4:122: AC_PROG_LIBTOOL is expanded from...
configure.ac:113: the top level
configure.ac:636: warning: The macro `AC_HEADER_TIME' is obsolete.
configure.ac:636: You should run autoupdate.
./lib/autoconf/headers.m4:743: AC_HEADER_TIME is expanded from...
configure.ac:636: the top level
configure.ac:140: error: possibly undefined macro: AC_MSG_FAILURE
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:328: error: possibly undefined macro: AC_CHECK_LIB
configure: error: cannot find required auxiliary files: compile config.guess config.sub missing install-sh
make[1]: *** No targets specified and no makefile found.  Stop.
cp: ./.libs/libarchive.a: No such file or directory
make: *** [libarchive] Error 1
```
</details>
