### PR TITLE
Fix crash with .env files that are exactly 159 bytes long

### DIFF
--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -895,7 +895,7 @@ pub const Loader = struct {
         errdefer this.allocator.free(buf);
         const amount_read = try file.readAll(buf[0..end]);
 
-        // The null byte here is mostly for debugging purposes. 
+        // The null byte here is mostly for debugging purposes.
         buf[end] = 0;
 
         const source = logger.Source.initPathString(base, buf[0..amount_read]);

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -884,18 +884,21 @@ pub const Loader = struct {
         defer file.close();
 
         const stat = try file.stat();
-        if (stat.size == 0) {
+        const end = stat.size;
+
+        if (end == 0) {
             @field(this, base) = logger.Source.initPathString(base, "");
             return;
         }
 
-        var buf = try this.allocator.allocSentinel(u8, stat.size, 0);
+        var buf = try this.allocator.alloc(u8, end + 1);
         errdefer this.allocator.free(buf);
-        var contents = try file.readAll(buf);
+        const amount_read = try file.readAll(buf[0..end]);
 
-        // always sentinel
-        buf.ptr[contents + 1] = 0;
-        const source = logger.Source.initPathString(base, buf.ptr[0..contents :0]);
+        // The null byte here is mostly for debugging purposes. 
+        buf[end] = 0;
+
+        const source = logger.Source.initPathString(base, buf[0..amount_read]);
 
         Parser.parse(
             &source,

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -194,6 +194,29 @@ describe("dotenv priority", () => {
   });
 });
 
+test(".env doesnt crash with 159 bytes", () => {
+  const dir = tempDirWithFiles("dotenv-159", {
+    ".env":
+      "123456789=1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678" +
+      "\n",
+    "index.ts": "console.log(process.env['123456789']);",
+    "package.json": `{
+      "name": "foo",
+      "devDependencies": {
+        "conditional-type-checks": "1.0.6",
+        "prettier": "2.8.8",
+        "tsd": "0.22.0",
+        "typescript": "5.0.4"
+      }
+    }`,
+  });
+
+  const { stdout } = bunRun(`${dir}/index.ts`);
+  expect(stdout.trim()).toBe(
+    `1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678`,
+  );
+});
+
 test.todo(".env space edgecase (issue #411)", () => {
   const dir = tempDirWithFiles("dotenv-issue-411", {
     ".env": "VARNAME=A B",


### PR DESCRIPTION
We were writing a zero 1 byte out of bounds of the array