### PR TITLE
Implement `require.cache`

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -250,6 +250,8 @@ public:
     Structure* requireResolveFunctionStructure() { return m_requireResolveFunctionStructure.getInitializedOnMainThread(this); }
     JSObject* requireResolveFunctionPrototype() { return m_resolveFunctionPrototype.getInitializedOnMainThread(this); }
 
+    JSObject* lazyRequireCacheObject() { return m_lazyRequireCacheObject.getInitializedOnMainThread(this); }
+
     JSFunction* bunSleepThenCallback() { return m_bunSleepThenCallback.getInitializedOnMainThread(this); }
 
     JSObject* dnsObject() { return m_dnsObject.getInitializedOnMainThread(this); }
@@ -466,6 +468,7 @@ private:
     LazyProperty<JSGlobalObject, JSObject> m_resolveFunctionPrototype;
     LazyProperty<JSGlobalObject, JSObject> m_dnsObject;
     LazyProperty<JSGlobalObject, JSWeakMap> m_vmModuleContextMap;
+    LazyProperty<JSGlobalObject, JSObject> m_lazyRequireCacheObject;
 
     LazyProperty<JSGlobalObject, JSFunction> m_bunSleepThenCallback;
     LazyProperty<JSGlobalObject, Structure> m_cachedGlobalObjectStructure;

--- a/src/bun.js/builtins/WebCoreJSBuiltins.cpp
+++ b/src/bun.js/builtins/WebCoreJSBuiltins.cpp
@@ -2208,6 +2208,14 @@ const int s_importMetaObjectInternalRequireCodeLength = 569;
 static const JSC::Intrinsic s_importMetaObjectInternalRequireCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_importMetaObjectInternalRequireCode = "(function (n){\"use strict\";var _=@requireMap.@get(n);const i=n.substring(n.length-5);if(_){if(i===\".node\")return _.exports;return _}if(i===\".json\"){var S=globalThis[Symbol.for(\"_fs\")]||=@Bun.fs(),F=JSON.parse(S.readFileSync(n,\"utf8\"));return @requireMap.@set(n,F),F}else if(i===\".node\"){var b={exports:{}};return process.dlopen(b,n),@requireMap.@set(n,b),b.exports}else if(i===\".toml\"){var S=globalThis[Symbol.for(\"_fs\")]||=@Bun.fs(),F=@Bun.TOML.parse(S.readFileSync(n,\"utf8\"));return @requireMap.@set(n,F),F}else{var F=@requireESM(n);return @requireMap.@set(n,F),F}})\n";
 
+// createRequireCache
+const JSC::ConstructAbility s_importMetaObjectCreateRequireCacheCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_importMetaObjectCreateRequireCacheCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_importMetaObjectCreateRequireCacheCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_importMetaObjectCreateRequireCacheCodeLength = 888;
+static const JSC::Intrinsic s_importMetaObjectCreateRequireCacheCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_importMetaObjectCreateRequireCacheCode = "(function (){\"use strict\";class r{id;parent;filename;children=[];paths=[];constructor(_){this.id=_;const c=_.lastIndexOf(\"/\");if(c!==-1&&_.length>c+1)this.filename=_.substring(c+1);else this.filename=_}get loaded(){return!0}require(_){return @internalRequire(@resolveSync(_,this.id))}get exports(){return @requireMap.@get(this.id)\?\?{}}set exports(_){@requireMap.@set(this.id,_)}}var w=new Map;return new Proxy({},{get(_,c){if(@requireMap.@get(c)){var b=w.@get(c);if(!b)b=new r(c),w.@set(c,b);return b}},set(_,c,t){if(!w.@has(c))w.@set(c,new r(c));return @requireMap.@set(c,t\?.exports),!0},has(_,c){return @requireMap.@has(c)},deleteProperty(_,c){return w.@delete(c),@requireMap.@delete(c),@Loader.registry.@delete(c)},ownKeys(_){return[...@requireMap.@keys()]},getPrototypeOf(_){return null},getOwnPropertyDescriptor(_,c){if(@requireMap.@has(c))return{configurable:!0,enumerable:!0}}})})\n";
+
 // require
 const JSC::ConstructAbility s_importMetaObjectRequireCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_importMetaObjectRequireCodeConstructorKind = JSC::ConstructorKind::None;

--- a/src/bun.js/builtins/WebCoreJSBuiltins.h
+++ b/src/bun.js/builtins/WebCoreJSBuiltins.h
@@ -3964,6 +3964,14 @@ extern const JSC::ConstructAbility s_importMetaObjectInternalRequireCodeConstruc
 extern const JSC::ConstructorKind s_importMetaObjectInternalRequireCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_importMetaObjectInternalRequireCodeImplementationVisibility;
 
+// createRequireCache
+#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_CREATEREQUIRECACHE 1
+extern const char* const s_importMetaObjectCreateRequireCacheCode;
+extern const int s_importMetaObjectCreateRequireCacheCodeLength;
+extern const JSC::ConstructAbility s_importMetaObjectCreateRequireCacheCodeConstructAbility;
+extern const JSC::ConstructorKind s_importMetaObjectCreateRequireCacheCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_importMetaObjectCreateRequireCacheCodeImplementationVisibility;
+
 // require
 #define WEBCORE_BUILTIN_IMPORTMETAOBJECT_REQUIRE 1
 extern const char* const s_importMetaObjectRequireCode;
@@ -3984,6 +3992,7 @@ extern const JSC::ImplementationVisibility s_importMetaObjectMainCodeImplementat
     macro(loadCJS2ESM, importMetaObjectLoadCJS2ESM, 1) \
     macro(requireESM, importMetaObjectRequireESM, 1) \
     macro(internalRequire, importMetaObjectInternalRequire, 1) \
+    macro(createRequireCache, importMetaObjectCreateRequireCache, 0) \
     macro(require, importMetaObjectRequire, 1) \
     macro(main, importMetaObjectMain, 0) \
 
@@ -3991,6 +4000,7 @@ extern const JSC::ImplementationVisibility s_importMetaObjectMainCodeImplementat
     macro(importMetaObjectLoadCJS2ESMCode, loadCJS2ESM, ASCIILiteral(), s_importMetaObjectLoadCJS2ESMCodeLength) \
     macro(importMetaObjectRequireESMCode, requireESM, ASCIILiteral(), s_importMetaObjectRequireESMCodeLength) \
     macro(importMetaObjectInternalRequireCode, internalRequire, ASCIILiteral(), s_importMetaObjectInternalRequireCodeLength) \
+    macro(importMetaObjectCreateRequireCacheCode, createRequireCache, ASCIILiteral(), s_importMetaObjectCreateRequireCacheCodeLength) \
     macro(importMetaObjectRequireCode, require, ASCIILiteral(), s_importMetaObjectRequireCodeLength) \
     macro(importMetaObjectMainCode, main, "get main"_s, s_importMetaObjectMainCodeLength) \
 
@@ -3998,6 +4008,7 @@ extern const JSC::ImplementationVisibility s_importMetaObjectMainCodeImplementat
     macro(loadCJS2ESM) \
     macro(requireESM) \
     macro(internalRequire) \
+    macro(createRequireCache) \
     macro(require) \
     macro(main) \
 

--- a/test/cli/run/require-cache-fixture-b.cjs
+++ b/test/cli/run/require-cache-fixture-b.cjs
@@ -1,0 +1,3 @@
+exports.foo = 123;
+exports.bar = 456;
+exports.baz = 789;

--- a/test/cli/run/require-cache-fixture.cjs
+++ b/test/cli/run/require-cache-fixture.cjs
@@ -1,0 +1,23 @@
+const foo = require("./require-cache-fixture-b.cjs");
+
+exports.foo = foo;
+
+if (require.cache[require.resolve("./require-cache-fixture-b.cjs")].exports !== exports.foo) {
+  throw new Error("exports.foo !== require.cache[require.resolve('./require-cache-fixture-b')]");
+}
+
+delete require.cache[require.resolve("./require-cache-fixture-b.cjs")];
+
+exports.bar = require("./require-cache-fixture-b.cjs");
+
+if (require.cache[require.resolve("./require-cache-fixture-b.cjs")].exports !== exports.bar) {
+  throw new Error("exports.bar !== require.cache[require.resolve('./require-cache-fixture-b')]");
+}
+
+if (require.cache[require.resolve("./require-cache-fixture-b.cjs")].exports === exports.foo) {
+  throw new Error("exports.bar === exports.foo");
+}
+
+console.log(require.cache);
+
+console.log("\n--pass--\n");

--- a/test/cli/run/require-cache.test.js
+++ b/test/cli/run/require-cache.test.js
@@ -1,0 +1,13 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+test("require.cache", () => {
+  const { stdout, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "run", join(import.meta.dir, "require-cache-fixture.cjs")],
+    env: bunEnv,
+  });
+
+  expect(stdout.toString().trim().endsWith("--pass--")).toBe(true);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
In this implementation of `require.cache`, `delete require.cache[id]` also deletes the ESM entry.

Fixes https://github.com/oven-sh/bun/issues/1530
Towards https://github.com/oven-sh/bun/issues/3043