### PR TITLE
Fix(semver): fix matching with pre-release version

### DIFF
--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -1266,7 +1266,7 @@ pub const Range = struct {
             return lhs.op == rhs.op and lhs.version.eql(rhs.version);
         }
 
-        pub fn satisfies(this: Comparator, version: Version) bool {
+        pub fn satisfies(this: Comparator, version: Version, include_pre: bool) bool {
             const order = version.orderWithoutTag(this.version);
 
             return switch (order) {
@@ -1275,11 +1275,11 @@ pub const Range = struct {
                     else => false,
                 },
                 .gt => switch (this.op) {
-                    .gt, .gte => true,
+                    .gt, .gte => if (!include_pre) false else true,
                     else => false,
                 },
                 .lt => switch (this.op) {
-                    .lt, .lte => true,
+                    .lt, .lte => if (!include_pre) false else true,
                     else => false,
                 },
             };
@@ -1287,15 +1287,46 @@ pub const Range = struct {
     };
 
     pub fn satisfies(this: Range, version: Version) bool {
-        if (!this.hasLeft()) {
+        const has_left = this.hasLeft();
+        const has_right = this.hasRight();
+
+        if (!has_left) {
             return true;
         }
 
-        if (!this.left.satisfies(version)) {
+        // When the boundaries of a range do not include a pre-release tag on either side,
+        // we should not consider that '7.0.0-rc2' < "7.0.0"
+        // ```
+        // > semver.satisfies("7.0.0-rc2", "<=7.0.0")
+        // false
+        // > semver.satisfies("7.0.0-rc2", ">=7.0.0")
+        // false
+        // > semver.satisfies("7.0.0-rc2", "<=7.0.0-rc2")
+        // true
+        // > semver.satisfies("7.0.0-rc2", ">=7.0.0-rc2")
+        // true
+        // ```
+        //
+        // - https://github.com/npm/node-semver#prerelease-tags
+        // - https://github.com/npm/node-semver/blob/cce61804ba6f997225a1267135c06676fe0524d2/classes/range.js#L505-L539
+        var include_pre = true;
+        if (version.tag.hasPre()) {
+            if (!has_right) {
+                if (!this.left.version.tag.hasPre()) {
+                    include_pre = false;
+                }
+            } else {
+                if (!this.left.version.tag.hasPre() and !this.right.version.tag.hasPre()) {
+                    include_pre = false;
+                }
+            }
+        }
+
+        if (!this.left.satisfies(version, include_pre)) {
             return false;
         }
 
-        if (this.hasRight() and !this.right.satisfies(version)) {
+        if (has_right and !this.right.satisfies(version, include_pre)) {
             return false;
         }
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1460,6 +1460,50 @@ it("should handle ^0.0.2b_4+cafe_b0ba in dependencies", async () => {
   await access(join(package_dir, "bun.lockb"));
 });
 
+it("should handle caret range in dependencies when the registry has prereleased packages, issue#4398", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "6.3.0": { as: "0.0.2" }, "7.0.0-rc2": { as: "0.0.3" } }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        bar: "^6.3.0",
+      },
+    }),
+  );
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: package_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr).toBeDefined();
+  const err = await new Response(stderr).text();
+  expect(err).toContain("Saved lockfile");
+  expect(err).not.toContain("error:");
+  expect(stdout).toBeDefined();
+  const out = await new Response(stdout).text();
+  expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+    " + bar@6.3.0",
+    "",
+    " 1 packages installed",
+  ]);
+  expect(await exited).toBe(0);
+  expect(urls.sort()).toEqual([`${root_url}/bar`, `${root_url}/bar-0.0.2.tgz`]);
+  expect(requested).toBe(2);
+  expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".cache", "bar"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", "bar"))).toEqual(["package.json"]);
+  expect(await file(join(package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
+    name: "bar",
+    version: "0.0.2",
+  });
+  await access(join(package_dir, "bun.lockb"));
+});
+
 it("should prefer latest-tagged dependency", async () => {
   const urls: string[] = [];
   setHandler(


### PR DESCRIPTION
### What does this PR do?

Before this, we believed that the version range `[6.3.0, 7.0.0]` included version `7.0.0-rc-2`. However, in npm, if a version with a pre-release tag is not explicitly specified in `package.json`, it is not allowed to match pre-release versions. This pr adds additional restrictions, close close https://github.com/oven-sh/bun/issues/4398


Ref: https://github.com/npm/node-semver#prerelease-tags


### How did you verify your code works?

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->



- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
