### PR TITLE
Fix memory leak in `buffer.toString("hex")`

### DIFF
--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -866,12 +866,14 @@ pub const Encoder = struct {
                 }
 
                 var str = bun.String.createUninitialized(.latin1, len) orelse return ZigString.init("Out of memory").toErrorInstance(global);
+                defer str.deref();
+
                 strings.copyLatin1IntoASCII(@constCast(str.latin1()), input);
                 return str.toJS(global);
             },
             .latin1 => {
                 var str = bun.String.createUninitialized(.latin1, len) orelse return ZigString.init("Out of memory").toErrorInstance(global);
-
+                defer str.deref();
                 @memcpy(@constCast(str.latin1()), input_ptr[0..len]);
 
                 return str.toJS(global);
@@ -901,6 +903,8 @@ pub const Encoder = struct {
 
             .hex => {
                 var str = bun.String.createUninitialized(.latin1, len * 2) orelse return ZigString.init("Out of memory").toErrorInstance(global);
+                defer str.deref();
+
                 var output = @constCast(str.latin1());
                 const wrote = strings.encodeBytesToHex(output, input);
                 std.debug.assert(wrote == output.len);

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -2374,6 +2374,7 @@ pub const E = struct {
 
             if (s.is_utf16) {
                 var out = bun.String.createUninitializedUTF16(s.len());
+                defer out.deref();
                 @memcpy(@constCast(out.utf16()), s.slice16());
                 return out.toJS(globalObject);
             }


### PR DESCRIPTION
### What does this PR do?

The following code:
```js
import crypto from "node:crypto";

let key = crypto.randomBytes(16);
const data = crypto.randomBytes(1024);
key.fill(130);
data.fill(130);

let i = 0;
while (i++ < 1000000) {
  key.toString("hex");
  data.toString("hex");
}
```

After:
```js
❯ mem bun-debug --smol classicy.js

Peak memory usage: 65 MB
```

Before:
```js
❯ mem bun --smol classicy.js

Peak memory usage: 2333 MB
```

### How did you verify your code works?

Existing tests for behavior, but manually for the leak