### PR TITLE
fix decoding invalid UTF-8 input

### DIFF
--- a/src/bun.js/bindings/JSStringDecoder.cpp
+++ b/src/bun.js/bindings/JSStringDecoder.cpp
@@ -129,7 +129,7 @@ uint8_t JSStringDecoder::utf8CheckIncomplete(uint8_t* bufPtr, uint32_t length, u
             m_lastNeed = nb - 1;
         return nb;
     }
-    if (--j < i || nb == -2)
+    if (j == 0 || --j < i || nb == -2)
         return 0;
     nb = utf8CheckByte(bufPtr[j]);
     if (nb >= 0) {
@@ -137,7 +137,7 @@ uint8_t JSStringDecoder::utf8CheckIncomplete(uint8_t* bufPtr, uint32_t length, u
             m_lastNeed = nb - 2;
         return nb;
     }
-    if (--j < i || nb == -2)
+    if (j == 0 || --j < i || nb == -2)
         return 0;
     nb = utf8CheckByte(bufPtr[j]);
     if (nb >= 0) {

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -241,3 +241,12 @@ for (const StringDecoder of [FakeStringDecoderCall, RealStringDecoder]) {
     });
   });
 }
+
+it("invalid utf-8 input, pr #3562", () => {
+  const decoder = new RealStringDecoder("utf-8");
+  let output = "";
+  output += decoder.write(Buffer.from("B9", "hex"));
+  output += decoder.write(Buffer.from("A9", "hex"));
+  output += decoder.end();
+  expect(output).toStrictEqual("\uFFFD\uFFFD");
+});


### PR DESCRIPTION
Close: #3562

- Add boundary check to `utf8CheckIncomplete` function.