### PR TITLE
feat(hot-clear-screen): clear terminal on hot reload

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -626,6 +626,12 @@ pub const VirtualMachine = struct {
             bun.reloadProcess(bun.default_allocator, !strings.eqlComptime(this.bundler.env.map.get("BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD") orelse "0", "true"));
         }
 
+        if (!strings.eqlComptime(this.bundler.env.map.get("BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD") orelse "0", "true")) {
+            Output.flush();
+            Output.disableBuffering();
+            Output.resetTerminalAll();
+        }
+
         this.global.reload();
         this.pending_internal_promise = this.reloadEntryPoint(this.main) catch @panic("Failed to reload");
     }
@@ -1792,13 +1798,6 @@ pub const VirtualMachine = struct {
             main_file_name,
         );
         this.eventLoop().ensureWaker();
-
-        // Clear the terminal
-        if (!strings.eqlComptime(this.bundler.env.map.get("BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD") orelse "0", "true")) {
-            Output.flush();
-            Output.disableBuffering();
-            Output.resetTerminalAll();
-        }
 
         var promise: *JSInternalPromise = undefined;
 

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1793,6 +1793,13 @@ pub const VirtualMachine = struct {
         );
         this.eventLoop().ensureWaker();
 
+        // Clear the terminal
+        if (!strings.eqlComptime(this.bundler.env.map.get("BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD") orelse "0", "true")) {
+            Output.flush();
+            Output.disableBuffering();
+            Output.resetTerminalAll();
+        }
+
         var promise: *JSInternalPromise = undefined;
 
         if (!this.bundler.options.disable_transpilation) {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -630,6 +630,7 @@ pub const VirtualMachine = struct {
             Output.flush();
             Output.disableBuffering();
             Output.resetTerminalAll();
+            Output.enableBuffering();
         }
 
         this.global.reload();


### PR DESCRIPTION
### feat(hot-clear-screen): clear terminal on hot reload

this clears the screen on file change when running with the `--hot` flag which is similar to how `--watch` behaves currently.
this will address #3954.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I tested it locally

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
