### PR TITLE
Fix `path.format` compatibility issue.

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1861,14 +1861,17 @@ pub const Path = struct {
         var insert_separator = true;
         if (path_object.getTruthy(globalThis, "dir")) |prop| {
             prop.toZigString(&dir, globalThis);
-            insert_separator = !dir.isEmpty();
-        } else if (path_object.getTruthy(globalThis, "root")) |prop| {
-            prop.toZigString(&dir, globalThis);
+        }
+        if (dir.isEmpty()) {
+            if (path_object.getTruthy(globalThis, "root")) |prop| {
+                prop.toZigString(&dir, globalThis);
+            }
         }
 
         if (path_object.getTruthy(globalThis, "base")) |prop| {
             prop.toZigString(&name_with_ext, globalThis);
-        } else {
+        }
+        if (name_with_ext.isEmpty()) {
             var had_ext = false;
             if (path_object.getTruthy(globalThis, "ext")) |prop| {
                 prop.toZigString(&ext, globalThis);
@@ -1897,6 +1900,16 @@ pub const Path = struct {
             defer allocator.free(out);
 
             return JSC.ZigString.init(out).withEncoding().toValueGC(globalThis);
+        } else {
+            if (!isWindows) {
+                if (dir.eqlComptime("/")) {
+                    insert_separator = false;
+                }
+            } else {
+                if (dir.eqlComptime("\\")) {
+                    insert_separator = false;
+                }
+            }
         }
 
         if (insert_separator) {

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -627,71 +627,204 @@ it("path.resolve", () => {
   strictEqual(failures.length, 0, failures.join("\n"));
 });
 
-it("path.parse", () => {
-  expect(path.parse("/tmp/test.txt")).toStrictEqual({
-    root: "/",
-    dir: "/tmp",
-    base: "test.txt",
-    ext: ".txt",
-    name: "test",
-  });
+describe("path.parse and path.format", () => {
+  const testCases = [
+    {
+      input: "/tmp/test.txt",
+      expected: {
+        root: "/",
+        dir: "/tmp",
+        base: "test.txt",
+        ext: ".txt",
+        name: "test",
+      },
+    },
+    {
+      input: "/tmp/test/file.txt",
+      expected: {
+        root: "/",
+        dir: "/tmp/test",
+        base: "file.txt",
+        ext: ".txt",
+        name: "file",
+      },
+    },
+    {
+      input: "/tmp/test/dir",
+      expected: {
+        root: "/",
+        dir: "/tmp/test",
+        base: "dir",
+        ext: "",
+        name: "dir",
+      },
+    },
+    {
+      input: "/tmp/test/dir/",
+      expected: {
+        root: "/",
+        dir: "/tmp/test",
+        base: "dir",
+        ext: "",
+        name: "dir",
+      },
+    },
+    {
+      input: ".",
+      expected: {
+        root: "",
+        dir: "",
+        base: ".",
+        ext: "",
+        name: ".",
+      },
+    },
+    {
+      input: "./",
+      expected: {
+        root: "",
+        dir: "",
+        base: ".",
+        ext: "",
+        name: ".",
+      },
+    },
+    {
+      input: "/.",
+      expected: {
+        root: "/",
+        dir: "/",
+        base: ".",
+        ext: "",
+        name: ".",
+      },
+    },
+    {
+      input: "/../",
+      expected: {
+        root: "/",
+        dir: "/",
+        base: "..",
+        ext: ".",
+        name: ".",
+      },
+    },
+    {
+      input: "./file.txt",
+      expected: {
+        root: "",
+        dir: ".",
+        base: "file.txt",
+        ext: ".txt",
+        name: "file",
+      },
+    },
+    {
+      input: "../file.txt",
+      expected: {
+        root: "",
+        dir: "..",
+        base: "file.txt",
+        ext: ".txt",
+        name: "file",
+      },
+    },
+    {
+      input: "../test/file.txt",
+      expected: {
+        root: "",
+        dir: "../test",
+        base: "file.txt",
+        ext: ".txt",
+        name: "file",
+      },
+    },
+    {
+      input: "test/file.txt",
+      expected: {
+        root: "",
+        dir: "test",
+        base: "file.txt",
+        ext: ".txt",
+        name: "file",
+      },
+    },
+    {
+      input: "test/dir",
+      expected: {
+        root: "",
+        dir: "test",
+        base: "dir",
+        ext: "",
+        name: "dir",
+      },
+    },
+    {
+      input: "test/dir/another_dir",
+      expected: {
+        root: "",
+        dir: "test/dir",
+        base: "another_dir",
+        ext: "",
+        name: "another_dir",
+      },
+    },
+    {
+      input: "./dir",
+      expected: {
+        root: "",
+        dir: ".",
+        base: "dir",
+        ext: "",
+        name: "dir",
+      },
+    },
+    {
+      input: "../dir",
+      expected: {
+        root: "",
+        dir: "..",
+        base: "dir",
+        ext: "",
+        name: "dir",
+      },
+    },
+    {
+      input: "../dir/another_dir",
+      expected: {
+        root: "",
+        dir: "../dir",
+        base: "another_dir",
+        ext: "",
+        name: "another_dir",
+      },
+    },
+  ];
+  testCases.forEach(({ input, expected }) => {
+    it(`case ${input}`, () => {
+      const parsed = path.parse(input);
+      expect(parsed).toStrictEqual(expected);
 
-  expect(path.parse("/tmp/test/file.txt")).toStrictEqual({
-    root: "/",
-    dir: "/tmp/test",
-    base: "file.txt",
-    ext: ".txt",
-    name: "file",
+      const formatted = path.format(parsed);
+      expect(formatted).toStrictEqual(input.slice(-1) === "/" ? input.slice(0, -1) : input);
+    });
   });
-
-  expect(path.parse("/tmp/test/dir")).toStrictEqual({ root: "/", dir: "/tmp/test", base: "dir", ext: "", name: "dir" });
-  expect(path.parse("/tmp/test/dir/")).toStrictEqual({
-    root: "/",
-    dir: "/tmp/test",
-    base: "dir",
-    ext: "",
-    name: "dir",
-  });
-
-  expect(path.parse(".")).toStrictEqual({ root: "", dir: "", base: ".", ext: "", name: "." });
-  expect(path.parse("./")).toStrictEqual({ root: "", dir: "", base: ".", ext: "", name: "." });
-  expect(path.parse("/.")).toStrictEqual({ root: "/", dir: "/", base: ".", ext: "", name: "." });
-  expect(path.parse("/../")).toStrictEqual({ root: "/", dir: "/", base: "..", ext: ".", name: "." });
-
-  expect(path.parse("./file.txt")).toStrictEqual({ root: "", dir: ".", base: "file.txt", ext: ".txt", name: "file" });
-  expect(path.parse("../file.txt")).toStrictEqual({ root: "", dir: "..", base: "file.txt", ext: ".txt", name: "file" });
-  expect(path.parse("../test/file.txt")).toStrictEqual({
-    root: "",
-    dir: "../test",
-    base: "file.txt",
-    ext: ".txt",
-    name: "file",
-  });
-  expect(path.parse("test/file.txt")).toStrictEqual({
-    root: "",
-    dir: "test",
-    base: "file.txt",
-    ext: ".txt",
-    name: "file",
-  });
-
-  expect(path.parse("test/dir")).toStrictEqual({ root: "", dir: "test", base: "dir", ext: "", name: "dir" });
-  expect(path.parse("test/dir/another_dir")).toStrictEqual({
-    root: "",
-    dir: "test/dir",
-    base: "another_dir",
-    ext: "",
-    name: "another_dir",
-  });
-
-  expect(path.parse("./dir")).toStrictEqual({ root: "", dir: ".", base: "dir", ext: "", name: "dir" });
-  expect(path.parse("../dir")).toStrictEqual({ root: "", dir: "..", base: "dir", ext: "", name: "dir" });
-  expect(path.parse("../dir/another_dir")).toStrictEqual({
-    root: "",
-    dir: "../dir",
-    base: "another_dir",
-    ext: "",
-    name: "another_dir",
+  it("empty string arguments, issue #4005", () => {
+    expect(
+      path.format({
+        root: "",
+        dir: "",
+        base: "",
+        name: "foo",
+        ext: ".ts",
+      }),
+    ).toStrictEqual("foo.ts");
+    expect(
+      path.format({
+        name: "foo",
+        ext: ".ts",
+      }),
+    ).toStrictEqual("foo.ts");
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

1. Check if the argument is an empty string in `path.format`. Close: #4005 
2. Avoid duplicating '/' at the beginning of the path. Fix following code.

```JavaScript
const path = require("node:path");
const assert = require("node:assert");
assert.strictEqual(
  path.format({
    root: "/",
    name: "file",
    ext: ".txt",
  }),
  "/file.txt",
);
```

In Bun 0.7.3

```
AssertionError: Expected values to be strictly equal:
+ actual - expected

+ '//file.txt'
- '/file.txt'
```


<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests



- [ ] I ran `make js` and committed the transpiled changes
- [x] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [x] I included a test for the new code, or an existing test covers it



<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
