### PR TITLE
Pass constructor arguments to TextDecoder

### DIFF
--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -676,25 +676,56 @@ pub const TextDecoder = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) callconv(.C) ?*TextDecoder {
-        var args_ = callframe.arguments(1);
+        var args_ = callframe.arguments(2);
         var arguments: []const JSC.JSValue = args_.ptr[0..args_.len];
 
-        var encoding = EncodingLabel.@"UTF-8";
-        if (arguments.len > 0) {
-            if (!arguments[0].isString()) {
-                globalThis.throwInvalidArguments("TextDecoder(encoding) label is invalid", .{});
+        var decoder = getAllocator(globalThis).create(TextDecoder) catch unreachable;
+        decoder.* = TextDecoder{}; // Is this necessary? Does allocation initialize variables?
+
+        var ctor_failed = false; // using errdefer would be much nicer but would require another fn
+        defer if (ctor_failed) getAllocator(globalThis).destroy(decoder);
+
+        if (arguments.len == 0) {
+            return decoder;
+        }
+
+        if (!arguments[0].isString()) {
+            globalThis.throwInvalidArguments("TextDecoder(encoding) label is invalid", .{});
+            ctor_failed = true;
+            return null;
+        }
+
+        // encoding
+        {
+            var str = arguments[0].toSlice(globalThis, default_allocator);
+            defer if (str.isAllocated()) str.deinit();
+            if (EncodingLabel.which(str.slice())) |label| {
+                decoder.encoding = label;
+            } else {
+                globalThis.throwInvalidArguments("Unsupported encoding label \"{s}\"", .{str.slice()});
+                ctor_failed = true;
+                return null;
+            }
+        }
+
+        if (arguments.len >= 2) {
+            const options = arguments[1];
+
+            if (!options.isObject()) {
+                globalThis.throwInvalidArguments("TextDecoder(options) is invalid", .{});
+                ctor_failed = true;
                 return null;
             }
 
-            var str = arguments[0].toSlice(globalThis, default_allocator);
-            defer if (str.isAllocated()) str.deinit();
-            encoding = EncodingLabel.which(str.slice()) orelse {
-                globalThis.throwInvalidArguments("Unsupported encoding label \"{s}\"", .{str.slice()});
-                return null;
-            };
+            if (options.get(globalThis, "fatal")) |fatal| {
+                decoder.fatal = fatal.asBoolean();
+            }
+
+            if (options.get(globalThis, "ignoreBOM")) |ignoreBOM| {
+                decoder.ignore_bom = ignoreBOM.asBoolean();
+            }
         }
-        var decoder = getAllocator(globalThis).create(TextDecoder) catch unreachable;
-        decoder.* = TextDecoder{ .encoding = encoding };
+
         return decoder;
     }
 };

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -630,11 +630,13 @@ pub const TextDecoder = struct {
                     } else |err| {
                         switch (err) {
                             error.InvalidByteSequence => {
-                                globalThis.throw("Invalid byte sequence", .{});
+                                globalThis.throwValue(
+                                    globalThis.createTypeErrorInstance("Invalid byte sequence", .{}),
+                                );
                                 return JSValue.zero;
                             },
                             error.OutOfMemory => {
-                                globalThis.throw("Out of memory", .{});
+                                globalThis.throwOutOfMemory();
                                 return JSValue.zero;
                             },
                         }
@@ -647,7 +649,7 @@ pub const TextDecoder = struct {
                     } else |err| {
                         switch (err) {
                             error.OutOfMemory => {
-                                globalThis.throw("Out of memory", .{});
+                                globalThis.throwOutOfMemory();
                                 return JSValue.zero;
                             },
                         }

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -684,21 +684,20 @@ pub const TextDecoder = struct {
         var decoder = TextDecoder{};
 
         if (arguments.len > 0) {
-            if (!arguments[0].isString()) {
-                globalThis.throwInvalidArguments("TextDecoder(encoding) label is invalid", .{});
-                return null;
-            }
-
             // encoding
-            {
+            if (arguments[0].isString()) {
                 var str = arguments[0].toSlice(globalThis, default_allocator);
                 defer if (str.isAllocated()) str.deinit();
+
                 if (EncodingLabel.which(str.slice())) |label| {
                     decoder.encoding = label;
                 } else {
                     globalThis.throwInvalidArguments("Unsupported encoding label \"{s}\"", .{str.slice()});
                     return null;
                 }
+            } else {
+                globalThis.throwInvalidArguments("TextDecoder(encoding) label is invalid", .{});
+                return null;
             }
 
             if (arguments.len >= 2) {

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -708,11 +708,21 @@ pub const TextDecoder = struct {
                 }
 
                 if (options.get(globalThis, "fatal")) |fatal| {
-                    decoder.fatal = fatal.asBoolean();
+                    if (fatal.isBoolean()) {
+                        decoder.fatal = fatal.asBoolean();
+                    } else {
+                        globalThis.throwInvalidArguments("TextDecoder(options) fatal is invalid. Expected boolean value", .{});
+                        return null;
+                    }
                 }
 
                 if (options.get(globalThis, "ignoreBOM")) |ignoreBOM| {
-                    decoder.ignore_bom = ignoreBOM.asBoolean();
+                    if (ignoreBOM.isBoolean()) {
+                        decoder.ignore_bom = ignoreBOM.asBoolean();
+                    } else {
+                        globalThis.throwInvalidArguments("TextDecoder(options) ignoreBOM is invalid. Expected boolean value", .{});
+                        return null;
+                    }
                 }
             }
         }

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -230,7 +230,7 @@ describe("TextDecoder", () => {
     const decoder = new TextDecoder("utf-8", { fatal: true });
     expect(() => {
       decoder.decode(new Uint8Array([0xC0])) // Invalid UTF8 
-    }).toThrow(); // should throw TypeError according to WHATWG Encoding Standard
+    }).toThrow(TypeError);
   });
 
   it("constructor should set values", () => {

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -225,6 +225,19 @@ describe("TextDecoder", () => {
     expect(decoder.decode(bytes.subarray(0, amount.written))).toBe(text);
     gcTrace(true);
   });
+
+  it("should respect fatal when encountering invalid data", () => {
+    const decoder = new TextDecoder("utf-8", { fatal: true });
+    expect(() => {
+      decoder.decode(new Uint8Array([0xC0])) // Invalid UTF8 
+    }).toThrow(); // should throw TypeError according to WHATWG Encoding Standard
+  });
+
+  it("constructor should set values", () => {
+    const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
+    expect(decoder.fatal).toBe(true);
+    // expect(decoder.ignoreBOM).toBe(false); // currently the getter for ignoreBOM doesn't work and always returns undefined
+  });
 });
 
 it("truncated sequences", () => {

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -238,6 +238,12 @@ describe("TextDecoder", () => {
     expect(decoder.fatal).toBe(true);
     // expect(decoder.ignoreBOM).toBe(false); // currently the getter for ignoreBOM doesn't work and always returns undefined
   });
+
+  it("should throw on invalid input", () => {
+    expect(() => {
+      const decoder = new TextDecoder("utf-8", { fatal: 10, ignoreBOM: {} });
+    }).toThrow();
+  });
 });
 
 it("truncated sequences", () => {


### PR DESCRIPTION
The constructor now actually sets TextDecoder properties using the options parameter. This lets users enable the `fatal` parameter, closing #3572.
