### PR TITLE
Implements the "throwIfNoEntry" option for the Node FS bindings.

### DIFF
--- a/src/bun.js/node/node_fs_binding.zig
+++ b/src/bun.js/node/node_fs_binding.zig
@@ -67,8 +67,15 @@ fn callSync(comptime FunctionEnum: NodeFSFunctionEnum) NodeFSFunction {
                 args,
                 comptime Flavor.sync,
             );
+
             switch (result) {
                 .err => |err| {
+                    if (comptime @hasField(Arguments, "throw_if_no_entry")) {
+                        if (args.throw_if_no_entry == false and err.errno == 2) { // .ENOENT
+                            return JSC.JSValue.jsUndefined();
+                        }
+                    }
+
                     globalObject.throwValue(JSC.JSValue.c(err.toJS(globalObject)));
                     return .zero;
                 },

--- a/test/regression/issue/001579.test.ts
+++ b/test/regression/issue/001579.test.ts
@@ -1,0 +1,14 @@
+import fs from "fs";
+import { expect, it } from "bun:test";
+
+it("does not throw for a file that does not exist if throwIfNoEntry is false", async () => {
+    expect(() => fs.statSync("file_that_does_not_exist", { throwIfNoEntry: false })).not.toThrow();
+});
+
+it("throws for a file that does not exist if throwIfNoEntry is true", async () => {
+    expect(() => fs.statSync("file_that_does_not_exist", { throwIfNoEntry: true })).toThrow();
+});
+
+it("throws for a file that does not exist with default settings", async () => {
+    expect(() => fs.statSync("file_that_does_not_exist")).toThrow();
+});


### PR DESCRIPTION
Fixes #1579.

I'm not entirely confident this is the best approach, and I left some notes below as to why. This PR fixes the issue by changing argument parsing for Stat to accept the new optional argument, and a works ugly check in `node_fs_binding.zig`.

TODOs:
- [ ] Investigate if there is a way to compare `err.errno` to `.ENOENT` instead of the int value
- [ ] Verify that the argument parsing changes are the correct way to make these changes
- [ ] Check to see if there's a better way to implement the error comparison for this. Ideally wrapping the `callSync` function for just the `.stat` call?

I think a better approach for this would be to change:
```
    pub const statSync = callSync(.stat);
```

to a function body that can introspect the args and catch the error if it is appropriate given the arguments. However, I do not understand Zig well enough to make that change.

Something like this as a replacement for src/bun.js/node/node_fs_binding.zig#231:
```
  pub const statSync = fn (args) {
      try {
      callSync(.stat);
     } catch err => .ENOENT {
     if (args[1]["throwIfNoEntry"]) {
        // don't throw
    }
  }
```