### PR TITLE
Fix ffi type

### DIFF
--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -449,36 +449,7 @@ declare module "bun:ffi" {
 
   export type FFITypeOrString =
     | FFIType
-    | "char"
-    | "int8_t"
-    | "i8"
-    | "uint8_t"
-    | "u8"
-    | "int16_t"
-    | "i16"
-    | "uint16_t"
-    | "u16"
-    | "int32_t"
-    | "i32"
-    | "int"
-    | "uint32_t"
-    | "u32"
-    | "int64_t"
-    | "i64"
-    | "uint64_t"
-    | "u64"
-    | "double"
-    | "f64"
-    | "float"
-    | "f32"
-    | "bool"
-    | "ptr"
-    | "pointer"
-    | "void"
-    | "cstring"
-    | "function"
-    | "usize"
-    | "callback";
+    | keyof FFITypeStringToType;
 
   interface FFIFunction {
     /**

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -374,13 +374,13 @@ declare module "bun:ffi" {
     [FFIType.float]: number;
     [FFIType.f32]: number;
     [FFIType.bool]: boolean;
-    [FFIType.ptr]: TypedArray | Pointer | CString;
-    [FFIType.pointer]: TypedArray | Pointer | CString;
+    [FFIType.ptr]: TypedArray | Pointer | CString | null;
+    [FFIType.pointer]: TypedArray | Pointer | CString | null;
     [FFIType.void]: void;
-    [FFIType.cstring]: TypedArray | Pointer | CString;
+    [FFIType.cstring]: TypedArray | Pointer | CString | null;
     [FFIType.i64_fast]: number | bigint;
     [FFIType.u64_fast]: number | bigint;
-    [FFIType.function]: Pointer | JSCallback;
+    [FFIType.function]: Pointer | JSCallback; // cannot be null
   }
   interface FFITypeToReturnsType {
     [FFIType.char]: number;
@@ -406,13 +406,13 @@ declare module "bun:ffi" {
     [FFIType.float]: number;
     [FFIType.f32]: number;
     [FFIType.bool]: boolean;
-    [FFIType.ptr]: Pointer;
-    [FFIType.pointer]: Pointer;
+    [FFIType.ptr]: Pointer | null;
+    [FFIType.pointer]: Pointer | null;
     [FFIType.void]: void;
     [FFIType.cstring]: CString;
     [FFIType.i64_fast]: number | bigint;
     [FFIType.u64_fast]: number | bigint;
-    [FFIType.function]: Pointer;
+    [FFIType.function]: Pointer | null;
   }
   interface FFITypeStringToType {
     ["char"]: FFIType.char;

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -584,8 +584,10 @@ declare module "bun:ffi" {
     [K in keyof Fns]: (
       ...args: Fns[K]["args"] extends infer A extends readonly FFITypeOrString[]
         ? { [L in keyof A]: FFITypeToArgsType[ToFFIType<A[L]>] }
-        : never
-    ) => FFITypeToReturnsType[ToFFIType<NonNullable<Fns[K]["returns"]>>];
+        : [unknown] extends [Fns[K]["args"]] ? [] : never
+    ) => [unknown] extends [Fns[K]["returns"]]
+      ? void
+      : FFITypeToReturnsType[ToFFIType<NonNullable<Fns[K]["returns"]>>];
   };
 
   /**

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -350,7 +350,7 @@ declare module "bun:ffi" {
   type UNTYPED = never;
   export type Pointer = number & {};
 
-  interface FFITypeToType {
+  interface FFITypeToArgsType {
     [FFIType.char]: number;
     [FFIType.int8_t]: number;
     [FFIType.i8]: number;
@@ -365,10 +365,42 @@ declare module "bun:ffi" {
     [FFIType.int]: number;
     [FFIType.uint32_t]: number;
     [FFIType.u32]: number;
-    [FFIType.int64_t]: number;
-    [FFIType.i64]: number;
-    [FFIType.uint64_t]: number;
-    [FFIType.u64]: number;
+    [FFIType.int64_t]: number | bigint;
+    [FFIType.i64]: number | bigint;
+    [FFIType.uint64_t]: number | bigint;
+    [FFIType.u64]: number | bigint;
+    [FFIType.double]: number;
+    [FFIType.f64]: number;
+    [FFIType.float]: number;
+    [FFIType.f32]: number;
+    [FFIType.bool]: boolean;
+    [FFIType.ptr]: TypedArray | Pointer | CString;
+    [FFIType.pointer]: TypedArray | Pointer | CString;
+    [FFIType.void]: void;
+    [FFIType.cstring]: TypedArray | Pointer | CString;
+    [FFIType.i64_fast]: number | bigint;
+    [FFIType.u64_fast]: number | bigint;
+    [FFIType.function]: Pointer;
+  }
+  interface FFITypeToReturnsType {
+    [FFIType.char]: number;
+    [FFIType.int8_t]: number;
+    [FFIType.i8]: number;
+    [FFIType.uint8_t]: number;
+    [FFIType.u8]: number;
+    [FFIType.int16_t]: number;
+    [FFIType.i16]: number;
+    [FFIType.uint16_t]: number;
+    [FFIType.u16]: number;
+    [FFIType.int32_t]: number;
+    [FFIType.i32]: number;
+    [FFIType.int]: number;
+    [FFIType.uint32_t]: number;
+    [FFIType.u32]: number;
+    [FFIType.int64_t]: bigint;
+    [FFIType.i64]: bigint;
+    [FFIType.uint64_t]: bigint;
+    [FFIType.u64]: bigint;
     [FFIType.double]: number;
     [FFIType.f64]: number;
     [FFIType.float]: number;
@@ -377,10 +409,10 @@ declare module "bun:ffi" {
     [FFIType.ptr]: Pointer;
     [FFIType.pointer]: Pointer;
     [FFIType.void]: void;
-    [FFIType.cstring]: CString;
+    [FFIType.cstring]: string;
     [FFIType.i64_fast]: number | bigint;
     [FFIType.u64_fast]: number | bigint;
-    [FFIType.function]: (...args: any[]) => any;
+    [FFIType.function]: Pointer;
   }
   interface FFITypeStringToType {
     ["char"]: FFIType.char;
@@ -580,9 +612,9 @@ declare module "bun:ffi" {
   type ConvertFns<Fns extends Readonly<Record<string, FFIFunction>>> = {
     [K in keyof Fns]: (
       ...args: Fns[K]["args"] extends infer A extends FFITypeOrString[]
-        ? { [L in keyof A]: FFITypeToType[ToFFIType<A[L]>] }
+        ? { [L in keyof A]: FFITypeToArgsType[ToFFIType<A[L]>] }
         : never
-    ) => FFITypeToType[ToFFIType<NonNullable<Fns[K]["returns"]>>];
+    ) => FFITypeToReturnsType[ToFFIType<NonNullable<Fns[K]["returns"]>>];
   };
 
   /**

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -582,7 +582,7 @@ declare module "bun:ffi" {
 
   type ConvertFns<Fns extends Readonly<Record<string, FFIFunction>>> = {
     [K in keyof Fns]: (
-      ...args: Fns[K]["args"] extends infer A extends FFITypeOrString[]
+      ...args: Fns[K]["args"] extends infer A extends readonly FFITypeOrString[]
         ? { [L in keyof A]: FFITypeToArgsType[ToFFIType<A[L]>] }
         : never
     ) => FFITypeToReturnsType[ToFFIType<NonNullable<Fns[K]["returns"]>>];

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -477,7 +477,7 @@ declare module "bun:ffi" {
      * }
      * ```
      */
-    args?: FFITypeOrString[];
+    readonly args?: readonly FFITypeOrString[];
     /**
      * Return type to a FFI function (C ABI)
      *
@@ -505,7 +505,7 @@ declare module "bun:ffi" {
      * }
      * ```
      */
-    returns?: FFITypeOrString;
+    readonly returns?: FFITypeOrString;
 
     /**
      * Function pointer to the native function
@@ -516,7 +516,7 @@ declare module "bun:ffi" {
      * This is useful if the library has already been loaded
      * or if the module is also using Node-API.
      */
-    ptr?: number | bigint;
+    readonly ptr?: number | bigint;
 
     /**
      * Can C/FFI code call this function from a separate thread?
@@ -533,10 +533,10 @@ declare module "bun:ffi" {
      *
      * @default false
      */
-    threadsafe?: boolean;
+    readonly threadsafe?: boolean;
   }
 
-  type Symbols = Record<string, FFIFunction>;
+  type Symbols = Readonly<Record<string, FFIFunction>>;
 
   // /**
   //  * Compile a callback function
@@ -546,7 +546,7 @@ declare module "bun:ffi" {
   //  */
   // export function callback(ffi: FFIFunction, cb: Function): number;
 
-  export interface Library<Fns extends Record<string, Narrow<FFIFunction>>> {
+  export interface Library<Fns extends Readonly<Record<string, Narrow<FFIFunction>>>> {
     symbols: ConvertFns<Fns>;
 
     /**
@@ -577,7 +577,7 @@ declare module "bun:ffi" {
     | (T extends object ? { [K in keyof T]: Narrow<T[K]> } : never)
     | Extract<{} | null | undefined, T>;
 
-  type ConvertFns<Fns extends Record<string, FFIFunction>> = {
+  type ConvertFns<Fns extends Readonly<Record<string, FFIFunction>>> = {
     [K in keyof Fns]: (
       ...args: Fns[K]["args"] extends infer A extends FFITypeOrString[]
         ? { [L in keyof A]: FFITypeToType[ToFFIType<A[L]>] }

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -409,7 +409,7 @@ declare module "bun:ffi" {
     [FFIType.ptr]: Pointer;
     [FFIType.pointer]: Pointer;
     [FFIType.void]: void;
-    [FFIType.cstring]: string;
+    [FFIType.cstring]: CString;
     [FFIType.i64_fast]: number | bigint;
     [FFIType.u64_fast]: number | bigint;
     [FFIType.function]: Pointer;

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -380,7 +380,7 @@ declare module "bun:ffi" {
     [FFIType.cstring]: TypedArray | Pointer | CString;
     [FFIType.i64_fast]: number | bigint;
     [FFIType.u64_fast]: number | bigint;
-    [FFIType.function]: Pointer;
+    [FFIType.function]: Pointer | JSCallback;
   }
   interface FFITypeToReturnsType {
     [FFIType.char]: number;

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -782,6 +782,165 @@ declare module "bun:ffi" {
     byteLength?: number,
   ): ArrayBuffer;
 
+  export namespace read {
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function u8(ptr: Pointer, byteOffset?: number): number;
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function i8(ptr: Pointer, byteOffset?: number): number;
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function u16(ptr: Pointer, byteOffset?: number): number;
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function i16(ptr: Pointer, byteOffset?: number): number;
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function u32(ptr: Pointer, byteOffset?: number): number;
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function i32(ptr: Pointer, byteOffset?: number): number;
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function f32(ptr: Pointer, byteOffset?: number): number;
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function u64(ptr: Pointer, byteOffset?: number): bigint;
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function i64(ptr: Pointer, byteOffset?: number): bigint;
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function f64(ptr: Pointer, byteOffset?: number): number;
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function ptr(ptr: Pointer, byteOffset?: number): number;
+    /**
+     * The read function behaves similarly to DataView,
+     * but it's usually faster because it doesn't need to create a DataView or ArrayBuffer.
+     * 
+     * @param ptr The memory address to read
+     * @param byteOffset bytes to skip before reading
+     *
+     * While there are some checks to catch invalid pointers, this is a difficult
+     * thing to do safely. Passing an invalid pointer can crash the program and
+     * reading beyond the bounds of the pointer will crash the program or cause
+     * undefined behavior. Use with care!
+     */
+    export function intptr(ptr: Pointer, byteOffset?: number): number;
+  }
+
   /**
    * Get the pointer backing a {@link TypedArray} or {@link ArrayBuffer}
    *

--- a/packages/bun-types/tests/ffi.test-d.ts
+++ b/packages/bun-types/tests/ffi.test-d.ts
@@ -77,10 +77,15 @@ tsd.expectType<CString>(lib.symbols.sqlite3_libversion());
 tsd.expectType<number>(lib.symbols.add(1, 2));
 
 tsd.expectType<Pointer | null>(lib.symbols.ptr_type(0));
-tc.assert<tc.IsExact<(typeof lib)["symbols"]["ptr_type"], TypedArray | Pointer | CString>>;
+tc.assert<
+  tc.IsExact<
+    (typeof lib)["symbols"]["ptr_type"],
+    TypedArray | Pointer | CString
+  >
+>;
 
 tsd.expectType<Pointer | null>(lib.symbols.fn_type(0));
-tc.assert<tc.IsExact<(typeof lib)["symbols"]["fn_type"], Pointer | JSCallback>>
+tc.assert<tc.IsExact<(typeof lib)["symbols"]["fn_type"], Pointer | JSCallback>>;
 
 tc.assert<
   tc.IsExact<
@@ -118,3 +123,27 @@ tc.assert<
     ]
   >
 >;
+
+const as_const_test = {
+  sqlite3_libversion: {
+    args: [],
+    returns: FFIType.cstring,
+  },
+  multi_args: {
+    args: [FFIType.i32, FFIType.f32],
+    returns: FFIType.void,
+  },
+  no_returns: {
+    args: [FFIType.i32],
+  },
+  no_args: {
+    returns: FFIType.i32,
+  }
+} as const;
+
+const lib2 = dlopen(path, as_const_test);
+
+tsd.expectType<CString>(lib2.symbols.sqlite3_libversion());
+tsd.expectType<void>(lib2.symbols.multi_args(1, 2));
+tc.assert<tc.IsExact<ReturnType<(typeof lib2)["symbols"]["no_returns"]>, void>>;
+tc.assert<tc.IsExact<(typeof lib2)["symbols"]["no_args"], []>>

--- a/packages/bun-types/tests/ffi.test-d.ts
+++ b/packages/bun-types/tests/ffi.test-d.ts
@@ -146,4 +146,4 @@ const lib2 = dlopen(path, as_const_test);
 tsd.expectType<CString>(lib2.symbols.sqlite3_libversion());
 tsd.expectType<void>(lib2.symbols.multi_args(1, 2));
 tc.assert<tc.IsExact<ReturnType<(typeof lib2)["symbols"]["no_returns"]>, void>>;
-tc.assert<tc.IsExact<(typeof lib2)["symbols"]["no_args"], []>>
+tc.assert<tc.IsExact<Parameters<(typeof lib2)["symbols"]["no_args"]>, []>>

--- a/packages/bun-types/tests/ffi.test-d.ts
+++ b/packages/bun-types/tests/ffi.test-d.ts
@@ -151,3 +151,14 @@ tc.assert<tc.IsExact<Parameters<(typeof lib2)["symbols"]["no_args"]>, []>>;
 
 tsd.expectType<number>(read.u8(0));
 tsd.expectType<number>(read.u8(0, 0));
+tsd.expectType<number>(read.i8(0, 0));
+tsd.expectType<number>(read.u16(0, 0));
+tsd.expectType<number>(read.i16(0, 0));
+tsd.expectType<number>(read.u32(0, 0));
+tsd.expectType<number>(read.i32(0, 0));
+tsd.expectType<bigint>(read.u64(0, 0));
+tsd.expectType<bigint>(read.i64(0, 0));
+tsd.expectType<number>(read.f32(0, 0));
+tsd.expectType<number>(read.f64(0, 0));
+tsd.expectType<number>(read.ptr(0, 0));
+tsd.expectType<number>(read.intptr(0, 0));

--- a/packages/bun-types/tests/ffi.test-d.ts
+++ b/packages/bun-types/tests/ffi.test-d.ts
@@ -4,6 +4,7 @@ import {
   suffix,
   CString,
   Pointer,
+  JSCallback,
   // FFIFunction,
   // ConvertFns,
   // Narrow,
@@ -26,6 +27,14 @@ const lib = dlopen(
     add: {
       args: [FFIType.i32, FFIType.i32],
       returns: FFIType.i32,
+    },
+    ptr_type: {
+      args: [FFIType.pointer],
+      returns: FFIType.pointer,
+    },
+    fn_type: {
+      args: [FFIType.function],
+      returns: FFIType.function,
     },
     allArgs: {
       args: [
@@ -66,6 +75,12 @@ const lib = dlopen(
 
 tsd.expectType<CString>(lib.symbols.sqlite3_libversion());
 tsd.expectType<number>(lib.symbols.add(1, 2));
+
+tsd.expectType<Pointer | null>(lib.symbols.ptr_type(0));
+tc.assert<tc.IsExact<(typeof lib)["symbols"]["ptr_type"], TypedArray | Pointer | CString>>;
+
+tsd.expectType<Pointer | null>(lib.symbols.fn_type(0));
+tc.assert<tc.IsExact<(typeof lib)["symbols"]["fn_type"], Pointer | JSCallback>>
 
 tc.assert<
   tc.IsExact<

--- a/packages/bun-types/tests/ffi.test-d.ts
+++ b/packages/bun-types/tests/ffi.test-d.ts
@@ -5,6 +5,7 @@ import {
   CString,
   Pointer,
   JSCallback,
+  read,
   // FFIFunction,
   // ConvertFns,
   // Narrow,
@@ -138,7 +139,7 @@ const as_const_test = {
   },
   no_args: {
     returns: FFIType.i32,
-  }
+  },
 } as const;
 
 const lib2 = dlopen(path, as_const_test);
@@ -146,4 +147,7 @@ const lib2 = dlopen(path, as_const_test);
 tsd.expectType<CString>(lib2.symbols.sqlite3_libversion());
 tsd.expectType<void>(lib2.symbols.multi_args(1, 2));
 tc.assert<tc.IsExact<ReturnType<(typeof lib2)["symbols"]["no_returns"]>, void>>;
-tc.assert<tc.IsExact<Parameters<(typeof lib2)["symbols"]["no_args"]>, []>>
+tc.assert<tc.IsExact<Parameters<(typeof lib2)["symbols"]["no_args"]>, []>>;
+
+tsd.expectType<number>(read.u8(0));
+tsd.expectType<number>(read.u8(0, 0));


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

I used its type in https://github.com/codehz/bun_python/blob/%F0%9F%A5%9F/src/types.ts and verified it should works better than current types.

It's just two small changes:
1. Add Readonly so we can use `as const` to forced type narrow (when use with dedicated SYMBOLS table like that https://github.com/codehz/bun_python/blob/%F0%9F%A5%9F/src/symbols.ts#L277)
2. Split FFITypeToType to FFITypeToArgsType and FFITypeToReturnsType, it more precisely reflects the actual type than before.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
