### PR TITLE
record cjs export name if it is assigned

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -17656,7 +17656,7 @@ fn NewParser_(
                                     },
                                     name_loc,
                                 );
-                            } else if (p.options.features.commonjs_at_runtime) {
+                            } else if (p.options.features.commonjs_at_runtime and identifier_opts.assign_target != .none) {
                                 // Record this CommonJS export name for use later.
                                 _ = p.commonjs_export_names.getOrPut(p.allocator, name) catch unreachable;
                             }


### PR DESCRIPTION
fixes #3152 

line 5 in `isBuffer.js` in lodash-es should not record `nodeType` as a cjs export because nothing is assigned to the property:
```js
var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
```