### PR TITLE
Implement process.env.npm_lifecycle_event

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -960,6 +960,7 @@ pub const RunCommand = struct {
         var ORIGINAL_PATH: string = "";
         var this_bundler: bundler.Bundler = undefined;
         var root_dir_info = try configureEnvForRun(ctx, &this_bundler, null, &ORIGINAL_PATH, log_errors, force_using_bun);
+        this_bundler.env.map.putDefault("npm_lifecycle_event", script_name_to_search) catch unreachable;
         if (root_dir_info.enclosing_package_json) |package_json| {
             if (package_json.scripts) |scripts| {
                 switch (script_name_to_search.len) {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1,47 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import os from "os";
-import fs from "fs";
-import path from "path";
-import { bunEnv, bunExe } from "harness";
-
-export function tempDirWithFiles(basename: string, files: Record<string, string>) {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), basename + "_"));
-  for (const [name, contents] of Object.entries(files)) {
-    fs.writeFileSync(path.join(dir, name), contents);
-  }
-  return dir;
-}
-
-function bunRun(file: string, env?: Record<string, string>) {
-  const result = Bun.spawnSync([bunExe(), file], {
-    cwd: path.dirname(file),
-    env: {
-      ...bunEnv,
-      NODE_ENV: undefined,
-      ...env,
-    },
-  });
-  if (!result.success) throw new Error(result.stderr.toString("utf8"));
-  return {
-    stdout: result.stdout.toString("utf8").trim(),
-    stderr: result.stderr.toString("utf8").trim(),
-  };
-}
-function bunTest(file: string, env?: Record<string, string>) {
-  const result = Bun.spawnSync([bunExe(), "test", path.basename(file)], {
-    cwd: path.dirname(file),
-    env: {
-      ...bunEnv,
-      NODE_ENV: undefined,
-      ...env,
-    },
-  });
-  if (!result.success) throw new Error(result.stderr.toString("utf8"));
-  return {
-    stdout: result.stdout.toString("utf8").trim(),
-    stderr: result.stderr.toString("utf8").trim(),
-  };
-}
+import { bunRun, bunTest, tempDirWithFiles } from "harness";
 
 describe(".env file is loaded", () => {
   test(".env", () => {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 import { bunEnv, bunExe } from "harness";
 
-function tempDirWithFiles(basename: string, files: Record<string, string>) {
+export function tempDirWithFiles(basename: string, files: Record<string, string>) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), basename + "_"));
   for (const [name, contents] of Object.entries(files)) {
     fs.writeFileSync(path.join(dir, name), contents);

--- a/test/cli/run/run-process-env.test.ts
+++ b/test/cli/run/run-process-env.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { tempDirWithFiles } from "./env.test";
+import { bunEnv, bunExe } from "harness";
+
+function bunRunAsScript(dir: string, script: string, env?: Record<string, string>) {
+    const result = Bun.spawnSync([bunExe(), `run`, `${script}`], {
+      cwd: dir,
+      env: {
+        ...bunEnv,
+        NODE_ENV: undefined,
+        ...env,
+      },
+    });
+
+    if (!result.success)
+        throw new Error(result.stderr.toString("utf8"));
+
+    return {
+      stdout: result.stdout.toString("utf8").trim(),
+      stderr: result.stderr.toString("utf8").trim(),
+    };
+}
+
+describe("process.env", () => {
+  test("npm_lifecycle_event", () => {
+    const scriptName = 'start:dev';
+
+    const dir = tempDirWithFiles("processenv", {
+      "package.json": `{'scripts': {'${scriptName}': 'bun run index.ts'}}`,
+      "index.ts": "console.log(process.env.npm_lifecycle_event);",
+    });
+    
+    const { stdout } = bunRunAsScript(dir, scriptName);
+    expect(stdout).toBe(scriptName);
+  });
+});

--- a/test/cli/run/run-process-env.test.ts
+++ b/test/cli/run/run-process-env.test.ts
@@ -1,25 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDirWithFiles } from "./env.test";
-import { bunEnv, bunExe } from "harness";
-
-function bunRunAsScript(dir: string, script: string, env?: Record<string, string>) {
-    const result = Bun.spawnSync([bunExe(), `run`, `${script}`], {
-      cwd: dir,
-      env: {
-        ...bunEnv,
-        NODE_ENV: undefined,
-        ...env,
-      },
-    });
-
-    if (!result.success)
-        throw new Error(result.stderr.toString("utf8"));
-
-    return {
-      stdout: result.stdout.toString("utf8").trim(),
-      stderr: result.stderr.toString("utf8").trim(),
-    };
-}
+import { bunRunAsScript, tempDirWithFiles } from "harness";
 
 describe("process.env", () => {
   test("npm_lifecycle_event", () => {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1,5 +1,8 @@
 import { gc as bunGC, unsafe } from "bun";
 import { heapStats } from "bun:jsc";
+import path from "path";
+import fs from 'fs';
+import os from 'os';
 
 export const bunEnv: any = {
   ...process.env,
@@ -74,4 +77,63 @@ export function hideFromStackTrace(block: CallableFunction) {
     enumerable: true,
     writable: true,
   });
+}
+
+export function tempDirWithFiles(basename: string, files: Record<string, string>) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), basename + "_"));
+  for (const [name, contents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), contents);
+  }
+  return dir;
+}
+
+export function bunRun(file: string, env?: Record<string, string>) {
+  const result = Bun.spawnSync([bunExe(), file], {
+    cwd: path.dirname(file),
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+      ...env,
+    },
+  });
+  if (!result.success) throw new Error(result.stderr.toString("utf8"));
+  return {
+    stdout: result.stdout.toString("utf8").trim(),
+    stderr: result.stderr.toString("utf8").trim(),
+  };
+}
+
+export function bunTest(file: string, env?: Record<string, string>) {
+  const result = Bun.spawnSync([bunExe(), "test", path.basename(file)], {
+    cwd: path.dirname(file),
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+      ...env,
+    },
+  });
+  if (!result.success) throw new Error(result.stderr.toString("utf8"));
+  return {
+    stdout: result.stdout.toString("utf8").trim(),
+    stderr: result.stderr.toString("utf8").trim(),
+  };
+}
+
+export function bunRunAsScript(dir: string, script: string, env?: Record<string, string>) {
+  const result = Bun.spawnSync([bunExe(), `run`, `${script}`], {
+    cwd: dir,
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+      ...env,
+    },
+  });
+
+  if (!result.success)
+      throw new Error(result.stderr.toString("utf8"));
+
+  return {
+    stdout: result.stdout.toString("utf8").trim(),
+    stderr: result.stderr.toString("utf8").trim(),
+  };
 }


### PR DESCRIPTION
This PR implements process.env.npm_lifecycle_event.

npm_lifecycle_event is an environment variable provided by the the script runner runtime during the execution of scripts. When running scripts defined in a project's package.json file using the npm run command, npm_lifecycle_event stores the name of the currently executing npm lifecycle event.

For example:
// package.json
```
{
  "scripts": {
    "start:dev": "bun a.js"
  }
}
```
// a.js
`console.log(process.env.npm_lifecycle_event);`

When running a.js using `bun run start:dev` it should output "start:dev", in current version of bun it just returns undefined.

Fixes #2972 