### PR TITLE
Fix event loop issue with `Bun.connect`

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -999,7 +999,6 @@ pub const Listener = struct {
                 .protos = null,
                 .server_name = null,
             };
-            tcp.poll_ref.ref(handlers.vm);
 
             TCPSocket.dataSetCached(tcp.getThisValue(globalObject), globalObject, default_data);
 
@@ -1012,6 +1011,7 @@ pub const Listener = struct {
                 exception.* = ZigString.static("Failed to connect").toErrorInstance(globalObject).asObjectRef();
                 return .zero;
             };
+            tcp.poll_ref.ref(handlers.vm);
 
             return promise_value;
         }

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -985,6 +985,7 @@ pub const Listener = struct {
                 exception.* = ZigString.static("Failed to connect").toErrorInstance(globalObject).asObjectRef();
                 return .zero;
             };
+            tls.poll_ref.ref(handlers.vm);
 
             return promise_value;
         } else {
@@ -998,6 +999,7 @@ pub const Listener = struct {
                 .protos = null,
                 .server_name = null,
             };
+            tcp.poll_ref.ref(handlers.vm);
 
             TCPSocket.dataSetCached(tcp.getThisValue(globalObject), globalObject, default_data);
 
@@ -1280,7 +1282,6 @@ fn NewSocket(comptime ssl: bool) type {
                 }
             }
 
-            this.poll_ref.ref(this.handlers.vm);
             this.detached = false;
             this.socket = socket;
 

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1177,7 +1177,7 @@ fn NewSocket(comptime ssl: bool) type {
             defer this.markInactive();
 
             const handlers = this.handlers;
-            this.poll_ref.unref(handlers.vm);
+            this.poll_ref.unrefOnNextTick(handlers.vm);
 
             const callback = handlers.onConnectError;
             var globalObject = handlers.globalObject;
@@ -1214,7 +1214,6 @@ fn NewSocket(comptime ssl: bool) type {
                 const err_ = err.toErrorInstance(globalObject);
                 promise.rejectOnNextTickAsHandled(globalObject, err_);
                 this.has_pending_activity.store(false, .Release);
-                this.poll_ref.unref(handlers.vm);
             }
         }
 

--- a/test/js/bun/net/keep-event-loop-alive.js
+++ b/test/js/bun/net/keep-event-loop-alive.js
@@ -1,0 +1,47 @@
+(async () => {
+  const port = process.argv[2] ? parseInt(process.argv[2]) : null;
+  await Bun.sleep(10);
+  // failed connection
+  console.log("test 1: failed connection");
+  try {
+    const socket = await Bun.connect({
+      hostname: "localhost",
+      port: 9999,
+      socket: { data() {} },
+    });
+    socket.end();
+  } catch (error) {}
+  // failed connection tls
+  console.log("test 2: failed connection [tls]");
+  try {
+    const socket = await Bun.connect({
+      hostname: "localhost",
+      port: 9999,
+      socket: { data() {} },
+      tls: true,
+    });
+    socket.end();
+  } catch (error) {}
+  if (port) {
+    // successful connection
+    console.log("test 3: successful connection");
+    const socket = await Bun.connect({
+      hostname: "localhost",
+      port,
+      socket: { data() {} },
+    });
+    socket.end();
+
+    // successful connection tls
+    console.log("test 4: successful connection [tls]");
+    const socket2 = await Bun.connect({
+      hostname: "localhost",
+      port,
+      socket: { data() {} },
+    });
+    socket2.end();
+  } else {
+    console.log("run with a port as an argument to try the success situation");
+  }
+  console.log("success: event loop was not killed");
+})();


### PR DESCRIPTION
### What does this PR do?

Before, the event loop is not reffed between the time `Bun.connect` is called and the `open` callback is emitted. We are relying on the `await` to keep the event loop on.

This fixes #4108 as well as this minimal repro.

```ts
(async () => {
  await Bun.sleep(10);
  console.log("connecting pool...");
  await Bun.connect({
    hostname: "localhost",
    port: 5432,
    socket: { data() {} },
  });
  console.log("connected pool");
})();
```

Though it makes me think if we'll need more cases for keeping the event loop alive, as we should not have to rely on top-level await to carry us. Later we should investigate if `Bun.build` and any other promise-returning API has this sort of issue.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

I verified the current tests work as well as the issue did not reproduce.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
