### PR TITLE
Buffer.copy should ignore out-of-range sourceEnd

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -949,7 +949,8 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_copyBody(JSC::JSGlob
     }
 
     targetStart = std::min(targetStart, targetEnd);
-    sourceStart = std::min(sourceStart, std::min(sourceEnd, sourceEndInit));
+    sourceEnd = std::min(sourceEnd, sourceEndInit);
+    sourceStart = std::min(sourceStart, sourceEnd);
 
     auto sourceLength = sourceEnd - sourceStart;
     auto targetLength = targetEnd - targetStart;

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1201,20 +1201,22 @@ it("Buffer.compare", () => {
   }
 });
 
-it("Buffer.copy", () => {
-  var array1 = new Uint8Array(128);
-  array1.fill(100);
-  array1 = new Buffer(array1.buffer);
-  var array2 = new Uint8Array(128);
-  array2.fill(200);
-  array2 = new Buffer(array2.buffer);
-  var array3 = new Uint8Array(128);
-  array3 = new Buffer(array3.buffer);
-  gc();
-  expect(array1.copy(array2)).toBe(128);
-  expect(array1.join("")).toBe(array2.join(""));
+describe("Buffer.copy", () => {
+  it("should work", () => {
+    var array1 = new Uint8Array(128);
+    array1.fill(100);
+    array1 = new Buffer(array1.buffer);
+    var array2 = new Uint8Array(128);
+    array2.fill(200);
+    array2 = new Buffer(array2.buffer);
+    var array3 = new Uint8Array(128);
+    array3 = new Buffer(array3.buffer);
+    gc();
+    expect(array1.copy(array2)).toBe(128);
+    expect(array1.join("")).toBe(array2.join(""));
+  });
 
-  {
+  it("should work with offset", () => {
     // Create two `Buffer` instances.
     const buf1 = Buffer.allocUnsafe(26);
     const buf2 = Buffer.allocUnsafe(26).fill("!");
@@ -1227,9 +1229,23 @@ it("Buffer.copy", () => {
     // Copy `buf1` bytes 16 through 19 into `buf2` starting at byte 8 of `buf2`.
     buf1.copy(buf2, 8, 16, 20);
     expect(buf2.toString("ascii", 0, 25)).toBe("!!!!!!!!qrst!!!!!!!!!!!!!");
-  }
+  });
 
-  {
+  it("should ignore sourceEnd if it's out of range", () => {
+    const buf1 = Buffer.allocUnsafe(26);
+    const buf2 = Buffer.allocUnsafe(10).fill("!");
+
+    for (let i = 0; i < 26; i++) {
+      // 97 is the decimal ASCII value for 'a'.
+      buf1[i] = i + 97;
+    }
+
+    // Copy `buf1` bytes "xyz" into `buf2` starting at byte 1 of `buf2`.
+    expect(buf1.copy(buf2, 1, 23, 100)).toBe(3);
+    expect(buf2.toString()).toBe("!xyz!!!!!!");
+  });
+
+  it("copy to the same buffer", () => {
     const buf = Buffer.allocUnsafe(26);
 
     for (let i = 0; i < 26; i++) {
@@ -1239,7 +1255,7 @@ it("Buffer.copy", () => {
 
     buf.copy(buf, 0, 4, 10);
     expect(buf.toString()).toBe("efghijghijklmnopqrstuvwxyz");
-  }
+  });
 });
 
 export function fillRepeating(dstBuffer, start, end) {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

fixes #3947 

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
