### PR TITLE
Fix the crash when importing a module that does not exist.

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1818,6 +1818,12 @@ pub const PackageManager = struct {
             else => |pkg_id| pkg_id,
         };
 
+        if (resolution_id == invalid_package_id) {
+            return .{
+                .not_found = {},
+            };
+        }
+
         return .{
             .resolution = .{
                 .resolution = this.lockfile.packages.items(.resolution)[resolution_id],

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -234,3 +234,25 @@ for (const entry of await decompress(Buffer.from(buffer))) {
   ]);
   expect(await exited2).toBe(0);
 });
+
+it("should not crash when downloading a non-existent module, issue#4240", async () => {
+  await writeFile(
+    join(run_dir, "test.js"),
+    `
+import { prueba } from "pruebadfasdfasdkafasdyuif.js";
+  `,
+  );
+  const { exited: exited } = spawn({
+    cmd: [bunExe(), "test.js"],
+    cwd: run_dir,
+    stdin: null,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      BUN_INSTALL_CACHE_DIR: join(run_dir, ".cache"),
+    },
+  });
+  // The exit code will not be 1 if it panics.
+  expect(await exited).toBe(1);
+});


### PR DESCRIPTION
Close: #4240

### What does this PR do?

Handle invalid `resolution_id`.


<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?


I wrote automated tests 

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
