### PR TITLE
Fix more types.

### DIFF
--- a/docs/runtime/typescript.md
+++ b/docs/runtime/typescript.md
@@ -78,6 +78,8 @@ These are the recommended `compilerOptions` for a Bun project.
     "moduleResolution": "bundler",
     "noEmit": true,
     "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
     "moduleDetection": "force",
     // if TS 4.x or earlier
     "moduleResolution": "nodenext",

--- a/packages/bun-plugin-server-components/tsconfig.json
+++ b/packages/bun-plugin-server-components/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "lib": [
-      "ESNext"
-    ],
+    "lib": ["ESNext"],
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "bundler",
     "moduleDetection": "force",
     "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
     "strict": true,
     "downlevelIteration": true,
     "skipLibCheck": true,
@@ -19,8 +19,5 @@
       "bun-types" // add Bun global
     ]
   },
-  "include": [
-    "**/*.ts",
-    "modules.d.ts"
-  ]
+  "include": ["**/*.ts", "modules.d.ts"]
 }

--- a/packages/bun-plugin-yaml/tsconfig.json
+++ b/packages/bun-plugin-yaml/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "lib": [
-      "ESNext"
-    ],
+    "lib": ["ESNext"],
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "bundler",
     "moduleDetection": "force",
     "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
     "strict": true,
     "downlevelIteration": true,
     "skipLibCheck": true,
@@ -19,8 +19,5 @@
       "bun-types" // add Bun global
     ]
   },
-  "include": [
-    "**/*.ts",
-    "modules.d.ts"
-  ]
+  "include": ["**/*.ts", "modules.d.ts"]
 }

--- a/packages/web-inspector-bun/tsconfig.json
+++ b/packages/web-inspector-bun/tsconfig.json
@@ -6,6 +6,8 @@
     "moduleResolution": "bundler",
     "moduleDetection": "force",
     "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
     "downlevelIteration": true,
     "skipLibCheck": true,
     "jsx": "preserve",

--- a/src/cli/tsconfig-for-init.json
+++ b/src/cli/tsconfig-for-init.json
@@ -6,6 +6,8 @@
     "moduleResolution": "bundler",
     "moduleDetection": "force",
     "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
     "strict": true,
     "downlevelIteration": true,
     "skipLibCheck": true,

--- a/test/js/third_party/es-module-lexer/tsconfig.json
+++ b/test/js/third_party/es-module-lexer/tsconfig.json
@@ -6,6 +6,8 @@
     "moduleResolution": "bundler",
     "moduleDetection": "force",
     "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
     "strict": true,
     "downlevelIteration": true,
     "skipLibCheck": true,

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -8,6 +8,8 @@
     "moduleResolution": "bundler",
     "moduleDetection": "force",
     "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
     "strict": true,
     "downlevelIteration": true,
     "skipLibCheck": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,6 +7,8 @@
     "target": "esnext",
     "moduleResolution": "nodenext",
     "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
     "strict": true,
     "noImplicitAny": false,
     "allowJs": true,


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fixed more tsconfig.json files. Related to #3256

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
