### PR TITLE
Fix require("console") #3820

### DIFF
--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -2396,6 +2396,7 @@ pub const HardcodedModule = enum {
             .{ "node:child_process", .{ .path = "node:child_process" } },
             .{ "node:constants", .{ .path = "node:constants" } },
             .{ "node:console", .{ .path = "node:console" } },
+            .{ "console", .{ .path = "node:console" } },
             .{ "node:querystring", .{ .path = "node:querystring" } },
             .{ "querystring", .{ .path = "node:querystring" } },
             .{ "node:domain", .{ .path = "node:domain" } },

--- a/src/bun.js/modules/NodeModuleModule.h
+++ b/src/bun.js/modules/NodeModuleModule.h
@@ -292,10 +292,12 @@ DEFINE_NATIVE_MODULE(NodeModule) {
     exportNames.append(name);
     exportValues.append(value);
   };
-  exportNames.reserveCapacity(14);
-  exportValues.ensureCapacity(14);
+  exportNames.reserveCapacity(15);
+  exportValues.ensureCapacity(15);
   exportNames.append(vm.propertyNames->defaultKeyword);
   exportValues.append(defaultObject);
+
+  put(Identifier::fromString(vm, "Module"_s), defaultObject);
 
   putNativeFn(Identifier::fromString(vm, "createRequire"_s),
               jsFunctionNodeModuleCreateRequire);

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -26,6 +26,10 @@ test("Module exists", () => {
   expect(Module).toBeDefined();
 });
 
+test("module.Module exists", () => {
+  expect(Module.Module === Module).toBeTrue();
+});
+
 test("_nodeModulePaths() works", () => {
   expect(() => {
     _nodeModulePaths();


### PR DESCRIPTION
### What does this PR do?

Add the alias we are missing for `console` mapping to `node:console`

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
