### PR TITLE
Fix memory leak in Buffer.toString('base64url')

### DIFF
--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -911,8 +911,8 @@ pub const Encoder = struct {
             .base64url => {
                 var out = bun.String.createUninitialized(.latin1, bun.base64.urlSafeEncodeLen(input)) orelse return ZigString.init("Out of memory").toErrorInstance(global);
                 defer out.deref();
-                const outlen = bun.base64.encodeURLSafe(@constCast(out.latin1()), input);
-                return out.toJSWithLength(global, outlen);
+                _ = bun.base64.encodeURLSafe(@constCast(out.latin1()), input);
+               return out.toJS(global);
             },
 
             .base64 => {


### PR DESCRIPTION
### What does this PR do?

https://github.com/oven-sh/bun/pull/4106 leaks the base64url string

### How did you verify your code works?


After:
```
cpu: Apple M1 Max
runtime: bun 0.7.4_debug (arm64-darwin)

benchmark                                 time (avg)             (min … max)       p75       p99      p995
---------------------------------------------------------------------------- -----------------------------
Buffer(110000).toString('base64url')   92.24 µs/iter    (48.58 µs … 3.21 ms)  52.63 µs 765.96 µs 875.54 µs

Peak memory usage: 60 MB
```

Before:
```
cpu: Apple M1 Max
runtime: bun 0.7.4 (arm64-darwin)

benchmark                                 time (avg)             (min … max)       p75       p99      p995
---------------------------------------------------------------------------- -----------------------------
Buffer(110000).toString('base64url')   60.46 µs/iter   (57.5 µs … 113.75 µs)  61.29 µs  70.75 µs  71.92 µs

Peak memory usage: 1226 MB
```