### PR TITLE
Implement --isolate flag in `bun:test`

### DIFF
--- a/src/bun.js/bindings/ScriptExecutionContext.cpp
+++ b/src/bun.js/bindings/ScriptExecutionContext.cpp
@@ -41,7 +41,7 @@ us_socket_context_t* ScriptExecutionContext::webSocketContextSSL()
         us_bun_socket_context_options_t opts;
         memset(&opts, 0, sizeof(us_bun_socket_context_options_t));
         // adds root ca
-        opts.request_cert = true; 
+        opts.request_cert = true;
         // but do not reject unauthorized
         opts.reject_unauthorized = false;
         this->m_ssl_client_websockets_ctx = us_create_bun_socket_context(1, loop, sizeof(size_t), opts);
@@ -109,7 +109,7 @@ void ScriptExecutionContext::regenerateIdentifier()
     Locker locker { allScriptExecutionContextsMapLock };
 
     ASSERT(allScriptExecutionContextsMap().contains(m_identifier));
-    allScriptExecutionContextsMap().remove(m_identifier);
+    // allScriptExecutionContextsMap().remove(m_identifier);
 
     m_identifier = ++lastUniqueIdentifier;
 
@@ -121,14 +121,14 @@ void ScriptExecutionContext::addToContextsMap()
 {
     Locker locker { allScriptExecutionContextsMapLock };
     ASSERT(!allScriptExecutionContextsMap().contains(m_identifier));
-    allScriptExecutionContextsMap().add(m_identifier, this);
+    // allScriptExecutionContextsMap().add(m_identifier, this);
 }
 
 void ScriptExecutionContext::removeFromContextsMap()
 {
     Locker locker { allScriptExecutionContextsMapLock };
     ASSERT(allScriptExecutionContextsMap().contains(m_identifier));
-    allScriptExecutionContextsMap().remove(m_identifier);
+    // allScriptExecutionContextsMap().remove(m_identifier);
 }
 
 }

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -376,6 +376,7 @@ pub const TestRunner = struct {
     test_timeout_timer: ?*bun.uws.Timer = null,
     last_test_timeout_timer_duration: u32 = 0,
     active_test_for_timeout: ?TestRunner.Test.ID = null,
+    isolate: bool = false,
 
     global_callbacks: struct {
         beforeAll: std.ArrayListUnmanaged(JSC.JSValue) = .{},

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -211,6 +211,7 @@ pub const Arguments = struct {
 
     // TODO: update test completions
     const test_only_params = [_]ParamType{
+        clap.parseParam("--isolate                        Create a new global for each test file") catch unreachable,
         clap.parseParam("--timeout <NUMBER>               Set the per-test timeout in milliseconds, default is 5000.") catch unreachable,
         clap.parseParam("--update-snapshots               Update snapshot files") catch unreachable,
         clap.parseParam("--rerun-each <NUMBER>            Re-run each test file <NUMBER> times, helps catch certain bugs") catch unreachable,
@@ -380,6 +381,8 @@ pub const Arguments = struct {
                     };
                 }
             }
+
+            ctx.test_options.isolate = args.flag("--isolate");
             ctx.test_options.update_snapshots = args.flag("--update-snapshots");
             if (args.option("--rerun-each")) |repeat_count| {
                 if (repeat_count.len > 0) {
@@ -916,6 +919,7 @@ pub const Command = struct {
         default_timeout_ms: u32 = 5 * std.time.ms_per_s,
         update_snapshots: bool = false,
         repeat_count: u32 = 0,
+        isolate: bool = false,
     };
 
     pub const Context = struct {

--- a/test/js/bun/test/test-isolation-first-2.test.js
+++ b/test/js/bun/test/test-isolation-first-2.test.js
@@ -1,0 +1,6 @@
+import { test, expect } from "bun:test";
+
+test("Object.foo", () => {
+  expect(Object.foo).toBeUndefined();
+  Object.bar = false;
+});

--- a/test/js/bun/test/test-isolation-first.test.js
+++ b/test/js/bun/test/test-isolation-first.test.js
@@ -1,0 +1,6 @@
+import { test, expect } from "bun:test";
+
+test("Object.foo", () => {
+  Object.foo = true;
+  expect(Object.bar).toBeUndefined();
+});


### PR DESCRIPTION
While it technically works, this is marked as a draft PR because a good amount of work needs to be done before this PR can meet our performance expectations.

In it's current form, this is a 26x slowdown to bun:test, but there're many obvious things to do to address that.

Let's start with a profile:

<img width="1560" alt="image" src="https://github.com/oven-sh/bun/assets/709451/4d98159a-ec47-4e64-9547-35878cace387">

<img width="1819" alt="image" src="https://github.com/oven-sh/bun/assets/709451/6fecad83-1983-4404-b9ad-02e199ca1b41">


We can see that a good chunk of this is in first Bun's JS Parser and 2nd JSC's JS parser. Parsing twice. The obvious thing.

We could cache the transpiled source code, but that means JSC will still parse the same code repeatedly.

Can we avoid parsing entirely after the first time?

If we look in JSC, we can see there is a [`getUnlinkedGlobalCodeBlock`](https://github.com/oven-sh/WebKit/blob/b2f1006a06f81bc860c89dd4c7cec3e7117c4c4c/Source/JavaScriptCore/runtime/CodeCache.h#L236
) which looks similar to what we want. But, WebKit/Safari does not use it because [it did not yield a performance improvement](https://bugs.webkit.org/show_bug.cgi?id=194047) due to what sounds like serialization overhead. Fortunately in our case, we won't be serializing since this is in memory.

Even with that [`UnlinkedModuleProgramCodeBlock`](https://github.com/oven-sh/WebKit/blob/autobuild-b2f1006a06f81bc860c89dd4c7cec3e7117c4c4c/Source/JavaScriptCore/bytecode/CodeBlock.cpp#L358-L367), we'd still need to go through [`JSModuleRecord::link`](https://github.com/oven-sh/WebKit/blob/autobuild-b2f1006a06f81bc860c89dd4c7cec3e7117c4c4c/Source/JavaScriptCore/runtime/JSModuleRecord.cpp#L90-L100) which involves [many promises](https://github.com/oven-sh/WebKit/blob/autobuild-b2f1006a06f81bc860c89dd4c7cec3e7117c4c4c/Source/JavaScriptCore/builtins/ModuleLoader.js#L194-L225) for code which had already loaded in memory before...is there a way to skip all that? I don't know yet.




