### PR TITLE
fix wrapping optional chains

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -12750,7 +12750,7 @@ fn NewParser_(
 
                         // Only continue if we have started
                         if ((optional_start orelse .ccontinue) == .start) {
-                            optional_start = .ccontinue;
+                            optional_chain = .ccontinue;
                         }
                     },
                     .t_no_substitution_template_literal => {


### PR DESCRIPTION
input:
`x?.[0].a`

output before change:
`(x?.[0]).a`

output now:
`x?.[0].a`