### PR TITLE
Implement `bun test --timeout`

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -35,8 +35,6 @@ const getAllocator = @import("../base.zig").getAllocator;
 const JSPrivateDataPtr = @import("../base.zig").JSPrivateDataPtr;
 const GetJSPrivateData = @import("../base.zig").GetJSPrivateData;
 
-const default_timeout = std.time.ms_per_min * 5;
-
 const ZigString = JSC.ZigString;
 const JSInternalPromise = JSC.JSInternalPromise;
 const JSPromise = JSC.JSPromise;
@@ -360,8 +358,6 @@ pub const TestRunner = struct {
     only: bool = false,
     last_file: u64 = 0,
 
-    timeout_seconds: f64 = 5.0,
-
     allocator: std.mem.Allocator,
     callback: *Callback = undefined,
 
@@ -376,6 +372,7 @@ pub const TestRunner = struct {
 
     snapshots: Snapshots,
 
+    default_timeout_ms: u32 = 0,
     test_timeout_timer: ?*bun.uws.Timer = null,
     last_test_timeout_timer_duration: u32 = 0,
     active_test_for_timeout: ?TestRunner.Test.ID = null,
@@ -3243,7 +3240,7 @@ pub const TestScope = struct {
     skipped: bool = false,
     is_todo: bool = false,
     snapshot_count: usize = 0,
-    timeout_millis: u32 = default_timeout,
+    timeout_millis: u32 = 0,
 
     pub const Class = NewClass(
         void,
@@ -3382,7 +3379,7 @@ pub const TestScope = struct {
             .label = label,
             .callback = function.asObjectRef(),
             .parent = DescribeScope.active,
-            .timeout_millis = if (arguments.len > 2) @intCast(u32, @max(args[2].coerce(i32, ctx), 0)) else default_timeout,
+            .timeout_millis = if (arguments.len > 2) @intCast(u32, @max(args[2].coerce(i32, ctx), 0)) else Jest.runner.?.default_timeout_ms,
         }) catch unreachable;
 
         if (test_elapsed_timer == null) create_tiemr: {

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -414,6 +414,7 @@ pub const TestCommand = struct {
                 .allocator = ctx.allocator,
                 .log = ctx.log,
                 .callback = undefined,
+                .default_timeout_ms = ctx.test_options.default_timeout_ms,
                 .snapshots = Snapshots{
                     .allocator = ctx.allocator,
                     .update_snapshots = ctx.test_options.update_snapshots,

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,0 +1,66 @@
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { spawnSync } from "bun";
+import { describe, test, expect } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+describe("bun test", () => {
+  describe("--timeout", () => {
+    test("must provide a number timeout", () => {
+      const stderr = runTest({
+        args: ["--timeout", "foo"],
+      });
+      expect(stderr).toContain("Invalid timeout");
+    });
+    test("must provide non-negative timeout", () => {
+      const stderr = runTest({
+        args: ["--timeout", "-1"],
+      });
+      expect(stderr).toContain("Invalid timeout");
+    });
+    test("timeout can be set to 1ms", () => {
+      const stderr = runTest({
+        args: ["--timeout", "1"],
+        code: `
+          import { test, expect } from "bun:test";
+          import { sleep } from "bun";
+          test("timeout", async () => {
+            await sleep(2);
+          });
+        `,
+      });
+      expect(stderr).toContain("timed out after 1ms");
+    });
+    test("timeout should default to 5000ms", () => {
+      const stderr = runTest({
+        code: `
+          import { test, expect } from "bun:test";
+          import { sleep } from "bun";
+          test("timeout", async () => {
+            await sleep(5001);
+          });
+        `,
+      });
+      expect(stderr).toContain("timed out after 5000ms");
+    });
+  });
+});
+
+function runTest({ code = "", args = [] }: { code?: string; args?: string[] }): string {
+  const dir = mkdtempSync(join(tmpdir(), "bun-test-"));
+  const path = join(dir, `bun-test-${Date.now()}.test.ts`);
+  writeFileSync(path, code);
+  try {
+    const { stderr } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "test", path, ...args],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "ignore",
+    });
+    return stderr.toString();
+  } finally {
+    rmSync(path);
+  }
+}


### PR DESCRIPTION
You can now change the default per-test timeout in `bun test` with the `--timeout` flag.

```sh
bun test --timeout 10
```
```
Timeout: test "test" timed out after 10ms
✗ test [18.24ms]
```

However, this does not change the timeout when `test(fn, timeout)` is used, such as:
```ts
import { test } from "bun:test";
import { sleep } from "bun";

test("test", async () => {
  await sleep(10);
}, 5);
``` 