### PR TITLE
Fix github annotation when using inspect()

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2041,6 +2041,7 @@ pub const ZigConsoleClient = struct {
                         Writer,
                         writer_,
                         enable_ansi_colors,
+                        false,
                     );
                 },
                 .Class => {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -317,7 +317,7 @@ describe("bun test", () => {
       });
       expect(stderr).not.toContain("::error");
     });
-    test("should not annotate errors when using inspect()", () => {
+    test("should not annotate errors with inspect() by default", () => {
       const stderr = runTest({
         input: `
           import { test } from "bun:test";
@@ -329,6 +329,22 @@ describe("bun test", () => {
         `,
         env: {
           GITHUB_ACTIONS: undefined,
+        },
+      });
+      expect(stderr).not.toContain("::error");
+    });
+    test("should not annotate errors with inspect() when enabled", () => {
+      const stderr = runTest({
+        input: `
+          import { test } from "bun:test";
+          import { inspect } from "bun";
+          test("inspect", () => {
+            inspect(new TypeError());
+            console.error(inspect(new TypeError()));
+          });
+        `,
+        env: {
+          GITHUB_ACTIONS: "true",
         },
       });
       expect(stderr).not.toContain("::error");


### PR DESCRIPTION
Fixes a bug where `inspect()` would emit a Github annotation.

![](https://cdn.discordapp.com/attachments/1022920581240344716/1113986956993503303/image.png)
