### PR TITLE
feat(test-clear-screen): clear when in watch mode

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -2735,7 +2735,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                     return;
 
                 if (comptime reload_immediately) {
-                    bun.reloadProcess(bun.default_allocator, Output.enable_ansi_colors);
+                    bun.reloadProcess(bun.default_allocator, true);
                     unreachable;
                 }
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -861,6 +861,12 @@ pub const TestCommand = struct {
             files: []const PathString,
             allocator: std.mem.Allocator,
             pub fn begin(this: *@This()) void {
+                if (this.vm.hot_reload == .watch) {
+                    Output.flush();
+                    Output.disableBuffering();
+                    Output.resetTerminalAll();
+                    Output.enableBuffering();
+                }
                 var reporter = this.reporter;
                 var vm = this.vm;
                 var files = this.files;

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -861,12 +861,6 @@ pub const TestCommand = struct {
             files: []const PathString,
             allocator: std.mem.Allocator,
             pub fn begin(this: *@This()) void {
-                if (this.vm.hot_reload == .watch) {
-                    Output.flush();
-                    Output.disableBuffering();
-                    Output.resetTerminalAll();
-                    Output.enableBuffering();
-                }
                 var reporter = this.reporter;
                 var vm = this.vm;
                 var files = this.files;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

This will partially address #3951 by clearing the screen if `bun test` is in `--watch` mode.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I ran it locally with `bun test` and `bun --watch test`

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
