### PR TITLE
Rename `ptr` to `_unsafe_ptr_do_not_use`

### DIFF
--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -88,9 +88,10 @@ pub const JSObject = extern struct {
 };
 
 pub const ZigString = extern struct {
-    // TODO: align this to align(2)
-    // That would improve perf a bit
-    ptr: [*]const u8,
+    /// This can be a UTF-16, Latin1, or UTF-8 string.
+    /// The pointer itself is tagged, so it cannot be used without untagging it first
+    /// Accessing it directly is unsafe.
+    _unsafe_ptr_do_not_use: [*]const u8,
     len: usize,
 
     pub const ByteString = union(enum) {
@@ -327,7 +328,7 @@ pub const ZigString = extern struct {
     }
 
     pub fn trunc(this: ZigString, len: usize) ZigString {
-        return .{ .ptr = this.ptr, .len = @min(len, this.len) };
+        return .{ ._unsafe_ptr_do_not_use = this._unsafe_ptr_do_not_use, .len = @min(len, this.len) };
     }
 
     pub fn eqlComptime(this: ZigString, comptime other: []const u8) bool {
@@ -448,7 +449,7 @@ pub const ZigString = extern struct {
     pub const namespace = "";
 
     pub inline fn is16Bit(this: *const ZigString) bool {
-        return (@ptrToInt(this.ptr) & (1 << 63)) != 0;
+        return (@ptrToInt(this._unsafe_ptr_do_not_use) & (1 << 63)) != 0;
     }
 
     pub inline fn utf16Slice(this: *const ZigString) []align(1) const u16 {
@@ -458,7 +459,7 @@ pub const ZigString = extern struct {
             }
         }
 
-        return @ptrCast([*]align(1) const u16, untagged(this.ptr))[0..this.len];
+        return @ptrCast([*]align(1) const u16, untagged(this._unsafe_ptr_do_not_use))[0..this.len];
     }
 
     pub inline fn utf16SliceAligned(this: *const ZigString) []const u16 {
@@ -468,7 +469,7 @@ pub const ZigString = extern struct {
             }
         }
 
-        return @ptrCast([*]const u16, @alignCast(@alignOf(u16), untagged(this.ptr)))[0..this.len];
+        return @ptrCast([*]const u16, @alignCast(@alignOf(u16), untagged(this._unsafe_ptr_do_not_use)))[0..this.len];
     }
 
     pub inline fn isEmpty(this: *const ZigString) bool {
@@ -478,7 +479,7 @@ pub const ZigString = extern struct {
     pub fn fromStringPointer(ptr: StringPointer, buf: string, to: *ZigString) void {
         to.* = ZigString{
             .len = ptr.length,
-            .ptr = buf[ptr.offset..][0..ptr.length].ptr,
+            ._unsafe_ptr_do_not_use = buf[ptr.offset..][0..ptr.length].ptr,
         };
     }
 
@@ -499,7 +500,7 @@ pub const ZigString = extern struct {
     }
 
     pub inline fn init(slice_: []const u8) ZigString {
-        return ZigString{ .ptr = slice_.ptr, .len = slice_.len };
+        return ZigString{ ._unsafe_ptr_do_not_use = slice_.ptr, .len = slice_.len };
     }
 
     pub fn initUTF8(slice_: []const u8) ZigString {
@@ -518,7 +519,7 @@ pub const ZigString = extern struct {
 
     pub fn static(comptime slice_: []const u8) *const ZigString {
         const Holder = struct {
-            pub const value = ZigString{ .ptr = slice_.ptr, .len = slice_.len };
+            pub const value = ZigString{ ._unsafe_ptr_do_not_use = slice_.ptr, .len = slice_.len };
         };
 
         return &Holder.value;
@@ -543,7 +544,7 @@ pub const ZigString = extern struct {
     }
 
     pub fn init16(slice_: []const u16) ZigString {
-        var out = ZigString{ .ptr = std.mem.sliceAsBytes(slice_).ptr, .len = slice_.len };
+        var out = ZigString{ ._unsafe_ptr_do_not_use = std.mem.sliceAsBytes(slice_).ptr, .len = slice_.len };
         out.markUTF16();
         return out;
     }
@@ -585,15 +586,15 @@ pub const ZigString = extern struct {
     }
 
     pub fn isUTF8(this: ZigString) bool {
-        return (@ptrToInt(this.ptr) & (1 << 61)) != 0;
+        return (@ptrToInt(this._unsafe_ptr_do_not_use) & (1 << 61)) != 0;
     }
 
     pub fn markUTF8(this: *ZigString) void {
-        this.ptr = @intToPtr([*]const u8, @ptrToInt(this.ptr) | (1 << 61));
+        this._unsafe_ptr_do_not_use = @intToPtr([*]const u8, @ptrToInt(this._unsafe_ptr_do_not_use) | (1 << 61));
     }
 
     pub fn markUTF16(this: *ZigString) void {
-        this.ptr = @intToPtr([*]const u8, @ptrToInt(this.ptr) | (1 << 63));
+        this._unsafe_ptr_do_not_use = @intToPtr([*]const u8, @ptrToInt(this._unsafe_ptr_do_not_use) | (1 << 63));
     }
 
     pub fn setOutputEncoding(this: *ZigString) void {
@@ -602,7 +603,7 @@ pub const ZigString = extern struct {
     }
 
     pub inline fn isGloballyAllocated(this: ZigString) bool {
-        return (@ptrToInt(this.ptr) & (1 << 62)) != 0;
+        return (@ptrToInt(this._unsafe_ptr_do_not_use) & (1 << 62)) != 0;
     }
 
     pub inline fn deinitGlobal(this: ZigString) void {
@@ -612,7 +613,7 @@ pub const ZigString = extern struct {
     pub const mark = markGlobal;
 
     pub inline fn markGlobal(this: *ZigString) void {
-        this.ptr = @intToPtr([*]const u8, @ptrToInt(this.ptr) | (1 << 62));
+        this._unsafe_ptr_do_not_use = @intToPtr([*]const u8, @ptrToInt(this._unsafe_ptr_do_not_use) | (1 << 62));
     }
 
     pub fn format(self: ZigString, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
@@ -633,7 +634,7 @@ pub const ZigString = extern struct {
         return init(slice_).toValue(global).asRef();
     }
 
-    pub const Empty = ZigString{ .ptr = "", .len = 0 };
+    pub const Empty = ZigString{ ._unsafe_ptr_do_not_use = "", .len = 0 };
 
     inline fn untagged(ptr: [*]const u8) [*]const u8 {
         // this can be null ptr, so long as it's also a 0 length string
@@ -648,7 +649,7 @@ pub const ZigString = extern struct {
             }
         }
 
-        return untagged(this.ptr)[0..@min(this.len, std.math.maxInt(u32))];
+        return untagged(this._unsafe_ptr_do_not_use)[0..@min(this.len, std.math.maxInt(u32))];
     }
 
     pub fn dupe(this: ZigString, allocator: std.mem.Allocator) ![]const u8 {
@@ -668,7 +669,7 @@ pub const ZigString = extern struct {
         }
 
         return Slice{
-            .ptr = untagged(this.ptr),
+            .ptr = untagged(this._unsafe_ptr_do_not_use),
             .len = @truncate(u32, this.len),
         };
     }
@@ -687,7 +688,7 @@ pub const ZigString = extern struct {
             };
         }
 
-        if (!this.isUTF8() and !strings.isAllASCII(untagged(this.ptr)[0..this.len])) {
+        if (!this.isUTF8() and !strings.isAllASCII(untagged(this._unsafe_ptr_do_not_use)[0..this.len])) {
             const buffer = this.toOwnedSlice(allocator) catch unreachable;
             return Slice{
                 .allocator = NullableAllocator.init(allocator),
@@ -697,7 +698,7 @@ pub const ZigString = extern struct {
         }
 
         return Slice{
-            .ptr = untagged(this.ptr),
+            .ptr = untagged(this._unsafe_ptr_do_not_use),
             .len = @truncate(u32, this.len),
         };
     }
@@ -727,7 +728,7 @@ pub const ZigString = extern struct {
         }
 
         return Slice{
-            .ptr = untagged(this.ptr),
+            .ptr = untagged(this._unsafe_ptr_do_not_use),
             .len = @truncate(u32, this.len),
         };
     }
@@ -737,7 +738,7 @@ pub const ZigString = extern struct {
     }
 
     pub inline fn full(this: *const ZigString) []const u8 {
-        return untagged(this.ptr)[0..this.len];
+        return untagged(this._unsafe_ptr_do_not_use)[0..this.len];
     }
 
     pub fn trimmedSlice(this: *const ZigString) []const u8 {
@@ -762,7 +763,9 @@ pub const ZigString = extern struct {
 
     inline fn assertGlobal(this: *const ZigString) void {
         if (comptime bun.Environment.allow_assert) {
-            std.debug.assert(this.len == 0 or bun.Mimalloc.mi_is_in_heap_region(untagged(this.ptr)) or bun.Mimalloc.mi_check_owned(untagged(this.ptr)));
+            std.debug.assert(this.len == 0 or
+                bun.Mimalloc.mi_is_in_heap_region(untagged(this._unsafe_ptr_do_not_use)) or
+                bun.Mimalloc.mi_check_owned(untagged(this._unsafe_ptr_do_not_use)));
         }
     }
 
@@ -814,9 +817,9 @@ pub const ZigString = extern struct {
         }
 
         return if (this.is16Bit())
-            C_API.JSStringCreateWithCharactersNoCopy(@ptrCast([*]const u16, @alignCast(@alignOf([*]const u16), untagged(this.ptr))), this.len)
+            C_API.JSStringCreateWithCharactersNoCopy(@ptrCast([*]const u16, @alignCast(@alignOf([*]const u16), untagged(this._unsafe_ptr_do_not_use))), this.len)
         else
-            C_API.JSStringCreateStatic(untagged(this.ptr), this.len);
+            C_API.JSStringCreateStatic(untagged(this._unsafe_ptr_do_not_use), this.len);
     }
 
     pub fn toErrorInstance(this: *const ZigString, global: *JSGlobalObject) JSValue {
@@ -2682,7 +2685,7 @@ pub const JSGlobalObject = extern struct {
         str.markUTF8();
         var err_value = str.toErrorInstance(this);
         this.vm().throwError(this, err_value);
-        this.bunVM().allocator.free(ZigString.untagged(str.ptr)[0..str.len]);
+        this.bunVM().allocator.free(ZigString.untagged(str._unsafe_ptr_do_not_use)[0..str.len]);
     }
 
     pub fn handleError(

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -688,9 +688,9 @@ pub const ZigStackFrame = extern struct {
     };
 
     pub const Zero: ZigStackFrame = ZigStackFrame{
-        .function_name = ZigString{ .ptr = "", .len = 0 },
+        .function_name = ZigString{ ._unsafe_ptr_do_not_use = "", .len = 0 },
         .code_type = ZigStackFrameCode.None,
-        .source_url = ZigString{ .ptr = "", .len = 0 },
+        .source_url = ZigString{ ._unsafe_ptr_do_not_use = "", .len = 0 },
         .position = ZigStackFramePosition.Invalid,
     };
 

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1425,9 +1425,9 @@ pub const VirtualMachine = struct {
             };
 
             if (vm.has_loaded) {
-                blobs.temporary.put(specifier_blob, .{ .ptr = result.source_code.ptr, .len = result.source_code.len }) catch {};
+                blobs.temporary.put(specifier_blob, .{ .ptr = result.source_code._unsafe_ptr_do_not_use, .len = result.source_code.len }) catch {};
             } else {
-                blobs.persistent.put(specifier_blob, .{ .ptr = result.source_code.ptr, .len = result.source_code.len }) catch {};
+                blobs.persistent.put(specifier_blob, .{ .ptr = result.source_code._unsafe_ptr_do_not_use, .len = result.source_code.len }) catch {};
             }
         }
 

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -502,7 +502,7 @@ pub const TextDecoder = struct {
                 return ZigString.init16(slice).toValueGC(ctx);
             } else {
                 var str = ZigString.init("");
-                str.ptr = @ptrCast([*]const u8, slice.ptr);
+                str._unsafe_ptr_do_not_use = @ptrCast([*]const u8, slice.ptr);
                 str.len = slice.len;
                 str.markUTF16();
                 return str.toValueGC(ctx.ptr());
@@ -575,7 +575,7 @@ pub const TextDecoder = struct {
         var full = buffer.toOwnedSlice(allocator) catch @panic("TODO");
 
         var out = ZigString.init("");
-        out.ptr = @ptrCast([*]u8, full.ptr);
+        out._unsafe_ptr_do_not_use = @ptrCast([*]u8, full.ptr);
         out.len = full.len;
         out.markUTF16();
         return out.toValueGC(ctx.ptr());

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1130,7 +1130,8 @@ pub const Fetch = struct {
                             } else {
                                 var proxy_str = proxy_arg.toStringOrNull(globalThis) orelse return .zero;
                                 // proxy + url 1 allocation
-                                var proxy_url_zig = proxy_str.getZigString(globalThis);
+                                var proxy_url_zig = proxy_str.toSlice(globalThis, bun.default_allocator);
+                                defer proxy_url_zig.deinit();
 
                                 // ignore proxy if it is len = 0
                                 if (proxy_url_zig.len == 0) {
@@ -1175,6 +1176,26 @@ pub const Fetch = struct {
                 }
             }
         } else if (first_arg.toStringOrNull(globalThis)) |jsstring| {
+
+            // Check the URL
+            var url_slice = jsstring.toSlice(globalThis, bun.default_allocator).cloneIfNeeded(bun.default_allocator) catch {
+                // clean hostname if any
+                if (hostname) |host| {
+                    bun.default_allocator.free(host);
+                }
+                JSC.JSError(bun.default_allocator, "Out of memory", .{}, ctx, exception);
+                return .zero;
+            };
+
+            if (url_slice.len == 0) {
+                const err = JSC.toTypeError(.ERR_INVALID_ARG_VALUE, fetch_error_blank_url, .{}, ctx);
+                // clean hostname if any
+                if (hostname) |host| {
+                    bun.default_allocator.free(host);
+                }
+                return JSPromise.rejectedPromiseValue(globalThis, err);
+            }
+
             if (args.nextEat()) |options| {
                 if (options.isObject() or options.jsType() == .DOMWrapper) {
                     if (options.fastGet(ctx.ptr(), .method)) |method_| {
@@ -1250,114 +1271,29 @@ pub const Fetch = struct {
                             signal = signal_;
                         }
                     }
-                    if (options.get(globalThis, "proxy")) |proxy_arg| {
-                        if (!proxy_arg.isUndefined()) {
-                            // proxy + url 1 allocation
-                            var url_zig = jsstring.getZigString(globalThis);
 
-                            if (url_zig.len == 0) {
-                                const err = JSC.toTypeError(.ERR_INVALID_ARG_VALUE, fetch_error_blank_url, .{}, ctx);
-                                // clean hostname if any
-                                if (hostname) |host| {
-                                    bun.default_allocator.free(host);
-                                }
-                                return JSPromise.rejectedPromiseValue(globalThis, err);
-                            }
+                    if (options.getTruthy(globalThis, "proxy")) |proxy_arg| {
+                        if (proxy_arg.isString() and proxy_arg.getLength(globalThis) > 0) {
+                            defer url_slice.deinit();
 
-                            if (proxy_arg.isNull()) {
-                                //if null we add an empty proxy to be ignore all proxy
-                                //only allocate url
-                                const url_slice = url_zig.toSlice(bun.default_allocator).cloneIfNeeded(bun.default_allocator) catch {
-                                    // clean hostname if any
-                                    if (hostname) |host| {
-                                        bun.default_allocator.free(host);
-                                    }
-                                    JSC.JSError(bun.default_allocator, "Out of memory", .{}, ctx, exception);
-                                    return .zero;
-                                };
-                                url = ZigURL.parse(url_slice.slice());
-                                url_proxy_buffer = url.href;
-                                proxy = ZigURL{}; //empty proxy
+                            var proxy_str = proxy_arg.toStringOrNull(globalThis) orelse return .zero;
+                            var proxy_url_zig = proxy_str.toSlice(globalThis, bun.default_allocator);
+                            defer proxy_url_zig.deinit();
 
-                            } else {
-                                var proxy_str = proxy_arg.toStringOrNull(globalThis) orelse return .zero;
-                                var proxy_url_zig = proxy_str.getZigString(globalThis);
-
-                                // proxy is actual 0 len so ignores it
-                                if (proxy_url_zig.len == 0) {
-                                    const url_slice = url_zig.toSlice(bun.default_allocator).cloneIfNeeded(bun.default_allocator) catch {
-                                        JSC.JSError(bun.default_allocator, "Out of memory", .{}, ctx, exception);
-                                        return .zero;
-                                    };
-                                    url = ZigURL.parse(url_slice.slice());
-                                    url_proxy_buffer = url.href;
-                                } else {
-                                    var buffer = getAllocator(ctx).alloc(u8, url_zig.len + proxy_url_zig.len) catch {
-                                        JSC.JSError(bun.default_allocator, "Out of memory", .{}, ctx, exception);
-                                        return .zero;
-                                    };
-                                    @memcpy(buffer.ptr, url_zig.ptr, url_zig.len);
-                                    var proxy_url_slice = buffer[url_zig.len..];
-                                    @memcpy(proxy_url_slice.ptr, proxy_url_zig.ptr, proxy_url_zig.len);
-
-                                    url = ZigURL.parse(buffer[0..url_zig.len]);
-                                    proxy = ZigURL.parse(proxy_url_slice);
-                                    url_proxy_buffer = buffer;
-                                }
-                            }
-                        } else {
-                            //no proxy only url
-                            var url_slice = jsstring.toSlice(globalThis, bun.default_allocator).cloneIfNeeded(bun.default_allocator) catch {
+                            var buffer = getAllocator(ctx).alloc(u8, url_slice.len + proxy_url_zig.len) catch {
                                 JSC.JSError(bun.default_allocator, "Out of memory", .{}, ctx, exception);
                                 return .zero;
                             };
+                            @memcpy(buffer.ptr, url_slice.ptr, url_slice.len);
+                            var proxy_url_slice = buffer[url_slice.len..];
+                            @memcpy(proxy_url_slice.ptr, proxy_url_zig.ptr, proxy_url_zig.len);
 
-                            if (url_slice.len == 0) {
-                                const err = JSC.toTypeError(.ERR_INVALID_ARG_VALUE, fetch_error_blank_url, .{}, ctx);
-                                return JSPromise.rejectedPromiseValue(globalThis, err);
-                            }
-
-                            url = ZigURL.parse(url_slice.slice());
-                            url_proxy_buffer = url.href;
+                            url = ZigURL.parse(buffer[0..url_slice.len]);
+                            proxy = ZigURL.parse(proxy_url_slice);
+                            url_proxy_buffer = buffer;
                         }
-                    } else {
-                        //no proxy only url
-                        var url_slice = jsstring.toSlice(globalThis, bun.default_allocator).cloneIfNeeded(bun.default_allocator) catch {
-                            // clean hostname if any
-                            if (hostname) |host| {
-                                bun.default_allocator.free(host);
-                            }
-                            JSC.JSError(bun.default_allocator, "Out of memory", .{}, ctx, exception);
-                            return .zero;
-                        };
-
-                        if (url_slice.len == 0) {
-                            const err = JSC.toTypeError(.ERR_INVALID_ARG_VALUE, fetch_error_blank_url, .{}, ctx);
-                            // clean hostname if any
-                            if (hostname) |host| {
-                                bun.default_allocator.free(host);
-                            }
-                            return JSPromise.rejectedPromiseValue(globalThis, err);
-                        }
-
-                        url = ZigURL.parse(url_slice.slice());
-                        url_proxy_buffer = url.href;
                     }
                 }
-            } else {
-                //no proxy only url
-                var url_slice = jsstring.toSlice(globalThis, bun.default_allocator).cloneIfNeeded(bun.default_allocator) catch {
-                    JSC.JSError(bun.default_allocator, "Out of memory", .{}, ctx, exception);
-                    return .zero;
-                };
-
-                if (url_slice.len == 0) {
-                    const err = JSC.toTypeError(.ERR_INVALID_ARG_VALUE, fetch_error_blank_url, .{}, ctx);
-                    return JSPromise.rejectedPromiseValue(globalThis, err);
-                }
-
-                url = ZigURL.parse(url_slice.slice());
-                url_proxy_buffer = url.href;
             }
         } else {
             const fetch_error = fetch_type_error_strings.get(js.JSValueGetType(ctx, first_arg.asRef()));


### PR DESCRIPTION
- Fixes a bug with `path.isAbsolute` that can cause a segfault
- Fixes a bug with `path.isAbsolute` where it wouldn't throw an error that Node does throw
- Fixes a bug with `"proxy"` in fetch that could cause a segfault when the URL is UTF-16