### PR TITLE
Fix coredump when reading an empty file(`node:stream:createReadStream`)

### DIFF
--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -4433,7 +4433,7 @@ pub const FileReader = struct {
                     var readable_file = File{ .loop = this.globalThis().bunVM().eventLoop() };
 
                     const result = readable_file.start(&blob.data.file);
-                    if (result != .ready) {
+                    if (result != .ready and result != .empty) {
                         return result;
                     }
 

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -4433,7 +4433,11 @@ pub const FileReader = struct {
                     var readable_file = File{ .loop = this.globalThis().bunVM().eventLoop() };
 
                     const result = readable_file.start(&blob.data.file);
-                    if (result != .ready and result != .empty) {
+                    if (result == .empty) {
+                        this.lazy_readable = .{ .empty = {} };
+                        return result;
+                    }
+                    if (result != .ready) {
                         return result;
                     }
 

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -41,6 +41,32 @@ describe("Readable", () => {
 
     readable.pipe(writable);
   });
+  it("should be able to be piped via .pipe, issue #3607", done => {
+    const path = `${tmpdir()}/${Date.now()}.testReadStreamEmptyFile.txt`;
+    writeFileSync(path, "");
+    const stream = createReadStream(path);
+    stream.on("error", err => {
+      done(err);
+    });
+
+    let called = false;
+    const writable = new Writable({
+      write(chunk, encoding, callback) {
+        called = true;
+        callback();
+      },
+    });
+    writable.on("finish", () => {
+      try {
+        expect(called).toBeFalse();
+      } catch (err) {
+        return done(err);
+      }
+      done();
+    });
+
+    stream.pipe(writable);
+  });
   it("should be able to be piped via .pipe, issue #3668", done => {
     const path = `${tmpdir()}/${Date.now()}.testReadStream.txt`;
     writeFileSync(path, "12345");


### PR DESCRIPTION
Close: #3607

### What does this PR do?

Fix coredump when reading an empty file.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### Something helpful

Please check the call stack information for the coredump in the issue #3607 .


When reading a empty file by `readStream`:

https://github.com/oven-sh/bun/blob/681be10294c19b8ce402ec44df5cd6554e2c86c0/src/bun.js/webcore/streams.zig#L4435-L4438

`readable_file.start(&blob.data.file);` will call

https://github.com/oven-sh/bun/blob/681be10294c19b8ce402ec44df5cd6554e2c86c0/src/bun.js/webcore/streams.zig#L4026-L4036

And the result could be `.empty` (`stat.size` will be 0 when file is empty).

```zig
 if (result != .ready) { 
     return result; 
 } 
```

This would cause an early return, preventing `this.lazy_readable` from transitioning from `.bloc` to `.readable`.

### How did you verify your code works?

I wrote automated tests

- [ ] I ran `make js` and committed the transpiled changes
- [x] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [x] I included a test for the new code, or an existing test covers it



<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
