### PR TITLE
Fix bug with // @bun annotation in main thread

### DIFF
--- a/test/js/node/child_process/child_process-node.test.js
+++ b/test/js/node/child_process/child_process-node.test.js
@@ -377,7 +377,7 @@ describe("child_process default options", () => {
 });
 
 describe("child_process double pipe", () => {
-  it.todo("should allow two pipes to be used at once", done => {
+  it("should allow two pipes to be used at once", done => {
     // const { mustCallAtLeast, mustCall } = createCallCheckCtx(done);
     const mustCallAtLeast = fn => fn;
     const mustCall = fn => fn;

--- a/test/transpiler/async-transpiler-entry.js
+++ b/test/transpiler/async-transpiler-entry.js
@@ -1,0 +1,1 @@
+export { default } from "./async-transpiler-imported.js";

--- a/test/transpiler/async-transpiler-imported.js
+++ b/test/transpiler/async-transpiler-imported.js
@@ -1,0 +1,6 @@
+// @bun
+export default 42;
+
+if (import.meta.main) {
+  console.log("Hello world!");
+}

--- a/test/transpiler/runtime-transpiler.test.ts
+++ b/test/transpiler/runtime-transpiler.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe("// @bun", () => {
+  beforeEach(() => {
+    delete require.cache[require.resolve("./async-transpiler-entry")];
+    delete require.cache[require.resolve("./async-transpiler-imported")];
+  });
+
+  test("async transpiler", async () => {
+    const { default: value } = await import("./async-transpiler-entry");
+    expect(value).toBe(42);
+  });
+
+  test("require()", async () => {
+    const { default: value } = require("./async-transpiler-entry");
+    expect(value).toBe(42);
+  });
+
+  test("synchronous", async () => {
+    const { stdout, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), require.resolve("./async-transpiler-imported")],
+      cwd: import.meta.dir,
+      env: bunEnv,
+      stderr: "inherit",
+    });
+    expect(stdout.toString()).toBe("Hello world!\n");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

<!-- **Please explain what your changes do**, example: -->

`// @bun`  broke due to async transpiler

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests 

### Checklist

<!-- **Please delete the sections which are not relevant. If there were no code changes, feel free to delete or ignore this section entirely** -->

If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

If Zig files changed:

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters

If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions

If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code

If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
