### PR TITLE
Remove Bun.plugin transpiler hook, encourage usage of `--preload` instead

### DIFF
--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -1258,7 +1258,6 @@ pub const Bundler = struct {
         macro_js_ctx: MacroJSValueType = default_macro_js_value,
         virtual_source: ?*const logger.Source = null,
         replace_exports: runtime.Runtime.Features.ReplaceableExport.Map = .{},
-        hoist_bun_plugin: bool = false,
         inject_jest_globals: bool = false,
 
         dont_bundle_twice: bool = false,
@@ -1412,7 +1411,6 @@ pub const Bundler = struct {
                     strings.eqlComptime(jsx.import_source.production, "react/jsx-runtime");
 
                 opts.features.jsx_optimization_hoist = bundler.options.jsx_optimization_hoist orelse opts.features.jsx_optimization_inline;
-                opts.features.hoist_bun_plugin = this_parse.hoist_bun_plugin;
                 opts.features.inject_jest_globals = this_parse.inject_jest_globals;
                 opts.features.minify_syntax = bundler.options.minify_syntax;
                 opts.features.minify_identifiers = bundler.options.minify_identifiers;

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -6411,7 +6411,6 @@ pub const Part = struct {
         cjs_imports,
         react_fast_refresh,
         dirname_filename,
-        // bun_plugin,
         bun_test,
         dead_due_to_inlining,
         commonjs_named_export,

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -5940,8 +5940,6 @@ pub const Ast = struct {
     wrapper_ref: Ref = Ref.None,
     require_ref: Ref = Ref.None,
 
-    bun_plugin: BunPlugin = .{},
-
     prepend_part: ?Part = null,
 
     // These are used when bundling. They are filled in during the parser pass
@@ -6413,7 +6411,7 @@ pub const Part = struct {
         cjs_imports,
         react_fast_refresh,
         dirname_filename,
-        bun_plugin,
+        // bun_plugin,
         bun_test,
         dead_due_to_inlining,
         commonjs_named_export,
@@ -6680,11 +6678,6 @@ pub fn printmem(comptime format: string, args: anytype) void {
     Output.initTest();
     Output.print(format, args);
 }
-
-pub const BunPlugin = struct {
-    ref: Ref = Ref.None,
-    hoisted_stmts: std.ArrayListUnmanaged(Stmt) = .{},
-};
 
 pub const Macro = struct {
     const JavaScript = @import("root").bun.JSC;

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -4803,7 +4803,6 @@ fn NewParser_(
         filename_ref: Ref = Ref.None,
         dirname_ref: Ref = Ref.None,
         import_meta_ref: Ref = Ref.None,
-        bun_plugin: js_ast.BunPlugin = .{},
         scopes_in_order_visitor_index: usize = 0,
         has_classic_runtime_warned: bool = false,
         macro_call_count: MacroCallCountType = 0,
@@ -8144,38 +8143,6 @@ fn NewParser_(
                 }
 
                 return p.s(S.Empty{}, loc);
-            }
-
-            if (p.options.features.hoist_bun_plugin and strings.eqlComptime(path.text, "bun")) {
-                var plugin_i: usize = std.math.maxInt(usize);
-                const items = stmt.items;
-                for (items, 0..) |item, i| {
-                    // Mark Bun.plugin()
-                    // TODO: remove if they have multiple imports of the same name?
-                    if (strings.eqlComptime(item.alias, "plugin")) {
-                        const name = p.loadNameFromRef(item.name.ref.?);
-                        const ref = try p.declareSymbol(.other, item.name.loc, name);
-                        try p.is_import_item.put(p.allocator, ref, {});
-                        p.bun_plugin.ref = ref;
-                        plugin_i = i;
-                        break;
-                    }
-                }
-
-                if (plugin_i != std.math.maxInt(usize)) {
-                    var list = std.ArrayListUnmanaged(@TypeOf(stmt.items[0])){
-                        .items = stmt.items,
-                        .capacity = stmt.items.len,
-                    };
-                    // remove it from the list
-                    _ = list.swapRemove(plugin_i);
-                    stmt.items = list.items;
-                }
-
-                // if the import statement is now empty, remove it completely
-                if (stmt.items.len == 0 and stmt.default_name == null and stmt.star_name_loc == null) {
-                    return p.s(S.Empty{}, loc);
-                }
             }
 
             const macro_remap = if ((comptime allow_macros) and !is_macro)
@@ -14563,10 +14530,6 @@ fn NewParser_(
             var partStmts = ListManaged(Stmt).fromOwnedSlice(allocator, stmts);
 
             //
-            const bun_plugin_usage_count_before: usize = if (p.options.features.hoist_bun_plugin and !p.bun_plugin.ref.isNull())
-                p.symbols.items[p.bun_plugin.ref.innerIndex()].use_count_estimate
-            else
-                0;
 
             try p.visitStmtsAndPrependTempRefs(&partStmts, &opts);
 
@@ -14601,52 +14564,6 @@ fn NewParser_(
 
             if (partStmts.items.len > 0) {
                 const _stmts = partStmts.items;
-
-                // -- hoist_bun_plugin --
-                if (_stmts.len == 1 and p.options.features.hoist_bun_plugin and !p.bun_plugin.ref.isNull()) {
-                    const bun_plugin_usage_count_after: usize = p.symbols.items[p.bun_plugin.ref.innerIndex()].use_count_estimate;
-                    if (bun_plugin_usage_count_after > bun_plugin_usage_count_before) {
-                        var previous_parts: []js_ast.Part = parts.items;
-
-                        for (previous_parts, 0..) |*previous_part, j| {
-                            if (previous_part.stmts.len == 0) continue;
-
-                            var refs = previous_part.declared_symbols.refs();
-
-                            for (refs) |ref| {
-                                if (p.symbol_uses.contains(ref)) {
-                                    // we move this part to our other file
-                                    for (previous_parts[0..j]) |*this_part| {
-                                        if (this_part.stmts.len == 0) continue;
-                                        const other_refs = this_part.declared_symbols.refs();
-
-                                        for (other_refs) |other_ref| {
-                                            if (previous_part.symbol_uses.contains(other_ref)) {
-                                                try p.bun_plugin.hoisted_stmts.appendSlice(p.allocator, this_part.stmts);
-                                                this_part.stmts = &.{};
-                                                break;
-                                            }
-                                        }
-                                    }
-
-                                    try p.bun_plugin.hoisted_stmts.appendSlice(p.allocator, previous_part.stmts);
-                                    break;
-                                }
-                            }
-                        }
-                        p.bun_plugin.hoisted_stmts.append(p.allocator, _stmts[0]) catch unreachable;
-
-                        // Single-statement part which uses Bun.plugin()
-                        // It's effectively an unrelated file
-                        if (p.declared_symbols.len() > 0 or p.symbol_uses.count() > 0) {
-                            p.clearSymbolUsagesFromDeadPart(.{ .stmts = undefined, .declared_symbols = p.declared_symbols, .symbol_uses = p.symbol_uses });
-                            p.declared_symbols.clearRetainingCapacity();
-                            p.import_records_for_current_part.items.len = 0;
-                        }
-                        return;
-                    }
-                }
-                // -- hoist_bun_plugin --
 
                 try parts.append(js_ast.Part{
                     .stmts = _stmts,
@@ -21922,7 +21839,6 @@ fn NewParser_(
                 else
                     false,
                 // .top_Level_await_keyword = p.top_level_await_keyword,
-                .bun_plugin = p.bun_plugin,
                 .commonjs_named_exports = p.commonjs_named_exports,
                 .commonjs_export_names = p.commonjs_export_names.keys(),
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -314,8 +314,6 @@ pub const Runtime = struct {
 
         replace_exports: ReplaceableExport.Map = .{},
 
-        hoist_bun_plugin: bool = false,
-
         dont_bundle_twice: bool = false,
 
         /// This is a list of packages which even when require() is used, we will


### PR DESCRIPTION
### What does this PR do?

This fully removes the transpiler macro we have for `import { plugin } from 'bun'`. What bun tried to do before is given code that calls plugin:

```ts
import { plugin } from "bun";
import mdx from "@mdx-js/esbuild";

plugin(mdx());

import { renderToStaticMarkup } from "react-dom/server";
import Foo from "./bar.mdx";
console.log(renderToStaticMarkup(<Foo />));
```

Bun used to hoist this call into a new file

```ts
import { plugin } from "bun";
import mdx from "@mdx-js/esbuild";
plugin(mdx());
```

And execute that as a preload.

The hook is broken for any non-trival use cases and is overall very confusing to developers because it's too magical.

What should be done instead is `plugin` should be called in it's own file, and then loaded with `--preload`. So you'd save the second code block above into it's own file like `preload.ts` and then run just your application code like `bun -r ./preload.ts ./index.tsx`, and it works.

This pattern gives the developer a better understanding of what is actually going on:
- Preload is loaded
- All imports in preload are evaluated before any code runs
- Plugin is registered
- Main script is loaded
- Those imports are all evaluated before code starts
- (Plugin onLoad/onResolve hits)
- Application code starts

So by this logic of `import` statements running before app code, it does mean you can register plugins during app code runtime and use `await import` after calling Bun.plugin, but this pattern we should discourage.

Closes #3968
Closes #3068
Closes #1441

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

ran the automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
