### PR TITLE
refactor: use main repository for upgrading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := $(shell which bash) # Use bash syntax to be consistent
 
 OS_NAME := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH_NAME_RAW := $(shell uname -m)
+# TODO: remove this in upcomming next few versions
 BUN_AUTO_UPDATER_REPO = Jarred-Sumner/bun-releases-for-updater
 
 CMAKE_CXX_COMPILER_LAUNCHER_FLAG :=
@@ -942,11 +943,13 @@ bump:
 identifier-cache:
 	$(ZIG) run src/js_lexer/identifier_data.zig
 
+# TODO: remove this in upcomming next few versions
 tag:
 	git tag $(BUN_BUILD_TAG)
 	git push --tags
 	cd ../bun-releases-for-updater && echo $(BUN_BUILD_TAG) > bumper && git add bumper && git commit -m "Update latest release" && git tag $(BUN_BUILD_TAG) && git push
 
+# TODO: remove this in upcomming next few versions
 .PHONY: prepare-release
 prepare-release: tag release-create
 
@@ -955,6 +958,7 @@ release-create-auto-updater:
 .PHONY: release-create
 release-create:
 	gh release create --title "bun v$(PACKAGE_JSON_VERSION)" "$(BUN_BUILD_TAG)"
+	# TODO: remove this in upcomming next few versions
 	gh release create --repo=$(BUN_AUTO_UPDATER_REPO) --title "bun v$(PACKAGE_JSON_VERSION)" "$(BUN_BUILD_TAG)" -n "See https://github.com/oven-sh/bun/releases/tag/$(BUN_BUILD_TAG) for release notes. Using the install script or bun upgrade is the recommended way to install bun. Join bun's Discord to get access https://bun.sh/discord"
 
 release-bin-entitlements:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := $(shell which bash) # Use bash syntax to be consistent
 
 OS_NAME := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH_NAME_RAW := $(shell uname -m)
-# TODO: remove this in upcomming next versions
+# For backwards compatibility, look into https://github.com/oven-sh/bun/pull/3155 for more informations
 BUN_AUTO_UPDATER_REPO = Jarred-Sumner/bun-releases-for-updater
 
 CMAKE_CXX_COMPILER_LAUNCHER_FLAG :=
@@ -943,13 +943,13 @@ bump:
 identifier-cache:
 	$(ZIG) run src/js_lexer/identifier_data.zig
 
-# TODO: remove this in upcomming next versions
+# For backwards compatibility, look into https://github.com/oven-sh/bun/pull/3155 for more informations
 tag:
 	git tag $(BUN_BUILD_TAG)
 	git push --tags
 	cd ../bun-releases-for-updater && echo $(BUN_BUILD_TAG) > bumper && git add bumper && git commit -m "Update latest release" && git tag $(BUN_BUILD_TAG) && git push
 
-# TODO: remove this in upcomming next versions
+# For backwards compatibility, look into https://github.com/oven-sh/bun/pull/3155 for more informations
 .PHONY: prepare-release
 prepare-release: tag release-create
 
@@ -958,7 +958,7 @@ release-create-auto-updater:
 .PHONY: release-create
 release-create:
 	gh release create --title "bun v$(PACKAGE_JSON_VERSION)" "$(BUN_BUILD_TAG)"
-	# TODO: remove this in upcomming next versions
+	# For backwards compatibility, look into https://github.com/oven-sh/bun/pull/3155 for more informations
 	gh release create --repo=$(BUN_AUTO_UPDATER_REPO) --title "bun v$(PACKAGE_JSON_VERSION)" "$(BUN_BUILD_TAG)" -n "See https://github.com/oven-sh/bun/releases/tag/$(BUN_BUILD_TAG) for release notes. Using the install script or bun upgrade is the recommended way to install bun. Join bun's Discord to get access https://bun.sh/discord"
 
 release-bin-entitlements:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := $(shell which bash) # Use bash syntax to be consistent
 
 OS_NAME := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH_NAME_RAW := $(shell uname -m)
-# TODO: remove this in upcomming next few versions
+# TODO: remove this in upcomming next versions
 BUN_AUTO_UPDATER_REPO = Jarred-Sumner/bun-releases-for-updater
 
 CMAKE_CXX_COMPILER_LAUNCHER_FLAG :=
@@ -943,13 +943,13 @@ bump:
 identifier-cache:
 	$(ZIG) run src/js_lexer/identifier_data.zig
 
-# TODO: remove this in upcomming next few versions
+# TODO: remove this in upcomming next versions
 tag:
 	git tag $(BUN_BUILD_TAG)
 	git push --tags
 	cd ../bun-releases-for-updater && echo $(BUN_BUILD_TAG) > bumper && git add bumper && git commit -m "Update latest release" && git tag $(BUN_BUILD_TAG) && git push
 
-# TODO: remove this in upcomming next few versions
+# TODO: remove this in upcomming next versions
 .PHONY: prepare-release
 prepare-release: tag release-create
 
@@ -958,7 +958,7 @@ release-create-auto-updater:
 .PHONY: release-create
 release-create:
 	gh release create --title "bun v$(PACKAGE_JSON_VERSION)" "$(BUN_BUILD_TAG)"
-	# TODO: remove this in upcomming next few versions
+	# TODO: remove this in upcomming next versions
 	gh release create --repo=$(BUN_AUTO_UPDATER_REPO) --title "bun v$(PACKAGE_JSON_VERSION)" "$(BUN_BUILD_TAG)" -n "See https://github.com/oven-sh/bun/releases/tag/$(BUN_BUILD_TAG) for release notes. Using the install script or bun upgrade is the recommended way to install bun. Join bun's Discord to get access https://bun.sh/discord"
 
 release-bin-entitlements:

--- a/docs/cli/bun-upgrade.md
+++ b/docs/cli/bun-upgrade.md
@@ -2,7 +2,7 @@ To upgrade Bun, run `bun upgrade`.
 
 It automatically downloads the latest version of Bun and overwrites the currently-running version.
 
-This works by checking the latest version of Bun in [bun-releases-for-updater](https://github.com/Jarred-Sumner/bun-releases-for-updater/releases) and unzipping it using the system-provided `unzip` library (so that Gatekeeper works on macOS)
+This works by checking the latest version of Bun in [bun-releases-for-updater](https://github.com/oven-sh/bun/releases) and unzipping it using the system-provided `unzip` library (so that Gatekeeper works on macOS)
 
 If for any reason you run into issues, you can also use the curl install script:
 
@@ -14,7 +14,7 @@ It will still work when Bun is already installed.
 
 Bun is distributed as a single binary file, so you can also do this manually:
 
-- Download the latest version of Bun for your platform in [bun-releases-for-updater](https://github.com/Jarred-Sumner/bun-releases-for-updater/releases/latest) (`darwin` == macOS)
+- Download the latest version of Bun for your platform in [bun](https://github.com/oven-sh/bun/releases/latest) (`darwin` == macOS)
 - Unzip the folder
 - Move the `bun` binary to `~/.bun/bin` (or anywhere)
 

--- a/docs/cli/bun-upgrade.md
+++ b/docs/cli/bun-upgrade.md
@@ -2,7 +2,7 @@ To upgrade Bun, run `bun upgrade`.
 
 It automatically downloads the latest version of Bun and overwrites the currently-running version.
 
-This works by checking the latest version of Bun in [bun-releases-for-updater](https://github.com/oven-sh/bun/releases) and unzipping it using the system-provided `unzip` library (so that Gatekeeper works on macOS)
+This works by checking the latest release of Bun from GitHub [releases](https://github.com/oven-sh/bun/releases) and unzipping it using the system-provided `unzip` library (so that Gatekeeper works on macOS)
 
 If for any reason you run into issues, you can also use the curl install script:
 

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -191,7 +191,7 @@ pub const UpgradeCommand = struct {
         var api_url = URL.parse(
             try std.fmt.bufPrint(
                 &github_repository_url_buf,
-                "https://{s}/repos/Jarred-Sumner/bun-releases-for-updater/releases/latest",
+                "https://{s}/repos/oven-sh/bun/releases/latest",
                 .{
                     github_api_domain,
                 },


### PR DESCRIPTION
I kept commands in Makefile because few more releases should be also released to the old repository but we should migrate.