### PR TITLE
fix dns lookup for 0.0.0.0

### DIFF
--- a/src/deps/c_ares.zig
+++ b/src/deps/c_ares.zig
@@ -482,7 +482,7 @@ pub const Channel = opaque {
         var host_buf: [1024]u8 = undefined;
         var port_buf: [52]u8 = undefined;
         const host_ptr: ?[*:0]const u8 = brk: {
-            if (!(host.len > 0 and !bun.strings.eqlComptime(host, "0.0.0.0") and !bun.strings.eqlComptime(host, "::0"))) {
+            if (host.len == 0) {
                 break :brk null;
             }
             const len = @min(host.len, host_buf.len - 1);

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -223,3 +223,23 @@ test("dns.getServers", done => {
   }
   done();
 });
+
+test("dns.lookup (0.0.0.0)", done => {
+  dns.lookup("0.0.0.0", (err, address, family) => {
+    expect(err).toBeNull();
+    expect(address).toBe("0.0.0.0");
+    expect(family).toBe(4);
+
+    done(err);
+  });
+});
+
+test("dns.lookup (::0)", done => {
+  dns.lookup("::0", (err, address, family) => {
+    expect(err).toBeNull();
+    expect(address).toBe("::");
+    expect(family).toBe(6);
+
+    done(err);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes: https://github.com/oven-sh/bun/issues/4338
`host_ptr` in `getAddrInfo` was null

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:
-->

- [X] I ran `make js` and committed the transpiled changes
- [X] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [X] I included a test for the new code, or an existing test covers it


<!-- If Zig files changed:
-->

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I or my editor ran `zig fmt` on the changed files
- [X] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
