### PR TITLE
fix zero length env var values

### DIFF
--- a/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
@@ -30,7 +30,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsGetterEnvironmentVariable, (JSGlobalObject * globalOb
     if (UNLIKELY(name.len == 0))
         return JSValue::encode(jsUndefined());
 
-    if (!Bun__getEnvValue(globalObject, &name, &value) || value.len == 0) {
+    if (!Bun__getEnvValue(globalObject, &name, &value)) {
         return JSValue::encode(jsUndefined());
     }
 

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -308,3 +308,13 @@ test(".env Windows-style newline (issue #3042)", () => {
   const { stdout } = bunRun(`${dir}/index.ts`);
   expect(stdout).toBe("|bar\n\nbaz|moo");
 });
+
+test(".env with zero length strings", () => {
+  const dir = tempDirWithFiles("dotenv-issue-zerolength", {
+    ".env": "FOO=''\n",
+    "index.ts":
+      "function i(a){return a}\nconsole.log([process.env.FOO,i(process.env).FOO,process.env.FOO.length,i(process.env).FOO.length].join('|'));",
+  });
+  const { stdout } = bunRun(`${dir}/index.ts`);
+  expect(stdout).toBe("||0|0");
+});


### PR DESCRIPTION
changes the lazy evaluated process.env.value getter to allow returning zero length strings. fixes this code:

```ts
var dotenv = require("dotenv");
var dotenvExpand = require("dotenv-expand");

var myEnv = dotenv.config();
dotenvExpand.expand(myEnv);

console.log(process.env);
```
with this dotenv
```
VALUE=''
```