### PR TITLE
Set the publishToSelf option to true

### DIFF
--- a/bench/websocket-server/chat-server.bun.js
+++ b/bench/websocket-server/chat-server.bun.js
@@ -32,6 +32,7 @@ const server = Bun.serve({
     },
 
     perMessageDeflate: false,
+    publishToSelf: true
   },
 
   fetch(req, server) {


### PR DESCRIPTION
All messages sent by the clients are expected to be received by all clients. Without the `publishToSelf` option a message is not sent back to the sender and the benchmark hangs.