### PR TITLE
random fixes that help vite/sveltekit

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -282,7 +282,7 @@ declare module "bun" {
    * @returns A promise that resolves with the concatenated chunks or the concatenated chunks as an `ArrayBuffer`.
    */
   export function readableStreamToArrayBuffer(
-    stream: ReadableStream,
+    stream: ReadableStream<ArrayBuffer>,
   ): Promise<ArrayBuffer> | ArrayBuffer;
 
   /**
@@ -323,7 +323,7 @@ declare module "bun" {
    *
    */
   export function readableStreamToArray<T>(
-    stream: ReadableStream,
+    stream: ReadableStream<T>,
   ): Promise<T[]> | T[];
 
   /**

--- a/src/bun.js/builtins/WebCoreJSBuiltins.cpp
+++ b/src/bun.js/builtins/WebCoreJSBuiltins.cpp
@@ -2420,9 +2420,9 @@ const char* const s_readableStreamReadableStreamToTextCode = "(function (_){\"us
 const JSC::ConstructAbility s_readableStreamReadableStreamToArrayBufferCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_readableStreamReadableStreamToArrayBufferCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_readableStreamReadableStreamToArrayBufferCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamReadableStreamToArrayBufferCodeLength = 212;
+const int s_readableStreamReadableStreamToArrayBufferCodeLength = 271;
 static const JSC::Intrinsic s_readableStreamReadableStreamToArrayBufferCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamReadableStreamToArrayBufferCode = "(function (_){\"use strict\";var p=@getByIdDirectPrivate(_,\"underlyingSource\");if(p!==@undefined)return @readableStreamToArrayBufferDirect(_,p);return @Bun.readableStreamToArray(_).@then(@Bun.concatArrayBuffers)})\n";
+const char* const s_readableStreamReadableStreamToArrayBufferCode = "(function (_){\"use strict\";var f=@getByIdDirectPrivate(_,\"underlyingSource\");if(f!==@undefined)return @readableStreamToArrayBufferDirect(_,f);var A=@Bun.readableStreamToArray(_);if(@isPromise(A))return A.@then(@Bun.concatArrayBuffers);return @Bun.concatArrayBuffers(A)})\n";
 
 // readableStreamToJSON
 const JSC::ConstructAbility s_readableStreamReadableStreamToJSONCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;

--- a/src/bun.js/builtins/builtins.d.ts
+++ b/src/bun.js/builtins/builtins.d.ts
@@ -441,10 +441,6 @@ declare class OutOfMemoryError {
   constructor();
 }
 
-declare class ReadableStream {
-  constructor(stream: unknown, view?: unknown);
-  values(options?: unknown): AsyncIterableIterator<unknown>;
-}
 declare class ReadableStreamDefaultController {
   constructor(
     stream: unknown,

--- a/src/bun.js/builtins/ts/ReadableStream.ts
+++ b/src/bun.js/builtins/ts/ReadableStream.ts
@@ -102,7 +102,7 @@ export function initializeReadableStream(this: any, underlyingSource: Underlying
 }
 
 $linkTimeConstant;
-export function readableStreamToArray(stream) {
+export function readableStreamToArray(stream: ReadableStream): Promise<unknown[]> {
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
   if (underlyingSource !== undefined) {
@@ -113,7 +113,7 @@ export function readableStreamToArray(stream) {
 }
 
 $linkTimeConstant;
-export function readableStreamToText(stream) {
+export function readableStreamToText(stream: ReadableStream): Promise<string> {
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
   if (underlyingSource !== undefined) {
@@ -124,7 +124,7 @@ export function readableStreamToText(stream) {
 }
 
 $linkTimeConstant;
-export function readableStreamToArrayBuffer(stream) {
+export function readableStreamToArrayBuffer(stream: ReadableStream<ArrayBuffer>): Promise<ArrayBuffer> | ArrayBuffer {
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
 
@@ -132,16 +132,21 @@ export function readableStreamToArrayBuffer(stream) {
     return $readableStreamToArrayBufferDirect(stream, underlyingSource);
   }
 
-  return Promise.resolve(Bun.readableStreamToArray(stream)).$then(Bun.concatArrayBuffers);
+  var array = Bun.readableStreamToArray(stream);
+  if ($isPromise(array)) {
+    return array.$then(Bun.concatArrayBuffers);
+  }
+
+  return Bun.concatArrayBuffers(array);
 }
 
 $linkTimeConstant;
-export function readableStreamToJSON(stream) {
+export function readableStreamToJSON(stream: ReadableStream): unknown {
   return Bun.readableStreamToText(stream).$then(globalThis.JSON.parse);
 }
 
 $linkTimeConstant;
-export function readableStreamToBlob(stream) {
+export function readableStreamToBlob(stream: ReadableStream): Promise<Blob> {
   return Promise.resolve(Bun.readableStreamToArray(stream)).$then(array => new Blob(array));
 }
 

--- a/src/bun.js/builtins/ts/ReadableStreamInternals.ts
+++ b/src/bun.js/builtins/ts/ReadableStreamInternals.ts
@@ -1750,8 +1750,6 @@ export async function readableStreamToArrayDirect(stream, underlyingSource) {
     stream = undefined;
     reader = undefined;
   }
-
-  return capability.$promise;
 }
 
 export function readableStreamDefineLazyIterators(prototype) {

--- a/src/bun.js/events.exports.js
+++ b/src/bun.js/events.exports.js
@@ -22,9 +22,7 @@ function EventEmitter(opts) {
   }
 
   this._maxListeners ??= undefined;
-  if (
-    (this[kCapture] = opts?.captureRejections ? Boolean(opts?.captureRejections) : EventEmitterPrototype[kCapture])
-  ) {
+  if ((this[kCapture] = opts?.captureRejections ? Boolean(opts?.captureRejections) : EventEmitterPrototype[kCapture])) {
     this.emit = emitWithRejectionCapture;
   }
 }

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1672,7 +1672,7 @@ pub const Path = struct {
         }
     }
     fn isAbsoluteString(path: JSC.ZigString, windows: bool) bool {
-        if (!windows) return path.len > 0 and path.slice()[0] == '/';
+        if (!windows) return path.len > 0 and path.ptr[0] == '/';
 
         return isZigStringAbsoluteWindows(path);
     }

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1672,7 +1672,7 @@ pub const Path = struct {
         }
     }
     fn isAbsoluteString(path: JSC.ZigString, windows: bool) bool {
-        if (!windows) return path.len > 0 and path.ptr[0] == '/';
+        if (!windows) return path.len > 0 and path.slice()[0] == '/';
 
         return isZigStringAbsoluteWindows(path);
     }

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1149,15 +1149,13 @@ pub const Resolver = struct {
                 };
             }
 
-            // TODO: this should only load the file itself
-            if (r.loadAsFileOrDirectory(path, kind)) |entry| {
+            if (r.loadAsFile(path, r.extension_order)) |file| {
                 return .{
                     .success = Result{
-                        .dirname_fd = entry.dirname_fd,
-                        .path_pair = entry.path_pair,
-                        .diff_case = entry.diff_case,
-                        .package_json = entry.package_json,
-                        .file_fd = entry.file_fd,
+                        .dirname_fd = file.dirname_fd,
+                        .path_pair = .{ .primary = Path.init(file.path) },
+                        .diff_case = file.diff_case,
+                        .file_fd = file.file_fd,
                         .jsx = r.opts.jsx,
                     },
                 };

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1129,7 +1129,7 @@ pub const Resolver = struct {
             return .{ .not_found = {} };
         }
 
-        if (strings.startsWith(import_path, "file:///")) {
+        if (strings.hasPrefixComptime(import_path, "file:///")) {
             const path = import_path[7..];
 
             if (r.opts.external.abs_paths.count() > 0 and r.opts.external.abs_paths.contains(path)) {

--- a/test.ts
+++ b/test.ts
@@ -1,2 +1,0 @@
-console.log(1)
-

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1159,3 +1159,10 @@ it("repro 1516: can use undefined/null to specify default flag", () => {
   expect(readFileSync(path, { encoding: "utf8", flag: null })).toBe("b");
   rmSync(path);
 });
+
+it("existsSync with invalid path doesn't throw", () => {
+  expect(existsSync(null as any)).toBe(false);
+  expect(existsSync(123 as any)).toBe(false);
+  expect(existsSync(undefined as any)).toBe(false);
+  expect(existsSync({ invalid: 1 } as any)).toBe(false);
+});


### PR DESCRIPTION
**Status** — hello worlds work, but real applications including the sveltekit demo do not fully work

This PR makes progress towards #250 and #600, fixing small random bugs in places to help vite and sveltekit run within bun's runtime:

- fs: `existsSync(null)` and other invalid paths must not throw
- resolver: `import "file:///..."`
- ~~`Path.isAbsoluteString` supports utf16 strings~~
- unrelated, make `Bun.readableStreamToArrayBuffer` sync if possible.

this also (temporarily) contains changes from #2913 which I think help out vite
