### PR TITLE
[install] fix stale life-cycle scripts from lockfile

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -7557,16 +7557,14 @@ pub const PackageManager = struct {
 
                         // Split this into two passes because the below may allocate memory or invalidate pointers
                         if (manager.summary.add > 0 or manager.summary.update > 0) {
-                            var remaining = mapping;
-                            var dependency_i: PackageID = off;
                             const changes = @as(PackageID, @truncate(mapping.len));
+                            var counter_i: PackageID = 0;
 
                             _ = manager.getCacheDirectory();
                             _ = manager.getTemporaryDirectory();
-                            var counter_i: PackageID = 0;
                             while (counter_i < changes) : (counter_i += 1) {
-                                if (remaining[counter_i] == invalid_package_id) {
-                                    dependency_i = counter_i + off;
+                                if (mapping[counter_i] == invalid_package_id) {
+                                    const dependency_i = counter_i + off;
                                     const dependency = manager.lockfile.buffers.dependencies.items[dependency_i];
                                     try manager.enqueueDependencyWithMain(
                                         dependency_i,

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2488,6 +2488,17 @@ pub const Package = extern struct {
 
             summary.add = @truncate(to_deps.len - (from_deps.len - summary.remove));
 
+            inline for (Package.Scripts.Hooks) |hook| {
+                if (!@field(to.scripts, hook).eql(
+                    @field(from.scripts, hook),
+                    to_lockfile.buffers.string_bytes.items,
+                    from_lockfile.buffers.string_bytes.items,
+                )) {
+                    // We found a changed life-cycle script
+                    summary.update += 1;
+                }
+            }
+
             return summary;
         }
     };

--- a/src/install/resolvers/folder_resolver.zig
+++ b/src/install/resolvers/folder_resolver.zig
@@ -185,10 +185,12 @@ pub const FolderResolution = union(Tag) {
         );
 
         if (manager.lockfile.getPackageID(package.name_hash, version, &package.resolution)) |existing_id| {
+            package.meta.id = existing_id;
+            manager.lockfile.packages.set(existing_id, package);
             return manager.lockfile.packages.get(existing_id);
         }
 
-        return manager.lockfile.appendPackage(package) catch unreachable;
+        return manager.lockfile.appendPackage(package);
     }
 
     pub const GlobalOrRelative = union(enum) {


### PR DESCRIPTION
fixes #4269

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

If Zig files changed:

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
