### PR TITLE
ref `req.url` for error message

### DIFF
--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -652,7 +652,7 @@ pub const Request = struct {
         const href = JSC.URL.hrefFromString(req.url);
         if (href.isEmpty()) {
             globalThis.throw("Failed to construct 'Request': Invalid URL \"{}\"", .{
-                req.url,
+                req.url.dupeRef(),
             });
             req.finalizeWithoutDeinit();
             _ = req.body.unref();

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -31,11 +31,18 @@ const payload = new Uint8Array(1024 * 1024 * 2);
 crypto.getRandomValues(payload);
 
 it("new Request(invalid url) throws", () => {
-  expect(() => new Request("http")).toThrow();
-  expect(() => new Request("")).toThrow();
-  expect(() => new Request("http://[::1")).toThrow();
-  expect(() => new Request("https://[::1")).toThrow();
-  expect(() => new Request("!")).toThrow();
+  for (let i = 0; i < 10; i++) {
+    expect(() => new Request("http")).toThrow();
+    gc(true);
+    expect(() => new Request("")).toThrow();
+    gc(true);
+    expect(() => new Request("http://[::1")).toThrow();
+    gc(true);
+    expect(() => new Request("https://[::1")).toThrow();
+    gc(true);
+    expect(() => new Request("!")).toThrow();
+    gc(true);
+  }
 });
 
 describe("fetch data urls", () => {


### PR DESCRIPTION
### What does this PR do?

This is necessary because `finalizeWithoutDeinit()` will deref the url string and if the string only has one ref it will be destroyed.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

modified test to repro this bug more often
