### PR TITLE
feat: Implement Bun.inspect.custom

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2309,6 +2309,12 @@ declare module "bun" {
    * @param args
    */
   export function inspect(arg: any, options: BunInspectOptions): string;
+  export namespace inspect {
+    /**
+     * That can be used to declare custom inspect functions.
+     */
+    const custom: typeof import("util").inspect.custom;
+  }
 
   interface MMapOptions {
     /**

--- a/src/bun.js/bindings/BunObject+exports.h
+++ b/src/bun.js/bindings/BunObject+exports.h
@@ -1,5 +1,6 @@
 // clang-format off
 
+// --- Getters ---
 #define FOR_EACH_GETTER(macro) \
     macro(CryptoHasher) \
     macro(FFI) \
@@ -19,14 +20,15 @@
     macro(cwd) \
     macro(enableANSIColors) \
     macro(hash) \
+    macro(inspect) \
     macro(main) \
     macro(origin) \
     macro(stderr) \
     macro(stdin) \
     macro(stdout) \
     macro(unsafe) \
-// --- Getters ---
 
+// --- Callbacks ---
 #define FOR_EACH_CALLBACK(macro) \
     macro(DO_NOT_USE_OR_YOU_WILL_BE_FIRED_mimalloc_dump) \
     macro(_Os) \
@@ -44,7 +46,6 @@
     macro(gzipSync) \
     macro(indexOfLine) \
     macro(inflateSync) \
-    macro(inspect) \
     macro(jest) \
     macro(listen) \
     macro(mmap) \
@@ -61,7 +62,6 @@
     macro(spawnSync) \
     macro(which) \
     macro(write) \
-
 
 #define DECLARE_ZIG_BUN_OBJECT_CALLBACK(name) extern "C" JSC::EncodedJSValue BunObject_callback_##name(JSC::JSGlobalObject*, JSC::CallFrame*);
 FOR_EACH_CALLBACK(DECLARE_ZIG_BUN_OBJECT_CALLBACK);

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -599,7 +599,7 @@ JSC_DEFINE_HOST_FUNCTION(functionHashCode,
     hash                                           BunObject_getter_wrap_hash                                          DontDelete|PropertyCallback
     indexOfLine                                    BunObject_callback_indexOfLine                                      DontDelete|Function 1
     inflateSync                                    BunObject_callback_inflateSync                                      DontDelete|Function 1
-    inspect                                        BunObject_callback_inspect                                          DontDelete|Function 1
+    inspect                                        BunObject_getter_wrap_inspect                                            DontDelete|PropertyCallback
     isMainThread                                   constructIsMainThread                                               ReadOnly|DontDelete|PropertyCallback
     jest                                           BunObject_callback_jest                                             DontEnum|DontDelete|Function 1
     listen                                         BunObject_callback_listen                                           DontDelete|Function 1

--- a/src/bun.js/bindings/BunObject.lut.h
+++ b/src/bun.js/bindings/BunObject.lut.h
@@ -315,7 +315,7 @@ static const struct HashTableValue bunObjectTableValues[81] = {
    { "hash"_s, static_cast<unsigned>(PropertyAttribute::DontDelete|PropertyAttribute::PropertyCallback), NoIntrinsic, { HashTableValue::LazyPropertyType, BunObject_getter_wrap_hash } },
    { "indexOfLine"_s, static_cast<unsigned>(PropertyAttribute::DontDelete|PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, BunObject_callback_indexOfLine, 1 } },
    { "inflateSync"_s, static_cast<unsigned>(PropertyAttribute::DontDelete|PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, BunObject_callback_inflateSync, 1 } },
-   { "inspect"_s, static_cast<unsigned>(PropertyAttribute::DontDelete|PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, BunObject_callback_inspect, 1 } },
+   { "inspect"_s, static_cast<unsigned>(PropertyAttribute::DontDelete|PropertyAttribute::PropertyCallback), NoIntrinsic, { HashTableValue::LazyPropertyType, BunObject_getter_wrap_inspect } },
    { "isMainThread"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly|PropertyAttribute::DontDelete|PropertyAttribute::PropertyCallback), NoIntrinsic, { HashTableValue::LazyPropertyType, constructIsMainThread } },
    { "jest"_s, static_cast<unsigned>(PropertyAttribute::DontEnum|PropertyAttribute::DontDelete|PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, BunObject_callback_jest, 1 } },
    { "listen"_s, static_cast<unsigned>(PropertyAttribute::DontDelete|PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, BunObject_callback_listen, 1 } },

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,4 +1,5 @@
 import { it, expect, describe } from "bun:test";
+import util from "util";
 
 it("getters", () => {
   const obj = {
@@ -356,4 +357,8 @@ it("new Date(..)", () => {
   expect(Bun.inspect(new Date("1679911059000"))).toBe("Invalid Date");
   expect(Bun.inspect(new Date("hello world"))).toBe("Invalid Date");
   expect(Bun.inspect(new Date("Invalid Date"))).toBe("Invalid Date");
+});
+
+it("Bun.inspect.custom exists", () => {
+  expect(Bun.inspect.custom).toBe(util.inspect.custom);
 });


### PR DESCRIPTION
### What does this PR do?

Implements `Bun.inspect.custom`, an alias for `util.inspect.custom`

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
