### PR TITLE
docs: improved ESM and built-in modules section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,13 +47,13 @@ TODO: document this (see [`bindings.zig`](src/bun.js/bindings/bindings.zig) and 
 
 Copy from examples like `Subprocess` or `Response`.
 
-### ESM Modules and Builtins JS
+### ESM and Bun/Node.js Built-in modules
 
-Bun implements ESM modules in a mix of native code and JavaScript.
+Bun implements ECMAScript modules in a mix of native code and JavaScript.
 
-Several Node.js modules are implemented in JavaScript and loosely based on browserify polyfills.
+Several Node.js built-in modules are implemented in JavaScript and loosely based on browserify polyfills.
 
-Builtin modules in Bun are located in [`src/js`](src/js/). These files are transpiled and support a JavaScriptCore-only syntax for internal slots, which is explained further in [`src/js/README.md`](src/js/README.md).
+Bun built-in modules are located in [`src/js`](src/js/). These files are transpiled and support a JavaScriptCore-only syntax for internal slots, which is explained further in [`src/js/README.md`](src/js/README.md).
 
 Native C++ modules are in `src/bun.js/modules/`.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ Bun ships as a single executable that can be installed a few different ways.
 $ curl -fsSL https://bun.sh/install | bash # for macOS, Linux, and WSL
 ```
 
-```bash#NPM
+```bash#npm
 $ npm install -g bun # the last `npm` command you'll ever need
 ```
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- Saying "ESM Modules" doesn't make sense. It translates to "ECMAScript Modules Modules" changed it to "ESM" and "ECMAScript Modules"
- "Builtins JS" ???
- "built-in modules" has far more Google search results than "builtins"
- "Node.js modules" doesn't clarify that the doc is referring to Node.js *built-in* modules