### PR TITLE
Fixes #3250

### DIFF
--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -1871,6 +1871,7 @@ pub const Crypto = struct {
                     // we use SHA512 to hash the password if it's longer than 72 bytes
                     if (password.len > 72) {
                         var sha_256 = bun.sha.SHA512.init();
+                        defer sha_256.deinit();
                         sha_256.update(password);
                         sha_256.final(outbuf[0..bun.sha.SHA512.digest]);
                         password_to_use = outbuf[0..bun.sha.SHA512.digest];

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -3125,6 +3125,29 @@ pub fn wrapStaticMethod(
                             args[i] = null;
                         }
                     },
+                    JSC.Node.SliceOrBuffer => {
+                        const arg = iter.nextEat() orelse {
+                            globalThis.throwInvalidArguments("expected string or buffer", .{});
+                            iter.deinit();
+                            return JSC.JSValue.zero;
+                        };
+                        args[i] = JSC.Node.SliceOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg) orelse {
+                            globalThis.throwInvalidArguments("expected string or buffer", .{});
+                            iter.deinit();
+                            return JSC.JSValue.zero;
+                        };
+                    },
+                    ?JSC.Node.SliceOrBuffer => {
+                        if (iter.nextEat()) |arg| {
+                            args[i] = JSC.Node.SliceOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg) orelse {
+                                globalThis.throwInvalidArguments("expected string or buffer", .{});
+                                iter.deinit();
+                                return JSC.JSValue.zero;
+                            };
+                        } else {
+                            args[i] = null;
+                        }
+                    },
                     JSC.ArrayBuffer => {
                         if (iter.nextEat()) |arg| {
                             args[i] = arg.asArrayBuffer(globalThis.ptr()) orelse {

--- a/src/sha.zig
+++ b/src/sha.zig
@@ -76,7 +76,7 @@ fn NewEVP(
         }
 
         pub fn deinit(this: *@This()) void {
-            BoringSSL.EVP_MD_CTX_cleanup(&this.ctx);
+            _ = BoringSSL.EVP_MD_CTX_cleanup(&this.ctx);
         }
     };
 }

--- a/src/sha.zig
+++ b/src/sha.zig
@@ -74,6 +74,10 @@ fn NewEVP(
         pub fn final(this: *@This(), out: *Digest) void {
             std.debug.assert(BoringSSL.EVP_DigestFinal(&this.ctx, out, null) == 1);
         }
+
+        pub fn deinit(this: *@This()) void {
+            BoringSSL.EVP_MD_CTX_cleanup(&this.ctx);
+        }
     };
 }
 pub const EVP = struct {
@@ -331,4 +335,3 @@ pub fn main() anyerror!void {
 //     std.crypto.hash.sha2.Sha256.hash(value, &hash2, .{});
 //     try std.testing.expectEqual(hash, hash2);
 // }
-


### PR DESCRIPTION
We must call `EVP_MD_CTX_cleanup` because `EVP_MD_CTX` containers pointers inside to allocated memory