### PR TITLE
make hardcoded -> make esm + document needing bun to build bun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -557,9 +557,9 @@ PYTHON=$(shell which python 2>/dev/null || which python3 2>/dev/null || which py
 builtins:
 	NODE_ENV=production bun src/js/builtins/codegen/index.ts --minify
 
-.PHONY: hardcoded
-hardcoded:
-	NODE_ENV=production bun src/js/build-hardcoded.ts
+.PHONY: esm
+esm:
+	NODE_ENV=production bun src/js/build-esm.ts
 
 .PHONY: generate-builtins
 generate-builtins: builtins
@@ -1085,7 +1085,7 @@ dev-obj-linux:
 	$(ZIG) build obj -Dtarget=x86_64-linux-gnu -Dcpu="$(CPU_TARGET)"
 
 .PHONY: dev
-dev: mkdir-dev hardcoded dev-obj bun-link-lld-debug
+dev: mkdir-dev esm dev-obj bun-link-lld-debug
 
 mkdir-dev:
 	mkdir -p $(DEBUG_PACKAGE_DIR)

--- a/docs/project/development.md
+++ b/docs/project/development.md
@@ -2,6 +2,34 @@ Configuring a development environment for Bun can take 10-30 minutes depending o
 
 If you are using Windows, you must use a WSL environment as Bun does not yet compile on Windows natively.
 
+Before starting, you will need to already have a release build of Bun installed, as we use our bundler to transpile and minify our code.
+
+{% codetabs %}
+
+```bash#Native
+$ curl -fsSL https://bun.sh/install | bash # for macOS, Linux, and WSL
+```
+
+```bash#npm
+$ npm install -g bun # the last `npm` command you'll ever need
+```
+
+```bash#Homebrew
+$ brew tap oven-sh/bun # for macOS and Linux
+$ brew install bun
+```
+
+```bash#Docker
+$ docker pull oven/bun
+$ docker run --rm --init --ulimit memlock=-1:-1 oven/bun
+```
+
+```bash#proto
+$ proto install bun
+```
+
+{% /codetabs %}
+
 ## Install LLVM
 
 Bun requires LLVM 15 and Clang 15 (`clang` is part of LLVM). This version requirement is to match WebKit (precompiled), as mismatching versions will cause memory allocation failures at runtime. In most cases, you can install LLVM through your system package manager:
@@ -148,14 +176,14 @@ $ make generate-sink
 
 You probably won't need to run that one much.
 
-## Modifying ESM hardcoded modules
+## Modifying ESM modules
 
 Certain modules like `node:fs`, `node:stream`, `bun:sqlite`, and `ws` are implemented in JavaScript. These live in `src/js/{node,bun,thirdparty}` files and are pre-bundled using Bun. The bundled code is committed so CI builds can run without needing a copy of Bun.
 
 When these are changed, run:
 
 ```
-$ make hardcoded
+$ make esm
 ```
 
 In debug builds, Bun automatically loads these from the filesystem, wherever it was compiled, so no need to re-run `make dev`. In release builds, this same behavior can be done via the environment variable `BUN_OVERRIDE_MODULE_PATH`. When set to the repository root, Bun will read from the bundled modules in the repository instead of the ones baked into the binary.

--- a/src/js/README.md
+++ b/src/js/README.md
@@ -7,7 +7,7 @@
 When you change any of those folders, run this to bundle and minify them:
 
 ```bash
-$ make hardcoded
+$ make esm
 ```
 
 These modules are bundled into the binary, but in debug mode they are loaded from the filesystem, so you do not need to rerun `make dev`. If you want to override the modules in a release build, you can set `BUN_OVERRIDE_MODULE_PATH` to the path to the repo:

--- a/src/js/build-esm.ts
+++ b/src/js/build-esm.ts
@@ -110,4 +110,4 @@ for (const [build, outdir] of [
   }
 }
 
-console.log(`Bundled hardcoded modules in ${performance.now().toFixed(2)}ms`);
+console.log(`Bundled esm modules in ${performance.now().toFixed(2)}ms`);


### PR DESCRIPTION
renames the hardcoded modules script to `make esm`, and then documents the fact you need bun to build bun as we do not explicitly state this