### PR TITLE
fix macro string escaping

### DIFF
--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -26,7 +26,6 @@ const is_bindgen = std.meta.globalOption("bindgen", bool) orelse false;
 const ComptimeStringMap = bun.ComptimeStringMap;
 const JSPrinter = @import("./js_printer.zig");
 const ThreadlocalArena = @import("./mimalloc_arena.zig").Arena;
-const js_printer = @import("./js_printer.zig");
 
 /// This is the index to the automatically-generated part containing code that
 /// calls "__export(exports, { ... getters ... })". This is used to generate

--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -75,6 +75,19 @@ pub const JSONOptions = struct {
     was_originally_macro: bool = false,
 };
 
+pub fn decodeUTF8(bytes: string, allocator: std.mem.Allocator) ![]const u16 {
+    var log = logger.Log.init(allocator);
+    defer log.deinit();
+    var source = logger.Source.initEmptyFile("");
+    var lexer = try NewLexer(.{}).init(&log, source, allocator);
+    defer lexer.deinit();
+
+    var buf = std.ArrayList(u16).init(allocator);
+    try lexer.decodeEscapeSequences(0, bytes, @TypeOf(buf), &buf);
+
+    return buf.items;
+}
+
 pub fn NewLexer(
     comptime json_options: JSONOptions,
 ) type {

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -2026,55 +2026,6 @@ pub fn elementLengthLatin1IntoUTF16(comptime Type: type, latin1_: Type) usize {
     return count;
 }
 
-pub fn unescape(_bytes: []u8) []const u8 {
-    var new_bytes = _bytes;
-    var new_i: usize = 0;
-    var remain = new_bytes;
-    while (indexOfChar(remain, '\\')) |i| {
-        bun.copy(u8, new_bytes[new_i..], remain[0..i]);
-        new_i += i;
-        if (i + 1 < remain.len) {
-            switch (remain[i + 1]) {
-                'b' => {
-                    new_bytes[new_i] = '\x08';
-                },
-                'f' => {
-                    new_bytes[new_i] = '\x0c';
-                },
-                'n' => {
-                    new_bytes[new_i] = '\n';
-                },
-                'r' => {
-                    new_bytes[new_i] = '\r';
-                },
-                't' => {
-                    new_bytes[new_i] = '\t';
-                },
-                'v' => {
-                    new_bytes[new_i] = '\x0b';
-                },
-                else => {
-                    new_bytes[new_i] = remain[i + 1];
-                },
-            }
-            new_i += 1;
-            remain = remain[i + 2 ..];
-        } else {
-            new_bytes[new_i] = '\\';
-            new_i += 1;
-            remain = remain[i + 1 ..];
-        }
-    }
-
-    if (remain.len > 0) {
-        bun.copy(u8, new_bytes[new_i..], remain);
-        new_i += remain.len;
-    }
-
-    new_bytes.len = new_i;
-    return new_bytes;
-}
-
 pub fn escapeHTMLForLatin1Input(allocator: std.mem.Allocator, latin1: []const u8) !Escaped(u8) {
     const Scalar = struct {
         pub const lengths: [std.math.maxInt(u8)]u4 = brk: {

--- a/test/transpiler/macro-test.test.ts
+++ b/test/transpiler/macro-test.test.ts
@@ -1,4 +1,4 @@
-import { identity } from "./macro.ts" assert { type: "macro" };
+import { identity, escape } from "./macro.ts" assert { type: "macro" };
 
 test("latin1 string", () => {
   expect(identity("©")).toBe("©");
@@ -6,6 +6,31 @@ test("latin1 string", () => {
 
 test("ascii string", () => {
   expect(identity("abc")).toBe("abc");
+});
+
+test("escaping", () => {
+  expect(identity("\\")).toBe("\\");
+  expect(identity("\f")).toBe("\f");
+  expect(identity("\n")).toBe("\n");
+  expect(identity("\r")).toBe("\r");
+  expect(identity("\t")).toBe("\t");
+  expect(identity("\v")).toBe("\v");
+  expect(identity("\0")).toBe("\0");
+  expect(identity("'")).toBe("'");
+  expect(identity('"')).toBe('"');
+  expect(identity("`")).toBe("`");
+  // prettier-ignore
+  expect(identity("\'")).toBe("\'");
+  // prettier-ignore
+  expect(identity('\"')).toBe('\"');
+  // prettier-ignore
+  expect(identity("\`")).toBe("\`");
+  expect(identity("$")).toBe("$");
+  expect(identity("\x00")).toBe("\x00");
+  expect(identity("\x0B")).toBe("\x0B");
+  expect(identity("\x0C")).toBe("\x0C");
+
+  expect(escape()).toBe("\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C");
 });
 
 test("utf16 string", () => {

--- a/test/transpiler/macro-test.test.ts
+++ b/test/transpiler/macro-test.test.ts
@@ -1,4 +1,4 @@
-import { identity, escape } from "./macro.ts" assert { type: "macro" };
+import { identity, escape, addStringsUTF16, addStrings } from "./macro.ts" assert { type: "macro" };
 
 test("latin1 string", () => {
   expect(identity("©")).toBe("©");
@@ -30,7 +30,43 @@ test("escaping", () => {
   expect(identity("\x0B")).toBe("\x0B");
   expect(identity("\x0C")).toBe("\x0C");
 
+  expect(identity("\\")).toBe("\\");
+
   expect(escape()).toBe("\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C");
+
+  expect(addStrings("abc")).toBe("abc\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("\n")).toBe("\n\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("\r")).toBe("\r\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("\t")).toBe("\t\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("©")).toBe("©\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("\x00")).toBe("\x00\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("\x0B")).toBe("\x0B\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("\x0C")).toBe("\x0C\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("\\")).toBe("\\\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("\f")).toBe("\f\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("\v")).toBe("\v\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("\0")).toBe("\0\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("'")).toBe("'\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings('"')).toBe('"\\\f\n\r\t\v\0\'"`$\x00\x0B\x0C©');
+  expect(addStrings("`")).toBe("`\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+  expect(addStrings("😊")).toBe("😊\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C©");
+
+  expect(addStringsUTF16("abc")).toBe("abc\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("\n")).toBe("\n\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("\r")).toBe("\r\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("\t")).toBe("\t\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("©")).toBe("©\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("\x00")).toBe("\x00\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("\x0B")).toBe("\x0B\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("\x0C")).toBe("\x0C\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("\\")).toBe("\\\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("\f")).toBe("\f\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("\v")).toBe("\v\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("\0")).toBe("\0\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("'")).toBe("'\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16('"')).toBe('"\\\f\n\r\t\v\0\'"`$\x00\x0B\x0C😊');
+  expect(addStringsUTF16("`")).toBe("`\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
+  expect(addStringsUTF16("😊")).toBe("😊\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C😊");
 });
 
 test("utf16 string", () => {

--- a/test/transpiler/macro.ts
+++ b/test/transpiler/macro.ts
@@ -1,3 +1,7 @@
 export function identity(arg: any) {
   return arg;
 }
+
+export function escape() {
+  return "\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C";
+}

--- a/test/transpiler/macro.ts
+++ b/test/transpiler/macro.ts
@@ -5,3 +5,11 @@ export function identity(arg: any) {
 export function escape() {
   return "\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C";
 }
+
+export function addStrings(arg: string) {
+  return arg + "\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C" + "©";
+}
+
+export function addStringsUTF16(arg: string) {
+  return arg + "\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C" + "😊";
+}


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
strings passed as arguments to macros and strings returned from macros are escaped correctly

### How did you verify your code works?
added macro tests for escape characters

fixes #3957 

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
