### PR TITLE
Start time performance improvements to build tools

### DIFF
--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -41,3 +41,11 @@ extern "C" void bun_ignore_sigpipe()
     // ignore SIGPIPE
     signal(SIGPIPE, SIG_IGN);
 }
+extern "C" ssize_t bun_sysconf__SC_CLK_TCK()
+{
+#ifdef __APPLE__
+    return sysconf(_SC_CLK_TCK);
+#else
+    return 0;
+#endif
+}

--- a/src/bun.js/node/fs_events.zig
+++ b/src/bun.js/node/fs_events.zig
@@ -267,10 +267,11 @@ pub const FSEventsLoop = struct {
 
         pub const Queue = UnboundedQueue(ConcurrentTask, .next);
 
-        pub fn from(this: *ConcurrentTask, task: Task) *ConcurrentTask {
+        pub fn from(this: *ConcurrentTask, task: Task, auto_delete: bool) *ConcurrentTask {
             this.* = .{
                 .task = task,
                 .next = null,
+                .auto_delete = auto_delete,
             };
             return this;
         }
@@ -339,8 +340,7 @@ pub const FSEventsLoop = struct {
     fn enqueueTaskConcurrent(this: *FSEventsLoop, task: Task) void {
         const CF = CoreFoundation.get();
         var concurrent = bun.default_allocator.create(ConcurrentTask) catch unreachable;
-        concurrent.auto_delete = true;
-        this.tasks.push(concurrent.from(task));
+        this.tasks.push(concurrent.from(task, true));
         CF.RunLoopSourceSignal(this.signal_source);
         CF.RunLoopWakeUp(this.loop);
     }
@@ -403,8 +403,9 @@ pub const FSEventsLoop = struct {
                         }
                     }
 
-                    handle.callback(handle.ctx, path, is_file, is_rename);
+                    handle.emit(path, is_file, is_rename);
                 }
+                handle.flush();
             }
         }
     }
@@ -572,17 +573,20 @@ pub const FSEventsLoop = struct {
 pub const FSEventsWatcher = struct {
     path: string,
     callback: Callback,
+    flushCallback: UpdateEndCallback,
     loop: ?*FSEventsLoop,
     recursive: bool,
     ctx: ?*anyopaque,
 
     const Callback = *const fn (ctx: ?*anyopaque, path: string, is_file: bool, is_rename: bool) void;
+    const UpdateEndCallback = *const fn (ctx: ?*anyopaque) void;
 
-    pub fn init(loop: *FSEventsLoop, path: string, recursive: bool, callback: Callback, ctx: ?*anyopaque) *FSEventsWatcher {
+    pub fn init(loop: *FSEventsLoop, path: string, recursive: bool, callback: Callback, updateEnd: UpdateEndCallback, ctx: ?*anyopaque) *FSEventsWatcher {
         var this = bun.default_allocator.create(FSEventsWatcher) catch unreachable;
         this.* = FSEventsWatcher{
             .path = path,
             .callback = callback,
+            .flushCallback = updateEnd,
             .loop = loop,
             .recursive = recursive,
             .ctx = ctx,
@@ -590,6 +594,14 @@ pub const FSEventsWatcher = struct {
 
         loop.registerWatcher(this);
         return this;
+    }
+
+    pub fn emit(this: *FSEventsWatcher, path: string, is_file: bool, is_rename: bool) void {
+        this.callback(this.ctx, path, is_file, is_rename);
+    }
+
+    pub fn flush(this: *FSEventsWatcher) void {
+        this.flushCallback(this.ctx);
     }
 
     pub fn deinit(this: *FSEventsWatcher) void {
@@ -600,15 +612,15 @@ pub const FSEventsWatcher = struct {
     }
 };
 
-pub fn watch(path: string, recursive: bool, callback: FSEventsWatcher.Callback, ctx: ?*anyopaque) !*FSEventsWatcher {
+pub fn watch(path: string, recursive: bool, callback: FSEventsWatcher.Callback, updateEnd: FSEventsWatcher.UpdateEndCallback, ctx: ?*anyopaque) !*FSEventsWatcher {
     if (fsevents_default_loop) |loop| {
-        return FSEventsWatcher.init(loop, path, recursive, callback, ctx);
+        return FSEventsWatcher.init(loop, path, recursive, callback, updateEnd, ctx);
     } else {
         fsevents_default_loop_mutex.lock();
         defer fsevents_default_loop_mutex.unlock();
         if (fsevents_default_loop == null) {
             fsevents_default_loop = try FSEventsLoop.init();
         }
-        return FSEventsWatcher.init(fsevents_default_loop.?, path, recursive, callback, ctx);
+        return FSEventsWatcher.init(fsevents_default_loop.?, path, recursive, callback, updateEnd, ctx);
     }
 }

--- a/src/bun.js/node/fs_events.zig
+++ b/src/bun.js/node/fs_events.zig
@@ -414,6 +414,7 @@ pub const FSEventsLoop = struct {
         this.mutex.lock();
         defer this.mutex.unlock();
         this.has_scheduled_watchers = false;
+        const watcher_count = this.watcher_count;
 
         var watchers = this.watchers.slice();
 
@@ -439,7 +440,11 @@ pub const FSEventsLoop = struct {
             CF.Release(cf);
         }
 
-        const paths = bun.default_allocator.alloc(?*anyopaque, this.watcher_count) catch unreachable;
+        if (watcher_count == 0) {
+            return;
+        }
+
+        const paths = bun.default_allocator.alloc(?*anyopaque, watcher_count) catch unreachable;
         var count: u32 = 0;
         for (watchers) |w| {
             if (w) |watcher| {

--- a/src/bun.js/node/fs_events.zig
+++ b/src/bun.js/node/fs_events.zig
@@ -432,7 +432,7 @@ pub const FSEventsLoop = struct {
         // clean old paths
         if (this.paths) |p| {
             this.paths = null;
-            bun.default_allocator.destroy(p);
+            bun.default_allocator.free(p);
         }
         if (this.cf_paths) |cf| {
             this.cf_paths = null;

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -208,6 +208,9 @@ pub const FSWatcher = struct {
 
     pub fn onUpdateEnd(ctx: ?*anyopaque) void {
         const this = bun.cast(*FSWatcher, ctx.?);
+        if (this.verbose) {
+            Output.flush();
+        }
         // we only enqueue after all events are processed
         // this is called by FSEventsWatcher or PathWatcher
         this.current_task.enqueue();

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -879,13 +879,11 @@ pub const FSWatcher = struct {
 
             default_watcher.addFile(fs_type.fd, file_path_clone, FSWatcher.Watcher.getHash(file_path), options.Loader.file, 0, null, false) catch |err| {
                 ctx.deinit();
-                default_watcher.deinit(true);
                 return err;
             };
         } else {
             addDirectory(ctx, default_watcher, fs_type.fd, file_path, args.recursive, &buf, true) catch |err| {
                 ctx.deinit();
-                default_watcher.deinit(true);
                 return err;
             };
         }

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -203,13 +203,13 @@ pub const FSWatcher = struct {
 
         switch (event_type) {
             .rename => {
-                this.current_task.append(relative_path, .rename, .destroy);
+                this.current_task.append(relative_path, .rename, .free);
             },
             .change => {
-                this.current_task.append(relative_path, .change, .destroy);
+                this.current_task.append(relative_path, .change, .free);
             },
             else => {
-                this.current_task.append(relative_path, .@"error", .destroy);
+                this.current_task.append(relative_path, .@"error", .free);
             },
         }
     }

--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -110,9 +110,14 @@ pub const Os = struct {
         // Read /proc/stat to get number of CPUs and times
         if (std.fs.openFileAbsolute("/proc/stat", .{})) |file| {
             defer file.close();
-            var reader = file.reader();
+            // TODO: remove all usages of file.reader(). zig's std.io.Reader()
+            // is extremely slow and should rarely ever be used in Bun until
+            // that is fixed.
+            var buffered_reader = std.io.BufferedReader(8096, @TypeOf(file.reader())){ .unbuffered_reader = file.reader() };
+            var reader = buffered_reader.reader();
 
             // Skip the first line (aggregate of all CPUs)
+            // TODO: use indexOfNewline
             try reader.skipUntilDelimiterOrEof('\n');
 
             // Read each CPU line
@@ -148,18 +153,23 @@ pub const Os = struct {
         // Read /proc/cpuinfo to get model information (optional)
         if (std.fs.openFileAbsolute("/proc/cpuinfo", .{})) |file| {
             defer file.close();
-            var reader = file.reader();
+            // TODO: remove all usages of file.reader(). zig's std.io.Reader()
+            // is extremely slow and should rarely ever be used in Bun until
+            // that is fixed.
+            var buffered_reader = std.io.BufferedReader(8096, @TypeOf(file.reader())){ .unbuffered_reader = file.reader() };
+            var reader = buffered_reader.reader();
+
             const key_processor = "processor\t: ";
             const key_model_name = "model name\t: ";
 
             var cpu_index: u32 = 0;
             while (try reader.readUntilDelimiterOrEof(&line_buffer, '\n')) |line| {
-                if (std.mem.startsWith(u8, line, key_processor)) {
+                if (strings.hasPrefixComptime(line, key_processor)) {
                     // If this line starts a new processor, parse the index from the line
                     const digits = std.mem.trim(u8, line[key_processor.len..], " \t\n");
                     cpu_index = try std.fmt.parseInt(u32, digits, 10);
                     if (cpu_index >= num_cpus) return error.too_may_cpus;
-                } else if (std.mem.startsWith(u8, line, key_model_name)) {
+                } else if (strings.hasPrefixComptime(line, key_model_name)) {
                     // If this is the model name, extract it and store on the current cpu
                     const model_name = line[key_model_name.len..];
                     const cpu = JSC.JSObject.getIndex(values, globalThis, cpu_index);
@@ -176,9 +186,8 @@ pub const Os = struct {
         }
 
         // Read /sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq to get current frequency (optional)
-        var cpu_index: u32 = 0;
-        while (cpu_index < num_cpus) : (cpu_index += 1) {
-            const cpu = JSC.JSObject.getIndex(values, globalThis, cpu_index);
+        for (0..num_cpus) |cpu_index| {
+            const cpu = JSC.JSObject.getIndex(values, globalThis, @truncate(cpu_index));
 
             var path_buf: [128]u8 = undefined;
             const path = try std.fmt.bufPrint(&path_buf, "/sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq", .{cpu_index});

--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -208,6 +208,7 @@ pub const Os = struct {
         return values;
     }
 
+    extern fn bun_sysconf__SC_CLK_TCK() isize;
     fn cpusImplDarwin(globalThis: *JSC.JSGlobalObject) !JSC.JSValue {
         const local_bindings = @import("../../darwin_c.zig");
         const c = std.c;
@@ -252,10 +253,7 @@ pub const Os = struct {
         }
 
         // Get the multiplier; this is the number of ms/tick
-        const unistd = @cImport({
-            @cInclude("unistd.h");
-        });
-        const ticks: i64 = unistd.sysconf(unistd._SC_CLK_TCK);
+        const ticks: i64 = bun_sysconf__SC_CLK_TCK();
         const multiplier = 1000 / @as(u64, @intCast(ticks));
 
         // Set up each CPU value in the return

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -367,7 +367,7 @@ pub const PathWatcherManager = struct {
                     const path_ = path.path;
                     this.main_watcher.remove(path.hash);
                     _ = this.file_paths.remove(path_);
-                    bun.default_allocator.destroy(path_);
+                    bun.default_allocator.free(path_);
                 }
             }
         }

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -171,8 +171,17 @@ pub const PathWatcherManager = struct {
                                 const entry_point = watcher.path.dirname;
                                 var path = file_path;
 
-                                if (path.len < entry_point.len or !bun.strings.startsWith(path, entry_point)) {
+                                if (path.len < entry_point.len) {
                                     continue;
+                                }
+                                if (watcher.path.is_file) {
+                                    if (watcher.path.hash != hash) {
+                                        continue;
+                                    }
+                                } else {
+                                    if (!bun.strings.startsWith(path, entry_point)) {
+                                        continue;
+                                    }
                                 }
                                 // Remove common prefix, unless the watched folder is "/"
                                 if (!(path.len == 1 and entry_point[0] == '/')) {
@@ -201,7 +210,6 @@ pub const PathWatcherManager = struct {
                                 if (path.len == 0 or (bun.strings.containsChar(path, '/') and !watcher.recursive)) {
                                     continue;
                                 }
-
                                 watcher.emit(path, hash, timestamp, true, event_type);
                             }
                         }
@@ -233,7 +241,7 @@ pub const PathWatcherManager = struct {
                                 const entry_point = watcher.path.dirname;
                                 var path = path_slice;
 
-                                if (path.len < entry_point.len or !bun.strings.startsWith(path, entry_point)) {
+                                if (watcher.path.is_file or path.len < entry_point.len or !bun.strings.startsWith(path, entry_point)) {
                                     continue;
                                 }
                                 // Remove common prefix, unless the watched folder is "/"

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -148,7 +148,7 @@ pub const PathWatcherManager = struct {
             const kind = kinds[event.index];
 
             if (comptime Environment.isDebug) {
-                Output.prettyErrorln("[watch] {s} ({s}, {})", .{ file_path, @tagName(kind), event.op });
+                log("[watch] {s} ({s}, {})", .{ file_path, @tagName(kind), event.op });
             }
 
             switch (kind) {

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -1,0 +1,553 @@
+const std = @import("std");
+
+const UnboundedQueue = @import("../unbounded_queue.zig").UnboundedQueue;
+const Path = @import("../../resolver/resolve_path.zig");
+const Fs = @import("../../fs.zig");
+const Mutex = @import("../../lock.zig").Lock;
+
+const bun = @import("root").bun;
+const Output = bun.Output;
+const Environment = bun.Environment;
+const StoredFileDescriptorType = bun.StoredFileDescriptorType;
+const string = bun.string;
+const JSC = bun.JSC;
+const VirtualMachine = JSC.VirtualMachine;
+
+const sync = @import("../../sync.zig");
+const Semaphore = sync.Semaphore;
+
+var default_manager_mutex: Mutex = Mutex.init();
+var default_manager: ?*PathWatcherManager = null;
+
+pub const PathWatcherManager = struct {
+    const GenericWatcher = @import("../../watcher.zig");
+    const options = @import("../../options.zig");
+    pub const Watcher = GenericWatcher.NewWatcher(*PathWatcherManager);
+    const log = Output.scoped(.PathWatcherManager, false);
+    main_watcher: *Watcher,
+
+    watchers: bun.BabyList(?*PathWatcher) = .{},
+    watcher_count: u32 = 0,
+    vm: *JSC.VirtualMachine,
+    file_paths: bun.StringHashMap(PathInfo),
+    deinit_on_last_watcher: bool = false,
+    mutex: Mutex,
+
+    const PathInfo = struct {
+        fd: StoredFileDescriptorType = 0,
+        is_file: bool = true,
+        path: [:0]const u8,
+        dirname: string,
+        refs: u32 = 0,
+        hash: Watcher.HashType,
+    };
+
+    fn _fdFromAbsolutePathZ(
+        this: *PathWatcherManager,
+        path: [:0]const u8,
+    ) !PathInfo {
+        if (this.file_paths.getEntry(path)) |entry| {
+            var info = entry.value_ptr;
+            info.refs += 1;
+            return info.*;
+        }
+        const cloned_path = try bun.default_allocator.dupeZ(u8, path);
+        errdefer bun.default_allocator.destroy(cloned_path);
+
+        var stat = try bun.C.lstat_absolute(cloned_path);
+        var result = PathInfo{
+            .path = cloned_path,
+            .dirname = cloned_path,
+            .hash = Watcher.getHash(cloned_path),
+            .refs = 1,
+        };
+
+        switch (stat.kind) {
+            .sym_link => {
+                var file = try std.fs.openFileAbsoluteZ(cloned_path, .{ .mode = .read_only });
+                result.fd = file.handle;
+                const _stat = try file.stat();
+
+                result.is_file = _stat.kind != .directory;
+                if (result.is_file) {
+                    result.dirname = std.fs.path.dirname(cloned_path) orelse cloned_path;
+                }
+            },
+            .directory => {
+                const dir = (try std.fs.openIterableDirAbsoluteZ(cloned_path, .{
+                    .access_sub_paths = true,
+                })).dir;
+                result.fd = dir.fd;
+                result.is_file = false;
+            },
+            else => {
+                const file = try std.fs.openFileAbsoluteZ(cloned_path, .{ .mode = .read_only });
+                result.fd = file.handle;
+                result.is_file = true;
+                result.dirname = std.fs.path.dirname(cloned_path) orelse cloned_path;
+            },
+        }
+
+        _ = try this.file_paths.put(cloned_path, result);
+        return result;
+    }
+
+    pub fn init(vm: *JSC.VirtualMachine) !*PathWatcherManager {
+        const this = try bun.default_allocator.create(PathWatcherManager);
+        errdefer bun.default_allocator.destroy(this);
+        var watchers = bun.BabyList(?*PathWatcher).initCapacity(bun.default_allocator, 1) catch |err| {
+            bun.default_allocator.destroy(this);
+            return err;
+        };
+        errdefer watchers.deinitWithAllocator(bun.default_allocator);
+        var manager = PathWatcherManager{
+            .file_paths = bun.StringHashMap(PathInfo).init(bun.default_allocator),
+            .watchers = watchers,
+            .main_watcher = try Watcher.init(
+                this,
+                vm.bundler.fs,
+                bun.default_allocator,
+            ),
+            .vm = vm,
+            .watcher_count = 0,
+            .mutex = Mutex.init(),
+        };
+
+        this.* = manager;
+        try this.main_watcher.start();
+        return this;
+    }
+
+    pub fn onFileUpdate(
+        this: *PathWatcherManager,
+        events: []GenericWatcher.WatchEvent,
+        changed_files: []?[:0]u8,
+        watchlist: GenericWatcher.Watchlist,
+    ) void {
+        var slice = watchlist.slice();
+        const file_paths = slice.items(.file_path);
+
+        var counts = slice.items(.count);
+        const kinds = slice.items(.kind);
+        var _on_file_update_path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+
+        var ctx = this.main_watcher;
+        defer ctx.flushEvictions();
+
+        const timestamp = std.time.milliTimestamp();
+
+        this.mutex.lock();
+        defer this.mutex.unlock();
+
+        const watchers = this.watchers.slice();
+
+        for (events) |event| {
+            const file_path = file_paths[event.index];
+            const update_count = counts[event.index] + 1;
+            counts[event.index] = update_count;
+            const kind = kinds[event.index];
+
+            switch (kind) {
+                .file => {
+                    if (event.op.delete) {
+                        ctx.removeAtIndex(
+                            event.index,
+                            0,
+                            &.{},
+                            .file,
+                        );
+                    }
+
+                    if (event.op.write or event.op.delete or event.op.rename) {
+                        const event_type: PathWatcher.EventType = if (event.op.delete or event.op.rename or event.op.move_to) .rename else .change;
+                        const is_file = true;
+                        const hash = Watcher.getHash(file_path);
+
+                        for (watchers) |w| {
+                            if (w) |watcher| {
+                                const entry_point = watcher.path.dirname;
+                                var path = file_path;
+
+                                if (path.len < entry_point.len or !bun.strings.startsWith(path, entry_point)) {
+                                    continue;
+                                }
+                                // Remove common prefix, unless the watched folder is "/"
+                                if (!(path.len == 1 and entry_point[0] == '/')) {
+                                    path = path[entry_point.len..];
+
+                                    // Ignore events with path equal to directory itself
+                                    if (path.len <= 1 and is_file) {
+                                        continue;
+                                    }
+                                    if (path.len == 0) {
+                                        while (path.len > 0) {
+                                            if (bun.strings.startsWithChar(path, '/')) {
+                                                path = path[1..];
+                                                break;
+                                            } else {
+                                                path = path[1..];
+                                            }
+                                        }
+                                    } else {
+                                        // Skip forward slash
+                                        path = path[1..];
+                                    }
+                                }
+
+                                // Do not emit events from subdirectories (without option set)
+                                if (path.len == 0 or (bun.strings.containsChar(path, '/') and !watcher.recursive)) {
+                                    continue;
+                                }
+
+                                watcher.emit(path, hash, timestamp, event_type);
+                            }
+                        }
+                    }
+                },
+                .directory => {
+                    const affected = event.names(changed_files);
+
+                    for (affected) |changed_name_| {
+                        const changed_name: []const u8 = bun.asByteSlice(changed_name_.?);
+                        if (changed_name.len == 0 or changed_name[0] == '~' or changed_name[0] == '.') continue;
+
+                        var file_path_without_trailing_slash = std.mem.trimRight(u8, file_path, std.fs.path.sep_str);
+
+                        @memcpy(_on_file_update_path_buf[0..file_path_without_trailing_slash.len], file_path_without_trailing_slash);
+
+                        _on_file_update_path_buf[file_path_without_trailing_slash.len] = std.fs.path.sep;
+
+                        @memcpy(_on_file_update_path_buf[file_path_without_trailing_slash.len + 1 ..][0..changed_name.len], changed_name);
+                        const len = file_path_without_trailing_slash.len + changed_name.len;
+                        const path_slice = _on_file_update_path_buf[0 .. len + 1];
+
+                        const hash = Watcher.getHash(path_slice);
+
+                        // skip consecutive duplicates
+                        const event_type: PathWatcher.EventType = .rename; // renaming folders, creating folder or files will be always be rename
+                        for (watchers) |w| {
+                            if (w) |watcher| {
+                                const entry_point = watcher.path.dirname;
+                                var path = path_slice;
+                                const is_file = false;
+
+                                if (path.len < entry_point.len or !bun.strings.startsWith(path, entry_point)) {
+                                    continue;
+                                }
+                                // Remove common prefix, unless the watched folder is "/"
+                                if (!(path.len == 1 and entry_point[0] == '/')) {
+                                    path = path[entry_point.len..];
+
+                                    // Ignore events with path equal to directory itself
+                                    if (path.len <= 1 and is_file) {
+                                        continue;
+                                    }
+                                    if (path.len == 0) {
+                                        while (path.len > 0) {
+                                            if (bun.strings.startsWithChar(path, '/')) {
+                                                path = path[1..];
+                                                break;
+                                            } else {
+                                                path = path[1..];
+                                            }
+                                        }
+                                    } else {
+                                        // Skip forward slash
+                                        path = path[1..];
+                                    }
+                                }
+
+                                // Do not emit events from subdirectories (without option set)
+                                if (path.len == 0 or (bun.strings.containsChar(path, '/') and !watcher.recursive)) {
+                                    continue;
+                                }
+
+                                watcher.emit(path, hash, timestamp, event_type);
+                            }
+                        }
+                    }
+                },
+            }
+        }
+
+        for (watchers) |w| {
+            if (w) |watcher| {
+                if (watcher.needs_flush) watcher.flush();
+            }
+        }
+    }
+
+    pub fn onError(
+        this: *PathWatcherManager,
+        err: anyerror,
+    ) void {
+        this.mutex.lock();
+        const watchers = this.watchers.slice();
+        const timestamp = std.time.milliTimestamp();
+
+        // stop all watchers
+        for (watchers) |w| {
+            if (w) |watcher| {
+                watcher.emit(@errorName(err), 0, timestamp, .@"error");
+                watcher.flush();
+            }
+        }
+
+        // we need a new manager at this point
+        default_manager_mutex.lock();
+        defer default_manager_mutex.unlock();
+        default_manager = null;
+
+        default_manager_mutex.unlock();
+
+        // deinit manager when all watchers are closed
+        this.mutex.unlock();
+        this.deinit();
+    }
+
+    fn addDirectory(this: *PathWatcherManager, watcher: *PathWatcher, path: PathInfo, buf: *[bun.MAX_PATH_BYTES + 1]u8) !void {
+        const fd = path.fd;
+        try this.main_watcher.addDirectory(fd, path.path, path.hash, false);
+
+        var iter = (std.fs.IterableDir{ .dir = std.fs.Dir{
+            .fd = fd,
+        } }).iterate();
+
+        while (try iter.next()) |entry| {
+            var parts = [2]string{ path.path, entry.name };
+            var entry_path = Path.joinAbsStringBuf(
+                Fs.FileSystem.instance.topLevelDirWithoutTrailingSlash(),
+                buf,
+                &parts,
+                .auto,
+            );
+
+            buf[entry_path.len] = 0;
+            var entry_path_z = buf[0..entry_path.len :0];
+
+            var child_path = try this._fdFromAbsolutePathZ(entry_path_z);
+            errdefer this._decrementPathRef(entry_path_z);
+            try watcher.file_paths.push(bun.default_allocator, child_path.path);
+
+            if (child_path.is_file) {
+                try this.main_watcher.addFile(child_path.fd, child_path.path, child_path.hash, options.Loader.file, 0, null, false);
+            } else {
+                if (watcher.recursive) {
+                    try this.addDirectory(watcher, child_path, buf);
+                }
+            }
+        }
+    }
+
+    fn registerWatcher(this: *PathWatcherManager, watcher: *PathWatcher) !void {
+        this.mutex.lock();
+        defer this.mutex.unlock();
+
+        if (this.watcher_count == this.watchers.len) {
+            this.watcher_count += 1;
+            this.watchers.push(bun.default_allocator, watcher) catch unreachable;
+        } else {
+            var watchers = this.watchers.slice();
+            for (watchers, 0..) |w, i| {
+                if (w == null) {
+                    watchers[i] = watcher;
+                    this.watcher_count += 1;
+                    break;
+                }
+            }
+        }
+        const path = watcher.path;
+        if (path.is_file) {
+            try this.main_watcher.addFile(path.fd, path.path, path.hash, options.Loader.file, 0, null, false);
+        } else {
+            var buf: [bun.MAX_PATH_BYTES + 1]u8 = undefined;
+            try this.addDirectory(watcher, path, &buf);
+        }
+    }
+
+    fn _decrementPathRef(this: *PathWatcherManager, file_path: [:0]const u8) void {
+        if (this.file_paths.getEntry(file_path)) |entry| {
+            var path = entry.value_ptr;
+            if (path.refs > 0) {
+                path.refs -= 1;
+                if (path.refs == 0) {
+                    this.main_watcher.remove(path.hash);
+                    bun.default_allocator.destroy(path.path);
+                    _ = this.file_paths.remove(path.path);
+                }
+            }
+        }
+    }
+
+    fn unregisterWatcher(this: *PathWatcherManager, watcher: *PathWatcher) void {
+        this.mutex.lock();
+        defer this.mutex.unlock();
+
+        var watchers = this.watchers.slice();
+        defer {
+            if (this.deinit_on_last_watcher and this.watcher_count == 0) {
+                this.deinit();
+            }
+        }
+
+        for (watchers, 0..) |w, i| {
+            if (w) |item| {
+                if (item == watcher) {
+                    watchers[i] = null;
+                    // if is the last one just pop
+                    if (i == watchers.len - 1) {
+                        this.watchers.len -= 1;
+                    }
+                    this.watcher_count -= 1;
+
+                    while (watcher.file_paths.popOrNull()) |file_path| {
+                        this._decrementPathRef(file_path);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    fn deinit(this: *PathWatcherManager) void {
+        // enable to create a new manager
+        default_manager_mutex.lock();
+        defer default_manager_mutex.unlock();
+        if (default_manager == this) {
+            default_manager = null;
+        }
+        default_manager_mutex.unlock();
+
+        // only deinit if no watchers are registered
+        if (this.watcher_count > 0) {
+            // wait last watcher to close
+            this.deinit_on_last_watcher = true;
+            return;
+        }
+
+        this.main_watcher.deinit(false);
+
+        if (this.watcher_count > 0) {
+            while (this.watchers.popOrNull()) |watcher| {
+                if (watcher) |w| {
+                    // unlink watcher
+                    w.manager = null;
+                }
+            }
+        }
+
+        // close all file descriptors and free paths
+        var it = this.file_paths.iterator();
+        while (it.next()) |*entry| {
+            const path = entry.value_ptr.*;
+            std.os.close(path.fd);
+            bun.default_allocator.destroy(path.path);
+        }
+
+        this.file_paths.deinit();
+
+        this.watchers.deinitWithAllocator(bun.default_allocator);
+        // this.mutex.deinit();
+
+        bun.default_allocator.destroy(this);
+    }
+};
+
+pub const PathWatcher = struct {
+    path: PathWatcherManager.PathInfo,
+    callback: Callback,
+    flushCallback: UpdateEndCallback,
+    manager: ?*PathWatcherManager,
+    recursive: bool,
+    needs_flush: bool = false,
+    ctx: ?*anyopaque,
+    // all watched file paths (including subpaths) except by path it self
+    file_paths: bun.BabyList([:0]const u8) = .{},
+    last_change_event: ChangeEvent = .{},
+
+    pub const ChangeEvent = struct {
+        hash: PathWatcherManager.Watcher.HashType = 0,
+        event_type: EventType = .change,
+        time_stamp: i64 = 0,
+    };
+
+    pub const EventType = enum {
+        rename,
+        change,
+        @"error",
+    };
+    const Callback = *const fn (ctx: ?*anyopaque, path: string, event_type: EventType) void;
+    const UpdateEndCallback = *const fn (ctx: ?*anyopaque) void;
+
+    pub fn init(manager: *PathWatcherManager, path: PathWatcherManager.PathInfo, recursive: bool, callback: Callback, updateEndCallback: UpdateEndCallback, ctx: ?*anyopaque) !*PathWatcher {
+        var this = try bun.default_allocator.create(PathWatcher);
+        this.* = PathWatcher{
+            .path = path,
+            .callback = callback,
+            .manager = manager,
+            .recursive = recursive,
+            .flushCallback = updateEndCallback,
+            .ctx = ctx,
+            .file_paths = bun.BabyList([:0]const u8).initCapacity(bun.default_allocator, 1) catch |err| {
+                bun.default_allocator.destroy(this);
+                return err;
+            },
+        };
+
+        errdefer this.deinit();
+
+        try manager.registerWatcher(this);
+        return this;
+    }
+
+    pub fn emit(this: *PathWatcher, path: string, hash: PathWatcherManager.Watcher.HashType, time_stamp: i64, event_type: EventType) void {
+        const time_diff = time_stamp - this.last_change_event.time_stamp;
+        // skip consecutive duplicates
+        if ((this.last_change_event.time_stamp == 0 or time_diff > 1) or this.last_change_event.event_type != event_type and this.last_change_event.hash != hash) {
+            this.last_change_event.time_stamp = time_stamp;
+            this.last_change_event.event_type = event_type;
+            this.last_change_event.hash = hash;
+            this.needs_flush = true;
+            this.callback(this.ctx, path, event_type);
+        }
+    }
+
+    pub fn flush(this: *PathWatcher) void {
+        this.needs_flush = false;
+        this.flushCallback(this.ctx);
+    }
+
+    pub fn deinit(this: *PathWatcher) void {
+        if (this.manager) |manager| {
+            manager.unregisterWatcher(this);
+        }
+        this.file_paths.deinitWithAllocator(bun.default_allocator);
+
+        bun.default_allocator.destroy(this);
+    }
+};
+
+pub fn watch(
+    vm: *VirtualMachine,
+    path: [:0]const u8,
+    recursive: bool,
+    callback: PathWatcher.Callback,
+    updateEnd: PathWatcher.UpdateEndCallback,
+    ctx: ?*anyopaque,
+) !*PathWatcher {
+    if (default_manager) |manager| {
+        const path_info = try manager._fdFromAbsolutePathZ(path);
+        errdefer manager._decrementPathRef(path);
+        return try PathWatcher.init(manager, path_info, recursive, callback, updateEnd, ctx);
+    } else {
+        default_manager_mutex.lock();
+        defer default_manager_mutex.unlock();
+        if (default_manager == null) {
+            default_manager = try PathWatcherManager.init(vm);
+        }
+        const manager = default_manager.?;
+        const path_info = try manager._fdFromAbsolutePathZ(path);
+        errdefer manager._decrementPathRef(path);
+        return try PathWatcher.init(manager, path_info, recursive, callback, updateEnd, ctx);
+    }
+}

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -147,6 +147,10 @@ pub const PathWatcherManager = struct {
             counts[event.index] = update_count;
             const kind = kinds[event.index];
 
+            if (comptime Environment.isDebug) {
+                Output.prettyErrorln("[watch] {s} ({s}, {})", .{ file_path, @tagName(kind), event.op });
+            }
+
             switch (kind) {
                 .file => {
                     if (event.op.delete) {
@@ -160,7 +164,6 @@ pub const PathWatcherManager = struct {
 
                     if (event.op.write or event.op.delete or event.op.rename) {
                         const event_type: PathWatcher.EventType = if (event.op.delete or event.op.rename or event.op.move_to) .rename else .change;
-
                         const hash = Watcher.getHash(file_path);
 
                         for (watchers) |w| {
@@ -265,6 +268,9 @@ pub const PathWatcherManager = struct {
             }
         }
 
+        if (comptime Environment.isDebug) {
+            Output.flush();
+        }
         for (watchers) |w| {
             if (w) |watcher| {
                 if (watcher.needs_flush) watcher.flush();

--- a/src/js/node/os.js
+++ b/src/js/node/os.js
@@ -14,11 +14,72 @@ export var tmpdir = function () {
   return tmpdir();
 };
 
-var cachedCpus;
+// os.cpus() is super expensive
+// Specifically: getting the CPU speed on Linux is very expensive
+// Some packages like FastGlob only bother to read the length of the array
+// so instead of actually populating the entire object
+// we turn them into getters
+function lazyCpus({ cpus }) {
+  return () => {
+    const array = new Array(navigator.hardwareConcurrency);
+    function populate() {
+      const results = cpus();
+      const length = results.length;
+      array.length = length;
+      for (let i = 0; i < length; i++) {
+        array[i] = results[i];
+      }
+    }
+
+    for (let i = 0; i < array.length; i++) {
+      // This is technically still observable via
+      // Object.getOwnPropertyDescriptors(), but it should be okay.
+      const instance = {
+        get model() {
+          if (array[i] === instance) populate();
+          return array[i].model;
+        },
+        set model(value) {
+          if (array[i] === instance) populate();
+          array[i].model = value;
+        },
+
+        get speed() {
+          if (array[i] === instance) populate();
+          return array[i].speed;
+        },
+
+        set speed(value) {
+          if (array[i] === instance) populate();
+          array[i].speed = value;
+        },
+
+        get times() {
+          if (array[i] === instance) populate();
+          return array[i].times;
+        },
+        set times(value) {
+          if (array[i] === instance) populate();
+          array[i].times = value;
+        },
+
+        toJSON() {
+          if (array[i] === instance) populate();
+          return array[i];
+        },
+      };
+
+      array[i] = instance;
+    }
+
+    return array;
+  };
+}
+
 function bound(obj) {
   return {
     arch: obj.arch.bind(obj),
-    cpus: () => (cachedCpus ??= obj.cpus()),
+    cpus: lazyCpus(obj),
     endianness: obj.endianness.bind(obj),
     freemem: obj.freemem.bind(obj),
     getPriority: obj.getPriority.bind(obj),

--- a/src/js/node/os.js
+++ b/src/js/node/os.js
@@ -14,10 +14,11 @@ export var tmpdir = function () {
   return tmpdir();
 };
 
+var cachedCpus;
 function bound(obj) {
   return {
     arch: obj.arch.bind(obj),
-    cpus: obj.cpus.bind(obj),
+    cpus: () => (cachedCpus ??= obj.cpus()),
     endianness: obj.endianness.bind(obj),
     freemem: obj.freemem.bind(obj),
     getPriority: obj.getPriority.bind(obj),

--- a/src/js/out/modules/node/os.js
+++ b/src/js/out/modules/node/os.js
@@ -1,7 +1,7 @@
 var bound = function(obj) {
   return {
     arch: obj.arch.bind(obj),
-    cpus: obj.cpus.bind(obj),
+    cpus: () => cachedCpus ??= obj.cpus(),
     endianness: obj.endianness.bind(obj),
     freemem: obj.freemem.bind(obj),
     getPriority: obj.getPriority.bind(obj),
@@ -35,7 +35,7 @@ var bound = function(obj) {
       path = path.slice(0, -1);
     return path;
   }, tmpdir();
-}, os = bound(Bun._Os()), {
+}, cachedCpus, os = bound(Bun._Os()), {
   arch,
   cpus,
   endianness,

--- a/src/js/out/modules/node/os.js
+++ b/src/js/out/modules/node/os.js
@@ -1,7 +1,58 @@
-var bound = function(obj) {
+var lazyCpus = function({ cpus }) {
+  return () => {
+    const array = new Array(navigator.hardwareConcurrency);
+    function populate() {
+      const results = cpus(), length = results.length;
+      array.length = length;
+      for (let i = 0;i < length; i++)
+        array[i] = results[i];
+    }
+    for (let i = 0;i < array.length; i++) {
+      const instance = {
+        get model() {
+          if (array[i] === instance)
+            populate();
+          return array[i].model;
+        },
+        set model(value) {
+          if (array[i] === instance)
+            populate();
+          array[i].model = value;
+        },
+        get speed() {
+          if (array[i] === instance)
+            populate();
+          return array[i].speed;
+        },
+        set speed(value) {
+          if (array[i] === instance)
+            populate();
+          array[i].speed = value;
+        },
+        get times() {
+          if (array[i] === instance)
+            populate();
+          return array[i].times;
+        },
+        set times(value) {
+          if (array[i] === instance)
+            populate();
+          array[i].times = value;
+        },
+        toJSON() {
+          if (array[i] === instance)
+            populate();
+          return array[i];
+        }
+      };
+      array[i] = instance;
+    }
+    return array;
+  };
+}, bound = function(obj) {
   return {
     arch: obj.arch.bind(obj),
-    cpus: () => cachedCpus ??= obj.cpus(),
+    cpus: lazyCpus(obj),
     endianness: obj.endianness.bind(obj),
     freemem: obj.freemem.bind(obj),
     getPriority: obj.getPriority.bind(obj),
@@ -35,7 +86,7 @@ var bound = function(obj) {
       path = path.slice(0, -1);
     return path;
   }, tmpdir();
-}, cachedCpus, os = bound(Bun._Os()), {
+}, os = bound(Bun._Os()), {
   arch,
   cpus,
   endianness,

--- a/src/lock.zig
+++ b/src/lock.zig
@@ -116,6 +116,12 @@ pub const Lock = struct {
     pub inline fn unlock(this: *Lock) void {
         this.mutex.release();
     }
+
+    pub inline fn assertUnlocked(this: *Lock, comptime message: []const u8) void {
+        if (this.mutex.state.load(.Monotonic) != 0) {
+            @panic(message);
+        }
+    }
 };
 
 pub fn spinCycle() void {}

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -672,15 +672,7 @@ pub fn startsWith(self: string, str: string) bool {
         return false;
     }
 
-    var i: usize = 0;
-    while (i < str.len) {
-        if (str[i] != self[i]) {
-            return false;
-        }
-        i += 1;
-    }
-
-    return true;
+    return eqlLong(self[0..str.len], str, false);
 }
 
 pub inline fn endsWith(self: string, str: string) bool {

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -382,6 +382,8 @@ pub fn NewWatcher(comptime ContextType: type) type {
 
         pub fn init(ctx: ContextType, fs: *Fs.FileSystem, allocator: std.mem.Allocator) !*Watcher {
             var watcher = try allocator.create(Watcher);
+            errdefer allocator.destroy(watcher);
+
             if (!PlatformWatcher.isRunning()) {
                 try PlatformWatcher.init();
             }

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -458,7 +458,19 @@ pub fn NewWatcher(comptime ContextType: type) type {
             allocator.destroy(this);
         }
 
+        pub fn remove(this: *Watcher, hash: HashType) void {
+            this.mutex.lock();
+            defer this.mutex.unlock();
+            if (this.indexOf(hash)) |index| {
+                const fds = this.watchlist.items(.fd);
+                const fd = fds[index];
+                std.os.close(fd);
+                this.watchlist.swapRemove(index);
+            }
+        }
+
         var evict_list_i: WatchItemIndex = 0;
+
         pub fn removeAtIndex(_: *Watcher, index: WatchItemIndex, hash: HashType, parents: []HashType, comptime kind: WatchItem.Kind) void {
             std.debug.assert(index != NoWatchItem);
 

--- a/test/js/node/watch/fixtures/relative.js
+++ b/test/js/node/watch/fixtures/relative.js
@@ -1,23 +1,28 @@
 import fs from "fs";
-const watcher = fs.watch("relative.txt", { signal: AbortSignal.timeout(2000) });
+try {
+  const watcher = fs.watch("relative.txt", { signal: AbortSignal.timeout(2000) });
 
-watcher.on("change", function (event, filename) {
-  if (filename !== "relative.txt" && event !== "change") {
-    console.error("fail");
+  watcher.on("change", function (event, filename) {
+    if (filename !== "relative.txt" && event !== "change") {
+      console.error("fail");
+      clearInterval(interval);
+      watcher.close();
+      process.exit(1);
+    } else {
+      clearInterval(interval);
+      watcher.close();
+    }
+  });
+  watcher.on("error", err => {
     clearInterval(interval);
-    watcher.close();
+    console.error(err.message);
     process.exit(1);
-  } else {
-    clearInterval(interval);
-    watcher.close();
-  }
-});
-watcher.on("error", err => {
-  clearInterval(interval);
+  });
+
+  const interval = setInterval(() => {
+    fs.writeFileSync("relative.txt", "world");
+  }, 10);
+} catch (err) {
   console.error(err.message);
   process.exit(1);
-});
-
-const interval = setInterval(() => {
-  fs.writeFileSync("relative.txt", "world");
-}, 10);
+}

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -189,7 +189,7 @@ describe("fs.watch", () => {
     const interval = repeat(() => {
       fs.writeFileSync(filepath, "world");
     });
-  });
+  }, 10000);
 
   test("should error on invalid path", done => {
     try {
@@ -248,7 +248,7 @@ describe("fs.watch", () => {
       clearInterval(interval);
       watchers.forEach(watcher => watcher.close());
     }
-  });
+  }, 10000);
 
   test("should work with url", done => {
     const filepath = path.join(testDir, "url.txt");
@@ -344,11 +344,6 @@ describe("fs.watch", () => {
     });
   });
 
-  test("immediately closing works correctly", async () => {
-    for (let i = 0; i < 100; i++) fs.watch(testDir, { persistent: true }).close();
-    for (let i = 0; i < 100; i++) fs.watch(testDir, { persistent: false }).close();
-  });
-
   test("should work with symlink", async () => {
     const filepath = path.join(testDir, "sym-symlink2.txt");
     await fs.promises.symlink(path.join(testDir, "sym-sync.txt"), filepath);
@@ -377,6 +372,12 @@ describe("fs.watch", () => {
       }, 3000);
     });
     expect(promise).resolves.toBe("change");
+  });
+
+
+  test("immediately closing works correctly", async () => {
+    for (let i = 0; i < 100; i++) fs.watch(testDir, { persistent: true }).close();
+    for (let i = 0; i < 100; i++) fs.watch(testDir, { persistent: false }).close();
   });
 });
 

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -374,7 +374,6 @@ describe("fs.watch", () => {
     expect(promise).resolves.toBe("change");
   });
 
-
   test("immediately closing works correctly", async () => {
     for (let i = 0; i < 100; i++) fs.watch(testDir, { persistent: true }).close();
     for (let i = 0; i < 100; i++) fs.watch(testDir, { persistent: false }).close();

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -344,6 +344,11 @@ describe("fs.watch", () => {
     });
   });
 
+  test("immediately closing works correctly", async () => {
+    for (let i = 0; i < 100; i++) fs.watch(testDir, { persistent: true }).close();
+    for (let i = 0; i < 100; i++) fs.watch(testDir, { persistent: false }).close();
+  });
+
   test("should work with symlink", async () => {
     const filepath = path.join(testDir, "sym-symlink2.txt");
     await fs.promises.symlink(path.join(testDir, "sym-sync.txt"), filepath);


### PR DESCRIPTION
- Buffer the file instead of calling read() one byte at a time...
- Use faster method for equality checks
- Cache the result since your CPUs will not change without restarting your computer