### PR TITLE
Fix memory leak in response.clone(), further reduce memory usage of Request & Response

### DIFF
--- a/bench/snippets/request-response-clone.mjs
+++ b/bench/snippets/request-response-clone.mjs
@@ -1,0 +1,15 @@
+// This mostly exists to check for a memory leak in response.clone()
+import { bench, run } from "./runner.mjs";
+
+const req = new Request("http://localhost:3000/");
+const resp = await fetch("http://example.com");
+
+bench("req.clone().url", () => {
+  return req.clone().url;
+});
+
+bench("resp.clone().url", () => {
+  return resp.clone().url;
+});
+
+await run();

--- a/bench/snippets/resposne-constructor.mjs
+++ b/bench/snippets/resposne-constructor.mjs
@@ -1,0 +1,1 @@
+for (let i = 0; i < 9999999; i++) new Request("http://aaaaaaaaaaaaaaaaaaaaa");

--- a/src/bun.js/api/filesystem_router.zig
+++ b/src/bun.js/api/filesystem_router.zig
@@ -75,6 +75,8 @@ const DeprecatedGlobalRouter = struct {
         };
 
         var path_: ?ZigString.Slice = null;
+        var req_url_slice: ZigString.Slice = .{};
+        defer req_url_slice.deinit();
         var pathname: string = "";
         defer {
             if (path_) |path| {
@@ -88,7 +90,8 @@ const DeprecatedGlobalRouter = struct {
             var url = URL.parse(path_.?.slice());
             pathname = url.pathname;
         } else if (arg.as(Request)) |req| {
-            var url = URL.parse(req.url);
+            req_url_slice = req.url.toUTF8(bun.default_allocator);
+            var url = URL.parse(req_url_slice.slice());
             pathname = url.pathname;
         }
 
@@ -389,7 +392,7 @@ pub const FileSystemRouter = struct {
             if (argument.isCell()) {
                 if (argument.as(JSC.WebCore.Request)) |req| {
                     req.ensureURL() catch unreachable;
-                    break :brk ZigString.Slice.fromUTF8NeverFree(req.url).clone(globalThis.allocator()) catch unreachable;
+                    break :brk req.url.toUTF8(globalThis.allocator());
                 }
 
                 if (argument.as(JSC.WebCore.Response)) |resp| {

--- a/src/bun.js/api/filesystem_router.zig
+++ b/src/bun.js/api/filesystem_router.zig
@@ -393,7 +393,7 @@ pub const FileSystemRouter = struct {
                 }
 
                 if (argument.as(JSC.WebCore.Response)) |resp| {
-                    break :brk ZigString.Slice.fromUTF8NeverFree(resp.url).clone(globalThis.allocator()) catch unreachable;
+                    break :brk resp.url.toUTF8(globalThis.allocator());
                 }
             }
 

--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -454,8 +454,8 @@ pub const HTMLRewriter = struct {
                 result.body.init.headers = headers.cloneThis(global);
             }
 
-            result.url = bun.default_allocator.dupe(u8, original.url) catch unreachable;
-            result.status_text = bun.default_allocator.dupe(u8, original.status_text) catch unreachable;
+            result.url = original.url.clone();
+            result.status_text = original.status_text.clone();
 
             var input = original.body.value.useAsAnyBlob();
             sink.input = input;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -4943,7 +4943,7 @@ pub fn NewServer(comptime ssl_enabled_: bool, comptime debug_mode_: bool) type {
             }
 
             if (response_value.as(JSC.WebCore.Response)) |resp| {
-                resp.url = this.allocator.dupe(u8, existing_request.url) catch unreachable;
+                resp.url = bun.String.create(existing_request.url);
             }
             return JSC.JSPromise.resolvedPromiseValue(ctx, response_value).asObjectRef();
         }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1069,7 +1069,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         byte_stream: ?*JSC.WebCore.ByteStream = null,
 
         /// Used in errors
-        pathname: []const u8 = "",
+        pathname: bun.String = bun.String.empty,
 
         /// Used either for temporary blob data or fallback
         /// When the response body is a temporary value
@@ -1550,10 +1550,9 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 stream.unpipe();
             }
 
-            if (this.pathname.len > 0) {
-                ctxLog("finalizeWithoutDeinit: this.pathname.len > 0 null", .{});
-                this.allocator.free(bun.constStrToU8(this.pathname));
-                this.pathname = "";
+            if (!this.pathname.isEmpty()) {
+                this.pathname.deref();
+                this.pathname = bun.String.empty;
             }
 
             // if we are waiting for the body yet and the request was not aborted we can safely clear the onData callback
@@ -2235,7 +2234,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 request_object.uws_request = req;
 
                 request_object.ensureURL() catch {
-                    request_object.url = "";
+                    request_object.url = bun.String.empty;
                 };
 
                 // we have to clone the request headers here since they will soon belong to a different request
@@ -2244,7 +2243,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 }
 
                 if (comptime debug_mode) {
-                    ctx.pathname = bun.default_allocator.dupe(u8, request_object.url) catch unreachable;
+                    ctx.pathname = request_object.url.clone();
                 }
 
                 // This object dies after the stack frame is popped
@@ -2596,15 +2595,28 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             runErrorHandlerWithStatusCode(this, value, 500);
         }
 
-        fn ensurePathname(this: *RequestContext) []const u8 {
-            if (this.pathname.len > 0)
-                return this.pathname;
+        const PathnameFormatter = struct {
+            ctx: *RequestContext,
 
-            if (!this.flags.has_abort_handler) {
-                return this.req.url();
+            pub fn format(formatter: @This(), comptime fmt: []const u8, opts: std.fmt.FormatOptions, writer: anytype) !void {
+                var this = formatter.ctx;
+
+                if (!this.pathname.isEmpty()) {
+                    try this.pathname.format(fmt, opts, writer);
+                    return;
+                }
+
+                if (!this.flags.has_abort_handler) {
+                    try writer.writeAll(this.req.url());
+                    return;
+                }
+
+                try writer.writeAll("/");
             }
+        };
 
-            return "/";
+        fn ensurePathname(this: *RequestContext) PathnameFormatter {
+            return .{ .ctx = this };
         }
 
         pub inline fn shouldCloseConnection(this: *const RequestContext) bool {
@@ -2625,7 +2637,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     vm.log,
                     error.ExceptionOcurred,
                     exception_list.toOwnedSlice() catch @panic("TODO"),
-                    "<r><red>{s}<r> - <b>{s}<r> failed",
+                    "<r><red>{s}<r> - <b>{}<r> failed",
                     .{ @as(string, @tagName(this.method)), this.ensurePathname() },
                 );
             } else {
@@ -4900,8 +4912,7 @@ pub fn NewServer(comptime ssl_enabled_: bool, comptime debug_mode_: bool) type {
                 }
 
                 existing_request = Request{
-                    .url = url.href,
-                    .url_was_allocated = true,
+                    .url = bun.String.create(url.href),
                     .headers = headers,
                     .body = JSC.WebCore.InitRequestBodyValue(body) catch unreachable,
                     .method = method,
@@ -4943,7 +4954,7 @@ pub fn NewServer(comptime ssl_enabled_: bool, comptime debug_mode_: bool) type {
             }
 
             if (response_value.as(JSC.WebCore.Response)) |resp| {
-                resp.url = bun.String.create(existing_request.url);
+                resp.url = existing_request.url.clone();
             }
             return JSC.JSPromise.resolvedPromiseValue(ctx, response_value).asObjectRef();
         }
@@ -5295,7 +5306,6 @@ pub fn NewServer(comptime ssl_enabled_: bool, comptime debug_mode_: bool) type {
             }
 
             request_object.* = .{
-                .url = "",
                 .method = ctx.method,
                 .uws_request = req,
                 .https = ssl_enabled,
@@ -5398,7 +5408,6 @@ pub fn NewServer(comptime ssl_enabled_: bool, comptime debug_mode_: bool) type {
             }
 
             request_object.* = .{
-                .url = "",
                 .method = ctx.method,
                 .uws_request = req,
                 .upgrader = ctx,

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -192,7 +192,6 @@ extern "C" BunString BunString__fromUTF16Unitialized(size_t length)
     if (UNLIKELY(!ptr))
         return { BunStringTag::Dead };
 
-    impl->ref();
     return { BunStringTag::WTFStringImpl, { .wtf = &impl.leakRef() } };
 }
 
@@ -203,7 +202,6 @@ extern "C" BunString BunString__fromLatin1Unitialized(size_t length)
     auto impl = WTF::StringImpl::createUninitialized(latin1Length, ptr);
     if (UNLIKELY(!ptr))
         return { BunStringTag::Dead };
-    impl->ref();
     return { BunStringTag::WTFStringImpl, { .wtf = &impl.leakRef() } };
 }
 
@@ -369,7 +367,7 @@ extern "C" BunString URL__getHrefFromJS(EncodedJSValue encodedValue, JSC::JSGlob
 
 extern "C" BunString URL__getHref(BunString* input)
 {
-    auto str = Bun::toWTFString(*input);
+    auto&& str = Bun::toWTFString(*input);
     auto url = WTF::URL(str);
     if (!url.isValid() || url.isEmpty())
         return { BunStringTag::Dead };
@@ -379,7 +377,7 @@ extern "C" BunString URL__getHref(BunString* input)
 
 extern "C" WTF::URL* URL__fromString(BunString* input)
 {
-    auto str = Bun::toWTFString(*input);
+    auto&& str = Bun::toWTFString(*input);
     auto url = WTF::URL(str);
     if (!url.isValid())
         return nullptr;

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -1404,7 +1404,7 @@ double JSC__JSValue__getLengthIfPropertyExistsInternal(JSC__JSValue value, JSC__
         return 0;
     }
 
-    case JSC::JSType(JSDOMWrapperType): {
+    case WebCore::JSDOMWrapperType: {
         if (auto* headers = jsDynamicCast<WebCore::JSFetchHeaders*>(cell))
             return static_cast<double>(jsCast<WebCore::JSFetchHeaders*>(cell)->wrapped().size());
 

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -866,13 +866,11 @@ pub const Encoder = struct {
                 }
 
                 var str = bun.String.createUninitialized(.latin1, len) orelse return ZigString.init("Out of memory").toErrorInstance(global);
-                defer str.deref();
                 strings.copyLatin1IntoASCII(@constCast(str.latin1()), input);
                 return str.toJS(global);
             },
             .latin1 => {
                 var str = bun.String.createUninitialized(.latin1, len) orelse return ZigString.init("Out of memory").toErrorInstance(global);
-                defer str.deref();
 
                 @memcpy(@constCast(str.latin1()), input_ptr[0..len]);
 
@@ -903,7 +901,6 @@ pub const Encoder = struct {
 
             .hex => {
                 var str = bun.String.createUninitialized(.latin1, len * 2) orelse return ZigString.init("Out of memory").toErrorInstance(global);
-                defer str.deref();
                 var output = @constCast(str.latin1());
                 const wrote = strings.encodeBytesToHex(output, input);
                 std.debug.assert(wrote == output.len);

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -510,8 +510,8 @@ pub const Request = struct {
                     }
 
                     if (!fields.contains(.url)) {
-                        if (response.url.len > 0) {
-                            req.url = globalThis.allocator().dupe(u8, response.url) catch unreachable;
+                        if (!response.url.isEmpty()) {
+                            req.url = response.url.toOwnedSlice(bun.default_allocator) catch unreachable;
                             req.url_was_allocated = true;
                             fields.insert(.url);
                         }

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1034,7 +1034,7 @@ pub const Fetch = struct {
         if (first_arg.as(Request)) |request| {
             request.ensureURL() catch unreachable;
 
-            if (request.url.len == 0) {
+            if (request.url.isEmpty()) {
                 const err = JSC.toTypeError(.ERR_INVALID_ARG_VALUE, fetch_error_blank_url, .{}, ctx);
                 // clean hostname if any
                 if (hostname) |host| {
@@ -1043,7 +1043,7 @@ pub const Fetch = struct {
                 return JSPromise.rejectedPromiseValue(globalThis, err);
             }
 
-            url = ZigURL.fromUTF8(bun.default_allocator, request.url) catch {
+            url = ZigURL.fromString(bun.default_allocator, request.url) catch {
                 const err = JSC.toTypeError(.ERR_INVALID_ARG_VALUE, "fetch() URL is invalid", .{}, ctx);
                 // clean hostname if any
                 if (hostname) |host| {

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -59,8 +59,8 @@ pub const Response = struct {
 
     allocator: std.mem.Allocator,
     body: Body,
-    url: string = "",
-    status_text: string = "",
+    url: bun.String = bun.String.empty,
+    status_text: bun.String = bun.String.empty,
     redirected: bool = false,
 
     // We must report a consistent value for this
@@ -85,7 +85,7 @@ pub const Response = struct {
         return this.reported_estimated_size orelse brk: {
             this.reported_estimated_size = @as(
                 u63,
-                @intCast(this.body.value.estimatedSize() + this.url.len + this.status_text.len + @sizeOf(Response)),
+                @intCast(this.body.value.estimatedSize() + this.url.byteSlice().len + this.status_text.byteSlice().len + @sizeOf(Response)),
             );
             break :brk this.reported_estimated_size.?;
         };
@@ -135,7 +135,7 @@ pub const Response = struct {
 
             try formatter.writeIndent(Writer, writer);
             try writer.writeAll(comptime Output.prettyFmt("<r>url<d>:<r> \"", enable_ansi_colors));
-            try writer.print(comptime Output.prettyFmt("<r><b>{s}<r>", enable_ansi_colors), .{this.url});
+            try writer.print(comptime Output.prettyFmt("<r><b>{}<r>", enable_ansi_colors), .{this.url});
             try writer.writeAll("\"");
             formatter.printComma(Writer, writer, enable_ansi_colors) catch unreachable;
             try writer.writeAll("\n");
@@ -148,7 +148,7 @@ pub const Response = struct {
 
             try formatter.writeIndent(Writer, writer);
             try writer.writeAll(comptime Output.prettyFmt("<r>statusText<d>:<r> ", enable_ansi_colors));
-            try JSPrinter.writeJSONString(this.status_text, Writer, writer, .ascii);
+            try writer.print(comptime Output.prettyFmt("<r>\"<b>{}<r>\"", enable_ansi_colors), .{this.status_text});
             formatter.printComma(Writer, writer, enable_ansi_colors) catch unreachable;
             try writer.writeAll("\n");
 
@@ -175,7 +175,7 @@ pub const Response = struct {
         globalThis: *JSC.JSGlobalObject,
     ) callconv(.C) JSC.JSValue {
         // https://developer.mozilla.org/en-US/docs/Web/API/Response/url
-        return ZigString.init(this.url).toValueGC(globalThis);
+        return this.url.toJS(globalThis);
     }
 
     pub fn getResponseType(
@@ -194,7 +194,7 @@ pub const Response = struct {
         globalThis: *JSC.JSGlobalObject,
     ) callconv(.C) JSC.JSValue {
         // https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText
-        return ZigString.init(this.status_text).withEncoding().toValueGC(globalThis);
+        return this.status_text.toJS(globalThis);
     }
 
     pub fn getRedirected(
@@ -262,8 +262,8 @@ pub const Response = struct {
         new_response.* = Response{
             .allocator = allocator,
             .body = this.body.clone(globalThis),
-            .url = allocator.dupe(u8, this.url) catch unreachable,
-            .status_text = allocator.dupe(u8, this.status_text) catch unreachable,
+            .url = this.url.clone(),
+            .status_text = this.status_text.clone(),
             .redirected = this.redirected,
         };
     }
@@ -289,13 +289,8 @@ pub const Response = struct {
 
         var allocator = this.allocator;
 
-        if (this.status_text.len > 0) {
-            allocator.free(this.status_text);
-        }
-
-        if (this.url.len > 0) {
-            allocator.free(this.url);
-        }
+        this.status_text.deref();
+        this.url.deref();
 
         allocator.destroy(this);
     }
@@ -381,7 +376,7 @@ pub const Response = struct {
                 .value = .{ .Empty = {} },
             },
             .allocator = getAllocator(globalThis),
-            .url = "",
+            .url = bun.String.empty,
         };
 
         const json_value = args.nextEat() orelse JSC.JSValue.zero;
@@ -443,7 +438,7 @@ pub const Response = struct {
                 .value = .{ .Empty = {} },
             },
             .allocator = getAllocator(globalThis),
-            .url = "",
+            .url = bun.String.empty,
         };
 
         const url_string_value = args.nextEat() orelse JSC.JSValue.zero;
@@ -487,7 +482,6 @@ pub const Response = struct {
                 .value = .{ .Empty = {} },
             },
             .allocator = getAllocator(globalThis),
-            .url = "",
         };
 
         return response.toJS(globalThis);
@@ -534,7 +528,6 @@ pub const Response = struct {
         response.* = Response{
             .body = body,
             .allocator = getAllocator(globalThis),
-            .url = "",
         };
 
         if (response.body.value == .Blob and
@@ -821,8 +814,8 @@ pub const Fetch = struct {
             const http_response = this.result.response;
             return Response{
                 .allocator = allocator,
-                .url = allocator.dupe(u8, this.result.href) catch unreachable,
-                .status_text = allocator.dupe(u8, http_response.status) catch unreachable,
+                .url = bun.String.createAtomIfPossible(this.result.href),
+                .status_text = bun.String.createAtomIfPossible(http_response.status),
                 .redirected = this.result.redirected,
                 .body = .{
                     .init = .{
@@ -1377,7 +1370,7 @@ pub const Fetch = struct {
                     .value = .{ .Blob = bun_file },
                 },
                 .allocator = bun.default_allocator,
-                .url = file_url_string.toOwnedSlice(bun.default_allocator) catch @panic("out of memory"),
+                .url = file_url_string.clone(),
             };
 
             return JSPromise.resolvedPromiseValue(globalThis, response.toJS(globalThis));

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -241,12 +241,7 @@ pub const Response = struct {
         _: *JSC.CallFrame,
     ) callconv(.C) JSValue {
         var cloned = this.clone(getAllocator(globalThis), globalThis);
-        const val = Response.makeMaybePooled(globalThis, cloned);
-        if (this.body.init.headers) |headers| {
-            cloned.body.init.headers = headers.cloneThis(globalThis);
-        }
-
-        return val;
+        return Response.makeMaybePooled(globalThis, cloned);
     }
 
     pub fn makeMaybePooled(globalObject: *JSC.JSGlobalObject, ptr: *Response) JSValue {

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -2367,7 +2367,6 @@ pub const E = struct {
 
             if (s.is_utf16) {
                 var out = bun.String.createUninitializedUTF16(s.len());
-                defer out.deref();
                 @memcpy(@constCast(out.utf16()), s.slice16());
                 return out.toJS(globalObject);
             }

--- a/src/string.zig
+++ b/src/string.zig
@@ -276,6 +276,10 @@ pub const String = extern struct {
     extern fn BunString__fromLatin1Unitialized(len: usize) String;
     extern fn BunString__fromUTF16Unitialized(len: usize) String;
 
+    pub fn isGlobal(this: String) bool {
+        return this.tag == Tag.ZigString and this.value.ZigString.isGloballyAllocated();
+    }
+
     pub fn toOwnedSlice(this: String, allocator: std.mem.Allocator) ![]u8 {
         switch (this.tag) {
             .ZigString => return try this.value.ZigString.toOwnedSlice(allocator),
@@ -337,6 +341,54 @@ pub const String = extern struct {
     pub fn dupeRef(this: String) String {
         this.ref();
         return this;
+    }
+
+    pub fn clone(this: String) String {
+        if (this.tag == .WTFStringImpl) {
+            return this.dupeRef();
+        }
+
+        if (this.isEmpty()) {
+            return this;
+        }
+
+        if (this.isUTF16()) {
+            var new = createUninitializedUTF16(this.length());
+            @memcpy(@constCast(new.byteSlice()), this.byteSlice());
+            return new;
+        }
+
+        return create(this.byteSlice());
+    }
+
+    extern fn BunString__createAtom(bytes: [*]const u8, len: usize) String;
+
+    /// May return .Dead if the string is too long or non-ascii.
+    pub fn createAtom(bytes: []const u8) String {
+        JSC.markBinding(@src());
+        return BunString__createAtom(bytes.ptr, bytes.len);
+    }
+
+    pub fn tryCreateAtom(bytes: []const u8) ?String {
+        const atom = createAtom(bytes);
+        if (atom.isEmpty()) {
+            return null;
+        }
+
+        return atom;
+    }
+
+    /// Atomized strings are interned strings
+    /// They're de-duplicated in a threadlocal hash table
+    /// They cannot be used from other threads.
+    pub fn createAtomIfPossible(bytes: []const u8) String {
+        if (bytes.len < 64) {
+            if (tryCreateAtom(bytes)) |atom| {
+                return atom;
+            }
+        }
+
+        return create(bytes);
     }
 
     pub fn utf8ByteLength(this: String) usize {

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -205,7 +205,7 @@ describe("Server", () => {
       },
     });
     try {
-      const url = `http://${server.hostname}:${server.port}`;
+      const url = `http://${server.hostname}:${server.port}/`;
       const response = await server.fetch(url);
       expect(await response.text()).toBe("Hello World!");
       expect(response.status).toBe(200);
@@ -222,7 +222,7 @@ describe("Server", () => {
       },
     });
     try {
-      const url = `http://${server.hostname}:${server.port}`;
+      const url = `http://${server.hostname}:${server.port}/`;
       const response = await server.fetch(new Request(url));
       expect(await response.text()).toBe("Hello World!");
       expect(response.status).toBe(200);

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -107,7 +107,7 @@ it("Request object", () => {
     `
 Request (0 KB) {
   method: "GET",
-  url: "https://example.com",
+  url: "https://example.com/",
   headers: Headers {}
 }`.trim(),
   );

--- a/test/js/web/fetch/body-stream.test.ts
+++ b/test/js/web/fetch/body-stream.test.ts
@@ -1,7 +1,6 @@
 // @ts-nocheck
-import { file, gc, serve, ServeOptions } from "bun";
-import { afterAll, afterEach, describe, expect, it, test } from "bun:test";
-import { readFileSync } from "fs";
+import { gc, ServeOptions } from "bun";
+import { afterAll, describe, expect, it, test } from "bun:test";
 
 var port = 0;
 


### PR DESCRIPTION
### What does this PR do?

- Fix a memory leak in response.clone() where the headers were cloned twice and the first clone was never freed
- Make `request.url` and `response.url` faster by avoiding the unnecessary UTF-8 clone
- Atomize/intern response.url, request.url, response.statusText
- Runs WebKit's URL parser on `new Request()`, which is a breaking change that aligns the `Request` constructor with web & other runtimes. It will now throw if the URL is invalid. Previously, it would only throw if the hostname was empty or the url was empty. This also properly normalizes the URL, so that `http://localhost:3000` becomes `http://localhost:3000/`. This makes the Request constructor about 2x slower than before, but it's still multiple times faster than node/deno so it's fine


```js
❯ mem bun --smol request-response-clone.mjs
cpu: Apple M1 Max
runtime: bun 0.7.2 (arm64-darwin)

benchmark time (avg) (min … max) p75 p99 p995
-------------------------------------------------------- -----------------------------
req.clone().url 77.3 ns/iter (40.35 ns … 222.64 ns) 91.53 ns 128.11 ns 172.78 ns
resp.clone().url 162.43 ns/iter (116 ns … 337.77 ns) 177.4 ns 232.38 ns 262.65 ns

Peak memory usage: 60 MB

❯ mem bun-0.7.1 --smol request-response-clone.mjs
cpu: Apple M1 Max
runtime: bun 0.7.1 (arm64-darwin)

benchmark time (avg) (min … max) p75 p99 p995
-------------------------------------------------------- -----------------------------
req.clone().url 115.85 ns/iter (80.35 ns … 247.39 ns) 128.19 ns 181.93 ns 207.23 ns
resp.clone().url 252.32 ns/iter (202.6 ns … 351.07 ns) 266.56 ns 325.88 ns 334.73 ns

Peak memory usage: 1179 MB

❯ mem node request-response-clone.mjs
cpu: Apple M1 Max
runtime: node v20.4.0 (arm64-darwin)

benchmark             time (avg)             (min … max)       p75       p99      p995
-------------------------------------------------------- -----------------------------
req.clone().url    45.52 µs/iter     (8.96 µs … 1.86 ms)  62.67 µs  82.83 µs  85.04 µs
resp.clone().url    70.3 µs/iter    (47.63 µs … 4.21 ms)  61.83 µs 152.29 µs 233.25 µs
(node:70671) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)

Peak memory usage: 485 MB
```

Probably will help with #3065 

### How did you verify your code works?


Existing tests, but I also added a couple