### PR TITLE
docs(sqlite): database prepare types reflect runtime

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -235,7 +235,7 @@ declare module "bun:sqlite" {
       ParamsType extends SQLQueryBindings | SQLQueryBindings[],
     >(
       sqlQuery: string,
-      params?: SQLQueryBindings[]
+      params?: ParamsType
     ): Statement<
       ReturnType,
       ParamsType extends Array<any> ? ParamsType : [ParamsType]

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -235,6 +235,7 @@ declare module "bun:sqlite" {
       ParamsType extends SQLQueryBindings | SQLQueryBindings[],
     >(
       sqlQuery: string,
+      params?: SQLQueryBindings[]
     ): Statement<
       ReturnType,
       ParamsType extends Array<any> ? ParamsType : [ParamsType]


### PR DESCRIPTION
This should fix #3080. 
In the database prepare function I added optional param types.
Feel free to correct if you feel like there are better types to reflect the current runtime behavior. 