### PR TITLE
Fix `XLSX.read` coredump

### DIFF
--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -808,7 +808,8 @@ pub const Encoder = struct {
             .utf16le => constructFromU16(input, len, .utf16le),
             .ucs2 => constructFromU16(input, len, .utf16le),
             .utf8 => constructFromU16(input, len, .utf8),
-            .ascii => constructFromU16(input, len, .utf8),
+            .ascii => constructFromU16(input, len, .ascii),
+            .latin1 => constructFromU16(input, len, .latin1),
             else => unreachable,
         };
         return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
@@ -1170,12 +1171,7 @@ pub const Encoder = struct {
             },
             .latin1, .buffer, .ascii => {
                 var to = allocator.alloc(u8, len) catch return &[_]u8{};
-                var input_bytes = std.mem.sliceAsBytes(input[0..len]);
-                @memcpy(to[0..input_bytes.len], input_bytes);
-                for (to[0..len], 0..) |c, i| {
-                    to[i] = @as(u8, @as(u7, @truncate(c)));
-                }
-
+                strings.copyU16IntoU8(to[0..len], []const u16, input[0..len]);
                 return to;
             },
             // string is already encoded, just need to copy the data

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -2552,3 +2552,15 @@ it("write alias", () => {
   shouldBeSame("writeBigUint64BE", "writeBigUInt64BE", BigInt(1000));
   shouldBeSame("writeBigUint64LE", "writeBigUInt64LE", BigInt(1000));
 });
+
+it("construct buffer from UTF16, issue #3914", () => {
+  const raw = Buffer.from([0, 104, 0, 101, 0, 108, 0, 108, 0, 111]);
+  const data = new Uint16Array(raw);
+
+  const decoder = new TextDecoder("UTF-16");
+  const str = decoder.decode(data);
+  expect(str).toStrictEqual("\x00h\x00e\x00l\x00l\x00o");
+
+  const buf = Buffer.from(str, "latin1");
+  expect(buf).toStrictEqual(raw);
+});


### PR DESCRIPTION
Close: #3914

### What does this PR do?

- Fix constructing buffer from a UTF16 string with the Latin1 encoding. If this issue is resolved, then `XLSX.read` will not coredump. 

Please see comments in #3914.


- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests 

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
