### PR TITLE
Explicitly ref/unref blobs before extracting the value

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -790,14 +790,9 @@ pub const Blob = struct {
             }
         }
 
-        if (path_or_blob == .blob) {
-            path_or_blob.blob.store.?.ref();
-        }
-        defer {
-            if (path_or_blob == .blob) {
-                path_or_blob.blob.store.?.deref();
-            }
-        }
+        var input_store: ?*Store = if (path_or_blob == .blob) path_or_blob.blob.store else null;
+        if (input_store) |st| st.ref();
+        defer if (input_store) |st| st.deref();
 
         var needs_async = false;
 

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -790,6 +790,15 @@ pub const Blob = struct {
             }
         }
 
+        if (path_or_blob == .blob) {
+            path_or_blob.blob.store.?.ref();
+        }
+        defer {
+            if (path_or_blob == .blob) {
+                path_or_blob.blob.store.?.deref();
+            }
+        }
+
         var needs_async = false;
 
         if (data.isString()) {
@@ -972,6 +981,17 @@ pub const Blob = struct {
                 return null;
             };
         };
+
+        var destination_store = destination_blob.store;
+        if (destination_store) |store| {
+            store.ref();
+        }
+
+        defer {
+            if (destination_store) |store| {
+                store.deref();
+            }
+        }
 
         return writeFileWithSourceDestination(ctx, &source_blob, &destination_blob);
     }
@@ -2503,6 +2523,9 @@ pub const Blob = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) callconv(.C) JSC.JSValue {
+        var store = this.store;
+        if (store) |st| st.ref();
+        defer if (store) |st| st.deref();
         return promisified(this.toString(globalThis, .clone), globalThis);
     }
 
@@ -2510,6 +2533,9 @@ pub const Blob = struct {
         this: *Blob,
         globalObject: *JSC.JSGlobalObject,
     ) JSC.JSValue {
+        var store = this.store;
+        if (store) |st| st.ref();
+        defer if (store) |st| st.deref();
         return promisified(this.toString(globalObject, .transfer), globalObject);
     }
 
@@ -2518,6 +2544,10 @@ pub const Blob = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) callconv(.C) JSC.JSValue {
+        var store = this.store;
+        if (store) |st| st.ref();
+        defer if (store) |st| st.deref();
+
         return promisified(this.toJSON(globalThis, .share), globalThis);
     }
 
@@ -2525,6 +2555,10 @@ pub const Blob = struct {
         this: *Blob,
         globalThis: *JSC.JSGlobalObject,
     ) JSC.JSValue {
+        var store = this.store;
+        if (store) |st| st.ref();
+        defer if (store) |st| st.deref();
+
         return promisified(this.toArrayBuffer(globalThis, .transfer), globalThis);
     }
 
@@ -2533,6 +2567,9 @@ pub const Blob = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) callconv(.C) JSValue {
+        var store = this.store;
+        if (store) |st| st.ref();
+        defer if (store) |st| st.deref();
         return promisified(this.toArrayBuffer(globalThis, .clone), globalThis);
     }
 
@@ -2541,6 +2578,10 @@ pub const Blob = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) callconv(.C) JSValue {
+        var store = this.store;
+        if (store) |st| st.ref();
+        defer if (store) |st| st.deref();
+
         return promisified(this.toFormData(globalThis, .temporary), globalThis);
     }
 


### PR DESCRIPTION
This makes the lifetime of the blob store more clear

