### PR TITLE
Ignore when printing to stdout errors

### DIFF
--- a/src/output.zig
+++ b/src/output.zig
@@ -402,10 +402,11 @@ pub noinline fn print(comptime fmt: string, args: anytype) void {
         if (comptime Environment.allow_assert)
             std.debug.assert(source_set);
 
+        // There's not much we can do if this errors. Especially if it's something like BrokenPipe.
         if (enable_buffering) {
-            std.fmt.format(source.buffered_stream.writer(), fmt, args) catch unreachable;
+            std.fmt.format(source.buffered_stream.writer(), fmt, args) catch {};
         } else {
-            std.fmt.format(writer(), fmt, args) catch unreachable;
+            std.fmt.format(writer(), fmt, args) catch {};
         }
     }
 }
@@ -664,6 +665,7 @@ pub noinline fn printError(comptime fmt: string, args: anytype) void {
         source.error_stream.writer().print(fmt, args) catch unreachable;
         root.console_error(root.Uint8Array.fromSlice(source.err_buffer[0..source.error_stream.pos]));
     } else {
+        // There's not much we can do if this errors. Especially if it's something like BrokenPipe
         if (enable_buffering)
             std.fmt.format(source.buffered_error_stream.writer(), fmt, args) catch {}
         else


### PR DESCRIPTION
### What does this PR do?

`bun foo.js | head` panics because `head` closes stdout causing printing to stdout to fail. The correct behavior here is a little ambiguous, but we can be sure that panicking is unhelpful. Node dumps an error to stderr. In this case, we change it to simply ignore errors. That can cause bugs if stdout is closed and a new file descriptor is assigned, but I don't think that happens because our many calls to close() explicitly ignore closing stdout

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

lets see what tests do
