### PR TITLE
Use BunString in JSBundlerPlugin

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -26,7 +26,7 @@ const strings = bun.strings;
 const NewClass = Base.NewClass;
 const To = Base.To;
 const Request = WebCore.Request;
-
+const String = bun.String;
 const FetchEvent = WebCore.FetchEvent;
 const MacroMap = @import("../../resolver/package_json.zig").MacroMap;
 const TSConfigJSON = @import("../../resolver/tsconfig_json.zig").TSConfigJSON;
@@ -871,16 +871,16 @@ pub const JSBundler = struct {
 
         extern fn JSBundlerPlugin__anyMatches(
             *Plugin,
-            namespaceString: *const ZigString,
-            path: *const ZigString,
+            namespaceString: *const String,
+            path: *const String,
             bool,
         ) bool;
 
         extern fn JSBundlerPlugin__matchOnLoad(
             *JSC.JSGlobalObject,
             *Plugin,
-            namespaceString: *const ZigString,
-            path: *const ZigString,
+            namespaceString: *const String,
+            path: *const String,
             context: *anyopaque,
             u8,
         ) void;
@@ -888,9 +888,9 @@ pub const JSBundler = struct {
         extern fn JSBundlerPlugin__matchOnResolve(
             *JSC.JSGlobalObject,
             *Plugin,
-            namespaceString: *const ZigString,
-            path: *const ZigString,
-            importer: *const ZigString,
+            namespaceString: *const String,
+            path: *const String,
+            importer: *const String,
             context: *anyopaque,
             u8,
         ) void;
@@ -905,10 +905,10 @@ pub const JSBundler = struct {
             defer tracer.end();
 
             const namespace_string = if (path.isFile())
-                ZigString.Empty
+                bun.String.empty
             else
-                ZigString.fromUTF8(path.namespace);
-            const path_string = ZigString.fromUTF8(path.text);
+                bun.String.create(path.namespace);
+            const path_string = bun.String.create(path.text);
             return JSBundlerPlugin__anyMatches(this, &namespace_string, &path_string, is_onLoad);
         }
 
@@ -924,10 +924,12 @@ pub const JSBundler = struct {
             const tracer = bun.tracy.traceNamed(@src(), "JSBundler.matchOnLoad");
             defer tracer.end();
             const namespace_string = if (namespace.len == 0)
-                ZigString.init("file")
+                bun.String.static("file")
             else
-                ZigString.fromUTF8(namespace);
-            const path_string = ZigString.fromUTF8(path);
+                bun.String.create(namespace);
+            const path_string = bun.String.create(path);
+            defer namespace_string.deref();
+            defer path_string.deref();
             JSBundlerPlugin__matchOnLoad(globalThis, this, &namespace_string, &path_string, context, @intFromEnum(default_loader));
         }
 
@@ -944,11 +946,14 @@ pub const JSBundler = struct {
             const tracer = bun.tracy.traceNamed(@src(), "JSBundler.matchOnResolve");
             defer tracer.end();
             const namespace_string = if (strings.eqlComptime(namespace, "file"))
-                ZigString.Empty
+                bun.String.empty
             else
-                ZigString.fromUTF8(namespace);
-            const path_string = ZigString.fromUTF8(path);
-            const importer_string = ZigString.fromUTF8(importer);
+                bun.String.create(namespace);
+            const path_string = bun.String.create(path);
+            const importer_string = bun.String.create(importer);
+            defer namespace_string.deref();
+            defer path_string.deref();
+            defer importer_string.deref();
             JSBundlerPlugin__matchOnResolve(globalThis, this, &namespace_string, &path_string, &importer_string, context, @intFromEnum(import_record_kind));
         }
 

--- a/src/bun.js/bindings/JSBundlerPlugin.h
+++ b/src/bun.js/bindings/JSBundlerPlugin.h
@@ -9,6 +9,10 @@
 #include <JavaScriptCore/Yarr.h>
 #include <JavaScriptCore/Strong.h>
 
+typedef void (*JSBundlerPluginAddErrorCallback)(void*, void*, JSC::EncodedJSValue, JSC::EncodedJSValue);
+typedef void (*JSBundlerPluginOnLoadAsyncCallback)(void*, void*, JSC::EncodedJSValue, JSC::EncodedJSValue);
+typedef void (*JSBundlerPluginOnResolveAsyncCallback)(void*, void*, JSC::EncodedJSValue, JSC::EncodedJSValue, JSC::EncodedJSValue);
+
 namespace Bun {
 
 using namespace JSC;
@@ -42,10 +46,13 @@ public:
     };
 
 public:
-    bool anyMatchesCrossThread(JSC::VM&, const ZigString* namespaceStr, const ZigString* path, bool isOnLoad);
+    bool anyMatchesCrossThread(JSC::VM&, const BunString* namespaceStr, const BunString* path, bool isOnLoad);
     void tombstone() { tombstoned = true; }
 
-    BundlerPlugin(void* config, BunPluginTarget target)
+    BundlerPlugin(void* config, BunPluginTarget target, JSBundlerPluginAddErrorCallback addError, JSBundlerPluginOnLoadAsyncCallback onLoadAsync, JSBundlerPluginOnResolveAsyncCallback onResolveAsync)
+        : addError(addError)
+        , onLoadAsync(onLoadAsync)
+        , onResolveAsync(onResolveAsync)
     {
         this->target = target;
         this->config = config;
@@ -54,6 +61,10 @@ public:
     NamespaceList onLoad = {};
     NamespaceList onResolve = {};
     BunPluginTarget target { BunPluginTargetBrowser };
+
+    JSBundlerPluginAddErrorCallback addError;
+    JSBundlerPluginOnLoadAsyncCallback onLoadAsync;
+    JSBundlerPluginOnResolveAsyncCallback onResolveAsync;
     void* config { nullptr };
     bool tombstoned { false };
 };


### PR DESCRIPTION
This is preparation for fixing the bugs with runtime plugins that block it from being used nicely in `bun test`

- First we should unify the implementations so there's only one for both bundler and runtime
- Then we should disable running module resolution twice - no more running it after transpilation and then again at runtime
- Then we should wire up JSBundlerPlugin to work with ModuleLoader.cpp

Will need to do something about async module resolution. Maybe we don't allow it at runtime?
