### PR TITLE
Add inline sourcemaps when `--inspect` is enabled

### DIFF
--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -50,6 +50,11 @@ JSC::JSValue toJS(JSC::JSGlobalObject* globalObject, BunString bunString)
         return JSValue(JSC::jsEmptyString(globalObject->vm()));
     }
     if (bunString.tag == BunStringTag::WTFStringImpl) {
+#if BUN_DEBUG
+        if (bunString.tag == BunStringTag::WTFStringImpl) {
+            RELEASE_ASSERT(bunString.impl.wtf->refCount() > 0);
+        }
+#endif
         return JSValue(jsString(globalObject->vm(), String(bunString.impl.wtf)));
     }
 
@@ -62,6 +67,11 @@ JSC::JSValue toJS(JSC::JSGlobalObject* globalObject, BunString bunString)
 
 JSC::JSValue toJS(JSC::JSGlobalObject* globalObject, BunString bunString, size_t length)
 {
+#if BUN_DEBUG
+    if (bunString.tag == BunStringTag::WTFStringImpl) {
+        RELEASE_ASSERT(bunString.impl.wtf->refCount() > 0);
+    }
+#endif
     return jsSubstring(globalObject, jsUndefined(), Bun::toWTFString(bunString), 0, length);
 }
 
@@ -79,6 +89,9 @@ WTF::String toWTFString(const BunString& bunString)
     }
 
     if (bunString.tag == BunStringTag::WTFStringImpl) {
+#if BUN_DEBUG
+        RELEASE_ASSERT(bunString.impl.wtf->refCount() > 0);
+#endif
         return WTF::String(bunString.impl.wtf);
     }
 

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -174,6 +174,11 @@ pub const SavedSourceMap = struct {
 
     mutex: bun.Lock = bun.Lock.init(),
 
+    pub const Inline = struct {
+        vm: *VirtualMachine,
+        printer: *js_printer.BufferPrinter,
+    };
+
     pub fn onSourceMapChunk(this: *SavedSourceMap, chunk: SourceMap.Chunk, source: logger.Source) anyerror!void {
         try this.putMappings(source, chunk.buffer);
     }
@@ -507,6 +512,51 @@ pub const VirtualMachine = struct {
 
     pub fn mimeType(this: *VirtualMachine, str: []const u8) ?bun.HTTP.MimeType {
         return this.rareData().mimeTypeFromString(this.allocator, str);
+    }
+
+    const SourceMapHandlerGetter = struct {
+        vm: *VirtualMachine,
+        printer: *js_printer.BufferPrinter,
+
+        pub fn get(this: *SourceMapHandlerGetter) js_printer.SourceMapHandler {
+            if (this.vm.debugger == null) {
+                return SavedSourceMap.SourceMapHandler.init(&this.vm.source_mappings);
+            }
+
+            return js_printer.SourceMapHandler.For(SourceMapHandlerGetter, onChunk).init(this);
+        }
+
+        /// When the inspector is enabled, we want to generate an inline sourcemap.
+        /// And, for now, we also store it in source_mappings like normal
+        /// This is hideously expensive memory-wise...
+        pub fn onChunk(this: *SourceMapHandlerGetter, chunk: SourceMap.Chunk, source: logger.Source) anyerror!void {
+            var temp_json_buffer = bun.MutableString.initEmpty(bun.default_allocator);
+            defer temp_json_buffer.deinit();
+            temp_json_buffer = try chunk.printSourceMapContents(source, temp_json_buffer, true, true);
+            const source_map_url_prefix_start = "//# sourceMappingURL=data:application/json;base64,";
+            // TODO: do we need to %-encode the path?
+            const source_url_len = source.path.text.len;
+            const source_mapping_url = "\n//# sourceURL=";
+            const prefix_len = source_map_url_prefix_start.len + source_mapping_url.len + source_url_len;
+
+            try this.vm.source_mappings.putMappings(source, chunk.buffer);
+            const encode_len = bun.base64.encodeLen(temp_json_buffer.list.items);
+            try this.printer.ctx.buffer.growIfNeeded(encode_len + prefix_len + 2);
+            this.printer.ctx.buffer.appendAssumeCapacity("\n" ++ source_map_url_prefix_start);
+            _ = bun.base64.encode(this.printer.ctx.buffer.list.items.ptr[this.printer.ctx.buffer.len()..this.printer.ctx.buffer.list.capacity], temp_json_buffer.list.items);
+            this.printer.ctx.buffer.list.items.len += encode_len;
+            this.printer.ctx.buffer.appendAssumeCapacity(source_mapping_url);
+            // TODO: do we need to %-encode the path?
+            this.printer.ctx.buffer.appendAssumeCapacity(source.path.text);
+            try this.printer.ctx.buffer.append("\n");
+        }
+    };
+
+    pub inline fn sourceMapHandler(this: *VirtualMachine, printer: *js_printer.BufferPrinter) SourceMapHandlerGetter {
+        return SourceMapHandlerGetter{
+            .vm = this,
+            .printer = printer,
+        };
     }
 
     pub const GCLevel = enum(u3) {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -174,11 +174,6 @@ pub const SavedSourceMap = struct {
 
     mutex: bun.Lock = bun.Lock.init(),
 
-    pub const Inline = struct {
-        vm: *VirtualMachine,
-        printer: *js_printer.BufferPrinter,
-    };
-
     pub fn onSourceMapChunk(this: *SavedSourceMap, chunk: SourceMap.Chunk, source: logger.Source) anyerror!void {
         try this.putMappings(source, chunk.buffer);
     }

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -526,13 +526,14 @@ pub const RuntimeTranspilerStore = struct {
             printer.ctx.reset();
 
             {
+                var mapper = vm.sourceMapHandler(&printer);
                 defer source_code_printer.?.* = printer;
                 _ = bundler.printWithSourceMap(
                     parse_result,
                     @TypeOf(&printer),
                     &printer,
                     .esm_ascii,
-                    SavedSourceMap.SourceMapHandler.init(&vm.source_mappings),
+                    mapper.get(),
                 ) catch |err| {
                     this.parse_error = err;
                     return;
@@ -1213,13 +1214,14 @@ pub const ModuleLoader = struct {
             printer.ctx.reset();
 
             {
+                var mapper = jsc_vm.sourceMapHandler(&printer);
                 defer VirtualMachine.source_code_printer.?.* = printer;
                 _ = try jsc_vm.bundler.printWithSourceMap(
                     parse_result,
                     @TypeOf(&printer),
                     &printer,
                     .esm_ascii,
-                    SavedSourceMap.SourceMapHandler.init(&jsc_vm.source_mappings),
+                    mapper.get(),
                 );
             }
 
@@ -1603,13 +1605,14 @@ pub const ModuleLoader = struct {
                 printer.ctx.reset();
 
                 _ = brk: {
+                    var mapper = jsc_vm.sourceMapHandler(&printer);
                     defer source_code_printer.* = printer;
                     break :brk try jsc_vm.bundler.printWithSourceMap(
                         parse_result,
                         @TypeOf(&printer),
                         &printer,
                         .esm_ascii,
-                        SavedSourceMap.SourceMapHandler.init(&jsc_vm.source_mappings),
+                        mapper.get(),
                     );
                 };
 


### PR DESCRIPTION
### What does this PR do?

This adds inline sourcemaps when `--inspect` is enabled. Inline sourcemaps are really slow. This makes every source file about 2x - 3x larger in-memory. But you need sourcemaps to debug in Bun properly.

### How did you verify your code works?

Manually tested in web inspector