### PR TITLE
Fix(bundler): allow generating exe file in nested path.

### DIFF
--- a/src/standalone_bun.zig
+++ b/src/standalone_bun.zig
@@ -439,7 +439,7 @@ pub const StandaloneModuleGraph = struct {
             std.fs.cwd().fd,
             &(try std.os.toPosixPath(temp_location)),
             root_dir.dir.fd,
-            &(try std.os.toPosixPath(outfile)),
+            &(try std.os.toPosixPath(std.fs.path.basename(outfile))),
         ) catch |err| {
             if (err == error.IsDir) {
                 Output.prettyErrorln("<r><red>error<r><d>:<r> {} is a directory. Please choose a different --outfile or delete the directory", .{bun.fmt.quote(outfile)});

--- a/src/standalone_bun.zig
+++ b/src/standalone_bun.zig
@@ -257,7 +257,7 @@ pub const StandaloneModuleGraph = struct {
                 // if we're on a mac, use clonefile() if we can
                 // failure is okay, clonefile is just a fast path.
                 if (Syscall.clonefile(self_exeZ, zname) == .result) {
-                    switch (Syscall.open(zname, std.os.O.WRONLY | std.os.O.CLOEXEC, 0)) {
+                    switch (Syscall.open(zname, std.os.O.RDWR | std.os.O.CLOEXEC, 0)) {
                         .result => |res| break :brk res,
                         .err => {},
                     }
@@ -269,7 +269,7 @@ pub const StandaloneModuleGraph = struct {
             const fd = brk2: {
                 var tried_changing_abs_dir = false;
                 for (0..3) |retry| {
-                    switch (Syscall.open(zname, std.os.O.CLOEXEC | std.os.O.WRONLY | std.os.O.CREAT, 0)) {
+                    switch (Syscall.open(zname, std.os.O.CLOEXEC | std.os.O.RDWR | std.os.O.CREAT, 0)) {
                         .result => |res| break :brk2 res,
                         .err => |err| {
                             if (retry < 2) {

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -1,6 +1,8 @@
 import { bunEnv, bunExe } from "harness";
-import path from "path";
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 describe("bun build", () => {
   test("warnings dont return exit code 1", () => {
@@ -12,5 +14,42 @@ describe("bun build", () => {
     expect(stderr.toString("utf8")).toContain(
       'warn: "key" prop before a {...spread} is deprecated in JSX. Falling back to classic runtime.',
     );
+  });
+
+  test("generating a standalone binary in nested path, issue #4195", () => {
+    function testCompile(outfile: string) {
+      const { exitCode } = Bun.spawnSync({
+        cmd: [
+          bunExe(),
+          "build",
+          path.join(import.meta.dir, "./fixtures/trivial/index.js"),
+          "--compile",
+          "--outfile",
+          outfile,
+        ],
+        env: bunEnv,
+      });
+      expect(exitCode).toBe(0);
+    }
+    function testExec(outfile: string) {
+      const { exitCode } = Bun.spawnSync({
+        cmd: [outfile],
+      });
+      expect(exitCode).toBe(0);
+    }
+    {
+      const baseDir = `${tmpdir()}/bun-build-outfile-${Date.now()}`;
+      const outfile = path.join(baseDir, "index.exe");
+      testCompile(outfile);
+      testExec(outfile);
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
+    {
+      const baseDir = `${tmpdir()}/bun-build-outfile2-${Date.now()}`;
+      const outfile = path.join(baseDir, "b/u/n", "index.exe");
+      testCompile(outfile);
+      testExec(outfile);
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
### What does this PR do?

1. Fix `--outfile` doesn't work with nested path.  Close: #4195

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests 

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
