### PR TITLE
ref(bun/test): Refractor 'toBeTypeOf()' + Move some tests 

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -28,6 +28,17 @@ pub const Counter = struct {
     actual: u32 = 0,
 };
 
+const JSTypeOfMap = bun.ComptimeStringMap([]const u8, .{
+    .{ "function", "function" },
+    .{ "object", "object" },
+    .{ "bigint", "bigint" },
+    .{ "boolean", "boolean" },
+    .{ "number", "number" },
+    .{ "string", "string" },
+    .{ "symbol", "symbol" },
+    .{ "undefined", "undefined" },
+});
+
 pub var active_test_expectation_counter: Counter = .{};
 
 /// https://jestjs.io/docs/expect
@@ -316,7 +327,7 @@ pub const Expect = struct {
         } else {
             _msg = ZigString.fromBytes("passes by .pass() assertion");
         }
-            
+
         active_test_expectation_counter.actual += 1;
 
         const not = this.flags.not;
@@ -364,12 +375,12 @@ pub const Expect = struct {
                 globalObject.throwInvalidArgumentType("fail", "message", "string");
                 return .zero;
             }
-   
+
             value.toZigString(&_msg, globalObject);
         } else {
             _msg = ZigString.fromBytes("fails by .fail() assertion");
         }
-            
+
         active_test_expectation_counter.actual += 1;
 
         const not = this.flags.not;
@@ -2317,15 +2328,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        if (!std.mem.eql(u8, expectedAsStr, "function") and
-            !std.mem.eql(u8, expectedAsStr, "object") and
-            !std.mem.eql(u8, expectedAsStr, "bigint") and
-            !std.mem.eql(u8, expectedAsStr, "boolean") and
-            !std.mem.eql(u8, expectedAsStr, "number") and
-            !std.mem.eql(u8, expectedAsStr, "string") and
-            !std.mem.eql(u8, expectedAsStr, "symbol") and
-            !std.mem.eql(u8, expectedAsStr, "undefined"))
-        {
+        if (!JSTypeOfMap.has(expectedAsStr)) {
             globalThis.throwInvalidArguments("toBeTypeOf() requires a valid type string argument ('function', 'object', 'bigint', 'boolean', 'number', 'string', 'symbol', 'undefined')", .{});
             return .zero;
         }
@@ -2356,7 +2359,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        pass = std.mem.eql(u8, expectedAsStr, whatIsTheType);
+        pass = strings.eql(expectedAsStr, whatIsTheType);
 
         if (not) pass = !pass;
         if (pass) return thisValue;

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2898,28 +2898,6 @@ describe("expect()", () => {
     expect({}).not.toBeNil();
   });
 
-  test("toBeArray()", () => {
-    expect([]).toBeArray();
-    expect([1, 2, 3, "🫓"]).toBeArray();
-    expect(new Array()).toBeArray();
-    expect(new Array(1, 2, 3)).toBeArray();
-    expect({}).not.toBeArray();
-    expect("🫓").not.toBeArray();
-    expect(0).not.toBeArray();
-    expect(true).not.toBeArray();
-    expect(null).not.toBeArray();
-  });
-
-  test("toBeArrayOfSize()", () => {
-    expect([]).toBeArrayOfSize(0);
-    expect(new Array()).toBeArrayOfSize(0);
-    expect([1, 2, 3, "🫓"]).toBeArrayOfSize(4);
-    expect(new Array(1, 2, 3, "🫓")).toBeArrayOfSize(4);
-    expect({}).not.toBeArrayOfSize(1);
-    expect("").not.toBeArrayOfSize(1);
-    expect(0).not.toBeArrayOfSize(1);
-  });
-
   test("toBeTypeOf()", () => {
     expect("Bun! 🫓").toBeTypeOf("string");
     expect(0).toBeTypeOf("number");

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -114,8 +114,28 @@ describe("jest-extended", () => {
 
   // Array
 
-  // test('toBeArray()')
-  // test('toBeArrayOfSize()')
+  test("toBeArray()", () => {
+    expect([]).toBeArray();
+    expect([1, 2, 3, "🫓"]).toBeArray();
+    expect(new Array()).toBeArray();
+    expect(new Array(1, 2, 3)).toBeArray();
+    expect({}).not.toBeArray();
+    expect("🫓").not.toBeArray();
+    expect(0).not.toBeArray();
+    expect(true).not.toBeArray();
+    expect(null).not.toBeArray();
+  });
+
+  test("toBeArrayOfSize()", () => {
+    expect([]).toBeArrayOfSize(0);
+    expect(new Array()).toBeArrayOfSize(0);
+    expect([1, 2, 3, "🫓"]).toBeArrayOfSize(4);
+    expect(new Array(1, 2, 3, "🫓")).toBeArrayOfSize(4);
+    expect({}).not.toBeArrayOfSize(1);
+    expect("").not.toBeArrayOfSize(1);
+    expect(0).not.toBeArrayOfSize(1);
+  });
+  
   // test('toIncludeAllMembers()')
   // test('toIncludeAllPartialMembers()')
   // test('toIncludeAnyMembers()')


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

(Reopened: <https://github.com/oven-sh/bun/pull/3366>)

Implements optimizations for the toBeTypeOf() matcher in jest(-extended),
Also I moved some tests to their desired location.

### How did you verify your code works?

Run it on my local hardware.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
