### PR TITLE
Support `napi_wrap` in constructors

### DIFF
--- a/src/bun.js/bindings/napi.h
+++ b/src/bun.js/bindings/napi.h
@@ -164,6 +164,7 @@ public:
 
     void* dataPtr = nullptr;
     FFIFunction m_constructor = nullptr;
+    NapiRef* napiRef = nullptr;
 
 private:
     NapiClass(VM& vm, NativeExecutable* executable, JSC::JSGlobalObject* global, Structure* structure)


### PR DESCRIPTION
Repro:
```c++
#include <node_api.h>
#include <stdio.h>

napi_value MyClassConstructor(napi_env env, napi_callback_info info) {
  napi_value this_arg;
  napi_get_cb_info(env, info, NULL, NULL, &this_arg, NULL);
  return this_arg;
}

napi_value Init(napi_env env, napi_value exports) {
  napi_value cls;
  napi_define_class(env, "MyClass", NAPI_AUTO_LENGTH, MyClassConstructor, NULL,
                    0, NULL, &cls);

  napi_status status = napi_wrap(env, cls, (void *)env, NULL, NULL, NULL);
  if (status != napi_ok) {
    printf("napi_wrap failed: %d\n", status);
    return NULL;
  }

  return exports;
}


NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)
```

```js
require("./addon.node")
```

This needs a test
