### PR TITLE
Bind `require.resolve`

### DIFF
--- a/src/bun.js/bindings/CommonJSModuleRecord.cpp
+++ b/src/bun.js/bindings/CommonJSModuleRecord.cpp
@@ -209,7 +209,8 @@ RequireFunctionPrototype* RequireFunctionPrototype::create(
     RequireFunctionPrototype* prototype = new (NotNull, JSC::allocateCell<RequireFunctionPrototype>(vm)) RequireFunctionPrototype(vm, structure);
     prototype->finishCreation(vm);
 
-    prototype->putDirect(vm, JSC::Identifier::fromString(vm, "resolve"_s), static_cast<Zig::GlobalObject*>(globalObject)->requireResolveFunctionUnbound(), PropertyAttribute::Function | 0);
+        prototype->putDirect(vm, JSC::Identifier::fromString(vm, "resolve"_s), static_cast<Zig::GlobalObject*>(globalObject)->requireResolveFunctionUnbound(), PropertyAttribute::Function | 0);
+
 
     return prototype;
 }

--- a/test/js/bun/resolve/baz-common.cjs
+++ b/test/js/bun/resolve/baz-common.cjs
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/js/bun/resolve/bound-require.test.cjs
+++ b/test/js/bun/resolve/bound-require.test.cjs
@@ -1,0 +1,49 @@
+"use strict";
+var toPass, toFail;
+
+if (process.versions.bun) {
+  const jest = Bun.jest(__filename);
+  toPass = (fn) => {
+    const string = fn.toString().slice(2).trim().slice(2).trim();
+    jest.test(string, () => {
+      expect(() => fn()).not.toThrow();
+    });
+  };
+  toFail = (fn) => {
+    const string = fn.toString().slice(2).trim().slice(2).trim();
+    jest.test(string, () => {
+      expect(() => fn()).toThrow();
+    });
+  };
+} else {
+  toPass = function toPass(fn) {
+    const string = fn.toString().slice(2).trim().slice(2).trim();
+    try {
+      fn();
+      console.log(`PASS: ${string} resolves`);
+    } catch (e) {
+      console.log(`X FAIL: ${string} (expected this to work)`);
+      console.log(e);
+    }
+  }
+  toFail = function toFail(fn) {
+    const string = fn.toString().slice(2).trim().slice(2).trim();
+    try {
+      fn();
+      console.log(`X FAIL: ${string} (expected this to break)`);
+    } catch (e) {
+      console.log(`PASS: ${string} errors`);
+    }
+  }
+}
+
+toPass(() => require('./baz-common.cjs'));
+toPass(() => require.call(null, './baz-common.cjs'));
+toPass(() => module.require('./baz-common.cjs'));
+
+toFail(() => module.require.call(null, './baz-common.cjs'));
+
+toPass(() => require.resolve('./baz-common.cjs'));
+toPass(() => require.resolve.call('./baz-common.cjs'));
+
+toFail(() => module.require.resolve('./baz-common.cjs'));


### PR DESCRIPTION
Have not really started it, this is what we need to match:

```
module.require         - is unbound
module.require.resolve - does not exist

require                - is bound
require.resolve        - exists and is bound
```

By bound I mean doing `.call(null, "...")` works.

Right now we have require.resolve set as a prototype on the require, so it needs `require.resolve.bind(require)` to work.

I only wrote tests so far but maybe we use lazy property stuff to generate a require function's resolve on the fly, or do we just call `.bind` when we generate the transpiled code?