### PR TITLE
Implement `Bun.password` and `Bun.passwordSync`

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1013,6 +1013,174 @@ declare module "bun" {
     //     };
   }
 
+  type PasswordAlgorithm =
+    | "bcrypt"
+    | "argon2"
+    | "argon2id"
+    | "argon2d"
+    | "argon2i";
+
+  /**
+   * Hash and verify passwords using argon2 or bcrypt. The default is argon2.
+   * Password hashing functions are necessarily slow, and this object will
+   * automatically run in a worker thread.
+   *
+   * The underlying implementation of these functions are provided by the Zig
+   * Standard Library. Thanks to @jedisct1 and other Zig constributors for their
+   * work on this.
+   *
+   * ### Example with argon2
+   *
+   * ```ts
+   * import {password} from "bun";
+   *
+   * const hash = await password.hash("hello world");
+   * const verify = await password.verify("hello world", hash);
+   * console.log(verify); // true
+   * ```
+   *
+   * ### Example with bcrypt
+   * ```ts
+   * import {password} from "bun";
+   *
+   * const hash = await password.hash("hello world", "bcrypt");
+   * // algorithm is optional, will be inferred from the hash if not specified
+   * const verify = await password.verify("hello world", hash, "bcrypt");
+   *
+   * console.log(verify); // true
+   * ```
+   */
+  export const password: {
+    /**
+     * Verify a password against a previously hashed password.
+     *
+     * @returns true if the password matches, false otherwise
+     *
+     * @example
+     * ```ts
+     * import {password} from "bun";
+     * await password.verify("hey", "$argon2id$v=19$m=65536,t=2,p=1$ddbcyBcbAcagei7wSkZFiouX6TqnUQHmTyS5mxGCzeM$+3OIaFatZ3n6LtMhUlfWbgJyNp7h8/oIsLK+LzZO+WI");
+     * // true
+     * ```
+     *
+     * @throws If the algorithm is specified and does not match the hash
+     * @throws If the algorithm is invalid
+     * @throws if the hash is invalid
+     *
+     */
+    verify(
+      /**
+       * The password to verify.
+       *
+       * If empty, always returns false
+       */
+      password: StringOrBuffer,
+      /**
+       * Previously hashed password.
+       * If empty, always returns false
+       */
+      hash: StringOrBuffer,
+      /**
+       * If not specified, the algorithm will be inferred from the hash.
+       *
+       * If specified and the algorithm does not match the hash, this function
+       * throws an error.
+       */
+      algorithm?: PasswordAlgorithm,
+    ): Promise<boolean>;
+    /**
+     * Asynchronously hash a password using argon2 or bcrypt. The default is argon2.
+     *
+     * @returns A promise that resolves to the hashed password
+     *
+     * ## Example with argon2
+     * ```ts
+     * import {password} from "bun";
+     * const hash = await password.hash("hello world");
+     * console.log(hash); // $argon2id$v=1...
+     * const verify = await password.verify("hello world", hash);
+     * ```
+     * ## Example with bcrypt
+     * ```ts
+     * import {password} from "bun";
+     * const hash = await password.hash("hello world", "bcrypt");
+     * console.log(hash); // $2b$10$...
+     * const verify = await password.verify("hello world", hash);
+     * ```
+     */
+    hash(
+      /**
+       * The password to hash
+       *
+       * If empty, this function throws an error. It is usually a programming
+       * mistake to hash an empty password.
+       */
+      password: StringOrBuffer,
+      /**
+       * @default "argon2"
+       *
+       * When using bcrypt, passwords exceeding 72 characters will be SHA256'd before
+       */
+      algorithm?: PasswordAlgorithm,
+    ): Promise<string>;
+  };
+
+  /**
+   * Synchronously hash and verify passwords using argon2 or bcrypt. The default is argon2.
+   * Warning: password hashing is slow, consider using {@link Bun.password}
+   * instead which runs in a worker thread.
+   *
+   * The underlying implementation of these functions are provided by the Zig
+   * Standard Library. Thanks to @jedisct1 and other Zig constributors for their
+   * work on this.
+   *
+   * ### Example with argon2
+   *
+   * ```ts
+   * import {password} from "bun";
+   *
+   * const hash = await password.hash("hello world");
+   * const verify = await password.verify("hello world", hash);
+   * console.log(verify); // true
+   * ```
+   *
+   * ### Example with bcrypt
+   * ```ts
+   * import {password} from "bun";
+   *
+   * const hash = await password.hash("hello world", "bcrypt");
+   * // algorithm is optional, will be inferred from the hash if not specified
+   * const verify = await password.verify("hello world", hash, "bcrypt");
+   *
+   * console.log(verify); // true
+   * ```
+   */
+  export const passwordSync: {
+    verify(
+      password: StringOrBuffer,
+      hash: StringOrBuffer,
+      /**
+       * If not specified, the algorithm will be inferred from the hash.
+       */
+      algorithm?: PasswordAlgorithm,
+    ): boolean;
+    hash(
+      /**
+       * The password to hash
+       *
+       * If empty, this function throws an error. It is usually a programming
+       * mistake to hash an empty password.
+       */
+      password: StringOrBuffer,
+      /**
+       * @default "argon2"
+       *
+       * When using bcrypt, passwords exceeding 72 characters will be SHA256'd before
+       */
+      algorithm?: PasswordAlgorithm,
+    ): string;
+  };
+
   interface BuildArtifact extends Blob {
     path: string;
     loader: Loader;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1012,13 +1012,30 @@ declare module "bun" {
     //       importSource?: string; // default: "react"
     //     };
   }
+  namespace Password {
+    export type AlgorithmLabel = "bcrypt" | "argon2id" | "argon2d" | "argon2i";
 
-  type PasswordAlgorithm =
-    | "bcrypt"
-    | "argon2"
-    | "argon2id"
-    | "argon2d"
-    | "argon2i";
+    export interface Argon2Algorithm {
+      algorithm: "argon2id" | "argon2d" | "argon2i";
+      /**
+       * Memory cost, which defines the memory usage, given in kibibytes.
+       */
+      memoryCost?: number;
+      /**
+       * Defines the amount of computation realized and therefore the execution
+       * time, given in number of iterations.
+       */
+      timeCost?: number;
+    }
+
+    export interface BCryptAlgorithm {
+      algorithm: "bcrypt";
+      /**
+       * A number between 4 and 31. The default is 10.
+       */
+      cost?: number;
+    }
+  }
 
   /**
    * Hash and verify passwords using argon2 or bcrypt. The default is argon2.
@@ -1086,7 +1103,7 @@ declare module "bun" {
        * If specified and the algorithm does not match the hash, this function
        * throws an error.
        */
-      algorithm?: PasswordAlgorithm,
+      algorithm?: Password.AlgorithmLabel,
     ): Promise<boolean>;
     /**
      * Asynchronously hash a password using argon2 or bcrypt. The default is argon2.
@@ -1117,11 +1134,14 @@ declare module "bun" {
        */
       password: StringOrBuffer,
       /**
-       * @default "argon2"
+       * @default "argon2id"
        *
-       * When using bcrypt, passwords exceeding 72 characters will be SHA256'd before
+       * When using bcrypt, passwords exceeding 72 characters will be SHA512'd before
        */
-      algorithm?: PasswordAlgorithm,
+      algorithm?:
+        | Password.AlgorithmLabel
+        | Password.Argon2Algorithm
+        | Password.BCryptAlgorithm,
     ): Promise<string>;
   };
 
@@ -1162,7 +1182,7 @@ declare module "bun" {
       /**
        * If not specified, the algorithm will be inferred from the hash.
        */
-      algorithm?: PasswordAlgorithm,
+      algorithm?: Password.AlgorithmLabel,
     ): boolean;
     hash(
       /**
@@ -1173,11 +1193,14 @@ declare module "bun" {
        */
       password: StringOrBuffer,
       /**
-       * @default "argon2"
+       * @default "argon2id"
        *
        * When using bcrypt, passwords exceeding 72 characters will be SHA256'd before
        */
-      algorithm?: PasswordAlgorithm,
+      algorithm?:
+        | Password.AlgorithmLabel
+        | Password.Argon2Algorithm
+        | Password.BCryptAlgorithm,
     ): string;
   };
 

--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -1810,7 +1810,7 @@ pub const Crypto = struct {
             object.put(
                 globalObject,
                 ZigString.static("hash"),
-                if (sync)
+                if (!sync)
                     JSC.NewFunction(globalObject, ZigString.static("hash"), 2, JSPasswordObject__hash, false)
                 else
                     JSC.NewFunction(globalObject, ZigString.static("hash"), 2, JSPasswordObject__hashSync, false),
@@ -1818,7 +1818,7 @@ pub const Crypto = struct {
             object.put(
                 globalObject,
                 ZigString.static("verify"),
-                if (sync)
+                if (!sync)
                     JSC.NewFunction(globalObject, ZigString.static("verify"), 2, JSPasswordObject__verify, false)
                 else
                     JSC.NewFunction(globalObject, ZigString.static("verify"), 2, JSPasswordObject__verifySync, false),

--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -1794,7 +1794,6 @@ pub const Crypto = struct {
                 .{
                     .{ "argon2i", .argon2i },
                     .{ "argon2d", .argon2d },
-                    .{ "argon2", .argon2id },
                     .{ "argon2id", .argon2id },
                     .{ "bcrypt", .bcrypt },
                 },

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2616,7 +2616,7 @@ void GlobalObject::finishCreation(VM& vm)
             JSC::VM& vm = init.vm;
             JSC::JSGlobalObject* globalObject = init.owner;
 
-            JSValue result = JSValue::decode(JSPasswordObject__create(globalObject, true));
+            JSValue result = JSValue::decode(JSPasswordObject__create(globalObject, false));
             init.set(result.toObject(globalObject));
         });
 
@@ -2625,7 +2625,7 @@ void GlobalObject::finishCreation(VM& vm)
             JSC::VM& vm = init.vm;
             JSC::JSGlobalObject* globalObject = init.owner;
 
-            JSValue result = JSValue::decode(JSPasswordObject__create(globalObject, false));
+            JSValue result = JSValue::decode(JSPasswordObject__create(globalObject, true));
             init.set(result.toObject(globalObject));
         });
 
@@ -3900,7 +3900,7 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_lazyPreloadTestModuleObject.visit(visitor);
     thisObject->m_commonJSModuleObjectStructure.visit(visitor);
     thisObject->m_lazyPasswordObject.visit(visitor);
-    thisObject->m_lazyPasswordObject.visit(visitor);
+    thisObject->m_lazyPasswordSyncObject.visit(visitor);
     thisObject->m_commonJSFunctionArgumentsStructure.visit(visitor);
     thisObject->m_cachedGlobalObjectStructure.visit(visitor);
     thisObject->m_cachedGlobalProxyStructure.visit(visitor);

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -361,6 +361,17 @@ extern "C" bool Zig__GlobalObject__resetModuleRegistryMap(JSC__JSGlobalObject* g
     return true;
 }
 
+#define BUN_LAZY_GETTER_FN_NAME(GetterName) BunLazyGetter##GetterName##_getter
+
+#define DEFINE_BUN_LAZY_GETTER(GetterName, __propertyName)                                    \
+    JSC_DEFINE_CUSTOM_GETTER(GetterName,                                                      \
+        (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue,            \
+            JSC::PropertyName))                                                               \
+    {                                                                                         \
+        Zig::GlobalObject* thisObject = JSC::jsCast<Zig::GlobalObject*>(lexicalGlobalObject); \
+        return JSC::JSValue::encode(thisObject->__propertyName());                            \
+    }
+
 #define GENERATED_CONSTRUCTOR_GETTER(ConstructorName)                                         \
     JSC_DECLARE_CUSTOM_GETTER(ConstructorName##_getter);                                      \
     JSC_DEFINE_CUSTOM_GETTER(ConstructorName##_getter,                                        \
@@ -2492,6 +2503,7 @@ JSC::JSValue GlobalObject::formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* le
 }
 
 extern "C" void Bun__remapStackFramePositions(JSC::JSGlobalObject*, ZigStackFrame*, size_t);
+extern "C" EncodedJSValue JSPasswordObject__create(JSC::JSGlobalObject*, bool);
 
 JSC_DECLARE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace);
 JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -2596,6 +2608,24 @@ void GlobalObject::finishCreation(VM& vm)
             JSC::JSGlobalObject* globalObject = init.owner;
 
             JSValue result = JSValue::decode(Bun__Jest__createTestModuleObject(globalObject));
+            init.set(result.toObject(globalObject));
+        });
+
+    m_lazyPasswordObject.initLater(
+        [](const Initializer<JSObject>& init) {
+            JSC::VM& vm = init.vm;
+            JSC::JSGlobalObject* globalObject = init.owner;
+
+            JSValue result = JSValue::decode(JSPasswordObject__create(globalObject, true));
+            init.set(result.toObject(globalObject));
+        });
+
+    m_lazyPasswordSyncObject.initLater(
+        [](const Initializer<JSObject>& init) {
+            JSC::VM& vm = init.vm;
+            JSC::JSGlobalObject* globalObject = init.owner;
+
+            JSValue result = JSValue::decode(JSPasswordObject__create(globalObject, false));
             init.set(result.toObject(globalObject));
         });
 
@@ -3525,6 +3555,9 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 extern "C" void Crypto__randomUUID__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value);
 extern "C" void Crypto__getRandomValues__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value);
 
+DEFINE_BUN_LAZY_GETTER(BUN_LAZY_GETTER_FN_NAME(password), passwordObject)
+DEFINE_BUN_LAZY_GETTER(BUN_LAZY_GETTER_FN_NAME(passwordSync), passwordSyncObject)
+
 // This is not a publicly exposed API currently.
 // This is used by the bundler to make Response, Request, FetchEvent,
 // and any other objects available globally.
@@ -3581,6 +3614,19 @@ void GlobalObject::installAPIGlobals(JSClassRef* globals, int count, JSC::VM& vm
             peekFunction->putDirect(vm, PropertyName(JSC::Identifier::fromString(vm, "status"_s)), peekStatus, JSC::PropertyAttribute::Function | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete | 0);
             object->putDirect(vm, PropertyName(identifier), JSValue(peekFunction),
                 JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontDelete | 0);
+        }
+
+        // TODO: code generate these
+        {
+            JSC::Identifier identifier = JSC::Identifier::fromString(vm, "password"_s);
+            object->putDirectCustomAccessor(vm, identifier, JSC::CustomGetterSetter::create(vm, BUN_LAZY_GETTER_FN_NAME(password), nullptr),
+                JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete | 0);
+        }
+
+        {
+            JSC::Identifier identifier = JSC::Identifier::fromString(vm, "passwordSync"_s);
+            object->putDirectCustomAccessor(vm, identifier, JSC::CustomGetterSetter::create(vm, BUN_LAZY_GETTER_FN_NAME(passwordSync), nullptr),
+                JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete | 0);
         }
 
         {
@@ -3853,6 +3899,8 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_lazyTestModuleObject.visit(visitor);
     thisObject->m_lazyPreloadTestModuleObject.visit(visitor);
     thisObject->m_commonJSModuleObjectStructure.visit(visitor);
+    thisObject->m_lazyPasswordObject.visit(visitor);
+    thisObject->m_lazyPasswordObject.visit(visitor);
     thisObject->m_commonJSFunctionArgumentsStructure.visit(visitor);
     thisObject->m_cachedGlobalObjectStructure.visit(visitor);
     thisObject->m_cachedGlobalProxyStructure.visit(visitor);
@@ -4094,7 +4142,6 @@ JSC::JSObject* GlobalObject::moduleLoaderCreateImportMetaProperties(JSGlobalObje
     JSModuleRecord* record,
     JSValue val)
 {
-
     JSC::VM& vm = globalObject->vm();
     JSC::JSString* keyString = key.toStringOrNull(globalObject);
     if (UNLIKELY(!keyString))
@@ -4108,7 +4155,6 @@ JSC::JSValue GlobalObject::moduleLoaderEvaluate(JSGlobalObject* globalObject,
     JSValue moduleRecordValue, JSValue scriptFetcher,
     JSValue sentValue, JSValue resumeMode)
 {
-
     if (UNLIKELY(scriptFetcher && scriptFetcher.isObject())) {
         return scriptFetcher;
     }

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -264,6 +264,9 @@ public:
 
     Structure* commonJSFunctionArgumentsStructure() { return m_commonJSFunctionArgumentsStructure.getInitializedOnMainThread(this); }
 
+    JSObject* passwordSyncObject() { return m_lazyPasswordSyncObject.getInitializedOnMainThread(this); }
+    JSObject* passwordObject() { return m_lazyPasswordObject.getInitializedOnMainThread(this); }
+
     JSWeakMap* vmModuleContextMap() { return m_vmModuleContextMap.getInitializedOnMainThread(this); }
 
     JSC::JSObject* processObject()
@@ -476,6 +479,8 @@ private:
     LazyProperty<JSGlobalObject, JSObject> m_lazyRequireCacheObject;
     LazyProperty<JSGlobalObject, JSObject> m_lazyTestModuleObject;
     LazyProperty<JSGlobalObject, JSObject> m_lazyPreloadTestModuleObject;
+    LazyProperty<JSGlobalObject, JSObject> m_lazyPasswordSyncObject;
+    LazyProperty<JSGlobalObject, JSObject> m_lazyPasswordObject;
 
     LazyProperty<JSGlobalObject, JSFunction> m_bunSleepThenCallback;
     LazyProperty<JSGlobalObject, Structure> m_cachedGlobalObjectStructure;

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -312,6 +312,18 @@ pub const SliceOrBuffer = union(Tag) {
     string: JSC.ZigString.Slice,
     buffer: Buffer,
 
+    pub fn ensureCloned(this: *SliceOrBuffer, allocator: std.mem.Allocator) !void {
+        if (this.* == .string) {
+            this.string = try this.string.cloneIfNeeded(allocator);
+            return;
+        }
+
+        const bytes = this.buffer.buffer.byteSlice();
+        this.* = .{
+            .string = JSC.ZigString.Slice.from(try allocator.dupe(u8, bytes), allocator),
+        };
+    }
+
     pub fn deinit(this: SliceOrBuffer) void {
         switch (this) {
             .string => {

--- a/src/bun.js/webcore.zig
+++ b/src/bun.js/webcore.zig
@@ -364,6 +364,28 @@ pub const Prompt = struct {
     }
 };
 
+pub const BCrypt = struct {
+    const bcrypt = std.crypto.pwhash.bcrypt;
+
+    // https://github.com/kelektiv/node.bcrypt.js/blob/11d2ddd185c163314bd91754c5803002d929b4ff/src/bcrypt.cc#LL274C1-L285C2
+    pub fn getRounds(encrypted: [bcrypt.hash_length]u8) u32 {
+        if (encrypted[0] != '$') {
+            // invalid
+            return 0;
+        }
+
+        if (encrypted[1] > '9' or encrypted[1] < '0') {
+            // invalid version
+            return 0;
+        }
+
+        if (encrypted[2] != '$') {
+            // invalid
+            return 0;
+        }
+    }
+};
+
 pub const Crypto = struct {
     const UUID = @import("./uuid.zig");
     const BoringSSL = @import("root").bun.BoringSSL;

--- a/src/bun.js/webcore.zig
+++ b/src/bun.js/webcore.zig
@@ -364,28 +364,6 @@ pub const Prompt = struct {
     }
 };
 
-pub const BCrypt = struct {
-    const bcrypt = std.crypto.pwhash.bcrypt;
-
-    // https://github.com/kelektiv/node.bcrypt.js/blob/11d2ddd185c163314bd91754c5803002d929b4ff/src/bcrypt.cc#LL274C1-L285C2
-    pub fn getRounds(encrypted: [bcrypt.hash_length]u8) u32 {
-        if (encrypted[0] != '$') {
-            // invalid
-            return 0;
-        }
-
-        if (encrypted[1] > '9' or encrypted[1] < '0') {
-            // invalid version
-            return 0;
-        }
-
-        if (encrypted[2] != '$') {
-            // invalid
-            return 0;
-        }
-    }
-};
-
 pub const Crypto = struct {
     const UUID = @import("./uuid.zig");
     const BoringSSL = @import("root").bun.BoringSSL;

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -25,7 +25,7 @@ pub const huge_allocator_threshold: comptime_int = @import("./memory_allocator.z
 pub const fs_allocator = default_allocator;
 
 pub const C = @import("c.zig");
-
+pub const sha = @import("./sha.zig");
 pub const FeatureFlags = @import("feature_flags.zig");
 pub const meta = @import("./meta.zig");
 pub const ComptimeStringMap = @import("./comptime_string_map.zig").ComptimeStringMap;

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -1,0 +1,214 @@
+import { test, expect, describe } from "bun:test";
+
+import { password, passwordSync } from "bun";
+
+const placeholder = "hey";
+
+describe("hash", () => {
+  describe("arguments parsing", () => {
+    for (let { hash } of [password, passwordSync]) {
+      test("no blank password allowed", () => {
+        expect(() => hash("")).toThrow("password must not be empty");
+      });
+
+      test("password is required", () => {
+        // @ts-expect-error
+        expect(() => hash()).toThrow();
+      });
+
+      test("invalid algorithm throws", () => {
+        // @ts-expect-error
+        expect(() => hash(placeholder, "scrpyt")).toThrow();
+        // @ts-expect-error
+        expect(() => hash(placeholder, 123)).toThrow();
+
+        expect(() =>
+          // @ts-expect-error
+          hash(placeholder, {
+            toString() {
+              return "scrypt";
+            },
+          }),
+        ).toThrow();
+      });
+
+      test("coercion throwing doesn't crash", () => {
+        // @ts-expect-error
+        expect(() => hash(Symbol())).toThrow();
+        expect(() =>
+          // @ts-expect-error
+          hash({
+            toString() {
+              throw new Error("toString() failed");
+            },
+          }),
+        ).toThrow();
+      });
+
+      for (let ArrayBufferView of [
+        Uint8Array,
+        Uint16Array,
+        Uint32Array,
+        Int8Array,
+        Int16Array,
+        Int32Array,
+        Float32Array,
+        Float64Array,
+        ArrayBuffer,
+      ]) {
+        test(`empty ${ArrayBufferView.name} throws`, () => {
+          expect(() => hash(new ArrayBufferView(0))).toThrow("password must not be empty");
+        });
+      }
+    }
+  });
+});
+
+describe("verify", () => {
+  describe("arguments parsing", () => {
+    for (let { verify } of [password, passwordSync]) {
+      test("minimum args", () => {
+        // @ts-expect-error
+        expect(() => verify()).toThrow();
+        // @ts-expect-error
+        expect(() => verify("")).toThrow();
+      });
+
+      test("empty values return false", async () => {
+        expect(await verify("", "$")).toBeFalse();
+        expect(await verify("$", "")).toBeFalse();
+      });
+
+      test("invalid algorithm throws", () => {
+        // @ts-expect-error
+        expect(() => verify(placeholder, "$", "scrpyt")).toThrow();
+        // @ts-expect-error
+        expect(() => verify(placeholder, "$", 123)).toThrow();
+        expect(() =>
+          // @ts-expect-error
+          verify(placeholder, "$", {
+            toString() {
+              return "scrypt";
+            },
+          }),
+        ).toThrow();
+      });
+
+      test("coercion throwing doesn't crash", () => {
+        // @ts-expect-error
+        expect(() => verify(Symbol(), Symbol())).toThrow();
+        expect(() =>
+          verify(
+            // @ts-expect-error
+            {
+              toString() {
+                throw new Error("toString() failed");
+              },
+            },
+            "valid",
+          ),
+        ).toThrow();
+        expect(() =>
+          // @ts-expect-error
+          verify("valid", {
+            toString() {
+              throw new Error("toString() failed");
+            },
+          }),
+        ).toThrow();
+      });
+
+      for (let ArrayBufferView of [
+        Uint8Array,
+        Uint16Array,
+        Uint32Array,
+        Int8Array,
+        Int16Array,
+        Int32Array,
+        Float32Array,
+        Float64Array,
+        ArrayBuffer,
+      ]) {
+        test(`empty ${ArrayBufferView.name} returns false`, async () => {
+          expect(await verify(new ArrayBufferView(0), new ArrayBufferView(0))).toBeFalse();
+          expect(await verify("", new ArrayBufferView(0))).toBeFalse();
+          expect(await verify(new ArrayBufferView(0), "")).toBeFalse();
+        });
+      }
+    }
+  });
+});
+
+test("bcrypt longer than 72 characters is the SHA-256", async () => {
+  const boop = Buffer.from("hey".repeat(100));
+  const hashed = await password.hash(boop, "bcrypt");
+  expect(await password.verify(Bun.SHA256.hash(boop), hashed, "bcrypt")).toBeTrue();
+});
+
+test("bcrypt shorter than 72 characters is NOT the SHA-256", async () => {
+  const boop = Buffer.from("hey".repeat(3));
+  const hashed = await password.hash(boop, "bcrypt");
+  expect(await password.verify(Bun.SHA256.hash(boop), hashed, "bcrypt")).toBeFalse();
+});
+
+const defaultAlgorithm = "argon2";
+const algorithms = [undefined, "argon2", "bcrypt"];
+const argons = ["argon2", "argon2i", "argon2id", "argon2d"];
+
+for (let algorithmValue of algorithms) {
+  const prefix = algorithmValue === "bcrypt" ? "$2" : "$" + (algorithmValue || defaultAlgorithm);
+
+  describe(algorithmValue ? algorithmValue : "default", () => {
+    const hash = (value: string | TypedArray) => {
+      return algorithmValue ? passwordSync.hash(value, algorithmValue as any) : passwordSync.hash(value);
+    };
+
+    const hashSync = (value: string | TypedArray) => {
+      return algorithmValue ? passwordSync.hash(value, algorithmValue as any) : passwordSync.hash(value);
+    };
+
+    const verify = (pw: string | TypedArray, value: string | TypedArray) => {
+      return algorithmValue ? password.verify(pw, value, algorithmValue as any) : password.verify(pw, value);
+    };
+
+    const verifySync = (pw: string | TypedArray, value: string | TypedArray) => {
+      return algorithmValue ? passwordSync.verify(pw, value, algorithmValue as any) : passwordSync.verify(pw, value);
+    };
+
+    for (let input of [placeholder, Buffer.from(placeholder)]) {
+      describe(typeof input === "string" ? "string" : "buffer", () => {
+        test("passwordSync", () => {
+          const hashed = hashSync(input);
+          expect(hashed).toStartWith(prefix);
+          expect(verifySync(input, hashed)).toBeTrue();
+          expect(() => verifySync(hashed, input)).toThrow();
+          expect(verifySync(input + "\0", hashed)).toBeFalse();
+        });
+
+        test("password", async () => {
+          async function runSlowTest(algorithm = algorithmValue as any) {
+            const hashed = await password.hash(input, algorithm);
+
+            expect(hashed).toStartWith(prefix);
+            expect(await password.verify(input, hashed, algorithm)).toBeTrue();
+            expect(() => password.verify(hashed, input, algorithm)).toThrow();
+            expect(await password.verify(input + "\0", hashed, algorithm)).toBeFalse();
+          }
+
+          if (algorithmValue === "argon2") {
+            // these tests are very slow
+            // run the hashing tests in parallel
+            await Promise.all(argons.map(runSlowTest));
+            return;
+          }
+
+          const hashed = await hash(input);
+          expect(hashed).toStartWith(prefix);
+          expect(await verify(input, hashed)).toBeTrue();
+          expect(() => verify(hashed, input)).toThrow();
+          expect(await verify(input + "\0", hashed)).toBeFalse();
+        });
+      });
+    }
+  });
+}


### PR DESCRIPTION
This adds password hashing and verifying functions to the `Bun` global and import. `Bun.password` runs each task in bun's thread pool and `passwordSync` runs on the same thread.

`bcrypt` and `argon2` is supported. `argon2` is the default.

```js
import {password, passwordSync} from "bun";

// uses argon2
const hash = await password.hash("hello world");

// reads the algorithm from the previous hash
const verify = await password.verify("hello world", hash);
console.log(verify); // true
```

```js
import {password, passwordSync} from "bun";

// uses bcrypt
const hash = await password.hash("hello world", "brypt");

// reads the algorithm from the previous hash, but you can specify it as well
const verify = await password.verify("hello world", hash);
console.log(verify); // true
```

cc @jedisct1, this uses `std.crypto.pwhash.bcrypt` and `std.crypto.pwhash.argon2` from Zig's standard library. Would love if you could look over this PR. There will be a couple unrelated test failures as CI isn't green right now