### PR TITLE
Fix `Bun.hash` functions

### DIFF
--- a/docs/api/hashing.md
+++ b/docs/api/hashing.md
@@ -77,7 +77,7 @@ The standard `Bun.hash` functions uses [Wyhash](https://github.com/wangyi-fudan/
 
 ```ts
 Bun.hash("some data here");
-// 976213160445840
+// 11562320457524636935n
 ```
 
 The input can be a string, `TypedArray`, `DataView`, `ArrayBuffer`, or `SharedArrayBuffer`.
@@ -91,14 +91,14 @@ Bun.hash(arr.buffer);
 Bun.hash(new DataView(arr.buffer));
 ```
 
-Optionally, an integer seed can be specified as the second parameter.
+Optionally, an integer seed can be specified as the second parameter. For 64-bit hashes seeds above `Number.MAX_SAFE_INTEGER` should be given as BigInt to avoid loss of precision.
 
 ```ts
 Bun.hash("some data here", 1234);
-// 1173484059023252
+// 15724820720172937558n
 ```
 
-Additional hashing algorithms are available as properties on `Bun.hash`. The API is the same for each.
+Additional hashing algorithms are available as properties on `Bun.hash`. The API is the same for each, only changing the return type from number for 32-bit hashes to bigint for 64-bit hashes.
 
 ```ts
 Bun.hash.wyhash("data", 1234); // equivalent to Bun.hash()
@@ -107,6 +107,7 @@ Bun.hash.adler32("data", 1234);
 Bun.hash.cityHash32("data", 1234);
 Bun.hash.cityHash64("data", 1234);
 Bun.hash.murmur32v3("data", 1234);
+Bun.hash.murmur32v2("data", 1234);
 Bun.hash.murmur64v2("data", 1234);
 ```
 

--- a/examples/hashing.js
+++ b/examples/hashing.js
@@ -1,18 +1,19 @@
-// Accepts a string, TypedArray, or Blob (file blob supported is not implemented but planned)
+// Accepts a string, TypedArray, or Blob (file blob support is not implemented but planned)
 const input = "hello world".repeat(400);
 
 // Bun.hash() defaults to Wyhash because it's fast
 console.log(Bun.hash(input));
 
 console.log(Bun.hash.wyhash(input));
-// and returns a number
-// all of these hashing functions return numbers, not typed arrays.
-console.log(Bun.hash.adler32(input));
-console.log(Bun.hash.crc32(input));
-console.log(Bun.hash.cityHash32(input));
-console.log(Bun.hash.cityHash64(input));
-console.log(Bun.hash.murmur32v3(input));
-console.log(Bun.hash.murmur64v2(input));
+// and returns a bigint
+// all of these hashing functions return number if 32-bit or bigint if 64-bit, not typed arrays.
+console.log(Bun.hash.adler32(input)); // number
+console.log(Bun.hash.crc32(input)); // number
+console.log(Bun.hash.cityHash32(input)); // number
+console.log(Bun.hash.cityHash64(input)); // bigint
+console.log(Bun.hash.murmur32v3(input)); // number
+console.log(Bun.hash.murmur32v2(input)); // number
+console.log(Bun.hash.murmur64v2(input)); // bigint
 
 // Second argument accepts a seed where relevant
 console.log(Bun.hash(input, 12345));

--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -3192,24 +3192,24 @@ pub const Hash = struct {
                 } else {
                     var seed: u64 = 0;
                     if (args.nextEat()) |arg| {
-                        if (arg.isNumber()) {
-                            seed = arg.toU32();
+                        if (arg.isNumber() or arg.isBigInt()) {
+                            seed = arg.toUInt64NoTruncate();
                         }
                     }
                     if (comptime std.meta.trait.isNumber(@TypeOf(function_args[0]))) {
-                        function_args[0] = @as(@TypeOf(function_args[0]), @intCast(seed));
+                        function_args[0] = @as(@TypeOf(function_args[0]), @truncate(seed));
                         function_args[1] = input;
                     } else {
-                        function_args[1] = @as(@TypeOf(function_args[1]), @intCast(seed));
                         function_args[0] = input;
+                        function_args[1] = @as(@TypeOf(function_args[1]), @truncate(seed));
                     }
 
                     const value = @call(.auto, Function, function_args);
 
                     if (@TypeOf(value) == u32) {
-                        return JSC.JSValue.jsNumber(@as(i32, @bitCast(value))).asObjectRef();
+                        return JSC.JSValue.jsNumber(@as(u32, @bitCast(value))).asObjectRef();
                     }
-                    return JSC.JSValue.jsNumber(value).asObjectRef();
+                    return JSC.JSValue.fromUInt64NoTruncate(ctx.ptr(), value).asObjectRef();
                 }
             }
         };

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -1,47 +1,50 @@
-import fs from "fs";
 import { it, expect } from "bun:test";
-import path from "path";
 import { gcTick } from "harness";
 
 it(`Bun.hash()`, () => {
   gcTick();
-  Bun.hash("hello world");
-  Bun.hash(new TextEncoder().encode("hello world"));
+  expect(Bun.hash("hello world")).toBe(0x668D5E431C3B2573n);
+  expect(Bun.hash(new TextEncoder().encode("hello world"))).toBe(0x668D5E431C3B2573n);
 });
 it(`Bun.hash.wyhash()`, () => {
-  Bun.hash.wyhash("hello world");
+  expect(Bun.hash.wyhash("hello world")).toBe(0x668D5E431C3B2573n);
   gcTick();
-  Bun.hash.wyhash(new TextEncoder().encode("hello world"));
+  expect(Bun.hash.wyhash(new TextEncoder().encode("hello world"))).toBe(0x668D5E431C3B2573n);
 });
 it(`Bun.hash.adler32()`, () => {
-  Bun.hash.adler32("hello world");
+  expect(Bun.hash.adler32("hello world")).toBe(0x1A0B045D);
   gcTick();
-  Bun.hash.adler32(new TextEncoder().encode("hello world"));
+  expect(Bun.hash.adler32(new TextEncoder().encode("hello world"))).toBe(0x1A0B045D);
 });
 it(`Bun.hash.crc32()`, () => {
-  Bun.hash.crc32("hello world");
+  expect(Bun.hash.crc32("hello world")).toBe(0x0D4A1185);
   gcTick();
-  Bun.hash.crc32(new TextEncoder().encode("hello world"));
+  expect(Bun.hash.crc32(new TextEncoder().encode("hello world"))).toBe(0x0D4A1185);
 });
 it(`Bun.hash.cityHash32()`, () => {
-  Bun.hash.cityHash32("hello world");
+  expect(Bun.hash.cityHash32("hello world")).toBe(0x19A7581A);
   gcTick();
-  Bun.hash.cityHash32(new TextEncoder().encode("hello world"));
+  expect(Bun.hash.cityHash32(new TextEncoder().encode("hello world"))).toBe(0x19A7581A);
   gcTick();
 });
 it(`Bun.hash.cityHash64()`, () => {
-  Bun.hash.cityHash64("hello world");
+  expect(Bun.hash.cityHash64("hello world")).toBe(0xC7920BBDBECEE42Fn);
   gcTick();
-  Bun.hash.cityHash64(new TextEncoder().encode("hello world"));
+  expect(Bun.hash.cityHash64(new TextEncoder().encode("hello world"))).toBe(0xC7920BBDBECEE42Fn);
   gcTick();
 });
 it(`Bun.hash.murmur32v3()`, () => {
-  Bun.hash.murmur32v3("hello world");
+  expect(Bun.hash.murmur32v3("hello world")).toBe(0x5E928F0F);
   gcTick();
-  Bun.hash.murmur32v3(new TextEncoder().encode("hello world"));
+  expect(Bun.hash.murmur32v3(new TextEncoder().encode("hello world"))).toBe(0x5E928F0F);
+});
+it(`Bun.hash.murmur32v2()`, () => {
+  expect(Bun.hash.murmur32v2("hello world")).toBe(0x44A81419);
+  gcTick();
+  expect(Bun.hash.murmur32v2(new TextEncoder().encode("hello world"))).toBe(0x44A81419);
 });
 it(`Bun.hash.murmur64v2()`, () => {
-  Bun.hash.murmur64v2("hello world");
+  expect(Bun.hash.murmur64v2("hello world")).toBe(0xD3BA2368A832AFCEn);
   gcTick();
-  Bun.hash.murmur64v2(new TextEncoder().encode("hello world"));
+  expect(Bun.hash.murmur64v2(new TextEncoder().encode("hello world"))).toBe(0xD3BA2368A832AFCEn);
 });

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -3,48 +3,48 @@ import { gcTick } from "harness";
 
 it(`Bun.hash()`, () => {
   gcTick();
-  expect(Bun.hash("hello world")).toBe(0x668D5E431C3B2573n);
-  expect(Bun.hash(new TextEncoder().encode("hello world"))).toBe(0x668D5E431C3B2573n);
+  expect(Bun.hash("hello world")).toBe(0x668d5e431c3b2573n);
+  expect(Bun.hash(new TextEncoder().encode("hello world"))).toBe(0x668d5e431c3b2573n);
 });
 it(`Bun.hash.wyhash()`, () => {
-  expect(Bun.hash.wyhash("hello world")).toBe(0x668D5E431C3B2573n);
+  expect(Bun.hash.wyhash("hello world")).toBe(0x668d5e431c3b2573n);
   gcTick();
-  expect(Bun.hash.wyhash(new TextEncoder().encode("hello world"))).toBe(0x668D5E431C3B2573n);
+  expect(Bun.hash.wyhash(new TextEncoder().encode("hello world"))).toBe(0x668d5e431c3b2573n);
 });
 it(`Bun.hash.adler32()`, () => {
-  expect(Bun.hash.adler32("hello world")).toBe(0x1A0B045D);
+  expect(Bun.hash.adler32("hello world")).toBe(0x1a0b045d);
   gcTick();
-  expect(Bun.hash.adler32(new TextEncoder().encode("hello world"))).toBe(0x1A0B045D);
+  expect(Bun.hash.adler32(new TextEncoder().encode("hello world"))).toBe(0x1a0b045d);
 });
 it(`Bun.hash.crc32()`, () => {
-  expect(Bun.hash.crc32("hello world")).toBe(0x0D4A1185);
+  expect(Bun.hash.crc32("hello world")).toBe(0x0d4a1185);
   gcTick();
-  expect(Bun.hash.crc32(new TextEncoder().encode("hello world"))).toBe(0x0D4A1185);
+  expect(Bun.hash.crc32(new TextEncoder().encode("hello world"))).toBe(0x0d4a1185);
 });
 it(`Bun.hash.cityHash32()`, () => {
-  expect(Bun.hash.cityHash32("hello world")).toBe(0x19A7581A);
+  expect(Bun.hash.cityHash32("hello world")).toBe(0x19a7581a);
   gcTick();
-  expect(Bun.hash.cityHash32(new TextEncoder().encode("hello world"))).toBe(0x19A7581A);
+  expect(Bun.hash.cityHash32(new TextEncoder().encode("hello world"))).toBe(0x19a7581a);
   gcTick();
 });
 it(`Bun.hash.cityHash64()`, () => {
-  expect(Bun.hash.cityHash64("hello world")).toBe(0xC7920BBDBECEE42Fn);
+  expect(Bun.hash.cityHash64("hello world")).toBe(0xc7920bbdbecee42fn);
   gcTick();
-  expect(Bun.hash.cityHash64(new TextEncoder().encode("hello world"))).toBe(0xC7920BBDBECEE42Fn);
+  expect(Bun.hash.cityHash64(new TextEncoder().encode("hello world"))).toBe(0xc7920bbdbecee42fn);
   gcTick();
 });
 it(`Bun.hash.murmur32v3()`, () => {
-  expect(Bun.hash.murmur32v3("hello world")).toBe(0x5E928F0F);
+  expect(Bun.hash.murmur32v3("hello world")).toBe(0x5e928f0f);
   gcTick();
-  expect(Bun.hash.murmur32v3(new TextEncoder().encode("hello world"))).toBe(0x5E928F0F);
+  expect(Bun.hash.murmur32v3(new TextEncoder().encode("hello world"))).toBe(0x5e928f0f);
 });
 it(`Bun.hash.murmur32v2()`, () => {
-  expect(Bun.hash.murmur32v2("hello world")).toBe(0x44A81419);
+  expect(Bun.hash.murmur32v2("hello world")).toBe(0x44a81419);
   gcTick();
-  expect(Bun.hash.murmur32v2(new TextEncoder().encode("hello world"))).toBe(0x44A81419);
+  expect(Bun.hash.murmur32v2(new TextEncoder().encode("hello world"))).toBe(0x44a81419);
 });
 it(`Bun.hash.murmur64v2()`, () => {
-  expect(Bun.hash.murmur64v2("hello world")).toBe(0xD3BA2368A832AFCEn);
+  expect(Bun.hash.murmur64v2("hello world")).toBe(0xd3ba2368a832afcen);
   gcTick();
-  expect(Bun.hash.murmur64v2(new TextEncoder().encode("hello world"))).toBe(0xD3BA2368A832AFCEn);
+  expect(Bun.hash.murmur64v2(new TextEncoder().encode("hello world"))).toBe(0xd3ba2368a832afcen);
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

The `Bun.hash` hashing functions have been both receiving and returning inaccurate data, this PR fixes these:
* The 64-bit hashes cannot be represented by plain JS numbers and were being truncated, yielding incorrect hashes, they now return bigints.
* The 64-bit hashes use 64-bit seeds, but the seeds were being truncated to 32 bits, resulting in the upper seed range being impossible to achieve.
* All hashes were ignoring bigint seed inputs, they now accept bigints alongside numbers, even 32-bit hashes, which will just truncate the input to 32 bits if needed.
* All hashes were returning signed values while hashes are not meant to be negative, they now return proper unsigned values.

Additionally, the hash `murmur32v2` was undocumented, so it is now. (I have already updated `bun-types` for these changes on the bun-polyfills branch so I'm not including them here to avoid a future merge conflict)

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

The existing `Bun.hash` tests have been updated to reflect the correct expected behavior with the fixes.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
