### PR TITLE
Align CommonJS evaluation order closer to Node.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1109,6 +1109,7 @@ jsc-copy-headers:
 	cp $(WEBKIT_DIR)/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h $(WEBKIT_RELEASE_DIR)/JavaScriptCore/PrivateHeaders/JavaScriptCore/JSTypedArrayViewPrototype.h
 	cp $(WEBKIT_DIR)/Source/JavaScriptCore/runtime/JSTypedArrayPrototypes.h $(WEBKIT_RELEASE_DIR)/JavaScriptCore/PrivateHeaders/JavaScriptCore/JSTypedArrayPrototypes.h
 	cp $(WEBKIT_DIR)/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h $(WEBKIT_RELEASE_DIR)/JavaScriptCore/PrivateHeaders/JavaScriptCore/JSModuleNamespaceObject.h
+	cp $(WEBKIT_DIR)/Source/JavaScriptCore/runtime/JSModuleEnvironment.h $(WEBKIT_RELEASE_DIR)/JavaScriptCore/PrivateHeaders/JavaScriptCore/JSModuleEnvironment.h
 	cp $(WEBKIT_DIR)/Source/JavaScriptCore/jit/JIT.h $(WEBKIT_RELEASE_DIR)/JavaScriptCore/PrivateHeaders/JavaScriptCore/JIT.h
 	cp $(WEBKIT_DIR)/Source/JavaScriptCore/bytecode/StructureStubInfo.h $(WEBKIT_RELEASE_DIR)/JavaScriptCore/PrivateHeaders/JavaScriptCore/StructureStubInfo.h
 	cp $(WEBKIT_DIR)/Source/JavaScriptCore/bytecode/AccessCase.h $(WEBKIT_RELEASE_DIR)/JavaScriptCore/PrivateHeaders/JavaScriptCore/AccessCase.h

--- a/src/bun.js/bindings/CommonJSModuleRecord.h
+++ b/src/bun.js/bindings/CommonJSModuleRecord.h
@@ -6,6 +6,8 @@ class GlobalObject;
 }
 namespace JSC {
 class SourceCode;
+class EvalExecutable;
+class SyntheticModuleRecord;
 }
 
 namespace Bun {
@@ -16,5 +18,10 @@ JSC::Structure* createCommonJSModuleStructure(
 JSC::SourceCode createCommonJSModule(
     Zig::GlobalObject* globalObject,
     ResolvedSource source);
+
+JSC::JSValue evaluateCommonJSModule(
+    Zig::GlobalObject* globalObject,
+    JSC::SyntheticModuleRecord* syntheticModuleRecord,
+    EvalExecutable* executable);
 
 } // namespace Bun

--- a/src/bun.js/bindings/node_util_types.cpp
+++ b/src/bun.js/bindings/node_util_types.cpp
@@ -313,7 +313,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsCryptoKey, (JSC::JSGlobalObject * globalObj
 }
 
 namespace Bun {
-void generateNodeUtilTypesSourceCode(JSC::JSGlobalObject* lexicalGlobalObject,
+JSC::JSValue generateNodeUtilTypesSourceCode(JSC::JSGlobalObject* lexicalGlobalObject,
     JSC::Identifier moduleKey,
     Vector<JSC::Identifier, 4>& exportNames,
     JSC::MarkedArgumentBuffer& exportValues)
@@ -379,5 +379,7 @@ void generateNodeUtilTypesSourceCode(JSC::JSGlobalObject* lexicalGlobalObject,
 
     exportNames.append(JSC::Identifier::fromString(vm, "default"_s));
     exportValues.append(defaultObject);
+    return {};
 }
+
 }

--- a/src/bun.js/bindings/node_util_types.h
+++ b/src/bun.js/bindings/node_util_types.h
@@ -4,7 +4,7 @@
 namespace Bun {
 using namespace WebCore;
 
-void generateNodeUtilTypesSourceCode(JSC::JSGlobalObject* lexicalGlobalObject,
+JSC::JSValue generateNodeUtilTypesSourceCode(JSC::JSGlobalObject* lexicalGlobalObject,
     JSC::Identifier moduleKey,
     Vector<JSC::Identifier, 4>& exportNames,
     JSC::MarkedArgumentBuffer& exportValues);

--- a/src/bun.js/modules/BufferModule.h
+++ b/src/bun.js/modules/BufferModule.h
@@ -18,10 +18,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNotImplemented,
   return JSValue::encode(jsUndefined());
 }
 
-inline void generateBufferSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
-                                     JSC::Identifier moduleKey,
-                                     Vector<JSC::Identifier, 4> &exportNames,
-                                     JSC::MarkedArgumentBuffer &exportValues) {
+inline JSValue
+generateBufferSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
+                         JSC::Identifier moduleKey,
+                         Vector<JSC::Identifier, 4> &exportNames,
+                         JSC::MarkedArgumentBuffer &exportValues) {
   JSC::VM &vm = lexicalGlobalObject->vm();
   GlobalObject *globalObject =
       reinterpret_cast<GlobalObject *>(lexicalGlobalObject);
@@ -105,6 +106,7 @@ inline void generateBufferSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
 
   exportNames.append(vm.propertyNames->defaultKeyword);
   exportValues.append(defaultObject);
+  return {};
 }
 
 } // namespace Zig

--- a/src/bun.js/modules/EventsModule.h
+++ b/src/bun.js/modules/EventsModule.h
@@ -4,10 +4,11 @@
 namespace Zig {
 using namespace WebCore;
 
-inline void generateEventsSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
-                                     JSC::Identifier moduleKey,
-                                     Vector<JSC::Identifier, 4> &exportNames,
-                                     JSC::MarkedArgumentBuffer &exportValues) {
+inline JSValue
+generateEventsSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
+                         JSC::Identifier moduleKey,
+                         Vector<JSC::Identifier, 4> &exportNames,
+                         JSC::MarkedArgumentBuffer &exportValues) {
   JSC::VM &vm = lexicalGlobalObject->vm();
   GlobalObject *globalObject =
       reinterpret_cast<GlobalObject *>(lexicalGlobalObject);
@@ -53,6 +54,8 @@ inline void generateEventsSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
 
   exportNames.append(JSC::Identifier::fromString(vm, "default"_s));
   exportValues.append(eventEmitterModuleCJS);
+
+  return {};
 }
 
 } // namespace Zig

--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -116,10 +116,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
 }
 
 namespace Zig {
-void generateNodeModuleModule(JSC::JSGlobalObject *globalObject,
-                              JSC::Identifier moduleKey,
-                              Vector<JSC::Identifier, 4> &exportNames,
-                              JSC::MarkedArgumentBuffer &exportValues) {
+JSValue generateNodeModuleModule(JSC::JSGlobalObject *globalObject,
+                                 JSC::Identifier moduleKey,
+                                 Vector<JSC::Identifier, 4> &exportNames,
+                                 JSC::MarkedArgumentBuffer &exportValues) {
   JSC::VM &vm = globalObject->vm();
 
   exportValues.append(JSFunction::create(
@@ -185,5 +185,7 @@ void generateNodeModuleModule(JSC::JSGlobalObject *globalObject,
   builtinModules->putDirectIndex(globalObject, 6,
                                  JSC::jsString(vm, String("bun:sqlite"_s)));
   exportValues.append(builtinModules);
+
+  return {};
 }
 } // namespace Zig

--- a/src/bun.js/modules/NodeModuleModule.h
+++ b/src/bun.js/modules/NodeModuleModule.h
@@ -4,9 +4,9 @@
 namespace Zig {
 
 // node:module
-void generateNodeModuleModule(JSC::JSGlobalObject *globalObject,
-                              JSC::Identifier moduleKey,
-                              Vector<JSC::Identifier, 4> &exportNames,
-                              JSC::MarkedArgumentBuffer &exportValues);
+JSValue generateNodeModuleModule(JSC::JSGlobalObject *globalObject,
+                                 JSC::Identifier moduleKey,
+                                 Vector<JSC::Identifier, 4> &exportNames,
+                                 JSC::MarkedArgumentBuffer &exportValues);
 
 } // namespace Zig

--- a/src/bun.js/modules/ObjectModule.cpp
+++ b/src/bun.js/modules/ObjectModule.cpp
@@ -9,7 +9,7 @@ generateObjectModuleSourceCode(JSC::JSGlobalObject *globalObject,
   return [object](JSC::JSGlobalObject *lexicalGlobalObject,
                   JSC::Identifier moduleKey,
                   Vector<JSC::Identifier, 4> &exportNames,
-                  JSC::MarkedArgumentBuffer &exportValues) -> void {
+                  JSC::MarkedArgumentBuffer &exportValues) -> JSValue {
     JSC::VM &vm = lexicalGlobalObject->vm();
     GlobalObject *globalObject =
         reinterpret_cast<GlobalObject *>(lexicalGlobalObject);
@@ -24,6 +24,8 @@ generateObjectModuleSourceCode(JSC::JSGlobalObject *globalObject,
       exportNames.append(entry);
       exportValues.append(object->get(globalObject, entry));
     }
+
+    return {};
   };
 }
 } // namespace Zig

--- a/src/bun.js/modules/ProcessModule.h
+++ b/src/bun.js/modules/ProcessModule.h
@@ -35,10 +35,11 @@ JSC_DEFINE_CUSTOM_SETTER(jsFunctionProcessModuleCommonJSSetter,
       ->putDirect(vm, propertyName, JSValue::decode(encodedValue), 0);
 }
 
-inline void generateProcessSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
-                                      JSC::Identifier moduleKey,
-                                      Vector<JSC::Identifier, 4> &exportNames,
-                                      JSC::MarkedArgumentBuffer &exportValues) {
+inline JSValue
+generateProcessSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
+                          JSC::Identifier moduleKey,
+                          Vector<JSC::Identifier, 4> &exportNames,
+                          JSC::MarkedArgumentBuffer &exportValues) {
   JSC::VM &vm = lexicalGlobalObject->vm();
   GlobalObject *globalObject =
       reinterpret_cast<GlobalObject *>(lexicalGlobalObject);
@@ -71,6 +72,8 @@ inline void generateProcessSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
                                         jsFunctionProcessModuleCommonJSSetter),
         0);
   }
+
+  return {};
 }
 
 } // namespace Zig

--- a/src/bun.js/modules/StringDecoderModule.h
+++ b/src/bun.js/modules/StringDecoderModule.h
@@ -4,7 +4,7 @@
 
 namespace Zig {
 
-inline void
+inline JSValue
 generateStringDecoderSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
                                 JSC::Identifier moduleKey,
                                 Vector<JSC::Identifier, 4> &exportNames,
@@ -28,6 +28,7 @@ generateStringDecoderSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
 
   exportNames.append(vm.propertyNames->defaultKeyword);
   exportValues.append(defaultObject);
+  return {};
 }
 
 } // namespace Zig

--- a/src/bun.js/modules/TTYModule.h
+++ b/src/bun.js/modules/TTYModule.h
@@ -31,10 +31,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNotImplementedYet,
   return JSValue::encode(jsUndefined());
 }
 
-inline void generateTTYSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
-                                  JSC::Identifier moduleKey,
-                                  Vector<JSC::Identifier, 4> &exportNames,
-                                  JSC::MarkedArgumentBuffer &exportValues) {
+inline JSValue generateTTYSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
+                                     JSC::Identifier moduleKey,
+                                     Vector<JSC::Identifier, 4> &exportNames,
+                                     JSC::MarkedArgumentBuffer &exportValues) {
   JSC::VM &vm = lexicalGlobalObject->vm();
   GlobalObject *globalObject =
       reinterpret_cast<GlobalObject *>(lexicalGlobalObject);
@@ -73,6 +73,8 @@ inline void generateTTYSourceCode(JSC::JSGlobalObject *lexicalGlobalObject,
 
   exportNames.append(vm.propertyNames->defaultKeyword);
   exportValues.append(tty);
+
+  return {};
 }
 
 } // namespace Zig


### PR DESCRIPTION
This changes our CommonJS runtime implementation to parse & evaluate in separate stages, similarly to Node.js. 

This is a draft because there is more stuff necessary before it will replicate the functionality in cjs-module-loader to pick up exports assignments

I'm hoping we don't have to merge this because it is fundamentally less reliable than the present approach at picking up module exports.

Fixes #3161 

