### PR TITLE
[Bun.serve] fix `Bun.serve` argument check

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -259,7 +259,7 @@ pub const SocketConfig = struct {
                 if (tls.toBoolean()) {
                     ssl = JSC.API.ServerConfig.SSLConfig.zero;
                 }
-            } else if (!tls.isEmptyOrUndefinedOrNull()) {
+            } else {
                 if (JSC.API.ServerConfig.SSLConfig.inJS(globalObject, tls, exception)) |ssl_config| {
                     ssl = ssl_config;
                 } else if (exception.* != null) {

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -261,7 +261,7 @@ pub const SocketConfig = struct {
                 }
 
                 break :outer;
-            } else {
+            } else if (!tls.isEmptyOrUndefinedOrNull()) {
                 if (JSC.API.ServerConfig.SSLConfig.inJS(globalObject, tls, exception)) |ssl_config| {
                     ssl = ssl_config;
                 } else if (exception.* != null) {

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -254,13 +254,11 @@ pub const SocketConfig = struct {
         var ssl: ?JSC.API.ServerConfig.SSLConfig = null;
         var default_data = JSValue.zero;
 
-        if (opts.getTruthy(globalObject, "tls")) |tls| outer: {
+        if (opts.getTruthy(globalObject, "tls")) |tls| {
             if (tls.isBoolean()) {
                 if (tls.toBoolean()) {
                     ssl = JSC.API.ServerConfig.SSLConfig.zero;
                 }
-
-                break :outer;
             } else if (!tls.isEmptyOrUndefinedOrNull()) {
                 if (JSC.API.ServerConfig.SSLConfig.inJS(globalObject, tls, exception)) |ssl_config| {
                     ssl = ssl_config;

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -261,12 +261,12 @@ pub const SocketConfig = struct {
                 }
 
                 break :outer;
-            }
-
-            if (JSC.API.ServerConfig.SSLConfig.inJS(globalObject, tls, exception)) |ssl_config| {
-                ssl = ssl_config;
-            } else if (exception.* != null) {
-                return null;
+            } else {
+                if (JSC.API.ServerConfig.SSLConfig.inJS(globalObject, tls, exception)) |ssl_config| {
+                    ssl = ssl_config;
+                } else if (exception.* != null) {
+                    return null;
+                }
             }
         }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -270,6 +270,8 @@ pub const ServerConfig = struct {
 
         pub fn inJS(global: *JSC.JSGlobalObject, obj: JSC.JSValue, exception: JSC.C.ExceptionRef) ?SSLConfig {
             var result = zero;
+            if (!obj.isObject()) return null;
+
             var any = false;
 
             // Required
@@ -688,7 +690,7 @@ pub const ServerConfig = struct {
         }
 
         if (arguments.next()) |arg| {
-            if (arg.isUndefinedOrNull() or !arg.isObject()) {
+            if (!arg.isObject()) {
                 JSC.throwInvalidArguments("Bun.serve expects an object", .{}, global, exception);
                 return args;
             }
@@ -812,6 +814,9 @@ pub const ServerConfig = struct {
                 }
                 return args;
             }
+        } else {
+            JSC.throwInvalidArguments("Bun.serve expects an object", .{}, global, exception);
+            return args;
         }
 
         if (args.base_uri.len > 0) {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -764,14 +764,12 @@ pub const ServerConfig = struct {
             }
 
             if (arg.getTruthy(global, "tls")) |tls| {
-                if (!tls.isEmptyOrUndefinedOrNull()) {
-                    if (SSLConfig.inJS(global, tls, exception)) |ssl_config| {
-                        args.ssl_config = ssl_config;
-                    }
+                if (SSLConfig.inJS(global, tls, exception)) |ssl_config| {
+                    args.ssl_config = ssl_config;
+                }
 
-                    if (exception.* != null) {
-                        return args;
-                    }
+                if (exception.* != null) {
+                    return args;
                 }
             }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -764,12 +764,14 @@ pub const ServerConfig = struct {
             }
 
             if (arg.getTruthy(global, "tls")) |tls| {
-                if (SSLConfig.inJS(global, tls, exception)) |ssl_config| {
-                    args.ssl_config = ssl_config;
-                }
+                if (!tls.isEmptyOrUndefinedOrNull()) {
+                    if (SSLConfig.inJS(global, tls, exception)) |ssl_config| {
+                        args.ssl_config = ssl_config;
+                    }
 
-                if (exception.* != null) {
-                    return args;
+                    if (exception.* != null) {
+                        return args;
+                    }
                 }
             }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -271,7 +271,7 @@ pub const ServerConfig = struct {
         pub fn inJS(global: *JSC.JSGlobalObject, obj: JSC.JSValue, exception: JSC.C.ExceptionRef) ?SSLConfig {
             var result = zero;
             if (!obj.isObject()) {
-                JSC.throwInvalidArguments("tls argument expects a object", .{}, global, exception);
+                JSC.throwInvalidArguments("tls option expects an object", .{}, global, exception);
                 return null;
             }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -270,7 +270,10 @@ pub const ServerConfig = struct {
 
         pub fn inJS(global: *JSC.JSGlobalObject, obj: JSC.JSValue, exception: JSC.C.ExceptionRef) ?SSLConfig {
             var result = zero;
-            if (!obj.isObject()) return null;
+            if (!obj.isObject()) {
+                JSC.throwInvalidArguments("tls argument expects a object", .{}, global, exception);
+                return null;
+            }
 
             var any = false;
 

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1,6 +1,54 @@
 import { describe, expect, test } from "bun:test";
 
 describe("Server", () => {
+  test("should not allow Bun.serve without first argument being a object", () => {
+    expect(() => {
+      //@ts-ignore
+      const server = Bun.serve();
+      server.stop(true);
+    }).toThrow("Bun.serve expects an object");
+
+    [undefined, null, 1, "string", true, false, Symbol("symbol")].forEach(value => {
+      expect(() => {
+        //@ts-ignore
+        const server = Bun.serve(value);
+        server.stop(true);
+      }).toThrow("Bun.serve expects an object");
+    });
+  });
+
+  test("should not allow Bun.serve with invalid tls option", () => {
+    [1, "string", true, Symbol("symbol"), false].forEach(value => {
+      expect(() => {
+        const server = Bun.serve({
+          //@ts-ignore
+          tls: value,
+          fetch() {
+            return new Response("Hello");
+          },
+          port: 0,
+        });
+        server.stop(true);
+      }).toThrow("tls option expects an object");
+    });
+  });
+
+  test("should allow Bun.serve using null or undefined, tls option", () => {
+    [null, undefined].forEach(value => {
+      expect(() => {
+        const server = Bun.serve({
+          //@ts-ignore
+          tls: value,
+          fetch() {
+            return new Response("Hello");
+          },
+          port: 0,
+        });
+        server.stop(true);
+      }).not.toThrow("tls option expects an object");
+    });
+  });
+
   test("returns active port when initializing server with 0 port", () => {
     const server = Bun.serve({
       fetch() {

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -33,7 +33,7 @@ describe("Server", () => {
     });
   });
 
-  test("should allow Bun.serve using null or undefined, tls option", () => {
+  test("should allow Bun.serve using null or undefined tls option", () => {
     [null, undefined].forEach(value => {
       expect(() => {
         const server = Bun.serve({

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -58,6 +58,44 @@ it("remoteAddress works", async () => {
   await prom;
 });
 
+it("should not allow invalid tls option", () => {
+  [1, "string", Symbol("symbol")].forEach(value => {
+    expect(() => {
+      // @ts-ignore
+      const server = Bun.listen({
+        socket: {
+          open(ws) {},
+          close() {},
+          data() {},
+        },
+        port: 0,
+        hostname: "localhost",
+        tls: value,
+      });
+      server.stop(true);
+    }).toThrow("tls option expects an object");
+  });
+});
+
+it("should allow using false, null or undefined tls option", () => {
+  [false, null, undefined].forEach(value => {
+    expect(() => {
+      // @ts-ignore
+      const server = Bun.listen({
+        socket: {
+          open(ws) {},
+          close() {},
+          data() {},
+        },
+        port: 0,
+        hostname: "localhost",
+        tls: value,
+      });
+      server.stop(true);
+    }).not.toThrow("tls option expects an object");
+  });
+});
+
 it("echo server 1 on 1", async () => {
   // wrap it in a separate closure so the GC knows to clean it up
   // the sockets & listener don't escape the closure


### PR DESCRIPTION
This adds the check into `tls` option (for sockets and Bun.serve) and also fails if no object/argument is passed into `Bun.serve()`