### PR TITLE
fix iterating headers with `set-cookie`

### DIFF
--- a/src/bun.js/bindings/webcore/FetchHeaders.cpp
+++ b/src/bun.js/bindings/webcore/FetchHeaders.cpp
@@ -280,9 +280,9 @@ std::optional<KeyValuePair<String, String>> FetchHeaders::Iterator::next()
         m_keys.reserveCapacity(m_headers->m_headers.size() + (hasSetCookie ? 1 : 0));
         for (auto& header : m_headers->m_headers)
             m_keys.uncheckedAppend(header.asciiLowerCaseName());
+        std::sort(m_keys.begin(), m_keys.end(), compareIteratorKeys);
         if (hasSetCookie)
             m_keys.uncheckedAppend(String());
-        std::sort(m_keys.begin(), m_keys.end(), compareIteratorKeys);
 
         m_currentIndex += m_cookieIndex;
         if (hasSetCookie) {

--- a/src/bun.js/bindings/webcore/FetchHeaders.cpp
+++ b/src/bun.js/bindings/webcore/FetchHeaders.cpp
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include "FetchHeaders.h"
+#include "HTTPHeaderNames.h"
 
 #include "HTTPParsers.h"
 
@@ -227,8 +228,6 @@ ExceptionOr<bool> FetchHeaders::has(const String& name) const
     return m_headers.contains(name);
 }
 
-static NeverDestroyed<const String> setCookieLowercaseString(MAKE_STATIC_STRING_IMPL("set-cookie"));
-
 ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
 {
     String normalizedValue = value.trim(isHTTPSpace);
@@ -239,12 +238,7 @@ ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
         return {};
 
     ++m_updateCounter;
-    if (equalIgnoringASCIICase(name, setCookieLowercaseString)) {
-        m_headers.getSetCookieHeaders().clear();
-        m_headers.getSetCookieHeaders().append(normalizedValue);
-    } else {
-        m_headers.set(name, normalizedValue);
-    }
+    m_headers.set(name, normalizedValue);
 
     if (m_guard == FetchHeaders::Guard::RequestNoCors)
         removePrivilegedNoCORSRequestHeaders(m_headers);
@@ -267,6 +261,8 @@ void FetchHeaders::filterAndFill(const HTTPHeaderMap& headers, Guard guard)
             m_headers.add(header.key, header.value);
     }
 }
+
+static const WTF::String setCookieLowercaseString = WTF::staticHeaderNames[static_cast<uint8_t>(HTTPHeaderName::SetCookie)];
 
 static bool compareIteratorKeys(const String& a, const String& b)
 {

--- a/src/bun.js/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/bun.js/bindings/webcore/HTTPHeaderMap.cpp
@@ -236,15 +236,7 @@ String HTTPHeaderMap::get(HTTPHeaderName name) const
 void HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
 {
     if (name == HTTPHeaderName::SetCookie) {
-        auto cookieName = extractCookieName(value);
-        size_t length = m_setCookieHeaders.size();
-        const auto& cookies = m_setCookieHeaders.data();
-        for (size_t i = 0; i < length; ++i) {
-            if (extractCookieName(cookies[i]) == cookieName) {
-                m_setCookieHeaders[i] = value;
-                return;
-            }
-        }
+        m_setCookieHeaders.clear();
         m_setCookieHeaders.append(value);
         return;
     }

--- a/src/bun.js/bindings/webcore/HTTPHeaderMap.h
+++ b/src/bun.js/bindings/webcore/HTTPHeaderMap.h
@@ -69,12 +69,9 @@ public:
             : m_table(table)
             , m_commonHeadersIt(commonHeadersIt)
             , m_uncommonHeadersIt(uncommonHeadersIt)
-            , m_setCookiesIter(setCookiesIter)
         {
             if (!updateKeyValue(m_commonHeadersIt)) {
-                if (!updateSetCookieHeaderPosition(setCookiesIter)) {
-                    updateKeyValue(m_uncommonHeadersIt);
-                }
+                updateKeyValue(m_uncommonHeadersIt);
             }
         }
 
@@ -107,9 +104,6 @@ public:
             if (m_commonHeadersIt != m_table.m_commonHeaders.end()) {
                 if (updateKeyValue(++m_commonHeadersIt))
                     return *this;
-            } else if (m_setCookiesIter != m_table.m_setCookieHeaders.end()) {
-                if (updateSetCookieHeaderPosition(++m_setCookiesIter))
-                    return *this;
             } else {
                 ++m_uncommonHeadersIt;
             }
@@ -122,7 +116,7 @@ public:
         bool operator!=(const HTTPHeaderMapConstIterator &other) const { return !(*this == other); }
         bool operator==(const HTTPHeaderMapConstIterator &other) const
         {
-            return m_commonHeadersIt == other.m_commonHeadersIt && m_uncommonHeadersIt == other.m_uncommonHeadersIt && m_setCookiesIter == other.m_setCookiesIter;
+            return m_commonHeadersIt == other.m_commonHeadersIt && m_uncommonHeadersIt == other.m_uncommonHeadersIt;
         }
 
     private:
@@ -145,22 +139,9 @@ public:
             return true;
         }
 
-        bool updateSetCookieHeaderPosition(Vector<String, 0>::const_iterator cookieI)
-        {
-            if (cookieI == m_table.m_setCookieHeaders.end()) {
-                return false;
-            }
-
-            m_keyValue.key = httpHeaderNameString(HTTPHeaderName::SetCookie).toStringWithoutCopying();
-            m_keyValue.keyAsHTTPHeaderName = HTTPHeaderName::SetCookie;
-            m_keyValue.value = *cookieI;
-            return true;
-        }
-
         const HTTPHeaderMap &m_table;
         CommonHeadersVector::const_iterator m_commonHeadersIt;
         UncommonHeadersVector::const_iterator m_uncommonHeadersIt;
-        Vector<String, 0>::const_iterator m_setCookiesIter;
         KeyValue m_keyValue;
     };
     typedef HTTPHeaderMapConstIterator const_iterator;
@@ -178,14 +159,12 @@ public:
     {
         m_commonHeaders.clear();
         m_uncommonHeaders.clear();
-        m_setCookieHeaders.clear();
     }
 
     void shrinkToFit()
     {
         m_commonHeaders.shrinkToFit();
         m_uncommonHeaders.shrinkToFit();
-        m_setCookieHeaders.shrinkToFit();
     }
 
     WEBCORE_EXPORT String get(const String &name) const;

--- a/test/js/deno/fetch/headers.test.ts
+++ b/test/js/deno/fetch/headers.test.ts
@@ -312,16 +312,16 @@ test(function headersInitMultiple() {
     ];
     assertEquals(actual, [
         [
+            "x-deno",
+            "foo, bar"
+        ],
+        [
             "set-cookie",
             "foo=bar"
         ],
         [
             "set-cookie",
             "bar=baz"
-        ],
-        [
-            "x-deno",
-            "foo, bar"
         ]
     ]);
 });
@@ -363,16 +363,16 @@ test(function headersAppendMultiple() {
     ];
     assertEquals(actual, [
         [
+            "x-deno",
+            "foo, bar"
+        ],
+        [
             "set-cookie",
             "foo=bar"
         ],
         [
             "set-cookie",
             "bar=baz"
-        ],
-        [
-            "x-deno",
-            "foo, bar"
         ]
     ]);
 });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -278,6 +278,17 @@ describe("Headers", () => {
     const actual = [...headers];
     expect(actual).toEqual([["set-cookie", "bar=qat"]]);
   });
+
+  it("should include set-cookie headers in array", () => {
+    const headers = new Headers();
+    headers.append("Set-Cookie", "foo=bar");
+    headers.append("Content-Type", "text/plain");
+    const actual = [...headers];
+    expect(actual).toEqual([
+      ["content-type", "text/plain"],
+      ["set-cookie", "foo=bar"],
+    ]);
+  });
 });
 
 describe("fetch", () => {

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -234,11 +234,11 @@ describe("Headers", () => {
     ]);
     const actual = [...headers];
     expect(actual).toEqual([
+      ["x-bun", "abc, def"],
       ["set-cookie", "foo=bar"],
       ["set-cookie", "bar=baz"],
-      ["x-bun", "abc, def"],
     ]);
-    expect([...headers.values()]).toEqual(["foo=bar", "bar=baz", "abc, def"]);
+    expect([...headers.values()]).toEqual(["abc, def", "foo=bar", "bar=baz"]);
   });
 
   it("Headers append multiple", () => {
@@ -253,9 +253,9 @@ describe("Headers", () => {
     // we do not preserve the order
     // which is kind of bad
     expect(actual).toEqual([
+      ["x-bun", "foo, bar"],
       ["set-cookie", "foo=bar"],
       ["set-cookie", "bar=baz"],
-      ["x-bun", "foo, bar"],
     ]);
   });
 

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -276,10 +276,7 @@ describe("Headers", () => {
     headers.set("set-Cookie", "foo=baz");
     headers.set("set-cookie", "bar=qat");
     const actual = [...headers];
-    expect(actual).toEqual([
-      ["set-cookie", "foo=baz"],
-      ["set-cookie", "bar=qat"],
-    ]);
+    expect(actual).toEqual([["set-cookie", "bar=qat"]]);
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
before:
```js
const headers = new Headers();
headers.append("Set-Cookie", "cookies");
headers.append("Content-Type", "application/json");

console.log([...headers]);
// output: [ [ "content-type", "application/json" ], [ "content-type", "application/json" ] ]
```
after:
```js
// output: [ [ "content-type", "application/json" ], [ "set-cookie", "cookies" ] ]
```

### How did you verify your code works?
updated and added test for headers with `set-cookie`
