### PR TITLE
ci: better structure, build workflow

### DIFF
--- a/.github/workflows/bun-mac-x64-baseline.yml
+++ b/.github/workflows/bun-mac-x64-baseline.yml
@@ -11,7 +11,7 @@ env:
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
     paths:
       - "src/**/*"
       - "test/**/*"


### PR DESCRIPTION
Have 100 of different workflows for macos and Linux is bad approach. We can make it in two (Mac and Linux) and readable.

First PR: https://github.com/oven-sh/bun/pull/898

This is not done, don't close or merge it.

> Warning
> I can't ly test this, because custom runners but I'll try to do what I can