### PR TITLE
Implement mocks in bun:test

### DIFF
--- a/packages/bun-types/bun-test.d.ts
+++ b/packages/bun-types/bun-test.d.ts
@@ -16,6 +16,49 @@
 
 declare module "bun:test" {
   /**
+   * -- Mocks --
+   */
+  export type Mock<T extends (...args: any[]) => any> = T & {
+    mockImplementation(fn: T): Mock<T>;
+    mockImplementationOnce(fn: T): Mock<T>;
+    mockReset(): void;
+    mockRestore(): void;
+    mockReturnValue(value: ReturnType<T>): Mock<T>;
+    mockReturnValueOnce(value: ReturnType<T>): Mock<T>;
+    mockResolvedValue(value: ReturnType<T>): Mock<T>;
+    mockResolvedValueOnce(value: ReturnType<T>): Mock<T>;
+    mockRejectedValue(value: ReturnType<T>): Mock<T>;
+    mockRejectedValueOnce(value: ReturnType<T>): Mock<T>;
+    mockName(name: string): Mock<T>;
+    mockClear(): void;
+    mock: {
+      calls: any[][];
+      instances: any[];
+      results: Array<{ type: "return" | "throw"; value: any }>;
+      contexts: any[];
+    };
+
+    (...args: Parameters<T>): ReturnType<T>;
+  };
+
+  export const mock: {
+    mockImplementation<T>(fn: T): Mock<T>;
+    mockImplementationOnce<T>(fn: T): Mock<T>;
+    mockReturnValue<T>(value: ReturnType<T>): Mock<T>;
+    mockReturnValueOnce<T>(value: ReturnType<T>): Mock<T>;
+    mockResolvedValue<T>(value: ReturnType<T>): Mock<T>;
+    mockResolvedValueOnce<T>(value: ReturnType<T>): Mock<T>;
+    mockRejectedValue<T>(value: ReturnType<T>): Mock<T>;
+    mockRejectedValueOnce<T>(value: ReturnType<T>): Mock<T>;
+    <T extends CallableFunction>(Function: T): Mock<T>;
+  };
+
+  export function spyOn<T extends object, K extends keyof T>(
+    obj: T,
+    methodOrPropertyValue: K,
+  ): Mock<T[K]>;
+
+  /**
    * Describes a group of related tests.
    *
    * @example

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -1,0 +1,88 @@
+#include "JSMockFunction.h"
+
+namespace Bun {
+
+class JSMockFunctionPrototype final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+
+    static JSMockFunctionPrototype* create(JSC::VM& vm, JSGlobalObject* globalObject, JSC::Structure* structure)
+    {
+        JSMockFunctionPrototype* ptr = new (NotNull, JSC::allocateCell<JSMockFunctionPrototype>(vm)) JSMockFunctionPrototype(vm, globalObject, structure);
+        ptr->finishCreation(vm, globalObject);
+        return ptr;
+    }
+
+    DECLARE_INFO;
+    template<typename CellType, JSC::SubspaceAccess>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        return &vm.plainObjectSpace();
+    }
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+    }
+
+private:
+    JSMockFunctionPrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(JSC::VM&, JSC::JSGlobalObject*);
+};
+
+JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_isMockFunction);
+JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
+JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetMockImplementation);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetMockName);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockClear);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReset);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockRestore);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockImplementation);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockImplementationOnce);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionWithImplementation);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionWithImplementation);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockName);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReturnThis);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReturnValue);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReturnValueOnce);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockResolvedValue);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockResolvedValueOnce);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockRejectedValue);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockRejectedValueOnce);
+
+static const HashTableValue JSMockFunctionPrototypeTableValues[] = {
+    { "mock"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsMockFunctionGetter_mock, 0 } },
+    { "_protoImpl"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsMockFunctionGetter_protoImpl, 0 } },
+    { "getMockImplementation"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionGetMockImplementation, 0 } },
+    { "getMockName"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionGetMockName, 0 } },
+    { "mockClear"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockClear, 0 } },
+    { "mockReset"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockReset, 0 } },
+    { "mockRestore"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockRestore, 0 } },
+    { "mockImplementation"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockImplementation, 1 } },
+    { "mockImplementationOnce"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockImplementationOnce, 1 } },
+    { "withImplementation"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionWithImplementation, 1 } },
+    { "withImplementation"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionWithImplementation, 1 } },
+    { "mockName"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockName, 1 } },
+    { "mockReturnThis"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockReturnThis, 1 } },
+    { "mockReturnValue"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockReturnValue, 1 } },
+    { "mockReturnValueOnce"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockReturnValueOnce, 1 } },
+    { "mockResolvedValue"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockResolvedValue, 1 } },
+    { "mockResolvedValueOnce"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockResolvedValueOnce, 1 } },
+    { "mockRejectedValueOnce"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockRejectedValue, 1 } },
+    { "mockRejectedValue"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockRejectedValueOnce, 1 } },
+};
+
+void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+{
+    Base::finishCreation(vm);
+    reifyStaticProperties(vm, JSMockFunction::info(), JSMockFunctionPrototypeTableValues, *this);
+    JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+
+    this->putDirect(vm, Identifier::fromString(vm, "_isMockFunction"_s), jsBoolean(true), 0);
+}
+
+}

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -1,6 +1,101 @@
 #include "JSMockFunction.h"
-
+#include <JavaScriptCore/JSPromise.h>
 namespace Bun {
+
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
+JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetMockImplementation);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetMockName);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockClear);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReset);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockRestore);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockImplementation);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockImplementationOnce);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockName);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReturnThis);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReturnValue);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReturnValueOnce);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockResolvedValue);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockResolvedValueOnce);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockRejectedValue);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockRejectedValueOnce);
+
+class JSMockFunction final : public JSC::InternalFunction {
+public:
+    using Base = JSC::InternalFunction;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static JSMockFunction* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
+    {
+        JSMockFunction* function = new (NotNull, JSC::allocateCell<JSMockFunction>(vm.heap)) JSMockFunction(vm, structure);
+        function->finishCreation(vm, globalObject);
+        return function;
+    }
+    static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+    {
+        return Structure::create(vm, globalObject, prototype, TypeInfo(JSC::InternalFunction, StructureFlags), info());
+    }
+
+    DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
+
+    JSC::LazyProperty<JSMockFunction, JSObject> mock;
+    mutable JSC::WriteBarrier<JSC::Unknown> implementation;
+    mutable JSC::WriteBarrier<JSC::JSArray> calls;
+    mutable JSC::WriteBarrier<JSC::JSArray> contexts;
+    mutable JSC::WriteBarrier<JSC::JSArray> instances;
+    mutable JSC::WriteBarrier<JSC::JSArray> returnValues;
+    mutable JSC::WriteBarrier<JSC::Unknown> tail;
+
+    template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
+            return nullptr;
+        return WebCore::subspaceForImpl<JSMockFunction, UseCustomHeapCellType::No>(
+            vm,
+            [](auto& spaces) { return spaces.m_clientSubspaceForJSMockFunction.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMockFunction = std::forward<decltype(space)>(space); },
+            [](auto& spaces) { return spaces.m_subspaceForJSMockFunction.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMockFunction = std::forward<decltype(space)>(space); });
+    }
+
+    JSMockFunction(JSC::VM& structure, JSC::Structure* structure)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+    {
+    }
+};
+
+JSMockModule JSMockModule::create(JSC::JSGlobalObject* globalObject)
+{
+    JSMockModule mock;
+    mock.mockFunctionStructure.initLater(
+        [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::Structure>::Initializer& init) {
+            init.set(object);
+        });
+    mock.mockResultStructure.initLater(
+        [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::Structure>::Initializer& init) {
+            JSPerformanceObject* object = JSPerformanceObject::create(init.vm, reinterpret_cast<Zig::GlobalObject*>(init.owner),
+                JSPerformanceObject::createStructure(init.vm, init.owner, init.owner->objectPrototype()));
+
+            init.set(object);
+        });
+    mock.mockImplementationStructure.initLater(
+        [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::Structure>::Initializer& init) {
+            JSPerformanceObject* object = JSPerformanceObject::create(init.vm, reinterpret_cast<Zig::GlobalObject*>(init.owner),
+                JSPerformanceObject::createStructure(init.vm, init.owner, init.owner->objectPrototype()));
+
+            init.set(object);
+        });
+    mock.mockObject.initLater(
+        [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::Structure>::Initializer& init) {
+            JSPerformanceObject* object = JSPerformanceObject::create(init.vm, reinterpret_cast<Zig::GlobalObject*>(init.owner),
+                JSPerformanceObject::createStructure(init.vm, init.owner, init.owner->objectPrototype()));
+
+            init.set(object);
+        });
+    return mock;
+}
 
 class JSMockImplementation final : public JSC::JSInternalFieldObjectImpl<2> {
 public:
@@ -12,12 +107,19 @@ public:
         ReturnThis,
     };
 
+    static JSMockImplementation* create(JSC::JSGlobalObject* globalObject, JSC::Structure* structure, Kind kind, JSC::JSValue heldValue, bool isOnce)
+    {
+        auto& vm = globalObject->vm();
+        JSMockImplementation* impl = new (NotNull, allocateCell<JSMockImplementation>(vm)) JSMockImplementation(vm, structure, kind);
+        impl->finishCreation(vm, heldValue, isOnce ? jsNumber(1) : jsUndefined());
+        return impl;
+    }
+
     using Base = JSC::JSInternalFieldObjectImpl<2>;
     static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
     {
         return Structure::create(vm, globalObject, prototype, TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
-
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {
         if constexpr (mode == JSC::SubspaceAccess::Concurrently)
@@ -36,7 +138,7 @@ public:
     {
         return { {
             jsUndefined(),
-            jsUndefined(),
+            jsNumber(1),
         } };
     }
 
@@ -45,12 +147,27 @@ public:
 
     Kind kind { Kind::ReturnValue };
 
+    bool isOnce()
+    {
+        auto secondField = internalField(1).get();
+        if (secondField.isNumber() && secondField.asInt32() == 1) {
+            return true;
+        }
+        return jsDynamicCast<JSMockImplementation*>(secondField);
+    }
+
     JSMockImplementation(JSC::VM& vm, JSC::Structure* structure, Kind kind)
         : Base(vm, structure)
         , kind(kind)
     {
     }
-    void finishCreation(JSC::VM&, JSC::JSValue, JSC::JSValue, JSC::JSValue);
+
+    void finishCreation(JSC::VM& vm, JSC::JSValue first, JSC::JSValue second)
+    {
+        Base::finishCreation(vm);
+        this->internalField(0).set(vm, this, first);
+        this->internalField(1).set(vm, this, second);
+    }
 };
 
 class JSMockFunctionPrototype final : public JSC::JSNonFinalObject {
@@ -84,26 +201,6 @@ private:
     void finishCreation(JSC::VM&, JSC::JSGlobalObject*);
 };
 
-JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
-JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetMockImplementation);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetMockName);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockClear);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReset);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockRestore);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockImplementation);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockImplementationOnce);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionWithImplementation);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionWithImplementation);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockName);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReturnThis);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReturnValue);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockReturnValueOnce);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockResolvedValue);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockResolvedValueOnce);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockRejectedValue);
-JSC_DECLARE_HOST_FUNCTION(jsMockFunctionMockRejectedValueOnce);
-
 static const HashTableValue JSMockFunctionPrototypeTableValues[] = {
     { "mock"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsMockFunctionGetter_mock, 0 } },
     { "_protoImpl"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsMockFunctionGetter_protoImpl, 0 } },
@@ -125,6 +222,199 @@ static const HashTableValue JSMockFunctionPrototypeTableValues[] = {
     { "mockRejectedValue"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockRejectedValueOnce, 1 } },
 };
 
+extern Structure* createMockResultStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+{
+    JSC::Structure* structure = globalObject->structureCache().emptyObjectStructureForPrototype(
+        globalObject,
+        globalObject->objectPrototype(),
+        2);
+    JSC::PropertyOffset offset;
+    auto& vm = globalObject->vm();
+
+    structure = structure->addPropertyTransition(
+        vm,
+        structure,
+        JSC::Identifier::fromString(vm, "type"_s),
+        0,
+        offset);
+
+    structure = structure->addPropertyTransition(
+        vm,
+        structure,
+        JSC::Identifier::fromString(vm, "value"_s),
+        0, offset);
+    return structure;
+}
+
+static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, const WTF::String& type, JSC::JSValue value)
+{
+    JSC::Structure* structure = globalObject->JSMockResultStructure();
+
+    JSC::JSObject* result = JSC::constructEmptyObject(vm, structure, 2);
+    result->putDirectOffset(vm, 0, jsString(vm, type));
+    result->putDirectOffset(vm, 1, value);
+    return result;
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * globalObject, CallFrame* callframe))
+{
+    auto& vm = globalObject->vm();
+    JSMockFunction* fn = jsDynamicCast<JSMockFunction*>(callframe->jsCallee());
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!fn)) {
+        throwTypeError(globalObject, scope, "Expected callee to be mock function"_s);
+        return {};
+    }
+
+    JSC::ArgList args = JSC::ArgList(callframe);
+    JSValue thisValue = callframe->thisValue();
+    JSC::JSArray* argumentsArray = nullptr;
+    {
+        JSC::ObjectInitializationScope object(vm);
+        argumentsArray = JSC::JSArray::tryCreateUninitializedRestricted(
+            object,
+            globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
+            callframe->argumentCount());
+        for (size_t i = 0; i < args.size(); i++) {
+            argumentsArray->initializeIndex(object, i, args.at(i));
+        }
+    }
+
+    JSC::JSArray* calls = fn->calls.get();
+    if (calls) {
+        calls->push(globalObject, argumentsArray);
+    } else {
+        JSC::ObjectInitializationScope object(vm);
+        calls = JSC::JSArray::tryCreateUninitializedRestricted(
+            object,
+            globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
+            1);
+        calls->initializeIndex(object, 0, argumentsArray);
+    }
+    fn->calls.set(vm, fn, calls);
+
+    JSC::JSArray* contexts = fn->contexts.get();
+    if (contexts) {
+        contexts->push(globalObject, thisValue);
+    } else {
+        JSC::ObjectInitializationScope object(vm);
+        contexts = JSC::JSArray::tryCreateUninitializedRestricted(
+            object,
+            globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
+            1);
+        contexts->initializeIndex(object, 0, thisValue);
+    }
+    fn->contexts.set(vm, fn, contexts);
+
+    JSValue implementationValue = fn->implementation.get();
+    if (!implementationValue)
+        implementationValue = jsUndefined();
+
+    if (auto* impl = jsDynamicCast<JSMockImplementation*>(implementationValue)) {
+        if (JSValue nextValue = impl->internalField(1).get()) {
+            if (nextValue.inherits<JSMockImplementation*>() || (nextValue.isInt32() && nextValue.asInt32() == 1)) {
+                fn->implementation.set(vm, fn, nextValue);
+            }
+        }
+
+        unsigned int returnValueIndex = 0;
+        auto setReturnValue = [&](JSC::JSValue value) -> {
+            if (auto* returnValuesArray = fn->returnValue.get()) {
+                returnValuesArray->push(globalObject, value);
+                returnValueIndex = returnValuesArray->length() - 1;
+            } else {
+                JSC::ObjectInitializationScope object(vm);
+                returnValuesArray = JSC::JSArray::tryCreateUninitializedRestricted(
+                    object,
+                    globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
+                    1);
+                returnValuesArray->initializeIndex(object, 0, value);
+                fn->returnValue.set(vm, fn, returnValuesArray);
+            }
+        };
+
+        switch (impl->kind) {
+        case JSMockImplementation::Kind::Call: {
+            JSValue result = impl->internalField(0).get();
+            JSC::CallData callData = JSC::getCallData(result);
+            if (UNLIKELY(callData.type == JSC::CallData::Type::None)) {
+                throwTypeError(globalObject, scope, "Expected mock implementation to be callable"_s);
+                return {};
+            }
+
+            setReturnValue(createMockResult(vm, globalObject, "incomplete"_s, jsUndefined()));
+
+            WTF::NakedPtr<JSC::Exception> exception;
+
+            JSValue returnValue = call(globalObject, result, callData, thisValue, args, exception);
+
+            if (auto* exc = exception.get()) {
+                if (auto* returnValuesArray = fn->returnValue.get()) {
+                    returnValuesArray->putDirectIndex(globalObject, returnValueIndex, createMockResult(vm, globalObject, "throw"_s, exc->value()));
+                    fn->returnValue.set(vm, fn, returnValuesArray);
+                    JSC::throwException(globalObject, throwScope, exc);
+                    return {};
+                }
+            }
+
+            if (UNLIKELY(!returnValue)) {
+                returnValue = jsUndefined();
+            }
+
+            if (auto* returnValuesArray = fn->returnValue.get()) {
+                returnValuesArray->putDirectIndex(globalObject, returnValueIndex, createMockResult(vm, globalObject, "return"_s, returnValue));
+                fn->returnValue.set(vm, fn, returnValuesArray);
+            }
+
+            return JSValue::encode(returnValue);
+        }
+        case JSMockImplementation::Kind::ReturnValue:
+        case JSMockImplementation::Kind::Promise: {
+            JSValue returnValue = impl->internalField(0).get();
+            setReturnValue(createMockResult(vm, globalObject, "return"_s, returnValue));
+            return JSValue::encode(returnValue);
+        }
+        case JSMockImplementation::Kind::ReturnThis: {
+            setReturnValue(createMockResult(vm, globalObject, "return"_s, thisValue));
+            return JSValue::encode(thisValue);
+        }
+        default: {
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        }
+    }
+
+    return JSValue::encode(jsUndefined());
+}
+
+static void pushImplInternal(JSMockFunction* fn, JSGlobalObject* jsGlobalObject, JSMockImplementation::Kind kind, JSValue value, bool isOnce)
+{
+    Zig::GlobalObject* globalObject = jsCast<Zig::GlobalObject*>(jsGlobalObject);
+    auto& vm = globalObject->vm();
+    JSValue currentTail = fn->tail.get();
+    JSMockImplementation* impl = JSMockImplementation::create(globalObject, globalObject->JSMockImplementationStructure(), kind, value, isOnce);
+    JSValue currentImpl = fn->implementation.get();
+    if (currentTail) {
+        if (auto* current = jsDynamicCast<JSMockImplementation*>(currentTail)) {
+            current->internalField(1).set(vm, current, impl);
+        }
+    }
+    fn->tail.set(vm, fn, impl);
+    if (!currentImpl || !currentImpl.inherits<JSMockImplementation>()) {
+        fn->implementation.set(vm, fn, impl);
+    }
+}
+
+static void pushImpl(JSMockFunction* fn, JSGlobalObject* globalObject, JSMockImplementation::Kind kind, JSValue value)
+{
+    pushImplInternal(fn, globalObject, kind, value, false);
+}
+
+static void pushImplOnce(JSMockFunction* fn, JSGlobalObject* globalObject, JSMockImplementation::Kind kind, JSValue value)
+{
+    pushImplInternal(fn, globalObject, kind, value, true);
+}
+
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
@@ -143,7 +433,14 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionGetMockImplementation, (JSC::JSGlobalObje
         throwTypeError(globalObject, scope, "Expected Mock"_s);
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject->implementation()));
+    JSValue impl = thisObject->implementation.get();
+    if (auto* implementation = jsDynamicCast<JSMockImplementation*>(impl)) {
+        if (implementation->kind == JSMockImplementation::Kind::Call) {
+            RELEASE_AND_RETURN(scope, JSValue::encode(implementation->internalField(0).get()));
+        }
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
 }
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionGetMockName, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
@@ -154,7 +451,23 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionGetMockName, (JSC::JSGlobalObject * globa
         throwTypeError(globalObject, scope, "Expected Mock"_s);
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+    JSValue implValue = thisObject->implementation.get();
+    if (!implValue) {
+        implValue = jsUndefined();
+    }
+
+    if (auto* impl = jsDynamicCast<JSMockImplementation*>(implValue)) {
+        if (impl->kind == JSMockImplementation::Kind::Call) {
+            JSObject* object = impl->internalField(0).get().asCell()->getObject();
+            if (auto nameValue = object->getIfPropertyExists(globalObject, PropertyName(vm.propertyNames->name))) {
+                RELEASE_AND_RETURN(scope, JSValue::encode(nameValue));
+            }
+
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsEmptyString(vm)));
 }
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockClear, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
@@ -209,19 +522,20 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockImplementationOnce, (JSC::JSGlobalObj
         throwTypeError(globalObject, scope, "Expected Mock"_s);
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
-}
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionWithImplementation, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
-{
-    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
-    auto& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!thisObject)) {
-        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    JSValue arg = callframe->argument(0);
+
+    if (callframe->argumentCount() < 1 || arg.isEmpty() || arg.isUndefined()) {
+        pushImplOnce(thisObject, globalObject, JSMockImplementation::Kind::ReturnValue, jsUndefined());
+    } else if (arg.isCallable()) {
+        pushImplOnce(thisObject, globalObject, JSMockImplementation::Kind::Call, arg);
+    } else {
+        throwTypeError(globalObject, scope, "Expected a function or undefined"_s);
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
 }
+
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionWithImplementation, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
     JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
@@ -229,6 +543,18 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionWithImplementation, (JSC::JSGlobalObject 
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (UNLIKELY(!thisObject)) {
         throwTypeError(globalObject, scope, "Expected Mock"_s);
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
+    }
+
+    JSValue arg = callframe->argument(0);
+
+    if (callframe->argumentCount() < 1 || arg.isEmpty() || arg.isUndefined()) {
+        pushImpl(thisObject, globalObject, JSMockImplementation::Kind::ReturnValue, jsUndefined());
+    } else if (arg.isCallable()) {
+        pushImpl(thisObject, globalObject, JSMockImplementation::Kind::Call, arg);
+    } else {
+        throwTypeError(globalObject, scope, "Expected a function or undefined"_s);
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
@@ -240,9 +566,19 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockName, (JSC::JSGlobalObject * globalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (UNLIKELY(!thisObject)) {
         throwTypeError(globalObject, scope, "Expected Mock"_s);
+        return {};
+    }
+    if (callframe->argumentCount() > 0) {
+        auto* newName = callframe->argument(0).toStringOrNull(globalObject);
+        if (UNLIKELY(!newName)) {
+            return {};
+        }
+
+        thisObject->putDirect(vm, vm.propertyNames->name, newName, 0);
+        RELEASE_AND_RETURN(scope, JSValue::encode(newName));
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, thisObject->calculatedDisplayName(vm))));
 }
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockReturnThis, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
@@ -253,6 +589,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockReturnThis, (JSC::JSGlobalObject * gl
         throwTypeError(globalObject, scope, "Expected Mock"_s);
     }
 
+    pushImpl(thisObject, globalObject, JSMockImplementation::Kind::ReturnThis, jsUndefined());
+
     RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
 }
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockReturnValue, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
@@ -262,6 +600,12 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockReturnValue, (JSC::JSGlobalObject * g
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (UNLIKELY(!thisObject)) {
         throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    if (callframe->argumentCount() < 1) {
+        pushImpl(thisObject, globalObject, JSMockImplementation::Kind::ReturnValue, jsUndefined());
+    } else {
+        pushImpl(thisObject, globalObject, JSMockImplementation::Kind::ReturnValue, callframe->argument(0));
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
@@ -275,6 +619,12 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockReturnValueOnce, (JSC::JSGlobalObject
         throwTypeError(globalObject, scope, "Expected Mock"_s);
     }
 
+    if (callframe->argumentCount() < 1) {
+        pushImplOnce(thisObject, globalObject, JSMockImplementation::Kind::ReturnValue, jsUndefined());
+    } else {
+        pushImplOnce(thisObject, globalObject, JSMockImplementation::Kind::ReturnValue, callframe->argument(0));
+    }
+
     RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
 }
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockResolvedValue, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
@@ -284,6 +634,12 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockResolvedValue, (JSC::JSGlobalObject *
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (UNLIKELY(!thisObject)) {
         throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    if (callframe->argumentCount() < 1) {
+        pushImpl(thisObject, globalObject, JSMockImplementation::Kind::Promise, JSC::JSPromise::resolvedPromise(globalObject, jsUndefined()));
+    } else {
+        pushImpl(thisObject, globalObject, JSMockImplementation::Kind::Promise, JSC::JSPromise::resolvedPromise(globalObject, callframe->argument(0)));
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
@@ -297,6 +653,12 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockResolvedValueOnce, (JSC::JSGlobalObje
         throwTypeError(globalObject, scope, "Expected Mock"_s);
     }
 
+    if (callframe->argumentCount() < 1) {
+        pushImplOnce(thisObject, globalObject, JSMockImplementation::Kind::Promise, JSC::JSPromise::resolvedPromise(globalObject, jsUndefined()));
+    } else {
+        pushImplOnce(thisObject, globalObject, JSMockImplementation::Kind::Promise, JSC::JSPromise::resolvedPromise(globalObject, callframe->argument(0)));
+    }
+
     RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
 }
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockRejectedValue, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
@@ -308,6 +670,12 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockRejectedValue, (JSC::JSGlobalObject *
         throwTypeError(globalObject, scope, "Expected Mock"_s);
     }
 
+    if (callframe->argumentCount() < 1) {
+        pushImpl(thisObject, globalObject, JSMockImplementation::Kind::Promise, JSC::JSPromise::rejectedPromise(globalObject, jsUndefined()));
+    } else {
+        pushImpl(thisObject, globalObject, JSMockImplementation::Kind::Promise, JSC::JSPromise::rejectedPromise(globalObject, callframe->argument(0)));
+    }
+
     RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
 }
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockRejectedValueOnce, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
@@ -317,6 +685,12 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockRejectedValueOnce, (JSC::JSGlobalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (UNLIKELY(!thisObject)) {
         throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    if (callframe->argumentCount() < 1) {
+        pushImplOnce(thisObject, globalObject, JSMockImplementation::Kind::Promise, JSC::JSPromise::rejected(globalObject, jsUndefined()));
+    } else {
+        pushImplOnce(thisObject, globalObject, JSMockImplementation::Kind::Promise, JSC::JSPromise::resolvedPromise(globalObject, callframe->argument(0)));
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -357,7 +357,7 @@ JSMockModule JSMockModule::create(JSC::JSGlobalObject* globalObject)
             structure = structure->addPropertyTransition(
                 init.vm,
                 structure,
-                JSC::Identifier::fromString(init.vm, "returnValues"_s),
+                JSC::Identifier::fromString(init.vm, "results"_s),
                 JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly,
                 offset);
 

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -2,6 +2,57 @@
 
 namespace Bun {
 
+class JSMockImplementation final : public JSC::JSInternalFieldObjectImpl<2> {
+public:
+    enum class Kind : uint8_t {
+        Call,
+        Promise,
+        ReturnValue,
+        ThrowValue,
+        ReturnThis,
+    };
+
+    using Base = JSC::JSInternalFieldObjectImpl<2>;
+    static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+    {
+        return Structure::create(vm, globalObject, prototype, TypeInfo(JSC::ObjectType, StructureFlags), info());
+    }
+
+    template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
+            return nullptr;
+        return WebCore::subspaceForImpl<JSMockImplementation, UseCustomHeapCellType::No>(
+            vm,
+            [](auto& spaces) { return spaces.m_clientSubspaceForJSMockImplementation.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMockImplementation = std::forward<decltype(space)>(space); },
+            [](auto& spaces) { return spaces.m_subspaceForJSMockImplementation.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMockImplementation = std::forward<decltype(space)>(space); });
+    }
+
+    static constexpr unsigned numberOfInternalFields = 2;
+
+    static std::array<JSValue, numberOfInternalFields> initialValues()
+    {
+        return { {
+            jsUndefined(),
+            jsUndefined(),
+        } };
+    }
+
+    DECLARE_EXPORT_INFO;
+    DECLARE_VISIT_CHILDREN;
+
+    Kind kind { Kind::ReturnValue };
+
+    JSMockImplementation(JSC::VM& vm, JSC::Structure* structure, Kind kind)
+        : Base(vm, structure)
+        , kind(kind)
+    {
+    }
+    void finishCreation(JSC::VM&, JSC::JSValue, JSC::JSValue, JSC::JSValue);
+};
+
 class JSMockFunctionPrototype final : public JSC::JSNonFinalObject {
 public:
     using Base = JSC::JSNonFinalObject;
@@ -33,7 +84,6 @@ private:
     void finishCreation(JSC::VM&, JSC::JSGlobalObject*);
 };
 
-JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_isMockFunction);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetMockImplementation);
@@ -65,7 +115,6 @@ static const HashTableValue JSMockFunctionPrototypeTableValues[] = {
     { "mockImplementation"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockImplementation, 1 } },
     { "mockImplementationOnce"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockImplementationOnce, 1 } },
     { "withImplementation"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionWithImplementation, 1 } },
-    { "withImplementation"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionWithImplementation, 1 } },
     { "mockName"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockName, 1 } },
     { "mockReturnThis"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockReturnThis, 1 } },
     { "mockReturnValue"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMockFunctionMockReturnValue, 1 } },
@@ -83,6 +132,194 @@ void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* g
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 
     this->putDirect(vm, Identifier::fromString(vm, "_isMockFunction"_s), jsBoolean(true), 0);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionGetMockImplementation, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject->implementation()));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionGetMockName, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockClear, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockReset, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockRestore, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockImplementation, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockImplementationOnce, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionWithImplementation, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionWithImplementation, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockName, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockReturnThis, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockReturnValue, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockReturnValueOnce, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockResolvedValue, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockResolvedValueOnce, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockRejectedValue, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
+}
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionMockRejectedValueOnce, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMockFunction* thisObject = jsDynamicCast<JSMockFunction*>(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(!thisObject)) {
+        throwTypeError(globalObject, scope, "Expected Mock"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
 }
 
 }

--- a/src/bun.js/bindings/JSMockFunction.h
+++ b/src/bun.js/bindings/JSMockFunction.h
@@ -12,66 +12,16 @@ namespace Bun {
 using namespace JSC;
 using namespace WebCore;
 
-class JSMockFunction final : public JSC::InternalFunction {
+class JSMockModule final {
 public:
-    using Base = JSC::InternalFunction;
-    static constexpr unsigned StructureFlags = Base::StructureFlags;
+    LazyProperty<JSC::JSGlobalObject, Structure> mockFunctionStructure;
+    LazyProperty<JSC::JSGlobalObject, Structure> mockResultStructure;
+    LazyProperty<JSC::JSGlobalObject, Structure> mockImplementationStructure;
+    LazyProperty<JSC::JSGlobalObject, Structure> mockObject;
 
-    static JSMockFunction* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSValue);
-    static Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject);
+    static JSMockModule create(JSC::JSGlobalObject*);
 
-    DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
-
-    JSC::LazyProperty<JSMockFunction, JSC::JSObject> m_mock;
-    mutable JSC::WriteBarrier<JSC::JSArray> m_returnValues;
-    mutable JSC::WriteBarrier<JSC::JSArray> m_calls;
-    mutable JSC::WriteBarrier<JSC::JSArray> m_instances;
-    mutable JSC::WriteBarrier<JSC::Unknown> m_next;
-
-    template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
-    {
-        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
-            return nullptr;
-        return WebCore::subspaceForImpl<JSMockFunction, UseCustomHeapCellType::No>(
-            vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSMockFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMockFunction = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSMockFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMockFunction = std::forward<decltype(space)>(space); });
-    }
-
-    void setNext(JSC::JSValue value)
-    {
-        m_next.set(this->globalObject()->vm(), this, value);
-    }
-
-    JSC::JSValue calls()
-    {
-        return m_calls.get();
-    }
-
-    JSC::JSValue instances()
-    {
-        return m_instances.get();
-    }
-
-    JSC::JSValue returnValues()
-    {
-        return m_returnValues.get();
-    }
-
-    JSC::JSValue mock()
-    {
-        return m_mock.getInitializedOnMainThread(this);
-    }
-
-    JSC::JSValue next()
-    {
-        return m_next.get();
-    }
-
-    JSMockFunction(JSC::VM&, JSC::Structure*);
 };
 
 }

--- a/src/bun.js/bindings/JSMockFunction.h
+++ b/src/bun.js/bindings/JSMockFunction.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "root.h"
+#include <JavaScriptCore/InternalFunction.h>
+#include "JavaScriptCore/SubspaceInlines.h"
+
+namespace WebCore {
+}
+
+namespace Bun {
+
+using namespace JSC;
+using namespace WebCore;
+
+class JSMockReturnValue final : public JSC::JSInternalFieldObjectImpl<3> {
+public:
+    using Base = JSC::JSInternalFieldObjectImpl<3>;
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    JSC::JSInternalPromise* internalPromise();
+
+    template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
+            return nullptr;
+        return WebCore::subspaceForImpl<JSMockReturnValue, UseCustomHeapCellType::No>(
+            vm,
+            [](auto& spaces) { return spaces.m_clientSubspaceForJSMockReturnValue.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMockReturnValue = std::forward<decltype(space)>(space); },
+            [](auto& spaces) { return spaces.m_subspaceForJSMockReturnValue.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMockReturnValue = std::forward<decltype(space)>(space); });
+    }
+
+    static constexpr unsigned numberOfInternalFields = 3;
+
+    static std::array<JSValue, numberOfInternalFields> initialValues()
+    {
+        return { {
+            jsNumber(-1),
+            jsUndefined(),
+            jsUndefined(),
+        } };
+    }
+
+    DECLARE_EXPORT_INFO;
+    DECLARE_VISIT_CHILDREN;
+
+    JSMockReturnValue(JSC::VM&, JSC::Structure*);
+    void finishCreation(JSC::VM&, JSC::JSValue, JSC::JSValue, JSC::JSValue);
+};
+
+class JSMockFunction final : public JSC::InternalFunction {
+public:
+    using Base = JSC::InternalFunction;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static JSMockFunction* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSValue);
+    static Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject);
+
+    DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
+
+    JSC::LazyProperty<JSMockFunction, JSC::JSObject> m_mock;
+    mutable JSC::WriteBarrier<JSC::JSArray> m_returnValues;
+    mutable JSC::WriteBarrier<JSC::JSArray> m_calls;
+    mutable JSC::WriteBarrier<JSC::JSArray> m_instances;
+    mutable JSC::WriteBarrier<JSC::Unknown> m_next;
+
+    template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
+            return nullptr;
+        return WebCore::subspaceForImpl<JSMockFunction, UseCustomHeapCellType::No>(
+            vm,
+            [](auto& spaces) { return spaces.m_clientSubspaceForJSMockFunction.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMockFunction = std::forward<decltype(space)>(space); },
+            [](auto& spaces) { return spaces.m_subspaceForJSMockFunction.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMockFunction = std::forward<decltype(space)>(space); });
+    }
+
+    void setNext(JSC::JSValue value)
+    {
+        m_next.set(this->globalObject()->vm(), this, value);
+    }
+
+    JSC::JSValue calls()
+    {
+        return m_calls.get();
+    }
+
+    JSC::JSValue instances()
+    {
+        return m_instances.get();
+    }
+
+    JSC::JSValue returnValues()
+    {
+        return m_returnValues.get();
+    }
+
+    JSC::JSValue mock()
+    {
+        return m_mock.getInitializedOnMainThread(this);
+    }
+
+    JSC::JSValue next()
+    {
+        return m_next.get();
+    }
+
+    JSMockFunction(JSC::VM&, JSC::Structure*);
+};
+
+}

--- a/src/bun.js/bindings/JSMockFunction.h
+++ b/src/bun.js/bindings/JSMockFunction.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "root.h"
-#include <JavaScriptCore/InternalFunction.h>
-#include "JavaScriptCore/SubspaceInlines.h"
+#include "JavaScriptCore/LazyProperty.h"
 
 namespace WebCore {
 }
@@ -17,7 +16,7 @@ public:
     LazyProperty<JSC::JSGlobalObject, Structure> mockFunctionStructure;
     LazyProperty<JSC::JSGlobalObject, Structure> mockResultStructure;
     LazyProperty<JSC::JSGlobalObject, Structure> mockImplementationStructure;
-    LazyProperty<JSC::JSGlobalObject, Structure> mockObject;
+    LazyProperty<JSC::JSGlobalObject, Structure> mockObjectStructure;
 
     static JSMockModule create(JSC::JSGlobalObject*);
 

--- a/src/bun.js/bindings/JSMockFunction.h
+++ b/src/bun.js/bindings/JSMockFunction.h
@@ -2,6 +2,7 @@
 
 #include "root.h"
 #include "JavaScriptCore/LazyProperty.h"
+#include "JavaScriptCore/Strong.h"
 
 namespace WebCore {
 }
@@ -11,16 +12,19 @@ namespace Bun {
 using namespace JSC;
 using namespace WebCore;
 
+class JSMockFunction;
+
 class JSMockModule final {
 public:
     LazyProperty<JSC::JSGlobalObject, Structure> mockFunctionStructure;
     LazyProperty<JSC::JSGlobalObject, Structure> mockResultStructure;
     LazyProperty<JSC::JSGlobalObject, Structure> mockImplementationStructure;
     LazyProperty<JSC::JSGlobalObject, Structure> mockObjectStructure;
+    LazyProperty<JSC::JSGlobalObject, Structure> activeSpySetStructure;
 
     static JSMockModule create(JSC::JSGlobalObject*);
 
-    DECLARE_VISIT_CHILDREN;
+    JSC::Strong<Unknown> activeSpies;
 };
 
 }

--- a/src/bun.js/bindings/JSMockFunction.h
+++ b/src/bun.js/bindings/JSMockFunction.h
@@ -12,43 +12,6 @@ namespace Bun {
 using namespace JSC;
 using namespace WebCore;
 
-class JSMockReturnValue final : public JSC::JSInternalFieldObjectImpl<3> {
-public:
-    using Base = JSC::JSInternalFieldObjectImpl<3>;
-    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
-
-    JSC::JSInternalPromise* internalPromise();
-
-    template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
-    {
-        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
-            return nullptr;
-        return WebCore::subspaceForImpl<JSMockReturnValue, UseCustomHeapCellType::No>(
-            vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSMockReturnValue.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMockReturnValue = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSMockReturnValue.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMockReturnValue = std::forward<decltype(space)>(space); });
-    }
-
-    static constexpr unsigned numberOfInternalFields = 3;
-
-    static std::array<JSValue, numberOfInternalFields> initialValues()
-    {
-        return { {
-            jsNumber(-1),
-            jsUndefined(),
-            jsUndefined(),
-        } };
-    }
-
-    DECLARE_EXPORT_INFO;
-    DECLARE_VISIT_CHILDREN;
-
-    JSMockReturnValue(JSC::VM&, JSC::Structure*);
-    void finishCreation(JSC::VM&, JSC::JSValue, JSC::JSValue, JSC::JSValue);
-};
-
 class JSMockFunction final : public JSC::InternalFunction {
 public:
     using Base = JSC::InternalFunction;

--- a/src/bun.js/bindings/ZigGeneratedClasses.cpp
+++ b/src/bun.js/bindings/ZigGeneratedClasses.cpp
@@ -2764,6 +2764,9 @@ JSC_DECLARE_HOST_FUNCTION(ExpectPrototype__toEndWithCallback);
 extern "C" EncodedJSValue ExpectPrototype__toEqual(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC_DECLARE_HOST_FUNCTION(ExpectPrototype__toEqualCallback);
 
+extern "C" EncodedJSValue ExpectPrototype__toHaveBeenCalled(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
+JSC_DECLARE_HOST_FUNCTION(ExpectPrototype__toHaveBeenCalledCallback);
+
 extern "C" EncodedJSValue ExpectPrototype__toHaveBeenCalledTimes(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC_DECLARE_HOST_FUNCTION(ExpectPrototype__toHaveBeenCalledTimesCallback);
 
@@ -2864,6 +2867,7 @@ static const HashTableValue JSExpectPrototypeTableValues[] = {
     { "toContainEqual"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, ExpectPrototype__toContainEqualCallback, 1 } },
     { "toEndWith"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, ExpectPrototype__toEndWithCallback, 1 } },
     { "toEqual"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, ExpectPrototype__toEqualCallback, 1 } },
+    { "toHaveBeenCalled"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, ExpectPrototype__toHaveBeenCalledCallback, 0 } },
     { "toHaveBeenCalledTimes"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, ExpectPrototype__toHaveBeenCalledTimesCallback, 1 } },
     { "toHaveBeenCalledWith"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, ExpectPrototype__toHaveBeenCalledWithCallback, 1 } },
     { "toHaveBeenLastCalledWith"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, ExpectPrototype__toHaveBeenLastCalledWithCallback, 1 } },
@@ -3852,6 +3856,33 @@ JSC_DEFINE_HOST_FUNCTION(ExpectPrototype__toEqualCallback, (JSGlobalObject * lex
 #endif
 
     return ExpectPrototype__toEqual(thisObject->wrapped(), lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(ExpectPrototype__toHaveBeenCalledCallback, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+
+    JSExpect* thisObject = jsDynamicCast<JSExpect*>(callFrame->thisValue());
+
+    if (UNLIKELY(!thisObject)) {
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope);
+    }
+
+    JSC::EnsureStillAliveScope thisArg = JSC::EnsureStillAliveScope(thisObject);
+
+#ifdef BUN_DEBUG
+    /** View the file name of the JS file that called this function
+     * from a debugger */
+    SourceOrigin sourceOrigin = callFrame->callerSourceOrigin(vm);
+    const char* fileName = sourceOrigin.string().utf8().data();
+    static const char* lastFileName = nullptr;
+    if (lastFileName != fileName) {
+        lastFileName = fileName;
+    }
+#endif
+
+    return ExpectPrototype__toHaveBeenCalled(thisObject->wrapped(), lexicalGlobalObject, callFrame);
 }
 
 JSC_DEFINE_HOST_FUNCTION(ExpectPrototype__toHaveBeenCalledTimesCallback, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3905,6 +3905,11 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_cachedGlobalObjectStructure.visit(visitor);
     thisObject->m_cachedGlobalProxyStructure.visit(visitor);
 
+    thisObject->mockModule.mockFunctionStructure.visit(visitor);
+    thisObject->mockModule.mockResultStructure.visit(visitor);
+    thisObject->mockModule.mockImplementationStructure.visit(visitor);
+    thisObject->mockModule.mockObjectStructure.visit(visitor);
+
     for (auto& barrier : thisObject->m_thenables) {
         visitor.append(barrier);
     }

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3909,6 +3909,7 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->mockModule.mockResultStructure.visit(visitor);
     thisObject->mockModule.mockImplementationStructure.visit(visitor);
     thisObject->mockModule.mockObjectStructure.visit(visitor);
+    thisObject->mockModule.activeSpySetStructure.visit(visitor);
 
     for (auto& barrier : thisObject->m_thenables) {
         visitor.append(barrier);

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -504,7 +504,7 @@ GlobalObject::GlobalObject(JSC::VM& vm, JSC::Structure* structure)
     , m_builtinInternalFunctions(vm)
 
 {
-
+    mockModule = Bun::JSMockModule::create(this);
     m_scriptExecutionContext = new WebCore::ScriptExecutionContext(&vm, this);
 }
 

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -41,6 +41,7 @@ class DOMWrapperWorld;
 
 #include "DOMConstructors.h"
 #include "BunPlugin.h"
+#include "JSMockFunction.h"
 
 namespace WebCore {
 class SubtleCrypto;
@@ -405,6 +406,8 @@ public:
     void* napiInstanceData = nullptr;
     void* napiInstanceDataFinalizer = nullptr;
     void* napiInstanceDataFinalizerHint = nullptr;
+
+    Bun::JSMockModule mockModule;
 
 #include "ZigGeneratedClasses+lazyStructureHeader.h"
 

--- a/src/bun.js/bindings/generated_classes.zig
+++ b/src/bun.js/bindings/generated_classes.zig
@@ -944,6 +944,8 @@ pub const JSExpect = struct {
             @compileLog("Expected Expect.toEndWith to be a callback but received " ++ @typeName(@TypeOf(Expect.toEndWith)));
         if (@TypeOf(Expect.toEqual) != CallbackType)
             @compileLog("Expected Expect.toEqual to be a callback but received " ++ @typeName(@TypeOf(Expect.toEqual)));
+        if (@TypeOf(Expect.toHaveBeenCalled) != CallbackType)
+            @compileLog("Expected Expect.toHaveBeenCalled to be a callback but received " ++ @typeName(@TypeOf(Expect.toHaveBeenCalled)));
         if (@TypeOf(Expect.toHaveBeenCalledTimes) != CallbackType)
             @compileLog("Expected Expect.toHaveBeenCalledTimes to be a callback but received " ++ @typeName(@TypeOf(Expect.toHaveBeenCalledTimes)));
         if (@TypeOf(Expect.toHaveBeenCalledWith) != CallbackType)
@@ -1069,6 +1071,7 @@ pub const JSExpect = struct {
             @export(Expect.toContainEqual, .{ .name = "ExpectPrototype__toContainEqual" });
             @export(Expect.toEndWith, .{ .name = "ExpectPrototype__toEndWith" });
             @export(Expect.toEqual, .{ .name = "ExpectPrototype__toEqual" });
+            @export(Expect.toHaveBeenCalled, .{ .name = "ExpectPrototype__toHaveBeenCalled" });
             @export(Expect.toHaveBeenCalledTimes, .{ .name = "ExpectPrototype__toHaveBeenCalledTimes" });
             @export(Expect.toHaveBeenCalledWith, .{ .name = "ExpectPrototype__toHaveBeenCalledWith" });
             @export(Expect.toHaveBeenLastCalledWith, .{ .name = "ExpectPrototype__toHaveBeenLastCalledWith" });

--- a/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
@@ -34,6 +34,9 @@ public:
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForBundlerPlugin;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNodeVMScript;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForCommonJSModuleRecord;
+    std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSMockImplementation;
+    std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSMockFunction;
+
 #include "ZigGeneratedClasses+DOMClientIsoSubspaces.h"
     /* --- bun --- */
 

--- a/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
@@ -34,6 +34,8 @@ public:
     std::unique_ptr<IsoSubspace> m_subspaceForBundlerPlugin;
     std::unique_ptr<IsoSubspace> m_subspaceForNodeVMScript;
     std::unique_ptr<IsoSubspace> m_subspaceForCommonJSModuleRecord;
+    std::unique_ptr<IsoSubspace> m_subspaceForJSMockImplementation;
+    std::unique_ptr<IsoSubspace> m_subspaceForJSMockFunction;
 
 #include "ZigGeneratedClasses+DOMIsoSubspaces.h"
     /*-- BUN --*/

--- a/src/bun.js/test/jest.classes.ts
+++ b/src/bun.js/test/jest.classes.ts
@@ -77,6 +77,10 @@ export default [
         fn: "toBe",
         length: 1,
       },
+      toHaveBeenCalled: {
+        fn: "toHaveBeenCalled",
+        length: 0,
+      },
       toHaveBeenCalledTimes: {
         fn: "toHaveBeenCalledTimes",
         length: 1,

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -697,8 +697,16 @@ pub const Jest = struct {
             Expect.getConstructor(globalObject),
         );
 
+        module.put(
+            globalObject,
+            ZigString.static("mock"),
+            JSMockFunction__createObject(globalObject),
+        );
+
         return module;
     }
+
+    extern fn JSMockFunction__createObject(*JSC.JSGlobalObject) JSC.JSValue;
 
     extern fn Bun__Jest__testPreloadObject(*JSC.JSGlobalObject) JSC.JSValue;
     extern fn Bun__Jest__testModuleObject(*JSC.JSGlobalObject) JSC.JSValue;

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -3893,7 +3893,7 @@ pub const Expect = struct {
 
         const times = arguments[0].coerce(i32, globalObject);
 
-        var pass = @intCast(i32, calls.getLength(globalObject)) >= times;
+        var pass = @intCast(i32, calls.getLength(globalObject)) == times;
 
         const not = this.op.contains(.not);
         if (not) pass = !pass;

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -3910,6 +3910,15 @@ pub const Expect = struct {
             }
             globalObject.throw(Output.prettyFmt(fmt, false), .{calls.toFmt(globalObject, &formatter)});
             return .zero;
+        } else {
+            const signature = comptime getSignature("toHaveBeenCalled", "<green>expected<r>", true);
+            const fmt = signature ++ "\n\nExpected <green>{any}<r>\n";
+            if (Output.enable_ansi_colors) {
+                globalObject.throw(Output.prettyFmt(fmt, true), .{calls.toFmt(globalObject, &formatter)});
+                return .zero;
+            }
+            globalObject.throw(Output.prettyFmt(fmt, false), .{calls.toFmt(globalObject, &formatter)});
+            return .zero;
         }
 
         unreachable;

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -697,11 +697,16 @@ pub const Jest = struct {
             Expect.getConstructor(globalObject),
         );
 
+        const mock_object = JSMockFunction__createObject(globalObject);
         module.put(
             globalObject,
             ZigString.static("mock"),
-            JSMockFunction__createObject(globalObject),
+            mock_object,
         );
+
+        const jest = JSValue.createEmptyObject(globalObject, 1);
+        jest.put(globalObject, ZigString.static("fn"), mock_object);
+        module.put(globalObject, ZigString.static("jest"), jest);
 
         return module;
     }

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -4674,6 +4674,7 @@ const Jest = struct {
     afterEach: Ref = Ref.None,
     beforeAll: Ref = Ref.None,
     afterAll: Ref = Ref.None,
+    jest: Ref = Ref.None,
 };
 
 // workaround for https://github.com/ziglang/zig/issues/10903
@@ -6474,6 +6475,7 @@ fn NewParser_(
             if (p.options.features.inject_jest_globals) {
                 p.jest.describe = try p.declareCommonJSSymbol(.unbound, "describe");
                 p.jest.@"test" = try p.declareCommonJSSymbol(.unbound, "test");
+                p.jest.jest = try p.declareCommonJSSymbol(.unbound, "jest");
                 p.jest.it = try p.declareCommonJSSymbol(.unbound, "it");
                 p.jest.expect = try p.declareCommonJSSymbol(.unbound, "expect");
                 p.jest.beforeEach = try p.declareCommonJSSymbol(.unbound, "beforeEach");

--- a/test/js/bun/test/mock-test.test.ts
+++ b/test/js/bun/test/mock-test.test.ts
@@ -1,12 +1,39 @@
-import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { test, mock, expect } from "bun:test";
 
-describe("mocks", () => {
-  it("are callable", () => {
-    const fn = mock(() => 42);
-    expect(fn()).toBe(42);
-    expect(fn.mock.calls.length).toBe(1);
-    expect(fn.mock.calls[0].length).toBe(0);
-    expect(fn).toHaveBeenCalled();
-    expect(fn).toHaveBeenCalledTimes(1);
+test("are callable", () => {
+  const fn = mock(() => 42);
+  expect(fn()).toBe(42);
+  expect(fn).toHaveBeenCalled();
+  expect(fn).toHaveBeenCalledTimes(1);
+  expect(fn.mock.calls).toHaveLength(1);
+  expect(fn.mock.calls[0]).toBeEmpty();
+
+  expect(fn()).toBe(42);
+  expect(fn).toHaveBeenCalledTimes(2);
+
+  expect(fn.mock.calls).toHaveLength(2);
+  expect(fn.mock.calls[1]).toBeEmpty();
+});
+
+test("include arguments", () => {
+  const fn = mock(f => f);
+  expect(fn(43)).toBe(43);
+  expect(fn.mock.results[0]).toEqual({
+    type: "return",
+    value: 43,
   });
+  expect(fn.mock.calls[0]).toEqual([43]);
+});
+
+test("works when throwing", () => {
+  const instance = new Error("foo");
+  const fn = mock(f => {
+    throw instance;
+  });
+  expect(() => fn(43)).toThrow("foo");
+  expect(fn.mock.results[0]).toEqual({
+    type: "throw",
+    value: instance,
+  });
+  expect(fn.mock.calls[0]).toEqual([43]);
 });

--- a/test/js/bun/test/mock-test.test.ts
+++ b/test/js/bun/test/mock-test.test.ts
@@ -1,4 +1,4 @@
-import { test, mock, expect } from "bun:test";
+import { test, mock, expect, spyOn, jest } from "bun:test";
 
 test("are callable", () => {
   const fn = mock(() => 42);
@@ -64,3 +64,68 @@ test("mockReset works", () => {
   });
   expect(fn.mock.calls[0]).toEqual([43]);
 });
+
+test("spyOn works on functions", () => {
+  var obj = {
+    original() {
+      return 42;
+    },
+  };
+  const fn = spyOn(obj, "original");
+  expect(fn).not.toHaveBeenCalled();
+  expect(obj.original()).toBe(42);
+  expect(fn).toHaveBeenCalled();
+  expect(fn).toHaveBeenCalledTimes(1);
+  expect(fn.mock.calls).toHaveLength(1);
+  expect(fn.mock.calls[0]).toBeEmpty();
+  jest.restoreAllMocks();
+  expect(() => expect(obj.original).toHaveBeenCalled()).toThrow();
+});
+
+test("spyOn works on object", () => {
+  var obj = { original: 42 };
+  obj.original = 42;
+  const fn = spyOn(obj, "original");
+  expect(fn).not.toHaveBeenCalled();
+  expect(obj.original).toBe(42);
+  expect(fn).toHaveBeenCalled();
+  expect(fn).toHaveBeenCalledTimes(1);
+  expect(fn.mock.calls).toHaveLength(1);
+  expect(fn.mock.calls[0]).toBeEmpty();
+  jest.restoreAllMocks();
+  expect(() => expect(obj.original).toHaveBeenCalled()).toThrow();
+});
+
+test("spyOn on object doens't crash if object GC'd", () => {
+  const spies = new Array(1000);
+  (() => {
+    for (let i = 0; i < 1000; i++) {
+      var obj = { original: 42 };
+      obj.original = 42;
+      const fn = spyOn(obj, "original");
+      spies[i] = fn;
+    }
+    Bun.gc(true);
+  })();
+  Bun.gc(true);
+
+  jest.restoreAllMocks();
+});
+
+test("spyOn works on globalThis", () => {
+  var obj = globalThis;
+  obj.original = 42;
+  const fn = spyOn(obj, "original");
+  expect(fn).not.toHaveBeenCalled();
+  expect(obj.original).toBe(42);
+  expect(fn).toHaveBeenCalled();
+  expect(fn).toHaveBeenCalledTimes(1);
+  expect(fn.mock.calls).toHaveLength(1);
+  expect(fn.mock.calls[0]).toBeEmpty();
+  jest.restoreAllMocks();
+  expect(() => expect(obj.original).toHaveBeenCalled()).toThrow();
+  obj.original;
+  expect(fn).not.toHaveBeenCalled();
+});
+
+// spyOn does not work with getters/setters yet.

--- a/test/js/bun/test/mock-test.test.ts
+++ b/test/js/bun/test/mock-test.test.ts
@@ -1,0 +1,12 @@
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+
+describe("mocks", () => {
+  it("are callable", () => {
+    const fn = mock(() => 42);
+    expect(fn()).toBe(42);
+    expect(fn.mock.calls.length).toBe(1);
+    expect(fn.mock.calls[0].length).toBe(0);
+    expect(fn).toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/js/bun/test/mock-test.test.ts
+++ b/test/js/bun/test/mock-test.test.ts
@@ -37,3 +37,30 @@ test("works when throwing", () => {
   });
   expect(fn.mock.calls[0]).toEqual([43]);
 });
+
+test("mockReset works", () => {
+  const instance = new Error("foo");
+  const fn = mock(f => {
+    throw instance;
+  });
+  expect(() => fn(43)).toThrow("foo");
+  expect(fn.mock.results[0]).toEqual({
+    type: "throw",
+    value: instance,
+  });
+  expect(fn.mock.calls[0]).toEqual([43]);
+
+  fn.mockReset();
+
+  expect(fn.mock.calls).toBeEmpty();
+  expect(fn.mock.results).toBeEmpty();
+  expect(fn.mock.instances).toBeEmpty();
+  expect(fn).not.toHaveBeenCalled();
+
+  expect(() => fn(43)).toThrow("foo");
+  expect(fn.mock.results[0]).toEqual({
+    type: "throw",
+    value: instance,
+  });
+  expect(fn.mock.calls[0]).toEqual([43]);
+});


### PR DESCRIPTION
This implements:
- `expect(fn).toHaveBeenCalled()`
- `expect(fn).toHaveBeenCalledTimes(1)`

```ts
import { describe, expect, it, mock } from "bun:test";

describe("mocks", () => {
  it("are callable", () => {
    const fn = mock(() => 42);
    expect(fn()).toBe(42);
    expect(fn.mock.calls.length).toBe(1);
    expect(fn.mock.calls[0].length).toBe(0);
    expect(fn).toHaveBeenCalled();
    expect(fn).toHaveBeenCalledTimes(1);
  });
});

```

This leaves `toHaveBeenReturned` & friends to a subsequent PR. 

mockImplementationOnce() doesn't work right yet
