### PR TITLE
chore: fix method name typo

### DIFF
--- a/src/string.zig
+++ b/src/string.zig
@@ -637,7 +637,7 @@ pub const String = extern struct {
 
     pub fn canBeUTF8(self: String) bool {
         if (self.tag == .WTFStringImpl)
-            return self.value.WTFStringImpl.is8Bit() and bun.strings.isAllASCII(self.value.WTFStringImpl.latin1());
+            return self.value.WTFStringImpl.is8Bit() and bun.strings.isAllASCII(self.value.WTFStringImpl.latin1Slice());
 
         if (self.tag == .ZigString or self.tag == .StaticZigString)
             return self.value.ZigString.isUTF8();


### PR DESCRIPTION
### What does this PR do?

The latest main branch cannot be built currently. Commit sha 1a6a52314f88946e66ac0f36d00d624ec1a5296f. Strangely, the CI status is still green 🤔. There is no `latin1` method in `WTFStringImplStruct`, only a `latin1Slice` method.


![2023-08-15_22-31](https://github.com/oven-sh/bun/assets/9482395/0b4e49fd-a2b6-4e88-8a32-4b4eeac1e526)


- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
