### PR TITLE
fix importing too long of strings

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -255,9 +255,8 @@ pub const FileSystem = struct {
         }
 
         pub fn get(entry: *const DirEntry, _query: string) ?Entry.Lookup {
-            if (_query.len == 0) return null;
-            var scratch_lookup_buffer: [256]u8 = undefined;
-            std.debug.assert(scratch_lookup_buffer.len >= _query.len);
+            if (_query.len == 0 or _query.len > bun.MAX_PATH_BYTES) return null;
+            var scratch_lookup_buffer: [bun.MAX_PATH_BYTES]u8 = undefined;
 
             const query = strings.copyLowercaseIfNeeded(_query, &scratch_lookup_buffer);
             const result = entry.data.get(query) orelse return null;

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -133,3 +133,24 @@ it("file url in require resolves", async () => {
   expect(exitCode).toBe(0);
   expect(stdout.toString("utf8")).toBe("1\n");
 });
+
+it("import long string should not segfault", async () => {
+  try {
+    await import("a".repeat(10000));
+  } catch {}
+});
+it("import long string should not segfault", async () => {
+  try {
+    import.meta.require("a".repeat(10000));
+  } catch {}
+});
+it("import long string should not segfault", async () => {
+  try {
+    await import.meta.resolve!("a".repeat(10000));
+  } catch {}
+});
+it("import long string should not segfault", async () => {
+  try {
+    await import.meta.require.resolve("a".repeat(10000));
+  } catch {}
+});


### PR DESCRIPTION
### What does this PR do?

Closes #4149 (doesnt fix the underlying problem but the source of the crash)

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

New tests

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
