### PR TITLE
Adjust os:freemem calculations

### DIFF
--- a/src/darwin_c.zig
+++ b/src/darwin_c.zig
@@ -488,21 +488,14 @@ pub const HOST_VM_INFO64 = 4;
 pub extern fn host_statistics64(host_priv: std.c.host_t, flavor: std.c.host_flavor_t, host_info64_out: std.c.host_info64_t, host_info64_outCnt: *std.c.mach_msg_type_number_t) std.c.E;
 
 pub fn get_free_memory() u64 {
-    const host: std.c.mach_port_t = std.c.mach_host_self();
     var count = std.c.TASK_VM_INFO_COUNT;
 
     var stats: std.c.vm_statistics64 = undefined;
-    var pageSize: std.c.vm_size_t = undefined;
-
-    if (std.c._host_page_size(host, &pageSize) != @as(c_int, 0)) {
-        pageSize = @as(std.c.vm_size_t, 4096);
-    }
-
-    if (host_statistics64(host, HOST_VM_INFO64, @as(std.c.host_info64_t, @ptrCast(&stats)), &count) != .SUCCESS) {
+    if (host_statistics64(std.c.mach_host_self(), HOST_VM_INFO64, @as(std.c.host_info64_t, @ptrCast(&stats)), &count) != .SUCCESS) {
         return 0;
     }
     
-    return @as(u64, @bitCast(@as(c_ulonglong, @as(std.c.vm_size_t, @bitCast(@as(c_ulong, stats.free_count))) *% pageSize)));
+    return stats.free_count *% std.mem.page_size;
 }
 
 pub fn get_total_memory() u64 {

--- a/src/linux_c.zig
+++ b/src/linux_c.zig
@@ -418,7 +418,7 @@ pub extern fn sysinfo(__info: [*c]struct_sysinfo) c_int;
 
 pub fn get_free_memory() u64 {
     var info: struct_sysinfo = undefined;
-    if (sysinfo(&info) == @as(c_int, 0)) return @as(u64, @bitCast(info.freeram)) *% @as(c_ulong, @bitCast(@as(c_ulong, info.mem_unit)));
+    if (sysinfo(&info) == @as(c_int, 0)) return @as(u64, @bitCast(info.freeram +% info.bufferram)) *% @as(c_ulong, @bitCast(@as(c_ulong, info.mem_unit)));
     return 0;
 }
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes
Implements get_free_memory for darwin_c, and adjusts how its calculated under linux to match how node does it.

https://github.com/oven-sh/bun/issues/3944

### How did you verify your code works?

I ran the sample code in [the ticket below](https://github.com/oven-sh/bun/issues/3944). Not too sure how to test it without a linux system?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
