### PR TITLE
Use WebKit's URL parser in fetch() and `bun install`

### DIFF
--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -298,3 +298,85 @@ extern "C" void BunString__toWTFString(BunString* bunString)
         bunString->tag = BunStringTag::WTFStringImpl;
     }
 }
+
+extern "C" WTF::URL* URL__fromJS(EncodedJSValue encodedValue, JSC::JSGlobalObject* globalObject)
+{
+    auto throwScope = DECLARE_THROW_SCOPE(globalObject->vm());
+    JSC::JSValue value = JSC::JSValue::decode(encodedValue);
+    auto str = value.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(throwScope, nullptr);
+    if (str.isEmpty()) {
+        return nullptr;
+    }
+
+    auto url = WTF::URL(str);
+    if (!url.isValid() || url.isNull())
+        return nullptr;
+
+    return new WTF::URL(WTFMove(url));
+}
+
+extern "C" WTF::URL* URL__fromString(BunString* input)
+{
+    auto str = Bun::toWTFString(*input);
+    auto url = WTF::URL(str);
+    if (!url.isValid())
+        return nullptr;
+
+    return new WTF::URL(WTFMove(url));
+}
+
+extern "C" BunString URL__protocol(WTF::URL* url)
+{
+    return Bun::toStringRef(url->protocol().toStringWithoutCopying());
+}
+
+extern "C" void URL__deinit(WTF::URL* url)
+{
+    delete url;
+}
+
+extern "C" BunString URL__href(WTF::URL* url)
+{
+    return Bun::toStringRef(url->string());
+}
+
+extern "C" BunString URL__username(WTF::URL* url)
+{
+    return Bun::toStringRef(url->user());
+}
+
+extern "C" BunString URL__password(WTF::URL* url)
+{
+    return Bun::toStringRef(url->password());
+}
+
+extern "C" BunString URL__search(WTF::URL* url)
+{
+    return Bun::toStringRef(url->query().toStringWithoutCopying());
+}
+
+extern "C" BunString URL__host(WTF::URL* url)
+{
+    return Bun::toStringRef(url->host().toStringWithoutCopying());
+}
+extern "C" BunString URL__hostname(WTF::URL* url)
+{
+    return Bun::toStringRef(url->hostAndPort());
+}
+
+extern "C" uint32_t URL__port(WTF::URL* url)
+{
+    auto port = url->port();
+
+    if (port.has_value()) {
+        return port.value();
+    }
+
+    return std::numeric_limits<uint32_t>::max();
+}
+
+extern "C" BunString URL__pathname(WTF::URL* url)
+{
+    return Bun::toStringRef(url->path().toStringWithoutCopying());
+}

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -316,6 +316,33 @@ extern "C" WTF::URL* URL__fromJS(EncodedJSValue encodedValue, JSC::JSGlobalObjec
     return new WTF::URL(WTFMove(url));
 }
 
+extern "C" BunString URL__getHrefFromJS(EncodedJSValue encodedValue, JSC::JSGlobalObject* globalObject)
+{
+    auto throwScope = DECLARE_THROW_SCOPE(globalObject->vm());
+    JSC::JSValue value = JSC::JSValue::decode(encodedValue);
+    auto str = value.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(throwScope, { BunStringTag::Dead });
+    if (str.isEmpty()) {
+        return { BunStringTag::Dead };
+    }
+
+    auto url = WTF::URL(str);
+    if (!url.isValid() || url.isEmpty())
+        return { BunStringTag::Dead };
+
+    return Bun::toStringRef(url.string());
+}
+
+extern "C" BunString URL__getHref(BunString* input)
+{
+    auto str = Bun::toWTFString(*input);
+    auto url = WTF::URL(str);
+    if (!url.isValid() || url.isEmpty())
+        return { BunStringTag::Dead };
+
+    return Bun::toStringRef(url.string());
+}
+
 extern "C" WTF::URL* URL__fromString(BunString* input)
 {
     auto str = Bun::toWTFString(*input);

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -5397,6 +5397,21 @@ pub const URL = opaque {
     extern fn URL__port(*URL) String;
     extern fn URL__deinit(*URL) void;
     extern fn URL__pathname(*URL) String;
+    extern fn URL__getHrefFromJS(JSValue, *JSC.JSGlobalObject) String;
+    extern fn URL__getHref(*String) String;
+    pub fn hrefFromString(str: bun.String) String {
+        JSC.markBinding(@src());
+        var input = str;
+        return URL__getHref(&input);
+    }
+
+    /// This percent-encodes the URL, punycode-encodes the hostname, and returns the result
+    /// If it fails, the tag is marked Dead
+    pub fn hrefFromJS(value: JSValue, globalObject: *JSC.JSGlobalObject) String {
+        JSC.markBinding(@src());
+        return URL__getHrefFromJS(value, globalObject);
+    }
+
     pub fn fromJS(value: JSValue, globalObject: *JSC.JSGlobalObject) ?*URL {
         JSC.markBinding(@src());
         return URL__fromJS(value, globalObject);

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -5384,6 +5384,74 @@ pub fn untrackFunction(
     return private.Bun__untrackFFIFunction(globalObject, value);
 }
 
+pub const URL = opaque {
+    extern fn URL__fromJS(JSValue, *JSC.JSGlobalObject) ?*URL;
+    extern fn URL__fromString(*bun.String) ?*URL;
+    extern fn URL__protocol(*URL) String;
+    extern fn URL__href(*URL) String;
+    extern fn URL__username(*URL) String;
+    extern fn URL__password(*URL) String;
+    extern fn URL__search(*URL) String;
+    extern fn URL__host(*URL) String;
+    extern fn URL__hostname(*URL) String;
+    extern fn URL__port(*URL) String;
+    extern fn URL__deinit(*URL) void;
+    extern fn URL__pathname(*URL) String;
+    pub fn fromJS(value: JSValue, globalObject: *JSC.JSGlobalObject) ?*URL {
+        JSC.markBinding(@src());
+        return URL__fromJS(value, globalObject);
+    }
+
+    pub fn fromUTF8(input: []const u8) ?*URL {
+        return fromString(String.fromUTF8(input));
+    }
+    pub fn fromString(str: bun.String) ?*URL {
+        JSC.markBinding(@src());
+        var input = str;
+        return URL__fromString(&input);
+    }
+    pub fn protocol(url: *URL) String {
+        JSC.markBinding(@src());
+        return URL__protocol(url);
+    }
+    pub fn href(url: *URL) String {
+        JSC.markBinding(@src());
+        return URL__href(url);
+    }
+    pub fn username(url: *URL) String {
+        JSC.markBinding(@src());
+        return URL__username(url);
+    }
+    pub fn password(url: *URL) String {
+        JSC.markBinding(@src());
+        return URL__password(url);
+    }
+    pub fn search(url: *URL) String {
+        JSC.markBinding(@src());
+        return URL__search(url);
+    }
+    pub fn host(url: *URL) String {
+        JSC.markBinding(@src());
+        return URL__host(url);
+    }
+    pub fn hostname(url: *URL) String {
+        JSC.markBinding(@src());
+        return URL__hostname(url);
+    }
+    pub fn port(url: *URL) String {
+        JSC.markBinding(@src());
+        return URL__port(url);
+    }
+    pub fn deinit(url: *URL) void {
+        JSC.markBinding(@src());
+        return URL__deinit(url);
+    }
+    pub fn pathname(url: *URL) String {
+        JSC.markBinding(@src());
+        return URL__pathname(url);
+    }
+};
+
 pub const URLSearchParams = opaque {
     extern fn URLSearchParams__create(globalObject: *JSGlobalObject, *const ZigString) JSValue;
     pub fn create(globalObject: *JSGlobalObject, init: ZigString) JSValue {

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1147,17 +1147,17 @@ pub const Fetch = struct {
 
                     if (options.get(globalThis, "proxy")) |proxy_arg| {
                         if (proxy_arg.isString() and proxy_arg.getLength(ctx) > 0) {
-                            var wtf_proxy_url = JSC.URL.fromJS(proxy_arg, globalThis) orelse {
+                            var href = JSC.URL.hrefFromJS(proxy_arg, globalThis);
+                            if (href.tag == .Dead) {
                                 const err = JSC.toTypeError(.ERR_INVALID_ARG_VALUE, "fetch() proxy URL is invalid", .{}, ctx);
                                 // clean hostname if any
                                 if (hostname) |host| {
                                     bun.default_allocator.free(host);
                                 }
-                                return JSPromise.rejectedPromiseValue(globalThis, err);
-                            };
-                            defer wtf_proxy_url.deinit();
+                                bun.default_allocator.free(url_proxy_buffer);
 
-                            var href = wtf_proxy_url.href();
+                                return JSPromise.rejectedPromiseValue(globalThis, err);
+                            }
                             defer href.deref();
                             var buffer = std.fmt.allocPrint(bun.default_allocator, "{s}{}", .{ url_proxy_buffer, href }) catch {
                                 globalThis.throwOutOfMemory();
@@ -1165,6 +1165,7 @@ pub const Fetch = struct {
                             };
                             url = ZigURL.parse(buffer[0..url.href.len]);
                             proxy = ZigURL.parse(buffer[url.href.len..]);
+                            bun.default_allocator.free(url_proxy_buffer);
                             url_proxy_buffer = buffer;
                         }
                     }
@@ -1281,17 +1282,17 @@ pub const Fetch = struct {
 
                     if (options.getTruthy(globalThis, "proxy")) |proxy_arg| {
                         if (proxy_arg.isString() and proxy_arg.getLength(globalThis) > 0) {
-                            var wtf_proxy_url = JSC.URL.fromJS(proxy_arg, globalThis) orelse {
+                            var href = JSC.URL.hrefFromJS(proxy_arg, globalThis);
+                            if (href.tag == .Dead) {
                                 const err = JSC.toTypeError(.ERR_INVALID_ARG_VALUE, "fetch() proxy URL is invalid", .{}, ctx);
                                 // clean hostname if any
                                 if (hostname) |host| {
                                     bun.default_allocator.free(host);
                                 }
-                                return JSPromise.rejectedPromiseValue(globalThis, err);
-                            };
-                            defer wtf_proxy_url.deinit();
+                                bun.default_allocator.free(url_proxy_buffer);
 
-                            var href = wtf_proxy_url.href();
+                                return JSPromise.rejectedPromiseValue(globalThis, err);
+                            }
                             defer href.deref();
                             var buffer = std.fmt.allocPrint(bun.default_allocator, "{s}{}", .{ url_proxy_buffer, href }) catch {
                                 globalThis.throwOutOfMemory();
@@ -1299,6 +1300,7 @@ pub const Fetch = struct {
                             };
                             url = ZigURL.parse(buffer[0..url.href.len]);
                             proxy = ZigURL.parse(buffer[url.href.len..]);
+                            bun.default_allocator.free(url_proxy_buffer);
                             url_proxy_buffer = buffer;
                         }
                     }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -4475,7 +4475,23 @@ pub const PackageManager = struct {
                     for (scoped.scopes, 0..) |name, i| {
                         var registry = scoped.registries[i];
                         if (registry.url.len == 0) registry.url = base.url;
-                        try this.registries.put(allocator, Npm.Registry.Scope.hash(name), try Npm.Registry.Scope.fromAPI(name, registry, allocator, env));
+                        try this.registries.put(allocator, Npm.Registry.Scope.hash(name), Npm.Registry.Scope.fromAPI(name, registry, allocator, env) catch |err| {
+                            if (err == error.InvalidURL) {
+                                log.addErrorFmt(
+                                    null,
+                                    logger.Loc.Empty,
+                                    allocator,
+                                    "{} is not a valid registry URL",
+                                    .{
+                                        strings.QuotedFormatter{
+                                            .text = registry.url,
+                                        },
+                                    },
+                                ) catch unreachable;
+                            }
+
+                            return err;
+                        });
                     }
                 }
 
@@ -4588,12 +4604,24 @@ pub const PackageManager = struct {
                             {
                                 const prev_scope = this.scope;
                                 var api_registry = std.mem.zeroes(Api.NpmRegistry);
-                                api_registry.url = registry_;
-                                api_registry.token = prev_scope.token;
-                                this.scope = try Npm.Registry.Scope.fromAPI("", api_registry, allocator, env);
-                                did_set = true;
-                                // stage1 bug: break inside inline is broken
-                                // break :load_registry;
+                                if (bun.JSC.URL.fromUTF8(registry_)) |url| {
+                                    defer url.deinit();
+
+                                    api_registry.token = prev_scope.token;
+                                    this.scope = try Npm.Registry.Scope.fromAPI("", api_registry, allocator, env);
+                                    var href = url.href();
+                                    defer href.deref();
+                                    api_registry.url = try href.toOwnedSlice(bun.default_allocator);
+                                    did_set = true;
+                                    // stage1 bug: break inside inline is broken
+                                    // break :load_registry;
+                                } else {
+                                    try log.addErrorFmt(null, logger.Loc.Empty, bun.default_allocator, "${s} has invalid URL {}", .{
+                                        registry_key, strings.QuotedFormatter{
+                                            .text = registry_,
+                                        },
+                                    });
+                                }
                             }
                         }
                     }
@@ -4626,7 +4654,18 @@ pub const PackageManager = struct {
                 if (cli.registry.len > 0 and strings.startsWith(cli.registry, "https://") or
                     strings.startsWith(cli.registry, "http://"))
                 {
-                    this.scope.url = URL.parse(cli.registry);
+                    if (bun.JSC.URL.fromUTF8(cli.registry)) |url| {
+                        defer url.deinit();
+                        var href = url.href();
+                        defer href.deref();
+                        this.scope.url = URL.parse(try href.toOwnedSlice(bun.default_allocator));
+                    } else {
+                        try log.addErrorFmt(null, logger.Loc.Empty, bun.default_allocator, "--registry has invalid URL {}", .{
+                            strings.QuotedFormatter{
+                                .text = cli.registry,
+                            },
+                        });
+                    }
                 }
 
                 if (cli.exact) {

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -68,7 +68,7 @@ pub const Registry = struct {
 
         pub fn fromAPI(name: string, registry_: Api.NpmRegistry, allocator: std.mem.Allocator, env: *DotEnv.Loader) !Scope {
             var registry = registry_;
-            var url = URL.parse(registry.url);
+            var url = try URL.fromUTF8(bun.default_allocator, registry.url);
             var auth: string = "";
 
             if (registry.token.len == 0) {

--- a/src/string.zig
+++ b/src/string.zig
@@ -280,15 +280,15 @@ pub const String = extern struct {
         switch (this.tag) {
             .ZigString => return try this.value.ZigString.toOwnedSlice(allocator),
             .WTFStringImpl => {
-                var utf8_slice = this.value.WTFStringImpl.toUTF8(allocator);
+                var utf8_slice = this.value.WTFStringImpl.toUTF8WithoutRef(allocator);
 
                 if (utf8_slice.allocator.get()) |alloc| {
-                    if (isWTFAllocator(alloc)) {
-                        return @constCast((try utf8_slice.clone(allocator)).slice());
+                    if (!isWTFAllocator(alloc)) {
+                        return @constCast(utf8_slice.slice());
                     }
                 }
 
-                return @constCast(utf8_slice.slice());
+                return @constCast((try utf8_slice.clone(allocator)).slice());
             },
             .StaticZigString => return try this.value.StaticZigString.toOwnedSlice(allocator),
             .Empty => return &[_]u8{},

--- a/src/url.zig
+++ b/src/url.zig
@@ -37,21 +37,20 @@ pub const URL = struct {
     port_was_automatically_set: bool = false,
 
     pub fn fromJS(js_value: JSC.JSValue, globalObject: *JSC.JSGlobalObject, allocator: std.mem.Allocator) !URL {
-        var wtf_url = JSC.URL.fromJS(js_value, globalObject) orelse {
-            return error.JSError;
-        };
-        defer wtf_url.deinit();
-        const href = wtf_url.href();
-        defer href.deref();
+        var href = JSC.URL.hrefFromJS(globalObject, js_value);
+        if (href.tag == .Dead) {
+            return error.InvalidURL;
+        }
+
         return URL.parse(try href.toOwnedSlice(allocator));
     }
 
     pub fn fromString(allocator: std.mem.Allocator, input: bun.String) !URL {
-        var wtf_url = JSC.URL.fromString(input) orelse {
+        var href = JSC.URL.hrefFromString(input);
+        if (href.tag == .Dead) {
             return error.InvalidURL;
-        };
-        defer wtf_url.deinit();
-        const href = wtf_url.href();
+        }
+
         defer href.deref();
         return URL.parse(try href.toOwnedSlice(allocator));
     }

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -264,7 +264,7 @@ describe("async context passes through", () => {
         },
       });
 
-      const response = await fetch(server.hostname + ":" + server.port);
+      const response = await fetch("http://" + server.hostname + ":" + server.port);
       expect(await response.text()).toBe("value");
 
       expect(s.getStore()).toBe("value");


### PR DESCRIPTION
This makes `fetch()` and `bun install` use WebKit's URL parser which has far better test coverage than ours. 

Fixes #3725

It probably also fixes other issues.