### PR TITLE
Add license, copy of docs/licensing.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,70 @@
+# License
+
+Bun itself is MIT-licensed.
+
+## JavaScriptCore
+
+Bun statically links JavaScriptCore (and WebKit) which is LGPL-2 licensed. WebCore files from WebKit are also licensed under LGPL2. Per LGPL2:
+
+> (1) If you statically link against an LGPL’d library, you must also provide your application in an object (not necessarily source) format, so that a user has the opportunity to modify the library and relink the application.
+
+You can find the patched version of WebKit used by Bun here: <https://github.com/oven-sh/webkit>. If you would like to relink Bun with changes:
+
+- `git submodule update --init --recursive`
+- `make jsc`
+- `zig build`
+
+This compiles JavaScriptCore, compiles Bun’s `.cpp` bindings for JavaScriptCore (which are the object files using JavaScriptCore) and outputs a new `bun` binary with your changes.
+
+## Linked libraries
+
+Bun statically links these libraries:
+
+| Library                                                                 | License                                                                                      |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [`boringssl`](https://boringssl.googlesource.com/boringssl/)            | [several licenses](https://boringssl.googlesource.com/boringssl/+/refs/heads/master/LICENSE) |
+| [`libarchive`](https://github.com/libarchive/libarchive)                | [several licenses](https://github.com/libarchive/libarchive/blob/master/COPYING)             |
+| [`lol-html`](https://github.com/cloudflare/lol-html/tree/master/c-api)  | BSD 3-Clause                                                                                 |
+| [`mimalloc`](https://github.com/microsoft/mimalloc)                     | MIT                                                                                          |
+| [`picohttp`](https://github.com/h2o/picohttpparser)                     | dual-licensed under the Perl License or the MIT License                                      |
+| [`zstd`](https://github.com/facebook/zstd)                              | dual-licensed under the BSD License or GPLv2 license                                         |
+| [`simdutf`](https://github.com/simdutf/simdutf)                         | Apache 2.0                                                                                   |
+| [`tinycc`](https://github.com/tinycc/tinycc)                            | LGPL v2.1                                                                                    |
+| [`uSockets`](https://github.com/uNetworking/uSockets)                   | Apache 2.0                                                                                   |
+| [`zlib-cloudflare`](https://github.com/cloudflare/zlib)                 | zlib                                                                                         |
+| [`c-ares`](https://github.com/c-ares/c-ares)                            | MIT licensed                                                                                 |
+| [`libicu`](https://github.com/unicode-org/icu) 72                       | [license here](https://github.com/unicode-org/icu/blob/main/icu4c/LICENSE)                   |
+| A fork of [`uWebsockets`](https://github.com/jarred-sumner/uwebsockets) | Apache 2.0 licensed                                                                          |
+
+## Polyfills
+
+For compatibility reasons, the following packages are embedded into Bun's binary and injected if imported.
+
+| Package                                                                  | License |
+| ------------------------------------------------------------------------ | ------- |
+| [`assert`](https://npmjs.com/package/assert)                             | MIT     |
+| [`browserify-zlib`](https://npmjs.com/package/browserify-zlib)           | MIT     |
+| [`buffer`](https://npmjs.com/package/buffer)                             | MIT     |
+| [`constants-browserify`](https://npmjs.com/package/constants-browserify) | MIT     |
+| [`crypto-browserify`](https://npmjs.com/package/crypto-browserify)       | MIT     |
+| [`domain-browser`](https://npmjs.com/package/domain-browser)             | MIT     |
+| [`events`](https://npmjs.com/package/events)                             | MIT     |
+| [`https-browserify`](https://npmjs.com/package/https-browserify)         | MIT     |
+| [`os-browserify`](https://npmjs.com/package/os-browserify)               | MIT     |
+| [`path-browserify`](https://npmjs.com/package/path-browserify)           | MIT     |
+| [`process`](https://npmjs.com/package/process)                           | MIT     |
+| [`punycode`](https://npmjs.com/package/punycode)                         | MIT     |
+| [`querystring-es3`](https://npmjs.com/package/querystring-es3)           | MIT     |
+| [`stream-browserify`](https://npmjs.com/package/stream-browserify)       | MIT     |
+| [`stream-http`](https://npmjs.com/package/stream-http)                   | MIT     |
+| [`string_decoder`](https://npmjs.com/package/string_decoder)             | MIT     |
+| [`timers-browserify`](https://npmjs.com/package/timers-browserify)       | MIT     |
+| [`tty-browserify`](https://npmjs.com/package/tty-browserify)             | MIT     |
+| [`url`](https://npmjs.com/package/url)                                   | MIT     |
+| [`util`](https://npmjs.com/package/util)                                 | MIT     |
+| [`vm-browserify`](https://npmjs.com/package/vm-browserify)               | MIT     |
+
+## Additional credits
+
+- Bun's JS transpiler, CSS lexer, and Node.js module resolver source code is a Zig port of [@evanw](https://github.com/evanw)’s [esbuild](https://github.com/evanw/esbuild) project.
+- Credit to [@kipply](https://github.com/kipply) for the name "Bun"!


### PR DESCRIPTION
Closes #241

The only reason to have this file is for the GitHub sidebar to show a link to the license, like:

<img width="363" alt="Screenshot 2023-06-03 at 2 48 06 AM" src="https://github.com/oven-sh/bun/assets/24465214/9488bc0e-cf6a-4791-82a2-ac5f051e5627">

`LICENSE.md` is enough to do that. Though we now have two copies of this file, one for docs website and one for the repo itself. Maybe we want to edit the site to point to this root file instead of the one in `docs/project/licensing.md` but there are slight differences in these files for formatting reasons.