### PR TITLE
Fixes #2356

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,10 +7,29 @@
       "name": "bun test",
       "program": "bun-debug",
       "args": ["test", "${file}"],
-      "cwd": "${workspaceFolder}",
+      "cwd": "${file}/../",
       "env": {
-        "FORCE_COLOR": "1"
+        "FORCE_COLOR": "1",
+        "BUN_DEBUG_QUIET_LOGS": "1",
+        "BUN_GARBAGE_COLLECTOR_LEVEL": "2"
       },
+      // SIGHUP must be ignored or the debugger will pause when a spawned subprocess exits.
+      "initCommands": ["process handle -p false -s false -n false SIGHUP"],
+      "console": "internalConsole"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "bun test (fast)",
+      "program": "bun-debug",
+      "args": ["test", "${file}"],
+      "cwd": "${file}/../",
+      "env": {
+        "FORCE_COLOR": "1",
+        "BUN_DEBUG_QUIET_LOGS": "1"
+      },
+      // SIGHUP must be ignored or the debugger will pause when a spawned subprocess exits.
+      "initCommands": ["process handle -p false -s false -n false SIGHUP"],
       "console": "internalConsole"
     },
     {
@@ -23,21 +42,37 @@
       "env": {
         "FORCE_COLOR": "1"
       },
-      "console": "internalConsole"
+      "console": "internalConsole",
+      // SIGHUP must be ignored or the debugger will pause when a spawned subprocess exits.
+      "initCommands": ["process handle -p false -s false -n false SIGHUP"]
     },
     {
       "type": "lldb",
       "request": "launch",
       "name": "bun test (all)",
       "program": "bun-debug",
-      "args": ["test"],
-      "cwd": "${workspaceFolder}/test",
+      "cwd": "${workspaceFolder}",
       "env": {
-        "FORCE_COLOR": "1",
-        "BUN_GARBAGE_COLLECTOR_LEVEL": "2",
+        "BUN_DEBUG_QUIET_LOGS": "1",
+        "BUN_GARBAGE_COLLECTOR_LEVEL": "2"
+      },
+      "console": "internalConsole",
+      // SIGHUP must be ignored or the debugger will pause when a spawned subprocess exits.
+      "initCommands": ["process handle -p false -s false -n false SIGHUP"]
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "bun test (all, fast)",
+      "program": "bun-debug",
+      "args": ["test"],
+      "cwd": "${workspaceFolder}",
+      "env": {
         "BUN_DEBUG_QUIET_LOGS": "1"
       },
-      "console": "internalConsole"
+      "console": "internalConsole",
+      // SIGHUP must be ignored or the debugger will pause when a spawned subprocess exits.
+      "initCommands": ["process handle -p false -s false -n false SIGHUP"]
     },
     {
       "type": "lldb",
@@ -49,7 +84,9 @@
       "env": {
         "FORCE_COLOR": "1"
       },
-      "console": "internalConsole"
+      "console": "internalConsole",
+      // SIGHUP must be ignored or the debugger will pause when a spawned subprocess exits.
+      "initCommands": ["process handle -p false -s false -n false SIGHUP"]
     },
     {
       "type": "lldb",
@@ -73,7 +110,9 @@
       "env": {
         "FORCE_COLOR": "1"
       },
-      "console": "internalConsole"
+      "console": "internalConsole",
+      // SIGHUP must be ignored or the debugger will pause when a spawned subprocess exits.
+      "initCommands": ["process handle -p false -s false -n false SIGHUP"]
     },
     {
       "type": "lldb",
@@ -98,7 +137,9 @@
       "env": {
         "FORCE_COLOR": "1"
       },
-      "console": "internalConsole"
+      "console": "internalConsole",
+      // SIGHUP must be ignored or the debugger will pause when a spawned subprocess exits.
+      "initCommands": ["process handle -p false -s false -n false SIGHUP"]
     },
     {
       "type": "lldb",
@@ -139,12 +180,14 @@
       "request": "launch",
       "name": "bun build debug",
       "program": "bun-debug",
-      "args": ["bun", "./test/fixtures/bundle/trivial/index.js"],
+      "args": ["bun", "${file}"],
       "cwd": "${workspaceFolder}",
       "console": "internalConsole",
       "env": {
         "BUN_CONFIG_MINIFY_WHITESPACE": "1"
-      }
+      },
+      // SIGHUP must be ignored or the debugger will pause when a spawned subprocess exits.
+      "initCommands": ["process handle -p false -s false -n false SIGHUP"]
     },
     {
       "type": "lldb",

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <sys/fcntl.h>
 #include <sys/stat.h>
+#include <sys/signal.h>
 
 extern "C" int32_t get_process_priority(uint32_t pid)
 {
@@ -33,4 +34,10 @@ extern "C" bool is_executable_file(const char* path)
 
     // regular file and user can execute
     return S_ISREG(st.st_mode) && (st.st_mode & S_IXUSR);
+}
+
+extern "C" void bun_ignore_sigpipe()
+{
+    // ignore SIGPIPE
+    signal(SIGPIPE, SIG_IGN);
 }

--- a/src/crash_reporter.zig
+++ b/src/crash_reporter.zig
@@ -44,17 +44,7 @@ pub fn reloadHandlers() !void {
 
     try setup_sigactions(&act);
 
-    var pipe = os.Sigaction{
-        .handler = .{ .sigaction = sigpipe_handler },
-        .mask = os.empty_sigset,
-        .flags = (os.SA.SIGINFO | os.SA.RESTART | os.SA.RESETHAND),
-    };
-
-    try os.sigaction(
-        os.SIG.PIPE,
-        &pipe,
-        null,
-    );
+    bun_ignore_sigpipe();
 }
 const os = std.os;
 pub fn start() !void {
@@ -65,17 +55,7 @@ pub fn start() !void {
     };
 
     try setup_sigactions(&act);
-    {
-        var pipe = os.Sigaction{
-            .handler = .{ .sigaction = sigpipe_handler },
-            .mask = os.empty_sigset,
-            .flags = (os.SA.SIGINFO | os.SA.RESTART | os.SA.RESETHAND),
-        };
-
-        try os.sigaction(
-            os.SIG.PIPE,
-            &pipe,
-            null,
-        );
-    }
+    bun_ignore_sigpipe();
 }
+
+extern fn bun_ignore_sigpipe() void;


### PR DESCRIPTION
This fixes a crash that can occur when using streaming files with Bun.file() from the HTTP server due to the operating system sending SIGPIPE. It seems that MSG_NOSIGNAL is not supported with `sendfile()` because it doesn't accept flags. On Linux, there is no way to set a socket option to ignore sigpipe (unlike BSDs). So we must globally ignore SIGPIPE for the entire process.

One downside is that spawned subprocesses will now pause the debugger on exit with "SIGINT". We handle this in launch.json by ignoring the SIGINT flag as part of the commands we send to LLDB. The question is if ignoring SIGPIPE globally will have any other unwanted side effects, particularly when dealing with pipes after they have disconnected.