### PR TITLE
Add typedefs for `Bun.argv`

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -51,6 +51,10 @@ declare module "bun" {
    *
    */
   export const env: Env;
+  /**
+   * The raw arguments passed to the process, including flags passed to Bun. If you want to easily read flags passed to your script, consider using `process.argv` instead.
+   */
+  export const argv: string[];
   export const origin: string;
 
   /**


### PR DESCRIPTION
Closes #3293

`Bun.argv` is weird, it's the raw arguments. Not 100% sure if the current behavior is what we even want, but maybe there is some value to being able to access the raw arguments.

Maybe later we should have a nice api like `Bun.args` which is equivalent of `process.argv.slice(2)`; that's what i assume the main usecase of process.argv is.
