### PR TITLE
Update module resolution order docs

### DIFF
--- a/docs/runtime/modules.md
+++ b/docs/runtime/modules.md
@@ -108,8 +108,8 @@ Once it finds the `foo` package, Bun reads the `package.json` to determine how t
     "worker": "./index.js",
     "module": "./index.js",
     "node": "./index.js",
-    "browser": "./index.js",
-    "default": "./index.js"     // lowest priority
+    "default": "./index.js",
+    "browser": "./index.js"     // lowest priority
   }
 }
 ```


### PR DESCRIPTION
If I'm reading and interpreting [these lines](https://github.com/oven-sh/bun/blob/69f558db8e0eba637febdc62c6ba752444b54401/src/options.zig#L605-L627) correct, the module resolution order [in the current docs](https://bun.sh/docs/runtime/modules#resolution) is outdated.

This change will fix the order.