### PR TITLE
remove uws from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -48,13 +48,6 @@ ignore = dirty
 depth = 1
 shallow = true
 fetchRecurseSubmodules = false
-[submodule "src/deps/uws"]
-path = src/deps/uws
-url = https://github.com/Jarred-Sumner/uWebSockets
-ignore = dirty
-depth = 1
-shallow = true
-fetchRecurseSubmodules = true
 [submodule "src/deps/tinycc"]
 path = src/deps/tinycc
 url = https://github.com/Jarred-Sumner/tinycc.git


### PR DESCRIPTION
### What does this PR do?

Running `make setup` was giving this error `error: pathspec 'src/deps/uws' did not match any file(s) known to git`.
It fixes it by removing 
```
[submodule "src/deps/uws"]
path = src/deps/uws
url = https://github.com/Jarred-Sumner/uWebSockets
ignore = dirty
depth = 1
shallow = true
fetchRecurseSubmodules = true
```
from `.gitmodules`.

### How did you verify your code works?

By running `make setup`.