### PR TITLE
Support FormData & file uploads in `fetch` body

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -113,7 +113,7 @@ pub const Blob = struct {
     }
 
     pub fn hasContentTypeFromUser(this: *const Blob) bool {
-        return this.content_type_was_set;
+        return this.content_type_was_set or (this.store != null and this.store.?.data == .file);
     }
 
     const FormDataContext = struct {

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -112,6 +112,10 @@ pub const Blob = struct {
         return bun.FormData.AsyncFormData.init(this.allocator orelse bun.default_allocator, encoding) catch unreachable;
     }
 
+    pub fn hasContentTypeFromUser(this: *const Blob) bool {
+        return this.content_type_was_set;
+    }
+
     const FormDataContext = struct {
         allocator: std.mem.Allocator,
         joiner: StringJoiner,
@@ -3509,9 +3513,9 @@ pub const AnyBlob = union(enum) {
     // InlineBlob: InlineBlob,
     InternalBlob: InternalBlob,
 
-    pub fn hasContentType(this: AnyBlob) bool {
+    pub fn hasContentTypeFromUser(this: AnyBlob) bool {
         return switch (this) {
-            .Blob => this.Blob.content_type_was_set,
+            .Blob => this.Blob.hasContentTypeFromUser(),
             .InternalBlob => false,
         };
     }

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -961,6 +961,14 @@ pub const Fetch = struct {
 
         var url = ZigURL{};
         var first_arg = args.nextEat().?;
+
+        // We must always get the Body before the Headers That way, we can set
+        // the Content-Type header from the Blob if no Content-Type header is
+        // set in the Headers
+        //
+        // which is important for FormData.
+        // https://github.com/oven-sh/bun/issues/2264
+        //
         var body: AnyBlob = AnyBlob{
             .Blob = .{},
         };
@@ -988,35 +996,11 @@ pub const Fetch = struct {
                         method = request.method;
                     }
 
-                    if (options.fastGet(ctx.ptr(), .headers)) |headers_| {
-                        if (headers_.as(FetchHeaders)) |headers__| {
-                            if (headers__.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
-                                hostname = _hostname.toOwnedSliceZ(bun.default_allocator) catch unreachable;
-                            }
-                            headers = Headers.from(headers__, bun.default_allocator) catch unreachable;
-                            // TODO: make this one pass
-                        } else if (FetchHeaders.createFromJS(ctx.ptr(), headers_)) |headers__| {
-                            if (headers__.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
-                                hostname = _hostname.toOwnedSliceZ(bun.default_allocator) catch unreachable;
-                            }
-                            headers = Headers.from(headers__, bun.default_allocator) catch unreachable;
-                            headers__.deref();
-                        } else if (request.headers) |head| {
-                            if (head.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
-                                hostname = _hostname.toOwnedSliceZ(bun.default_allocator) catch unreachable;
-                            }
-                            headers = Headers.from(head, bun.default_allocator) catch unreachable;
-                        }
-                    } else if (request.headers) |head| {
-                        headers = Headers.from(head, bun.default_allocator) catch unreachable;
-                    }
-
                     if (options.fastGet(ctx.ptr(), .body)) |body__| {
                         if (Body.Value.fromJS(ctx.ptr(), body__)) |body_const| {
                             var body_value = body_const;
                             // TODO: buffer ReadableStream?
                             // we have to explicitly check for InternalBlob
-
                             body = body_value.useAsAnyBlob();
                         } else {
                             // clean hostname if any
@@ -1028,6 +1012,29 @@ pub const Fetch = struct {
                         }
                     } else {
                         body = request.body.value.useAsAnyBlob();
+                    }
+
+                    if (options.fastGet(ctx.ptr(), .headers)) |headers_| {
+                        if (headers_.as(FetchHeaders)) |headers__| {
+                            if (headers__.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
+                                hostname = _hostname.toOwnedSliceZ(bun.default_allocator) catch unreachable;
+                            }
+                            headers = Headers.from(headers__, bun.default_allocator, .{ .body = &body }) catch unreachable;
+                            // TODO: make this one pass
+                        } else if (FetchHeaders.createFromJS(ctx.ptr(), headers_)) |headers__| {
+                            if (headers__.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
+                                hostname = _hostname.toOwnedSliceZ(bun.default_allocator) catch unreachable;
+                            }
+                            headers = Headers.from(headers__, bun.default_allocator, .{ .body = &body }) catch unreachable;
+                            headers__.deref();
+                        } else if (request.headers) |head| {
+                            if (head.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
+                                hostname = _hostname.toOwnedSliceZ(bun.default_allocator) catch unreachable;
+                            }
+                            headers = Headers.from(head, bun.default_allocator, .{ .body = &body }) catch unreachable;
+                        }
+                    } else if (request.headers) |head| {
+                        headers = Headers.from(head, bun.default_allocator, .{ .body = &body }) catch unreachable;
                     }
 
                     if (options.get(ctx, "timeout")) |timeout_value| {
@@ -1100,13 +1107,13 @@ pub const Fetch = struct {
                 }
             } else {
                 method = request.method;
+                body = request.body.value.useAsAnyBlob();
                 if (request.headers) |head| {
                     if (head.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
                         hostname = _hostname.toOwnedSliceZ(bun.default_allocator) catch unreachable;
                     }
-                    headers = Headers.from(head, bun.default_allocator) catch unreachable;
+                    headers = Headers.from(head, bun.default_allocator, .{ .body = &body }) catch unreachable;
                 }
-                body = request.body.value.useAsAnyBlob();
                 // no proxy only url
                 url = ZigURL.parse(getAllocator(ctx).dupe(u8, request.url) catch unreachable);
                 url_proxy_buffer = url.href;
@@ -1124,26 +1131,6 @@ pub const Fetch = struct {
                         method = Method.which(slice_.slice()) orelse .GET;
                     }
 
-                    if (options.fastGet(ctx.ptr(), .headers)) |headers_| {
-                        if (headers_.as(FetchHeaders)) |headers__| {
-                            if (headers__.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
-                                hostname = _hostname.toOwnedSliceZ(bun.default_allocator) catch unreachable;
-                            }
-                            headers = Headers.from(headers__, bun.default_allocator) catch unreachable;
-                            // TODO: make this one pass
-                        } else if (FetchHeaders.createFromJS(ctx.ptr(), headers_)) |headers__| {
-                            defer headers__.deref();
-                            if (headers__.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
-                                hostname = _hostname.toOwnedSliceZ(bun.default_allocator) catch unreachable;
-                            }
-                            headers = Headers.from(headers__, bun.default_allocator) catch unreachable;
-                        } else {
-                            // Converting the headers failed; return null and
-                            //  let the set exception get thrown
-                            return .zero;
-                        }
-                    }
-
                     if (options.fastGet(ctx.ptr(), .body)) |body__| {
                         if (Body.Value.fromJS(ctx.ptr(), body__)) |body_const| {
                             var body_value = body_const;
@@ -1157,6 +1144,26 @@ pub const Fetch = struct {
                             }
                             // an error was thrown
                             return JSC.JSValue.jsUndefined();
+                        }
+                    }
+
+                    if (options.fastGet(ctx.ptr(), .headers)) |headers_| {
+                        if (headers_.as(FetchHeaders)) |headers__| {
+                            if (headers__.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
+                                hostname = _hostname.toOwnedSliceZ(bun.default_allocator) catch unreachable;
+                            }
+                            headers = Headers.from(headers__, bun.default_allocator, .{ .body = &body }) catch unreachable;
+                            // TODO: make this one pass
+                        } else if (FetchHeaders.createFromJS(ctx.ptr(), headers_)) |headers__| {
+                            defer headers__.deref();
+                            if (headers__.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
+                                hostname = _hostname.toOwnedSliceZ(bun.default_allocator) catch unreachable;
+                            }
+                            headers = Headers.from(headers__, bun.default_allocator, .{ .body = &body }) catch unreachable;
+                        } else {
+                            // Converting the headers failed; return null and
+                            //  let the set exception get thrown
+                            return .zero;
                         }
                     }
 
@@ -1324,6 +1331,45 @@ pub const Fetch = struct {
             return JSPromise.rejectedPromiseValue(globalThis, err);
         }
 
+        if (headers == null and body.size() > 0 and body.hasContentTypeFromUser()) {
+            headers = Headers.from(
+                null,
+                bun.default_allocator,
+                .{ .body = &body },
+            ) catch unreachable;
+        }
+
+        if (body.needsToReadFile()) {
+            // TODO: make this async + lazy
+            const res = JSC.Node.NodeFS.readFile(
+                globalThis.bunVM().nodeFS(),
+                .{
+                    .encoding = .buffer,
+                    .path = body.Blob.store.?.data.file.pathlike,
+                    .offset = body.Blob.offset,
+                    .max_size = body.Blob.size,
+                },
+                .sync,
+            );
+
+            switch (res) {
+                .err => |err| {
+                    bun.default_allocator.free(url.href);
+                    if (proxy) |prox| {
+                        bun.default_allocator.free(prox.href);
+                    }
+
+                    const rejected_value = JSPromise.rejectedPromiseValue(globalThis, err.toJSC(globalThis));
+                    body.detach();
+                    return rejected_value;
+                },
+                .result => |result| {
+                    body.detach();
+                    body.from(std.ArrayList(u8).fromOwnedSlice(bun.default_allocator, @constCast(result.slice())));
+                },
+            }
+        }
+
         // Only create this after we have validated all the input.
         // or else we will leak it
         var promise = JSPromise.Strong.init(globalThis);
@@ -1376,14 +1422,30 @@ pub const Headers = struct {
             "";
     }
 
-    pub fn from(headers_ref: *FetchHeaders, allocator: std.mem.Allocator) !Headers {
+    pub const Options = struct {
+        body: ?*const AnyBlob = null,
+    };
+
+    pub fn from(fetch_headers_ref: ?*FetchHeaders, allocator: std.mem.Allocator, options: Options) !Headers {
         var header_count: u32 = 0;
         var buf_len: u32 = 0;
-        headers_ref.count(&header_count, &buf_len);
+        if (fetch_headers_ref) |headers_ref|
+            headers_ref.count(&header_count, &buf_len);
         var headers = Headers{
             .entries = .{},
             .buf = .{},
             .allocator = allocator,
+        };
+        const buf_len_before_content_type = buf_len;
+        const needs_content_type = brk: {
+            if (options.body) |body| {
+                if (body.hasContentTypeFromUser() and (fetch_headers_ref == null or !fetch_headers_ref.?.fastHas(.ContentType))) {
+                    header_count += 1;
+                    buf_len += @truncate(u32, body.contentType().len + "Content-Type".len);
+                    break :brk true;
+                }
+            }
+            break :brk false;
         };
         headers.entries.ensureTotalCapacity(allocator, header_count) catch unreachable;
         headers.entries.len = header_count;
@@ -1392,7 +1454,24 @@ pub const Headers = struct {
         var sliced = headers.entries.slice();
         var names = sliced.items(.name);
         var values = sliced.items(.value);
-        headers_ref.copyTo(names.ptr, values.ptr, headers.buf.items.ptr);
+        if (fetch_headers_ref) |headers_ref|
+            headers_ref.copyTo(names.ptr, values.ptr, headers.buf.items.ptr);
+
+        // TODO: maybe we should send Content-Type header first instead of last?
+        if (needs_content_type) {
+            bun.copy(u8, headers.buf.items[buf_len_before_content_type..], "Content-Type");
+            names[header_count - 1] = .{
+                .offset = buf_len_before_content_type,
+                .length = "Content-Type".len,
+            };
+
+            bun.copy(u8, headers.buf.items[buf_len_before_content_type + "Content-Type".len ..], options.body.?.contentType());
+            values[header_count - 1] = .{
+                .offset = buf_len_before_content_type + @as(u32, "Content-Type".len),
+                .length = @truncate(u32, options.body.?.contentType().len),
+            };
+        }
+
         return headers;
     }
 };
@@ -1567,7 +1646,7 @@ pub const FetchEvent = struct {
         var content_length: ?usize = null;
 
         if (response.body.init.headers) |headers_ref| {
-            var headers = Headers.from(headers_ref, request_context.allocator) catch unreachable;
+            var headers = Headers.from(headers_ref, request_context.allocator, .{}) catch unreachable;
 
             var i: usize = 0;
             while (i < headers.entries.len) : (i += 1) {

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1354,13 +1354,15 @@ pub const Fetch = struct {
 
             switch (res) {
                 .err => |err| {
-                    bun.default_allocator.free(url.href);
-                    if (proxy) |prox| {
-                        bun.default_allocator.free(prox.href);
-                    }
+                    bun.default_allocator.free(url_proxy_buffer);
 
                     const rejected_value = JSPromise.rejectedPromiseValue(globalThis, err.toJSC(globalThis));
                     body.detach();
+                    if (headers) |*headers_| {
+                        headers_.buf.deinit(bun.default_allocator);
+                        headers_.entries.deinit(bun.default_allocator);
+                    }
+
                     return rejected_value;
                 },
                 .result => |result| {

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -1,0 +1,44 @@
+import { expect, test, describe } from "bun:test";
+
+test("uploads roundtrip", async () => {
+  const body = Bun.file(import.meta.dir + "/fetch.js.txt");
+  const bodyText = await body.text();
+
+  const server = Bun.serve({
+    port: 0,
+    development: false,
+    async fetch(req) {
+      const text = await req.text();
+      expect(text).toBe(bodyText);
+
+      return new Response(Bun.file(import.meta.dir + "/fetch.js.txt"));
+    },
+  });
+
+  // @ts-ignore
+  const reqBody = new Request(`http://${server.hostname}:${server.port}`, {
+    body,
+    method: "POST",
+  });
+  const res = await fetch(reqBody);
+  expect(res.status).toBe(200);
+
+  // but it does for Response
+  expect(res.headers.get("Content-Type")).toBe("text/plain;charset=utf-8");
+  const resText = await res.text();
+  expect(resText).toBe(bodyText);
+
+  server.stop(true);
+});
+
+test("missing file throws the expected error", async () => {
+  const body = Bun.file(import.meta.dir + "/fetch123123231123.js.txt");
+
+  const reqBody = new Request(`http://example.com`, {
+    body,
+    method: "POST",
+  });
+  const resp = fetch(reqBody);
+  expect(Bun.peek.status(resp)).toBe("rejected");
+  expect(async () => await resp).toThrow("No such file or directory");
+});

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1007,11 +1007,7 @@ it("request body and signal life cycle", async () => {
   }
 });
 
-// The behavior here is
-// it does on Bun.serve()
-// it does not on fetch()
-// it uploads the file
-it("doesn't infer content-type from a Bun.file()'s file path in fetch()", async () => {
+it("propagates content-type from a Bun.file()'s file path in fetch()", async () => {
   const body = Bun.file(import.meta.dir + "/fetch.js.txt");
   const bodyText = await body.text();
 
@@ -1019,7 +1015,7 @@ it("doesn't infer content-type from a Bun.file()'s file path in fetch()", async 
     port: 0,
     development: false,
     async fetch(req) {
-      expect(req.headers.get("Content-Type")).toBeNull();
+      expect(req.headers.get("Content-Type")).toBe("text/plain;charset=utf-8");
       const text = await req.text();
       expect(text).toBe(bodyText);
 


### PR DESCRIPTION
This fixes #2264 and implements a non-streaming, unoptimized version of file upload support in `fetch()`.

Upload with `Bun.file`:
```js
const body = Bun.file("img.jpg");
await fetch("https://example.com", {method: "PUT", body});
```

Upload multi-part with `FormData`:

```js
const body = new FormData();
body.append("image", Bun.file("img.jpg"));
await fetch("https://example.com", {method: "PUT", body});
```

This also fixes a hypothetical crash when many `Blob` are used with a custom `type` property 


