### PR TITLE
Fix custom config path not working.

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -317,7 +317,7 @@ pub const Arguments = struct {
         defer ctx.debug.loaded_bunfig = true;
         var config_path: [:0]u8 = undefined;
         if (config_path_[0] == '/') {
-            @memcpy(config_buf[0..config_path.len], config_path);
+            @memcpy(config_buf[0..config_path_.len], config_path_);
             config_buf[config_path_.len] = 0;
             config_path = config_buf[0..config_path_.len :0];
         } else {

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect } from "bun:test";
 import { spawnSync } from "bun";
 import { bunExe } from "harness";
+import { tmpdir } from "node:os";
+import fs from "node:fs";
 
 describe("bun", () => {
   describe("NO_COLOR", () => {
@@ -57,6 +59,24 @@ describe("bun", () => {
           "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
         ),
       );
+    });
+  });
+
+  describe("test command line arguments", () => {
+    test("test --config, issue #4128", () => {
+      const path = `${tmpdir()}/bunfig-${Date.now()}.toml`;
+      fs.writeFileSync(path, "[debug]");
+
+      const p = Bun.spawnSync({
+        cmd: [bunExe(), "--config", path],
+        env: {},
+        stderr: "inherit",
+      });
+      try {
+        expect(p.exitCode).toBe(0);
+      } finally {
+        fs.unlinkSync(path);
+      }
     });
   });
 });


### PR DESCRIPTION
Close: #4128

### What does this PR do?

- Fix `bun --config <PATH>`

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->



- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
