### PR TITLE
Make `Bun.argv` the same as `process.argv`

### DIFF
--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -440,7 +440,7 @@ pub fn getAssetPrefix(
     _: js.JSStringRef,
     _: js.ExceptionRef,
 ) js.JSValueRef {
-    return ZigString.init(VirtualMachine.get().bundler.options.routes.asset_prefix_path).toValue(ctx.ptr()).asRef();
+    return ZigString.init(VirtualMachine.get().bundler.options.routes.asset_prefix_path).toValueGC(ctx.ptr()).asRef();
 }
 
 pub fn getArgv(
@@ -450,19 +450,8 @@ pub fn getArgv(
     _: js.JSStringRef,
     _: js.ExceptionRef,
 ) js.JSValueRef {
-    if (comptime Environment.isWindows) {
-        @compileError("argv not supported on windows");
-    }
-
-    var argv_list = std.heap.stackFallback(128, getAllocator(ctx));
-    var allocator = argv_list.get();
-    var argv = allocator.alloc(ZigString, std.os.argv.len) catch unreachable;
-    defer if (argv.len > 128) allocator.free(argv);
-    for (std.os.argv, 0..) |arg, i| {
-        argv[i] = ZigString.init(std.mem.span(arg));
-    }
-
-    return JSValue.createStringArray(ctx.ptr(), argv.ptr, argv.len, true).asObjectRef();
+    // TODO: cache this
+    return JSC.Node.Process.getArgv(ctx).asObjectRef();
 }
 
 pub fn getRoutesDir(

--- a/src/bun.js/bindings/Process.cpp
+++ b/src/bun.js/bindings/Process.cpp
@@ -825,16 +825,12 @@ JSC_DEFINE_CUSTOM_GETTER(Process_getArgv, (JSC::JSGlobalObject * globalObject, J
     if (!thisObject) {
         return JSValue::encode(JSC::jsUndefined());
     }
-    auto clientData = WebCore::clientData(vm);
-
-    if (JSC::JSValue argv = thisObject->getIfPropertyExists(
-            globalObject, clientData->builtinNames().argvPrivateName())) {
-        return JSValue::encode(argv);
-    }
 
     JSC::EncodedJSValue argv_ = Bun__Process__getArgv(globalObject);
-    thisObject->putDirect(vm, clientData->builtinNames().argvPrivateName(),
-        JSC::JSValue::decode(argv_));
+    auto clientData = WebCore::clientData(vm);
+
+    thisObject->putDirect(vm, clientData->builtinNames().argvPublicName(),
+        JSC::JSValue::decode(argv_), 0);
 
     return argv_;
 }
@@ -852,7 +848,7 @@ JSC_DEFINE_CUSTOM_SETTER(Process_setArgv,
 
     auto clientData = WebCore::clientData(vm);
 
-    return thisObject->putDirect(vm, clientData->builtinNames().argvPrivateName(),
+    return thisObject->putDirect(vm, clientData->builtinNames().argvPublicName(),
         JSC::JSValue::decode(value));
 }
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,6 +1,7 @@
 import { resolveSync, which } from "bun";
 import { describe, expect, it } from "bun:test";
 import { existsSync, readFileSync, realpathSync } from "fs";
+import { bunExe } from "harness";
 import { basename, resolve } from "path";
 
 it("process", () => {
@@ -223,4 +224,13 @@ it("process.execArgv", () => {
 
 it("process.binding", () => {
   expect(() => process.binding("buffer")).toThrow();
+});
+
+it("process.argv", () => {
+  expect(process.argv).toBeInstanceOf(Array);
+  expect(process.argv[0]).toBe(bunExe());
+  expect(process.argv).toEqual(Bun.argv);
+
+  // assert we aren't creating a new process.argv each call
+  expect(process.argv).toBe(process.argv);
 });


### PR DESCRIPTION
This makes `process.argv` and `Bun.argv` return the same thing. Also makes `process.argv` faster because it becomes the value 

This fixes #3307 