### PR TITLE
don't remove const declaration if referenced before declaration

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -5798,8 +5798,7 @@ fn NewParser_(
 
             if (p.options.features.inlining) {
                 if (p.const_values.get(ref)) |replacement| {
-                    // TODO:
-                    // p.ignoreUsage(ref);
+                    p.ignoreUsage(ref);
                     return replacement;
                 }
             }
@@ -20427,7 +20426,8 @@ fn NewParser_(
                                     var end: usize = 0;
                                     for (decls) |decl| {
                                         if (decl.binding.data == .b_identifier) {
-                                            if (p.const_values.contains(decl.binding.data.b_identifier.ref)) {
+                                            const symbol = p.symbols.items[decl.binding.data.b_identifier.ref.innerIndex()];
+                                            if (p.const_values.contains(decl.binding.data.b_identifier.ref) and symbol.use_count_estimate == 0) {
                                                 continue;
                                             }
                                         }

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -6520,4 +6520,46 @@ describe("bundler", () => {
       `,
     },
   });
+  itBundled("default/ConstDeclNotRemovedIfReferencedBeforeDecl", {
+    files: {
+      "/entry.js": `
+        {
+          const foo = () => {
+            return data;
+          }
+          const data = 123;
+
+          console.log(foo());
+        }
+      `,
+    },
+    minifySyntax: true,
+    run: {
+      stdout: "123",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("data = 123");
+    },
+  });
+  itBundled("default/ConstDeclRemovedIfReferencedBeforeAllUses", {
+    files: {
+      "/entry.js": `
+        {
+          const data = 123;
+          const foo = () => {
+            return data;
+          }
+
+          console.log(foo());
+        }
+      `,
+    },
+    minifySyntax: true,
+    run: {
+      stdout: "123",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("data = 123");
+    },
+  });
 });


### PR DESCRIPTION
input:
```js
{
  const foo = () => {
    return data;
  }
  const data = 123;

  foo();
}
```
output before change:
```js
(() => {
  return data;
})();
```
after change:
```js
{
  const foo = () => {
    return data;
  }, data = 123;
  foo();
}
```
fixes #3328