### PR TITLE
Fix `<const T>() =>`

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -446,6 +446,9 @@ pub const TypeScript = struct {
         // Look ahead to see if this should be an arrow function instead
         var is_ts_arrow_fn = false;
 
+        if (p.lexer.token == .t_const) {
+            try p.lexer.next();
+        }
         if (p.lexer.token == .t_identifier) {
             try p.lexer.next();
             if (p.lexer.token == .t_comma) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -929,6 +929,76 @@ describe("bundler", () => {
       stdout: "pass",
     },
   });
+  itBundled("edgecase/TS_LessThanAmbiguity", {
+    files: {
+      "/entry.ts": `
+        function expectArrow(item) {
+          if(typeof item !== 'function') {
+            throw new Error('Expected arrow function');
+          }
+        }
+        function expectTypeCast(item) {
+          if(typeof item !== 'number') {
+            throw new Error('Expected arrow function');
+          }
+        }
+        const x = 1;
+        expectTypeCast(<A>(x));
+        expectTypeCast(<[]>(x));
+        expectTypeCast(<A[]>(x));
+
+        expectArrow(<A>(x) => {})
+        expectArrow(<A, B>(x) => {})
+        expectArrow(<A = B>(x) => {})
+        expectArrow(<A extends B>(x) => {})
+        expectArrow(<const A extends B>(x) => {})
+
+        console.log('pass');
+      `,
+    },
+    run: {
+      stdout: "pass",
+    },
+  });
+  itBundled("edgecase/TSX_LessThanAmbiguity", {
+    files: {
+      "/entry.tsx": `
+        function expectJSX(item) {
+          if(typeof item !== 'object') {
+            throw new Error('Expected JSX');
+          }
+        }
+        function expectArrow(item) {
+          if(typeof item !== 'function') {
+            throw new Error('Expected arrow function');
+          }
+        }
+
+        const A = 1;
+        expectJSX(<A>(x) ...</A>);
+        expectJSX(<A extends>(x) ... </A>);
+        expectJSX(<A extends={false}>(x) ... </A>);
+        expectJSX(<const A extends>(x) ...</const>);
+        expectJSX(<const extends T>(x) ...</const>);
+        expectJSX(<const A B>(x) ...</const>);
+        expectJSX(<const A B C>(x) ...</const>);
+
+        expectArrow(<A, B>(x) => {});
+        expectArrow(<A extends B>(x) => {});
+        expectArrow(<const A extends B>(x) => {});
+
+        console.log('pass');
+      `,
+      "/node_modules/react/jsx-dev-runtime.js": `
+        export function jsxDEV(type, props, key, isStaticChildren, source, self) {
+          return {};
+        }
+      `,
+    },
+    run: {
+      stdout: "pass",
+    },
+  });
   itBundled("edgecase/IsBuffer2", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
### What does this PR do?

Fixes #4270

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
