### PR TITLE
Fixes #4010

### DIFF
--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -1496,7 +1496,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
                 return;
             }
 
-            _ = this.sendData(bytes, !this.hasBackpressure(), false, opcode);
+            _ = this.sendData(bytes, !this.hasBackpressure(), opcode);
         }
         pub fn writeString(
             this: *WebSocket,
@@ -1543,7 +1543,6 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
                 else
                     Copy{ .latin1 = str.slice() },
                 !this.hasBackpressure(),
-                false,
                 opcode,
             );
         }


### PR DESCRIPTION
### What does this PR do?

MSG_MORE causes a 200ms delay when sending small messages. We already are buffering, so OS-level buffering is unnecessary. macOS is unaffected because MSG_MORE is a linux thing.

### How did you verify your code works?

There are existing tests, but I also manually tested with this script:

```js
const server = Bun.serve({
  port: 0,
  fetch(req, server) {
    return server.upgrade(req);
  },
  websocket: {
    open(ws) {},
    message(ws, data) {
      console.log(Math.trunc(performance.now()), "recv", data);
    },
  },
});

const ws = new WebSocket("ws://localhost:" + server.port);

ws.onopen = () => {
  setInterval(() => {
    const bin = new Uint8Array(8);
    const view = new DataView(bin.buffer);
    const now = BigInt(Date.now());
    view.setBigUint64(0, now, true);
    console.log("send", performance.now());
    ws.send(bin);
  }, 1000);
};
```

```js
❯ bun /tmp/server.js
send 1210.31908
1415 recv Buffer(8) [ 190, 237, 172, 205, 137, 1, 0, 0 ]
send 2209.949123
2415 recv Buffer(8) [ 166, 241, 172, 205, 137, 1, 0, 0 ]
❯ bun-debug /tmp/server.js
send 1011.896231
1012 recv Buffer(8) [ 185, 255, 172, 205, 137, 1, 0, 0 ]
send 2011.51938
2011 recv Buffer(8) [ 160, 3, 173, 205, 137, 1, 0, 0 ]
```

The existing `websocket.test.js` file seems to run about 4x faster in the debug build:
```js
❯ bun-debug test websocket.test
bun test v0.7.4_debug (0b2be88b)

test/js/web/websocket/websocket.test.js:
✓ WebSocket > nodebuffer > should support 'nodebuffer' binaryType [3.29ms]
✓ WebSocket > nodebuffer > should support 'nodebuffer' binaryType when the handler is not immediately provided [0.86ms]
✓ WebSocket > should connect [0.82ms]
✓ WebSocket > should connect over https [347.30ms]
✓ WebSocket > supports headers [1.34ms]
✓ WebSocket > should connect over http [1.01ms]
✓ WebSocket > should send and receive messages [1232.07ms]
✓ websocket in subprocess > should exit [19.51ms]
✓ websocket in subprocess > should exit after killed [0.65ms]
✓ websocket in subprocess > should exit with invalid url [13.76ms]
✓ websocket in subprocess > should exit after timeout [318.15ms]
✓ websocket in subprocess > should exit after server stop and 0 messages [18.61ms]

 12 pass
 0 fail
 36 expect() calls
Ran 12 tests across 1 files. [2.02s]

❯ bun test websocket.test
bun test v0.7.2 (9574db35)

test/js/web/websocket/websocket.test.js:
✓ WebSocket > nodebuffer > should support 'nodebuffer' binaryType [206.02ms]
✓ WebSocket > nodebuffer > should support 'nodebuffer' binaryType when the handler is not immediately provided [202.60ms]
✓ WebSocket > should connect [204.61ms]
✓ WebSocket > should connect over https [938.14ms]
✓ WebSocket > supports headers [205.60ms]
✓ WebSocket > should connect over http [203.82ms]
✓ WebSocket > should send and receive messages [5151.47ms]
✓ websocket in subprocess > should exit [422.46ms]
✓ websocket in subprocess > should exit after killed [0.62ms]
✓ websocket in subprocess > should exit with invalid url [9.61ms]
✓ websocket in subprocess > should exit after timeout [721.69ms]
✓ websocket in subprocess > should exit after server stop and 0 messages [13.72ms]

 12 pass
 0 fail
 36 expect() calls
Ran 12 tests across 1 files. [8.33s]
```