### PR TITLE
docs: add troubleshooting section to installation page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -143,3 +143,29 @@ To write the completions to a custom location:
 $ bun completions > path-to-file      # write to file
 $ bun completions /path/to/directory  # write into directory
 ```
+
+## Troubleshooting
+
+### Unzip is required
+
+Unzip is required to install Bun on Linux. You can use one of the following commands to install `unzip`:
+
+{% codetabs %}
+
+```sh#Debian/Ubuntu/Mint
+$ sudo apt install unzip
+```
+
+```sh#RedHat/CentOS/Fedora
+$ sudo dnf install unzip
+```
+
+```sh#Arch/Manjaro
+$ sudo pacman -S unzip
+```
+
+```sh#OpenSUSE
+$ sudo zypper install unzip
+```
+
+{% /codetabs %}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,17 +3,17 @@ Bun ships as a single executable that can be installed a few different ways.
 {% callout %}
 **Windows users** — Bun does not currently provide a native Windows build. We're working on this; progress can be tracked at [this issue](https://github.com/oven-sh/bun/issues/43). In the meantime, use one of the installation methods below for Windows Subsystem for Linux.
 
-**Linux users** — Kernel version 5.6 or higher is strongly recommended, but the minimum is 5.1.
+**Linux users** — The `unzip` package is required to install Bun. Kernel version 5.6 or higher is strongly recommended, but the minimum is 5.1.
 {% /callout %}
 
 {% codetabs %}
 
-```bash#Native
-$ curl -fsSL https://bun.sh/install | bash # for macOS, Linux, and WSL
+```bash#NPM
+$ npm install -g bun # the last `npm` command you'll ever need
 ```
 
-```bash#npm
-$ npm install -g bun # the last `npm` command you'll ever need
+```bash#Native
+$ curl -fsSL https://bun.sh/install | bash # for macOS, Linux, and WSL
 ```
 
 ```bash#Homebrew
@@ -26,7 +26,7 @@ $ docker pull oven/bun
 $ docker run --rm --init --ulimit memlock=-1:-1 oven/bun
 ```
 
-```bash#proto
+```bash#Proto
 $ proto install bun
 ```
 
@@ -143,29 +143,3 @@ To write the completions to a custom location:
 $ bun completions > path-to-file      # write to file
 $ bun completions /path/to/directory  # write into directory
 ```
-
-## Troubleshooting
-
-### Unzip is required
-
-Unzip is required to install Bun on Linux. You can use one of the following commands to install `unzip`:
-
-{% codetabs %}
-
-```sh#Debian/Ubuntu/Mint
-$ sudo apt install unzip
-```
-
-```sh#RedHat/CentOS/Fedora
-$ sudo dnf install unzip
-```
-
-```sh#Arch/Manjaro
-$ sudo pacman -S unzip
-```
-
-```sh#OpenSUSE
-$ sudo zypper install unzip
-```
-
-{% /codetabs %}

--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -50,7 +50,7 @@ success() {
 }
 
 command -v unzip >/dev/null ||
-    error 'unzip is required to install bun (see: https://bun.sh/docs/installation#unzip-is-required)'
+    error 'unzip is required to install bun'
 
 if [[ $# -gt 2 ]]; then
     error 'Too many arguments, only 2 are allowed. The first can be a specific tag of bun to install. (e.g. "bun-v0.1.4") The second can be a build variant of bun to install. (e.g. "debug-info")'

--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -50,7 +50,7 @@ success() {
 }
 
 command -v unzip >/dev/null ||
-    error 'unzip is required to install bun (see: https://bun.sh/docs/installation)'
+    error 'unzip is required to install bun (see: https://bun.sh/docs/installation#unzip-is-required)'
 
 if [[ $# -gt 2 ]]; then
     error 'Too many arguments, only 2 are allowed. The first can be a specific tag of bun to install. (e.g. "bun-v0.1.4") The second can be a build variant of bun to install. (e.g. "debug-info")'


### PR DESCRIPTION
Hi, when I tried to install Bun on WSL today, I got:

```
error: unzip is required to install bun (see: https://github.com/oven-sh/bun#unzip-is-required)
```
Which I quickly found out this documentation does not exist at this location anymore. It looks like the main branch has already fixed this, but the [docs page it points to](https://bun.sh/docs/installation) contains no information about this error. It looks like the error is described on the [troubleshooting ](https://github.com/oven-sh/bun/blob/main/docs/troubleshooting.md) page, however, that page is commented out in nav.ts [here](https://github.com/oven-sh/bun/blob/217501e180eadd1999f30733e0f13580cd1f0abf/docs/nav.ts#L318).

This PR adds a troubleshooting section to the installation page containing the info about unzip which has been taken verbatim from the troubleshooting page. This seemed more innocuous than bringing back the troubleshooting page altogether as I assume it was commented out for a reason at some point. 

This also updates the link in install.sh to bring users directly to the troubleshooting section.

Please feel free to close this out if this is not a desired change. Also happy to tweak this if something else is needed. Thanks!