### PR TITLE
fix: export `ClientRequest` and `OutgoingMessage` as part of the `node:http` package

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -1804,6 +1804,8 @@ var defaultObject = {
     debug(`${NODE_HTTP_WARNING}\n`, "setMaxIdleHTTPParsers() is a no-op");
   },
   globalAgent,
+  ClientRequest,
+  OutgoingMessage,
   [Symbol.for("CommonJS")]: 0,
 };
 


### PR DESCRIPTION
For the following issue, https://github.com/oven-sh/bun/issues/3061 was `ClientRequest` and `OutgoingMessage` missing in the export. This is causing some packages depending to receive undefined when using the `http` package.



```
 6 | const {initializeTLSOptions } = require('./request-options');
 7 | const http = require('http');
 8 | const https = require('https');
 9 | const {Stream} = require('stream');
10 | function addFunctions(container , obj){
11 |   const proto = obj.prototype;
                    ^
TypeError: undefined is not an object (evaluating 'obj.prototype')
      at /Users/stijnvanhulle/GitHub/kubb/node_modules/.pnpm/http2-client@1.3.5/node_modules/http2-client/lib/request.js:11:16
      at /Users/stijnvanhulle/GitHub/kubb/node_modules/.pnpm/http2-client@1.3.5/node_modules/http2-client/lib/request.js:28:0
      at globalThis (/Users/stijnvanhulle/GitHub/kubb/node_modules/.pnpm/http2-client@1.3.5/node_modules/http2-client/lib/request.js:591:0)
      at /Users/stijnvanhulle/GitHub/kubb/node_modules/.pnpm/http2-client@1.3.5/node_modules/http2-client/lib/index.js:2:46
      at globalThis (/Users/stijnvanhulle/GitHub/kubb/node_modules/.pnpm/http2-client@1.3.5/node_modules/http2-client/lib/index.js:21:0)
```


```
console.log(http.ClientRequest, http, require('node:http'))

{
  Agent: [Function: Agent],
  Server: [Function: Server],
  METHODS: [ "ACL", "BIND", "CHECKOUT", "CONNECT", "COPY", "DELETE", "GET", "HEAD", "LINK", "LOCK", "M-SEARCH", "MERGE",
    "MKACTIVITY", "MKCALENDAR", "MKCOL", "MOVE", "NOTIFY", "OPTIONS", "PATCH", "POST", "PROPFIND", "PROPPATCH",
    "PURGE", "PUT", "REBIND", "REPORT", "SEARCH", "SOURCE", "SUBSCRIBE", "TRACE", "UNBIND", "UNLINK", "UNLOCK", "UNSUBSCRIBE"
  ],
  STATUS_CODES: {
    "100": "Continue",
    "101": "Switching Protocols",
    "102": "Processing",
    "103": "Early Hints",
    "200": "OK",
    "201": "Created",
    "202": "Accepted",
    "203": "Non-Authoritative Information",
    "204": "No Content",
    "205": "Reset Content",
    "206": "Partial Content",
    "207": "Multi-Status",
    "208": "Already Reported",
    "226": "IM Used",
    "300": "Multiple Choices",
    "301": "Moved Permanently",
    "302": "Found",
    "303": "See Other",
    "304": "Not Modified",
    "305": "Use Proxy",
    "307": "Temporary Redirect",
    "308": "Permanent Redirect",
    "400": "Bad Request",
    "401": "Unauthorized",
    "402": "Payment Required",
    "403": "Forbidden",
    "404": "Not Found",
    "405": "Method Not Allowed",
    "406": "Not Acceptable",
    "407": "Proxy Authentication Required",
    "408": "Request Timeout",
    "409": "Conflict",
    "410": "Gone",
    "411": "Length Required",
    "412": "Precondition Failed",
    "413": "Payload Too Large",
    "414": "URI Too Long",
    "415": "Unsupported Media Type",
    "416": "Range Not Satisfiable",
    "417": "Expectation Failed",
    "418": "I'm a Teapot",
    "421": "Misdirected Request",
    "422": "Unprocessable Entity",
    "423": "Locked",
    "424": "Failed Dependency",
    "425": "Too Early",
    "426": "Upgrade Required",
    "428": "Precondition Required",
    "429": "Too Many Requests",
    "431": "Request Header Fields Too Large",
    "451": "Unavailable For Legal Reasons",
    "500": "Internal Server Error",
    "501": "Not Implemented",
    "502": "Bad Gateway",
    "503": "Service Unavailable",
    "504": "Gateway Timeout",
    "505": "HTTP Version Not Supported",
    "506": "Variant Also Negotiates",
    "507": "Insufficient Storage",
    "508": "Loop Detected",
    "509": "Bandwidth Limit Exceeded",
    "510": "Not Extended",
    "511": "Network Authentication Required"
  },
  createServer: [Function: createServer],
  ServerResponse: [Function: ServerResponse],
  IncomingMessage: [Function: IncomingMessage],
  request: [Function: request],
  get: [Function: get],
  maxHeaderSize: 16384,
  setMaxIdleHTTPParsers: [Function: setMaxIdleHTTPParsers],
  globalAgent: [Getter],
  [Symbol(CommonJS)]: 0
}
```