### PR TITLE
prefer `module` in `exports` field

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1610,6 +1610,7 @@ pub const Resolver = struct {
                                     .allocator = r.allocator,
                                     .debug_logs = if (r.debug_logs) |*debug| debug else null,
                                     .module_type = &module_type,
+                                    .prefer_module_field_in_exports = r.prefer_module_field,
                                 };
 
                                 // Resolve against the path "/", then join it with the absolute
@@ -1875,6 +1876,7 @@ pub const Resolver = struct {
                                         debug
                                     else
                                         null,
+                                    .prefer_module_field_in_exports = r.prefer_module_field,
                                 };
 
                                 // Resolve against the path "/", then join it with the absolute
@@ -2853,6 +2855,7 @@ pub const Resolver = struct {
             .allocator = r.allocator,
             .debug_logs = if (r.debug_logs) |*debug| debug else null,
             .module_type = &module_type,
+            .prefer_module_field_in_exports = r.prefer_module_field,
         };
 
         const esm_resolution = esmodule.resolveImports(import_path, imports_map.root);

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -6836,4 +6836,77 @@ describe("bundler", () => {
       stdout: "5 9 2 7",
     },
   });
+  const fooNodeModule = {
+    "/node_modules/foo/package.json": `
+      {
+        "name": "foo",
+        "version": "2.0.0",
+        "exports": {
+          ".": {
+            "module": "./import.js",
+            "require": "./require.js",
+            "import": "./import.js"
+          }
+        }
+      }
+    `,
+    "/node_modules/foo/import.js": `
+      export const foo = 'import';
+    `,
+    "/node_modules/foo/require.js": `
+      export const foo = 'require';
+    `,
+  };
+  itBundled("default/ExportFieldWithModuleRuntimeImport", {
+    files: {
+      "/entry.js": `
+        import { foo } from 'foo';
+        console.log(foo);
+      `,
+      ...fooNodeModule,
+    },
+    bundling: false,
+    run: {
+      stdout: "import",
+    },
+  });
+  itBundled("default/ExportsFieldWithModuleBundleImport", {
+    files: {
+      "/entry.js": `
+        import { foo } from 'foo';
+        console.log(foo);
+      `,
+      ...fooNodeModule,
+    },
+    bundling: true,
+    run: {
+      stdout: "import",
+    },
+  });
+  itBundled("default/ExportsFieldWithModuleRuntimeRequire", {
+    files: {
+      "/entry.js": `
+        const { foo } = require('foo');
+        console.log(foo);
+      `,
+      ...fooNodeModule,
+    },
+    bundling: false,
+    run: {
+      stdout: "require",
+    },
+  });
+  itBundled("default/ExportsFieldWithModuleBundleRequire", {
+    files: {
+      "/entry.js": `
+        const { foo } = require('foo');
+        console.log(foo);
+      `,
+      ...fooNodeModule,
+    },
+    bundling: true,
+    run: {
+      stdout: "import",
+    },
+  });
 });


### PR DESCRIPTION
### What does this PR do?

This pr will ensure the `module` field in `exports` does not resolve before `require`, `import`, or `default` for runtime imports.

### How did you verify your code works?

I wrote tests to run the same code bundled and unbundled and compared the output to make sure the correct files were imported.

fixes #3901 
