### PR TITLE
Fix crash impacting sharp & resvg

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -202,7 +202,7 @@ JSC::EncodedJSValue JSBuffer__bufferFromPointerAndLengthAndDeinit(JSC::JSGlobalO
     auto* subclassStructure = globalObject->JSBufferSubclassStructure();
 
     if (LIKELY(length > 0)) {
-        auto buffer = ArrayBuffer::createFromBytes(ptr, length, createSharedTask<void(void*)>([=](void* p) {
+        auto buffer = ArrayBuffer::createFromBytes(ptr, length, createSharedTask<void(void*)>([ctx, bytesDeallocator](void* p) {
             if (bytesDeallocator)
                 bytesDeallocator(p, ctx);
         }));

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -707,20 +707,8 @@ pub export fn napi_create_arraybuffer(env: napi_env, byte_length: usize, data: [
     return .ok;
 }
 
-pub export fn napi_create_external_arraybuffer(env: napi_env, external_data: ?*anyopaque, byte_length: usize, finalize_cb: napi_finalize, finalize_hint: ?*anyopaque, result: *napi_value) napi_status {
-    log("napi_create_external_arraybuffer", .{});
-    var external = JSC.ExternalBuffer.create(
-        finalize_hint,
-        @as([*]u8, @ptrCast(external_data.?))[0..byte_length],
-        env,
-        finalize_cb,
-        env.bunVM().allocator,
-    ) catch {
-        return genericFailure();
-    };
-    result.* = external.toArrayBuffer(env);
-    return .ok;
-}
+pub extern fn napi_create_external_arraybuffer(env: napi_env, external_data: ?*anyopaque, byte_length: usize, finalize_cb: napi_finalize, finalize_hint: ?*anyopaque, result: *napi_value) napi_status;
+
 pub export fn napi_get_arraybuffer_info(env: napi_env, arraybuffer: napi_value, data: ?*[*]u8, byte_length: ?*usize) napi_status {
     log("napi_get_arraybuffer_info", .{});
     const array_buffer = arraybuffer.asArrayBuffer(env) orelse return .arraybuffer_expected;
@@ -1072,15 +1060,7 @@ pub export fn napi_create_buffer(env: napi_env, length: usize, data: ?**anyopaqu
     result.* = buffer;
     return .ok;
 }
-pub export fn napi_create_external_buffer(env: napi_env, length: usize, data: ?*anyopaque, finalize_cb: napi_finalize, finalize_hint: ?*anyopaque, result: *napi_value) napi_status {
-    log("napi_create_external_buffer: {d}", .{length});
-    var buf = JSC.ExternalBuffer.create(finalize_hint, @as([*]u8, @ptrCast(data.?))[0..length], env, finalize_cb, bun.default_allocator) catch {
-        return genericFailure();
-    };
-
-    result.* = buf.toJS(env);
-    return .ok;
-}
+pub extern fn napi_create_external_buffer(env: napi_env, length: usize, data: ?*anyopaque, finalize_cb: napi_finalize, finalize_hint: ?*anyopaque, result: *napi_value) napi_status;
 pub export fn napi_create_buffer_copy(env: napi_env, length: usize, data: [*]u8, result_data: ?*?*anyopaque, result: *napi_value) napi_status {
     log("napi_create_buffer_copy: {d}", .{length});
     var buffer = JSC.JSValue.createBufferFromLength(env, length);

--- a/test/js/third_party/resvg/bbox.test.js
+++ b/test/js/third_party/resvg/bbox.test.js
@@ -1,6 +1,16 @@
 import { test, expect } from "bun:test";
 import { Resvg } from "@resvg/resvg-js";
 
+const opts = {
+  fitTo: {
+    mode: "width",
+    value: 500,
+  },
+  font: {
+    loadSystemFonts: false,
+  },
+};
+
 const svg = `<svg viewBox="-40 0 180 260" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <g fill="green" transform="rotate(-10 50 100) translate(-36 45.5) skewX(40) scale(1 0.5)">
   <path id="heart" d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z" />
@@ -20,16 +30,6 @@ for (let Class of [
   },
 ]) {
   test(`bbox ${Class.name}`, () => {
-    const opts = {
-      fitTo: {
-        mode: "width",
-        value: 500,
-      },
-      font: {
-        loadSystemFonts: false,
-      },
-    };
-
     const resvg = new Class(svg, opts);
     const bbox = resvg.getBBox();
 
@@ -37,10 +37,11 @@ for (let Class of [
     expect(resvg.height).toBe(260);
 
     if (bbox) resvg.cropByBBox(bbox);
-    const pngData = resvg.render();
 
     expect(bbox.width).toBe(112.20712208389321);
     expect(bbox.height).toBe(81);
+
+    const pngData = resvg.render();
 
     expect(pngData.width).toBe(500);
     expect(pngData.height).toBe(362);
@@ -51,3 +52,11 @@ for (let Class of [
     }
   });
 }
+
+test("napi_create_external_buffer", () => {
+  const resvg = new Resvg(svg, opts);
+  for (let i = 0; i < 10; i++) {
+    resvg.render().asPng();
+    Bun.gc();
+  }
+});


### PR DESCRIPTION
### What does this PR do?

The implementation of napi_create_external_arraybuffer and napi_create_external_buffer was wrong. It called the finalizer with incorrect arguments, causing a crash when the memory is freed. This calls the finalizer with the expected arguments.

### How did you verify your code works?

Integration test via resvg. Manually tested sharp as well.