### PR TITLE
Fix `path.normalize` edge case.

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -2008,7 +2008,7 @@ pub const Path = struct {
         if (args_len == 0) return JSC.ZigString.init("").toValue(globalThis);
 
         var zig_str: JSC.ZigString = args_ptr[0].getZigString(globalThis);
-        if (zig_str.len == 0) return JSC.ZigString.init("").toValue(globalThis);
+        if (zig_str.len == 0) return JSC.ZigString.init(".").toValue(globalThis);
 
         var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
         var str_slice = zig_str.toSlice(heap_allocator);

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -566,6 +566,7 @@ it("path.normalize", () => {
   strictEqual(path.posix.normalize("../foobar/barfoo/foo/../../../bar/../../"), "../../");
   strictEqual(path.posix.normalize("../.../../foobar/../../../bar/../../baz"), "../../../../baz");
   strictEqual(path.posix.normalize("foo/bar\\baz"), "foo/bar\\baz");
+  strictEqual(path.posix.normalize(""), ".");
 });
 
 it("path.resolve", () => {


### PR DESCRIPTION
Close: #4041

### What does this PR do?

`path.normalize("")`: If the path is a zero-length string, '.' is returned, representing the current working directory.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->



- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
