### PR TITLE
Fix(cli/init): support subpath entrypoint.

### DIFF
--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -337,7 +337,14 @@ pub const InitCommand = struct {
         }
 
         if (fields.entry_point.len > 0 and !exists(fields.entry_point)) {
-            var entry = try std.fs.cwd().createFile(fields.entry_point, .{ .truncate = true });
+            const cwd = std.fs.cwd();
+            if (std.fs.path.dirname(fields.entry_point)) |dirname| {
+                if (!(dirname.len == 0 and dirname[0] == '.')) {
+                    cwd.makePath(dirname) catch {};
+                }
+            }
+
+            var entry = try cwd.createFile(fields.entry_point, .{ .truncate = true });
             entry.writeAll("console.log(\"Hello via Bun!\");") catch {};
             entry.close();
             Output.prettyln(" + <r><d>{s}<r>", .{fields.entry_point});

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -339,7 +339,7 @@ pub const InitCommand = struct {
         if (fields.entry_point.len > 0 and !exists(fields.entry_point)) {
             const cwd = std.fs.cwd();
             if (std.fs.path.dirname(fields.entry_point)) |dirname| {
-                if (!(dirname.len == 0 and dirname[0] == '.')) {
+                if (!strings.eqlComptime(dirname, ".")) {
                     cwd.makePath(dirname) catch {};
                 }
             }


### PR DESCRIPTION
Close: #3444

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- Support subpath entrypoint, e.g. `./src/index.ts`

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

test locally with

- `./src/index.ts`
- `src/index.ts`


<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
