### PR TITLE
bun:sqlite gets 10% faster

### DIFF
--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -1290,8 +1290,6 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
 
             JSC::JSArray* resultArray = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, 0);
             {
-                JSC::ObjectInitializationScope initializationScope(vm);
-                JSC::GCDeferralContext deferralContext(vm);
 
                 while (status == SQLITE_ROW) {
                     JSC::JSValue result = constructResultObject(lexicalGlobalObject, castedThis);

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -1103,7 +1103,8 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
                     const void* blob = len > 0 ? sqlite3_column_blob(stmt, i) : nullptr;
                     JSC::JSUint8Array* array = JSC::JSUint8Array::createUninitialized(lexicalGlobalObject, lexicalGlobalObject->m_typedArrayUint8.get(lexicalGlobalObject), len);
 
-                    memcpy(array->vector(), blob, len);
+                    if (LIKELY(blob && len))
+                        memcpy(array->vector(), blob, len);
 
                     *value = array;
                     break;
@@ -1166,7 +1167,10 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
                 size_t len = sqlite3_column_bytes(stmt, i);
                 const void* blob = len > 0 ? sqlite3_column_blob(stmt, i) : nullptr;
                 JSC::JSUint8Array* array = JSC::JSUint8Array::createUninitialized(lexicalGlobalObject, lexicalGlobalObject->m_typedArrayUint8.get(lexicalGlobalObject), len);
-                memcpy(array->vector(), blob, len);
+
+                if (LIKELY(blob && len))
+                    memcpy(array->vector(), blob, len);
+
                 result->putDirect(vm, name, array, 0);
                 break;
             }


### PR DESCRIPTION
By being a little smarter about how JSC APIs are used, bun:sqlite gets 10% faster at returning results from sqlite

<img width="682" alt="image" src="https://github.com/oven-sh/bun/assets/709451/f3143807-10bd-48a5-b4fb-d65111268aa9">


cc @AlexBlokh 