### PR TITLE
[breaking][bun:sqlite] `.values()` returns `[]` instead of `null`

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -579,7 +579,9 @@ declare module "bun:sqlite" {
     /**
      * Execute the prepared statement and return the results as an array of arrays.
      *
-     * This is a little faster than {@link all}.
+     * In Bun v0.6.7 and earlier, this method returned `null` if there were no
+     * results instead of `[]`. This was changed in v0.6.8 to align
+     * more with what people expect.
      *
      * @param params optional values to bind to the statement. If omitted, the statement is run with the last bound values or no parameters if there are none.
      *
@@ -595,12 +597,15 @@ declare module "bun:sqlite" {
      *
      * stmt.values("foo");
      * // => [['foo']]
+     *
+     * stmt.values("not-found");
+     * // => []
      * ```
      *
      * The following types can be used when binding parameters:
      *
      * | JavaScript type | SQLite type |
-     * | -------------- | ----------- |
+     * | ---------------|-------------|
      * | `string` | `TEXT` |
      * | `number` | `INTEGER` or `DECIMAL` |
      * | `boolean` | `INTEGER` (1 or 0) |

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -1417,6 +1417,9 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
 
             result = resultArray;
         }
+    } else if (status == SQLITE_DONE && columnCount != 0) {
+        // breaking change in Bun v0.6.8
+        result = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, 0);
     }
 
     if (UNLIKELY(status != SQLITE_DONE && status != SQLITE_OK)) {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -503,6 +503,14 @@ it("latin1 supplement chars", () => {
       greeting: "¿Qué sucedió?",
     },
   ]);
+
+  expect(db.query("SELECT * FROM foo").values()).toEqual([
+    [1, "Welcome to bun!"],
+    [2, "Español"],
+    [3, "¿Qué sucedió?"],
+  ]);
+  expect(db.query("SELECT * FROM foo WHERE id > 9999").all()).toEqual([]);
+  expect(db.query("SELECT * FROM foo WHERE id > 9999").values()).toEqual([]);
 });
 
 describe("Database.run", () => {


### PR DESCRIPTION
Not sure if we'll merge this yet

Previously, the following returned `null` due to no matching rows:
```js
db.query("SELECT * FROM foo WHERE id > 9999").values();
// null
```

After this PR, it returns `[]`:
```js
db.query("SELECT * FROM foo WHERE id > 9999").values();
// []
```

This is consistent with `.all()` and what people usually expect for functions that return an array of results - to always return an array and not change between an array and `null`.

