### PR TITLE
Use `BunString` in `SystemError`

### DIFF
--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1925,8 +1925,8 @@ pub const DNSResolver = struct {
             .err => |err| {
                 const system_error = JSC.SystemError{
                     .errno = -1,
-                    .code = JSC.ZigString.init(err.code()),
-                    .message = JSC.ZigString.init(err.label()),
+                    .code = bun.String.static(err.code()),
+                    .message = bun.String.static(err.label()),
                 };
 
                 globalThis.throwValue(system_error.toErrorInstance(globalThis));
@@ -1972,8 +1972,8 @@ pub const DNSResolver = struct {
             .err => |err| {
                 const system_error = JSC.SystemError{
                     .errno = -1,
-                    .code = JSC.ZigString.init(err.code()),
-                    .message = JSC.ZigString.init(err.label()),
+                    .code = bun.String.static(err.code()),
+                    .message = bun.String.static(err.label()),
                 };
 
                 globalThis.throwValue(system_error.toErrorInstance(globalThis));

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1022,8 +1022,8 @@ fn NewSocket(comptime ssl: bool) type {
             var globalObject = handlers.globalObject;
             const err = JSC.SystemError{
                 .errno = errno,
-                .message = ZigString.init("Failed to connect"),
-                .syscall = ZigString.init("connect"),
+                .message = bun.String.static("Failed to connect"),
+                .syscall = bun.String.static("connect"),
             };
 
             if (callback == .zero) {
@@ -1232,8 +1232,8 @@ fn NewSocket(comptime ssl: bool) type {
                     const reason = if (ssl_error.reason == null) "" else ssl_error.reason[0..bun.len(ssl_error.reason)];
 
                     const fallback = JSC.SystemError{
-                        .code = ZigString.init(code),
-                        .message = ZigString.init(reason),
+                        .code = bun.String.create(code),
+                        .message = bun.String.create(reason),
                     };
 
                     authorization_error = fallback.toErrorInstance(globalObject);
@@ -1409,8 +1409,8 @@ fn NewSocket(comptime ssl: bool) type {
             const reason = if (ssl_error.reason == null) "" else ssl_error.reason[0..bun.len(ssl_error.reason)];
 
             const fallback = JSC.SystemError{
-                .code = ZigString.init(code),
-                .message = ZigString.init(reason),
+                .code = bun.String.create(code),
+                .message = bun.String.create(reason),
             };
 
             return fallback.toErrorInstance(globalObject);

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -311,9 +311,9 @@ pub const FFI = struct {
                 break :brk std.DynLib.open(backup_name) catch {
                     // Then, if that fails, report an error.
                     const system_error = JSC.SystemError{
-                        .code = ZigString.init(@tagName(JSC.Node.ErrorCode.ERR_DLOPEN_FAILED)),
-                        .message = ZigString.init("Failed to open library. This is usually caused by a missing library or an invalid library path."),
-                        .syscall = ZigString.init("dlopen"),
+                        .code = bun.String.create(@tagName(JSC.Node.ErrorCode.ERR_DLOPEN_FAILED)),
+                        .message = bun.String.create("Failed to open library. This is usually caused by a missing library or an invalid library path."),
+                        .syscall = bun.String.create("dlopen"),
                     };
                     return system_error.toErrorInstance(global);
                 };

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1796,7 +1796,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                         .syscall = .sendfile,
                     };
                     var sys = err.withPathLike(file.pathlike).toSystemError();
-                    sys.message = ZigString.init("MacOS does not support sending non-regular files");
+                    sys.message = bun.String.static("MacOS does not support sending non-regular files");
                     this.runErrorHandler(sys.toErrorInstance(
                         this.server.globalThis,
                     ));
@@ -1815,7 +1815,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                         .syscall = .sendfile,
                     };
                     var sys = err.withPathLike(file.pathlike).toSystemError();
-                    sys.message = ZigString.init("File must be regular or FIFO");
+                    sys.message = bun.String.static("File must be regular or FIFO");
                     this.runErrorHandler(sys.toErrorInstance(
                         this.server.globalThis,
                     ));
@@ -2375,8 +2375,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             }
 
             const fallback = JSC.SystemError{
-                .code = ZigString.init(@as(string, @tagName(JSC.Node.ErrorCode.ERR_UNHANDLED_ERROR))),
-                .message = ZigString.init("Unhandled error in ReadableStream"),
+                .code = bun.String.static(@as(string, @tagName(JSC.Node.ErrorCode.ERR_UNHANDLED_ERROR))),
+                .message = bun.String.static("Unhandled error in ReadableStream"),
             };
             req.handleReject(fallback.toErrorInstance(globalThis));
         }
@@ -2422,8 +2422,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                         if (stream.isLocked(this.server.globalThis)) {
                             streamLog("was locked but it shouldn't be", .{});
                             var err = JSC.SystemError{
-                                .code = ZigString.init(@as(string, @tagName(JSC.Node.ErrorCode.ERR_STREAM_CANNOT_PIPE))),
-                                .message = ZigString.init("Stream already used, please create a new one"),
+                                .code = bun.String.static(@as(string, @tagName(JSC.Node.ErrorCode.ERR_STREAM_CANNOT_PIPE))),
+                                .message = bun.String.static("Stream already used, please create a new one"),
                             };
                             stream.value.unprotect();
                             this.runErrorHandler(err.toErrorInstance(this.server.globalThis));

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -86,31 +86,69 @@ BunString toString(JSC::JSGlobalObject* globalObject, JSValue value)
     return fromJS(globalObject, value);
 }
 
+BunString toStringRef(JSC::JSGlobalObject* globalObject, JSValue value)
+{
+    auto str = value.toWTFString(globalObject);
+    if (str.isEmpty()) {
+        return { BunStringTag::Empty };
+    }
+
+    str.impl()->ref();
+
+    return { BunStringTag::WTFStringImpl, { .wtf = str.impl() } };
+}
+
 BunString toString(WTF::String& wtfString)
 {
-    if (wtfString.length() == 0)
+    if (wtfString.isEmpty())
         return { BunStringTag::Empty };
 
     return { BunStringTag::WTFStringImpl, { .wtf = wtfString.impl() } };
 }
 BunString toString(const WTF::String& wtfString)
 {
-    if (wtfString.length() == 0)
+    if (wtfString.isEmpty())
         return { BunStringTag::Empty };
 
     return { BunStringTag::WTFStringImpl, { .wtf = wtfString.impl() } };
 }
 BunString toString(WTF::StringImpl* wtfString)
 {
-    if (wtfString->length() == 0)
+    if (wtfString->isEmpty())
         return { BunStringTag::Empty };
+
+    return { BunStringTag::WTFStringImpl, { .wtf = wtfString } };
+}
+
+BunString toStringRef(WTF::String& wtfString)
+{
+    if (wtfString.isEmpty())
+        return { BunStringTag::Empty };
+
+    wtfString.impl()->ref();
+    return { BunStringTag::WTFStringImpl, { .wtf = wtfString.impl() } };
+}
+BunString toStringRef(const WTF::String& wtfString)
+{
+    if (wtfString.isEmpty())
+        return { BunStringTag::Empty };
+
+    wtfString.impl()->ref();
+    return { BunStringTag::WTFStringImpl, { .wtf = wtfString.impl() } };
+}
+BunString toStringRef(WTF::StringImpl* wtfString)
+{
+    if (wtfString->isEmpty())
+        return { BunStringTag::Empty };
+
+    wtfString->ref();
 
     return { BunStringTag::WTFStringImpl, { .wtf = wtfString } };
 }
 
 BunString fromString(WTF::String& wtfString)
 {
-    if (wtfString.length() == 0)
+    if (wtfString.isEmpty())
         return { BunStringTag::Empty };
 
     return { BunStringTag::WTFStringImpl, { .wtf = wtfString.impl() } };
@@ -118,7 +156,7 @@ BunString fromString(WTF::String& wtfString)
 
 BunString fromString(WTF::StringImpl* wtfString)
 {
-    if (wtfString->length() == 0)
+    if (wtfString->isEmpty())
         return { BunStringTag::Empty };
 
     return { BunStringTag::WTFStringImpl, { .wtf = wtfString } };

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -1561,10 +1561,10 @@ pub const FetchHeaders = opaque {
 pub const SystemError = extern struct {
     errno: c_int = 0,
     /// label for errno
-    code: ZigString = ZigString.init(""),
-    message: ZigString = ZigString.init(""),
-    path: ZigString = ZigString.init(""),
-    syscall: ZigString = ZigString.init(""),
+    code: String = String.empty,
+    message: String = String.empty,
+    path: String = String.empty,
+    syscall: String = String.empty,
     fd: i32 = -1,
 
     pub fn Maybe(comptime Result: type) type {

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -84,10 +84,10 @@ typedef struct ErrorableResolvedSource {
 
 typedef struct SystemError {
     int errno_;
-    ZigString code;
-    ZigString message;
-    ZigString path;
-    ZigString syscall;
+    BunString code;
+    BunString message;
+    BunString path;
+    BunString syscall;
     int fd;
 } SystemError;
 
@@ -246,6 +246,10 @@ BunString toString(WTF::String& wtfString);
 BunString toString(const WTF::String& wtfString);
 BunString toString(WTF::StringImpl* wtfString);
 
+BunString toStringRef(JSC::JSGlobalObject* globalObject, JSC::JSValue value);
+BunString toStringRef(WTF::String& wtfString);
+BunString toStringRef(const WTF::String& wtfString);
+BunString toStringRef(WTF::StringImpl* wtfString);
 }
 
 using Uint8Array_alias = JSC::JSUint8Array;

--- a/src/bun.js/bindings/helpers.h
+++ b/src/bun.js/bindings/helpers.h
@@ -342,10 +342,10 @@ static const WTF::String toStringStatic(ZigString str)
     }
 
     if (isTaggedUTF16Ptr(str.ptr)) {
-        return WTF::String(WTF::ExternalStringImpl::createStatic(reinterpret_cast<const UChar*>(untag(str.ptr)), str.len));
+        return WTF::String(AtomStringImpl::add(reinterpret_cast<const UChar*>(untag(str.ptr)), str.len));
     }
 
-    return WTF::String(WTF::ExternalStringImpl::createStatic(
+    return WTF::String(AtomStringImpl::add(
         reinterpret_cast<const LChar*>(untag(str.ptr)), str.len));
 }
 

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -554,7 +554,6 @@ extern "C" napi_status napi_wrap(napi_env env,
 
     auto* globalObject = toJS(env);
     auto& vm = globalObject->vm();
-    
 
     auto* val = jsDynamicCast<NapiPrototype*>(value);
 
@@ -572,7 +571,7 @@ extern "C" napi_status napi_wrap(napi_env env,
     auto clientData = WebCore::clientData(vm);
 
     auto* ref = new NapiRef(globalObject, 1);
-    ref->strongRef.set(globalObject->vm(), value.getObject());    
+    ref->strongRef.set(globalObject->vm(), value.getObject());
 
     if (finalize_cb) {
         ref->finalizer.finalize_cb = finalize_cb;
@@ -816,7 +815,7 @@ extern "C" napi_status napi_create_reference(napi_env env, napi_value value,
         }
     }
 
-    if(object) {
+    if (object) {
         object->napiRef = ref;
     }
 
@@ -1029,7 +1028,26 @@ extern "C" napi_status napi_create_type_error(napi_env env, napi_value code,
 
     auto error = JSC::createTypeError(globalObject, messageValue.toWTFString(globalObject));
     if (codeValue) {
-        error->putDirect(vm, Identifier::fromString(vm, "code"_s), codeValue, 0);
+        error->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), codeValue, 0);
+    }
+
+    *result = reinterpret_cast<napi_value>(JSC::JSValue::encode(error));
+    return napi_ok;
+}
+
+extern "C" napi_status napi_create_error(napi_env env, napi_value code,
+    napi_value msg,
+    napi_value* result)
+{
+    Zig::GlobalObject* globalObject = toJS(env);
+    JSC::VM& vm = globalObject->vm();
+
+    JSC::JSValue codeValue = JSC::JSValue::decode(reinterpret_cast<JSC::EncodedJSValue>(code));
+    JSC::JSValue messageValue = JSC::JSValue::decode(reinterpret_cast<JSC::EncodedJSValue>(msg));
+
+    auto error = JSC::createError(globalObject, messageValue.toWTFString(globalObject));
+    if (codeValue) {
+        error->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), codeValue, 0);
     }
 
     *result = reinterpret_cast<napi_value>(JSC::JSValue::encode(error));
@@ -1474,7 +1492,8 @@ extern "C" napi_status napi_get_property_names(napi_env env, napi_value object,
     return napi_ok;
 }
 
-extern "C" napi_status napi_create_object(napi_env env, napi_value* result){
+extern "C" napi_status napi_create_object(napi_env env, napi_value* result)
+{
 
     if (UNLIKELY(result == nullptr)) {
         return napi_invalid_arg;

--- a/src/bun.js/bindings/webcore/JSCloseEvent.cpp
+++ b/src/bun.js/bindings/webcore/JSCloseEvent.cpp
@@ -99,7 +99,7 @@ template<> CloseEvent::Init convertDictionary<CloseEvent::Init>(JSGlobalObject& 
     if (isNullOrUndefined)
         codeValue = jsUndefined();
     else {
-        codeValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "code"_s));
+        codeValue = object->get(&lexicalGlobalObject, WebCore::builtinNames(vm).codePublicName());
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!codeValue.isUndefined()) {

--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -78,8 +78,8 @@ pub const Os = struct {
         return if (comptime Environment.isLinux)
             cpusImplLinux(globalThis) catch {
                 const err = JSC.SystemError{
-                    .message = JSC.ZigString.init("Failed to get cpu information"),
-                    .code = JSC.ZigString.init(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
+                    .message = bun.String.static("Failed to get cpu information"),
+                    .code = bun.String.static(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
                 };
 
                 globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));
@@ -88,8 +88,8 @@ pub const Os = struct {
         else if (comptime Environment.isMac)
             cpusImplDarwin(globalThis) catch {
                 const err = JSC.SystemError{
-                    .message = JSC.ZigString.init("Failed to get cpu information"),
-                    .code = JSC.ZigString.init(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
+                    .message = bun.String.static("Failed to get cpu information"),
+                    .code = bun.String.static(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
                 };
 
                 globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));
@@ -318,11 +318,11 @@ pub const Os = struct {
             //info.put(globalThis, JSC.ZigString.static("syscall"), JSC.ZigString.init("uv_os_getpriority").withEncoding().toValueGC(globalThis));
 
             const err = JSC.SystemError{
-                .message = JSC.ZigString.init("A system error occurred: uv_os_getpriority returned ESRCH (no such process)"),
-                .code = JSC.ZigString.init(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
+                .message = bun.String.static("A system error occurred: uv_os_getpriority returned ESRCH (no such process)"),
+                .code = bun.String.static(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
                 //.info = info,
                 .errno = -3,
-                .syscall = JSC.ZigString.init("uv_os_getpriority"),
+                .syscall = bun.String.static("uv_os_getpriority"),
             };
 
             globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));
@@ -377,10 +377,10 @@ pub const Os = struct {
         const rc = C.getifaddrs(&interface_start);
         if (rc != 0) {
             const err = JSC.SystemError{
-                .message = JSC.ZigString.init("A system error occurred: getifaddrs returned an error"),
-                .code = JSC.ZigString.init(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
+                .message = bun.String.static("A system error occurred: getifaddrs returned an error"),
+                .code = bun.String.static(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
                 .errno = @intFromEnum(std.os.errno(rc)),
-                .syscall = JSC.ZigString.init("getifaddrs"),
+                .syscall = bun.String.static("getifaddrs"),
             };
 
             globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));
@@ -591,11 +591,11 @@ pub const Os = struct {
         switch (errcode) {
             .SRCH => {
                 const err = JSC.SystemError{
-                    .message = JSC.ZigString.init("A system error occurred: uv_os_setpriority returned ESRCH (no such process)"),
-                    .code = JSC.ZigString.init(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
+                    .message = bun.String.static("A system error occurred: uv_os_setpriority returned ESRCH (no such process)"),
+                    .code = bun.String.static(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
                     //.info = info,
                     .errno = -3,
-                    .syscall = JSC.ZigString.init("uv_os_setpriority"),
+                    .syscall = bun.String.static("uv_os_setpriority"),
                 };
 
                 globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));
@@ -603,11 +603,11 @@ pub const Os = struct {
             },
             .ACCES => {
                 const err = JSC.SystemError{
-                    .message = JSC.ZigString.init("A system error occurred: uv_os_setpriority returned EACCESS (permission denied)"),
-                    .code = JSC.ZigString.init(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
+                    .message = bun.String.static("A system error occurred: uv_os_setpriority returned EACCESS (permission denied)"),
+                    .code = bun.String.static(@as(string, @tagName(JSC.Node.ErrorCode.ERR_SYSTEM_ERROR))),
                     //.info = info,
                     .errno = -13,
-                    .syscall = JSC.ZigString.init("uv_os_setpriority"),
+                    .syscall = bun.String.static("uv_os_setpriority"),
                 };
 
                 globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));

--- a/src/bun.js/node/syscall.zig
+++ b/src/bun.js/node/syscall.zig
@@ -873,20 +873,20 @@ pub const Error = struct {
     pub fn toSystemError(this: Error) SystemError {
         var err = SystemError{
             .errno = @as(c_int, this.errno) * -1,
-            .syscall = JSC.ZigString.init(@tagName(this.syscall)),
+            .syscall = bun.String.static(@tagName(this.syscall)),
         };
 
         // errno label
         if (this.errno > 0 and this.errno < C.SystemErrno.max) {
             const system_errno = @enumFromInt(C.SystemErrno, this.errno);
-            err.code = JSC.ZigString.init(@tagName(system_errno));
+            err.code = bun.String.static(@tagName(system_errno));
             if (C.SystemErrno.labels.get(system_errno)) |label| {
-                err.message = JSC.ZigString.init(label);
+                err.message = bun.String.static(label);
             }
         }
 
         if (this.path.len > 0) {
-            err.path = JSC.ZigString.init(this.path);
+            err.path = bun.String.create(this.path);
         }
 
         if (this.fd != -1) {

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1194,9 +1194,6 @@ pub const Blob = struct {
                                     .syscall = .open,
                                 }).toSystemError();
 
-                                // assert we never end up reusing the memory
-                                std.debug.assert(@intFromPtr(this.system_error.?.path.slice().ptr) != @intFromPtr(path_buffer));
-
                                 callback(this, null_fd);
                                 return;
                             };

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -777,15 +777,15 @@ pub const Fetch = struct {
             }
 
             const fetch_error = JSC.SystemError{
-                .code = ZigString.init(@errorName(this.result.fail)),
+                .code = bun.String.static(@errorName(this.result.fail)),
                 .message = switch (this.result.fail) {
-                    error.ConnectionClosed => ZigString.init("The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()"),
-                    error.FailedToOpenSocket => ZigString.init("Was there a typo in the url or port?"),
-                    error.TooManyRedirects => ZigString.init("The response redirected too many times. For more information, pass `verbose: true` in the second argument to fetch()"),
-                    error.ConnectionRefused => ZigString.init("Unable to connect. Is the computer able to access the url?"),
-                    else => ZigString.init("fetch() failed. For more information, pass `verbose: true` in the second argument to fetch()"),
+                    error.ConnectionClosed => bun.String.static("The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()"),
+                    error.FailedToOpenSocket => bun.String.static("Was there a typo in the url or port?"),
+                    error.TooManyRedirects => bun.String.static("The response redirected too many times. For more information, pass `verbose: true` in the second argument to fetch()"),
+                    error.ConnectionRefused => bun.String.static("Unable to connect. Is the computer able to access the url?"),
+                    else => bun.String.static("fetch() failed. For more information, pass `verbose: true` in the second argument to fetch()"),
                 },
-                .path = ZigString.init(this.http.?.url.href),
+                .path = bun.String.create(this.http.?.url.href),
             };
 
             return fetch_error.toErrorInstance(this.global_this);

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -1964,10 +1964,10 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
                     pub const message = std.fmt.comptimePrint("{s} is not constructable", .{SinkType.name});
                 };
                 const err = JSC.SystemError{
-                    .message = ZigString.init(Static.message),
-                    .code = ZigString.init(@as(string, @tagName(JSC.Node.ErrorCode.ERR_ILLEGAL_CONSTRUCTOR))),
+                    .message = bun.String.static(Static.message),
+                    .code = bun.String.static(@as(string, @tagName(JSC.Node.ErrorCode.ERR_ILLEGAL_CONSTRUCTOR))),
                 };
-                globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));
+                globalThis.throwValue(err.toErrorInstance(globalThis));
                 return JSC.JSValue.jsUndefined();
             }
 

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -9174,8 +9174,10 @@ const LinkerContext = struct {
                         },
                     )) {
                         .err => |err| {
+                            var message = err.toSystemError().message.toUTF8(bun.default_allocator);
+                            defer message.deinit();
                             c.log.addErrorFmt(null, Logger.Loc.Empty, bun.default_allocator, "{} writing sourcemap for chunk {}", .{
-                                bun.fmt.quote(err.toSystemError().message.slice()),
+                                bun.fmt.quote(message.slice()),
                                 bun.fmt.quote(chunk.final_rel_path),
                             }) catch unreachable;
                             return error.WriteFailed;
@@ -9242,8 +9244,10 @@ const LinkerContext = struct {
                 },
             )) {
                 .err => |err| {
+                    var message = err.toSystemError().message.toUTF8(bun.default_allocator);
+                    defer message.deinit();
                     c.log.addErrorFmt(null, Logger.Loc.Empty, bun.default_allocator, "{} writing chunk {}", .{
-                        bun.fmt.quote(err.toSystemError().message.slice()),
+                        bun.fmt.quote(message.slice()),
                         bun.fmt.quote(chunk.final_rel_path),
                     }) catch unreachable;
                     return error.WriteFailed;
@@ -9309,8 +9313,10 @@ const LinkerContext = struct {
                 },
             )) {
                 .err => |err| {
+                    const utf8 = err.toSystemError().message.toUTF8(bun.default_allocator);
+                    defer utf8.deinit();
                     c.log.addErrorFmt(null, Logger.Loc.Empty, bun.default_allocator, "{} writing chunk {}", .{
-                        bun.fmt.quote(err.toSystemError().message.slice()),
+                        bun.fmt.quote(utf8.slice()),
                         bun.fmt.quote(components_manifest_path),
                     }) catch unreachable;
                     return error.WriteFailed;
@@ -9383,8 +9389,10 @@ const LinkerContext = struct {
                     },
                 )) {
                     .err => |err| {
+                        const utf8 = err.toSystemError().message.toUTF8(bun.default_allocator);
+                        defer utf8.deinit();
                         c.log.addErrorFmt(null, Logger.Loc.Empty, bun.default_allocator, "{} writing file {}", .{
-                            bun.fmt.quote(err.toSystemError().message.slice()),
+                            bun.fmt.quote(utf8.slice()),
                             bun.fmt.quote(src.src_path.text),
                         }) catch unreachable;
                         return error.WriteFailed;

--- a/src/http.zig
+++ b/src/http.zig
@@ -684,8 +684,9 @@ pub const RequestContext = struct {
                     if (erro == error.EBADF or erro == error.ECONNABORTED or erro == error.ECONNREFUSED) {
                         return error.SocketClosed;
                     }
-
-                    Output.prettyErrorln("send() error: {s}", .{err.toSystemError().message.slice()});
+                    const msg = err.toSystemError().message.toUTF8(bun.default_allocator);
+                    defer msg.deinit();
+                    Output.prettyErrorln("send() error: {s}", .{msg.slice()});
 
                     return erro;
                 },

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -303,16 +303,7 @@ pub export fn napi_create_string_utf16(env: napi_env, str: [*]const char16_t, le
     return .ok;
 }
 pub extern fn napi_create_symbol(env: napi_env, description: napi_value, result: *napi_value) napi_status;
-pub export fn napi_create_error(env: napi_env, code: napi_value, msg: napi_value, result: *napi_value) napi_status {
-    log("napi_create_error: \"{any}\"", .{msg.getZigString(env)});
-    const system_error = JSC.SystemError{
-        .code = if (!code.isEmptyOrUndefinedOrNull()) code.getZigString(env) else ZigString.Empty,
-        .message = msg.getZigString(env),
-    };
-    result.* = system_error.toErrorInstance(env);
-    return .ok;
-}
-
+pub extern fn napi_create_error(env: napi_env, code: napi_value, msg: napi_value, result: *napi_value) napi_status;
 pub extern fn napi_create_type_error(env: napi_env, code: napi_value, msg: napi_value, result: *napi_value) napi_status;
 pub extern fn napi_create_range_error(env: napi_env, code: napi_value, msg: napi_value, result: *napi_value) napi_status;
 pub extern fn napi_typeof(env: napi_env, value: napi_value, result: *napi_valuetype) napi_status;

--- a/test/js/bun/util/error-gc-test.test.js
+++ b/test/js/bun/util/error-gc-test.test.js
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-
+import { readFileSync } from "fs";
 // This test checks that printing stack traces increments and decrements
 // reference-counted strings
 test("error gc test", () => {
@@ -34,11 +34,36 @@ test("error gc test #2", () => {
   }
 });
 
-test("error gc test #2", () => {
+test("error gc test #3", () => {
   for (let i = 0; i < 1000; i++) {
     var err = new Error();
     Error.captureStackTrace(err);
     Bun.inspect(err);
     Bun.gc();
+  }
+});
+
+// This test fails if:
+// - it crashes
+// - The test failure message gets a non-sensical error
+test("error gc test #4", () => {
+  for (let i = 0; i < 1000; i++) {
+    const path =
+      // Use a long-enough string for it to be obvious if we leak memory
+      "i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/ii/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/ii/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i/don/t/exist/tmp/i";
+    try {
+      readFileSync(path);
+    } catch (e) {
+      const inspected = Bun.inspect(e);
+      // Deliberately avoid using .toContain() because we want to rule out any
+      // BunString shenanigins.
+      //
+      // Only JSC builtin functions to operate on the string after inspecting it.
+      //
+      expect(inspected.includes(path)).toBeTrue();
+      expect(inspected.includes("ENOENT")).toBeTrue();
+    } finally {
+      Bun.gc(true);
+    }
   }
 });


### PR DESCRIPTION
- This fixes a crash that can happen when certain exceptions are thrown and GC'd introduced in Bun v0.6.12
- This switches the `SystemError` type used for throwing exceptions with extra context to use `bun.String` instead of `ZigString`. 
- This makes usages of static strings go through the AtomString lookup table instead of leaking the `ExternalStringImpl*` type forever on each call
- This adds a test that checks we don't crash as a result of GC'ing exceptions thrown by `node:fs` (SystemError)