### PR TITLE
Support `--dev`/`-D` and support dependency flags on `bun install`

### DIFF
--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -49,7 +49,7 @@ _bun() {
                 '--production[Don'"'"'t install devDependencies]' \
                 '--frozen-lockfile[Disallow changes to lockfile]' \
                 '--optional[Add dependency to optionalDependencies]' \
-                '--development[Add dependency to devDependencies]' \
+                '--dev[Add dependency to devDependencies]' \
                 '-d[Add dependency to devDependencies]' \
                 '-p[Don'"'"'t install devDependencies]' \
                 '--no-save[]' \
@@ -91,7 +91,7 @@ _bun() {
                 '--production[Don'"'"'t install devDependencies]' \
                 '--frozen-lockfile[Disallow changes to lockfile]' \
                 '--optional[Add dependency to optionalDependencies]' \
-                '--development[Add dependency to devDependencies]' \
+                '--dev[Add dependency to devDependencies]' \
                 '-d[Add dependency to devDependencies]' \
                 '-p[Don'"'"'t install devDependencies]' \
                 '--no-save[]' \
@@ -127,7 +127,7 @@ _bun() {
                 '--production[Don'"'"'t install devDependencies]' \
                 '--frozen-lockfile[Disallow changes to lockfile]' \
                 '--optional[Add dependency to optionalDependencies]' \
-                '--development[Add dependency to devDependencies]' \
+                '--dev[Add dependency to devDependencies]' \
                 '-d[Add dependency to devDependencies]' \
                 '-p[Don'"'"'t install devDependencies]' \
                 '--no-save[]' \

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -114,7 +114,7 @@ $ bun add zod@latest
 To add a package as a dev dependency (`"devDependencies"`):
 
 ```bash
-$ bun add --development @types/react
+$ bun add --dev @types/react
 $ bun add -d @types/react
 ```
 

--- a/docs/guides/install/add-dev.md
+++ b/docs/guides/install/add-dev.md
@@ -5,7 +5,7 @@ name: Add a development dependency
 To add an npm package as a development dependency, use `bun add --development`.
 
 ```sh
-$ bun add zod --development
+$ bun add zod --dev
 $ bun add zod -d # shorthand
 ```
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -114,7 +114,7 @@ $ bun add zod@latest
 To add a package as a dev dependency (`"devDependencies"`):
 
 ```bash
-$ bun add --development @types/react
+$ bun add --dev @types/react
 $ bun add -d @types/react
 ```
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5772,6 +5772,10 @@ pub const PackageManager = struct {
     };
 
     const install_params = install_params_ ++ [_]ParamType{
+        clap.parseParam("-d, --dev                 Add dependency to \"devDependencies\"") catch unreachable,
+        clap.parseParam("-D, --development") catch unreachable,
+        clap.parseParam("--optional                        Add dependency to \"optionalDependencies\"") catch unreachable,
+        clap.parseParam("--exact                      Add the exact version instead of the ^range") catch unreachable,
         clap.parseParam("<POS> ...                         ") catch unreachable,
     };
 
@@ -5780,7 +5784,8 @@ pub const PackageManager = struct {
     };
 
     const add_params = install_params_ ++ [_]ParamType{
-        clap.parseParam("-d, --development                 Add dependency to \"devDependencies\"") catch unreachable,
+        clap.parseParam("-d, --dev                 Add dependency to \"devDependencies\"") catch unreachable,
+        clap.parseParam("-D, --development") catch unreachable,
         clap.parseParam("--optional                        Add dependency to \"optionalDependencies\"") catch unreachable,
         clap.parseParam("--exact                      Add the exact version instead of the ^range") catch unreachable,
         clap.parseParam("<POS> ...                         \"name\" or \"name@version\" of packages to install") catch unreachable,
@@ -5910,8 +5915,8 @@ pub const PackageManager = struct {
 
             cli.link_native_bins = args.options("--link-native-bins");
 
-            if (comptime subcommand == .add) {
-                cli.development = args.flag("--development");
+            if (comptime subcommand == .add or subcommand == .install) {
+                cli.development = args.flag("--development") or args.flag("--dev");
                 cli.optional = args.flag("--optional");
                 cli.exact = args.flag("--exact");
             }


### PR DESCRIPTION
### What does this PR do?

Support `--dev`/`-D`. Yarn ~and pnpm~ use `--dev` so it is more expected.
Support dependency flags on `bun install` (long overdue)

Ideally we'd rework clap to support "hidden flags". Currently the helptext looks as below. Separate lines for both `-d, --dev` and `-D, --development` but visually they share a description.

```txt
bun-debug add -h    
[SYS] read(3, 4096) = 4096 (0.211ms)
[SYS] close(3)
	-c, --config <STR>?            	Load config (bunfig.toml)
	-y, --yarn                     	Write a yarn.lock file (yarn v1)
	-p, --production               	Don't install devDependencies
	    --no-save                  	Don't save a lockfile
	    --save                     	Save to package.json
	    --dry-run                  	Don't install anything
	    --lockfile <PATH>          	Store & load a lockfile at a specific filepath
	    --frozen-lockfile          	Disallow changes to lockfile
	-f, --force                    	Always request the latest versions from the registry & reinstall all dependencies
	    --cache-dir <PATH>         	Store & load cached data from a specific directory path
	    --no-cache                 	Ignore manifest cache entirely
	    --silent                   	Don't log anything
	    --verbose                  	Excessively verbose logging
	    --no-progress              	Disable the progress bar
	    --no-summary               	Don't print a summary
	    --no-verify                	Skip verifying integrity of newly downloaded packages
	    --ignore-scripts           	Skip lifecycle scripts in the project's package.json (dependency scripts are never run)
	-g, --global                   	Install globally
	    --cwd <STR>                	Set a specific cwd
	    --backend <STR>            	Platform-specific optimizations for installing dependencies. Possible values: "clonefile" (default), "hardlink", "symlink", "copyfile"
	    --link-native-bins <STR>...	Link "bin" from a matching platform-specific "optionalDependencies" instead. Default: esbuild, turbo
	    --help                     	Print this help menu
	-d, --dev                      	Add dependency to "devDependencies"
	-D, --development              	
	    --optional                 	Add dependency to "optionalDependencies"
	    --exact                    	Add the exact version instead of the ^range
```

