### PR TITLE
fix the chunk boundary (`node:stream:createReadStream`)

### DIFF
--- a/src/js/node/fs.js
+++ b/src/js/node/fs.js
@@ -540,14 +540,14 @@ ReadStream = (function (InternalReadStream) {
             chunk = chunk.slice(-n);
             var [_, ...rest] = arguments;
             this.pos = this.bytesRead;
-            if (this.end && this.bytesRead >= this.end) {
+            if (this.end !== undefined && this.bytesRead > this.end) {
               chunk = chunk.slice(0, this.end - this.start + 1);
             }
             return super.push(chunk, ...rest);
           }
           var end = this.end;
           // This is multi-chunk read case where we go passed the end of the what we want to read in the last chunk
-          if (end && this.bytesRead >= end) {
+          if (end !== undefined && this.bytesRead > end) {
             chunk = chunk.slice(0, end - currPos + 1);
             var [_, ...rest] = arguments;
             this.pos = this.bytesRead;

--- a/src/js/node/fs.js
+++ b/src/js/node/fs.js
@@ -541,14 +541,14 @@ ReadStream = (function (InternalReadStream) {
             var [_, ...rest] = arguments;
             this.pos = this.bytesRead;
             if (this.end && this.bytesRead >= this.end) {
-              chunk = chunk.slice(0, this.end - this.start);
+              chunk = chunk.slice(0, this.end - this.start + 1);
             }
             return super.push(chunk, ...rest);
           }
           var end = this.end;
           // This is multi-chunk read case where we go passed the end of the what we want to read in the last chunk
           if (end && this.bytesRead >= end) {
-            chunk = chunk.slice(0, end - currPos);
+            chunk = chunk.slice(0, end - currPos + 1);
             var [_, ...rest] = arguments;
             this.pos = this.bytesRead;
             return super.push(chunk, ...rest);

--- a/src/js/out/modules/node/fs.js
+++ b/src/js/out/modules/node/fs.js
@@ -310,12 +310,12 @@ ReadStream = function(InternalReadStream) {
           var n = this.bytesRead - currPos;
           chunk = chunk.slice(-n);
           var [_, ...rest] = arguments;
-          if (this.pos = this.bytesRead, this.end && this.bytesRead >= this.end)
+          if (this.pos = this.bytesRead, this.end !== void 0 && this.bytesRead > this.end)
             chunk = chunk.slice(0, this.end - this.start + 1);
           return super.push(chunk, ...rest);
         }
         var end = this.end;
-        if (end && this.bytesRead >= end) {
+        if (end !== void 0 && this.bytesRead > end) {
           chunk = chunk.slice(0, end - currPos + 1);
           var [_, ...rest] = arguments;
           return this.pos = this.bytesRead, super.push(chunk, ...rest);

--- a/src/js/out/modules/node/fs.js
+++ b/src/js/out/modules/node/fs.js
@@ -311,12 +311,12 @@ ReadStream = function(InternalReadStream) {
           chunk = chunk.slice(-n);
           var [_, ...rest] = arguments;
           if (this.pos = this.bytesRead, this.end && this.bytesRead >= this.end)
-            chunk = chunk.slice(0, this.end - this.start);
+            chunk = chunk.slice(0, this.end - this.start + 1);
           return super.push(chunk, ...rest);
         }
         var end = this.end;
         if (end && this.bytesRead >= end) {
-          chunk = chunk.slice(0, end - currPos);
+          chunk = chunk.slice(0, end - currPos + 1);
           var [_, ...rest] = arguments;
           return this.pos = this.bytesRead, super.push(chunk, ...rest);
         }

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -65,6 +65,61 @@ describe("Readable", () => {
 
     stream.pipe(writable);
   });
+  it("should be able to be piped via .pipe, both start and end are 0", done => {
+    const path = `${tmpdir()}/${Date.now()}.testReadStream2.txt`;
+    writeFileSync(path, "12345");
+    const stream = createReadStream(path, { start: 0, end: 0 });
+
+    const writable = new Writable({
+      write(chunk, encoding, callback) {
+        try {
+          // Both start and end are inclusive and start counting at 0.
+          expect(chunk.toString()).toBe("1");
+        } catch (err) {
+          done(err);
+          return;
+        }
+        callback();
+        done();
+      },
+    });
+
+    stream.on("error", err => {
+      done(err);
+    });
+
+    stream.pipe(writable);
+  });
+  it("should be able to be piped via .pipe with a large file", done => {
+    const length = 128 * 1024;
+    const data = "B".repeat(length);
+    const path = `${tmpdir()}/${Date.now()}.testReadStreamLargeFile.txt`;
+    writeFileSync(path, data);
+    const stream = createReadStream(path, { start: 0, end: length - 1 });
+
+    let res = "";
+    let count = 0;
+    const writable = new Writable({
+      write(chunk, encoding, callback) {
+        count += 1;
+        res += chunk;
+        callback();
+      },
+    });
+    writable.on("finish", () => {
+      try {
+        expect(res).toEqual(data);
+        expect(count).toBeGreaterThan(1);
+      } catch (err) {
+        return done(err);
+      }
+      done();
+    });
+    stream.on("error", err => {
+      done(err);
+    });
+    stream.pipe(writable);
+  });
 });
 
 describe("Duplex", () => {

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -1,5 +1,8 @@
 import { expect, describe, it } from "bun:test";
 import { Readable, Writable, Duplex, Transform, PassThrough } from "node:stream";
+import { createReadStream } from "node:fs";
+import { tmpdir } from "node:os";
+import { writeFileSync } from "node:fs";
 
 describe("Readable", () => {
   it("should be able to be created without _construct method defined", done => {
@@ -37,6 +40,30 @@ describe("Readable", () => {
     });
 
     readable.pipe(writable);
+  });
+  it("should be able to be piped via .pipe, issue #3668", done => {
+    const path = `${tmpdir()}/${Date.now()}.testReadStream.txt`;
+    writeFileSync(path, "12345");
+    const stream = createReadStream(path, { start: 0, end: 4 });
+
+    const writable = new Writable({
+      write(chunk, encoding, callback) {
+        try {
+          expect(chunk.toString()).toBe("12345");
+        } catch (err) {
+          done(err);
+          return;
+        }
+        callback();
+        done();
+      },
+    });
+
+    stream.on("error", err => {
+      done(err);
+    });
+
+    stream.pipe(writable);
   });
 });
 


### PR DESCRIPTION
Close: #3668

## What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Test Code:

```JavaScript

const fs = require("node:fs");
const s = require("node:stream");

const path = "./test.txt";
fs.writeFileSync(path, "12345");

const stream = fs.createReadStream(path, { start: 0, end: 4 });

const writable = new s.Writable({
  write(chunk, encoding, callback) {
    console.log(chunk);
  },
});

stream.pipe(writable);

```

![2023-07-28_13-03](https://github.com/oven-sh/bun/assets/9482395/beac1f3c-c3c2-4419-b9a3-60e9c5872e1e)



### Checklist

<!-- **Please delete the sections which are not relevant. If there were no code changes, feel free to delete or ignore this section entirely** -->

If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [x] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [x] I included a test for the new code, or an existing test covers it

If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters

If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions

If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code

If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
