### PR TITLE
Merge import.meta.require and require to be the same thing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -245,17 +245,6 @@
     {
       "type": "lldb",
       "request": "launch",
-      "name": "bun build debug STDOUT (--target=bun)",
-      "program": "bun-debug",
-      "args": ["bun", "${file}", "--target=bun", "--minify"],
-      "cwd": "${file}/../",
-      "console": "internalConsole",
-      "env": {}
-    },
-
-    {
-      "type": "lldb",
-      "request": "launch",
       "name": "bun build debug (no splitting, browser entry)",
       "program": "bun-debug",
       "args": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -242,6 +242,16 @@
       "console": "internalConsole",
       "env": {}
     },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "bun build debug STDOUT (--target=bun)",
+      "program": "bun-debug",
+      "args": ["bun", "${file}", "--target=bun", "--minify"],
+      "cwd": "${file}/../",
+      "console": "internalConsole",
+      "env": {}
+    },
 
     {
       "type": "lldb",

--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -405,13 +405,9 @@ EncodedJSValue BunPlugin::OnLoad::run(JSC::JSGlobalObject* globalObject, BunStri
 
     if (auto* promise = JSC::jsDynamicCast<JSPromise*>(result)) {
         switch (promise->status(vm)) {
+        case JSPromise::Status::Rejected:
         case JSPromise::Status::Pending: {
             return JSValue::encode(promise);
-        }
-        case JSPromise::Status::Rejected: {
-            promise->internalField(JSC::JSPromise::Field::Flags).set(vm, promise, jsNumber(static_cast<unsigned>(JSC::JSPromise::Status::Fulfilled)));
-            result = promise->result(vm);
-            return JSValue::encode(result);
         }
         case JSPromise::Status::Fulfilled: {
             result = promise->result(vm);

--- a/src/bun.js/bindings/CommonJSModuleRecord.cpp
+++ b/src/bun.js/bindings/CommonJSModuleRecord.cpp
@@ -852,37 +852,6 @@ bool JSCommonJSModule::evaluate(
     return true;
 }
 
-bool JSCommonJSModule::evaluate(
-    Zig::GlobalObject* globalObject,
-    const WTF::String& key,
-    JSC::JSSourceCode* sourceCode)
-{
-    auto& vm = globalObject->vm();
-
-    if (this->hasEvaluated)
-        return true;
-
-    this->sourceCode.set(vm, this, sourceCode);
-
-    WTF::NakedPtr<JSC::Exception> exception;
-
-    evaluateCommonJSModuleOnce(vm, globalObject, this, this->m_dirname.get(), this->m_filename.get(), exception);
-
-    if (exception.get()) {
-        // On error, remove the module from the require map/
-        // so that it can be re-evaluated on the next require.
-        globalObject->requireMap()->remove(globalObject, this->id());
-
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
-        throwException(globalObject, throwScope, exception.get());
-        exception.clear();
-
-        return false;
-    }
-
-    return true;
-}
-
 std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
     ResolvedSource source)

--- a/src/bun.js/bindings/CommonJSModuleRecord.cpp
+++ b/src/bun.js/bindings/CommonJSModuleRecord.cpp
@@ -852,6 +852,37 @@ bool JSCommonJSModule::evaluate(
     return true;
 }
 
+bool JSCommonJSModule::evaluate(
+    Zig::GlobalObject* globalObject,
+    const WTF::String& key,
+    JSC::JSSourceCode* sourceCode)
+{
+    auto& vm = globalObject->vm();
+
+    if (this->hasEvaluated)
+        return true;
+
+    this->sourceCode.set(vm, this, sourceCode);
+
+    WTF::NakedPtr<JSC::Exception> exception;
+
+    evaluateCommonJSModuleOnce(vm, globalObject, this, this->m_dirname.get(), this->m_filename.get(), exception);
+
+    if (exception.get()) {
+        // On error, remove the module from the require map/
+        // so that it can be re-evaluated on the next require.
+        globalObject->requireMap()->remove(globalObject, this->id());
+
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        throwException(globalObject, throwScope, exception.get());
+        exception.clear();
+
+        return false;
+    }
+
+    return true;
+}
+
 std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
     ResolvedSource source)

--- a/src/bun.js/bindings/CommonJSModuleRecord.h
+++ b/src/bun.js/bindings/CommonJSModuleRecord.h
@@ -39,6 +39,7 @@ public:
 
     bool evaluate(Zig::GlobalObject* globalObject, const WTF::String& sourceURL, ResolvedSource resolvedSource);
     bool evaluate(Zig::GlobalObject* globalObject, const WTF::String& key, const SyntheticSourceProvider::SyntheticSourceGenerator& generator);
+    bool evaluate(Zig::GlobalObject* globalObject, const WTF::String& key, JSSourceCode* sourceCode);
 
     static JSCommonJSModule* create(JSC::VM& vm, JSC::Structure* structure,
         JSC::JSString* id,

--- a/src/bun.js/bindings/CommonJSModuleRecord.h
+++ b/src/bun.js/bindings/CommonJSModuleRecord.h
@@ -56,6 +56,8 @@ public:
         const WTF::String& key,
         ResolvedSource resolvedSource);
 
+    static JSObject* createBoundRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, const WTF::String& pathString);
+
     void toSyntheticSource(JSC::JSGlobalObject* globalObject,
         JSC::Identifier moduleKey,
         Vector<JSC::Identifier, 4>& exportNames,
@@ -94,5 +96,51 @@ JSC::Structure* createCommonJSModuleStructure(
 std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
     ResolvedSource source);
+
+class RequireResolveFunctionPrototype final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+    static RequireResolveFunctionPrototype* create(JSC::JSGlobalObject* globalObject);
+
+    DECLARE_INFO;
+
+    RequireResolveFunctionPrototype(
+        JSC::VM& vm,
+        JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    template<typename CellType, JSC::SubspaceAccess>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        return &vm.plainObjectSpace();
+    }
+
+    void finishCreation(JSC::VM& vm);
+};
+
+class RequireFunctionPrototype final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+    static RequireFunctionPrototype* create(JSC::JSGlobalObject* globalObject);
+
+    RequireFunctionPrototype(
+        JSC::VM& vm,
+        JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    template<typename CellType, JSC::SubspaceAccess>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        return &vm.plainObjectSpace();
+    }
+
+    DECLARE_INFO;
+
+    void finishCreation(JSC::VM& vm);
+};
 
 } // namespace Bun

--- a/src/bun.js/bindings/ImportMetaObject.h
+++ b/src/bun.js/bindings/ImportMetaObject.h
@@ -19,17 +19,12 @@ namespace Zig {
 using namespace JSC;
 using namespace WebCore;
 
-JSC_DECLARE_CUSTOM_GETTER(jsRequireCacheGetter);
-JSC_DECLARE_CUSTOM_SETTER(jsRequireCacheSetter);
-
 class ImportMetaObject final : public JSC::JSNonFinalObject {
 public:
     using Base = JSC::JSNonFinalObject;
 
     static ImportMetaObject* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const WTF::String& url);
 
-    static JSC::JSObject* createRequireFunctionUnbound(JSC::VM& vm, JSGlobalObject* globalObject);
-    static JSC::JSObject* createRequireResolveFunctionUnbound(JSC::VM& vm, JSGlobalObject* globalObject);
     static JSObject* createRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, const WTF::String& pathString);
 
     static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSC::JSString* keyString);

--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -421,14 +421,19 @@ JSValue fetchCommonJSModule(
     }
 
     if (JSC::JSValue virtualModuleResult = JSValue::decode(Bun__runVirtualModule(globalObject, specifier))) {
-        JSInternalPromise* promise = jsCast<JSInternalPromise*>(handleVirtualModuleResult<true>(globalObject, virtualModuleResult, res, specifier, referrer));
+        JSPromise* promise = jsCast<JSPromise*>(handleVirtualModuleResult<true>(globalObject, virtualModuleResult, res, specifier, referrer));
         switch (promise->status(vm)) {
-        case JSPromise::Status::Rejected:
-        case JSPromise::Status::Pending:
-            // CommonJS must be sync. TODO: throw
+        case JSPromise::Status::Rejected: {
+            uint32_t promiseFlags = promise->internalField(JSPromise::Field::Flags).get().asUInt32AsAnyInt();
+            promise->internalField(JSPromise::Field::Flags).set(vm, promise, jsNumber(promiseFlags | JSPromise::isHandledFlag));
+            JSC::throwException(globalObject, scope, promise->result(vm));
+            RELEASE_AND_RETURN(scope, JSValue {});
+        }
+        case JSPromise::Status::Pending: {
             JSC::throwTypeError(globalObject, scope, makeString("require() async module \""_s, Bun::toWTFString(*specifier), "\" is unsupported. use \"await import()\" instead."_s));
             RELEASE_AND_RETURN(scope, JSValue {});
-        case JSPromise::Status::Fulfilled:
+        }
+        case JSPromise::Status::Fulfilled: {
             if (!res->success) {
                 throwException(scope, res->result.err, globalObject);
                 RELEASE_AND_RETURN(scope, {});
@@ -437,6 +442,7 @@ JSValue fetchCommonJSModule(
             globalObject->moduleLoader()->provideFetch(globalObject, specifierValue, jsSourceCode->sourceCode());
             RETURN_IF_EXCEPTION(scope, {});
             RELEASE_AND_RETURN(scope, jsNumber(-1));
+        }
         }
     }
 

--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -420,9 +420,26 @@ JSValue fetchCommonJSModule(
         }
     }
 
-    // if (JSC::JSValue virtualModuleResult = JSValue::decode(Bun__runVirtualModule(globalObject, specifier))) {
-    //     return handleVirtualModuleResult<allowPromise>(globalObject, virtualModuleResult, res, specifier, referrer);
-    // }
+    if (JSC::JSValue virtualModuleResult = JSValue::decode(Bun__runVirtualModule(globalObject, specifier))) {
+        JSInternalPromise* promise = jsCast<JSInternalPromise*>(handleVirtualModuleResult<true>(globalObject, virtualModuleResult, res, specifier, referrer));
+        switch (promise->status(vm)) {
+        case JSPromise::Status::Rejected:
+        case JSPromise::Status::Pending:
+            // CommonJS must be sync. TODO: throw
+            JSC::throwTypeError(globalObject, scope, makeString("require() async module \""_s, Bun::toWTFString(*specifier), "\" is unsupported. use \"await import()\" instead."_s));
+            RELEASE_AND_RETURN(scope, JSValue {});
+        case JSPromise::Status::Fulfilled:
+            if (!res->success) {
+                throwException(scope, res->result.err, globalObject);
+                RELEASE_AND_RETURN(scope, {});
+            }
+            auto* jsSourceCode = jsCast<JSSourceCode*>(promise->result(vm));
+            globalObject->moduleLoader()->provideFetch(globalObject, specifierValue, jsSourceCode->sourceCode());
+            RETURN_IF_EXCEPTION(scope, {});
+            RELEASE_AND_RETURN(scope, jsNumber(-1));
+        }
+    }
+
     auto* loader = globalObject->moduleLoader();
     JSMap* registry = jsCast<JSMap*>(loader->getDirect(vm, Identifier::fromString(vm, "registry"_s)));
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3448,15 +3448,23 @@ void GlobalObject::finishCreation(VM& vm)
             init.set(structure);
         });
 
-    m_importMetaRequireFunctionUnbound.initLater(
+    m_requireFunctionUnbound.initLater(
         [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSObject>::Initializer& init) {
             init.set(
-                Zig::ImportMetaObject::createRequireFunctionUnbound(init.vm, init.owner));
+                JSFunction::create(
+                    init.vm,
+                    moduleRequireCodeGenerator(init.vm),
+                    init.owner->globalScope(),
+                    JSFunction::createStructure(init.vm, init.owner, RequireFunctionPrototype::create(init.owner))));
         });
-    m_importMetaRequireResolveFunctionUnbound.initLater(
+    m_requireResolveFunctionUnbound.initLater(
         [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSObject>::Initializer& init) {
             init.set(
-                Zig::ImportMetaObject::createRequireResolveFunctionUnbound(init.vm, init.owner));
+                JSFunction::create(
+                    init.vm,
+                    moduleRequireResolveCodeGenerator(init.vm),
+                    init.owner->globalScope(),
+                    JSFunction::createStructure(init.vm, init.owner, RequireResolveFunctionPrototype::create(init.owner))));
         });
 
     m_importMetaObjectStructure.initLater(
@@ -4622,8 +4630,8 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_emitReadableNextTickFunction.visit(visitor);
     thisObject->m_JSBufferSubclassStructure.visit(visitor);
 
-    thisObject->m_importMetaRequireFunctionUnbound.visit(visitor);
-    thisObject->m_importMetaRequireResolveFunctionUnbound.visit(visitor);
+    thisObject->m_requireFunctionUnbound.visit(visitor);
+    thisObject->m_requireResolveFunctionUnbound.visit(visitor);
     thisObject->m_importMetaObjectStructure.visit(visitor);
     thisObject->m_asyncBoundFunctionStructure.visit(visitor);
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -4115,7 +4115,6 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     putDirectBuiltinFunction(vm, this, builtinNames.createNativeReadableStreamPrivateName(), readableStreamCreateNativeReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 
     putDirectBuiltinFunction(vm, this, builtinNames.requireESMPrivateName(), importMetaObjectRequireESMCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    putDirectBuiltinFunction(vm, this, builtinNames.requirePrivateName(), importMetaObjectRequireCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectBuiltinFunction(vm, this, builtinNames.loadCJS2ESMPrivateName(), importMetaObjectLoadCJS2ESMCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectBuiltinFunction(vm, this, builtinNames.internalRequirePrivateName(), importMetaObjectInternalRequireCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.createUninitializedArrayBufferPrivateName(), 1, functionCreateUninitializedArrayBuffer, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | PropertyAttribute::Function);

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -262,8 +262,8 @@ public:
 
     JSC::JSFunction* emitReadableNextTickFunction() { return m_emitReadableNextTickFunction.getInitializedOnMainThread(this); }
 
-    JSObject* importMetaRequireFunctionUnbound() { return m_importMetaRequireFunctionUnbound.getInitializedOnMainThread(this); }
-    JSObject* importMetaRequireResolveFunctionUnbound() { return m_importMetaRequireResolveFunctionUnbound.getInitializedOnMainThread(this); }
+    JSObject* requireFunctionUnbound() { return m_requireFunctionUnbound.getInitializedOnMainThread(this); }
+    JSObject* requireResolveFunctionUnbound() { return m_requireResolveFunctionUnbound.getInitializedOnMainThread(this); }
 
     JSObject* lazyRequireCacheObject() { return m_lazyRequireCacheObject.getInitializedOnMainThread(this); }
 
@@ -523,8 +523,8 @@ private:
     LazyProperty<JSGlobalObject, Structure> m_commonJSModuleObjectStructure;
     LazyProperty<JSGlobalObject, Structure> m_commonJSFunctionArgumentsStructure;
 
-    LazyProperty<JSGlobalObject, JSC::JSObject> m_importMetaRequireFunctionUnbound;
-    LazyProperty<JSGlobalObject, JSC::JSObject> m_importMetaRequireResolveFunctionUnbound;
+    LazyProperty<JSGlobalObject, JSC::JSObject> m_requireFunctionUnbound;
+    LazyProperty<JSGlobalObject, JSC::JSObject> m_requireResolveFunctionUnbound;
     LazyProperty<JSGlobalObject, JSC::Structure> m_importMetaObjectStructure;
     LazyProperty<JSGlobalObject, JSC::Structure> m_asyncBoundFunctionStructure;
 

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1693,7 +1693,7 @@ pub const VirtualMachine = struct {
                         &ZigString.init(
                             std.fmt.allocPrint(globalThis.allocator(), "{d} errors building \"{}\"", .{
                                 errors.len,
-                                referrer,
+                                specifier,
                             }) catch unreachable,
                         ),
                     ).asVoid(),

--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -2,6 +2,7 @@
 
 #include "./NodeModuleModule.h"
 
+#include "CommonJSModuleRecord.h"
 #include "ImportMetaObject.h"
 #include "JavaScriptCore/JSBoundFunction.h"
 #include "JavaScriptCore/ObjectConstructor.h"
@@ -126,14 +127,13 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeModuleCreateRequire,
   if (callFrame->argumentCount() < 1) {
     throwTypeError(globalObject, scope,
                    "createRequire() requires at least one argument"_s);
-    return JSC::JSValue::encode(JSC::jsUndefined());
+    RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::jsUndefined()));
   }
 
   auto val = callFrame->uncheckedArgument(0).toWTFString(globalObject);
   RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
-  auto clientData = WebCore::clientData(vm);
   RELEASE_AND_RETURN(
-      scope, JSValue::encode(Zig::ImportMetaObject::createRequireFunction(
+      scope, JSValue::encode(Bun::JSCommonJSModule::createBoundRequireFunction(
                  vm, globalObject, val)));
 }
 extern "C" EncodedJSValue Resolver__nodeModulePathsForJS(JSGlobalObject *,

--- a/src/js/builtins/ImportMetaObject.ts
+++ b/src/js/builtins/ImportMetaObject.ts
@@ -214,10 +214,6 @@ export function createRequireCache() {
   });
 }
 
-export function require(this: string, name) {
-  return $internalRequire($resolveSync(name, $toString(this), false));
-}
-
 $getter;
 export function main(this: ImportMetaObject) {
   return this.path === Bun.main;

--- a/src/js/out/WebCoreJSBuiltins.cpp
+++ b/src/js/out/WebCoreJSBuiltins.cpp
@@ -2284,14 +2284,6 @@ const int s_importMetaObjectCreateRequireCacheCodeLength = 854;
 static const JSC::Intrinsic s_importMetaObjectCreateRequireCacheCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_importMetaObjectCreateRequireCacheCode = "(function (){\"use strict\";var c=new Map,L={};return new Proxy(L,{get(f,_){const h=@requireMap.@get(_);if(h)return h;const t=@Loader.registry.@get(_);if(t\?.evaluated){const u=@Loader.getModuleNamespaceObject(t.module),g=u[@commonJSSymbol]===0||u.default\?.[@commonJSSymbol]\?u.default:u,b=@createCommonJSModule(_,g,!0);return @requireMap.@set(_,b),b}return L[_]},set(f,_,h){return @requireMap.@set(_,h),!0},has(f,_){return @requireMap.@has(_)||@Loader.registry.@has(_)},deleteProperty(f,_){return c.@delete(_),@requireMap.@delete(_),@Loader.registry.@delete(_),!0},ownKeys(f){var _=[...@requireMap.@keys()];const h=[...@Loader.registry.@keys()];for(let t of h)if(!_.includes(t))@arrayPush(_,t);return _},getPrototypeOf(f){return null},getOwnPropertyDescriptor(f,_){if(@requireMap.@has(_)||@Loader.registry.@has(_))return{configurable:!0,enumerable:!0}}})})\n";
 
-// require
-const JSC::ConstructAbility s_importMetaObjectRequireCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_importMetaObjectRequireCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_importMetaObjectRequireCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_importMetaObjectRequireCodeLength = 89;
-static const JSC::Intrinsic s_importMetaObjectRequireCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_importMetaObjectRequireCode = "(function (l){\"use strict\";return @internalRequire(@resolveSync(l,@toString(this),!1))})\n";
-
 // main
 const JSC::ConstructAbility s_importMetaObjectMainCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_importMetaObjectMainCodeConstructorKind = JSC::ConstructorKind::None;

--- a/src/js/out/WebCoreJSBuiltins.h
+++ b/src/js/out/WebCoreJSBuiltins.h
@@ -4172,14 +4172,6 @@ extern const JSC::ConstructAbility s_importMetaObjectCreateRequireCacheCodeConst
 extern const JSC::ConstructorKind s_importMetaObjectCreateRequireCacheCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_importMetaObjectCreateRequireCacheCodeImplementationVisibility;
 
-// require
-#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_REQUIRE 1
-extern const char* const s_importMetaObjectRequireCode;
-extern const int s_importMetaObjectRequireCodeLength;
-extern const JSC::ConstructAbility s_importMetaObjectRequireCodeConstructAbility;
-extern const JSC::ConstructorKind s_importMetaObjectRequireCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_importMetaObjectRequireCodeImplementationVisibility;
-
 // main
 #define WEBCORE_BUILTIN_IMPORTMETAOBJECT_MAIN 1
 extern const char* const s_importMetaObjectMainCode;
@@ -4193,7 +4185,6 @@ extern const JSC::ImplementationVisibility s_importMetaObjectMainCodeImplementat
     macro(requireESM, importMetaObjectRequireESM, 1) \
     macro(internalRequire, importMetaObjectInternalRequire, 1) \
     macro(createRequireCache, importMetaObjectCreateRequireCache, 0) \
-    macro(require, importMetaObjectRequire, 1) \
     macro(main, importMetaObjectMain, 0) \
 
 #define WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(macro) \
@@ -4201,7 +4192,6 @@ extern const JSC::ImplementationVisibility s_importMetaObjectMainCodeImplementat
     macro(importMetaObjectRequireESMCode, requireESM, ASCIILiteral(), s_importMetaObjectRequireESMCodeLength) \
     macro(importMetaObjectInternalRequireCode, internalRequire, ASCIILiteral(), s_importMetaObjectInternalRequireCodeLength) \
     macro(importMetaObjectCreateRequireCacheCode, createRequireCache, ASCIILiteral(), s_importMetaObjectCreateRequireCacheCodeLength) \
-    macro(importMetaObjectRequireCode, require, ASCIILiteral(), s_importMetaObjectRequireCodeLength) \
     macro(importMetaObjectMainCode, main, "get main"_s, s_importMetaObjectMainCodeLength) \
 
 #define WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_FUNCTION_NAME(macro) \
@@ -4209,7 +4199,6 @@ extern const JSC::ImplementationVisibility s_importMetaObjectMainCodeImplementat
     macro(requireESM) \
     macro(internalRequire) \
     macro(createRequireCache) \
-    macro(require) \
     macro(main) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1682,9 +1682,9 @@ fn NewPrinter(
         }
 
         pub fn printRequireError(p: *Printer, text: string) void {
-            p.print("(() => { throw (new Error(`Cannot require module ");
+            p.print("(()=>{ throw new Error(`Cannot require module ");
             p.printQuotedUTF8(text, false);
-            p.print("`)); } )()");
+            p.print("`);})()");
         }
 
         pub inline fn importRecord(
@@ -4826,7 +4826,7 @@ fn NewPrinter(
         }
 
         inline fn printDisabledImport(p: *Printer) void {
-            p.print("(() => ({}))");
+            p.print("(()=>({}))");
         }
 
         pub fn printLoadFromBundleWithoutCall(p: *Printer, import_record_index: u32) void {

--- a/test/js/bun/plugin/plugins.d.ts
+++ b/test/js/bun/plugin/plugins.d.ts
@@ -9,3 +9,5 @@ declare module "async-obj:*";
 declare module "obj:*";
 declare module "delay:*";
 declare module "./*.svelte";
+declare module "rejected-promise:*";
+declare module "rejected-promise2:*";

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -326,7 +326,7 @@ describe("errors", () => {
     }
   });
 
-  it.skip("async transpiler errors work", async () => {
+  it.todo("async transpiler errors work", async () => {
     expect(async () => {
       globalThis.asyncOnLoad = `const x: string = -NaNAn../!!;`;
       await import("async:fail");


### PR DESCRIPTION
We used to implement `require` twice. once for `import.meta.require` and then once in the actual `require` implementation. This is just old code from before the CJS rewrite.

`import.meta.require` and `createRequire` now create an empty `JSCommonJSModule` and return it's `require` function.

Fixes #3724, because the old require implementation would not append `__esModule` to certain case.