### PR TITLE
Load `.env.test`, set NODE_ENV=test in `bun test`, load `.env.{test,production,development}.local`

### DIFF
--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -211,6 +211,8 @@ pub const Run = struct {
             }
         }
 
+        vm.bundler.env.loadTracy();
+
         var callback = OpaqueWrap(Run, Run.start);
         vm.global.vm().holdAPILock(&run, callback);
     }

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -693,27 +693,8 @@ pub const BundleV2 = struct {
         thread_pool: ?*ThreadPoolLib,
         heap: ?ThreadlocalArena,
     ) !*BundleV2 {
-        tracy: {
-            if (bundler.env.get("BUN_TRACY") != null) {
-                if (!bun.tracy.init()) {
-                    Output.prettyErrorln("Failed to load Tracy. Is it installed in your include path?", .{});
-                    Output.flush();
-                    break :tracy;
-                }
+        bundler.env.loadTracy();
 
-                bun.tracy.start();
-
-                if (!bun.tracy.isConnected()) {
-                    std.time.sleep(std.time.ns_per_ms * 10);
-                }
-
-                if (!bun.tracy.isConnected()) {
-                    Output.prettyErrorln("Tracy is not connected. Is Tracy running on your computer?", .{});
-                    Output.flush();
-                    break :tracy;
-                }
-            }
-        }
         var generator = try allocator.create(BundleV2);
         bundler.options.mark_builtins_as_external = bundler.options.target.isBun() or bundler.options.target == .node;
         bundler.resolver.opts.mark_builtins_as_external = bundler.options.target.isBun() or bundler.options.target == .node;

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -506,9 +506,9 @@ pub const RunCommand = struct {
             if (root_dir_info.getEntries(0)) |dir| {
                 // Run .env again if it exists in a parent dir
                 if (this_bundler.options.production) {
-                    this_bundler.env.load(&this_bundler.fs.fs, dir, false) catch {};
+                    this_bundler.env.load(&this_bundler.fs.fs, dir, .production) catch {};
                 } else {
-                    this_bundler.env.load(&this_bundler.fs.fs, dir, true) catch {};
+                    this_bundler.env.load(&this_bundler.fs.fs, dir, .development) catch {};
                 }
             }
         }

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -453,9 +453,9 @@ pub const TestCommand = struct {
         );
         vm.argv = ctx.passthrough;
         vm.preload = ctx.preloads;
+        vm.bundler.options.rewrite_jest_for_tests = true;
 
         try vm.bundler.configureDefines();
-        vm.bundler.options.rewrite_jest_for_tests = true;
 
         vm.loadExtraEnv();
         vm.is_main_thread = true;
@@ -466,9 +466,11 @@ pub const TestCommand = struct {
         var TZ_NAME: string =
             // We use the string "Etc/UTC" instead of "UTC" so there is no normalization difference.
             "Etc/UTC";
+
         if (vm.bundler.env.get("TZ")) |tz| {
             TZ_NAME = tz;
         }
+
         if (TZ_NAME.len > 0) {
             _ = vm.global.setTimeZone(&JSC.ZigString.init(TZ_NAME));
         }

--- a/src/defines.zig
+++ b/src/defines.zig
@@ -152,6 +152,7 @@ pub const DefineData = struct {
 
             user_defines.putAssumeCapacity(entry.key_ptr.*, DefineData{
                 .value = data,
+                .can_be_removed_if_unused = @as(js_ast.Expr.Tag, data).isPrimitiveLiteral(),
             });
         }
     }

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -803,13 +803,13 @@ pub const Loader = struct {
 
     pub fn printLoaded(this: *Loader, start: i128) void {
         const count =
+            @intCast(u8, @boolToInt(this.@".env.development.local" != null)) +
+            @intCast(u8, @boolToInt(this.@".env.production.local" != null)) +
+            @intCast(u8, @boolToInt(this.@".env.test.local" != null)) +
             @intCast(u8, @boolToInt(this.@".env.local" != null)) +
             @intCast(u8, @boolToInt(this.@".env.development" != null)) +
             @intCast(u8, @boolToInt(this.@".env.production" != null)) +
             @intCast(u8, @boolToInt(this.@".env.test" != null)) +
-            @intCast(u8, @boolToInt(this.@".env.test.local" != null)) +
-            @intCast(u8, @boolToInt(this.@".env.development.local" != null)) +
-            @intCast(u8, @boolToInt(this.@".env.production.local" != null)) +
             @intCast(u8, @boolToInt(this.@".env" != null));
 
         if (count == 0) return;
@@ -826,13 +826,13 @@ pub const Loader = struct {
             ".env",
         };
         const loaded = [_]bool{
+            this.@".env.development.local" != null,
+            this.@".env.production.local" != null,
+            this.@".env.test.local" != null,
             this.@".env.local" != null,
             this.@".env.development" != null,
             this.@".env.production" != null,
             this.@".env.test" != null,
-            this.@".env.development.local" != null,
-            this.@".env.production.local" != null,
-            this.@".env.test.local" != null,
             this.@".env" != null,
         };
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5086,7 +5086,7 @@ pub const PackageManager = struct {
         };
 
         env.loadProcess();
-        try env.load(&fs.fs, entries_option.entries, false);
+        try env.load(&fs.fs, entries_option.entries, .production);
 
         if (env.map.get("BUN_INSTALL_VERBOSE") != null) {
             PackageManager.verbose_install = true;

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -918,7 +918,7 @@ pub const Printer = struct {
         };
 
         env_loader.loadProcess();
-        try env_loader.load(&fs.fs, entries_option.entries, false);
+        try env_loader.load(&fs.fs, entries_option.entries, .production);
         var log = logger.Log.init(allocator);
         try options.load(
             allocator,

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -19497,13 +19497,9 @@ fn NewParser_(
                             return false;
                         }
 
-                        return
-                        // TODO: figure out why this is needed when bundling
-                        // The problem is all the top-level vars are getting removed when they're not actually side effect free
-                        !p.source.index.isRuntime() and
-                            // when there's actually no symbol by that name, we return Ref.None
-                            // If a symbol had already existed by that name, we return .unbound
-                            (result.ref.isNull() or p.symbols.items[result.ref.innerIndex()].kind == .unbound);
+                        // when there's actually no symbol by that name, we return Ref.None
+                        // If a symbol had already existed by that name, we return .unbound
+                        return (result.ref.isNull() or p.symbols.items[result.ref.innerIndex()].kind == .unbound);
                     }
                 },
                 else => {},

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from "bun:test";
+import os from "os";
+import fs from "fs";
+import path from "path";
+import { bunEnv, bunExe } from "harness";
+
+function tempDirWithFiles(basename: string, files: Record<string, string>) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), basename + "_"));
+  for (const [name, contents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), contents);
+  }
+  return dir;
+}
+
+function bunRun(file: string, env?: Record<string, string>) {
+  const result = Bun.spawnSync([bunExe(), file], {
+    cwd: path.dirname(file),
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+      ...env,
+    },
+  });
+  if (!result.success) throw new Error(result.stderr.toString("utf8"));
+  return {
+    stdout: result.stdout.toString("utf8").trim(),
+    stderr: result.stderr.toString("utf8").trim(),
+  };
+}
+function bunTest(file: string, env?: Record<string, string>) {
+  const result = Bun.spawnSync([bunExe(), "test", path.basename(file)], {
+    cwd: path.dirname(file),
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+      ...env,
+    },
+  });
+  if (!result.success) throw new Error(result.stderr.toString("utf8"));
+  return {
+    stdout: result.stdout.toString("utf8").trim(),
+    stderr: result.stderr.toString("utf8").trim(),
+  };
+}
+
+describe(".env file is loaded", () => {
+  test(".env", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FOO=bar\n",
+      "index.ts": "console.log(process.env.FOO);",
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("bar");
+  });
+  test(".env.local", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FOO=fail\nBAR=baz\n",
+      ".env.local": "FOO=bar\n",
+      "index.ts": "console.log(process.env.FOO, process.env.BAR);",
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("bar baz");
+  });
+  test(".env.development (NODE_ENV=undefined)", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FOO=fail\nBAR=baz\n",
+      ".env.development": "FOO=bar\n",
+      ".env.local": "LOCAL=true\n",
+      "index.ts": "console.log(process.env.FOO, process.env.BAR, process.env.LOCAL);",
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("bar baz true");
+  });
+  test(".env.development (NODE_ENV=development)", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FOO=fail\nBAR=baz\n",
+      ".env.development": "FOO=bar\n",
+      ".env.local": "LOCAL=true\n",
+      "index.ts": "console.log(process.env.FOO, process.env.BAR, process.env.LOCAL);",
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("bar baz true");
+  });
+  test(".env.production", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FOO=fail\nBAR=baz\n",
+      ".env.production": "FOO=bar\n",
+      ".env.local": "LOCAL=true\n",
+      "index.ts": "console.log(process.env.FOO, process.env.BAR, process.env.LOCAL);",
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`, { NODE_ENV: "production" });
+    expect(stdout).toBe("bar baz true");
+  });
+  test(".env.development and .env.test ignored when NODE_ENV=production", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FOO=bar\nBAR=baz\n",
+      ".env.development": "FOO=development\n",
+      ".env.development.local": "FOO=development.local\n",
+      ".env.test": "FOO=test\n",
+      ".env.test.local": "FOO=test.local\n",
+      ".env.local": "LOCAL=true\n",
+      "index.ts": "console.log(process.env.FOO, process.env.BAR, process.env.LOCAL);",
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`, { NODE_ENV: "production" });
+    expect(stdout).toBe("bar baz true");
+  });
+  test(".env.production and .env.test ignored when NODE_ENV=development", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FOO=bar\nBAR=baz\n",
+      ".env.production": "FOO=production\n",
+      ".env.production.local": "FOO=production.local\n",
+      ".env.test": "FOO=test\n",
+      ".env.test.local": "FOO=test.local\n",
+      ".env.local": "LOCAL=true\n",
+      "index.ts": "console.log(process.env.FOO, process.env.BAR, process.env.LOCAL);",
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`, {});
+    expect(stdout).toBe("bar baz true");
+  });
+  test(".env and .env.test used in testing", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "A=a\n",
+      ".env.test.local": "B=b\n",
+      ".env.test": "C=c\n",
+      ".env.development": "FAIL=.env.development\n",
+      ".env.development.local": "FAIL=.env.development.local\n",
+      ".env.production": "FAIL=.env.production\n",
+      ".env.production.local": "FAIL=.env.production.local\n",
+      "index.test.ts": "console.log(process.env.A,process.env.B,process.env.C,process.env.FAIL);",
+    });
+    const { stdout } = bunTest(`${dir}/index.test.ts`, {});
+    expect(stdout).toBe("a b c undefined");
+  });
+  test(".env.local ignored when bun test", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FAILED=false\n",
+      ".env.local": "FAILED=true\n",
+      "index.test.ts": "console.log(process.env.FAILED, process.env.NODE_ENV);",
+    });
+    const { stdout } = bunTest(`${dir}/index.test.ts`, {});
+    expect(stdout).toBe("false test");
+  });
+  test(".env.development and .env.production ignored when bun test", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FAILED=false\n",
+      ".env.development": "FAILED=development\n",
+      ".env.development.local": "FAILED=development.local\n",
+      ".env.production": "FAILED=production\n",
+      ".env.production.local": "FAILED=production.local\n",
+      "index.test.ts": "console.log(process.env.FAILED, process.env.NODE_ENV);",
+    });
+    const { stdout } = bunTest(`${dir}/index.test.ts`);
+    expect(stdout).toBe("false test");
+  });
+});
+describe("dotenv priority", () => {
+  test("process env overrides everything else", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FOO=.env\n",
+      ".env.development": "FOO=.env.development\n",
+      ".env.development.local": "FOO=.env.development.local\n",
+      ".env.production": "FOO=.env.production\n",
+      ".env.production.local": "FOO=.env.production.local\n",
+      ".env.test.local": "FOO=.env.test.local\n",
+      ".env.test": "FOO=.env.test\n",
+      ".env.local": "FOO=.env.local\n",
+      "index.ts": "console.log(process.env.FOO);",
+      "index.test.ts": "console.log(process.env.FOO);",
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`, { FOO: "override" });
+    expect(stdout).toBe("override");
+
+    const { stdout: stdout2 } = bunTest(`${dir}/index.test.ts`, { FOO: "override" });
+    expect(stdout2).toBe("override");
+  });
+  test(".env.{NODE_ENV}.local overrides .env.local", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FOO=.env\n",
+      ".env.development": "FOO=.env.development\n",
+      ".env.development.local": "FOO=.env.development.local\n",
+      ".env.production": "FOO=.env.production\n",
+      ".env.production.local": "FOO=.env.production.local\n",
+      ".env.test.local": "FOO=.env.test.local\n",
+      ".env.test": "FOO=.env.test\n",
+      ".env.local": "FOO=.env.local\n",
+      "index.ts": "console.log(process.env.FOO);",
+      "index.test.ts": "console.log(process.env.FOO);",
+    });
+    const { stdout: stdout_dev } = bunRun(`${dir}/index.ts`, { NODE_ENV: "development" });
+    expect(stdout_dev).toBe(".env.development.local");
+    const { stdout: stdout_prod } = bunRun(`${dir}/index.ts`, { NODE_ENV: "production" });
+    expect(stdout_prod).toBe(".env.production.local");
+    const { stdout: stdout_test } = bunTest(`${dir}/index.test.ts`, {});
+    expect(stdout_test).toBe(".env.test.local");
+  });
+  test(".env.local overrides .env.{NODE_ENV}", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FOO=.env\n",
+      ".env.development": "FOO=.env.development\n",
+      ".env.production": "FOO=.env.production\n",
+      ".env.test": "FOO=.env.test\n",
+      ".env.local": "FOO=.env.local\n",
+      "index.ts": "console.log(process.env.FOO);",
+      "index.test.ts": "console.log(process.env.FOO);",
+    });
+    const { stdout: stdout_dev } = bunRun(`${dir}/index.ts`, { NODE_ENV: "development" });
+    expect(stdout_dev).toBe(".env.local");
+    const { stdout: stdout_prod } = bunRun(`${dir}/index.ts`, { NODE_ENV: "production" });
+    expect(stdout_prod).toBe(".env.local");
+    // .env.local is "not checked when `NODE_ENV` is `test`"
+    const { stdout: stdout_test } = bunTest(`${dir}/index.test.ts`, {});
+    expect(stdout_test).toBe(".env.test");
+  });
+  test(".env.{NODE_ENV} overrides .env", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "FOO=.env\n",
+      ".env.development": "FOO=.env.development\n",
+      ".env.production": "FOO=.env.production\n",
+      ".env.test": "FOO=.env.test\n",
+      "index.ts": "console.log(process.env.FOO);",
+      "index.test.ts": "console.log(process.env.FOO);",
+    });
+    const { stdout: stdout_dev } = bunRun(`${dir}/index.ts`, { NODE_ENV: "development" });
+    expect(stdout_dev).toBe(".env.development");
+    const { stdout: stdout_prod } = bunRun(`${dir}/index.ts`, { NODE_ENV: "production" });
+    expect(stdout_prod).toBe(".env.production");
+    const { stdout: stdout_test } = bunTest(`${dir}/index.test.ts`, {});
+    expect(stdout_test).toBe(".env.test");
+  });
+});
+
+test.todo(".env space edgecase (issue #411)", () => {
+  const dir = tempDirWithFiles("dotenv-issue-411", {
+    ".env": "VARNAME=A B",
+    "index.ts": "console.log('[' + process.env.VARNAME + ']'); ",
+  });
+  const { stdout } = bunRun(`${dir}/index.ts`);
+  expect(stdout).toBe("[A B]");
+});
+
+test.todo(".env special characters 1 (issue #2823)", () => {
+  const dir = tempDirWithFiles("dotenv-issue-411", {
+    ".env": 'A="a$t"\n',
+    "index.ts": "console.log('[' + process.env.A + ']'); ",
+  });
+  const { stdout } = bunRun(`${dir}/index.ts`);
+  expect(stdout).toBe("[a$t]");
+});
+
+test.todo("env escaped quote (issue #2484)", () => {
+  const dir = tempDirWithFiles("dotenv-issue-411", {
+    "index.ts": "console.log(process.env.VALUE, process.env.VALUE2);",
+  });
+  const { stdout } = bunRun(`${dir}/index.ts`, { VALUE: `\\"`, VALUE2: `\\\\"` });
+  expect(stdout).toBe('\\" \\\\"');
+});


### PR DESCRIPTION
This also reintroduces accidentally removed process.env.NODE_ENV inlining by default in v0.6

```js
import { test } from "bun:test";

test("load .env", () => {
  console.log((process.env.NODE_ENV = "production") === process.env.NODE_ENV);
});
```

That means the following will log `false`.

While `process.env.NODE_ENV` is updated at runtime to `"production"`, at build time, `process.env.NODE_ENV` when not being assigned or deleted is inlined into the string literal `"test"`. This can be changed by explicitly passing the `NODE_ENV` variable. 