### PR TITLE
Set the timezone in spawn in tests

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -6,6 +6,7 @@ export const bunEnv: any = {
   BUN_DEBUG_QUIET_LOGS: "1",
   NO_COLOR: "1",
   FORCE_COLOR: undefined,
+  TZ: "Etc/UTC",
 };
 
 export function bunExe() {


### PR DESCRIPTION
### What does this PR do?

Some tests are flaky due to the test runner defaulting to `Etc/UTC` but spawn/spawnSync having a different time zone in certain cases