### PR TITLE
Workaround edgecase in bun build --compile

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1457,6 +1457,15 @@ pub const VirtualMachine = struct {
             ret.result = null;
             ret.path = @as(string, @tagName(result));
             return;
+        } else if (jsc_vm.standalone_module_graph) |graph| {
+            if (strings.hasPrefixComptime(specifier, "compiled://")) {
+                if (graph.files.contains(specifier)) {
+                    ret.result = null;
+                    ret.path = specifier;
+                } else {
+                    return error.ModuleNotFound;
+                }
+            }
         }
 
         const is_special_source = strings.eqlComptime(source, main_file_name) or js_ast.Macro.isMacroPath(source);

--- a/src/linker.zig
+++ b/src/linker.zig
@@ -264,6 +264,15 @@ pub const Linker = struct {
                             continue;
                         }
 
+                        if (linker.resolver.standalone_module_graph) |graph| {
+                            if (strings.hasPrefixComptime(import_record.path.text, "compiled://")) {
+                                if (graph.files.contains(import_record.path.text)) {
+                                    externals.append(record_index) catch unreachable;
+                                }
+                                continue;
+                            }
+                        }
+
                         // if (strings.eqlComptime(import_record.path.text, "process")) {
                         //     import_record.path.text = "node:process";
                         //     externals.append(record_index) catch unreachable;

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -823,23 +823,6 @@ pub const Resolver = struct {
             };
         }
 
-        if (r.standalone_module_graph) |graph| {
-            if (strings.hasPrefixComptime(import_path, "compiled://")) {
-                if (graph.files.contains(import_path)) {
-                    return .{
-                        .success = Result{
-                            .import_kind = kind,
-                            .path_pair = PathPair{
-                                .primary = Path.init(import_path),
-                            },
-                            .is_standalone_module = true,
-                            .module_type = .esm,
-                        },
-                    };
-                }
-            }
-        }
-
         if (DataURL.parse(import_path) catch {
             return .{ .failure = error.InvalidDataURL };
         }) |_data_url| {


### PR DESCRIPTION
### What does this PR do?

We cannot go through the module resolution code successfully when the module is `compiled://` 

This happens when you run `bun build --compile` with input:
```js
import { unpack, pack } from "msgpackr";
console.log(unpack(pack({ a: 1, b: 2 })));
```