### PR TITLE
docs: add one missing line in typescript.md

### DIFF
--- a/docs/runtime/typescript.md
+++ b/docs/runtime/typescript.md
@@ -76,6 +76,7 @@ These are the recommended `compilerOptions` for a Bun project.
 
     // if TS 5.x+
     "moduleResolution": "bundler",
+    "noEmit": true,
     "allowImportingTsExtensions": true,
     "moduleDetection": "force",
     // if TS 4.x or earlier


### PR DESCRIPTION
When the line is missing:
![image](https://github.com/oven-sh/bun/assets/1305378/aee63027-2ecc-414b-a955-82e052c9a393)
