### PR TITLE
Cleanup CommonJS changes

### DIFF
--- a/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
@@ -33,6 +33,7 @@ public:
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForRequireResolveFunction;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForBundlerPlugin;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNodeVMScript;
+    std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForCommonJSModuleRecord;
 #include "ZigGeneratedClasses+DOMClientIsoSubspaces.h"
     /* --- bun --- */
 

--- a/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
@@ -33,6 +33,8 @@ public:
     std::unique_ptr<IsoSubspace> m_subspaceForRequireResolveFunction;
     std::unique_ptr<IsoSubspace> m_subspaceForBundlerPlugin;
     std::unique_ptr<IsoSubspace> m_subspaceForNodeVMScript;
+    std::unique_ptr<IsoSubspace> m_subspaceForCommonJSModuleRecord;
+
 #include "ZigGeneratedClasses+DOMIsoSubspaces.h"
     /*-- BUN --*/
 

--- a/src/bun.js/builtins/BunBuiltinNames.h
+++ b/src/bun.js/builtins/BunBuiltinNames.h
@@ -84,6 +84,7 @@ using namespace JSC;
     macro(errno) \
     macro(errorSteps) \
     macro(execArgv) \
+    macro(exports) \
     macro(extname) \
     macro(failureKind) \
     macro(fatal) \

--- a/src/bun.js/builtins/WebCoreJSBuiltins.cpp
+++ b/src/bun.js/builtins/WebCoreJSBuiltins.cpp
@@ -2196,9 +2196,9 @@ const char* const s_importMetaObjectLoadCJS2ESMCode = "(function (_){\"use stric
 const JSC::ConstructAbility s_importMetaObjectRequireESMCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_importMetaObjectRequireESMCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_importMetaObjectRequireESMCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_importMetaObjectRequireESMCodeLength = 406;
+const int s_importMetaObjectRequireESMCodeLength = 419;
 static const JSC::Intrinsic s_importMetaObjectRequireESMCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_importMetaObjectRequireESMCode = "(function (a){\"use strict\";var _=@Loader.registry.@get(a);if(!_||!_.evaluated)_=@loadCJS2ESM(a);if(!_||!_.evaluated||!_.module)@throwTypeError(`require() failed to evaluate module \"${a}\". This is an internal consistentency error.`);var i=@Loader.getModuleNamespaceObject(_.module),u=i.default,E=u\?.[@commonJSSymbol];if(E===0||i[@commonJSSymbol]===0)return u;else if(E&&@isCallable(u))return u();return i})\n";
+const char* const s_importMetaObjectRequireESMCode = "(function (a){\"use strict\";var i=@Loader.registry.@get(a);if(!i||!i.evaluated)i=@loadCJS2ESM(a);if(!i||!i.evaluated||!i.module)@throwTypeError(`require() failed to evaluate module \"${a}\". This is an internal consistentency error.`);var u=@Loader.getModuleNamespaceObject(i.module);if(u[@commonJSSymbol]===0)return;var E=u.default,_=E\?.[@commonJSSymbol];if(_===0)return E;else if(_&&@isCallable(E))return E();return u})\n";
 
 // internalRequire
 const JSC::ConstructAbility s_importMetaObjectInternalRequireCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
@@ -2212,9 +2212,9 @@ const char* const s_importMetaObjectInternalRequireCode = "(function (n){\"use s
 const JSC::ConstructAbility s_importMetaObjectCreateRequireCacheCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_importMetaObjectCreateRequireCacheCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_importMetaObjectCreateRequireCacheCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_importMetaObjectCreateRequireCacheCodeLength = 888;
+const int s_importMetaObjectCreateRequireCacheCodeLength = 891;
 static const JSC::Intrinsic s_importMetaObjectCreateRequireCacheCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_importMetaObjectCreateRequireCacheCode = "(function (){\"use strict\";class r{id;parent;filename;children=[];paths=[];constructor(_){this.id=_;const c=_.lastIndexOf(\"/\");if(c!==-1&&_.length>c+1)this.filename=_.substring(c+1);else this.filename=_}get loaded(){return!0}require(_){return @internalRequire(@resolveSync(_,this.id))}get exports(){return @requireMap.@get(this.id)\?\?{}}set exports(_){@requireMap.@set(this.id,_)}}var w=new Map;return new Proxy({},{get(_,c){if(@requireMap.@get(c)){var b=w.@get(c);if(!b)b=new r(c),w.@set(c,b);return b}},set(_,c,t){if(!w.@has(c))w.@set(c,new r(c));return @requireMap.@set(c,t\?.exports),!0},has(_,c){return @requireMap.@has(c)},deleteProperty(_,c){return w.@delete(c),@requireMap.@delete(c),@Loader.registry.@delete(c)},ownKeys(_){return[...@requireMap.@keys()]},getPrototypeOf(_){return null},getOwnPropertyDescriptor(_,c){if(@requireMap.@has(c))return{configurable:!0,enumerable:!0}}})})\n";
+const char* const s_importMetaObjectCreateRequireCacheCode = "(function (){\"use strict\";class r{id;parent;filename;children=[];paths=[];constructor(w){this.id=w;const c=w.lastIndexOf(\"/\");if(c!==-1&&w.length>c+1)this.filename=w.substring(c+1);else this.filename=w}get loaded(){return!0}require(w){return @internalRequire(@resolveSync(w,this.id))}get exports(){return @requireMap.@get(this.id)\?\?{}}set exports(w){@requireMap.@set(this.id,w)}}var _=new Map;return new Proxy({},{get(w,c){if(@requireMap.@get(c)){var g=_.@get(c);if(!g)g=new r(c),_.@set(c,g);return g}},set(w,c,b){if(!_.@has(c))_.@set(c,new r(c));return @requireMap.@set(c,b\?.exports),!0},has(w,c){return @requireMap.@has(c)},deleteProperty(w,c){return _.@delete(c),@requireMap.@delete(c),@Loader.registry.@delete(c),!0},ownKeys(w){return[...@requireMap.@keys()]},getPrototypeOf(w){return null},getOwnPropertyDescriptor(w,c){if(@requireMap.@has(c))return{configurable:!0,enumerable:!0}}})})\n";
 
 // require
 const JSC::ConstructAbility s_importMetaObjectRequireCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -8572,6 +8572,7 @@ const LinkerContext = struct {
             .const_values = c.graph.const_values,
             .minify_whitespace = c.options.minify_whitespace,
             .minify_syntax = c.options.minify_syntax,
+            .module_type = c.options.output_format,
 
             .allocator = allocator,
             .to_esm_ref = toESMRef,

--- a/test/cli/run/require-cache-fixture.cjs
+++ b/test/cli/run/require-cache-fixture.cjs
@@ -1,3 +1,6 @@
+// So it could be run in Node.js
+const Bun = (globalThis.Bun ??= { gc() {} });
+
 const foo = require("./require-cache-fixture-b.cjs");
 
 exports.foo = foo;
@@ -6,9 +9,15 @@ if (require.cache[require.resolve("./require-cache-fixture-b.cjs")].exports !== 
   throw new Error("exports.foo !== require.cache[require.resolve('./require-cache-fixture-b')]");
 }
 
+Bun.gc(true);
+
 delete require.cache[require.resolve("./require-cache-fixture-b.cjs")];
 
+Bun.gc(true);
+
 exports.bar = require("./require-cache-fixture-b.cjs");
+
+Bun.gc(true);
 
 if (require.cache[require.resolve("./require-cache-fixture-b.cjs")].exports !== exports.bar) {
   throw new Error("exports.bar !== require.cache[require.resolve('./require-cache-fixture-b')]");

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1037,7 +1037,7 @@ describe("websocket server", () => {
     });
     expect(serverCounter).toBe(sendQueue.length);
     server.stop(true);
-  });
+  }, 10_000);
   it("can close with reason and code #2631", done => {
     let timeout: any;
     let server = Bun.serve({


### PR DESCRIPTION
- This fixes `module.exports = function() {}` which broke several packages
- This adds a `JSCommonJSModule` C++ object which overrides `put` to observe changes to `module.exports =` without JS noticing. We automatically update the internal require map whenever `module.exports =` happens. That is a different than what Node.js does, but it lets us skip re-evaluating the same modules multiple times during cyclical imports.  Importantly, `module.exports =` may update the entry in the require map **before** the module finishes executing.
- This adds a hidden `"module"` symbol onto the ESM registry entry which points back to the CommonJS module. This exists mostly for GC purposes. It seems that we need a strong reference somewhere to the CommonJS module object or else it will crash during the finalizer. By putting it in the ESM registry map, it will get cleared when the ESM registry is cleared. Since the exports object is JSC::Weak, it shouldn't cause a cycle