### PR TITLE
Bind require.resolve()

### DIFF
--- a/src/js/builtins/Module.ts
+++ b/src/js/builtins/Module.ts
@@ -81,8 +81,8 @@ export function require(this: CommonJSModuleRecord, id: string) {
   return mod.exports;
 }
 
-export function requireResolve(this: CommonJSModuleRecord, id: string) {
-  return $resolveSync(id, this.path, false);
+export function requireResolve(this: string | { path: string }, id: string) {
+  return $resolveSync(id, typeof this === "string" ? this : this?.path, false);
 }
 
 export function requireNativeModule(id: string) {

--- a/src/js/out/WebCoreJSBuiltins.cpp
+++ b/src/js/out/WebCoreJSBuiltins.cpp
@@ -722,9 +722,9 @@ const char* const s_moduleRequireCode = "(function (id){\"use strict\";const exi
 const JSC::ConstructAbility s_moduleRequireResolveCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_moduleRequireResolveCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_moduleRequireResolveCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_moduleRequireResolveCodeLength = 67;
+const int s_moduleRequireResolveCodeLength = 96;
 static const JSC::Intrinsic s_moduleRequireResolveCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_moduleRequireResolveCode = "(function (id){\"use strict\";return @resolveSync(id,this.path,!1)})\n";
+const char* const s_moduleRequireResolveCode = "(function (id){\"use strict\";return @resolveSync(id,typeof this===\"string\"\?this:this\?.path,!1)})\n";
 
 // requireNativeModule
 const JSC::ConstructAbility s_moduleRequireNativeModuleCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;

--- a/test/cli/run/require-cache-fixture.cjs
+++ b/test/cli/run/require-cache-fixture.cjs
@@ -27,13 +27,15 @@ const foo = require("./require-cache-fixture-b.cjs");
 
 exports.foo = foo;
 
-if (require.cache[require.resolve("./require-cache-fixture-b.cjs")].exports !== exports.foo) {
+var res = require.resolve;
+
+if (require.cache[res("./require-cache-fixture-b.cjs")].exports !== exports.foo) {
   throw new Error("exports.foo !== require.cache[require.resolve('./require-cache-fixture-b')]");
 }
 
 Bun.gc(true);
 
-delete require.cache[require.resolve("./require-cache-fixture-b.cjs")];
+delete require.cache[res("./require-cache-fixture-b.cjs")];
 
 Bun.gc(true);
 
@@ -41,7 +43,7 @@ exports.bar = require("./require-cache-fixture-b.cjs");
 
 Bun.gc(true);
 
-if (require.cache[require.resolve("./require-cache-fixture-b.cjs")].exports !== exports.bar) {
+if (require.cache[res("./require-cache-fixture-b.cjs")].exports !== exports.bar) {
   throw new Error("exports.bar !== require.cache[require.resolve('./require-cache-fixture-b')]");
 }
 


### PR DESCRIPTION
### What does this PR do?

This fixes code like the following:
```js
var r = require.resolve;
r("foo");
```

Previously, it would throw a strange error about `undefined is not an object`.

Our CommonJS function wrapper now looks like this:

```js
(function (module, exports, require, __dirname, __filename) {
}).call(
  $_BunCommonJSModule_$.module.exports,
  $_BunCommonJSModule_$.module,
  $_BunCommonJSModule_$.module.exports,
  (($_BunCommonJSModule_$.module.require =
    $_BunCommonJSModule_$.module.require.bind($_BunCommonJSModule_$.module)),
  ($_BunCommonJSModule_$.module.require.path = $_BunCommonJSModule_$.module.id),
  ($_BunCommonJSModule_$.module.require.resolve =
    $_BunCommonJSModule_$.module.require.resolve.bind(
      $_BunCommonJSModule_$.module.id
    )),
  $_BunCommonJSModule_$.module.require),
  $_BunCommonJSModule_$.__dirname,
  $_BunCommonJSModule_$.__filename
);
```



### How did you verify your code works?

Updated our require-cache fixture to also use require.resolve from a `var`