### PR TITLE
Make the server not crash if an error occurs in the dev build.

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1023,7 +1023,7 @@ fn NewFlags(comptime debug_mode: bool) type {
         has_written_status: bool = false,
         response_protected: bool = false,
         aborted: bool = false,
-        finalized: bun.DebugOnly(bool) = bun.DebugOnlyDefault(false),
+        has_finalized: bun.DebugOnly(bool) = bun.DebugOnlyDefault(false),
     };
 }
 
@@ -1515,9 +1515,9 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             ctxLog("finalizeWithoutDeinit<d> ({*})<r>", .{this});
             this.blob.detach();
 
-            if (comptime Environment.allow_assert) {
-                std.debug.assert(!this.flags.finalized);
-                this.flags.finalized = true;
+            if (comptime Environment.isDebug) {
+                ctxLog("finalizeWithoutDeinit: has_finalized {any}", .{this.flags.has_finalized});
+                this.flags.has_finalized = true;
             }
 
             if (!this.response_jsvalue.isEmpty()) {
@@ -1596,7 +1596,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
             ctxLog("deinit<d> ({*})<r>", .{this});
             if (comptime Environment.allow_assert)
-                std.debug.assert(this.flags.finalized);
+                std.debug.assert(this.flags.has_finalized);
 
             if (comptime Environment.allow_assert)
                 std.debug.assert(this.flags.has_marked_complete);

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -750,4 +750,20 @@ describe("node:http", () => {
       }
     });
   });
+
+  test("test server internal error, issue#4298", done => {
+    const server = createServer((req, res) => {
+      throw Error("throw an error here.");
+    });
+    server.listen({ port: 0 }, async (_err, host, port) => {
+      try {
+        await fetch(`http://${host}:${port}`).then(res => {
+          expect(res.status).toBe(500);
+          done();
+        });
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

- Make the server not crash if an error occurs in the dev build.

Close: #4298 

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
