### PR TITLE
Add support for bun --revision

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -218,7 +218,6 @@ pub fn build(b: *Build) !void {
                     .argv = &.{
                         "git",
                         "rev-parse",
-                        "--short",
                         "HEAD",
                     },
                     .cwd = b.pathFromRoot("."),

--- a/src/__global.zig
+++ b/src/__global.zig
@@ -25,11 +25,11 @@ else
 pub const package_json_version_with_revision = if (Environment.git_sha.len == 0)
     package_json_version
 else if (Environment.isDebug)
-    std.fmt.comptimePrint(BASE_VERSION ++ ".{d}_debug+{s}", .{ build_id, Environment.git_sha })
+    std.fmt.comptimePrint(BASE_VERSION ++ ".{d}-debug+{s}", .{ build_id, Environment.git_sha })
 else if (Environment.is_canary)
-    std.fmt.comptimePrint(BASE_VERSION ++ ".{d}_canary+{s}", .{ build_id, Environment.git_sha })
+    std.fmt.comptimePrint(BASE_VERSION ++ ".{d}-canary+{s}", .{ build_id, Environment.git_sha })
 else if (Environment.isTest)
-    std.fmt.comptimePrint(BASE_VERSION ++ ".{d}_test+{s}", .{ build_id, Environment.git_sha })
+    std.fmt.comptimePrint(BASE_VERSION ++ ".{d}-test+{s}", .{ build_id, Environment.git_sha })
 else
     std.fmt.comptimePrint(BASE_VERSION ++ ".{d}+{s}", .{ build_id, Environment.git_sha });
 

--- a/src/__global.zig
+++ b/src/__global.zig
@@ -22,6 +22,17 @@ else if (Environment.isDebug)
 else
     std.fmt.comptimePrint(BASE_VERSION ++ ".{d} ({s})", .{ build_id, Environment.git_sha[0..@min(Environment.git_sha.len, 8)] });
 
+pub const package_json_version_with_revision = if (Environment.git_sha.len == 0)
+    package_json_version
+else if (Environment.isDebug)
+    std.fmt.comptimePrint(BASE_VERSION ++ ".{d}_debug+{s}", .{ build_id, Environment.git_sha })
+else if (Environment.is_canary)
+    std.fmt.comptimePrint(BASE_VERSION ++ ".{d}_canary+{s}", .{ build_id, Environment.git_sha })
+else if (Environment.isTest)
+    std.fmt.comptimePrint(BASE_VERSION ++ ".{d}_test+{s}", .{ build_id, Environment.git_sha })
+else
+    std.fmt.comptimePrint(BASE_VERSION ++ ".{d}+{s}", .{ build_id, Environment.git_sha });
+
 pub const os_name = if (Environment.isWindows)
     "win32"
 else if (Environment.isMac)

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -147,6 +147,7 @@ pub const Arguments = struct {
         clap.parseParam("--main-fields <STR>...            Main fields to lookup in package.json. Defaults to --target dependent") catch unreachable,
         clap.parseParam("--no-summary                      Don't print a summary (when generating .bun)") catch unreachable,
         clap.parseParam("-v, --version                     Print version and exit") catch unreachable,
+        clap.parseParam("--revision                        Print version with revision and exit") catch unreachable,
         clap.parseParam("--tsconfig-override <STR>         Load tsconfig from path instead of cwd/tsconfig.json") catch unreachable,
         clap.parseParam("-d, --define <STR>...             Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:\"development\". Values are parsed as JSON.") catch unreachable,
         clap.parseParam("-e, --external <STR>...           Exclude module from transpilation (can use * wildcards). ex: -e react") catch unreachable,
@@ -228,6 +229,12 @@ pub const Arguments = struct {
     fn printVersionAndExit() noreturn {
         @setCold(true);
         Output.writer().writeAll(Global.package_json_version ++ "\n") catch {};
+        Global.exit(0);
+    }
+
+    fn printRevisionAndExit() noreturn {
+        @setCold(true);
+        Output.writer().writeAll(Global.package_json_version_with_sha ++ "\n") catch {};
         Global.exit(0);
     }
 
@@ -360,6 +367,10 @@ pub const Arguments = struct {
 
         if (args.flag("--version")) {
             printVersionAndExit();
+        }
+
+        if (args.flag("--revision")) {
+            printRevisionAndExit();
         }
 
         var cwd: []u8 = undefined;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -234,7 +234,7 @@ pub const Arguments = struct {
 
     fn printRevisionAndExit() noreturn {
         @setCold(true);
-        Output.writer().writeAll(Global.package_json_version_with_sha ++ "\n") catch {};
+        Output.writer().writeAll(Global.package_json_version_with_revision ++ "\n") catch {};
         Global.exit(0);
     }
 

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -32,4 +32,27 @@ describe("bun", () => {
       });
     }
   });
+
+  describe("revision", () => {
+    test("revision generates version numbers correctly", () => {
+      var { stdout, exitCode } = Bun.spawnSync({
+        cmd: [bunExe(), "--version"],
+        env: {},
+        stderr: "inherit",
+      });
+      var version = stdout.toString().trim();
+
+      var { stdout, exitCode } = Bun.spawnSync({
+        cmd: [bunExe(), "--revision"],
+        env: {},
+        stderr: "inherit",
+      });
+      var revision = stdout.toString().trim();
+
+      expect(exitCode).toBe(0);
+      expect(revision).toStartWith(version);
+      // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+      expect(revision).toMatch(new RegExp('\^\(0\|\[1\-9\]\\d\*\)\\\.\(0\|\[1\-9\]\\d\*\)\\\.\(0\|\[1\-9\]\\d\*\)\(\?\:\-\(\(\?\:0\|\[1\-9\]\\d\*\|\\d\*\[a\-zA\-Z\-\]\[0\-9a\-zA\-Z\-\]\*\)\(\?\:\\\.\(\?\:0\|\[1\-9\]\\d\*\|\\d\*\[a\-zA\-Z\-\]\[0\-9a\-zA\-Z\-\]\*\)\)\*\)\)\?\(\?\:\\\+\(\[0\-9a\-zA\-Z\-\]\+\(\?\:\\\.\[0\-9a\-zA\-Z\-\]\+\)\*\)\)\?\$'))
+    });
+  });
 });

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -52,7 +52,11 @@ describe("bun", () => {
       expect(exitCode).toBe(0);
       expect(revision).toStartWith(version);
       // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-      expect(revision).toMatch(new RegExp('\^\(0\|\[1\-9\]\\d\*\)\\\.\(0\|\[1\-9\]\\d\*\)\\\.\(0\|\[1\-9\]\\d\*\)\(\?\:\-\(\(\?\:0\|\[1\-9\]\\d\*\|\\d\*\[a\-zA\-Z\-\]\[0\-9a\-zA\-Z\-\]\*\)\(\?\:\\\.\(\?\:0\|\[1\-9\]\\d\*\|\\d\*\[a\-zA\-Z\-\]\[0\-9a\-zA\-Z\-\]\*\)\)\*\)\)\?\(\?\:\\\+\(\[0\-9a\-zA\-Z\-\]\+\(\?\:\\\.\[0\-9a\-zA\-Z\-\]\+\)\*\)\)\?\$'))
+      expect(revision).toMatch(
+        new RegExp(
+          "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+        ),
+      );
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes
Adds a CLI flag to print bun version with revision
https://github.com/oven-sh/bun/issues/3676

### How did you verify your code works?

```
bun-debug --revision
0.7.3_debug (ddf78d8a)
```

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
