### PR TITLE
throw error if node module does not exist

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1262,6 +1262,12 @@ pub const Resolver = struct {
                 const had_node_prefix = strings.hasPrefixComptime(import_path, "node:");
                 const import_path_without_node_prefix = if (had_node_prefix) import_path["node:".len..] else import_path;
 
+                if (had_node_prefix) {
+                    // because all node modules are already checked in ../linker.zig (JSC.HardcodedModule.Aliases.get) if module is not found here, it is not found at all
+                    // so we can just return not_found
+                    return .{ .not_found = {} };
+                }
+
                 if (NodeFallbackModules.Map.get(import_path_without_node_prefix)) |*fallback_module| {
                     result.path_pair.primary = fallback_module.path;
                     result.module_type = .cjs;

--- a/test/js/node/missing-module.test.js
+++ b/test/js/node/missing-module.test.js
@@ -1,0 +1,7 @@
+import { expect, test } from "bun:test";
+
+test("not implemented yet module masquerades as undefined and throws an error", () => {
+  const missingModule = "node:missing" + "";
+  expect(() => require(missingModule)).toThrow(/^Cannot find package "node:missing" from "/);
+  expect(() => import(missingModule)).toThrow(/^Cannot find package "node:missing" from "/);
+});


### PR DESCRIPTION
### What does this PR do?

An error will occur when you try to import a built-in module that does not exist
Fixes https://github.com/oven-sh/bun/issues/3912

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
I included a test for the new code, or an existing test covers it

### Zig files changed:

I or my editor ran `zig fmt` on the changed files
I included a test for the new code, or an existing test covers it

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
