### PR TITLE
fix overwriting jsx development setting in `configureLinker`

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1617,8 +1617,8 @@ pub const BundleV2 = struct {
         bundler.resolver.generation = generation;
         bundler.options.code_splitting = config.code_splitting;
 
-        try bundler.configureDefines();
         bundler.configureLinker();
+        try bundler.configureDefines();
 
         bundler.resolver.opts = bundler.options;
 


### PR DESCRIPTION
fixes #3413 