### PR TITLE
Support reading embedded files in compiled executables

### DIFF
--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -896,6 +896,9 @@ pub fn createNodeFS(
 ) js.JSValueRef {
     var module = ctx.allocator().create(JSC.Node.NodeJSFS) catch unreachable;
     module.* = .{};
+    var vm = ctx.bunVM();
+    if (vm.standalone_module_graph != null)
+        module.node_fs.vm = vm;
 
     return module.toJS(ctx).asObjectRef();
 }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2744,19 +2744,15 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             // 1. Bun.file("foo")
             // 2. The content-disposition header is not present
             if (!has_content_disposition and content_type.category.autosetFilename()) {
-                if (this.blob.store()) |store| {
-                    if (store.data == .file) {
-                        if (store.data.file.pathlike == .path) {
-                            const basename = std.fs.path.basename(store.data.file.pathlike.path.slice());
-                            if (basename.len > 0) {
-                                var filename_buf: [1024]u8 = undefined;
+                if (this.blob.getFileName()) |filename| {
+                    const basename = std.fs.path.basename(filename);
+                    if (basename.len > 0) {
+                        var filename_buf: [1024]u8 = undefined;
 
-                                resp.writeHeader(
-                                    "content-disposition",
-                                    std.fmt.bufPrint(&filename_buf, "filename=\"{s}\"", .{basename[0..@min(basename.len, 1024 - 32)]}) catch "",
-                                );
-                            }
-                        }
+                        resp.writeHeader(
+                            "content-disposition",
+                            std.fmt.bufPrint(&filename_buf, "filename=\"{s}\"", .{basename[0..@min(basename.len, 1024 - 32)]}) catch "",
+                        );
                     }
                 }
             }

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -593,7 +593,10 @@ pub const VirtualMachine = struct {
     pub inline fn nodeFS(this: *VirtualMachine) *Node.NodeFS {
         return this.node_fs orelse brk: {
             this.node_fs = bun.default_allocator.create(Node.NodeFS) catch unreachable;
-            this.node_fs.?.* = Node.NodeFS{};
+            this.node_fs.?.* = Node.NodeFS{
+                // only used when standalone module graph is enabled
+                .vm = if (this.standalone_module_graph != null) this else null,
+            };
             break :brk this.node_fs.?;
         };
     }

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -2492,6 +2492,7 @@ pub const NodeFS = struct {
     /// That means a stack-allocated buffer won't suffice. Instead, we re-use
     /// the heap allocated buffer on the NodefS struct
     sync_error_buf: [bun.MAX_PATH_BYTES]u8 = undefined,
+    vm: ?*JSC.VirtualMachine = null,
 
     pub const ReturnType = Return;
 
@@ -3442,6 +3443,34 @@ pub const NodeFS = struct {
                 const fd = switch (args.path) {
                     .path => brk: {
                         path = args.path.path.sliceZ(&this.sync_error_buf);
+                        if (this.vm) |vm| {
+                            if (vm.standalone_module_graph) |graph| {
+                                if (graph.find(path)) |file| {
+                                    return switch (args.encoding) {
+                                        .buffer => .{
+                                            .result = .{
+                                                .buffer = Buffer.fromBytes(bun.default_allocator.dupe(u8, file.contents) catch @panic("out of memory"), bun.default_allocator, .Uint8Array),
+                                            },
+                                        },
+                                        else => brk2: {
+                                            if (comptime string_type == .default) {
+                                                break :brk2 .{
+                                                    .result = .{
+                                                        .string = bun.default_allocator.dupe(u8, file.contents) catch @panic("out of memory"),
+                                                    },
+                                                };
+                                            } else {
+                                                break :brk2 .{
+                                                    .result = .{
+                                                        .null_terminated = bun.default_allocator.dupeZ(u8, file.contents) catch @panic("out of memory"),
+                                                    },
+                                                };
+                                            }
+                                        },
+                                    };
+                                }
+                            }
+                        }
                         break :brk switch (Syscall.open(
                             path,
                             os.O.RDONLY | os.O.NOCTTY,

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -107,6 +107,7 @@ pub const BuildCommand = struct {
             // We never want to hit the filesystem for these files
             // This "compiled" protocol is specially handled by the module resolver.
             this_bundler.options.public_path = "compiled://root/";
+            this_bundler.resolver.opts.public_path = "compiled://root/";
 
             if (outfile.len == 0) {
                 outfile = std.fs.path.basename(this_bundler.options.entry_points[0]);


### PR DESCRIPTION
This adds support for reading files embedded in executables created via `bun build --compile`.

The following snippet works now:

```bash
bun build --compile ./hello.ts
```


```ts
// hello.ts
import index from "./file.html";
import pic from "./favicon.png";
import { readFileSync } from "node:fs";
import { file, serve } from "bun";

serve({
  fetch(req) {
    const { pathname } = new URL(req.url);
    if (pathname === "/") {
      return new Response(file(index));
    }

    if (pathname === "/favicon.png") {
      return new Response(file(pic));
    }

    return new Response("Not found", { status: 404 });
  },
});

// Works with readFileSync() as well.
console.log("index.html is", readFileSync(index).byteLength, "bytes");
```

This adds support for `Bun.file(path)` and `readFileSync(path)`. it doesn't add support for the rest of the `node:fs` functions.

Confusingly, outside of `bun build --compile`, the snippet above doesn't work without setting `.html` and `.png` to be a `file` loader:
```bash
bun --loader=.html:file --loader=.png:file ./hello.ts
```