### PR TITLE
typo in readline

### DIFF
--- a/src/js/node/readline.js
+++ b/src/js/node/readline.js
@@ -690,7 +690,6 @@ function* emitKeys(stream) {
       keyCtrl = !!(modifier & 4);
       keyMeta = !!(modifier & 10);
       keyShift = !!(modifier & 1);
-      keyCode = code;
 
       // Parse the key itself
       switch (code) {

--- a/src/js/out/modules/node/readline.js
+++ b/src/js/out/modules/node/readline.js
@@ -143,7 +143,7 @@ function* emitKeys(stream) {
         else
           code += cmd;
       }
-      switch (keyCtrl2 = !!(modifier & 4), keyMeta = !!(modifier & 10), keyShift = !!(modifier & 1), keyCode = code, code) {
+      switch (keyCtrl2 = !!(modifier & 4), keyMeta = !!(modifier & 10), keyShift = !!(modifier & 1), code) {
         case "[P":
           keyName = "f1";
           break;


### PR DESCRIPTION
this variable isn't used or defined. doesn't seem to unblock any issues directly but it does fix a thrown referenceerror when using readline