### PR TITLE
Dave/removedeprecation

### DIFF
--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -582,88 +582,6 @@ pub fn newPath(
     return Node.Path.create(ctx.ptr(), is_windows).asObjectRef();
 }
 
-pub fn readFileAsStringCallback(
-    ctx: js.JSContextRef,
-    buf_z: [:0]const u8,
-    exception: js.ExceptionRef,
-) js.JSValueRef {
-    const path = buf_z.ptr[0..buf_z.len];
-    var file = std.fs.cwd().openFileZ(buf_z, .{ .mode = .read_only }) catch |err| {
-        JSError(getAllocator(ctx), "Opening file {s} for path: \"{s}\"", .{ @errorName(err), path }, ctx, exception);
-        return js.JSValueMakeUndefined(ctx);
-    };
-
-    defer file.close();
-
-    const stat = file.stat() catch |err| {
-        JSError(getAllocator(ctx), "Getting file size {s} for \"{s}\"", .{ @errorName(err), path }, ctx, exception);
-        return js.JSValueMakeUndefined(ctx);
-    };
-
-    if (stat.kind != .file) {
-        JSError(getAllocator(ctx), "Can't read a {s} as a string (\"{s}\")", .{ @tagName(stat.kind), path }, ctx, exception);
-        return js.JSValueMakeUndefined(ctx);
-    }
-
-    var contents_buf = VirtualMachine.get().allocator.alloc(u8, stat.size + 2) catch unreachable; // OOM
-    defer VirtualMachine.get().allocator.free(contents_buf);
-    const contents_len = file.readAll(contents_buf) catch |err| {
-        JSError(getAllocator(ctx), "{s} reading file (\"{s}\")", .{ @errorName(err), path }, ctx, exception);
-        return js.JSValueMakeUndefined(ctx);
-    };
-
-    contents_buf[contents_len] = 0;
-
-    // Very slow to do it this way. We're copying the string twice.
-    // But it's important that this string is garbage collected instead of manually managed.
-    // We can't really recycle this one.
-    // TODO: use external string
-    return js.JSValueMakeString(ctx, js.JSStringCreateWithUTF8CString(contents_buf.ptr));
-}
-
-pub fn readFileAsBytesCallback(
-    ctx: js.JSContextRef,
-    buf_z: [:0]const u8,
-    exception: js.ExceptionRef,
-) js.JSValueRef {
-    const path = buf_z.ptr[0..buf_z.len];
-    const allocator = VirtualMachine.get().allocator;
-
-    var file = std.fs.cwd().openFileZ(buf_z, .{ .mode = .read_only }) catch |err| {
-        JSError(allocator, "Opening file {s} for path: \"{s}\"", .{ @errorName(err), path }, ctx, exception);
-        return js.JSValueMakeUndefined(ctx);
-    };
-
-    defer file.close();
-
-    const stat = file.stat() catch |err| {
-        JSError(allocator, "Getting file size {s} for \"{s}\"", .{ @errorName(err), path }, ctx, exception);
-        return js.JSValueMakeUndefined(ctx);
-    };
-
-    if (stat.kind != .file) {
-        JSError(allocator, "Can't read a {s} as a string (\"{s}\")", .{ @tagName(stat.kind), path }, ctx, exception);
-        return js.JSValueMakeUndefined(ctx);
-    }
-
-    var contents_buf = allocator.alloc(u8, stat.size + 2) catch unreachable; // OOM
-    const contents_len = file.readAll(contents_buf) catch |err| {
-        JSError(allocator, "{s} reading file (\"{s}\")", .{ @errorName(err), path }, ctx, exception);
-        return js.JSValueMakeUndefined(ctx);
-    };
-
-    contents_buf[contents_len] = 0;
-
-    var marked_array_buffer = allocator.create(MarkedArrayBuffer) catch unreachable;
-    marked_array_buffer.* = MarkedArrayBuffer.fromBytes(
-        contents_buf[0..contents_len],
-        allocator,
-        .Uint8Array,
-    );
-
-    return marked_array_buffer.toJSObjectRef(ctx, exception);
-}
-
 pub fn getRouteFiles(
     _: void,
     ctx: js.JSContextRef,
@@ -781,40 +699,6 @@ pub fn openInEditor(
     };
 
     return JSC.JSValue.jsUndefined().asObjectRef();
-}
-
-pub fn readFileAsBytes(
-    _: void,
-    ctx: js.JSContextRef,
-    _: js.JSObjectRef,
-    _: js.JSObjectRef,
-    arguments: []const js.JSValueRef,
-    exception: js.ExceptionRef,
-) js.JSValueRef {
-    var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-    const path = getFilePath(ctx, arguments, &buf, exception) orelse return null;
-    buf[path.len] = 0;
-
-    const buf_z: [:0]const u8 = buf[0..path.len :0];
-    const result = readFileAsBytesCallback(ctx, buf_z, exception);
-    return result;
-}
-
-pub fn readFileAsString(
-    _: void,
-    ctx: js.JSContextRef,
-    _: js.JSObjectRef,
-    _: js.JSObjectRef,
-    arguments: []const js.JSValueRef,
-    exception: js.ExceptionRef,
-) js.JSValueRef {
-    var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-    const path = getFilePath(ctx, arguments, &buf, exception) orelse return null;
-    buf[path.len] = 0;
-
-    const buf_z: [:0]const u8 = buf[0..path.len :0];
-    const result = readFileAsStringCallback(ctx, buf_z, exception);
-    return result;
 }
 
 pub fn getPublicPath(to: string, origin: URL, comptime Writer: type, writer: Writer) void {
@@ -1108,27 +992,6 @@ comptime {
     }
 }
 
-pub fn readAllStdinSync(
-    _: void,
-    ctx: js.JSContextRef,
-    _: js.JSObjectRef,
-    _: js.JSObjectRef,
-    _: []const js.JSValueRef,
-    exception: js.ExceptionRef,
-) js.JSValueRef {
-    var stack = std.heap.stackFallback(2048, getAllocator(ctx));
-    var allocator = stack.get();
-
-    var stdin = std.io.getStdIn();
-    var result = stdin.readToEndAlloc(allocator, std.math.maxInt(u32)) catch |err| {
-        JSError(undefined, "{s} reading stdin", .{@errorName(err)}, ctx, exception);
-        return null;
-    };
-    var out = ZigString.init(result);
-    out.detectEncoding();
-    return out.toValueGC(ctx.ptr()).asObjectRef();
-}
-
 var public_path_temp_str: [bun.MAX_PATH_BYTES]u8 = undefined;
 
 pub fn getPublicPathJS(
@@ -1158,47 +1021,19 @@ pub const Class = NewClass(
         .read_only = true,
     },
     .{
-        .match = .{
-            .rfn = &Router.deprecatedBunGlobalMatch,
-        },
-        .sleepSync = .{
-            .rfn = &sleepSync,
-        },
-        // .fetch = .{
-        //     .rfn = &Fetch.call,
-        // },
-        .getImportedStyles = .{
-            .rfn = &Bun.getImportedStyles,
-        },
-        .inspect = .{
-            .rfn = &Bun.inspect,
-        },
-        .getRouteFiles = .{
-            .rfn = &Bun.getRouteFiles,
+        // Private
+        // TODO: We should remove _Os, _Path, and make registerMacro and fs be private builtins
+        .DO_NOT_USE_OR_YOU_WILL_BE_FIRED_mimalloc_dump = .{
+            .rfn = &dump_mimalloc,
+            .enumerable = false,
         },
         ._Os = .{
             .rfn = &Bun.newOs,
+            .enumerable = false,
         },
         ._Path = .{
             .rfn = &Bun.newPath,
-        },
-        .getRouteNames = .{
-            .rfn = &Bun.getRouteNames,
-        },
-        .readFile = .{
-            .rfn = &Bun.readFileAsString,
-        },
-        .resolveSync = .{
-            .rfn = &Bun.resolveSync,
-        },
-        .resolve = .{
-            .rfn = &Bun.resolve,
-        },
-        .readFileBytes = .{
-            .rfn = &Bun.readFileAsBytes,
-        },
-        .getPublicPath = .{
-            .rfn = &Bun.getPublicPathJS,
+            .enumerable = false,
         },
         .registerMacro = .{
             .rfn = &Bun.registerMacro,
@@ -1211,6 +1046,44 @@ pub const Class = NewClass(
         .jest = .{
             .rfn = &@import("../test/jest.zig").Jest.call,
             .enumerable = false,
+        },
+
+        // TODO: remove these deprecated methods before 1.0
+        .getImportedStyles = .{
+            .rfn = &Bun.getImportedStyles,
+            .enumerable = false,
+        },
+        .getRouteFiles = .{
+            .rfn = &Bun.getRouteFiles,
+            .enumerable = false,
+        },
+        .match = .{
+            .rfn = &Router.deprecatedBunGlobalMatch,
+            .enumerable = false,
+        },
+        .getRouteNames = .{
+            .rfn = &Bun.getRouteNames,
+            .enumerable = false,
+        },
+
+        // Public API
+        .sleepSync = .{
+            .rfn = &sleepSync,
+        },
+        // .fetch = .{
+        //     .rfn = &Fetch.call,
+        // },
+        .inspect = .{
+            .rfn = &Bun.inspect,
+        },
+        .resolveSync = .{
+            .rfn = &Bun.resolveSync,
+        },
+        .resolve = .{
+            .rfn = &Bun.resolve,
+        },
+        .getPublicPath = .{
+            .rfn = &Bun.getPublicPathJS,
         },
         .indexOfLine = .{
             .rfn = &Bun.indexOfLine,
@@ -1233,9 +1106,6 @@ pub const Class = NewClass(
         .openInEditor = .{
             .rfn = &Bun.openInEditor,
         },
-        .readAllStdinSync = .{
-            .rfn = &Bun.readAllStdinSync,
-        },
         .serve = .{
             .rfn = &Bun.serve,
         },
@@ -1251,9 +1121,6 @@ pub const Class = NewClass(
         .nanoseconds = .{
             .rfn = &nanoseconds,
         },
-        .DO_NOT_USE_OR_YOU_WILL_BE_FIRED_mimalloc_dump = .{
-            .rfn = &dump_mimalloc,
-        },
         .gzipSync = .{
             .rfn = &JSC.wrapWithHasContainer(JSZlib, "gzipSync", false, false, true),
         },
@@ -1266,7 +1133,6 @@ pub const Class = NewClass(
         .inflateSync = .{
             .rfn = &JSC.wrapWithHasContainer(JSZlib, "inflateSync", false, false, true),
         },
-
         .which = .{
             .rfn = &which,
         },
@@ -1279,11 +1145,9 @@ pub const Class = NewClass(
         .build = .{
             .rfn = &Bun.JSBundler.buildFn,
         },
-
         .listen = .{
             .rfn = &JSC.wrapWithHasContainer(JSC.API.Listener, "listen", false, false, false),
         },
-
         .connect = .{
             .rfn = &JSC.wrapWithHasContainer(JSC.API.Listener, "connect", false, false, false),
         },
@@ -1307,11 +1171,15 @@ pub const Class = NewClass(
         .stderr = .{
             .get = getStderr,
         },
+        // TODO: remove this before 1.0
         .routesDir = .{
             .get = getRoutesDir,
+            .enumerable = false,
         },
+        // TODO: remove this before 1.0
         .assetPrefix = .{
             .get = getAssetPrefix,
+            .enumerable = false,
         },
         .argv = .{
             .get = getArgv,

--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -1156,8 +1156,10 @@ pub const Class = NewClass(
         .main = .{
             .get = getMain,
         },
+        // TODO: decide what we want to do
         .cwd = .{
             .get = getCWD,
+            .enumerable = false,
         },
         .origin = .{
             .get = getOrigin,

--- a/src/js/wasi-runner.js
+++ b/src/js/wasi-runner.js
@@ -35,7 +35,7 @@ const wasi = new WASI({
 
 let source = globalThis.wasmSourceBytes;
 if (!source) {
-  const fs = Bun.fs();
+  const fs = import.meta.require('fs');
   const file = import.meta.path;
   source = fs.readFileSync(file);
 }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
