### PR TITLE
Support `bun.json`

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5260,7 +5260,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 editor.open(ctx.path, url, line, column, this.allocator) catch Output.prettyErrorln("Failed to open editor", .{});
             } else {
                 resp.writeStatus("500 Missing Editor :(");
-                resp.end("Please set your editor in bunfig.toml", false);
+                resp.end("Please set your editor in bun.json", false);
             }
         }
 

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -55,7 +55,6 @@ pub const Run = struct {
         var arena = try Arena.init();
 
         if (!ctx.debug.loaded_bunfig) {
-            // _ = try bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand);
             _ = bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bun.json", &ctx, .RunCommand) catch blk: {
                 break :blk bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand) catch false;
             };

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -55,7 +55,10 @@ pub const Run = struct {
         var arena = try Arena.init();
 
         if (!ctx.debug.loaded_bunfig) {
-            try bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand);
+            // _ = try bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand);
+            _ = bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bun.json", &ctx, .RunCommand) catch blk: {
+                break :blk bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand) catch false;
+            };
         }
 
         run = .{
@@ -142,7 +145,9 @@ pub const Run = struct {
         var arena = try Arena.init();
 
         if (!ctx.debug.loaded_bunfig) {
-            try bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand);
+            _ = bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bun.json", &ctx, .RunCommand) catch blk: {
+                break :blk bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand) catch false;
+            };
         }
 
         run = .{

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -133,10 +133,10 @@ pub const Arguments = struct {
     pub const ParamType = clap.Param(clap.Help);
 
     const shared_public_params = [_]ParamType{
-        clap.parseParam("-h, --help                        Display this help and exit.") catch unreachable,
+        clap.parseParam("-h, --help                        Display this help and exit") catch unreachable,
         clap.parseParam("-b, --bun                         Force a script or package to use Bun.js instead of Node.js (via symlinking node)") catch unreachable,
         clap.parseParam("--cwd <STR>                       Absolute path to resolve files & entry points from. This just changes the process' cwd.") catch unreachable,
-        clap.parseParam("-c, --config <PATH>               Config file to load bun from (e.g. -c bun.json") catch unreachable,
+        clap.parseParam("-c, --config <PATH>               Specify path to config file (e.g. -c bun.json)") catch unreachable,
         clap.parseParam("--extension-order <STR>...        Defaults to: .tsx,.ts,.jsx,.js,.json ") catch unreachable,
         clap.parseParam("--jsx-factory <STR>               Changes the function called when compiling JSX elements using the classic JSX runtime") catch unreachable,
         clap.parseParam("--jsx-fragment <STR>              Changes the function called when compiling JSX fragments") catch unreachable,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -299,18 +299,6 @@ pub const Arguments = struct {
         if (comptime cmd.readGlobalConfig()) brk: {
             if (ctx.has_loaded_global_config) break :brk;
 
-            if (getRootBunfigPath(&config_buf)) |path| {
-                Output.debug("trying to load {s}\n", .{path});
-                const success = loadConfigPath(allocator, true, path, ctx, comptime cmd) catch false;
-                if (success) {
-                    Output.debug("successfully loaded global bunfig\n", .{});
-                    ctx.has_loaded_global_config = true;
-                    break :brk;
-                } else {
-                    Output.debug("failed to load global bunfig\n", .{});
-                }
-            }
-
             if (getRootBunJSONPath(&config_buf)) |path| {
                 Output.debug("trying to load {s}\n", .{path});
                 const success = loadConfigPath(allocator, true, path, ctx, comptime cmd) catch false;
@@ -320,6 +308,18 @@ pub const Arguments = struct {
                     break :brk;
                 } else {
                     Output.debug("failed to load global bun.json\n", .{});
+                }
+            }
+
+            if (getRootBunfigPath(&config_buf)) |path| {
+                Output.debug("trying to load {s}\n", .{path});
+                const success = loadConfigPath(allocator, true, path, ctx, comptime cmd) catch false;
+                if (success) {
+                    Output.debug("successfully loaded global bunfig\n", .{});
+                    ctx.has_loaded_global_config = true;
+                    break :brk;
+                } else {
+                    Output.debug("failed to load global bunfig\n", .{});
                 }
             }
         }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1583,9 +1583,6 @@ pub const Command = struct {
 
                     if (extension.len > 0) {
                         if (!ctx.debug.loaded_bunfig) {
-                            // get absolute path to bunfig.toml
-                            // var config_path
-
                             var success = Arguments.loadConfigPath(ctx.allocator, true, "bun.json", &ctx, .RunCommand) catch false;
                             if (!success) {
                                 _ = Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand) catch false;

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -933,7 +933,9 @@ pub const RunCommand = struct {
                         // once we know it's a file, check if they have any preloads
                         if (ext.len > 0 and !has_loader) {
                             if (!ctx.debug.loaded_bunfig) {
-                                try bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand);
+                                _ = bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bun.json", &ctx, .RunCommand) catch brk: {
+                                    break :brk bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand) catch false;
+                                };
                             }
 
                             if (ctx.preloads.len == 0)

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5722,7 +5722,7 @@ pub const PackageManager = struct {
         "Possible values: \"hardlink\" (default), \"symlink\", \"copyfile\"";
 
     const install_params_ = [_]ParamType{
-        clap.parseParam("-c, --config <STR>?               Load config (bunfig.toml)") catch unreachable,
+        clap.parseParam("-c, --config <STR>                Load config (bun.json)") catch unreachable,
         clap.parseParam("-y, --yarn                        Write a yarn.lock file (yarn v1)") catch unreachable,
         clap.parseParam("-p, --production                  Don't install devDependencies") catch unreachable,
         clap.parseParam("--no-save                         Don't save a lockfile") catch unreachable,

--- a/test/cli/run/bunfig.test.ts
+++ b/test/cli/run/bunfig.test.ts
@@ -9,7 +9,6 @@ describe("config", () => {
         "index.ts": "console.log(caterpillar);",
       });
       const { stdout } = bunRun(`${dir}/index.ts`);
-      // should be "a\n but console.log adds a newline
       expect(stdout).toBe("butterfly");
     }
   });
@@ -21,7 +20,6 @@ describe("config", () => {
         "index.ts": "console.log(caterpillar);",
       });
       const { stdout } = bunRun(`${dir}/index.ts`);
-      // should be "a\n but console.log adds a newline
       expect(stdout).toBe("butterfly");
     }
   });
@@ -34,7 +32,6 @@ describe("config", () => {
         "index.ts": "console.log(caterpillar);",
       });
       const { stdout } = bunRun(`${dir}/index.ts`);
-      // should be "a\n but console.log adds a newline
       expect(stdout).toBe("correct");
     }
   });
@@ -46,7 +43,6 @@ describe("config", () => {
         "index.ts": "console.log(caterpillar);",
       });
       const { stdout } = bunRun(`${dir}/index.ts`, {}, { flags: ["--config", "bun2.json"] });
-      // should be "a\n but console.log adds a newline
       expect(stdout).toBe("butterfly");
     }
   });
@@ -58,7 +54,6 @@ describe("config", () => {
         "index.ts": "console.log(caterpillar);",
       });
       const { stdout } = bunRun(`${dir}/index.ts`, {}, { flags: ["-c", "bun2.json"] });
-      // should be "a\n but console.log adds a newline
       expect(stdout).toBe("butterfly");
     }
   });
@@ -70,7 +65,6 @@ describe("config", () => {
         "index.ts": "console.log(caterpillar);",
       });
       const { stdout } = bunRun(`${dir}/index.ts`, {}, { flags: ["--config", "bun2.toml"] });
-      // should be "a\n but console.log adds a newline
       expect(stdout).toBe("butterfly");
     }
   });
@@ -81,7 +75,6 @@ describe("config", () => {
         "index.ts": "console.log(caterpillar);",
       });
       const { stdout } = bunRun(`${dir}/index.ts`, {}, { flags: ["-c", "bun2.toml"] });
-      // should be "a\n but console.log adds a newline
       expect(stdout).toBe("butterfly");
     }
   });

--- a/test/cli/run/bunfig.test.ts
+++ b/test/cli/run/bunfig.test.ts
@@ -58,6 +58,17 @@ describe("config", () => {
     }
   });
 
+  test("read --config *.json absolute path", () => {
+    {
+      const dir = tempDirWithFiles("dotenv", {
+        "bun2.json": `{"define": { "caterpillar": "'butterfly'" }}`,
+        "index.ts": "console.log(caterpillar);",
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`, {}, { flags: ["-c", `${dir}/bun2.json`] });
+      expect(stdout).toBe("butterfly");
+    }
+  });
+
   test("read --config *.toml", () => {
     {
       const dir = tempDirWithFiles("dotenv", {
@@ -68,6 +79,7 @@ describe("config", () => {
       expect(stdout).toBe("butterfly");
     }
   });
+
   test("read -c *.toml", () => {
     {
       const dir = tempDirWithFiles("dotenv", {
@@ -78,4 +90,39 @@ describe("config", () => {
       expect(stdout).toBe("butterfly");
     }
   });
+
+  test("read --config absolute path", () => {
+    {
+      const dir = tempDirWithFiles("dotenv", {
+        "bun2.toml": `[define]\n"caterpillar" = "'butterfly'"`,
+        "index.ts": "console.log(caterpillar);",
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`, {}, { flags: ["-c", `${dir}/bun2.toml`] });
+      expect(stdout).toBe("butterfly");
+    }
+  });
+
+  test("fail if --config absolute path can't be found", () => {
+    {
+      const dir = tempDirWithFiles("dotenv", {
+        "index.ts": "console.log(caterpillar);",
+      });
+
+      {
+        expect(() => {
+          bunRun(`${dir}/index.ts`, {}, { flags: ["-c", `${dir}/notreal.json`] });
+        }).toThrow();
+      }
+    }
+  });
+  // test("read --config absolute path", () => {
+  //   {
+  //     const dir = tempDirWithFiles("dotenv", {
+  //       "bun2.toml": `[define]\n"caterpillar" = "'butterfly'"`,
+  //       "index.ts": "console.log(caterpillar);",
+  //     });
+  //     const { stdout } = bunRun(`${dir}/index.ts`, {}, { flags: ["-c", "bun2.toml"] });
+  //     expect(stdout).toBe("butterfly");
+  //   }
+  // });
 });

--- a/test/cli/run/bunfig.test.ts
+++ b/test/cli/run/bunfig.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { bunRun, tempDirWithFiles } from "harness";
+
+describe("config", () => {
+  test("read bun.json", () => {
+    {
+      const dir = tempDirWithFiles("dotenv", {
+        "bun.json": `{"define": { "caterpillar": "'butterfly'" }}`,
+        "index.ts": "console.log(caterpillar);",
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`);
+      // should be "a\n but console.log adds a newline
+      expect(stdout).toBe("butterfly");
+    }
+  });
+
+  test("read bunfig.toml", () => {
+    {
+      const dir = tempDirWithFiles("dotenv", {
+        "bunfig.toml": `[define]\n"caterpillar" = "'butterfly'"`,
+        "index.ts": "console.log(caterpillar);",
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`);
+      // should be "a\n but console.log adds a newline
+      expect(stdout).toBe("butterfly");
+    }
+  });
+
+  test("ignore bunfig.toml if bun.json is found", () => {
+    {
+      const dir = tempDirWithFiles("dotenv", {
+        "bun.json": `{"define": { "caterpillar": "'correct'" }}`,
+        "bunfig.toml": `[define]\n"caterpillar" = "'wrong'"`,
+        "index.ts": "console.log(caterpillar);",
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`);
+      // should be "a\n but console.log adds a newline
+      expect(stdout).toBe("correct");
+    }
+  });
+
+  test("read --config *.json", () => {
+    {
+      const dir = tempDirWithFiles("dotenv", {
+        "bun2.json": `{"define": { "caterpillar": "'butterfly'" }}`,
+        "index.ts": "console.log(caterpillar);",
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`, {}, { flags: ["--config", "bun2.json"] });
+      // should be "a\n but console.log adds a newline
+      expect(stdout).toBe("butterfly");
+    }
+  });
+
+  test("read -c *.json", () => {
+    {
+      const dir = tempDirWithFiles("dotenv", {
+        "bun2.json": `{"define": { "caterpillar": "'butterfly'" }}`,
+        "index.ts": "console.log(caterpillar);",
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`, {}, { flags: ["-c", "bun2.json"] });
+      // should be "a\n but console.log adds a newline
+      expect(stdout).toBe("butterfly");
+    }
+  });
+
+  test("read --config *.toml", () => {
+    {
+      const dir = tempDirWithFiles("dotenv", {
+        "bun2.toml": `[define]\n"caterpillar" = "'butterfly'"`,
+        "index.ts": "console.log(caterpillar);",
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`, {}, { flags: ["--config", "bun2.toml"] });
+      // should be "a\n but console.log adds a newline
+      expect(stdout).toBe("butterfly");
+    }
+  });
+  test("read -c *.toml", () => {
+    {
+      const dir = tempDirWithFiles("dotenv", {
+        "bun2.toml": `[define]\n"caterpillar" = "'butterfly'"`,
+        "index.ts": "console.log(caterpillar);",
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`, {}, { flags: ["-c", "bun2.toml"] });
+      // should be "a\n but console.log adds a newline
+      expect(stdout).toBe("butterfly");
+    }
+  });
+});

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -101,9 +101,15 @@ export function tempDirWithFiles(basename: string, files: Record<string, string 
   return dir;
 }
 
-export function bunRun(file: string, env?: Record<string, string>) {
+export function bunRun(
+  file: string,
+  env?: Record<string, string>,
+  params?: {
+    flags?: string[];
+  },
+) {
   var path = require("path");
-  const result = Bun.spawnSync([bunExe(), file], {
+  const result = Bun.spawnSync([bunExe(), ...(params?.flags ?? []), file], {
     cwd: path.dirname(file),
     env: {
       ...bunEnv,

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -119,6 +119,7 @@ export function bunRun(
   });
   if (!result.success) throw new Error(result.stderr.toString("utf8"));
   return {
+    code: result.exitCode,
     stdout: result.stdout.toString("utf8").trim(),
     stderr: result.stderr.toString("utf8").trim(),
   };
@@ -154,6 +155,7 @@ export function bunRunAsScript(dir: string, script: string, env?: Record<string,
   if (!result.success) throw new Error(result.stderr.toString("utf8"));
 
   return {
+    code: result.exitCode,
     stdout: result.stdout.toString("utf8").trim(),
     stderr: result.stderr.toString("utf8").trim(),
   };


### PR DESCRIPTION
### What does this PR do?


<!-- **Please explain what your changes do**, example: -->

Add support for `bun.json`. This doesn't include any docs changes currently.

- The `bun` CLI now reads `bun.json` in addition to `bunfig.toml`
- If `bun.json` is found, `bunfig.toml` is not read
- Global configuration can be placed at `~/bun.json`. If this is found, `~/.bunfig.toml` is not read. (By `~` I mean `$XDG_CONFIG_HOME || $HOME`)

### How did you verify your code works?

Added tests to `cli/run/bunfig.test.ts`

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

### Open questions

- What should be the path to the global config file? Currently it's `$HOME/bun.json` (no dot prefix). We could either add a dot prefix (`$HOME/bun.json`) or put it in `~/.bun` (`$HOME/.bun/bun.json`). I think the latter is my preference.