### PR TITLE
docs: fixed small errors

### DIFF
--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -482,7 +482,7 @@ n/a
 
 {% /codetabs %}
 
-Bun implements a univeral plugin system for both Bun's runtime and bundler. Refer to the [plugin documentation](/docs/bundler/plugins) for complete documentation.
+Bun implements a universal plugin system for both Bun's runtime and bundler. Refer to the [plugin documentation](/docs/bundler/plugins) for complete documentation.
 
 <!-- ### `manifest`
 

--- a/docs/bundler/macros.md
+++ b/docs/bundler/macros.md
@@ -33,7 +33,7 @@ As you can see, the source code of the `random` function occurs nowhere in the b
 
 ## When to use macros
 
-If you have several build scripts for small things where you would otherwise have a one-off build script, bundle-time code execution can be easier to maintain. It lives with the rest of your code, it runs with the rest of the build, it is automatically paralellized, and if it fails, the build fails too.
+If you have several build scripts for small things where you would otherwise have a one-off build script, bundle-time code execution can be easier to maintain. It lives with the rest of your code, it runs with the rest of the build, it is automatically parallelized, and if it fails, the build fails too.
 
 If you find yourself running a lot of code at bundle-time though, consider running a server instead.
 

--- a/docs/install/cache.md
+++ b/docs/install/cache.md
@@ -19,7 +19,7 @@ disableManifest = false
 
 ## Minimizing re-downloads
 
-Bun strives to avoid re-downloading packages mutiple times. When installing a package, if the cache already contains a version in the range specified by `package.json`, Bun will use the cached package instead of downloading it again.
+Bun strives to avoid re-downloading packages multiple times. When installing a package, if the cache already contains a version in the range specified by `package.json`, Bun will use the cached package instead of downloading it again.
 
 {% details summary="Installation details" %}
 If the semver version has pre-release suffix (`1.0.0-beta.0`) or a build suffix (`1.0.0+20220101`), it is replaced with a hash of that value instead, to reduce the chances of errors associated with long file paths.

--- a/docs/test/writing.md
+++ b/docs/test/writing.md
@@ -101,7 +101,7 @@ test.todo("fix this", () => {
 });
 ```
 
-To exlusively run tests marked as _todo_, use `bun test --todo`.
+To exclusively run tests marked as _todo_, use `bun test --todo`.
 
 ```sh
 $ bun test --todo


### PR DESCRIPTION
While reading the docs, I found some typo errors. 