### PR TITLE
[install] handle `bun add` of existing `peerDependencies` correctly

### DIFF
--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -287,3 +287,33 @@ it("should retain a new line in the end of package.json", async () => {
     ) + "\n",
   );
 });
+
+it("should remove peerDependencies", async () => {
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      peerDependencies: {
+        bar: "~0.0.1",
+      },
+    }),
+  );
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "remove", "bar"],
+    cwd: package_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr).toBeDefined();
+  const err = await new Response(stderr).text();
+  expect(err).not.toContain("error:");
+  expect(stdout).toBeDefined();
+  const out = await new Response(stdout).text();
+  expect(out.replace(/\s*\[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual([" done", ""]);
+  expect(await exited).toBe(0);
+  expect(await file(join(package_dir, "package.json")).json()).toEqual({
+    name: "foo",
+  });
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Previously `bun add pkg` on the following `package.json`:
```json
{
  "peerDependencies": {
    "pkg": "^1.2.3"
  }
}
```
will result in failure, i.e.:
```json
{
  "peerDependencies": {
    "pkg": ""
  }
}
```
without installing `pkg`.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
