### PR TITLE
Make cold `bun install` use 2x less memory

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -72,6 +72,37 @@ pub fn initializeStore() void {
     JSAst.Stmt.Data.Store.create(default_allocator);
 }
 
+/// The default store we use pre-allocates around 16 MB of memory per thread
+/// That adds up in multi-threaded scenarios.
+/// ASTMemoryAllocator uses a smaller fixed buffer allocator
+pub fn initializeMiniStore() void {
+    const MiniStore = struct {
+        heap: bun.MimallocArena,
+        memory_allocator: JSAst.ASTMemoryAllocator,
+
+        pub threadlocal var instance: ?*@This() = null;
+    };
+    if (MiniStore.instance == null) {
+        var mini_store = bun.default_allocator.create(MiniStore) catch @panic("OOM");
+        mini_store.* = .{
+            .heap = bun.MimallocArena.init() catch @panic("OOM"),
+            .memory_allocator = undefined,
+        };
+        mini_store.memory_allocator = .{ .allocator = mini_store.heap.allocator() };
+        mini_store.memory_allocator.reset();
+        MiniStore.instance = mini_store;
+        mini_store.memory_allocator.push();
+    } else {
+        var mini_store = MiniStore.instance.?;
+        if (mini_store.memory_allocator.stack_allocator.fixed_buffer_allocator.end_index >= mini_store.memory_allocator.stack_allocator.fixed_buffer_allocator.buffer.len -| 1) {
+            mini_store.heap.reset();
+            mini_store.memory_allocator.allocator = mini_store.heap.allocator();
+        }
+        mini_store.memory_allocator.reset();
+        mini_store.memory_allocator.push();
+    }
+}
+
 const IdentityContext = @import("../identity_context.zig").IdentityContext;
 const ArrayIdentityContext = @import("../identity_context.zig").ArrayIdentityContext;
 const NetworkQueue = std.fifo.LinearFifo(*NetworkTask, .{ .Static = 32 });
@@ -558,10 +589,18 @@ const Task = struct {
         switch (this.tag) {
             .package_manifest => {
                 var allocator = bun.default_allocator;
+                const body = this.request.package_manifest.network.response_buffer.toOwnedSliceLeaky();
+                this.request.package_manifest.network.response_buffer.list.items.len = 0;
+                this.request.package_manifest.network.response_buffer.list.capacity = 0;
+
+                defer {
+                    bun.default_allocator.free(body);
+                    this.package_manager.resolve_tasks.writeItem(this.*) catch unreachable;
+                }
                 const package_manifest = Npm.Registry.getPackageMetadata(
                     allocator,
                     this.request.package_manifest.network.http.response.?,
-                    this.request.package_manifest.network.response_buffer.toOwnedSliceLeaky(),
+                    body,
                     &this.log,
                     this.request.package_manifest.name.slice(),
                     this.request.package_manifest.network.callback.package_manifest.loaded_manifest,
@@ -575,7 +614,6 @@ const Task = struct {
                     this.err = err;
                     this.status = Status.fail;
                     this.data = .{ .package_manifest = .{} };
-                    this.package_manager.resolve_tasks.writeItem(this.*) catch unreachable;
                     return;
                 };
 
@@ -584,7 +622,6 @@ const Task = struct {
                     .fresh => |manifest| {
                         this.status = Status.success;
                         this.data = .{ .package_manifest = manifest };
-                        this.package_manager.resolve_tasks.writeItem(this.*) catch unreachable;
                         return;
                     },
                     .not_found => {
@@ -593,14 +630,22 @@ const Task = struct {
                         }) catch unreachable;
                         this.status = Status.fail;
                         this.data = .{ .package_manifest = .{} };
-                        this.package_manager.resolve_tasks.writeItem(this.*) catch unreachable;
                         return;
                     },
                 }
             },
             .extract => {
+                const bytes = this.request.extract.network.response_buffer.toOwnedSliceLeaky();
+                this.request.extract.network.response_buffer.list.capacity = 0;
+                this.request.extract.network.response_buffer.list.items.len = 0;
+
+                defer {
+                    bun.default_allocator.free(bytes);
+                    this.package_manager.resolve_tasks.writeItem(this.*) catch unreachable;
+                }
+
                 const result = this.request.extract.tarball.run(
-                    this.request.extract.network.response_buffer.toOwnedSliceLeaky(),
+                    bytes,
                 ) catch |err| {
                     if (comptime Environment.isDebug) {
                         if (@errorReturnTrace()) |trace| {
@@ -611,13 +656,11 @@ const Task = struct {
                     this.err = err;
                     this.status = Status.fail;
                     this.data = .{ .extract = .{} };
-                    this.package_manager.resolve_tasks.writeItem(this.*) catch unreachable;
                     return;
                 };
 
                 this.data = .{ .extract = result };
                 this.status = Status.success;
-                this.package_manager.resolve_tasks.writeItem(this.*) catch unreachable;
             },
             .git_clone => {
                 const manager = this.package_manager;
@@ -1690,6 +1733,7 @@ pub const PackageManager = struct {
 
     pub fn sleep(this: *PackageManager) void {
         if (this.wait_count.swap(0, .Monotonic) > 0) return;
+        bun.Mimalloc.mi_collect(false);
         _ = this.waiter.wait() catch 0;
     }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -589,13 +589,11 @@ const Task = struct {
         switch (this.tag) {
             .package_manifest => {
                 var allocator = bun.default_allocator;
-                const body = this.request.package_manifest.network.response_buffer.toOwnedSliceLeaky();
-                this.request.package_manifest.network.response_buffer.list.items.len = 0;
-                this.request.package_manifest.network.response_buffer.list.capacity = 0;
+                const body = this.request.package_manifest.network.response_buffer.move();
 
                 defer {
-                    bun.default_allocator.free(body);
                     this.package_manager.resolve_tasks.writeItem(this.*) catch unreachable;
+                    bun.default_allocator.free(body);
                 }
                 const package_manifest = Npm.Registry.getPackageMetadata(
                     allocator,
@@ -635,13 +633,11 @@ const Task = struct {
                 }
             },
             .extract => {
-                const bytes = this.request.extract.network.response_buffer.toOwnedSliceLeaky();
-                this.request.extract.network.response_buffer.list.capacity = 0;
-                this.request.extract.network.response_buffer.list.items.len = 0;
+                const bytes = this.request.extract.network.response_buffer.move();
 
                 defer {
-                    bun.default_allocator.free(bytes);
                     this.package_manager.resolve_tasks.writeItem(this.*) catch unreachable;
+                    bun.default_allocator.free(bytes);
                 }
 
                 const result = this.request.extract.tarball.run(

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -11,7 +11,7 @@ const PackageManager = @import("./install.zig").PackageManager;
 const ExternalStringMap = @import("./install.zig").ExternalStringMap;
 const ExternalStringList = @import("./install.zig").ExternalStringList;
 const ExternalSlice = @import("./install.zig").ExternalSlice;
-const initializeStore = @import("./install.zig").initializeStore;
+const initializeStore = @import("./install.zig").initializeMiniStore;
 const logger = @import("root").bun.logger;
 const Output = @import("root").bun.Output;
 const Integrity = @import("./integrity.zig").Integrity;
@@ -789,7 +789,14 @@ pub const PackageManifest = struct {
     ) !?PackageManifest {
         const source = logger.Source.initPathString(expected_name, json_buffer);
         initializeStore();
-        const json = json_parser.ParseJSONUTF8(&source, log, allocator) catch return null;
+        defer bun.JSAst.Stmt.Data.Store.memory_allocator.?.pop();
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        const json = json_parser.ParseJSONUTF8(
+            &source,
+            log,
+            arena.allocator(),
+        ) catch return null;
 
         if (json.asProperty("error")) |error_q| {
             if (error_q.expr.asString(allocator)) |err| {
@@ -800,27 +807,12 @@ pub const PackageManifest = struct {
 
         var result = PackageManifest{};
 
-        if (!string_pool_loaded) {
-            string_pool_ = String.Builder.StringPool.init(default_allocator);
-            string_pool_loaded = true;
-        }
-
-        if (!external_string_maps_loaded) {
-            external_string_maps_ = ExternalStringMapDeduper.initContext(default_allocator, .{});
-            external_string_maps_loaded = true;
-        }
-
-        if (!optional_peer_dep_names_loaded) {
-            optional_peer_dep_names_ = std.ArrayList(u64).init(default_allocator);
-            optional_peer_dep_names_loaded = true;
-        }
-
-        var string_pool = string_pool_;
-        string_pool.clearRetainingCapacity();
-        var external_string_maps = external_string_maps_;
-        external_string_maps.clearRetainingCapacity();
-        var optional_peer_dep_names = optional_peer_dep_names_;
-        optional_peer_dep_names.clearRetainingCapacity();
+        var string_pool = String.Builder.StringPool.init(default_allocator);
+        defer string_pool.deinit();
+        var external_string_maps = ExternalStringMapDeduper.initContext(default_allocator, .{});
+        defer external_string_maps.deinit();
+        var optional_peer_dep_names = std.ArrayList(u64).init(default_allocator);
+        defer optional_peer_dep_names.deinit();
 
         defer string_pool_ = string_pool;
         defer external_string_maps_ = external_string_maps;

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -768,15 +768,6 @@ pub const PackageManifest = struct {
 
     const ExternalStringMapDeduper = std.HashMap(u64, ExternalStringList, IdentityContext(u64), 80);
 
-    threadlocal var string_pool_: String.Builder.StringPool = undefined;
-    threadlocal var string_pool_loaded: bool = false;
-
-    threadlocal var external_string_maps_: ExternalStringMapDeduper = undefined;
-    threadlocal var external_string_maps_loaded: bool = false;
-
-    threadlocal var optional_peer_dep_names_: std.ArrayList(u64) = undefined;
-    threadlocal var optional_peer_dep_names_loaded: bool = false;
-
     /// This parses [Abbreviated metadata](https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-metadata-format)
     pub fn parse(
         allocator: std.mem.Allocator,
@@ -813,10 +804,6 @@ pub const PackageManifest = struct {
         defer external_string_maps.deinit();
         var optional_peer_dep_names = std.ArrayList(u64).init(default_allocator);
         defer optional_peer_dep_names.deinit();
-
-        defer string_pool_ = string_pool;
-        defer external_string_maps_ = external_string_maps;
-        defer optional_peer_dep_names_ = optional_peer_dep_names;
 
         var string_builder = String.Builder{
             .string_pool = string_pool,

--- a/src/string_mutable.zig
+++ b/src/string_mutable.zig
@@ -235,6 +235,13 @@ pub const MutableString = struct {
         return self.list.items;
     }
 
+    /// Clear the existing value without freeing the memory or shrinking the capacity.
+    pub fn move(self: *MutableString) []u8 {
+        const out = self.list.items;
+        self.list = .{};
+        return out;
+    }
+
     pub fn toOwnedSentinelLeaky(self: *MutableString) [:0]u8 {
         if (self.list.items.len > 0 and self.list.items[self.list.items.len - 1] != 0) {
             self.list.append(


### PR DESCRIPTION
In this benchmark: https://github.com/orogene/orogene/blob/main/BENCHMARKS.md

Under "no lockfile, no cache", this PR brings us from around 2.7 GB to 1.2 GB of memory

<details> 

<summary>package.json</summary>

```json
{
  "name": "floc",
  "version": "0.1.0",
  "private": true,
  "scripts": {
    "css": "unocss 'src/**/*.tsx'",
    "build": "npm run css && next build",
    "dev": "concurrently \"next dev\" \"npm run dev:css\"",
    "dev:css": "npm run css -- --watch",
    "postinstall": "prisma generate",
    "lint": "next lint",
    "start": "next start",
    "typecheck": "tsc -p .",
    "typecheck:watch": "npm run typecheck -- --watch"
  },
  "dependencies": {
    "@iconify-json/ph": "^1.1.4",
    "@iconify-json/uil": "^1.1.4",
    "@iconify-json/uim": "^1.1.5",
    "@iconify-json/uis": "^1.1.4",
    "@iconify-json/uit": "^1.1.4",
    "@prisma/client": "^4.11.0",
    "@react-types/shared": "^3.17.0",
    "@sindresorhus/is": "^5.3.0",
    "@tanstack/react-query": "^4.24.10",
    "@trpc/client": "^10.13.2",
    "@trpc/next": "^10.13.2",
    "@trpc/react-query": "^10.13.2",
    "@trpc/server": "^10.13.2",
    "@types/lodash-es": "^4.17.6",
    "@unocss/cli": "^0.50.3",
    "clsx": "^1.2.1",
    "concurrently": "^7.6.0",
    "eslint-plugin-simple-import-sort": "^10.0.0",
    "eslint-plugin-unused-imports": "^2.0.0",
    "husky": "^8.0.3",
    "i18next": "^22.4.10",
    "i18next-chained-backend": "^4.2.0",
    "i18next-http-backend": "^2.1.1",
    "immer": "^9.0.19",
    "iron-session": "^6.3.1",
    "lodash-es": "^4.17.21",
    "masto": "^5.10.0",
    "next": "13.2.3",
    "next-i18next": "^13.2.0",
    "react": "18.2.0",
    "react-aria": "^3.23.0",
    "react-dom": "18.2.0",
    "react-i18next": "^12.2.0",
    "react-merge-refs": "^2.0.1",
    "react-stately": "^3.21.0",
    "react-use": "^17.4.0",
    "superjson": "^1.12.2",
    "unocss": "^0.50.3",
    "zod": "^3.20.6",
    "zustand": "^4.3.5"
  },
  "devDependencies": {
    "@commitlint/cli": "^17.4.4",
    "@commitlint/config-conventional": "^17.4.4",
    "@types/node": "^18.14.2",
    "@types/prettier": "^2.7.2",
    "@types/react": "^18.0.28",
    "@types/react-dom": "^18.0.11",
    "@typescript-eslint/eslint-plugin": "^5.54.0",
    "@typescript-eslint/parser": "^5.54.0",
    "@unocss/eslint-config": "^0.50.3",
    "eslint": "^8.35.0",
    "eslint-config-next": "13.2.3",
    "lint-staged": "^13.1.2",
    "prettier": "^2.8.4",
    "prisma": "^4.11.0",
    "typescript": "^4.9.5"
  },
  "browserslist": [
    "defaults and supports es6-module"
  ],
  "ct3aMetadata": {
    "initVersion": "7.4.0"
  }
}
```

</details>

Command:
```js
rm -rf  ~/.bun/install/cache node_modules bun.lockb
gtime -v bun install
```

Will need to see what the perf impact is, as the memory allocators used here are slower at resizing large amounts of data and I haven't run this on a release build yet.

The main differences are:
- Free the package manifest API request bodies
- Free the tarballs we downloaded
- Use a smaller AST node arena (also used by the bundler) and reset it more often
- Use an arena allocator for parsing manifest JSON

This PR has no impact on the following scenario:
```bash
rm -rf  ~/.bun/install/cache node_modules
gtime -v bun install
```

Which likely means similar changes can be applied to the main thread and have a similar ~2x impact