### PR TITLE
docs: fix http simple example log statement

### DIFF
--- a/docs/guides/http/simple.md
+++ b/docs/guides/http/simple.md
@@ -14,5 +14,5 @@ const server = Bun.serve({
   },
 });
 
-console.log(`Listening on localhost:\${server.port}`);
+console.log(`Listening on localhost: ${server.port}`);
 ```


### PR DESCRIPTION
I just removed the incorrect escape of the port number in the simple http server example:

![Screenshot 2023-08-25 at 11 34 48](https://github.com/oven-sh/bun/assets/68194/79577815-26e6-4880-a80f-29f5a4f91752)

Feel free to close and fix as part of another change if that is preferred.