### PR TITLE
Fix `writeFileSync` when the mode is greater than 0o777.

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1005,12 +1005,12 @@ pub fn modeFromJS(ctx: JSC.C.JSContextRef, value: JSC.JSValue, exception: JSC.C.
         };
     };
 
-    if (mode_int < 0 or mode_int > 0o777) {
-        JSC.throwInvalidArguments("Invalid mode: must be an octal number", .{}, ctx, exception);
+    if (mode_int < 0) {
+        JSC.throwInvalidArguments("Invalid mode: must be greater than or equal to 0.", .{}, ctx, exception);
         return null;
     }
 
-    return mode_int;
+    return mode_int & 0o777;
 }
 
 pub const PathOrFileDescriptor = union(Tag) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -548,7 +548,12 @@ describe("writeFileSync", () => {
 
     expect(readFileSync(path, "utf8")).toBe("File written successfully");
   });
-
+  it("write file with mode, issue #3740", () => {
+    const path = `${tmpdir()}/${Date.now()}.writeFileSyncWithMode.txt`;
+    writeFileSync(path, "bun", { mode: 33188 });
+    const stat = fs.statSync(path);
+    expect(stat.mode).toBe(33188);
+  });
   it("returning Buffer works", () => {
     const buffer = new Buffer([
       70, 105, 108, 101, 32, 119, 114, 105, 116, 116, 101, 110, 32, 115, 117, 99, 99, 101, 115, 115, 102, 117, 108, 108,


### PR DESCRIPTION
Close: #3740

The octal representation of `33188` is `0o100644`, and it appears that this value is from `stat.st_mode`.
![2023-07-22_23-07](https://github.com/oven-sh/bun/assets/9482395/d6d69bbe-a6ee-4703-9568-e93e52360232)


Ref: https://man7.org/linux/man-pages/man7/inode.7.html
