### PR TITLE
Make `buffer.toString("base64")` 4x faster

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -69,3 +69,9 @@ fetchRecurseSubmodules = false
 	path = src/deps/zstd
 	url = https://github.com/facebook/zstd.git
 	ignore = dirty
+[submodule "src/deps/base64"]
+	path = src/deps/base64
+	url = https://github.com/aklomp/base64.git
+	ignore = dirty
+	depth = 1
+	shallow = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -295,6 +295,27 @@ WORKDIR $BUN_DIR
 RUN cd $BUN_DIR && \
     make uws && rm -rf src/deps/uws Makefile
 
+FROM bun-base as base64
+
+ARG DEBIAN_FRONTEND
+ARG GITHUB_WORKSPACE
+ARG ZIG_PATH
+# Directory extracts to "bun-webkit"
+ARG WEBKIT_DIR
+ARG BUN_RELEASE_DIR
+ARG BUN_DEPS_OUT_DIR
+ARG BUN_DIR
+ARG CPU_TARGET
+ENV CPU_TARGET=${CPU_TARGET}
+
+COPY Makefile ${BUN_DIR}/Makefile
+COPY src/deps/base64 ${BUN_DIR}/src/deps/base64
+
+WORKDIR $BUN_DIR
+
+RUN cd $BUN_DIR && \
+    make base64 && rm -rf src/deps/base64 Makefile
+
 FROM bun-base as picohttp
 
 ARG DEBIAN_FRONTEND
@@ -556,6 +577,7 @@ ENV JSC_BASE_DIR=${WEBKIT_DIR}
 ENV LIB_ICU_PATH=${WEBKIT_DIR}/lib
 
 COPY --from=zlib ${BUN_DEPS_OUT_DIR}/*.a ${BUN_DEPS_OUT_DIR}/
+COPY --from=base64 ${BUN_DEPS_OUT_DIR}/*.a ${BUN_DEPS_OUT_DIR}/
 COPY --from=libarchive ${BUN_DEPS_OUT_DIR}/*.a ${BUN_DEPS_OUT_DIR}/
 COPY --from=boringssl ${BUN_DEPS_OUT_DIR}/*.a ${BUN_DEPS_OUT_DIR}/
 COPY --from=lolhtml ${BUN_DEPS_OUT_DIR}/*.a ${BUN_DEPS_OUT_DIR}/

--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,8 @@ MINIMUM_ARCHIVE_FILES = -L$(BUN_DEPS_OUT_DIR) \
 	-ldecrepit \
 	-lssl \
 	-lcrypto \
-	-llolhtml
+	-llolhtml \
+	-lbase64
 
 ARCHIVE_FILES_WITHOUT_LIBCRYPTO = $(MINIMUM_ARCHIVE_FILES) \
 		-larchive \
@@ -1850,6 +1851,10 @@ copy-to-bun-release-dir-bin:
 
 PACKAGE_MAP = --pkg-begin async_io $(BUN_DIR)/src/io/io_darwin.zig --pkg-begin bun $(BUN_DIR)/src/bun_redirect.zig --pkg-end --pkg-end --pkg-begin javascript_core $(BUN_DIR)/src/jsc.zig --pkg-begin bun $(BUN_DIR)/src/bun_redirect.zig --pkg-end --pkg-end --pkg-begin bun $(BUN_DIR)/src/bun_redirect.zig --pkg-end
 
+.PHONY: base64
+base64:
+	cd $(BUN_DEPS_DIR)/base64 && make clean && cmake $(CMAKE_FLAGS) . && make
+	cp $(BUN_DEPS_DIR)/base64/libbase64.a $(BUN_DEPS_OUT_DIR)/libbase64.a
 
 .PHONY: cold-jsc-start
 cold-jsc-start:
@@ -1868,7 +1873,8 @@ cold-jsc-start:
 		misctools/cold-jsc-start.cpp -o cold-jsc-start
 
 .PHONY: vendor-without-npm
-vendor-without-npm: node-fallbacks runtime_js fallback_decoder bun_error mimalloc picohttp zlib boringssl libarchive lolhtml sqlite usockets uws tinycc c-ares zstd
+vendor-without-npm: node-fallbacks runtime_js fallback_decoder bun_error mimalloc picohttp zlib boringssl libarchive lolhtml sqlite usockets uws tinycc c-ares zstd base64
+
 
 .PHONY: vendor-without-check
 vendor-without-check: npm-install vendor-without-npm

--- a/bench/snippets/base64-buffer-to-string.mjs
+++ b/bench/snippets/base64-buffer-to-string.mjs
@@ -1,0 +1,14 @@
+import { bench, run } from "./runner.mjs";
+import { Buffer } from "node:buffer";
+
+const bigBuffer = Buffer.from("hello world".repeat(10000));
+const converted = bigBuffer.toString("base64");
+bench("Buffer.toString('base64')", () => {
+  return bigBuffer.toString("base64");
+});
+
+// bench("Buffer.from(str, 'base64')", () => {
+//   return Buffer.from(converted, "base64");
+// });
+
+await run();

--- a/docs/project/licensing.md
+++ b/docs/project/licensing.md
@@ -85,6 +85,11 @@ Bun statically links these libraries:
 
 ---
 
+- [`libbase64`](https://github.com/aklomp/base64/blob/master/LICENSE)
+- BSD 2-Clause
+
+---
+
 - A fork of [`uWebsockets`](https://github.com/jarred-sumner/uwebsockets)
 - Apache 2.0 licensed
 

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -524,8 +524,8 @@ pub const Encoding = enum(u8) {
         switch (encoding) {
             .base64 => {
                 var base64: [std.base64.standard.Encoder.calcSize(size)]u8 = undefined;
-                const result = JSC.ZigString.init(std.base64.standard.Encoder.encode(&base64, input)).toValueGC(globalThis);
-                return result;
+                const len = bun.base64.encode(&base64, input);
+                return JSC.ZigString.init(base64[0..len]).toValueGC(globalThis);
             },
             .base64url => {
                 var buf: [std.base64.url_safe.Encoder.calcSize(size) + "data:;base64,".len]u8 = undefined;


### PR DESCRIPTION
This adds https://github.com/aklomp/base64 as a dependency to Bun, which is the same library that Node uses.

```zig
cpu: Apple M1 Max
runtime: bun 0.6.13_debug (arm64-darwin)

benchmark                      time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------------------- -----------------------------
Buffer.toString('base64')   40.41 µs/iter    (12.5 µs … 10.22 ms)  15.58 µs 561.83 µs   1.13 ms

❯ bun
cpu: Apple M1 Max
runtime: bun 0.6.12 (arm64-darwin)

benchmark                      time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------------------- -----------------------------
Buffer.toString('base64')  269.96 µs/iter     (177 µs … 38.42 ms) 186.92 µs 905.17 µs   3.41 ms

❯ node
cpu: Apple M1 Max
runtime: node v20.1.0 (arm64-darwin)

benchmark                      time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------------------- -----------------------------
Buffer.toString('base64')  129.44 µs/iter    (22.08 µs … 6.61 ms)  57.79 µs   1.65 ms   2.02 ms


❯ deno
cpu: unknown
runtime: deno 1.34.2 (aarch64-apple-darwin)

benchmark                      time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------------------- -----------------------------
Buffer.toString('base64')   154.7 µs/iter   (36.29 µs … 12.95 ms) 105.54 µs   1.44 ms   1.91 ms
```