### PR TITLE
Fix leaking .ptr

### DIFF
--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -386,6 +386,7 @@ pub const FFI = struct {
                         @as(u32, @intCast(function.arg_types.items.len)),
                         bun.cast(JSC.JSHostFunctionPtr, compiled.ptr),
                         false,
+                        true,
                     );
                     compiled.js_function = cb;
                     obj.put(global, &str, cb);
@@ -482,6 +483,7 @@ pub const FFI = struct {
                         @as(u32, @intCast(function.arg_types.items.len)),
                         bun.cast(JSC.JSHostFunctionPtr, compiled.ptr),
                         false,
+                        true,
                     );
                     compiled.js_function = cb;
 

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -5357,6 +5357,7 @@ const private = struct {
         argCount: u32,
         functionPointer: JSHostFunctionPtr,
         strong: bool,
+        add_ptr_field: bool,
     ) JSValue;
 
     pub extern fn Bun__untrackFFIFunction(
@@ -5380,7 +5381,7 @@ pub fn NewFunction(
     comptime functionPointer: JSHostFunctionType,
     strong: bool,
 ) JSValue {
-    return NewRuntimeFunction(globalObject, symbolName, argCount, &functionPointer, strong);
+    return NewRuntimeFunction(globalObject, symbolName, argCount, &functionPointer, strong, false);
 }
 
 pub fn NewRuntimeFunction(
@@ -5389,9 +5390,10 @@ pub fn NewRuntimeFunction(
     argCount: u32,
     functionPointer: JSHostFunctionPtr,
     strong: bool,
+    add_ptr_property: bool,
 ) JSValue {
     JSC.markBinding(@src());
-    return private.Bun__CreateFFIFunctionValue(globalObject, symbolName, argCount, functionPointer, strong);
+    return private.Bun__CreateFFIFunctionValue(globalObject, symbolName, argCount, functionPointer, strong, add_ptr_property);
 }
 
 pub fn getFunctionData(function: JSValue) ?*anyopaque {

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -425,22 +425,22 @@ pub const Jest = struct {
         module.put(
             globalObject,
             ZigString.static("beforeAll"),
-            JSC.NewRuntimeFunction(globalObject, ZigString.static("beforeAll"), 1, DescribeScope.beforeAll, false),
+            JSC.NewRuntimeFunction(globalObject, ZigString.static("beforeAll"), 1, DescribeScope.beforeAll, false, false),
         );
         module.put(
             globalObject,
             ZigString.static("beforeEach"),
-            JSC.NewRuntimeFunction(globalObject, ZigString.static("beforeEach"), 1, DescribeScope.beforeEach, false),
+            JSC.NewRuntimeFunction(globalObject, ZigString.static("beforeEach"), 1, DescribeScope.beforeEach, false, false),
         );
         module.put(
             globalObject,
             ZigString.static("afterAll"),
-            JSC.NewRuntimeFunction(globalObject, ZigString.static("afterAll"), 1, DescribeScope.afterAll, false),
+            JSC.NewRuntimeFunction(globalObject, ZigString.static("afterAll"), 1, DescribeScope.afterAll, false, false),
         );
         module.put(
             globalObject,
             ZigString.static("afterEach"),
-            JSC.NewRuntimeFunction(globalObject, ZigString.static("afterEach"), 1, DescribeScope.afterEach, false),
+            JSC.NewRuntimeFunction(globalObject, ZigString.static("afterEach"), 1, DescribeScope.afterEach, false, false),
         );
         module.put(
             globalObject,

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -580,7 +580,8 @@ function ffiRunner(fast) {
 }
 
 it("read", () => {
-  const buffer = new BigInt64Array(16);
+  // The usage of globalThis is a GC thing we should really fix
+  globalThis.buffer = new BigInt64Array(16);
   const dataView = new DataView(buffer.buffer);
   const addr = ptr(buffer);
 
@@ -607,6 +608,8 @@ it("read", () => {
     expect(read.u32(addr, i)).toBe(dataView.getUint32(i, true));
     expect(read.f32(addr, i)).toBe(dataView.getFloat32(i, true));
   }
+
+  delete globalThis.buffer;
 });
 
 if (ok) {
@@ -630,4 +633,11 @@ it("dlopen throws an error instead of returning it", () => {
 
 it('suffix does not start with a "."', () => {
   expect(suffix).not.toMatch(/^\./);
+});
+
+it(".ptr is not leaked", () => {
+  for (let fn of [Bun.password.hash, Bun.password.verify, it]) {
+    expect(fn).not.toHaveProperty("ptr");
+    expect(fn.ptr).toBeUndefined();
+  }
 });


### PR DESCRIPTION
### What does this PR do?

JSFFIFunction is repurposed in a few other places to create functions from Zig -> JS, and is not supposed to have `.ptr` property when not used from FFI.