### PR TITLE
minor rebuild diffs

### DIFF
--- a/src/analytics/analytics_schema.zig
+++ b/src/analytics/analytics_schema.zig
@@ -346,7 +346,7 @@ pub const analytics = struct {
 
         _,
 
-        pub fn jsonStringify(self: *const @This(), writer: anytype) !void {
+        pub fn jsonStringify(self: @This(), writer: anytype) !void {
             return try writer.write(@tagName(self));
         }
     };
@@ -361,7 +361,7 @@ pub const analytics = struct {
 
         _,
 
-        pub fn jsonStringify(self: *const @This(), writer: anytype) !void {
+        pub fn jsonStringify(self: @This(), writer: anytype) !void {
             return try writer.write(@tagName(self));
         }
     };
@@ -411,7 +411,7 @@ pub const analytics = struct {
 
         _,
 
-        pub fn jsonStringify(self: *const @This(), writer: anytype) !void {
+        pub fn jsonStringify(self: @This(), writer: anytype) !void {
             return try writer.write(@tagName(self));
         }
     };

--- a/src/js/out/WebCoreJSBuiltins.cpp
+++ b/src/js/out/WebCoreJSBuiltins.cpp
@@ -9,104 +9,474 @@ namespace Zig { class GlobalObject; }
 
 namespace WebCore {
 
-/* WritableStreamDefaultWriter.ts */
-// initializeWritableStreamDefaultWriter
-const JSC::ConstructAbility s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeLength = 301;
-static const JSC::Intrinsic s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCode = "(function (stream){\"use strict\";const internalStream=@getInternalWritableStream(stream);if(internalStream)stream=internalStream;if(!@isWritableStream(stream))@throwTypeError(\"WritableStreamDefaultWriter constructor takes a WritableStream\");return @setUpWritableStreamDefaultWriter(this,stream),this})\n";
+/* BundlerPlugin.ts */
+// runSetupFunction
+const JSC::ConstructAbility s_bundlerPluginRunSetupFunctionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_bundlerPluginRunSetupFunctionCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_bundlerPluginRunSetupFunctionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_bundlerPluginRunSetupFunctionCodeLength = 3224;
+static const JSC::Intrinsic s_bundlerPluginRunSetupFunctionCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_bundlerPluginRunSetupFunctionCode = "(function (setup,config){\"use strict\";var onLoadPlugins=new Map,onResolvePlugins=new Map;function validate(filterObject,callback,map){if(!filterObject||!@isObject(filterObject))@throwTypeError('Expected an object with \"filter\" RegExp');if(!callback||!@isCallable(callback))@throwTypeError(\"callback must be a function\");var{filter,namespace=\"file\"}=filterObject;if(!filter)@throwTypeError('Expected an object with \"filter\" RegExp');if(!@isRegExpObject(filter))@throwTypeError(\"filter must be a RegExp\");if(namespace&&typeof namespace!==\"string\")@throwTypeError(\"namespace must be a string\");if((namespace\?.length\?\?0)===0)namespace=\"file\";if(!/^([/@a-zA-Z0-9_\\\\-]+)$/.test(namespace))@throwTypeError(\"namespace can only contain $a-zA-Z0-9_\\\\-\");var callbacks=map.@get(namespace);if(!callbacks)map.@set(namespace,[[filter,callback]]);else @arrayPush(callbacks,[filter,callback])}function onLoad(filterObject,callback){validate(filterObject,callback,onLoadPlugins)}function onResolve(filterObject,callback){validate(filterObject,callback,onResolvePlugins)}const processSetupResult=()=>{var anyOnLoad=!1,anyOnResolve=!1;for(var[namespace,callbacks]of onLoadPlugins.entries())for(var[filter]of callbacks)this.addFilter(filter,namespace,1),anyOnLoad=!0;for(var[namespace,callbacks]of onResolvePlugins.entries())for(var[filter]of callbacks)this.addFilter(filter,namespace,0),anyOnResolve=!0;if(anyOnResolve){var onResolveObject=this.onResolve;if(!onResolveObject)this.onResolve=onResolvePlugins;else for(var[namespace,callbacks]of onResolvePlugins.entries()){var existing=onResolveObject.@get(namespace);if(!existing)onResolveObject.@set(namespace,callbacks);else onResolveObject.@set(namespace,existing.concat(callbacks))}}if(anyOnLoad){var onLoadObject=this.onLoad;if(!onLoadObject)this.onLoad=onLoadPlugins;else for(var[namespace,callbacks]of onLoadPlugins.entries()){var existing=onLoadObject.@get(namespace);if(!existing)onLoadObject.@set(namespace,callbacks);else onLoadObject.@set(namespace,existing.concat(callbacks))}}return anyOnLoad||anyOnResolve};var setupResult=setup({config,onDispose:()=>@throwTypeError(\"@{@2} is not implemented yet. See https://github.com/oven-sh/bun/issues/@1\"),onEnd:()=>@throwTypeError(\"@{@2} is not implemented yet. See https://github.com/oven-sh/bun/issues/@1\"),onLoad,onResolve,onStart:()=>@throwTypeError(\"@{@2} is not implemented yet. See https://github.com/oven-sh/bun/issues/@1\"),resolve:()=>@throwTypeError(\"@{@2} is not implemented yet. See https://github.com/oven-sh/bun/issues/@1\"),initialOptions:{...config,bundle:!0,entryPoints:config.entrypoints\?\?config.entryPoints\?\?[],minify:typeof config.minify===\"boolean\"\?config.minify:!1,minifyIdentifiers:config.minify===!0||config.minify\?.identifiers,minifyWhitespace:config.minify===!0||config.minify\?.whitespace,minifySyntax:config.minify===!0||config.minify\?.syntax,outbase:config.root,platform:config.target===\"bun\"\?\"node\":config.target},esbuild:{}});if(setupResult&&@isPromise(setupResult))if(@getPromiseInternalField(setupResult,@promiseFieldFlags)&@promiseStateFulfilled)setupResult=@getPromiseInternalField(setupResult,@promiseFieldReactionsOrResult);else return setupResult.@then(processSetupResult);return processSetupResult()})\n";
 
-// closed
-const JSC::ConstructAbility s_writableStreamDefaultWriterClosedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamDefaultWriterClosedCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamDefaultWriterClosedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamDefaultWriterClosedCodeLength = 214;
-static const JSC::Intrinsic s_writableStreamDefaultWriterClosedCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamDefaultWriterClosedCode = "(function (){\"use strict\";if(!@isWritableStreamDefaultWriter(this))return @Promise.@reject(@makeGetterTypeError(\"WritableStreamDefaultWriter\",\"closed\"));return @getByIdDirectPrivate(this,\"closedPromise\").promise})\n";
+// runOnResolvePlugins
+const JSC::ConstructAbility s_bundlerPluginRunOnResolvePluginsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_bundlerPluginRunOnResolvePluginsCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_bundlerPluginRunOnResolvePluginsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_bundlerPluginRunOnResolvePluginsCodeLength = 2359;
+static const JSC::Intrinsic s_bundlerPluginRunOnResolvePluginsCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_bundlerPluginRunOnResolvePluginsCode = "(function (specifier,inputNamespace,importer,internalID,kindId){\"use strict\";const kind=[\"entry-point\",\"import-statement\",\"require-call\",\"dynamic-import\",\"require-resolve\",\"import-rule\",\"url-token\",\"internal\"][kindId];var promiseResult=(async(inputPath,inputNamespace2,importer2,kind2)=>{var{onResolve,onLoad}=this,results=onResolve.@get(inputNamespace2);if(!results)return this.onResolveAsync(internalID,null,null,null),null;for(let[filter,callback]of results)if(filter.test(inputPath)){var result=callback({path:inputPath,importer:importer2,namespace:inputNamespace2,kind:kind2});while(result&&@isPromise(result)&&(@getPromiseInternalField(result,@promiseFieldFlags)&@promiseStateMask)===@promiseStateFulfilled)result=@getPromiseInternalField(result,@promiseFieldReactionsOrResult);if(result&&@isPromise(result))result=await result;if(!result||!@isObject(result))continue;var{path,namespace:userNamespace=inputNamespace2,external}=result;if(typeof path!==\"string\"||typeof userNamespace!==\"string\")@throwTypeError(\"onResolve plugins must return an object with a string 'path' and string 'loader' field\");if(!path)continue;if(!userNamespace)userNamespace=inputNamespace2;if(typeof external!==\"boolean\"&&!@isUndefinedOrNull(external))@throwTypeError('onResolve plugins \"external\" field must be boolean or unspecified');if(!external){if(userNamespace===\"file\"){if(process.platform!==\"win32\"){if(path[0]!==\"/\"||path.includes(\"..\"))@throwTypeError('onResolve plugin \"path\" must be absolute when the namespace is \"file\"')}}if(userNamespace===\"dataurl\"){if(!path.startsWith(\"data:\"))@throwTypeError('onResolve plugin \"path\" must start with \"data:\" when the namespace is \"dataurl\"')}if(userNamespace&&userNamespace!==\"file\"&&(!onLoad||!onLoad.@has(userNamespace)))@throwTypeError(`Expected onLoad plugin for namespace ${userNamespace} to exist`)}return this.onResolveAsync(internalID,path,userNamespace,external),null}return this.onResolveAsync(internalID,null,null,null),null})(specifier,inputNamespace,importer,kind);while(promiseResult&&@isPromise(promiseResult)&&(@getPromiseInternalField(promiseResult,@promiseFieldFlags)&@promiseStateMask)===@promiseStateFulfilled)promiseResult=@getPromiseInternalField(promiseResult,@promiseFieldReactionsOrResult);if(promiseResult&&@isPromise(promiseResult))promiseResult.then(()=>{},(e)=>{this.addError(internalID,e,0)})})\n";
 
-// desiredSize
-const JSC::ConstructAbility s_writableStreamDefaultWriterDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamDefaultWriterDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamDefaultWriterDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamDefaultWriterDesiredSizeCodeLength = 309;
-static const JSC::Intrinsic s_writableStreamDefaultWriterDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamDefaultWriterDesiredSizeCode = "(function (){\"use strict\";if(!@isWritableStreamDefaultWriter(this))throw @makeThisTypeError(\"WritableStreamDefaultWriter\",\"desiredSize\");if(@getByIdDirectPrivate(this,\"stream\")===@undefined)@throwTypeError(\"WritableStreamDefaultWriter has no stream\");return @writableStreamDefaultWriterGetDesiredSize(this)})\n";
-
-// ready
-const JSC::ConstructAbility s_writableStreamDefaultWriterReadyCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamDefaultWriterReadyCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamDefaultWriterReadyCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamDefaultWriterReadyCodeLength = 210;
-static const JSC::Intrinsic s_writableStreamDefaultWriterReadyCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamDefaultWriterReadyCode = "(function (){\"use strict\";if(!@isWritableStreamDefaultWriter(this))return @Promise.@reject(@makeThisTypeError(\"WritableStreamDefaultWriter\",\"ready\"));return @getByIdDirectPrivate(this,\"readyPromise\").promise})\n";
-
-// abort
-const JSC::ConstructAbility s_writableStreamDefaultWriterAbortCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamDefaultWriterAbortCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamDefaultWriterAbortCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamDefaultWriterAbortCodeLength = 350;
-static const JSC::Intrinsic s_writableStreamDefaultWriterAbortCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamDefaultWriterAbortCode = "(function (reason){\"use strict\";if(!@isWritableStreamDefaultWriter(this))return @Promise.@reject(@makeThisTypeError(\"WritableStreamDefaultWriter\",\"abort\"));if(@getByIdDirectPrivate(this,\"stream\")===@undefined)return @Promise.@reject(@makeTypeError(\"WritableStreamDefaultWriter has no stream\"));return @writableStreamDefaultWriterAbort(this,reason)})\n";
-
-// close
-const JSC::ConstructAbility s_writableStreamDefaultWriterCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamDefaultWriterCloseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamDefaultWriterCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamDefaultWriterCloseCodeLength = 492;
-static const JSC::Intrinsic s_writableStreamDefaultWriterCloseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamDefaultWriterCloseCode = "(function (){\"use strict\";if(!@isWritableStreamDefaultWriter(this))return @Promise.@reject(@makeThisTypeError(\"WritableStreamDefaultWriter\",\"close\"));const stream=@getByIdDirectPrivate(this,\"stream\");if(stream===@undefined)return @Promise.@reject(@makeTypeError(\"WritableStreamDefaultWriter has no stream\"));if(@writableStreamCloseQueuedOrInFlight(stream))return @Promise.@reject(@makeTypeError(\"WritableStreamDefaultWriter is being closed\"));return @writableStreamDefaultWriterClose(this)})\n";
-
-// releaseLock
-const JSC::ConstructAbility s_writableStreamDefaultWriterReleaseLockCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamDefaultWriterReleaseLockCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamDefaultWriterReleaseLockCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamDefaultWriterReleaseLockCodeLength = 241;
-static const JSC::Intrinsic s_writableStreamDefaultWriterReleaseLockCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamDefaultWriterReleaseLockCode = "(function (){\"use strict\";if(!@isWritableStreamDefaultWriter(this))throw @makeThisTypeError(\"WritableStreamDefaultWriter\",\"releaseLock\");if(@getByIdDirectPrivate(this,\"stream\")===@undefined)return;@writableStreamDefaultWriterRelease(this)})\n";
-
-// write
-const JSC::ConstructAbility s_writableStreamDefaultWriterWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamDefaultWriterWriteCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamDefaultWriterWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamDefaultWriterWriteCodeLength = 348;
-static const JSC::Intrinsic s_writableStreamDefaultWriterWriteCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamDefaultWriterWriteCode = "(function (chunk){\"use strict\";if(!@isWritableStreamDefaultWriter(this))return @Promise.@reject(@makeThisTypeError(\"WritableStreamDefaultWriter\",\"write\"));if(@getByIdDirectPrivate(this,\"stream\")===@undefined)return @Promise.@reject(@makeTypeError(\"WritableStreamDefaultWriter has no stream\"));return @writableStreamDefaultWriterWrite(this,chunk)})\n";
+// runOnLoadPlugins
+const JSC::ConstructAbility s_bundlerPluginRunOnLoadPluginsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_bundlerPluginRunOnLoadPluginsCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_bundlerPluginRunOnLoadPluginsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_bundlerPluginRunOnLoadPluginsCodeLength = 1835;
+static const JSC::Intrinsic s_bundlerPluginRunOnLoadPluginsCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_bundlerPluginRunOnLoadPluginsCode = "(function (internalID,path,namespace,defaultLoaderId){\"use strict\";const LOADERS_MAP={jsx:0,js:1,ts:2,tsx:3,css:4,file:5,json:6,toml:7,wasm:8,napi:9,base64:10,dataurl:11,text:12},loaderName=[\"jsx\",\"js\",\"ts\",\"tsx\",\"css\",\"file\",\"json\",\"toml\",\"wasm\",\"napi\",\"base64\",\"dataurl\",\"text\"][defaultLoaderId];var promiseResult=(async(internalID2,path2,namespace2,defaultLoader)=>{var results=this.onLoad.@get(namespace2);if(!results)return this.onLoadAsync(internalID2,null,null),null;for(let[filter,callback]of results)if(filter.test(path2)){var result=callback({path:path2,namespace:namespace2,loader:defaultLoader});while(result&&@isPromise(result)&&(@getPromiseInternalField(result,@promiseFieldFlags)&@promiseStateMask)===@promiseStateFulfilled)result=@getPromiseInternalField(result,@promiseFieldReactionsOrResult);if(result&&@isPromise(result))result=await result;if(!result||!@isObject(result))continue;var{contents,loader=defaultLoader}=result;if(typeof contents!==\"string\"&&!@isTypedArrayView(contents))@throwTypeError('onLoad plugins must return an object with \"contents\" as a string or Uint8Array');if(typeof loader!==\"string\")@throwTypeError('onLoad plugins must return an object with \"loader\" as a string');const chosenLoader=LOADERS_MAP[loader];if(chosenLoader===@undefined)@throwTypeError(`Loader ${loader} is not supported.`);return this.onLoadAsync(internalID2,contents,chosenLoader),null}return this.onLoadAsync(internalID2,null,null),null})(internalID,path,namespace,loaderName);while(promiseResult&&@isPromise(promiseResult)&&(@getPromiseInternalField(promiseResult,@promiseFieldFlags)&@promiseStateMask)===@promiseStateFulfilled)promiseResult=@getPromiseInternalField(promiseResult,@promiseFieldReactionsOrResult);if(promiseResult&&@isPromise(promiseResult))promiseResult.then(()=>{},(e)=>{this.addError(internalID,e,1)})})\n";
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 {\
     JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().writableStreamDefaultWriterBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().writableStreamDefaultWriterBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+    return clientData->builtinFunctions().bundlerPluginBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().bundlerPluginBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
 }
-WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
-/* ConsoleObject.ts */
-// asyncIterator
-const JSC::ConstructAbility s_consoleObjectAsyncIteratorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_consoleObjectAsyncIteratorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_consoleObjectAsyncIteratorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_consoleObjectAsyncIteratorCodeLength = 949;
-static const JSC::Intrinsic s_consoleObjectAsyncIteratorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_consoleObjectAsyncIteratorCode = "(function (){\"use strict\";const Iterator=async function*ConsoleAsyncIterator(){var reader=@Bun.stdin.stream().getReader(),decoder=new globalThis.TextDecoder(\"utf-8\",{fatal:!1}),deferredError,indexOf=@Bun.indexOfLine;try{while(!0){var done,value,pendingChunk;const firstResult=reader.readMany();if(@isPromise(firstResult))({done,value}=await firstResult);else({done,value}=firstResult);if(done){if(pendingChunk)yield decoder.decode(pendingChunk);return}var actualChunk;for(let chunk of value){if(actualChunk=chunk,pendingChunk)actualChunk=@Buffer.concat([pendingChunk,chunk]),pendingChunk=null;var last=0,i=indexOf(actualChunk,last);while(i!==-1)yield decoder.decode(actualChunk.subarray(last,i)),last=i+1,i=indexOf(actualChunk,last);pendingChunk=actualChunk.subarray(last)}}}catch(e){deferredError=e}finally{if(reader.releaseLock(),deferredError)throw deferredError}},symbol=globalThis.Symbol.asyncIterator;return this[symbol]=Iterator,Iterator()})\n";
+/* ByteLengthQueuingStrategy.ts */
+// highWaterMark
+const JSC::ConstructAbility s_byteLengthQueuingStrategyHighWaterMarkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_byteLengthQueuingStrategyHighWaterMarkCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_byteLengthQueuingStrategyHighWaterMarkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_byteLengthQueuingStrategyHighWaterMarkCodeLength = 246;
+static const JSC::Intrinsic s_byteLengthQueuingStrategyHighWaterMarkCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_byteLengthQueuingStrategyHighWaterMarkCode = "(function (){\"use strict\";const highWaterMark=@getByIdDirectPrivate(this,\"highWaterMark\");if(highWaterMark===@undefined)@throwTypeError(\"ByteLengthQueuingStrategy.highWaterMark getter called on incompatible |this| value.\");return highWaterMark})\n";
 
-// write
-const JSC::ConstructAbility s_consoleObjectWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_consoleObjectWriteCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_consoleObjectWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_consoleObjectWriteCodeLength = 392;
-static const JSC::Intrinsic s_consoleObjectWriteCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_consoleObjectWriteCode = "(function (input){\"use strict\";var writer=@getByIdDirectPrivate(this,\"writer\");if(!writer){var length=@toLength(input\?.length\?\?0);writer=@Bun.stdout.writer({highWaterMark:length>65536\?length:65536}),@putByIdDirectPrivate(this,\"writer\",writer)}var wrote=writer.write(input);const count=@argumentCount();for(var i=1;i<count;i++)wrote+=writer.write(@argument(i));return writer.flush(!0),wrote})\n";
+// size
+const JSC::ConstructAbility s_byteLengthQueuingStrategySizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_byteLengthQueuingStrategySizeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_byteLengthQueuingStrategySizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_byteLengthQueuingStrategySizeCodeLength = 57;
+static const JSC::Intrinsic s_byteLengthQueuingStrategySizeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_byteLengthQueuingStrategySizeCode = "(function (chunk){\"use strict\";return chunk.byteLength})\n";
+
+// initializeByteLengthQueuingStrategy
+const JSC::ConstructAbility s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeLength = 139;
+static const JSC::Intrinsic s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCode = "(function (parameters){\"use strict\";@putByIdDirectPrivate(this,\"highWaterMark\",@extractHighWaterMarkFromQueuingStrategyInit(parameters))})\n";
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 {\
     JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().consoleObjectBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().consoleObjectBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+    return clientData->builtinFunctions().byteLengthQueuingStrategyBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().byteLengthQueuingStrategyBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
 }
-WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+#undef DEFINE_BUILTIN_GENERATOR
+
+/* WritableStreamInternals.ts */
+// isWritableStream
+const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsIsWritableStreamCodeLength = 109;
+static const JSC::Intrinsic s_writableStreamInternalsIsWritableStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsIsWritableStreamCode = "(function (stream){\"use strict\";return @isObject(stream)&&!!@getByIdDirectPrivate(stream,\"underlyingSink\")})\n";
+
+// isWritableStreamDefaultWriter
+const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamDefaultWriterCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamDefaultWriterCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamDefaultWriterCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsIsWritableStreamDefaultWriterCodeLength = 108;
+static const JSC::Intrinsic s_writableStreamInternalsIsWritableStreamDefaultWriterCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsIsWritableStreamDefaultWriterCode = "(function (writer){\"use strict\";return @isObject(writer)&&!!@getByIdDirectPrivate(writer,\"closedPromise\")})\n";
+
+// acquireWritableStreamDefaultWriter
+const JSC::ConstructAbility s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeLength = 82;
+static const JSC::Intrinsic s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsAcquireWritableStreamDefaultWriterCode = "(function (stream){\"use strict\";return new @WritableStreamDefaultWriter(stream)})\n";
+
+// createWritableStream
+const JSC::ConstructAbility s_writableStreamInternalsCreateWritableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsCreateWritableStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsCreateWritableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsCreateWritableStreamCodeLength = 453;
+static const JSC::Intrinsic s_writableStreamInternalsCreateWritableStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsCreateWritableStreamCode = "(function (startAlgorithm,writeAlgorithm,closeAlgorithm,abortAlgorithm,highWaterMark,sizeAlgorithm){\"use strict\";const internalStream={};@initializeWritableStreamSlots(internalStream,{});const controller=new @WritableStreamDefaultController;return @setUpWritableStreamDefaultController(internalStream,controller,startAlgorithm,writeAlgorithm,closeAlgorithm,abortAlgorithm,highWaterMark,sizeAlgorithm),@createWritableStreamFromInternal(internalStream)})\n";
+
+// createInternalWritableStreamFromUnderlyingSink
+const JSC::ConstructAbility s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeLength = 1388;
+static const JSC::Intrinsic s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCode = "(function (underlyingSink,strategy){\"use strict\";const stream={};if(underlyingSink===@undefined)underlyingSink={};if(strategy===@undefined)strategy={};if(!@isObject(underlyingSink))@throwTypeError(\"WritableStream constructor takes an object as first argument\");if(\"type\"in underlyingSink)@throwRangeError(\"Invalid type is specified\");const sizeAlgorithm=@extractSizeAlgorithm(strategy),highWaterMark=@extractHighWaterMark(strategy,1),underlyingSinkDict={};if(\"start\"in underlyingSink){if(underlyingSinkDict.start=underlyingSink.start,typeof underlyingSinkDict.start!==\"function\")@throwTypeError(\"underlyingSink.start should be a function\")}if(\"write\"in underlyingSink){if(underlyingSinkDict.write=underlyingSink.write,typeof underlyingSinkDict.write!==\"function\")@throwTypeError(\"underlyingSink.write should be a function\")}if(\"close\"in underlyingSink){if(underlyingSinkDict.close=underlyingSink.close,typeof underlyingSinkDict.close!==\"function\")@throwTypeError(\"underlyingSink.close should be a function\")}if(\"abort\"in underlyingSink){if(underlyingSinkDict.abort=underlyingSink.abort,typeof underlyingSinkDict.abort!==\"function\")@throwTypeError(\"underlyingSink.abort should be a function\")}return @initializeWritableStreamSlots(stream,underlyingSink),@setUpWritableStreamDefaultControllerFromUnderlyingSink(stream,underlyingSink,underlyingSinkDict,highWaterMark,sizeAlgorithm),stream})\n";
+
+// initializeWritableStreamSlots
+const JSC::ConstructAbility s_writableStreamInternalsInitializeWritableStreamSlotsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsInitializeWritableStreamSlotsCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsInitializeWritableStreamSlotsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsInitializeWritableStreamSlotsCodeLength = 674;
+static const JSC::Intrinsic s_writableStreamInternalsInitializeWritableStreamSlotsCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsInitializeWritableStreamSlotsCode = "(function (stream,underlyingSink){\"use strict\";@putByIdDirectPrivate(stream,\"state\",\"writable\"),@putByIdDirectPrivate(stream,\"storedError\",@undefined),@putByIdDirectPrivate(stream,\"writer\",@undefined),@putByIdDirectPrivate(stream,\"controller\",@undefined),@putByIdDirectPrivate(stream,\"inFlightWriteRequest\",@undefined),@putByIdDirectPrivate(stream,\"closeRequest\",@undefined),@putByIdDirectPrivate(stream,\"inFlightCloseRequest\",@undefined),@putByIdDirectPrivate(stream,\"pendingAbortRequest\",@undefined),@putByIdDirectPrivate(stream,\"writeRequests\",@createFIFO()),@putByIdDirectPrivate(stream,\"backpressure\",!1),@putByIdDirectPrivate(stream,\"underlyingSink\",underlyingSink)})\n";
+
+// writableStreamCloseForBindings
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseForBindingsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseForBindingsCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseForBindingsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamCloseForBindingsCodeLength = 390;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamCloseForBindingsCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamCloseForBindingsCode = "(function (stream){\"use strict\";if(@isWritableStreamLocked(stream))return @Promise.@reject(@makeTypeError(\"WritableStream.close method can only be used on non locked WritableStream\"));if(@writableStreamCloseQueuedOrInFlight(stream))return @Promise.@reject(@makeTypeError(\"WritableStream.close method can only be used on a being close WritableStream\"));return @writableStreamClose(stream)})\n";
+
+// writableStreamAbortForBindings
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAbortForBindingsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAbortForBindingsCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAbortForBindingsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamAbortForBindingsCodeLength = 236;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamAbortForBindingsCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamAbortForBindingsCode = "(function (stream,reason){\"use strict\";if(@isWritableStreamLocked(stream))return @Promise.@reject(@makeTypeError(\"WritableStream.abort method can only be used on non locked WritableStream\"));return @writableStreamAbort(stream,reason)})\n";
+
+// isWritableStreamLocked
+const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsIsWritableStreamLockedCodeLength = 93;
+static const JSC::Intrinsic s_writableStreamInternalsIsWritableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsIsWritableStreamLockedCode = "(function (stream){\"use strict\";return @getByIdDirectPrivate(stream,\"writer\")!==@undefined})\n";
+
+// setUpWritableStreamDefaultWriter
+const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeLength = 1249;
+static const JSC::Intrinsic s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsSetUpWritableStreamDefaultWriterCode = "(function (writer,stream){\"use strict\";if(@isWritableStreamLocked(stream))@throwTypeError(\"WritableStream is locked\");@putByIdDirectPrivate(writer,\"stream\",stream),@putByIdDirectPrivate(stream,\"writer\",writer);const readyPromiseCapability=@newPromiseCapability(@Promise),closedPromiseCapability=@newPromiseCapability(@Promise);@putByIdDirectPrivate(writer,\"readyPromise\",readyPromiseCapability),@putByIdDirectPrivate(writer,\"closedPromise\",closedPromiseCapability);const state=@getByIdDirectPrivate(stream,\"state\");if(state===\"writable\"){if(@writableStreamCloseQueuedOrInFlight(stream)||!@getByIdDirectPrivate(stream,\"backpressure\"))readyPromiseCapability.resolve.@call()}else if(state===\"erroring\")readyPromiseCapability.reject.@call(@undefined,@getByIdDirectPrivate(stream,\"storedError\")),@markPromiseAsHandled(readyPromiseCapability.promise);else if(state===\"closed\")readyPromiseCapability.resolve.@call(),closedPromiseCapability.resolve.@call();else{const storedError=@getByIdDirectPrivate(stream,\"storedError\");readyPromiseCapability.reject.@call(@undefined,storedError),@markPromiseAsHandled(readyPromiseCapability.promise),closedPromiseCapability.reject.@call(@undefined,storedError),@markPromiseAsHandled(closedPromiseCapability.promise)}})\n";
+
+// writableStreamAbort
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAbortCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAbortCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAbortCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamAbortCodeLength = 679;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamAbortCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamAbortCode = "(function (stream,reason){\"use strict\";const state=@getByIdDirectPrivate(stream,\"state\");if(state===\"closed\"||state===\"errored\")return @Promise.@resolve();const pendingAbortRequest=@getByIdDirectPrivate(stream,\"pendingAbortRequest\");if(pendingAbortRequest!==@undefined)return pendingAbortRequest.promise.promise;let wasAlreadyErroring=!1;if(state===\"erroring\")wasAlreadyErroring=!0,reason=@undefined;const abortPromiseCapability=@newPromiseCapability(@Promise);if(@putByIdDirectPrivate(stream,\"pendingAbortRequest\",{promise:abortPromiseCapability,reason,wasAlreadyErroring}),!wasAlreadyErroring)@writableStreamStartErroring(stream,reason);return abortPromiseCapability.promise})\n";
+
+// writableStreamClose
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamCloseCodeLength = 674;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamCloseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamCloseCode = "(function (stream){\"use strict\";const state=@getByIdDirectPrivate(stream,\"state\");if(state===\"closed\"||state===\"errored\")return @Promise.@reject(@makeTypeError(\"Cannot close a writable stream that is closed or errored\"));const closePromiseCapability=@newPromiseCapability(@Promise);@putByIdDirectPrivate(stream,\"closeRequest\",closePromiseCapability);const writer=@getByIdDirectPrivate(stream,\"writer\");if(writer!==@undefined&&@getByIdDirectPrivate(stream,\"backpressure\")&&state===\"writable\")@getByIdDirectPrivate(writer,\"readyPromise\").resolve.@call();return @writableStreamDefaultControllerClose(@getByIdDirectPrivate(stream,\"controller\")),closePromiseCapability.promise})\n";
+
+// writableStreamAddWriteRequest
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAddWriteRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAddWriteRequestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAddWriteRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamAddWriteRequestCodeLength = 208;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamAddWriteRequestCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamAddWriteRequestCode = "(function (stream){\"use strict\";const writePromiseCapability=@newPromiseCapability(@Promise);return @getByIdDirectPrivate(stream,\"writeRequests\").push(writePromiseCapability),writePromiseCapability.promise})\n";
+
+// writableStreamCloseQueuedOrInFlight
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeLength = 166;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCode = "(function (stream){\"use strict\";return @getByIdDirectPrivate(stream,\"closeRequest\")!==@undefined||@getByIdDirectPrivate(stream,\"inFlightCloseRequest\")!==@undefined})\n";
+
+// writableStreamDealWithRejection
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDealWithRejectionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDealWithRejectionCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDealWithRejectionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDealWithRejectionCodeLength = 183;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDealWithRejectionCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDealWithRejectionCode = "(function (stream,error){\"use strict\";if(@getByIdDirectPrivate(stream,\"state\")===\"writable\"){@writableStreamStartErroring(stream,error);return}@writableStreamFinishErroring(stream)})\n";
+
+// writableStreamFinishErroring
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishErroringCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishErroringCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishErroringCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamFinishErroringCodeLength = 1193;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamFinishErroringCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamFinishErroringCode = "(function (stream){\"use strict\";@putByIdDirectPrivate(stream,\"state\",\"errored\");const controller=@getByIdDirectPrivate(stream,\"controller\");@getByIdDirectPrivate(controller,\"errorSteps\").@call();const storedError=@getByIdDirectPrivate(stream,\"storedError\"),requests=@getByIdDirectPrivate(stream,\"writeRequests\");for(var request=requests.shift();request;request=requests.shift())request.reject.@call(@undefined,storedError);@putByIdDirectPrivate(stream,\"writeRequests\",@createFIFO());const abortRequest=@getByIdDirectPrivate(stream,\"pendingAbortRequest\");if(abortRequest===@undefined){@writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);return}if(@putByIdDirectPrivate(stream,\"pendingAbortRequest\",@undefined),abortRequest.wasAlreadyErroring){abortRequest.promise.reject.@call(@undefined,storedError),@writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);return}@getByIdDirectPrivate(controller,\"abortSteps\").@call(@undefined,abortRequest.reason).@then(()=>{abortRequest.promise.resolve.@call(),@writableStreamRejectCloseAndClosedPromiseIfNeeded(stream)},(reason)=>{abortRequest.promise.reject.@call(@undefined,reason),@writableStreamRejectCloseAndClosedPromiseIfNeeded(stream)})})\n";
+
+// writableStreamFinishInFlightClose
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeLength = 661;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamFinishInFlightCloseCode = "(function (stream){\"use strict\";if(@getByIdDirectPrivate(stream,\"inFlightCloseRequest\").resolve.@call(),@putByIdDirectPrivate(stream,\"inFlightCloseRequest\",@undefined),@getByIdDirectPrivate(stream,\"state\")===\"erroring\"){@putByIdDirectPrivate(stream,\"storedError\",@undefined);const abortRequest=@getByIdDirectPrivate(stream,\"pendingAbortRequest\");if(abortRequest!==@undefined)abortRequest.promise.resolve.@call(),@putByIdDirectPrivate(stream,\"pendingAbortRequest\",@undefined)}@putByIdDirectPrivate(stream,\"state\",\"closed\");const writer=@getByIdDirectPrivate(stream,\"writer\");if(writer!==@undefined)@getByIdDirectPrivate(writer,\"closedPromise\").resolve.@call()})\n";
+
+// writableStreamFinishInFlightCloseWithError
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeLength = 494;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCode = "(function (stream,error){\"use strict\";@getByIdDirectPrivate(stream,\"inFlightCloseRequest\").reject.@call(@undefined,error),@putByIdDirectPrivate(stream,\"inFlightCloseRequest\",@undefined);const state=@getByIdDirectPrivate(stream,\"state\"),abortRequest=@getByIdDirectPrivate(stream,\"pendingAbortRequest\");if(abortRequest!==@undefined)abortRequest.promise.reject.@call(@undefined,error),@putByIdDirectPrivate(stream,\"pendingAbortRequest\",@undefined);@writableStreamDealWithRejection(stream,error)})\n";
+
+// writableStreamFinishInFlightWrite
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeLength = 167;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamFinishInFlightWriteCode = "(function (stream){\"use strict\";@getByIdDirectPrivate(stream,\"inFlightWriteRequest\").resolve.@call(),@putByIdDirectPrivate(stream,\"inFlightWriteRequest\",@undefined)})\n";
+
+// writableStreamFinishInFlightWriteWithError
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeLength = 285;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCode = "(function (stream,error){\"use strict\";@getByIdDirectPrivate(stream,\"inFlightWriteRequest\").reject.@call(@undefined,error),@putByIdDirectPrivate(stream,\"inFlightWriteRequest\",@undefined);const state=@getByIdDirectPrivate(stream,\"state\");@writableStreamDealWithRejection(stream,error)})\n";
+
+// writableStreamHasOperationMarkedInFlight
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeLength = 174;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCode = "(function (stream){\"use strict\";return @getByIdDirectPrivate(stream,\"inFlightWriteRequest\")!==@undefined||@getByIdDirectPrivate(stream,\"inFlightCloseRequest\")!==@undefined})\n";
+
+// writableStreamMarkCloseRequestInFlight
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeLength = 220;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCode = "(function (stream){\"use strict\";const closeRequest=@getByIdDirectPrivate(stream,\"closeRequest\");@putByIdDirectPrivate(stream,\"inFlightCloseRequest\",closeRequest),@putByIdDirectPrivate(stream,\"closeRequest\",@undefined)})\n";
+
+// writableStreamMarkFirstWriteRequestInFlight
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeLength = 173;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCode = "(function (stream){\"use strict\";const writeRequest=@getByIdDirectPrivate(stream,\"writeRequests\").shift();@putByIdDirectPrivate(stream,\"inFlightWriteRequest\",writeRequest)})\n";
+
+// writableStreamRejectCloseAndClosedPromiseIfNeeded
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeLength = 528;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCode = "(function (stream){\"use strict\";const storedError=@getByIdDirectPrivate(stream,\"storedError\"),closeRequest=@getByIdDirectPrivate(stream,\"closeRequest\");if(closeRequest!==@undefined)closeRequest.reject.@call(@undefined,storedError),@putByIdDirectPrivate(stream,\"closeRequest\",@undefined);const writer=@getByIdDirectPrivate(stream,\"writer\");if(writer!==@undefined){const closedPromise=@getByIdDirectPrivate(writer,\"closedPromise\");closedPromise.reject.@call(@undefined,storedError),@markPromiseAsHandled(closedPromise.promise)}})\n";
+
+// writableStreamStartErroring
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamStartErroringCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamStartErroringCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamStartErroringCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamStartErroringCodeLength = 487;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamStartErroringCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamStartErroringCode = "(function (stream,reason){\"use strict\";const controller=@getByIdDirectPrivate(stream,\"controller\");@putByIdDirectPrivate(stream,\"state\",\"erroring\"),@putByIdDirectPrivate(stream,\"storedError\",reason);const writer=@getByIdDirectPrivate(stream,\"writer\");if(writer!==@undefined)@writableStreamDefaultWriterEnsureReadyPromiseRejected(writer,reason);if(!@writableStreamHasOperationMarkedInFlight(stream)&&@getByIdDirectPrivate(controller,\"started\")===1)@writableStreamFinishErroring(stream)})\n";
+
+// writableStreamUpdateBackpressure
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamUpdateBackpressureCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamUpdateBackpressureCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamUpdateBackpressureCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamUpdateBackpressureCodeLength = 400;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamUpdateBackpressureCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamUpdateBackpressureCode = "(function (stream,backpressure){\"use strict\";const writer=@getByIdDirectPrivate(stream,\"writer\");if(writer!==@undefined&&backpressure!==@getByIdDirectPrivate(stream,\"backpressure\"))if(backpressure)@putByIdDirectPrivate(writer,\"readyPromise\",@newPromiseCapability(@Promise));else @getByIdDirectPrivate(writer,\"readyPromise\").resolve.@call();@putByIdDirectPrivate(stream,\"backpressure\",backpressure)})\n";
+
+// writableStreamDefaultWriterAbort
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeLength = 136;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultWriterAbortCode = "(function (writer,reason){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\");return @writableStreamAbort(stream,reason)})\n";
+
+// writableStreamDefaultWriterClose
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeLength = 122;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultWriterCloseCode = "(function (writer){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\");return @writableStreamClose(stream)})\n";
+
+// writableStreamDefaultWriterCloseWithErrorPropagation
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeLength = 362;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCode = "(function (writer){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\"),state=@getByIdDirectPrivate(stream,\"state\");if(@writableStreamCloseQueuedOrInFlight(stream)||state===\"closed\")return @Promise.@resolve();if(state===\"errored\")return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));return @writableStreamDefaultWriterClose(writer)})\n";
+
+// writableStreamDefaultWriterEnsureClosedPromiseRejected
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeLength = 529;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCode = "(function (writer,error){\"use strict\";let closedPromiseCapability=@getByIdDirectPrivate(writer,\"closedPromise\"),closedPromise=closedPromiseCapability.promise;if((@getPromiseInternalField(closedPromise,@promiseFieldFlags)&@promiseStateMask)!==@promiseStatePending)closedPromiseCapability=@newPromiseCapability(@Promise),closedPromise=closedPromiseCapability.promise,@putByIdDirectPrivate(writer,\"closedPromise\",closedPromiseCapability);closedPromiseCapability.reject.@call(@undefined,error),@markPromiseAsHandled(closedPromise)})\n";
+
+// writableStreamDefaultWriterEnsureReadyPromiseRejected
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeLength = 517;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCode = "(function (writer,error){\"use strict\";let readyPromiseCapability=@getByIdDirectPrivate(writer,\"readyPromise\"),readyPromise=readyPromiseCapability.promise;if((@getPromiseInternalField(readyPromise,@promiseFieldFlags)&@promiseStateMask)!==@promiseStatePending)readyPromiseCapability=@newPromiseCapability(@Promise),readyPromise=readyPromiseCapability.promise,@putByIdDirectPrivate(writer,\"readyPromise\",readyPromiseCapability);readyPromiseCapability.reject.@call(@undefined,error),@markPromiseAsHandled(readyPromise)})\n";
+
+// writableStreamDefaultWriterGetDesiredSize
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeLength = 310;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCode = "(function (writer){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\"),state=@getByIdDirectPrivate(stream,\"state\");if(state===\"errored\"||state===\"erroring\")return null;if(state===\"closed\")return 0;return @writableStreamDefaultControllerGetDesiredSize(@getByIdDirectPrivate(stream,\"controller\"))})\n";
+
+// writableStreamDefaultWriterRelease
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeLength = 408;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultWriterReleaseCode = "(function (writer){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\"),releasedError=@makeTypeError(\"writableStreamDefaultWriterRelease\");@writableStreamDefaultWriterEnsureReadyPromiseRejected(writer,releasedError),@writableStreamDefaultWriterEnsureClosedPromiseRejected(writer,releasedError),@putByIdDirectPrivate(stream,\"writer\",@undefined),@putByIdDirectPrivate(writer,\"stream\",@undefined)})\n";
+
+// writableStreamDefaultWriterWrite
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeLength = 982;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultWriterWriteCode = "(function (writer,chunk){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\"),controller=@getByIdDirectPrivate(stream,\"controller\"),chunkSize=@writableStreamDefaultControllerGetChunkSize(controller,chunk);if(stream!==@getByIdDirectPrivate(writer,\"stream\"))return @Promise.@reject(@makeTypeError(\"writer is not stream's writer\"));const state=@getByIdDirectPrivate(stream,\"state\");if(state===\"errored\")return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));if(@writableStreamCloseQueuedOrInFlight(stream)||state===\"closed\")return @Promise.@reject(@makeTypeError(\"stream is closing or closed\"));if(@writableStreamCloseQueuedOrInFlight(stream)||state===\"closed\")return @Promise.@reject(@makeTypeError(\"stream is closing or closed\"));if(state===\"erroring\")return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));const promise=@writableStreamAddWriteRequest(stream);return @writableStreamDefaultControllerWrite(controller,chunk,chunkSize),promise})\n";
+
+// setUpWritableStreamDefaultController
+const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeLength = 921;
+static const JSC::Intrinsic s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsSetUpWritableStreamDefaultControllerCode = "(function (stream,controller,startAlgorithm,writeAlgorithm,closeAlgorithm,abortAlgorithm,highWaterMark,sizeAlgorithm){\"use strict\";@putByIdDirectPrivate(controller,\"stream\",stream),@putByIdDirectPrivate(stream,\"controller\",controller),@resetQueue(@getByIdDirectPrivate(controller,\"queue\")),@putByIdDirectPrivate(controller,\"started\",-1),@putByIdDirectPrivate(controller,\"startAlgorithm\",startAlgorithm),@putByIdDirectPrivate(controller,\"strategySizeAlgorithm\",sizeAlgorithm),@putByIdDirectPrivate(controller,\"strategyHWM\",highWaterMark),@putByIdDirectPrivate(controller,\"writeAlgorithm\",writeAlgorithm),@putByIdDirectPrivate(controller,\"closeAlgorithm\",closeAlgorithm),@putByIdDirectPrivate(controller,\"abortAlgorithm\",abortAlgorithm);const backpressure=@writableStreamDefaultControllerGetBackpressure(controller);@writableStreamUpdateBackpressure(stream,backpressure),@writableStreamDefaultControllerStart(controller)})\n";
+
+// writableStreamDefaultControllerStart
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerStartCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerStartCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerStartCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerStartCodeLength = 710;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerStartCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerStartCode = "(function (controller){\"use strict\";if(@getByIdDirectPrivate(controller,\"started\")!==-1)return;@putByIdDirectPrivate(controller,\"started\",0);const startAlgorithm=@getByIdDirectPrivate(controller,\"startAlgorithm\");@putByIdDirectPrivate(controller,\"startAlgorithm\",@undefined);const stream=@getByIdDirectPrivate(controller,\"stream\");return @Promise.@resolve(startAlgorithm.@call()).@then(()=>{const state=@getByIdDirectPrivate(stream,\"state\");@putByIdDirectPrivate(controller,\"started\",1),@writableStreamDefaultControllerAdvanceQueueIfNeeded(controller)},(error)=>{const state=@getByIdDirectPrivate(stream,\"state\");@putByIdDirectPrivate(controller,\"started\",1),@writableStreamDealWithRejection(stream,error)})})\n";
+
+// setUpWritableStreamDefaultControllerFromUnderlyingSink
+const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeLength = 1127;
+static const JSC::Intrinsic s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCode = "(function (stream,underlyingSink,underlyingSinkDict,highWaterMark,sizeAlgorithm){\"use strict\";const controller=new @WritableStreamDefaultController;let startAlgorithm=()=>{},writeAlgorithm=()=>{return @Promise.@resolve()},closeAlgorithm=()=>{return @Promise.@resolve()},abortAlgorithm=()=>{return @Promise.@resolve()};if(\"start\"in underlyingSinkDict){const startMethod=underlyingSinkDict.start;startAlgorithm=()=>@promiseInvokeOrNoopMethodNoCatch(underlyingSink,startMethod,[controller])}if(\"write\"in underlyingSinkDict){const writeMethod=underlyingSinkDict.write;writeAlgorithm=(chunk)=>@promiseInvokeOrNoopMethod(underlyingSink,writeMethod,[chunk,controller])}if(\"close\"in underlyingSinkDict){const closeMethod=underlyingSinkDict.close;closeAlgorithm=()=>@promiseInvokeOrNoopMethod(underlyingSink,closeMethod,[])}if(\"abort\"in underlyingSinkDict){const abortMethod=underlyingSinkDict.abort;abortAlgorithm=(reason)=>@promiseInvokeOrNoopMethod(underlyingSink,abortMethod,[reason])}@setUpWritableStreamDefaultController(stream,controller,startAlgorithm,writeAlgorithm,closeAlgorithm,abortAlgorithm,highWaterMark,sizeAlgorithm)})\n";
+
+// writableStreamDefaultControllerAdvanceQueueIfNeeded
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeLength = 609;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"stream\");if(@getByIdDirectPrivate(controller,\"started\")!==1)return;if(@getByIdDirectPrivate(stream,\"inFlightWriteRequest\")!==@undefined)return;if(@getByIdDirectPrivate(stream,\"state\")===\"erroring\"){@writableStreamFinishErroring(stream);return}const queue=@getByIdDirectPrivate(controller,\"queue\");if(queue.content\?.isEmpty()\?\?!1)return;const value=@peekQueueValue(queue);if(value===@isCloseSentinel)@writableStreamDefaultControllerProcessClose(controller);else @writableStreamDefaultControllerProcessWrite(controller,value)})\n";
+
+// isCloseSentinel
+const JSC::ConstructAbility s_writableStreamInternalsIsCloseSentinelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsIsCloseSentinelCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsIsCloseSentinelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsIsCloseSentinelCodeLength = 29;
+static const JSC::Intrinsic s_writableStreamInternalsIsCloseSentinelCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsIsCloseSentinelCode = "(function (){\"use strict\";})\n";
+
+// writableStreamDefaultControllerClearAlgorithms
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeLength = 293;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCode = "(function (controller){\"use strict\";@putByIdDirectPrivate(controller,\"writeAlgorithm\",@undefined),@putByIdDirectPrivate(controller,\"closeAlgorithm\",@undefined),@putByIdDirectPrivate(controller,\"abortAlgorithm\",@undefined),@putByIdDirectPrivate(controller,\"strategySizeAlgorithm\",@undefined)})\n";
+
+// writableStreamDefaultControllerClose
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeLength = 187;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerCloseCode = "(function (controller){\"use strict\";@enqueueValueWithSize(@getByIdDirectPrivate(controller,\"queue\"),@isCloseSentinel,0),@writableStreamDefaultControllerAdvanceQueueIfNeeded(controller)})\n";
+
+// writableStreamDefaultControllerError
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeLength = 203;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerErrorCode = "(function (controller,error){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"stream\");@writableStreamDefaultControllerClearAlgorithms(controller),@writableStreamStartErroring(stream,error)})\n";
+
+// writableStreamDefaultControllerErrorIfNeeded
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeLength = 210;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCode = "(function (controller,error){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"stream\");if(@getByIdDirectPrivate(stream,\"state\")===\"writable\")@writableStreamDefaultControllerError(controller,error)})\n";
+
+// writableStreamDefaultControllerGetBackpressure
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeLength = 107;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCode = "(function (controller){\"use strict\";return @writableStreamDefaultControllerGetDesiredSize(controller)<=0})\n";
+
+// writableStreamDefaultControllerGetChunkSize
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeLength = 216;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCode = "(function (controller,chunk){\"use strict\";try{return @getByIdDirectPrivate(controller,\"strategySizeAlgorithm\").@call(@undefined,chunk)}catch(e){return @writableStreamDefaultControllerErrorIfNeeded(controller,e),1}})\n";
+
+// writableStreamDefaultControllerGetDesiredSize
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeLength = 140;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCode = "(function (controller){\"use strict\";return @getByIdDirectPrivate(controller,\"strategyHWM\")-@getByIdDirectPrivate(controller,\"queue\").size})\n";
+
+// writableStreamDefaultControllerProcessClose
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeLength = 485;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"stream\");@writableStreamMarkCloseRequestInFlight(stream),@dequeueValue(@getByIdDirectPrivate(controller,\"queue\"));const sinkClosePromise=@getByIdDirectPrivate(controller,\"closeAlgorithm\").@call();@writableStreamDefaultControllerClearAlgorithms(controller),sinkClosePromise.@then(()=>{@writableStreamFinishInFlightClose(stream)},(reason)=>{@writableStreamFinishInFlightCloseWithError(stream,reason)})})\n";
+
+// writableStreamDefaultControllerProcessWrite
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeLength = 845;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCode = "(function (controller,chunk){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"stream\");@writableStreamMarkFirstWriteRequestInFlight(stream),@getByIdDirectPrivate(controller,\"writeAlgorithm\").@call(@undefined,chunk).@then(()=>{@writableStreamFinishInFlightWrite(stream);const state=@getByIdDirectPrivate(stream,\"state\");if(@dequeueValue(@getByIdDirectPrivate(controller,\"queue\")),!@writableStreamCloseQueuedOrInFlight(stream)&&state===\"writable\"){const backpressure=@writableStreamDefaultControllerGetBackpressure(controller);@writableStreamUpdateBackpressure(stream,backpressure)}@writableStreamDefaultControllerAdvanceQueueIfNeeded(controller)},(reason)=>{if(@getByIdDirectPrivate(stream,\"state\")===\"writable\")@writableStreamDefaultControllerClearAlgorithms(controller);@writableStreamFinishInFlightWriteWithError(stream,reason)})})\n";
+
+// writableStreamDefaultControllerWrite
+const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeLength = 578;
+static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamInternalsWritableStreamDefaultControllerWriteCode = "(function (controller,chunk,chunkSize){\"use strict\";try{@enqueueValueWithSize(@getByIdDirectPrivate(controller,\"queue\"),chunk,chunkSize);const stream=@getByIdDirectPrivate(controller,\"stream\"),state=@getByIdDirectPrivate(stream,\"state\");if(!@writableStreamCloseQueuedOrInFlight(stream)&&state===\"writable\"){const backpressure=@writableStreamDefaultControllerGetBackpressure(controller);@writableStreamUpdateBackpressure(stream,backpressure)}@writableStreamDefaultControllerAdvanceQueueIfNeeded(controller)}catch(e){@writableStreamDefaultControllerErrorIfNeeded(controller,e)}})\n";
+
+#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
+{\
+    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
+    return clientData->builtinFunctions().writableStreamInternalsBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().writableStreamInternalsBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+}
+WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
 /* TransformStreamInternals.ts */
@@ -263,122 +633,72 @@ JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 WEBCORE_FOREACH_TRANSFORMSTREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
-/* ReadableStreamBYOBRequest.ts */
-// initializeReadableStreamBYOBRequest
-const JSC::ConstructAbility s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeLength = 267;
-static const JSC::Intrinsic s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCode = "(function (controller,view){\"use strict\";if(arguments.length!==3&&arguments[2]!==@isReadableStream)@throwTypeError(\"ReadableStreamBYOBRequest constructor should not be called directly\");return @privateInitializeReadableStreamBYOBRequest.@call(this,controller,view)})\n";
+/* ProcessObjectInternals.ts */
+// binding
+const JSC::ConstructAbility s_processObjectInternalsBindingCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_processObjectInternalsBindingCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_processObjectInternalsBindingCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_processObjectInternalsBindingCodeLength = 511;
+static const JSC::Intrinsic s_processObjectInternalsBindingCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_processObjectInternalsBindingCode = "(function (bindingName){\"use strict\";if(bindingName===\"constants\")return @processBindingConstants;const issue={fs:3546,buffer:2020,natives:2254,uv:2891}[bindingName];if(issue)throw new Error(`process.binding(\"${bindingName}\") is not implemented in Bun. Track the status & thumbs up the issue: https://github.com/oven-sh/bun/issues/${issue}`);@throwTypeError(`process.binding(\"${bindingName}\") is not implemented in Bun. If that breaks something, please file an issue and include a reproducible code sample.`)})\n";
 
-// respond
-const JSC::ConstructAbility s_readableStreamBYOBRequestRespondCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamBYOBRequestRespondCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamBYOBRequestRespondCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamBYOBRequestRespondCodeLength = 452;
-static const JSC::Intrinsic s_readableStreamBYOBRequestRespondCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamBYOBRequestRespondCode = "(function (bytesWritten){\"use strict\";if(!@isReadableStreamBYOBRequest(this))throw @makeThisTypeError(\"ReadableStreamBYOBRequest\",\"respond\");if(@getByIdDirectPrivate(this,\"associatedReadableByteStreamController\")===@undefined)@throwTypeError(\"ReadableStreamBYOBRequest.associatedReadableByteStreamController is undefined\");return @readableByteStreamControllerRespond(@getByIdDirectPrivate(this,\"associatedReadableByteStreamController\"),bytesWritten)})\n";
+// getStdioWriteStream
+const JSC::ConstructAbility s_processObjectInternalsGetStdioWriteStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_processObjectInternalsGetStdioWriteStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_processObjectInternalsGetStdioWriteStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_processObjectInternalsGetStdioWriteStreamCodeLength = 621;
+static const JSC::Intrinsic s_processObjectInternalsGetStdioWriteStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_processObjectInternalsGetStdioWriteStreamCode = "(function (fd){\"use strict\";const stream=(@getInternalField(@internalModuleRegistry,42)||@createInternalModuleById(42)).WriteStream(fd);if(process.on(\"SIGWINCH\",()=>{stream._refreshSize()}),fd===1)stream.destroySoon=stream.destroy,stream._destroy=function(err,cb){if(cb(err),this._undestroy(),!this._writableState.emitClose)process.nextTick(()=>{this.emit(\"close\")})};else if(fd===2)stream.destroySoon=stream.destroy,stream._destroy=function(err,cb){if(cb(err),this._undestroy(),!this._writableState.emitClose)process.nextTick(()=>{this.emit(\"close\")})};return stream._type=\"tty\",stream._isStdio=!0,stream.fd=fd,stream})\n";
 
-// respondWithNewView
-const JSC::ConstructAbility s_readableStreamBYOBRequestRespondWithNewViewCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamBYOBRequestRespondWithNewViewCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamBYOBRequestRespondWithNewViewCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamBYOBRequestRespondWithNewViewCodeLength = 607;
-static const JSC::Intrinsic s_readableStreamBYOBRequestRespondWithNewViewCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamBYOBRequestRespondWithNewViewCode = "(function (view){\"use strict\";if(!@isReadableStreamBYOBRequest(this))throw @makeThisTypeError(\"ReadableStreamBYOBRequest\",\"respond\");if(@getByIdDirectPrivate(this,\"associatedReadableByteStreamController\")===@undefined)@throwTypeError(\"ReadableStreamBYOBRequest.associatedReadableByteStreamController is undefined\");if(!@isObject(view))@throwTypeError(\"Provided view is not an object\");if(!@ArrayBuffer.@isView(view))@throwTypeError(\"Provided view is not an ArrayBufferView\");return @readableByteStreamControllerRespondWithNewView(@getByIdDirectPrivate(this,\"associatedReadableByteStreamController\"),view)})\n";
-
-// view
-const JSC::ConstructAbility s_readableStreamBYOBRequestViewCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamBYOBRequestViewCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamBYOBRequestViewCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamBYOBRequestViewCodeLength = 172;
-static const JSC::Intrinsic s_readableStreamBYOBRequestViewCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamBYOBRequestViewCode = "(function (){\"use strict\";if(!@isReadableStreamBYOBRequest(this))throw @makeGetterTypeError(\"ReadableStreamBYOBRequest\",\"view\");return @getByIdDirectPrivate(this,\"view\")})\n";
+// getStdinStream
+const JSC::ConstructAbility s_processObjectInternalsGetStdinStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_processObjectInternalsGetStdinStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_processObjectInternalsGetStdinStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_processObjectInternalsGetStdinStreamCodeLength = 1386;
+static const JSC::Intrinsic s_processObjectInternalsGetStdinStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_processObjectInternalsGetStdinStreamCode = "(function (fd){\"use strict\";var reader,readerRef;function ref(){reader\?\?=@Bun.stdin.stream().getReader(),readerRef\?\?=setInterval(()=>{},1<<30)}function unref(){if(readerRef)clearInterval(readerRef),readerRef=@undefined;if(reader)reader.cancel(),reader=@undefined}const stream=new((@getInternalField(@internalModuleRegistry,42))||(@createInternalModuleById(42))).ReadStream(fd),originalOn=stream.on;stream.on=function(event,listener){if(event===\"readable\")ref();return originalOn.call(this,event,listener)},stream.fd=fd;const originalPause=stream.pause;stream.pause=function(){return unref(),originalPause.call(this)};const originalResume=stream.resume;stream.resume=function(){return ref(),originalResume.call(this)};async function internalRead(stream2){try{var done,value;const read=reader\?.readMany();if(@isPromise(read))({done,value}=await read);else({done,value}=read);if(!done){stream2.push(value[0]);const length=value.length;for(let i=1;i<length;i++)stream2.push(value[i])}else stream2.emit(\"end\"),stream2.pause()}catch(err){stream2.destroy(err)}}return stream._read=function(size){internalRead(this)},stream.on(\"resume\",()=>{ref(),stream._undestroy()}),stream._readableState.reading=!1,stream.on(\"pause\",()=>{process.nextTick(()=>{if(!stream.readableFlowing)stream._readableState.reading=!1})}),stream.on(\"close\",()=>{process.nextTick(()=>{stream.destroy(),unref()})}),stream})\n";
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 {\
     JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().readableStreamBYOBRequestBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableStreamBYOBRequestBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+    return clientData->builtinFunctions().processObjectInternalsBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().processObjectInternalsBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
 }
-WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
-/* ReadableStreamBYOBReader.ts */
-// initializeReadableStreamBYOBReader
-const JSC::ConstructAbility s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeLength = 510;
-static const JSC::Intrinsic s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCode = "(function (stream){\"use strict\";if(!@isReadableStream(stream))@throwTypeError(\"ReadableStreamBYOBReader needs a ReadableStream\");if(!@isReadableByteStreamController(@getByIdDirectPrivate(stream,\"readableStreamController\")))@throwTypeError(\"ReadableStreamBYOBReader needs a ReadableByteStreamController\");if(@isReadableStreamLocked(stream))@throwTypeError(\"ReadableStream is locked\");return @readableStreamReaderGenericInitialize(this,stream),@putByIdDirectPrivate(this,\"readIntoRequests\",@createFIFO()),this})\n";
+/* TransformStream.ts */
+// initializeTransformStream
+const JSC::ConstructAbility s_transformStreamInitializeTransformStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_transformStreamInitializeTransformStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_transformStreamInitializeTransformStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_transformStreamInitializeTransformStreamCodeLength = 2041;
+static const JSC::Intrinsic s_transformStreamInitializeTransformStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_transformStreamInitializeTransformStreamCode = "(function (){\"use strict\";let transformer=arguments[0];if(@isObject(transformer)&&@getByIdDirectPrivate(transformer,\"TransformStream\"))return this;let writableStrategy=arguments[1],readableStrategy=arguments[2];if(transformer===@undefined)transformer=null;if(readableStrategy===@undefined)readableStrategy={};if(writableStrategy===@undefined)writableStrategy={};let transformerDict={};if(transformer!==null){if(\"start\"in transformer){if(transformerDict.start=transformer.start,typeof transformerDict.start!==\"function\")@throwTypeError(\"transformer.start should be a function\")}if(\"transform\"in transformer){if(transformerDict.transform=transformer.transform,typeof transformerDict.transform!==\"function\")@throwTypeError(\"transformer.transform should be a function\")}if(\"flush\"in transformer){if(transformerDict.flush=transformer.flush,typeof transformerDict.flush!==\"function\")@throwTypeError(\"transformer.flush should be a function\")}if(\"readableType\"in transformer)@throwRangeError(\"TransformStream transformer has a readableType\");if(\"writableType\"in transformer)@throwRangeError(\"TransformStream transformer has a writableType\")}const readableHighWaterMark=@extractHighWaterMark(readableStrategy,0),readableSizeAlgorithm=@extractSizeAlgorithm(readableStrategy),writableHighWaterMark=@extractHighWaterMark(writableStrategy,1),writableSizeAlgorithm=@extractSizeAlgorithm(writableStrategy),startPromiseCapability=@newPromiseCapability(@Promise);if(@initializeTransformStream(this,startPromiseCapability.promise,writableHighWaterMark,writableSizeAlgorithm,readableHighWaterMark,readableSizeAlgorithm),@setUpTransformStreamDefaultControllerFromTransformer(this,transformer,transformerDict),(\"start\"in transformerDict)){const controller=@getByIdDirectPrivate(this,\"controller\");(()=>@promiseInvokeOrNoopMethodNoCatch(transformer,transformerDict.start,[controller]))().@then(()=>{startPromiseCapability.resolve.@call()},(error)=>{startPromiseCapability.reject.@call(@undefined,error)})}else startPromiseCapability.resolve.@call();return this})\n";
 
-// cancel
-const JSC::ConstructAbility s_readableStreamBYOBReaderCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamBYOBReaderCancelCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamBYOBReaderCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamBYOBReaderCancelCodeLength = 361;
-static const JSC::Intrinsic s_readableStreamBYOBReaderCancelCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamBYOBReaderCancelCode = "(function (reason){\"use strict\";if(!@isReadableStreamBYOBReader(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStreamBYOBReader\",\"cancel\"));if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return @Promise.@reject(@makeTypeError(\"cancel() called on a reader owned by no readable stream\"));return @readableStreamReaderGenericCancel(this,reason)})\n";
+// readable
+const JSC::ConstructAbility s_transformStreamReadableCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_transformStreamReadableCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_transformStreamReadableCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_transformStreamReadableCodeLength = 158;
+static const JSC::Intrinsic s_transformStreamReadableCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_transformStreamReadableCode = "(function (){\"use strict\";if(!@isTransformStream(this))throw @makeThisTypeError(\"TransformStream\",\"readable\");return @getByIdDirectPrivate(this,\"readable\")})\n";
 
-// read
-const JSC::ConstructAbility s_readableStreamBYOBReaderReadCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamBYOBReaderReadCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamBYOBReaderReadCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamBYOBReaderReadCodeLength = 663;
-static const JSC::Intrinsic s_readableStreamBYOBReaderReadCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamBYOBReaderReadCode = "(function (view){\"use strict\";if(!@isReadableStreamBYOBReader(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStreamBYOBReader\",\"read\"));if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return @Promise.@reject(@makeTypeError(\"read() called on a reader owned by no readable stream\"));if(!@isObject(view))return @Promise.@reject(@makeTypeError(\"Provided view is not an object\"));if(!@ArrayBuffer.@isView(view))return @Promise.@reject(@makeTypeError(\"Provided view is not an ArrayBufferView\"));if(view.byteLength===0)return @Promise.@reject(@makeTypeError(\"Provided view cannot have a 0 byteLength\"));return @readableStreamBYOBReaderRead(this,view)})\n";
-
-// releaseLock
-const JSC::ConstructAbility s_readableStreamBYOBReaderReleaseLockCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamBYOBReaderReleaseLockCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamBYOBReaderReleaseLockCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamBYOBReaderReleaseLockCodeLength = 382;
-static const JSC::Intrinsic s_readableStreamBYOBReaderReleaseLockCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamBYOBReaderReleaseLockCode = "(function (){\"use strict\";if(!@isReadableStreamBYOBReader(this))throw @makeThisTypeError(\"ReadableStreamBYOBReader\",\"releaseLock\");if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return;if(@getByIdDirectPrivate(this,\"readIntoRequests\")\?.isNotEmpty())@throwTypeError(\"There are still pending read requests, cannot release the lock\");@readableStreamReaderGenericRelease(this)})\n";
-
-// closed
-const JSC::ConstructAbility s_readableStreamBYOBReaderClosedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamBYOBReaderClosedCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamBYOBReaderClosedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamBYOBReaderClosedCodeLength = 218;
-static const JSC::Intrinsic s_readableStreamBYOBReaderClosedCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamBYOBReaderClosedCode = "(function (){\"use strict\";if(!@isReadableStreamBYOBReader(this))return @Promise.@reject(@makeGetterTypeError(\"ReadableStreamBYOBReader\",\"closed\"));return @getByIdDirectPrivate(this,\"closedPromiseCapability\").promise})\n";
+// writable
+const JSC::ConstructAbility s_transformStreamWritableCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_transformStreamWritableCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_transformStreamWritableCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_transformStreamWritableCodeLength = 158;
+static const JSC::Intrinsic s_transformStreamWritableCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_transformStreamWritableCode = "(function (){\"use strict\";if(!@isTransformStream(this))throw @makeThisTypeError(\"TransformStream\",\"writable\");return @getByIdDirectPrivate(this,\"writable\")})\n";
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 {\
     JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().readableStreamBYOBReaderBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableStreamBYOBReaderBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+    return clientData->builtinFunctions().transformStreamBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().transformStreamBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
 }
-WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
-#undef DEFINE_BUILTIN_GENERATOR
-
-/* WritableStreamDefaultController.ts */
-// initializeWritableStreamDefaultController
-const JSC::ConstructAbility s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeLength = 388;
-static const JSC::Intrinsic s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCode = "(function (){\"use strict\";return @putByIdDirectPrivate(this,\"queue\",@newQueue()),@putByIdDirectPrivate(this,\"abortSteps\",(reason)=>{const result=@getByIdDirectPrivate(this,\"abortAlgorithm\").@call(@undefined,reason);return @writableStreamDefaultControllerClearAlgorithms(this),result}),@putByIdDirectPrivate(this,\"errorSteps\",()=>{@resetQueue(@getByIdDirectPrivate(this,\"queue\"))}),this})\n";
-
-// error
-const JSC::ConstructAbility s_writableStreamDefaultControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamDefaultControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamDefaultControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamDefaultControllerErrorCodeLength = 311;
-static const JSC::Intrinsic s_writableStreamDefaultControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamDefaultControllerErrorCode = "(function (e){\"use strict\";if(@getByIdDirectPrivate(this,\"abortSteps\")===@undefined)throw @makeThisTypeError(\"WritableStreamDefaultController\",\"error\");const stream=@getByIdDirectPrivate(this,\"stream\");if(@getByIdDirectPrivate(stream,\"state\")!==\"writable\")return;@writableStreamDefaultControllerError(this,e)})\n";
-
-#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
-{\
-    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().writableStreamDefaultControllerBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().writableStreamDefaultControllerBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
-}
-WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
 /* Module.ts */
@@ -421,1112 +741,6 @@ JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
     return clientData->builtinFunctions().moduleBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().moduleBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
 }
 WEBCORE_FOREACH_MODULE_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
-#undef DEFINE_BUILTIN_GENERATOR
-
-/* ReadableByteStreamController.ts */
-// initializeReadableByteStreamController
-const JSC::ConstructAbility s_readableByteStreamControllerInitializeReadableByteStreamControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamControllerInitializeReadableByteStreamControllerCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamControllerInitializeReadableByteStreamControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamControllerInitializeReadableByteStreamControllerCodeLength = 325;
-static const JSC::Intrinsic s_readableByteStreamControllerInitializeReadableByteStreamControllerCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamControllerInitializeReadableByteStreamControllerCode = "(function (stream,underlyingByteSource,highWaterMark){\"use strict\";if(arguments.length!==4&&arguments[3]!==@isReadableStream)@throwTypeError(\"ReadableByteStreamController constructor should not be called directly\");return @privateInitializeReadableByteStreamController.@call(this,stream,underlyingByteSource,highWaterMark)})\n";
-
-// enqueue
-const JSC::ConstructAbility s_readableByteStreamControllerEnqueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamControllerEnqueueCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamControllerEnqueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamControllerEnqueueCodeLength = 578;
-static const JSC::Intrinsic s_readableByteStreamControllerEnqueueCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamControllerEnqueueCode = "(function (chunk){\"use strict\";if(!@isReadableByteStreamController(this))throw @makeThisTypeError(\"ReadableByteStreamController\",\"enqueue\");if(@getByIdDirectPrivate(this,\"closeRequested\"))@throwTypeError(\"ReadableByteStreamController is requested to close\");if(@getByIdDirectPrivate(@getByIdDirectPrivate(this,\"controlledReadableStream\"),\"state\")!==@streamReadable)@throwTypeError(\"ReadableStream is not readable\");if(!@isObject(chunk)||!@ArrayBuffer.@isView(chunk))@throwTypeError(\"Provided chunk is not a TypedArray\");return @readableByteStreamControllerEnqueue(this,chunk)})\n";
-
-// error
-const JSC::ConstructAbility s_readableByteStreamControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamControllerErrorCodeLength = 344;
-static const JSC::Intrinsic s_readableByteStreamControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamControllerErrorCode = "(function (error){\"use strict\";if(!@isReadableByteStreamController(this))throw @makeThisTypeError(\"ReadableByteStreamController\",\"error\");if(@getByIdDirectPrivate(@getByIdDirectPrivate(this,\"controlledReadableStream\"),\"state\")!==@streamReadable)@throwTypeError(\"ReadableStream is not readable\");@readableByteStreamControllerError(this,error)})\n";
-
-// close
-const JSC::ConstructAbility s_readableByteStreamControllerCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamControllerCloseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamControllerCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamControllerCloseCodeLength = 433;
-static const JSC::Intrinsic s_readableByteStreamControllerCloseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamControllerCloseCode = "(function (){\"use strict\";if(!@isReadableByteStreamController(this))throw @makeThisTypeError(\"ReadableByteStreamController\",\"close\");if(@getByIdDirectPrivate(this,\"closeRequested\"))@throwTypeError(\"Close has already been requested\");if(@getByIdDirectPrivate(@getByIdDirectPrivate(this,\"controlledReadableStream\"),\"state\")!==@streamReadable)@throwTypeError(\"ReadableStream is not readable\");@readableByteStreamControllerClose(this)})\n";
-
-// byobRequest
-const JSC::ConstructAbility s_readableByteStreamControllerByobRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamControllerByobRequestCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamControllerByobRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamControllerByobRequestCodeLength = 651;
-static const JSC::Intrinsic s_readableByteStreamControllerByobRequestCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamControllerByobRequestCode = "(function (){\"use strict\";if(!@isReadableByteStreamController(this))throw @makeGetterTypeError(\"ReadableByteStreamController\",\"byobRequest\");var request=@getByIdDirectPrivate(this,\"byobRequest\");if(request===@undefined){var pending=@getByIdDirectPrivate(this,\"pendingPullIntos\");const firstDescriptor=pending.peek();if(firstDescriptor){const view=new @Uint8Array(firstDescriptor.buffer,firstDescriptor.byteOffset+firstDescriptor.bytesFilled,firstDescriptor.byteLength-firstDescriptor.bytesFilled);@putByIdDirectPrivate(this,\"byobRequest\",new @ReadableStreamBYOBRequest(this,view,@isReadableStream))}}return @getByIdDirectPrivate(this,\"byobRequest\")})\n";
-
-// desiredSize
-const JSC::ConstructAbility s_readableByteStreamControllerDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamControllerDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamControllerDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamControllerDesiredSizeCodeLength = 200;
-static const JSC::Intrinsic s_readableByteStreamControllerDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamControllerDesiredSizeCode = "(function (){\"use strict\";if(!@isReadableByteStreamController(this))throw @makeGetterTypeError(\"ReadableByteStreamController\",\"desiredSize\");return @readableByteStreamControllerGetDesiredSize(this)})\n";
-
-#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
-{\
-    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().readableByteStreamControllerBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableByteStreamControllerBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
-}
-WEBCORE_FOREACH_READABLEBYTESTREAMCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
-#undef DEFINE_BUILTIN_GENERATOR
-
-/* ReadableStreamDefaultReader.ts */
-// initializeReadableStreamDefaultReader
-const JSC::ConstructAbility s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeLength = 334;
-static const JSC::Intrinsic s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCode = "(function (stream){\"use strict\";if(!@isReadableStream(stream))@throwTypeError(\"ReadableStreamDefaultReader needs a ReadableStream\");if(@isReadableStreamLocked(stream))@throwTypeError(\"ReadableStream is locked\");return @readableStreamReaderGenericInitialize(this,stream),@putByIdDirectPrivate(this,\"readRequests\",@createFIFO()),this})\n";
-
-// cancel
-const JSC::ConstructAbility s_readableStreamDefaultReaderCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamDefaultReaderCancelCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamDefaultReaderCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamDefaultReaderCancelCodeLength = 367;
-static const JSC::Intrinsic s_readableStreamDefaultReaderCancelCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamDefaultReaderCancelCode = "(function (reason){\"use strict\";if(!@isReadableStreamDefaultReader(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStreamDefaultReader\",\"cancel\"));if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return @Promise.@reject(@makeTypeError(\"cancel() called on a reader owned by no readable stream\"));return @readableStreamReaderGenericCancel(this,reason)})\n";
-
-// readMany
-const JSC::ConstructAbility s_readableStreamDefaultReaderReadManyCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamDefaultReaderReadManyCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamDefaultReaderReadManyCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamDefaultReaderReadManyCodeLength = 3230;
-static const JSC::Intrinsic s_readableStreamDefaultReaderReadManyCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamDefaultReaderReadManyCode = "(function (){\"use strict\";if(!@isReadableStreamDefaultReader(this))@throwTypeError(\"ReadableStreamDefaultReader.readMany() should not be called directly\");const stream=@getByIdDirectPrivate(this,\"ownerReadableStream\");if(!stream)@throwTypeError(\"readMany() called on a reader owned by no readable stream\");const state=@getByIdDirectPrivate(stream,\"state\");if(@putByIdDirectPrivate(stream,\"disturbed\",!0),state===@streamClosed)return{value:[],size:0,done:!0};else if(state===@streamErrored)throw @getByIdDirectPrivate(stream,\"storedError\");var controller=@getByIdDirectPrivate(stream,\"readableStreamController\"),queue=@getByIdDirectPrivate(controller,\"queue\");if(!queue)return controller.@pull(controller).@then(function({done,value}){return done\?{done:!0,value:[],size:0}:{value:[value],size:1,done:!1}});const content=queue.content;var size=queue.size,values=content.toArray(!1),length=values.length;if(length>0){var outValues=@newArrayWithSize(length);if(@isReadableByteStreamController(controller)){{const buf=values[0];if(!(@ArrayBuffer.@isView(buf)||buf instanceof @ArrayBuffer))@putByValDirect(outValues,0,new @Uint8Array(buf.buffer,buf.byteOffset,buf.byteLength));else @putByValDirect(outValues,0,buf)}for(var i=1;i<length;i++){const buf=values[i];if(!(@ArrayBuffer.@isView(buf)||buf instanceof @ArrayBuffer))@putByValDirect(outValues,i,new @Uint8Array(buf.buffer,buf.byteOffset,buf.byteLength));else @putByValDirect(outValues,i,buf)}}else{@putByValDirect(outValues,0,values[0].value);for(var i=1;i<length;i++)@putByValDirect(outValues,i,values[i].value)}if(@resetQueue(@getByIdDirectPrivate(controller,\"queue\")),@getByIdDirectPrivate(controller,\"closeRequested\"))@readableStreamClose(@getByIdDirectPrivate(controller,\"controlledReadableStream\"));else if(@isReadableStreamDefaultController(controller))@readableStreamDefaultControllerCallPullIfNeeded(controller);else if(@isReadableByteStreamController(controller))@readableByteStreamControllerCallPullIfNeeded(controller);return{value:outValues,size,done:!1}}var onPullMany=(result)=>{if(result.done)return{value:[],size:0,done:!0};var controller2=@getByIdDirectPrivate(stream,\"readableStreamController\"),queue2=@getByIdDirectPrivate(controller2,\"queue\"),value=[result.value].concat(queue2.content.toArray(!1)),length2=value.length;if(@isReadableByteStreamController(controller2))for(var i2=0;i2<length2;i2++){const buf=value[i2];if(!(@ArrayBuffer.@isView(buf)||buf instanceof @ArrayBuffer)){const{buffer,byteOffset,byteLength}=buf;@putByValDirect(value,i2,new @Uint8Array(buffer,byteOffset,byteLength))}}else for(var i2=1;i2<length2;i2++)@putByValDirect(value,i2,value[i2].value);var size2=queue2.size;if(@resetQueue(queue2),@getByIdDirectPrivate(controller2,\"closeRequested\"))@readableStreamClose(@getByIdDirectPrivate(controller2,\"controlledReadableStream\"));else if(@isReadableStreamDefaultController(controller2))@readableStreamDefaultControllerCallPullIfNeeded(controller2);else if(@isReadableByteStreamController(controller2))@readableByteStreamControllerCallPullIfNeeded(controller2);return{value,size:size2,done:!1}},pullResult=controller.@pull(controller);if(pullResult&&@isPromise(pullResult))return pullResult.@then(onPullMany);return onPullMany(pullResult)})\n";
-
-// read
-const JSC::ConstructAbility s_readableStreamDefaultReaderReadCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamDefaultReaderReadCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamDefaultReaderReadCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamDefaultReaderReadCodeLength = 348;
-static const JSC::Intrinsic s_readableStreamDefaultReaderReadCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamDefaultReaderReadCode = "(function (){\"use strict\";if(!@isReadableStreamDefaultReader(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStreamDefaultReader\",\"read\"));if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return @Promise.@reject(@makeTypeError(\"read() called on a reader owned by no readable stream\"));return @readableStreamDefaultReaderRead(this)})\n";
-
-// releaseLock
-const JSC::ConstructAbility s_readableStreamDefaultReaderReleaseLockCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamDefaultReaderReleaseLockCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamDefaultReaderReleaseLockCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamDefaultReaderReleaseLockCodeLength = 384;
-static const JSC::Intrinsic s_readableStreamDefaultReaderReleaseLockCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamDefaultReaderReleaseLockCode = "(function (){\"use strict\";if(!@isReadableStreamDefaultReader(this))throw @makeThisTypeError(\"ReadableStreamDefaultReader\",\"releaseLock\");if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return;if(@getByIdDirectPrivate(this,\"readRequests\")\?.isNotEmpty())@throwTypeError(\"There are still pending read requests, cannot release the lock\");@readableStreamReaderGenericRelease(this)})\n";
-
-// closed
-const JSC::ConstructAbility s_readableStreamDefaultReaderClosedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamDefaultReaderClosedCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamDefaultReaderClosedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamDefaultReaderClosedCodeLength = 224;
-static const JSC::Intrinsic s_readableStreamDefaultReaderClosedCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamDefaultReaderClosedCode = "(function (){\"use strict\";if(!@isReadableStreamDefaultReader(this))return @Promise.@reject(@makeGetterTypeError(\"ReadableStreamDefaultReader\",\"closed\"));return @getByIdDirectPrivate(this,\"closedPromiseCapability\").promise})\n";
-
-#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
-{\
-    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().readableStreamDefaultReaderBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableStreamDefaultReaderBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
-}
-WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
-#undef DEFINE_BUILTIN_GENERATOR
-
-/* ByteLengthQueuingStrategy.ts */
-// highWaterMark
-const JSC::ConstructAbility s_byteLengthQueuingStrategyHighWaterMarkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_byteLengthQueuingStrategyHighWaterMarkCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_byteLengthQueuingStrategyHighWaterMarkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_byteLengthQueuingStrategyHighWaterMarkCodeLength = 246;
-static const JSC::Intrinsic s_byteLengthQueuingStrategyHighWaterMarkCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_byteLengthQueuingStrategyHighWaterMarkCode = "(function (){\"use strict\";const highWaterMark=@getByIdDirectPrivate(this,\"highWaterMark\");if(highWaterMark===@undefined)@throwTypeError(\"ByteLengthQueuingStrategy.highWaterMark getter called on incompatible |this| value.\");return highWaterMark})\n";
-
-// size
-const JSC::ConstructAbility s_byteLengthQueuingStrategySizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_byteLengthQueuingStrategySizeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_byteLengthQueuingStrategySizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_byteLengthQueuingStrategySizeCodeLength = 57;
-static const JSC::Intrinsic s_byteLengthQueuingStrategySizeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_byteLengthQueuingStrategySizeCode = "(function (chunk){\"use strict\";return chunk.byteLength})\n";
-
-// initializeByteLengthQueuingStrategy
-const JSC::ConstructAbility s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeLength = 139;
-static const JSC::Intrinsic s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCode = "(function (parameters){\"use strict\";@putByIdDirectPrivate(this,\"highWaterMark\",@extractHighWaterMarkFromQueuingStrategyInit(parameters))})\n";
-
-#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
-{\
-    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().byteLengthQueuingStrategyBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().byteLengthQueuingStrategyBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
-}
-WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
-#undef DEFINE_BUILTIN_GENERATOR
-
-/* JSBufferConstructor.ts */
-// from
-const JSC::ConstructAbility s_jsBufferConstructorFromCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_jsBufferConstructorFromCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_jsBufferConstructorFromCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_jsBufferConstructorFromCodeLength = 1274;
-static const JSC::Intrinsic s_jsBufferConstructorFromCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_jsBufferConstructorFromCode = "(function (items){\"use strict\";if(@isUndefinedOrNull(items))@throwTypeError(\"The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object.\");if(typeof items===\"string\"||typeof items===\"object\"&&(@isTypedArrayView(items)||items instanceof @ArrayBuffer||items instanceof SharedArrayBuffer||items instanceof @String))switch(@argumentCount()){case 1:return new @Buffer(items);case 2:return new @Buffer(items,@argument(1));default:return new @Buffer(items,@argument(1),@argument(2))}var arrayLike=@toObject(items,\"The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object.\");if(!@isJSArray(arrayLike)){const toPrimitive=@tryGetByIdWithWellKnownSymbol(items,\"toPrimitive\");if(toPrimitive){const primitive=toPrimitive.@call(items,\"string\");if(typeof primitive===\"string\")switch(@argumentCount()){case 1:return new @Buffer(primitive);case 2:return new @Buffer(primitive,@argument(1));default:return new @Buffer(primitive,@argument(1),@argument(2))}}if(!(\"length\"in arrayLike)||@isCallable(arrayLike))@throwTypeError(\"The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object.\")}return new @Buffer(@Uint8Array.from(arrayLike).buffer)})\n";
-
-// isBuffer
-const JSC::ConstructAbility s_jsBufferConstructorIsBufferCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_jsBufferConstructorIsBufferCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_jsBufferConstructorIsBufferCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_jsBufferConstructorIsBufferCodeLength = 75;
-static const JSC::Intrinsic s_jsBufferConstructorIsBufferCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_jsBufferConstructorIsBufferCode = "(function (bufferlike){\"use strict\";return bufferlike instanceof @Buffer})\n";
-
-#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
-{\
-    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().jsBufferConstructorBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().jsBufferConstructorBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
-}
-WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
-#undef DEFINE_BUILTIN_GENERATOR
-
-/* ImportMetaObject.ts */
-// loadCJS2ESM
-const JSC::ConstructAbility s_importMetaObjectLoadCJS2ESMCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_importMetaObjectLoadCJS2ESMCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_importMetaObjectLoadCJS2ESMCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_importMetaObjectLoadCJS2ESMCodeLength = 2214;
-static const JSC::Intrinsic s_importMetaObjectLoadCJS2ESMCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_importMetaObjectLoadCJS2ESMCode = "(function (resolvedSpecifier){\"use strict\";var loader=@Loader,queue=@createFIFO(),key=resolvedSpecifier;while(key){var entry=loader.registry.@get(key);if((entry\?.state\?\?0)<=@ModuleFetch)@fulfillModuleSync(key),entry=loader.registry.@get(key);var sourceCodeObject=@getPromiseInternalField(entry.fetch,@promiseFieldReactionsOrResult),moduleRecordPromise=loader.parseModule(key,sourceCodeObject),mod=entry.module;if(moduleRecordPromise&&@isPromise(moduleRecordPromise)){var reactionsOrResult=@getPromiseInternalField(moduleRecordPromise,@promiseFieldReactionsOrResult),flags=@getPromiseInternalField(moduleRecordPromise,@promiseFieldFlags),state=flags&@promiseStateMask;if(state===@promiseStatePending||reactionsOrResult&&@isPromise(reactionsOrResult))@throwTypeError(`require() async module \"${key}\" is unsupported. use \"await import()\" instead.`);else if(state===@promiseStateRejected){if(!reactionsOrResult\?.message)@throwTypeError(`${reactionsOrResult+\"\"\?reactionsOrResult:\"An error occurred\"} occurred while parsing module \\\"${key}\\\"`);throw reactionsOrResult}entry.module=mod=reactionsOrResult}else if(moduleRecordPromise&&!mod)entry.module=mod=moduleRecordPromise;@setStateToMax(entry,@ModuleLink);var dependenciesMap=mod.dependenciesMap,requestedModules=loader.requestedModules(mod),dependencies=@newArrayWithSize(requestedModules.length);for(var i=0,length=requestedModules.length;i<length;++i){var depName=requestedModules[i],depKey=depName[0]===\"/\"\?depName:loader.resolve(depName,key),depEntry=loader.ensureRegistered(depKey);if(depEntry.state<@ModuleLink)queue.push(depKey);@putByValDirect(dependencies,i,depEntry),dependenciesMap.@set(depName,depEntry)}entry.dependencies=dependencies,entry.instantiate=@Promise.@resolve(entry),entry.satisfy=@Promise.@resolve(entry),entry.isSatisfied=!0,key=queue.shift();while(key&&(loader.registry.@get(key)\?.state\?\?@ModuleFetch)>=@ModuleLink)key=queue.shift()}var linkAndEvaluateResult=loader.linkAndEvaluateModule(resolvedSpecifier,@undefined);if(linkAndEvaluateResult&&@isPromise(linkAndEvaluateResult))@throwTypeError(`require() async module \\\"${resolvedSpecifier}\\\" is unsupported. use \"await import()\" instead.`);return loader.registry.@get(resolvedSpecifier)})\n";
-
-// requireESM
-const JSC::ConstructAbility s_importMetaObjectRequireESMCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_importMetaObjectRequireESMCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_importMetaObjectRequireESMCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_importMetaObjectRequireESMCodeLength = 364;
-static const JSC::Intrinsic s_importMetaObjectRequireESMCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_importMetaObjectRequireESMCode = "(function (resolved){\"use strict\";var entry=@Loader.registry.@get(resolved);if(!entry||!entry.evaluated)entry=@loadCJS2ESM(resolved);if(!entry||!entry.evaluated||!entry.module)@throwTypeError(`require() failed to evaluate module \"${resolved}\". This is an internal consistentency error.`);var exports=@Loader.getModuleNamespaceObject(entry.module);return exports})\n";
-
-// internalRequire
-const JSC::ConstructAbility s_importMetaObjectInternalRequireCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_importMetaObjectInternalRequireCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_importMetaObjectInternalRequireCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_importMetaObjectInternalRequireCodeLength = 857;
-static const JSC::Intrinsic s_importMetaObjectInternalRequireCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_importMetaObjectInternalRequireCode = "(function (id){\"use strict\";var cached=@requireMap.@get(id);const last5=id.substring(id.length-5);if(cached)return cached.exports;if(last5===\".json\"){var fs=globalThis[Symbol.for(\"_fs\")]||=@Bun.fs(),exports=JSON.parse(fs.readFileSync(id,\"utf8\"));return @requireMap.@set(id,@createCommonJSModule(id,exports,!0)),exports}else if(last5===\".node\"){const module=@createCommonJSModule(id,{},!0);return process.dlopen(module,id),@requireMap.@set(id,module),module.exports}else if(last5===\".toml\"){var fs=globalThis[Symbol.for(\"_fs\")]||=@Bun.fs(),exports=@Bun.TOML.parse(fs.readFileSync(id,\"utf8\"));return @requireMap.@set(id,@createCommonJSModule(id,exports,!0)),exports}else{var exports=@requireESM(id);const cachedModule=@requireMap.@get(id);if(cachedModule)return cachedModule.exports;return @requireMap.@set(id,@createCommonJSModule(id,exports,!0)),exports}})\n";
-
-// createRequireCache
-const JSC::ConstructAbility s_importMetaObjectCreateRequireCacheCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_importMetaObjectCreateRequireCacheCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_importMetaObjectCreateRequireCacheCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_importMetaObjectCreateRequireCacheCodeLength = 978;
-static const JSC::Intrinsic s_importMetaObjectCreateRequireCacheCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_importMetaObjectCreateRequireCacheCode = "(function (){\"use strict\";var moduleMap=new Map,inner={};return new Proxy(inner,{get(target,key){const entry=@requireMap.@get(key);if(entry)return entry;const esm=@Loader.registry.@get(key);if(esm\?.evaluated){const namespace=@Loader.getModuleNamespaceObject(esm.module),mod=@createCommonJSModule(key,namespace,!0);return @requireMap.@set(key,mod),mod}return inner[key]},set(target,key,value){return @requireMap.@set(key,value),!0},has(target,key){return @requireMap.@has(key)||@Loader.registry.@has(key)},deleteProperty(target,key){return moduleMap.@delete(key),@requireMap.@delete(key),@Loader.registry.@delete(key),!0},ownKeys(target){var array=[...@requireMap.@keys()];const registryKeys=[...@Loader.registry.@keys()];for(let key of registryKeys)if(!array.includes(key))@arrayPush(array,key);return array},getPrototypeOf(target){return null},getOwnPropertyDescriptor(target,key){if(@requireMap.@has(key)||@Loader.registry.@has(key))return{configurable:!0,enumerable:!0}}})})\n";
-
-// main
-const JSC::ConstructAbility s_importMetaObjectMainCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_importMetaObjectMainCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_importMetaObjectMainCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_importMetaObjectMainCodeLength = 76;
-static const JSC::Intrinsic s_importMetaObjectMainCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_importMetaObjectMainCode = "(function (){\"use strict\";return this.path===@Bun.main&&@Bun.isMainThread})\n";
-
-#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
-{\
-    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().importMetaObjectBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().importMetaObjectBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
-}
-WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
-#undef DEFINE_BUILTIN_GENERATOR
-
-/* TransformStream.ts */
-// initializeTransformStream
-const JSC::ConstructAbility s_transformStreamInitializeTransformStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_transformStreamInitializeTransformStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_transformStreamInitializeTransformStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_transformStreamInitializeTransformStreamCodeLength = 2041;
-static const JSC::Intrinsic s_transformStreamInitializeTransformStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_transformStreamInitializeTransformStreamCode = "(function (){\"use strict\";let transformer=arguments[0];if(@isObject(transformer)&&@getByIdDirectPrivate(transformer,\"TransformStream\"))return this;let writableStrategy=arguments[1],readableStrategy=arguments[2];if(transformer===@undefined)transformer=null;if(readableStrategy===@undefined)readableStrategy={};if(writableStrategy===@undefined)writableStrategy={};let transformerDict={};if(transformer!==null){if(\"start\"in transformer){if(transformerDict.start=transformer.start,typeof transformerDict.start!==\"function\")@throwTypeError(\"transformer.start should be a function\")}if(\"transform\"in transformer){if(transformerDict.transform=transformer.transform,typeof transformerDict.transform!==\"function\")@throwTypeError(\"transformer.transform should be a function\")}if(\"flush\"in transformer){if(transformerDict.flush=transformer.flush,typeof transformerDict.flush!==\"function\")@throwTypeError(\"transformer.flush should be a function\")}if(\"readableType\"in transformer)@throwRangeError(\"TransformStream transformer has a readableType\");if(\"writableType\"in transformer)@throwRangeError(\"TransformStream transformer has a writableType\")}const readableHighWaterMark=@extractHighWaterMark(readableStrategy,0),readableSizeAlgorithm=@extractSizeAlgorithm(readableStrategy),writableHighWaterMark=@extractHighWaterMark(writableStrategy,1),writableSizeAlgorithm=@extractSizeAlgorithm(writableStrategy),startPromiseCapability=@newPromiseCapability(@Promise);if(@initializeTransformStream(this,startPromiseCapability.promise,writableHighWaterMark,writableSizeAlgorithm,readableHighWaterMark,readableSizeAlgorithm),@setUpTransformStreamDefaultControllerFromTransformer(this,transformer,transformerDict),(\"start\"in transformerDict)){const controller=@getByIdDirectPrivate(this,\"controller\");(()=>@promiseInvokeOrNoopMethodNoCatch(transformer,transformerDict.start,[controller]))().@then(()=>{startPromiseCapability.resolve.@call()},(error)=>{startPromiseCapability.reject.@call(@undefined,error)})}else startPromiseCapability.resolve.@call();return this})\n";
-
-// readable
-const JSC::ConstructAbility s_transformStreamReadableCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_transformStreamReadableCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_transformStreamReadableCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_transformStreamReadableCodeLength = 158;
-static const JSC::Intrinsic s_transformStreamReadableCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_transformStreamReadableCode = "(function (){\"use strict\";if(!@isTransformStream(this))throw @makeThisTypeError(\"TransformStream\",\"readable\");return @getByIdDirectPrivate(this,\"readable\")})\n";
-
-// writable
-const JSC::ConstructAbility s_transformStreamWritableCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_transformStreamWritableCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_transformStreamWritableCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_transformStreamWritableCodeLength = 158;
-static const JSC::Intrinsic s_transformStreamWritableCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_transformStreamWritableCode = "(function (){\"use strict\";if(!@isTransformStream(this))throw @makeThisTypeError(\"TransformStream\",\"writable\");return @getByIdDirectPrivate(this,\"writable\")})\n";
-
-#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
-{\
-    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().transformStreamBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().transformStreamBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
-}
-WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
-#undef DEFINE_BUILTIN_GENERATOR
-
-/* ReadableStreamInternals.ts */
-// readableStreamReaderGenericInitialize
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamReaderGenericInitializeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamReaderGenericInitializeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamReaderGenericInitializeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamReaderGenericInitializeCodeLength = 584;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamReaderGenericInitializeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamReaderGenericInitializeCode = "(function (reader,stream){\"use strict\";if(@putByIdDirectPrivate(reader,\"ownerReadableStream\",stream),@putByIdDirectPrivate(stream,\"reader\",reader),@getByIdDirectPrivate(stream,\"state\")===@streamReadable)@putByIdDirectPrivate(reader,\"closedPromiseCapability\",@newPromiseCapability(@Promise));else if(@getByIdDirectPrivate(stream,\"state\")===@streamClosed)@putByIdDirectPrivate(reader,\"closedPromiseCapability\",{promise:@Promise.@resolve()});else @putByIdDirectPrivate(reader,\"closedPromiseCapability\",{promise:@newHandledRejectedPromise(@getByIdDirectPrivate(stream,\"storedError\"))})})\n";
-
-// privateInitializeReadableStreamDefaultController
-const JSC::ConstructAbility s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCodeLength = 755;
-static const JSC::Intrinsic s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCode = "(function (stream,underlyingSource,size,highWaterMark){\"use strict\";if(!@isReadableStream(stream))@throwTypeError(\"ReadableStreamDefaultController needs a ReadableStream\");if(@getByIdDirectPrivate(stream,\"readableStreamController\")!==null)@throwTypeError(\"ReadableStream already has a controller\");return @putByIdDirectPrivate(this,\"controlledReadableStream\",stream),@putByIdDirectPrivate(this,\"underlyingSource\",underlyingSource),@putByIdDirectPrivate(this,\"queue\",@newQueue()),@putByIdDirectPrivate(this,\"started\",-1),@putByIdDirectPrivate(this,\"closeRequested\",!1),@putByIdDirectPrivate(this,\"pullAgain\",!1),@putByIdDirectPrivate(this,\"pulling\",!1),@putByIdDirectPrivate(this,\"strategy\",@validateAndNormalizeQueuingStrategy(size,highWaterMark)),this})\n";
-
-// readableStreamDefaultControllerError
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefaultControllerErrorCodeLength = 273;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefaultControllerErrorCode = "(function (controller,error){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(@getByIdDirectPrivate(stream,\"state\")!==@streamReadable)return;@putByIdDirectPrivate(controller,\"queue\",@newQueue()),@readableStreamError(stream,error)})\n";
-
-// readableStreamPipeTo
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamPipeToCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamPipeToCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamPipeToCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamPipeToCodeLength = 469;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamPipeToCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamPipeToCode = "(function (stream,sink){\"use strict\";const reader=new @ReadableStreamDefaultReader(stream);@getByIdDirectPrivate(reader,\"closedPromiseCapability\").promise.@then(()=>{},(e)=>{sink.error(e)});function doPipe(){@readableStreamDefaultReaderRead(reader).@then(function(result){if(result.done){sink.close();return}try{sink.enqueue(result.value)}catch(e){sink.error(\"ReadableStream chunk enqueueing in the sink failed\");return}doPipe()},function(e){sink.error(e)})}doPipe()})\n";
-
-// acquireReadableStreamDefaultReader
-const JSC::ConstructAbility s_readableStreamInternalsAcquireReadableStreamDefaultReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsAcquireReadableStreamDefaultReaderCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsAcquireReadableStreamDefaultReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsAcquireReadableStreamDefaultReaderCodeLength = 159;
-static const JSC::Intrinsic s_readableStreamInternalsAcquireReadableStreamDefaultReaderCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsAcquireReadableStreamDefaultReaderCode = "(function (stream){\"use strict\";var start=@getByIdDirectPrivate(stream,\"start\");if(start)start.@call(stream);return new @ReadableStreamDefaultReader(stream)})\n";
-
-// setupReadableStreamDefaultController
-const JSC::ConstructAbility s_readableStreamInternalsSetupReadableStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsSetupReadableStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsSetupReadableStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsSetupReadableStreamDefaultControllerCodeLength = 1105;
-static const JSC::Intrinsic s_readableStreamInternalsSetupReadableStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsSetupReadableStreamDefaultControllerCode = "(function (stream,underlyingSource,size,highWaterMark,startMethod,pullMethod,cancelMethod){\"use strict\";const controller=new @ReadableStreamDefaultController(stream,underlyingSource,size,highWaterMark,@isReadableStream);var asyncContext=stream.@asyncContext;const pullAlgorithm=()=>@promiseInvokeOrNoopMethod(underlyingSource,pullMethod,[controller]),cancelAlgorithm=asyncContext\?(reason)=>{var prev=@getInternalField(@asyncContext,0);@putInternalField(@asyncContext,0,asyncContext);var result=@promiseInvokeOrNoopMethod(underlyingSource,cancelMethod,[reason]);return @putInternalField(@asyncContext,0,prev),result}:(reason)=>@promiseInvokeOrNoopMethod(underlyingSource,cancelMethod,[reason]);@putByIdDirectPrivate(controller,\"pullAlgorithm\",pullAlgorithm),@putByIdDirectPrivate(controller,\"cancelAlgorithm\",cancelAlgorithm),@putByIdDirectPrivate(controller,\"pull\",@readableStreamDefaultControllerPull),@putByIdDirectPrivate(controller,\"cancel\",@readableStreamDefaultControllerCancel),@putByIdDirectPrivate(stream,\"readableStreamController\",controller),@readableStreamDefaultControllerStart(controller)})\n";
-
-// createReadableStreamController
-const JSC::ConstructAbility s_readableStreamInternalsCreateReadableStreamControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsCreateReadableStreamControllerCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsCreateReadableStreamControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsCreateReadableStreamControllerCodeLength = 946;
-static const JSC::Intrinsic s_readableStreamInternalsCreateReadableStreamControllerCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsCreateReadableStreamControllerCode = "(function (stream,underlyingSource,strategy){\"use strict\";const type=underlyingSource.type,typeString=@toString(type);if(typeString===\"bytes\"){if(strategy.highWaterMark===@undefined)strategy.highWaterMark=0;if(strategy.size!==@undefined)@throwRangeError(\"Strategy for a ReadableByteStreamController cannot have a size\");@putByIdDirectPrivate(stream,\"readableStreamController\",new @ReadableByteStreamController(stream,underlyingSource,strategy.highWaterMark,@isReadableStream))}else if(typeString===\"direct\"){var highWaterMark=strategy\?.highWaterMark;@initializeArrayBufferStream.@call(stream,underlyingSource,highWaterMark)}else if(type===@undefined){if(strategy.highWaterMark===@undefined)strategy.highWaterMark=1;@setupReadableStreamDefaultController(stream,underlyingSource,strategy.size,strategy.highWaterMark,underlyingSource.start,underlyingSource.pull,underlyingSource.cancel)}else @throwRangeError(\"Invalid type for underlying source\")})\n";
-
-// readableStreamDefaultControllerStart
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerStartCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerStartCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerStartCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefaultControllerStartCodeLength = 518;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerStartCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefaultControllerStartCode = "(function (controller){\"use strict\";if(@getByIdDirectPrivate(controller,\"started\")!==-1)return;const underlyingSource=@getByIdDirectPrivate(controller,\"underlyingSource\"),startMethod=underlyingSource.start;@putByIdDirectPrivate(controller,\"started\",0),@promiseInvokeOrNoopMethodNoCatch(underlyingSource,startMethod,[controller]).@then(()=>{@putByIdDirectPrivate(controller,\"started\",1),@readableStreamDefaultControllerCallPullIfNeeded(controller)},(error)=>{@readableStreamDefaultControllerError(controller,error)})})\n";
-
-// readableStreamPipeToWritableStream
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamPipeToWritableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamPipeToWritableStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamPipeToWritableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamPipeToWritableStreamCodeLength = 2022;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamPipeToWritableStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamPipeToWritableStreamCode = "(function (source,destination,preventClose,preventAbort,preventCancel,signal){\"use strict\";if(@getByIdDirectPrivate(source,\"underlyingByteSource\")!==@undefined)return @Promise.@reject(\"Piping to a readable bytestream is not supported\");let pipeState={source,destination,preventAbort,preventCancel,preventClose,signal};if(pipeState.reader=@acquireReadableStreamDefaultReader(source),pipeState.writer=@acquireWritableStreamDefaultWriter(destination),@putByIdDirectPrivate(source,\"disturbed\",!0),pipeState.finalized=!1,pipeState.shuttingDown=!1,pipeState.promiseCapability=@newPromiseCapability(@Promise),pipeState.pendingReadPromiseCapability=@newPromiseCapability(@Promise),pipeState.pendingReadPromiseCapability.resolve.@call(),pipeState.pendingWritePromise=@Promise.@resolve(),signal!==@undefined){const algorithm=(reason)=>{if(pipeState.finalized)return;@pipeToShutdownWithAction(pipeState,()=>{const promiseDestination=!pipeState.preventAbort&&@getByIdDirectPrivate(pipeState.destination,\"state\")===\"writable\"\?@writableStreamAbort(pipeState.destination,reason):@Promise.@resolve(),promiseSource=!pipeState.preventCancel&&@getByIdDirectPrivate(pipeState.source,\"state\")===@streamReadable\?@readableStreamCancel(pipeState.source,reason):@Promise.@resolve();let promiseCapability=@newPromiseCapability(@Promise),shouldWait=!0,handleResolvedPromise=()=>{if(shouldWait){shouldWait=!1;return}promiseCapability.resolve.@call()},handleRejectedPromise=(e)=>{promiseCapability.reject.@call(@undefined,e)};return promiseDestination.@then(handleResolvedPromise,handleRejectedPromise),promiseSource.@then(handleResolvedPromise,handleRejectedPromise),promiseCapability.promise},reason)};if(@whenSignalAborted(signal,algorithm))return pipeState.promiseCapability.promise}return @pipeToErrorsMustBePropagatedForward(pipeState),@pipeToErrorsMustBePropagatedBackward(pipeState),@pipeToClosingMustBePropagatedForward(pipeState),@pipeToClosingMustBePropagatedBackward(pipeState),@pipeToLoop(pipeState),pipeState.promiseCapability.promise})\n";
-
-// pipeToLoop
-const JSC::ConstructAbility s_readableStreamInternalsPipeToLoopCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsPipeToLoopCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsPipeToLoopCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsPipeToLoopCodeLength = 152;
-static const JSC::Intrinsic s_readableStreamInternalsPipeToLoopCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsPipeToLoopCode = "(function (pipeState){\"use strict\";if(pipeState.shuttingDown)return;@pipeToDoReadWrite(pipeState).@then((result)=>{if(result)@pipeToLoop(pipeState)})})\n";
-
-// pipeToDoReadWrite
-const JSC::ConstructAbility s_readableStreamInternalsPipeToDoReadWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsPipeToDoReadWriteCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsPipeToDoReadWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsPipeToDoReadWriteCodeLength = 840;
-static const JSC::Intrinsic s_readableStreamInternalsPipeToDoReadWriteCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsPipeToDoReadWriteCode = "(function (pipeState){\"use strict\";return pipeState.pendingReadPromiseCapability=@newPromiseCapability(@Promise),@getByIdDirectPrivate(pipeState.writer,\"readyPromise\").promise.@then(()=>{if(pipeState.shuttingDown){pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,!1);return}@readableStreamDefaultReaderRead(pipeState.reader).@then((result)=>{const canWrite=!result.done&&@getByIdDirectPrivate(pipeState.writer,\"stream\")!==@undefined;if(pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,canWrite),!canWrite)return;pipeState.pendingWritePromise=@writableStreamDefaultWriterWrite(pipeState.writer,result.value)},(e)=>{pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,!1)})},(e)=>{pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,!1)}),pipeState.pendingReadPromiseCapability.promise})\n";
-
-// pipeToErrorsMustBePropagatedForward
-const JSC::ConstructAbility s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCodeLength = 539;
-static const JSC::Intrinsic s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCode = "(function (pipeState){\"use strict\";const action=()=>{pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,!1);const error=@getByIdDirectPrivate(pipeState.source,\"storedError\");if(!pipeState.preventAbort){@pipeToShutdownWithAction(pipeState,()=>@writableStreamAbort(pipeState.destination,error),error);return}@pipeToShutdown(pipeState,error)};if(@getByIdDirectPrivate(pipeState.source,\"state\")===@streamErrored){action();return}@getByIdDirectPrivate(pipeState.reader,\"closedPromiseCapability\").promise.@then(@undefined,action)})\n";
-
-// pipeToErrorsMustBePropagatedBackward
-const JSC::ConstructAbility s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCodeLength = 463;
-static const JSC::Intrinsic s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCode = "(function (pipeState){\"use strict\";const action=()=>{const error=@getByIdDirectPrivate(pipeState.destination,\"storedError\");if(!pipeState.preventCancel){@pipeToShutdownWithAction(pipeState,()=>@readableStreamCancel(pipeState.source,error),error);return}@pipeToShutdown(pipeState,error)};if(@getByIdDirectPrivate(pipeState.destination,\"state\")===\"errored\"){action();return}@getByIdDirectPrivate(pipeState.writer,\"closedPromise\").promise.@then(@undefined,action)})\n";
-
-// pipeToClosingMustBePropagatedForward
-const JSC::ConstructAbility s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCodeLength = 482;
-static const JSC::Intrinsic s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCode = "(function (pipeState){\"use strict\";const action=()=>{if(pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,!1),!pipeState.preventClose){@pipeToShutdownWithAction(pipeState,()=>@writableStreamDefaultWriterCloseWithErrorPropagation(pipeState.writer));return}@pipeToShutdown(pipeState)};if(@getByIdDirectPrivate(pipeState.source,\"state\")===@streamClosed){action();return}@getByIdDirectPrivate(pipeState.reader,\"closedPromiseCapability\").promise.@then(action,@undefined)})\n";
-
-// pipeToClosingMustBePropagatedBackward
-const JSC::ConstructAbility s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCodeLength = 396;
-static const JSC::Intrinsic s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCode = "(function (pipeState){\"use strict\";if(!@writableStreamCloseQueuedOrInFlight(pipeState.destination)&&@getByIdDirectPrivate(pipeState.destination,\"state\")!==\"closed\")return;const error=@makeTypeError(\"closing is propagated backward\");if(!pipeState.preventCancel){@pipeToShutdownWithAction(pipeState,()=>@readableStreamCancel(pipeState.source,error),error);return}@pipeToShutdown(pipeState,error)})\n";
-
-// pipeToShutdownWithAction
-const JSC::ConstructAbility s_readableStreamInternalsPipeToShutdownWithActionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsPipeToShutdownWithActionCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsPipeToShutdownWithActionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsPipeToShutdownWithActionCodeLength = 605;
-static const JSC::Intrinsic s_readableStreamInternalsPipeToShutdownWithActionCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsPipeToShutdownWithActionCode = "(function (pipeState,action){\"use strict\";if(pipeState.shuttingDown)return;pipeState.shuttingDown=!0;const hasError=arguments.length>2,error=arguments[2],finalize=()=>{action().@then(()=>{if(hasError)@pipeToFinalize(pipeState,error);else @pipeToFinalize(pipeState)},(e)=>{@pipeToFinalize(pipeState,e)})};if(@getByIdDirectPrivate(pipeState.destination,\"state\")===\"writable\"&&!@writableStreamCloseQueuedOrInFlight(pipeState.destination)){pipeState.pendingReadPromiseCapability.promise.@then(()=>{pipeState.pendingWritePromise.@then(finalize,finalize)},(e)=>@pipeToFinalize(pipeState,e));return}finalize()})\n";
-
-// pipeToShutdown
-const JSC::ConstructAbility s_readableStreamInternalsPipeToShutdownCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsPipeToShutdownCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsPipeToShutdownCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsPipeToShutdownCodeLength = 540;
-static const JSC::Intrinsic s_readableStreamInternalsPipeToShutdownCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsPipeToShutdownCode = "(function (pipeState){\"use strict\";if(pipeState.shuttingDown)return;pipeState.shuttingDown=!0;const hasError=arguments.length>1,error=arguments[1],finalize=()=>{if(hasError)@pipeToFinalize(pipeState,error);else @pipeToFinalize(pipeState)};if(@getByIdDirectPrivate(pipeState.destination,\"state\")===\"writable\"&&!@writableStreamCloseQueuedOrInFlight(pipeState.destination)){pipeState.pendingReadPromiseCapability.promise.@then(()=>{pipeState.pendingWritePromise.@then(finalize,finalize)},(e)=>@pipeToFinalize(pipeState,e));return}finalize()})\n";
-
-// pipeToFinalize
-const JSC::ConstructAbility s_readableStreamInternalsPipeToFinalizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsPipeToFinalizeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsPipeToFinalizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsPipeToFinalizeCodeLength = 305;
-static const JSC::Intrinsic s_readableStreamInternalsPipeToFinalizeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsPipeToFinalizeCode = "(function (pipeState){\"use strict\";if(@writableStreamDefaultWriterRelease(pipeState.writer),@readableStreamReaderGenericRelease(pipeState.reader),pipeState.finalized=!0,arguments.length>1)pipeState.promiseCapability.reject.@call(@undefined,arguments[1]);else pipeState.promiseCapability.resolve.@call()})\n";
-
-// readableStreamTee
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamTeeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamTeeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamTeeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamTeeCodeLength = 1383;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamTeeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamTeeCode = "(function (stream,shouldClone){\"use strict\";var start_=@getByIdDirectPrivate(stream,\"start\");if(start_)@putByIdDirectPrivate(stream,\"start\",@undefined),start_();const reader=new @ReadableStreamDefaultReader(stream),teeState={closedOrErrored:!1,canceled1:!1,canceled2:!1,reason1:@undefined,reason2:@undefined};teeState.cancelPromiseCapability=@newPromiseCapability(@Promise);const pullFunction=@readableStreamTeePullFunction(teeState,reader,shouldClone),branch1Source={};@putByIdDirectPrivate(branch1Source,\"pull\",pullFunction),@putByIdDirectPrivate(branch1Source,\"cancel\",@readableStreamTeeBranch1CancelFunction(teeState,stream));const branch2Source={};@putByIdDirectPrivate(branch2Source,\"pull\",pullFunction),@putByIdDirectPrivate(branch2Source,\"cancel\",@readableStreamTeeBranch2CancelFunction(teeState,stream));const branch1=new @ReadableStream(branch1Source),branch2=new @ReadableStream(branch2Source);return @getByIdDirectPrivate(reader,\"closedPromiseCapability\").promise.@then(@undefined,function(e){if(teeState.closedOrErrored)return;if(@readableStreamDefaultControllerError(branch1.@readableStreamController,e),@readableStreamDefaultControllerError(branch2.@readableStreamController,e),teeState.closedOrErrored=!0,!teeState.canceled1||!teeState.canceled2)teeState.cancelPromiseCapability.resolve.@call()}),teeState.branch1=branch1,teeState.branch2=branch2,[branch1,branch2]})\n";
-
-// readableStreamTeePullFunction
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamTeePullFunctionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamTeePullFunctionCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamTeePullFunctionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamTeePullFunctionCodeLength = 866;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamTeePullFunctionCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamTeePullFunctionCode = "(function (teeState,reader,shouldClone){\"use strict\";return function(){@Promise.prototype.@then.@call(@readableStreamDefaultReaderRead(reader),function(result){if(result.done&&!teeState.closedOrErrored){if(!teeState.canceled1)@readableStreamDefaultControllerClose(teeState.branch1.@readableStreamController);if(!teeState.canceled2)@readableStreamDefaultControllerClose(teeState.branch2.@readableStreamController);if(teeState.closedOrErrored=!0,!teeState.canceled1||!teeState.canceled2)teeState.cancelPromiseCapability.resolve.@call()}if(teeState.closedOrErrored)return;if(!teeState.canceled1)@readableStreamDefaultControllerEnqueue(teeState.branch1.@readableStreamController,result.value);if(!teeState.canceled2)@readableStreamDefaultControllerEnqueue(teeState.branch2.@readableStreamController,shouldClone\?@structuredCloneForStream(result.value):result.value)})}})\n";
-
-// readableStreamTeeBranch1CancelFunction
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCodeLength = 330;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCode = "(function (teeState,stream){\"use strict\";return function(r){if(teeState.canceled1=!0,teeState.reason1=r,teeState.canceled2)@readableStreamCancel(stream,[teeState.reason1,teeState.reason2]).@then(teeState.cancelPromiseCapability.@resolve,teeState.cancelPromiseCapability.@reject);return teeState.cancelPromiseCapability.promise}})\n";
-
-// readableStreamTeeBranch2CancelFunction
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCodeLength = 330;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCode = "(function (teeState,stream){\"use strict\";return function(r){if(teeState.canceled2=!0,teeState.reason2=r,teeState.canceled1)@readableStreamCancel(stream,[teeState.reason1,teeState.reason2]).@then(teeState.cancelPromiseCapability.@resolve,teeState.cancelPromiseCapability.@reject);return teeState.cancelPromiseCapability.promise}})\n";
-
-// isReadableStream
-const JSC::ConstructAbility s_readableStreamInternalsIsReadableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsIsReadableStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsIsReadableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsIsReadableStreamCodeLength = 130;
-static const JSC::Intrinsic s_readableStreamInternalsIsReadableStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsIsReadableStreamCode = "(function (stream){\"use strict\";return @isObject(stream)&&@getByIdDirectPrivate(stream,\"readableStreamController\")!==@undefined})\n";
-
-// isReadableStreamDefaultReader
-const JSC::ConstructAbility s_readableStreamInternalsIsReadableStreamDefaultReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsIsReadableStreamDefaultReaderCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsIsReadableStreamDefaultReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsIsReadableStreamDefaultReaderCodeLength = 107;
-static const JSC::Intrinsic s_readableStreamInternalsIsReadableStreamDefaultReaderCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsIsReadableStreamDefaultReaderCode = "(function (reader){\"use strict\";return @isObject(reader)&&!!@getByIdDirectPrivate(reader,\"readRequests\")})\n";
-
-// isReadableStreamDefaultController
-const JSC::ConstructAbility s_readableStreamInternalsIsReadableStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsIsReadableStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsIsReadableStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsIsReadableStreamDefaultControllerCodeLength = 123;
-static const JSC::Intrinsic s_readableStreamInternalsIsReadableStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsIsReadableStreamDefaultControllerCode = "(function (controller){\"use strict\";return @isObject(controller)&&!!@getByIdDirectPrivate(controller,\"underlyingSource\")})\n";
-
-// readDirectStream
-const JSC::ConstructAbility s_readableStreamInternalsReadDirectStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadDirectStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadDirectStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadDirectStreamCodeLength = 1281;
-static const JSC::Intrinsic s_readableStreamInternalsReadDirectStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadDirectStreamCode = "(function (stream,sink,underlyingSource){\"use strict\";@putByIdDirectPrivate(stream,\"underlyingSource\",@undefined),@putByIdDirectPrivate(stream,\"start\",@undefined);function close(stream2,reason){if(reason&&underlyingSource\?.cancel){try{var prom=underlyingSource.cancel(reason);@markPromiseAsHandled(prom)}catch(e){}underlyingSource=@undefined}if(stream2){if(@putByIdDirectPrivate(stream2,\"readableStreamController\",@undefined),@putByIdDirectPrivate(stream2,\"reader\",@undefined),reason)@putByIdDirectPrivate(stream2,\"state\",@streamErrored),@putByIdDirectPrivate(stream2,\"storedError\",reason);else @putByIdDirectPrivate(stream2,\"state\",@streamClosed);stream2=@undefined}}if(!underlyingSource.pull){close();return}if(!@isCallable(underlyingSource.pull)){close(),@throwTypeError(\"pull is not a function\");return}@putByIdDirectPrivate(stream,\"readableStreamController\",sink);const highWaterMark=@getByIdDirectPrivate(stream,\"highWaterMark\");sink.start({highWaterMark:!highWaterMark||highWaterMark<64\?64:highWaterMark}),@startDirectStream.@call(sink,stream,underlyingSource.pull,close,stream.@asyncContext),@putByIdDirectPrivate(stream,\"reader\",{});var maybePromise=underlyingSource.pull(sink);if(sink=@undefined,maybePromise&&@isPromise(maybePromise))return maybePromise.@then(()=>{})})\n";
-
-// assignToStream
-const JSC::ConstructAbility s_readableStreamInternalsAssignToStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsAssignToStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsAssignToStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamInternalsAssignToStreamCodeLength = 318;
-static const JSC::Intrinsic s_readableStreamInternalsAssignToStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsAssignToStreamCode = "(function (stream,sink){\"use strict\";var underlyingSource=@getByIdDirectPrivate(stream,\"underlyingSource\");if(underlyingSource)try{return @readDirectStream(stream,sink,underlyingSource)}catch(e){throw e}finally{underlyingSource=@undefined,stream=@undefined,sink=@undefined}return @readStreamIntoSink(stream,sink,!0)})\n";
-
-// readStreamIntoSink
-const JSC::ConstructAbility s_readableStreamInternalsReadStreamIntoSinkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadStreamIntoSinkCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadStreamIntoSinkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadStreamIntoSinkCodeLength = 1943;
-static const JSC::Intrinsic s_readableStreamInternalsReadStreamIntoSinkCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadStreamIntoSinkCode = "(async function (stream,sink,isNative){\"use strict\";var didClose=!1,didThrow=!1;try{var reader=stream.getReader(),many=reader.readMany();if(many&&@isPromise(many))many=await many;if(many.done)return didClose=!0,sink.end();var wroteCount=many.value.length;const highWaterMark=@getByIdDirectPrivate(stream,\"highWaterMark\");if(isNative)@startDirectStream.@call(sink,stream,@undefined,()=>!didThrow&&@markPromiseAsHandled(stream.cancel()),stream.@asyncContext);sink.start({highWaterMark:highWaterMark||0});for(var i=0,values=many.value,length=many.value.length;i<length;i++)sink.write(values[i]);var streamState=@getByIdDirectPrivate(stream,\"state\");if(streamState===@streamClosed)return didClose=!0,sink.end();while(!0){var{value,done}=await reader.read();if(done)return didClose=!0,sink.end();sink.write(value)}}catch(e){didThrow=!0;try{reader=@undefined;const prom=stream.cancel(e);@markPromiseAsHandled(prom)}catch(j){}if(sink&&!didClose){didClose=!0;try{sink.close(e)}catch(j){throw new globalThis.AggregateError([e,j])}}throw e}finally{if(reader){try{reader.releaseLock()}catch(e){}reader=@undefined}sink=@undefined;var streamState=@getByIdDirectPrivate(stream,\"state\");if(stream){var readableStreamController=@getByIdDirectPrivate(stream,\"readableStreamController\");if(readableStreamController){if(@getByIdDirectPrivate(readableStreamController,\"underlyingSource\"))@putByIdDirectPrivate(readableStreamController,\"underlyingSource\",@undefined);if(@getByIdDirectPrivate(readableStreamController,\"controlledReadableStream\"))@putByIdDirectPrivate(readableStreamController,\"controlledReadableStream\",@undefined);if(@putByIdDirectPrivate(stream,\"readableStreamController\",null),@getByIdDirectPrivate(stream,\"underlyingSource\"))@putByIdDirectPrivate(stream,\"underlyingSource\",@undefined);readableStreamController=@undefined}if(!didThrow&&streamState!==@streamClosed&&streamState!==@streamErrored)@readableStreamClose(stream);stream=@undefined}}})\n";
-
-// handleDirectStreamError
-const JSC::ConstructAbility s_readableStreamInternalsHandleDirectStreamErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsHandleDirectStreamErrorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsHandleDirectStreamErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsHandleDirectStreamErrorCodeLength = 584;
-static const JSC::Intrinsic s_readableStreamInternalsHandleDirectStreamErrorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsHandleDirectStreamErrorCode = "(function (e){\"use strict\";var controller=this,sink=controller.@sink;if(sink){@putByIdDirectPrivate(controller,\"sink\",@undefined);try{sink.close(e)}catch(f){}}if(this.error=this.flush=this.write=this.close=this.end=@onReadableStreamDirectControllerClosed,typeof this.@underlyingSource.close===\"function\")try{this.@underlyingSource.close.@call(this.@underlyingSource,e)}catch(e2){}try{var pend=controller._pendingRead;if(pend)controller._pendingRead=@undefined,@rejectPromise(pend,e)}catch(f){}var stream=controller.@controlledReadableStream;if(stream)@readableStreamError(stream,e)})\n";
-
-// handleDirectStreamErrorReject
-const JSC::ConstructAbility s_readableStreamInternalsHandleDirectStreamErrorRejectCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsHandleDirectStreamErrorRejectCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsHandleDirectStreamErrorRejectCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsHandleDirectStreamErrorRejectCodeLength = 95;
-static const JSC::Intrinsic s_readableStreamInternalsHandleDirectStreamErrorRejectCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsHandleDirectStreamErrorRejectCode = "(function (e){\"use strict\";return @handleDirectStreamError.@call(this,e),@Promise.@reject(e)})\n";
-
-// onPullDirectStream
-const JSC::ConstructAbility s_readableStreamInternalsOnPullDirectStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsOnPullDirectStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsOnPullDirectStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsOnPullDirectStreamCodeLength = 1356;
-static const JSC::Intrinsic s_readableStreamInternalsOnPullDirectStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsOnPullDirectStreamCode = "(function (controller){\"use strict\";var stream=controller.@controlledReadableStream;if(!stream||@getByIdDirectPrivate(stream,\"state\")!==@streamReadable)return;if(controller._deferClose===-1)return;controller._deferClose=-1,controller._deferFlush=-1;var deferClose,deferFlush,asyncContext=stream.@asyncContext;if(asyncContext){var prev=@getInternalField(@asyncContext,0);@putInternalField(@asyncContext,0,asyncContext)}try{var result=controller.@underlyingSource.pull(controller);if(result&&@isPromise(result)){if(controller._handleError===@undefined)controller._handleError=@handleDirectStreamErrorReject.bind(controller);@Promise.prototype.catch.@call(result,controller._handleError)}}catch(e){return @handleDirectStreamErrorReject.@call(controller,e)}finally{if(deferClose=controller._deferClose,deferFlush=controller._deferFlush,controller._deferFlush=controller._deferClose=0,asyncContext)@putInternalField(@asyncContext,0,prev)}var promiseToReturn;if(controller._pendingRead===@undefined)controller._pendingRead=promiseToReturn=@newPromise();else promiseToReturn=@readableStreamAddReadRequest(stream);if(deferClose===1){var reason=controller._deferCloseReason;return controller._deferCloseReason=@undefined,@onCloseDirectStream.@call(controller,reason),promiseToReturn}if(deferFlush===1)@onFlushDirectStream.@call(controller);return promiseToReturn})\n";
-
-// noopDoneFunction
-const JSC::ConstructAbility s_readableStreamInternalsNoopDoneFunctionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsNoopDoneFunctionCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsNoopDoneFunctionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsNoopDoneFunctionCodeLength = 81;
-static const JSC::Intrinsic s_readableStreamInternalsNoopDoneFunctionCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsNoopDoneFunctionCode = "(function (){\"use strict\";return @Promise.@resolve({value:@undefined,done:!0})})\n";
-
-// onReadableStreamDirectControllerClosed
-const JSC::ConstructAbility s_readableStreamInternalsOnReadableStreamDirectControllerClosedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsOnReadableStreamDirectControllerClosedCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsOnReadableStreamDirectControllerClosedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsOnReadableStreamDirectControllerClosedCodeLength = 98;
-static const JSC::Intrinsic s_readableStreamInternalsOnReadableStreamDirectControllerClosedCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsOnReadableStreamDirectControllerClosedCode = "(function (reason){\"use strict\";@throwTypeError(\"ReadableStreamDirectController is now closed\")})\n";
-
-// onCloseDirectStream
-const JSC::ConstructAbility s_readableStreamInternalsOnCloseDirectStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsOnCloseDirectStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsOnCloseDirectStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsOnCloseDirectStreamCodeLength = 1696;
-static const JSC::Intrinsic s_readableStreamInternalsOnCloseDirectStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsOnCloseDirectStreamCode = "(function (reason){\"use strict\";var stream=this.@controlledReadableStream;if(!stream||@getByIdDirectPrivate(stream,\"state\")!==@streamReadable)return;if(this._deferClose!==0){this._deferClose=1,this._deferCloseReason=reason;return}if(@putByIdDirectPrivate(stream,\"state\",@streamClosing),typeof this.@underlyingSource.close===\"function\")try{this.@underlyingSource.close.@call(this.@underlyingSource,reason)}catch(e){}var flushed;try{flushed=this.@sink.end(),@putByIdDirectPrivate(this,\"sink\",@undefined)}catch(e){if(this._pendingRead){var read=this._pendingRead;this._pendingRead=@undefined,@rejectPromise(read,e)}@readableStreamError(stream,e);return}this.error=this.flush=this.write=this.close=this.end=@onReadableStreamDirectControllerClosed;var reader=@getByIdDirectPrivate(stream,\"reader\");if(reader&&@isReadableStreamDefaultReader(reader)){var _pendingRead=this._pendingRead;if(_pendingRead&&@isPromise(_pendingRead)&&flushed\?.byteLength){this._pendingRead=@undefined,@fulfillPromise(_pendingRead,{value:flushed,done:!1}),@readableStreamClose(stream);return}}if(flushed\?.byteLength){var requests=@getByIdDirectPrivate(reader,\"readRequests\");if(requests\?.isNotEmpty()){@readableStreamFulfillReadRequest(stream,flushed,!1),@readableStreamClose(stream);return}@putByIdDirectPrivate(stream,\"state\",@streamReadable),this.@pull=()=>{var thisResult=@createFulfilledPromise({value:flushed,done:!1});return flushed=@undefined,@readableStreamClose(stream),stream=@undefined,thisResult}}else if(this._pendingRead){var read=this._pendingRead;this._pendingRead=@undefined,@putByIdDirectPrivate(this,\"pull\",@noopDoneFunction),@fulfillPromise(read,{value:@undefined,done:!0})}@readableStreamClose(stream)})\n";
-
-// onFlushDirectStream
-const JSC::ConstructAbility s_readableStreamInternalsOnFlushDirectStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsOnFlushDirectStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsOnFlushDirectStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsOnFlushDirectStreamCodeLength = 722;
-static const JSC::Intrinsic s_readableStreamInternalsOnFlushDirectStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsOnFlushDirectStreamCode = "(function (){\"use strict\";var stream=this.@controlledReadableStream,reader=@getByIdDirectPrivate(stream,\"reader\");if(!reader||!@isReadableStreamDefaultReader(reader))return;var _pendingRead=this._pendingRead;if(this._pendingRead=@undefined,_pendingRead&&@isPromise(_pendingRead)){var flushed=this.@sink.flush();if(flushed\?.byteLength)this._pendingRead=@getByIdDirectPrivate(stream,\"readRequests\")\?.shift(),@fulfillPromise(_pendingRead,{value:flushed,done:!1});else this._pendingRead=_pendingRead}else if(@getByIdDirectPrivate(stream,\"readRequests\")\?.isNotEmpty()){var flushed=this.@sink.flush();if(flushed\?.byteLength)@readableStreamFulfillReadRequest(stream,flushed,!1)}else if(this._deferFlush===-1)this._deferFlush=1})\n";
-
-// createTextStream
-const JSC::ConstructAbility s_readableStreamInternalsCreateTextStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsCreateTextStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsCreateTextStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsCreateTextStreamCodeLength = 1479;
-static const JSC::Intrinsic s_readableStreamInternalsCreateTextStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsCreateTextStreamCode = "(function (highWaterMark){\"use strict\";var sink,array=[],hasString=!1,hasBuffer=!1,rope=\"\",estimatedLength=@toLength(0),capability=@newPromiseCapability(@Promise),calledDone=!1;return sink={start(){},write(chunk){if(typeof chunk===\"string\"){var chunkLength=@toLength(chunk.length);if(chunkLength>0)rope+=chunk,hasString=!0,estimatedLength+=chunkLength;return chunkLength}if(!chunk||!(@ArrayBuffer.@isView(chunk)||chunk instanceof @ArrayBuffer))@throwTypeError(\"Expected text, ArrayBuffer or ArrayBufferView\");const byteLength=@toLength(chunk.byteLength);if(byteLength>0)if(hasBuffer=!0,rope.length>0)@arrayPush(array,rope,chunk),rope=\"\";else @arrayPush(array,chunk);return estimatedLength+=byteLength,byteLength},flush(){return 0},end(){if(calledDone)return\"\";return sink.fulfill()},fulfill(){calledDone=!0;const result=sink.finishInternal();return @fulfillPromise(capability.promise,result),result},finishInternal(){if(!hasString&&!hasBuffer)return\"\";if(hasString&&!hasBuffer)return rope;if(hasBuffer&&!hasString)return new globalThis.TextDecoder().decode(@Bun.concatArrayBuffers(array));var arrayBufferSink=new @Bun.ArrayBufferSink;arrayBufferSink.start({highWaterMark:estimatedLength,asUint8Array:!0});for(let item of array)arrayBufferSink.write(item);if(array.length=0,rope.length>0)arrayBufferSink.write(rope),rope=\"\";return new globalThis.TextDecoder().decode(arrayBufferSink.end())},close(){try{if(!calledDone)calledDone=!0,sink.fulfill()}catch(e){}}},[sink,capability]})\n";
-
-// initializeTextStream
-const JSC::ConstructAbility s_readableStreamInternalsInitializeTextStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsInitializeTextStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsInitializeTextStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsInitializeTextStreamCodeLength = 685;
-static const JSC::Intrinsic s_readableStreamInternalsInitializeTextStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsInitializeTextStreamCode = "(function (underlyingSource,highWaterMark){\"use strict\";var[sink,closingPromise]=@createTextStream(highWaterMark),controller={@underlyingSource:underlyingSource,@pull:@onPullDirectStream,@controlledReadableStream:this,@sink:sink,close:@onCloseDirectStream,write:sink.write,error:@handleDirectStreamError,end:@onCloseDirectStream,@close:@onCloseDirectStream,flush:@onFlushDirectStream,_pendingRead:@undefined,_deferClose:0,_deferFlush:0,_deferCloseReason:@undefined,_handleError:@undefined};return @putByIdDirectPrivate(this,\"readableStreamController\",controller),@putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@putByIdDirectPrivate(this,\"start\",@undefined),closingPromise})\n";
-
-// initializeArrayStream
-const JSC::ConstructAbility s_readableStreamInternalsInitializeArrayStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsInitializeArrayStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsInitializeArrayStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsInitializeArrayStreamCodeLength = 990;
-static const JSC::Intrinsic s_readableStreamInternalsInitializeArrayStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsInitializeArrayStreamCode = "(function (underlyingSource,highWaterMark){\"use strict\";var array=[],closingPromise=@newPromiseCapability(@Promise),calledDone=!1;function fulfill(){return calledDone=!0,closingPromise.resolve.@call(@undefined,array),array}var sink={start(){},write(chunk){return @arrayPush(array,chunk),chunk.byteLength||chunk.length},flush(){return 0},end(){if(calledDone)return[];return fulfill()},close(){if(!calledDone)fulfill()}},controller={@underlyingSource:underlyingSource,@pull:@onPullDirectStream,@controlledReadableStream:this,@sink:sink,close:@onCloseDirectStream,write:sink.write,error:@handleDirectStreamError,end:@onCloseDirectStream,@close:@onCloseDirectStream,flush:@onFlushDirectStream,_pendingRead:@undefined,_deferClose:0,_deferFlush:0,_deferCloseReason:@undefined,_handleError:@undefined};return @putByIdDirectPrivate(this,\"readableStreamController\",controller),@putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@putByIdDirectPrivate(this,\"start\",@undefined),closingPromise})\n";
-
-// initializeArrayBufferStream
-const JSC::ConstructAbility s_readableStreamInternalsInitializeArrayBufferStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsInitializeArrayBufferStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsInitializeArrayBufferStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsInitializeArrayBufferStreamCodeLength = 793;
-static const JSC::Intrinsic s_readableStreamInternalsInitializeArrayBufferStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsInitializeArrayBufferStreamCode = "(function (underlyingSource,highWaterMark){\"use strict\";var opts=highWaterMark&&typeof highWaterMark===\"number\"\?{highWaterMark,stream:!0,asUint8Array:!0}:{stream:!0,asUint8Array:!0},sink=new @Bun.ArrayBufferSink;sink.start(opts);var controller={@underlyingSource:underlyingSource,@pull:@onPullDirectStream,@controlledReadableStream:this,@sink:sink,close:@onCloseDirectStream,write:sink.write.bind(sink),error:@handleDirectStreamError,end:@onCloseDirectStream,@close:@onCloseDirectStream,flush:@onFlushDirectStream,_pendingRead:@undefined,_deferClose:0,_deferFlush:0,_deferCloseReason:@undefined,_handleError:@undefined};@putByIdDirectPrivate(this,\"readableStreamController\",controller),@putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@putByIdDirectPrivate(this,\"start\",@undefined)})\n";
-
-// readableStreamError
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamErrorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamErrorCodeLength = 895;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamErrorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamErrorCode = "(function (stream,error){\"use strict\";@putByIdDirectPrivate(stream,\"state\",@streamErrored),@putByIdDirectPrivate(stream,\"storedError\",error);const reader=@getByIdDirectPrivate(stream,\"reader\");if(!reader)return;if(@isReadableStreamDefaultReader(reader)){const requests=@getByIdDirectPrivate(reader,\"readRequests\");@putByIdDirectPrivate(reader,\"readRequests\",@createFIFO());for(var request=requests.shift();request;request=requests.shift())@rejectPromise(request,error)}else{const requests=@getByIdDirectPrivate(reader,\"readIntoRequests\");@putByIdDirectPrivate(reader,\"readIntoRequests\",@createFIFO());for(var request=requests.shift();request;request=requests.shift())@rejectPromise(request,error)}@getByIdDirectPrivate(reader,\"closedPromiseCapability\").reject.@call(@undefined,error);const promise=@getByIdDirectPrivate(reader,\"closedPromiseCapability\").promise;@markPromiseAsHandled(promise)})\n";
-
-// readableStreamDefaultControllerShouldCallPull
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCodeLength = 518;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(!@readableStreamDefaultControllerCanCloseOrEnqueue(controller))return!1;if(@getByIdDirectPrivate(controller,\"started\")!==1)return!1;if((!@isReadableStreamLocked(stream)||!@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\")\?.isNotEmpty())&&@readableStreamDefaultControllerGetDesiredSize(controller)<=0)return!1;return @readableStreamDefaultControllerGetDesiredSize(controller)>0})\n";
-
-// readableStreamDefaultControllerCallPullIfNeeded
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCodeLength = 961;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(!@readableStreamDefaultControllerCanCloseOrEnqueue(controller))return;if(@getByIdDirectPrivate(controller,\"started\")!==1)return;if((!@isReadableStreamLocked(stream)||!@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\")\?.isNotEmpty())&&@readableStreamDefaultControllerGetDesiredSize(controller)<=0)return;if(@getByIdDirectPrivate(controller,\"pulling\")){@putByIdDirectPrivate(controller,\"pullAgain\",!0);return}@putByIdDirectPrivate(controller,\"pulling\",!0),@getByIdDirectPrivate(controller,\"pullAlgorithm\").@call(@undefined).@then(function(){if(@putByIdDirectPrivate(controller,\"pulling\",!1),@getByIdDirectPrivate(controller,\"pullAgain\"))@putByIdDirectPrivate(controller,\"pullAgain\",!1),@readableStreamDefaultControllerCallPullIfNeeded(controller)},function(error){@readableStreamDefaultControllerError(controller,error)})})\n";
-
-// isReadableStreamLocked
-const JSC::ConstructAbility s_readableStreamInternalsIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsIsReadableStreamLockedCodeLength = 81;
-static const JSC::Intrinsic s_readableStreamInternalsIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsIsReadableStreamLockedCode = "(function (stream){\"use strict\";return!!@getByIdDirectPrivate(stream,\"reader\")})\n";
-
-// readableStreamDefaultControllerGetDesiredSize
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCodeLength = 341;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\"),state=@getByIdDirectPrivate(stream,\"state\");if(state===@streamErrored)return null;if(state===@streamClosed)return 0;return @getByIdDirectPrivate(controller,\"strategy\").highWaterMark-@getByIdDirectPrivate(controller,\"queue\").size})\n";
-
-// readableStreamReaderGenericCancel
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamReaderGenericCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamReaderGenericCancelCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamReaderGenericCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamReaderGenericCancelCodeLength = 150;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamReaderGenericCancelCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamReaderGenericCancelCode = "(function (reader,reason){\"use strict\";const stream=@getByIdDirectPrivate(reader,\"ownerReadableStream\");return @readableStreamCancel(stream,reason)})\n";
-
-// readableStreamCancel
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamCancelCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamCancelCodeLength = 634;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamCancelCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamCancelCode = "(function (stream,reason){\"use strict\";@putByIdDirectPrivate(stream,\"disturbed\",!0);const state=@getByIdDirectPrivate(stream,\"state\");if(state===@streamClosed)return @Promise.@resolve();if(state===@streamErrored)return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));@readableStreamClose(stream);var controller=@getByIdDirectPrivate(stream,\"readableStreamController\"),cancel=controller.@cancel;if(cancel)return cancel(controller,reason).@then(function(){});var close=controller.close;if(close)return @Promise.@resolve(controller.close(reason));@throwTypeError(\"ReadableStreamController has no cancel or close method\")})\n";
-
-// readableStreamDefaultControllerCancel
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerCancelCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefaultControllerCancelCodeLength = 183;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerCancelCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefaultControllerCancelCode = "(function (controller,reason){\"use strict\";return @putByIdDirectPrivate(controller,\"queue\",@newQueue()),@getByIdDirectPrivate(controller,\"cancelAlgorithm\").@call(@undefined,reason)})\n";
-
-// readableStreamDefaultControllerPull
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerPullCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerPullCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerPullCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefaultControllerPullCodeLength = 632;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerPullCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefaultControllerPullCode = "(function (controller){\"use strict\";var queue=@getByIdDirectPrivate(controller,\"queue\");if(queue.content.isNotEmpty()){const chunk=@dequeueValue(queue);if(@getByIdDirectPrivate(controller,\"closeRequested\")&&queue.content.isEmpty())@readableStreamClose(@getByIdDirectPrivate(controller,\"controlledReadableStream\"));else @readableStreamDefaultControllerCallPullIfNeeded(controller);return @createFulfilledPromise({value:chunk,done:!1})}const pendingPromise=@readableStreamAddReadRequest(@getByIdDirectPrivate(controller,\"controlledReadableStream\"));return @readableStreamDefaultControllerCallPullIfNeeded(controller),pendingPromise})\n";
-
-// readableStreamDefaultControllerClose
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerCloseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefaultControllerCloseCodeLength = 240;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerCloseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefaultControllerCloseCode = "(function (controller){\"use strict\";if(@putByIdDirectPrivate(controller,\"closeRequested\",!0),@getByIdDirectPrivate(controller,\"queue\")\?.content\?.isEmpty())@readableStreamClose(@getByIdDirectPrivate(controller,\"controlledReadableStream\"))})\n";
-
-// readableStreamClose
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamCloseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamCloseCodeLength = 643;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamCloseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamCloseCode = "(function (stream){\"use strict\";if(@putByIdDirectPrivate(stream,\"state\",@streamClosed),!@getByIdDirectPrivate(stream,\"reader\"))return;if(@isReadableStreamDefaultReader(@getByIdDirectPrivate(stream,\"reader\"))){const requests=@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\");if(requests.isNotEmpty()){@putByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\",@createFIFO());for(var request=requests.shift();request;request=requests.shift())@fulfillPromise(request,{value:@undefined,done:!0})}}@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"closedPromiseCapability\").resolve.@call()})\n";
-
-// readableStreamFulfillReadRequest
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamFulfillReadRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamFulfillReadRequestCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamFulfillReadRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamFulfillReadRequestCodeLength = 196;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamFulfillReadRequestCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamFulfillReadRequestCode = "(function (stream,chunk,done){\"use strict\";const readRequest=@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\").shift();@fulfillPromise(readRequest,{value:chunk,done})})\n";
-
-// readableStreamDefaultControllerEnqueue
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCodeLength = 741;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCode = "(function (controller,chunk){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(@isReadableStreamLocked(stream)&&@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\")\?.isNotEmpty()){@readableStreamFulfillReadRequest(stream,chunk,!1),@readableStreamDefaultControllerCallPullIfNeeded(controller);return}try{let chunkSize=1;if(@getByIdDirectPrivate(controller,\"strategy\").size!==@undefined)chunkSize=@getByIdDirectPrivate(controller,\"strategy\").size(chunk);@enqueueValueWithSize(@getByIdDirectPrivate(controller,\"queue\"),chunk,chunkSize)}catch(error){throw @readableStreamDefaultControllerError(controller,error),error}@readableStreamDefaultControllerCallPullIfNeeded(controller)})\n";
-
-// readableStreamDefaultReaderRead
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultReaderReadCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultReaderReadCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultReaderReadCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefaultReaderReadCodeLength = 495;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultReaderReadCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefaultReaderReadCode = "(function (reader){\"use strict\";const stream=@getByIdDirectPrivate(reader,\"ownerReadableStream\"),state=@getByIdDirectPrivate(stream,\"state\");if(@putByIdDirectPrivate(stream,\"disturbed\",!0),state===@streamClosed)return @createFulfilledPromise({value:@undefined,done:!0});if(state===@streamErrored)return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));return @getByIdDirectPrivate(stream,\"readableStreamController\").@pull(@getByIdDirectPrivate(stream,\"readableStreamController\"))})\n";
-
-// readableStreamAddReadRequest
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamAddReadRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamAddReadRequestCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamAddReadRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamAddReadRequestCodeLength = 180;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamAddReadRequestCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamAddReadRequestCode = "(function (stream){\"use strict\";const readRequest=@newPromise();return @getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\").push(readRequest),readRequest})\n";
-
-// isReadableStreamDisturbed
-const JSC::ConstructAbility s_readableStreamInternalsIsReadableStreamDisturbedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsIsReadableStreamDisturbedCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsIsReadableStreamDisturbedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsIsReadableStreamDisturbedCodeLength = 83;
-static const JSC::Intrinsic s_readableStreamInternalsIsReadableStreamDisturbedCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsIsReadableStreamDisturbedCode = "(function (stream){\"use strict\";return @getByIdDirectPrivate(stream,\"disturbed\")})\n";
-
-// readableStreamReaderGenericRelease
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamReaderGenericReleaseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamReaderGenericReleaseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamReaderGenericReleaseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamReaderGenericReleaseCodeLength = 707;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamReaderGenericReleaseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamReaderGenericReleaseCode = "(function (reader){\"use strict\";if(@getByIdDirectPrivate(@getByIdDirectPrivate(reader,\"ownerReadableStream\"),\"state\")===@streamReadable)@getByIdDirectPrivate(reader,\"closedPromiseCapability\").reject.@call(@undefined,@makeTypeError(\"releasing lock of reader whose stream is still in readable state\"));else @putByIdDirectPrivate(reader,\"closedPromiseCapability\",{promise:@newHandledRejectedPromise(@makeTypeError(\"reader released lock\"))});const promise=@getByIdDirectPrivate(reader,\"closedPromiseCapability\").promise;@markPromiseAsHandled(promise),@putByIdDirectPrivate(@getByIdDirectPrivate(reader,\"ownerReadableStream\"),\"reader\",@undefined),@putByIdDirectPrivate(reader,\"ownerReadableStream\",@undefined)})\n";
-
-// readableStreamDefaultControllerCanCloseOrEnqueue
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCodeLength = 207;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCode = "(function (controller){\"use strict\";return!@getByIdDirectPrivate(controller,\"closeRequested\")&&@getByIdDirectPrivate(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),\"state\")===@streamReadable})\n";
-
-// lazyLoadStream
-const JSC::ConstructAbility s_readableStreamInternalsLazyLoadStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsLazyLoadStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsLazyLoadStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsLazyLoadStreamCodeLength = 2994;
-static const JSC::Intrinsic s_readableStreamInternalsLazyLoadStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsLazyLoadStreamCode = "(function (stream,autoAllocateChunkSize){\"use strict\";var nativeType=@getByIdDirectPrivate(stream,\"bunNativeType\"),nativePtr=@getByIdDirectPrivate(stream,\"bunNativePtr\"),Prototype=@lazyStreamPrototypeMap.@get(nativeType);if(Prototype===@undefined){let handleNativeReadableStreamPromiseResult2=function(val){var{c,v}=this;this.c=@undefined,this.v=@undefined,handleResult(val,c,v)},callClose2=function(controller){try{if(@getByIdDirectPrivate(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),\"state\")===@streamReadable)controller.close()}catch(e){globalThis.reportError(e)}},createResult2=function(tag,controller,view,closer2){closer2[0]=!1;var result;try{result=pull(tag,view,closer2)}catch(err){return controller.error(err)}return handleResult(result,controller,view)};var handleNativeReadableStreamPromiseResult=handleNativeReadableStreamPromiseResult2,callClose=callClose2,createResult=createResult2,[pull,start,cancel,setClose,deinit,setRefOrUnref,drain]=@lazyLoad(nativeType),closer=[!1],handleResult;handleResult=function handleResult(result,controller,view){if(result&&@isPromise(result))return result.then(handleNativeReadableStreamPromiseResult2.bind({c:controller,v:view}),(err)=>controller.error(err));else if(typeof result===\"number\")if(view&&view.byteLength===result&&view.buffer===controller.byobRequest\?.view\?.buffer)controller.byobRequest.respondWithNewView(view);else controller.byobRequest.respond(result);else if(result.constructor===@Uint8Array)controller.enqueue(result);if(closer[0]||result===!1)@enqueueJob(callClose2,controller),closer[0]=!1};const registry=deinit\?new FinalizationRegistry(deinit):null;Prototype=class NativeReadableStreamSource{constructor(tag,autoAllocateChunkSize2,drainValue2){if(this.#tag=tag,this.#cancellationToken={},this.pull=this.#pull.bind(this),this.cancel=this.#cancel.bind(this),this.autoAllocateChunkSize=autoAllocateChunkSize2,drainValue2!==@undefined)this.start=(controller)=>{controller.enqueue(drainValue2)};if(registry)registry.register(this,tag,this.#cancellationToken)}#cancellationToken;pull;cancel;start;#tag;type=\"bytes\";autoAllocateChunkSize=0;static startSync=start;#pull(controller){var tag=this.#tag;if(!tag){controller.close();return}createResult2(tag,controller,controller.byobRequest.view,closer)}#cancel(reason){var tag=this.#tag;registry&&registry.unregister(this.#cancellationToken),setRefOrUnref&&setRefOrUnref(tag,!1),cancel(tag,reason)}static deinit=deinit;static drain=drain},@lazyStreamPrototypeMap.@set(nativeType,Prototype)}const chunkSize=Prototype.startSync(nativePtr,autoAllocateChunkSize);var drainValue;const{drain:drainFn,deinit:deinitFn}=Prototype;if(drainFn)drainValue=drainFn(nativePtr);if(chunkSize===0){if(deinit&&nativePtr&&@enqueueJob(deinit,nativePtr),(drainValue\?.byteLength\?\?0)>0)return{start(controller){controller.enqueue(drainValue),controller.close()},type:\"bytes\"};return{start(controller){controller.close()},type:\"bytes\"}}return new Prototype(nativePtr,chunkSize,drainValue)})\n";
-
-// readableStreamIntoArray
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamIntoArrayCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamIntoArrayCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamIntoArrayCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamIntoArrayCodeLength = 427;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamIntoArrayCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamIntoArrayCode = "(function (stream){\"use strict\";var reader=stream.getReader(),manyResult=reader.readMany();async function processManyResult(result){if(result.done)return[];var chunks=result.value||[];while(!0){var thisResult=await reader.read();if(thisResult.done)break;chunks=chunks.concat(thisResult.value)}return chunks}if(manyResult&&@isPromise(manyResult))return manyResult.@then(processManyResult);return processManyResult(manyResult)})\n";
-
-// readableStreamIntoText
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamIntoTextCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamIntoTextCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamIntoTextCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamIntoTextCodeLength = 272;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamIntoTextCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamIntoTextCode = "(function (stream){\"use strict\";const[textStream,closer]=@createTextStream(@getByIdDirectPrivate(stream,\"highWaterMark\")),prom=@readStreamIntoSink(stream,textStream,!1);if(prom&&@isPromise(prom))return @Promise.@resolve(prom).@then(closer.promise);return closer.promise})\n";
-
-// readableStreamToArrayBufferDirect
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamToArrayBufferDirectCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamToArrayBufferDirectCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamToArrayBufferDirectCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamToArrayBufferDirectCodeLength = 1079;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamToArrayBufferDirectCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamToArrayBufferDirectCode = "(function (stream,underlyingSource){\"use strict\";var sink=new @Bun.ArrayBufferSink;@putByIdDirectPrivate(stream,\"underlyingSource\",@undefined);var highWaterMark=@getByIdDirectPrivate(stream,\"highWaterMark\");sink.start(highWaterMark\?{highWaterMark}:{});var capability=@newPromiseCapability(@Promise),ended=!1,pull=underlyingSource.pull,close=underlyingSource.close,controller={start(){},close(reason){if(!ended){if(ended=!0,close)close();@fulfillPromise(capability.promise,sink.end())}},end(){if(!ended){if(ended=!0,close)close();@fulfillPromise(capability.promise,sink.end())}},flush(){return 0},write:sink.write.bind(sink)},didError=!1;try{const firstPull=pull(controller);if(firstPull&&@isObject(firstPull)&&@isPromise(firstPull))return async function(controller2,promise2,pull2){while(!ended)await pull2(controller2);return await promise2}(controller,promise,pull);return capability.promise}catch(e){return didError=!0,@readableStreamError(stream,e),@Promise.@reject(e)}finally{if(!didError&&stream)@readableStreamClose(stream);controller=close=sink=pull=stream=@undefined}})\n";
-
-// readableStreamToTextDirect
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamToTextDirectCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamToTextDirectCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamToTextDirectCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamToTextDirectCodeLength = 388;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamToTextDirectCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamToTextDirectCode = "(async function (stream,underlyingSource){\"use strict\";const capability=@initializeTextStream.@call(stream,underlyingSource,@undefined);var reader=stream.getReader();while(@getByIdDirectPrivate(stream,\"state\")===@streamReadable){var thisResult=await reader.read();if(thisResult.done)break}try{reader.releaseLock()}catch(e){}return reader=@undefined,stream=@undefined,capability.promise})\n";
-
-// readableStreamToArrayDirect
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamToArrayDirectCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamToArrayDirectCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamToArrayDirectCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamToArrayDirectCodeLength = 484;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamToArrayDirectCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamToArrayDirectCode = "(async function (stream,underlyingSource){\"use strict\";const capability=@initializeArrayStream.@call(stream,underlyingSource,@undefined);underlyingSource=@undefined;var reader=stream.getReader();try{while(@getByIdDirectPrivate(stream,\"state\")===@streamReadable){var thisResult=await reader.read();if(thisResult.done)break}try{reader.releaseLock()}catch(e){}return reader=@undefined,@Promise.@resolve(capability.promise)}catch(e){throw e}finally{stream=@undefined,reader=@undefined}})\n";
-
-// readableStreamDefineLazyIterators
-const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefineLazyIteratorsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefineLazyIteratorsCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefineLazyIteratorsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInternalsReadableStreamDefineLazyIteratorsCodeLength = 921;
-static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefineLazyIteratorsCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInternalsReadableStreamDefineLazyIteratorsCode = "(function (prototype){\"use strict\";var asyncIterator=globalThis.Symbol.asyncIterator,ReadableStreamAsyncIterator=async function*ReadableStreamAsyncIterator(stream,preventCancel){var reader=stream.getReader(),deferredError;try{while(!0){var done,value;const firstResult=reader.readMany();if(@isPromise(firstResult))({done,value}=await firstResult);else({done,value}=firstResult);if(done)return;yield*value}}catch(e){deferredError=e}finally{if(reader.releaseLock(),!preventCancel)stream.cancel(deferredError);if(deferredError)throw deferredError}},createAsyncIterator=function asyncIterator(){return ReadableStreamAsyncIterator(this,!1)},createValues=function values({preventCancel=!1}={preventCancel:!1}){return ReadableStreamAsyncIterator(this,preventCancel)};return @Object.@defineProperty(prototype,asyncIterator,{value:createAsyncIterator}),@Object.@defineProperty(prototype,\"values\",{value:createValues}),prototype})\n";
-
-#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
-{\
-    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().readableStreamInternalsBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableStreamInternalsBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
-}
-WEBCORE_FOREACH_READABLESTREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
-#undef DEFINE_BUILTIN_GENERATOR
-
-/* ReadableByteStreamInternals.ts */
-// privateInitializeReadableByteStreamController
-const JSC::ConstructAbility s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCodeLength = 1896;
-static const JSC::Intrinsic s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCode = "(function (stream,underlyingByteSource,highWaterMark){\"use strict\";if(!@isReadableStream(stream))@throwTypeError(\"ReadableByteStreamController needs a ReadableStream\");if(@getByIdDirectPrivate(stream,\"readableStreamController\")!==null)@throwTypeError(\"ReadableStream already has a controller\");@putByIdDirectPrivate(this,\"controlledReadableStream\",stream),@putByIdDirectPrivate(this,\"underlyingByteSource\",underlyingByteSource),@putByIdDirectPrivate(this,\"pullAgain\",!1),@putByIdDirectPrivate(this,\"pulling\",!1),@readableByteStreamControllerClearPendingPullIntos(this),@putByIdDirectPrivate(this,\"queue\",@newQueue()),@putByIdDirectPrivate(this,\"started\",0),@putByIdDirectPrivate(this,\"closeRequested\",!1);let hwm=@toNumber(highWaterMark);if(hwm!==hwm||hwm<0)@throwRangeError(\"highWaterMark value is negative or not a number\");@putByIdDirectPrivate(this,\"strategyHWM\",hwm);let autoAllocateChunkSize=underlyingByteSource.autoAllocateChunkSize;if(autoAllocateChunkSize!==@undefined){if(autoAllocateChunkSize=@toNumber(autoAllocateChunkSize),autoAllocateChunkSize<=0||autoAllocateChunkSize===@Infinity||autoAllocateChunkSize===-@Infinity)@throwRangeError(\"autoAllocateChunkSize value is negative or equal to positive or negative infinity\")}@putByIdDirectPrivate(this,\"autoAllocateChunkSize\",autoAllocateChunkSize),@putByIdDirectPrivate(this,\"pendingPullIntos\",@createFIFO());const controller=this;return @promiseInvokeOrNoopNoCatch(@getByIdDirectPrivate(controller,\"underlyingByteSource\"),\"start\",[controller]).@then(()=>{@putByIdDirectPrivate(controller,\"started\",1),@readableByteStreamControllerCallPullIfNeeded(controller)},(error)=>{if(@getByIdDirectPrivate(stream,\"state\")===@streamReadable)@readableByteStreamControllerError(controller,error)}),@putByIdDirectPrivate(this,\"cancel\",@readableByteStreamControllerCancel),@putByIdDirectPrivate(this,\"pull\",@readableByteStreamControllerPull),this})\n";
-
-// readableStreamByteStreamControllerStart
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCodeLength = 91;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCode = "(function (controller){\"use strict\";@putByIdDirectPrivate(controller,\"start\",@undefined)})\n";
-
-// privateInitializeReadableStreamBYOBRequest
-const JSC::ConstructAbility s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCodeLength = 163;
-static const JSC::Intrinsic s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCode = "(function (controller,view){\"use strict\";@putByIdDirectPrivate(this,\"associatedReadableByteStreamController\",controller),@putByIdDirectPrivate(this,\"view\",view)})\n";
-
-// isReadableByteStreamController
-const JSC::ConstructAbility s_readableByteStreamInternalsIsReadableByteStreamControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsIsReadableByteStreamControllerCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsIsReadableByteStreamControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsIsReadableByteStreamControllerCodeLength = 127;
-static const JSC::Intrinsic s_readableByteStreamInternalsIsReadableByteStreamControllerCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsIsReadableByteStreamControllerCode = "(function (controller){\"use strict\";return @isObject(controller)&&!!@getByIdDirectPrivate(controller,\"underlyingByteSource\")})\n";
-
-// isReadableStreamBYOBRequest
-const JSC::ConstructAbility s_readableByteStreamInternalsIsReadableStreamBYOBRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsIsReadableStreamBYOBRequestCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsIsReadableStreamBYOBRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsIsReadableStreamBYOBRequestCodeLength = 148;
-static const JSC::Intrinsic s_readableByteStreamInternalsIsReadableStreamBYOBRequestCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsIsReadableStreamBYOBRequestCode = "(function (byobRequest){\"use strict\";return @isObject(byobRequest)&&!!@getByIdDirectPrivate(byobRequest,\"associatedReadableByteStreamController\")})\n";
-
-// isReadableStreamBYOBReader
-const JSC::ConstructAbility s_readableByteStreamInternalsIsReadableStreamBYOBReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsIsReadableStreamBYOBReaderCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsIsReadableStreamBYOBReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsIsReadableStreamBYOBReaderCodeLength = 111;
-static const JSC::Intrinsic s_readableByteStreamInternalsIsReadableStreamBYOBReaderCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsIsReadableStreamBYOBReaderCode = "(function (reader){\"use strict\";return @isObject(reader)&&!!@getByIdDirectPrivate(reader,\"readIntoRequests\")})\n";
-
-// readableByteStreamControllerCancel
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerCancelCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerCancelCodeLength = 336;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerCancelCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerCancelCode = "(function (controller,reason){\"use strict\";var pendingPullIntos=@getByIdDirectPrivate(controller,\"pendingPullIntos\"),first=pendingPullIntos.peek();if(first)first.bytesFilled=0;return @putByIdDirectPrivate(controller,\"queue\",@newQueue()),@promiseInvokeOrNoop(@getByIdDirectPrivate(controller,\"underlyingByteSource\"),\"cancel\",[reason])})\n";
-
-// readableByteStreamControllerError
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerErrorCodeLength = 242;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerErrorCode = "(function (controller,e){\"use strict\";@readableByteStreamControllerClearPendingPullIntos(controller),@putByIdDirectPrivate(controller,\"queue\",@newQueue()),@readableStreamError(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),e)})\n";
-
-// readableByteStreamControllerClose
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerCloseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerCloseCodeLength = 473;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerCloseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerCloseCode = "(function (controller){\"use strict\";if(@getByIdDirectPrivate(controller,\"queue\").size>0){@putByIdDirectPrivate(controller,\"closeRequested\",!0);return}var first=@getByIdDirectPrivate(controller,\"pendingPullIntos\")\?.peek();if(first){if(first.bytesFilled>0){const e=@makeTypeError(\"Close requested while there remain pending bytes\");throw @readableByteStreamControllerError(controller,e),e}}@readableStreamClose(@getByIdDirectPrivate(controller,\"controlledReadableStream\"))})\n";
-
-// readableByteStreamControllerClearPendingPullIntos
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCodeLength = 281;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCode = "(function (controller){\"use strict\";@readableByteStreamControllerInvalidateBYOBRequest(controller);var existing=@getByIdDirectPrivate(controller,\"pendingPullIntos\");if(existing!==@undefined)existing.clear();else @putByIdDirectPrivate(controller,\"pendingPullIntos\",@createFIFO())})\n";
-
-// readableByteStreamControllerGetDesiredSize
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCodeLength = 330;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\"),state=@getByIdDirectPrivate(stream,\"state\");if(state===@streamErrored)return null;if(state===@streamClosed)return 0;return @getByIdDirectPrivate(controller,\"strategyHWM\")-@getByIdDirectPrivate(controller,\"queue\").size})\n";
-
-// readableStreamHasBYOBReader
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamHasBYOBReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamHasBYOBReaderCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamHasBYOBReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableStreamHasBYOBReaderCodeLength = 150;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamHasBYOBReaderCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableStreamHasBYOBReaderCode = "(function (stream){\"use strict\";const reader=@getByIdDirectPrivate(stream,\"reader\");return reader!==@undefined&&@isReadableStreamBYOBReader(reader)})\n";
-
-// readableStreamHasDefaultReader
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamHasDefaultReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamHasDefaultReaderCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamHasDefaultReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableStreamHasDefaultReaderCodeLength = 153;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamHasDefaultReaderCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableStreamHasDefaultReaderCode = "(function (stream){\"use strict\";const reader=@getByIdDirectPrivate(stream,\"reader\");return reader!==@undefined&&@isReadableStreamDefaultReader(reader)})\n";
-
-// readableByteStreamControllerHandleQueueDrain
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCodeLength = 287;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCode = "(function (controller){\"use strict\";if(!@getByIdDirectPrivate(controller,\"queue\").size&&@getByIdDirectPrivate(controller,\"closeRequested\"))@readableStreamClose(@getByIdDirectPrivate(controller,\"controlledReadableStream\"));else @readableByteStreamControllerCallPullIfNeeded(controller)})\n";
-
-// readableByteStreamControllerPull
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerPullCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerPullCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerPullCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerPullCodeLength = 1169;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerPullCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerPullCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(@getByIdDirectPrivate(controller,\"queue\").content\?.isNotEmpty()){const entry=@getByIdDirectPrivate(controller,\"queue\").content.shift();@getByIdDirectPrivate(controller,\"queue\").size-=entry.byteLength,@readableByteStreamControllerHandleQueueDrain(controller);let view;try{view=new @Uint8Array(entry.buffer,entry.byteOffset,entry.byteLength)}catch(error){return @Promise.@reject(error)}return @createFulfilledPromise({value:view,done:!1})}if(@getByIdDirectPrivate(controller,\"autoAllocateChunkSize\")!==@undefined){let buffer;try{buffer=@createUninitializedArrayBuffer(@getByIdDirectPrivate(controller,\"autoAllocateChunkSize\"))}catch(error){return @Promise.@reject(error)}const pullIntoDescriptor={buffer,byteOffset:0,byteLength:@getByIdDirectPrivate(controller,\"autoAllocateChunkSize\"),bytesFilled:0,elementSize:1,ctor:@Uint8Array,readerType:\"default\"};@getByIdDirectPrivate(controller,\"pendingPullIntos\").push(pullIntoDescriptor)}const promise=@readableStreamAddReadRequest(stream);return @readableByteStreamControllerCallPullIfNeeded(controller),promise})\n";
-
-// readableByteStreamControllerShouldCallPull
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCodeLength = 709;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(@getByIdDirectPrivate(stream,\"state\")!==@streamReadable)return!1;if(@getByIdDirectPrivate(controller,\"closeRequested\"))return!1;if(!(@getByIdDirectPrivate(controller,\"started\")>0))return!1;const reader=@getByIdDirectPrivate(stream,\"reader\");if(reader&&(@getByIdDirectPrivate(reader,\"readRequests\")\?.isNotEmpty()||!!@getByIdDirectPrivate(reader,\"bunNativePtr\")))return!0;if(@readableStreamHasBYOBReader(stream)&&@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readIntoRequests\")\?.isNotEmpty())return!0;if(@readableByteStreamControllerGetDesiredSize(controller)>0)return!0;return!1})\n";
-
-// readableByteStreamControllerCallPullIfNeeded
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCodeLength = 748;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCode = "(function (controller){\"use strict\";if(!@readableByteStreamControllerShouldCallPull(controller))return;if(@getByIdDirectPrivate(controller,\"pulling\")){@putByIdDirectPrivate(controller,\"pullAgain\",!0);return}@putByIdDirectPrivate(controller,\"pulling\",!0),@promiseInvokeOrNoop(@getByIdDirectPrivate(controller,\"underlyingByteSource\"),\"pull\",[controller]).@then(()=>{if(@putByIdDirectPrivate(controller,\"pulling\",!1),@getByIdDirectPrivate(controller,\"pullAgain\"))@putByIdDirectPrivate(controller,\"pullAgain\",!1),@readableByteStreamControllerCallPullIfNeeded(controller)},(error)=>{if(@getByIdDirectPrivate(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),\"state\")===@streamReadable)@readableByteStreamControllerError(controller,error)})})\n";
-
-// transferBufferToCurrentRealm
-const JSC::ConstructAbility s_readableByteStreamInternalsTransferBufferToCurrentRealmCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsTransferBufferToCurrentRealmCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsTransferBufferToCurrentRealmCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsTransferBufferToCurrentRealmCodeLength = 48;
-static const JSC::Intrinsic s_readableByteStreamInternalsTransferBufferToCurrentRealmCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsTransferBufferToCurrentRealmCode = "(function (buffer){\"use strict\";return buffer})\n";
-
-// readableStreamReaderKind
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamReaderKindCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamReaderKindCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamReaderKindCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableStreamReaderKindCodeLength = 208;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamReaderKindCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableStreamReaderKindCode = "(function (reader){\"use strict\";if(@getByIdDirectPrivate(reader,\"readRequests\"))return @getByIdDirectPrivate(reader,\"bunNativePtr\")\?3:1;if(@getByIdDirectPrivate(reader,\"readIntoRequests\"))return 2;return 0})\n";
-
-// readableByteStreamControllerEnqueue
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCodeLength = 1036;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCode = "(function (controller,chunk){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");switch(@getByIdDirectPrivate(stream,\"reader\")\?@readableStreamReaderKind(@getByIdDirectPrivate(stream,\"reader\")):0){case 1:{if(!@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\")\?.isNotEmpty())@readableByteStreamControllerEnqueueChunk(controller,@transferBufferToCurrentRealm(chunk.buffer),chunk.byteOffset,chunk.byteLength);else{const transferredView=chunk.constructor===@Uint8Array\?chunk:new @Uint8Array(chunk.buffer,chunk.byteOffset,chunk.byteLength);@readableStreamFulfillReadRequest(stream,transferredView,!1)}break}case 2:{@readableByteStreamControllerEnqueueChunk(controller,@transferBufferToCurrentRealm(chunk.buffer),chunk.byteOffset,chunk.byteLength),@readableByteStreamControllerProcessPullDescriptors(controller);break}case 3:break;default:{@readableByteStreamControllerEnqueueChunk(controller,@transferBufferToCurrentRealm(chunk.buffer),chunk.byteOffset,chunk.byteLength);break}}})\n";
-
-// readableByteStreamControllerEnqueueChunk
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCodeLength = 213;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCode = "(function (controller,buffer,byteOffset,byteLength){\"use strict\";@getByIdDirectPrivate(controller,\"queue\").content.push({buffer,byteOffset,byteLength}),@getByIdDirectPrivate(controller,\"queue\").size+=byteLength})\n";
-
-// readableByteStreamControllerRespondWithNewView
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCodeLength = 463;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCode = "(function (controller,view){\"use strict\";let firstDescriptor=@getByIdDirectPrivate(controller,\"pendingPullIntos\").peek();if(firstDescriptor.byteOffset+firstDescriptor.bytesFilled!==view.byteOffset)@throwRangeError(\"Invalid value for view.byteOffset\");if(firstDescriptor.byteLength!==view.byteLength)@throwRangeError(\"Invalid value for view.byteLength\");firstDescriptor.buffer=view.buffer,@readableByteStreamControllerRespondInternal(controller,view.byteLength)})\n";
-
-// readableByteStreamControllerRespond
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerRespondCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerRespondCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerRespondCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerRespondCodeLength = 287;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerRespondCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerRespondCode = "(function (controller,bytesWritten){\"use strict\";if(bytesWritten=@toNumber(bytesWritten),bytesWritten!==bytesWritten||bytesWritten===@Infinity||bytesWritten<0)@throwRangeError(\"bytesWritten has an incorrect value\");@readableByteStreamControllerRespondInternal(controller,bytesWritten)})\n";
-
-// readableByteStreamControllerRespondInternal
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCodeLength = 534;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCode = "(function (controller,bytesWritten){\"use strict\";let firstDescriptor=@getByIdDirectPrivate(controller,\"pendingPullIntos\").peek(),stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(@getByIdDirectPrivate(stream,\"state\")===@streamClosed){if(bytesWritten!==0)@throwTypeError(\"bytesWritten is different from 0 even though stream is closed\");@readableByteStreamControllerRespondInClosedState(controller,firstDescriptor)}else @readableByteStreamControllerRespondInReadableState(controller,bytesWritten,firstDescriptor)})\n";
-
-// readableByteStreamControllerRespondInReadableState
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCodeLength = 1110;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCode = "(function (controller,bytesWritten,pullIntoDescriptor){\"use strict\";if(pullIntoDescriptor.bytesFilled+bytesWritten>pullIntoDescriptor.byteLength)@throwRangeError(\"bytesWritten value is too great\");if(@readableByteStreamControllerInvalidateBYOBRequest(controller),pullIntoDescriptor.bytesFilled+=bytesWritten,pullIntoDescriptor.bytesFilled<pullIntoDescriptor.elementSize)return;@readableByteStreamControllerShiftPendingDescriptor(controller);const remainderSize=pullIntoDescriptor.bytesFilled%pullIntoDescriptor.elementSize;if(remainderSize>0){const end=pullIntoDescriptor.byteOffset+pullIntoDescriptor.bytesFilled,remainder=@cloneArrayBuffer(pullIntoDescriptor.buffer,end-remainderSize,remainderSize);@readableByteStreamControllerEnqueueChunk(controller,remainder,0,remainder.byteLength)}pullIntoDescriptor.buffer=@transferBufferToCurrentRealm(pullIntoDescriptor.buffer),pullIntoDescriptor.bytesFilled-=remainderSize,@readableByteStreamControllerCommitDescriptor(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),pullIntoDescriptor),@readableByteStreamControllerProcessPullDescriptors(controller)})\n";
-
-// readableByteStreamControllerRespondInClosedState
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCodeLength = 596;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCode = "(function (controller,firstDescriptor){\"use strict\";if(firstDescriptor.buffer=@transferBufferToCurrentRealm(firstDescriptor.buffer),@readableStreamHasBYOBReader(@getByIdDirectPrivate(controller,\"controlledReadableStream\")))while(@getByIdDirectPrivate(@getByIdDirectPrivate(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),\"reader\"),\"readIntoRequests\")\?.isNotEmpty()){let pullIntoDescriptor=@readableByteStreamControllerShiftPendingDescriptor(controller);@readableByteStreamControllerCommitDescriptor(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),pullIntoDescriptor)}})\n";
-
-// readableByteStreamControllerProcessPullDescriptors
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCodeLength = 534;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCode = "(function (controller){\"use strict\";while(@getByIdDirectPrivate(controller,\"pendingPullIntos\").isNotEmpty()){if(@getByIdDirectPrivate(controller,\"queue\").size===0)return;let pullIntoDescriptor=@getByIdDirectPrivate(controller,\"pendingPullIntos\").peek();if(@readableByteStreamControllerFillDescriptorFromQueue(controller,pullIntoDescriptor))@readableByteStreamControllerShiftPendingDescriptor(controller),@readableByteStreamControllerCommitDescriptor(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),pullIntoDescriptor)}})\n";
-
-// readableByteStreamControllerFillDescriptorFromQueue
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCodeLength = 1538;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCode = "(function (controller,pullIntoDescriptor){\"use strict\";const currentAlignedBytes=pullIntoDescriptor.bytesFilled-pullIntoDescriptor.bytesFilled%pullIntoDescriptor.elementSize,maxBytesToCopy=@getByIdDirectPrivate(controller,\"queue\").size<pullIntoDescriptor.byteLength-pullIntoDescriptor.bytesFilled\?@getByIdDirectPrivate(controller,\"queue\").size:pullIntoDescriptor.byteLength-pullIntoDescriptor.bytesFilled,maxBytesFilled=pullIntoDescriptor.bytesFilled+maxBytesToCopy,maxAlignedBytes=maxBytesFilled-maxBytesFilled%pullIntoDescriptor.elementSize;let totalBytesToCopyRemaining=maxBytesToCopy,ready=!1;if(maxAlignedBytes>currentAlignedBytes)totalBytesToCopyRemaining=maxAlignedBytes-pullIntoDescriptor.bytesFilled,ready=!0;while(totalBytesToCopyRemaining>0){let headOfQueue=@getByIdDirectPrivate(controller,\"queue\").content.peek();const bytesToCopy=totalBytesToCopyRemaining<headOfQueue.byteLength\?totalBytesToCopyRemaining:headOfQueue.byteLength,destStart=pullIntoDescriptor.byteOffset+pullIntoDescriptor.bytesFilled;if(new @Uint8Array(pullIntoDescriptor.buffer).set(new @Uint8Array(headOfQueue.buffer,headOfQueue.byteOffset,bytesToCopy),destStart),headOfQueue.byteLength===bytesToCopy)@getByIdDirectPrivate(controller,\"queue\").content.shift();else headOfQueue.byteOffset+=bytesToCopy,headOfQueue.byteLength-=bytesToCopy;@getByIdDirectPrivate(controller,\"queue\").size-=bytesToCopy,@readableByteStreamControllerInvalidateBYOBRequest(controller),pullIntoDescriptor.bytesFilled+=bytesToCopy,totalBytesToCopyRemaining-=bytesToCopy}return ready})\n";
-
-// readableByteStreamControllerShiftPendingDescriptor
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCodeLength = 195;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCode = "(function (controller){\"use strict\";let descriptor=@getByIdDirectPrivate(controller,\"pendingPullIntos\").shift();return @readableByteStreamControllerInvalidateBYOBRequest(controller),descriptor})\n";
-
-// readableByteStreamControllerInvalidateBYOBRequest
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCodeLength = 374;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCode = "(function (controller){\"use strict\";if(@getByIdDirectPrivate(controller,\"byobRequest\")===@undefined)return;const byobRequest=@getByIdDirectPrivate(controller,\"byobRequest\");@putByIdDirectPrivate(byobRequest,\"associatedReadableByteStreamController\",@undefined),@putByIdDirectPrivate(byobRequest,\"view\",@undefined),@putByIdDirectPrivate(controller,\"byobRequest\",@undefined)})\n";
-
-// readableByteStreamControllerCommitDescriptor
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCodeLength = 382;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCode = "(function (stream,pullIntoDescriptor){\"use strict\";let done=!1;if(@getByIdDirectPrivate(stream,\"state\")===@streamClosed)done=!0;let filledView=@readableByteStreamControllerConvertDescriptor(pullIntoDescriptor);if(pullIntoDescriptor.readerType===\"default\")@readableStreamFulfillReadRequest(stream,filledView,done);else @readableStreamFulfillReadIntoRequest(stream,filledView,done)})\n";
-
-// readableByteStreamControllerConvertDescriptor
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCodeLength = 200;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCode = "(function (pullIntoDescriptor){\"use strict\";return new pullIntoDescriptor.ctor(pullIntoDescriptor.buffer,pullIntoDescriptor.byteOffset,pullIntoDescriptor.bytesFilled/pullIntoDescriptor.elementSize)})\n";
-
-// readableStreamFulfillReadIntoRequest
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCodeLength = 208;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCode = "(function (stream,chunk,done){\"use strict\";const readIntoRequest=@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readIntoRequests\").shift();@fulfillPromise(readIntoRequest,{value:chunk,done})})\n";
-
-// readableStreamBYOBReaderRead
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamBYOBReaderReadCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamBYOBReaderReadCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamBYOBReaderReadCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableStreamBYOBReaderReadCodeLength = 384;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamBYOBReaderReadCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableStreamBYOBReaderReadCode = "(function (reader,view){\"use strict\";const stream=@getByIdDirectPrivate(reader,\"ownerReadableStream\");if(@putByIdDirectPrivate(stream,\"disturbed\",!0),@getByIdDirectPrivate(stream,\"state\")===@streamErrored)return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));return @readableByteStreamControllerPullInto(@getByIdDirectPrivate(stream,\"readableStreamController\"),view)})\n";
-
-// readableByteStreamControllerPullInto
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCodeLength = 1659;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCode = "(function (controller,view){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");let elementSize=1;if(view.BYTES_PER_ELEMENT!==@undefined)elementSize=view.BYTES_PER_ELEMENT;const ctor=view.constructor,pullIntoDescriptor={buffer:view.buffer,byteOffset:view.byteOffset,byteLength:view.byteLength,bytesFilled:0,elementSize,ctor,readerType:\"byob\"};var pending=@getByIdDirectPrivate(controller,\"pendingPullIntos\");if(pending\?.isNotEmpty())return pullIntoDescriptor.buffer=@transferBufferToCurrentRealm(pullIntoDescriptor.buffer),pending.push(pullIntoDescriptor),@readableStreamAddReadIntoRequest(stream);if(@getByIdDirectPrivate(stream,\"state\")===@streamClosed){const emptyView=new ctor(pullIntoDescriptor.buffer,pullIntoDescriptor.byteOffset,0);return @createFulfilledPromise({value:emptyView,done:!0})}if(@getByIdDirectPrivate(controller,\"queue\").size>0){if(@readableByteStreamControllerFillDescriptorFromQueue(controller,pullIntoDescriptor)){const filledView=@readableByteStreamControllerConvertDescriptor(pullIntoDescriptor);return @readableByteStreamControllerHandleQueueDrain(controller),@createFulfilledPromise({value:filledView,done:!1})}if(@getByIdDirectPrivate(controller,\"closeRequested\")){const e=@makeTypeError(\"Closing stream has been requested\");return @readableByteStreamControllerError(controller,e),@Promise.@reject(e)}}pullIntoDescriptor.buffer=@transferBufferToCurrentRealm(pullIntoDescriptor.buffer),@getByIdDirectPrivate(controller,\"pendingPullIntos\").push(pullIntoDescriptor);const promise=@readableStreamAddReadIntoRequest(stream);return @readableByteStreamControllerCallPullIfNeeded(controller),promise})\n";
-
-// readableStreamAddReadIntoRequest
-const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCodeLength = 184;
-static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCode = "(function (stream){\"use strict\";const readRequest=@newPromise();return @getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readIntoRequests\").push(readRequest),readRequest})\n";
-
-#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
-{\
-    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().readableByteStreamInternalsBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableByteStreamInternalsBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
-}
-WEBCORE_FOREACH_READABLEBYTESTREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
-#undef DEFINE_BUILTIN_GENERATOR
-
-/* UtilInspect.ts */
-// getStylizeWithColor
-const JSC::ConstructAbility s_utilInspectGetStylizeWithColorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_utilInspectGetStylizeWithColorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_utilInspectGetStylizeWithColorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_utilInspectGetStylizeWithColorCodeLength = 261;
-static const JSC::Intrinsic s_utilInspectGetStylizeWithColorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_utilInspectGetStylizeWithColorCode = "(function (inspect){\"use strict\";return function stylizeWithColor(str,styleType){const style=inspect.styles[styleType];if(style!==@undefined){const color=inspect.colors[style];if(color!==@undefined)return`\\x1B[${color[0]}m${str}\\x1B[${color[1]}m`}return str}})\n";
-
-// stylizeWithNoColor
-const JSC::ConstructAbility s_utilInspectStylizeWithNoColorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_utilInspectStylizeWithNoColorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_utilInspectStylizeWithNoColorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_utilInspectStylizeWithNoColorCodeLength = 42;
-static const JSC::Intrinsic s_utilInspectStylizeWithNoColorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_utilInspectStylizeWithNoColorCode = "(function (str){\"use strict\";return str})\n";
-
-#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
-{\
-    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().utilInspectBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().utilInspectBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
-}
-WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
 /* JSBufferPrototype.ts */
@@ -2067,192 +1281,820 @@ JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
-/* ReadableStream.ts */
-// initializeReadableStream
-const JSC::ConstructAbility s_readableStreamInitializeReadableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamInitializeReadableStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamInitializeReadableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamInitializeReadableStreamCodeLength = 2702;
-static const JSC::Intrinsic s_readableStreamInitializeReadableStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamInitializeReadableStreamCode = "(function (underlyingSource,strategy){\"use strict\";if(underlyingSource===@undefined)underlyingSource={@bunNativeType:0,@bunNativePtr:0,@lazy:!1};if(strategy===@undefined)strategy={};if(!@isObject(underlyingSource))@throwTypeError(\"ReadableStream constructor takes an object as first argument\");if(strategy!==@undefined&&!@isObject(strategy))@throwTypeError(\"ReadableStream constructor takes an object as second argument, if any\");@putByIdDirectPrivate(this,\"state\",@streamReadable),@putByIdDirectPrivate(this,\"reader\",@undefined),@putByIdDirectPrivate(this,\"storedError\",@undefined),@putByIdDirectPrivate(this,\"disturbed\",!1),@putByIdDirectPrivate(this,\"readableStreamController\",null),@putByIdDirectPrivate(this,\"bunNativeType\",@getByIdDirectPrivate(underlyingSource,\"bunNativeType\")\?\?0),@putByIdDirectPrivate(this,\"bunNativePtr\",@getByIdDirectPrivate(underlyingSource,\"bunNativePtr\")\?\?0),@putByIdDirectPrivate(this,\"asyncContext\",@getInternalField(@asyncContext,0));const isDirect=underlyingSource.type===\"direct\",isUnderlyingSourceLazy=!!underlyingSource.@lazy,isLazy=isDirect||isUnderlyingSourceLazy;if(@getByIdDirectPrivate(underlyingSource,\"pull\")!==@undefined&&!isLazy){const size=@getByIdDirectPrivate(strategy,\"size\"),highWaterMark=@getByIdDirectPrivate(strategy,\"highWaterMark\");return @putByIdDirectPrivate(this,\"highWaterMark\",highWaterMark),@putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@setupReadableStreamDefaultController(this,underlyingSource,size,highWaterMark!==@undefined\?highWaterMark:1,@getByIdDirectPrivate(underlyingSource,\"start\"),@getByIdDirectPrivate(underlyingSource,\"pull\"),@getByIdDirectPrivate(underlyingSource,\"cancel\")),this}if(isDirect)@putByIdDirectPrivate(this,\"underlyingSource\",underlyingSource),@putByIdDirectPrivate(this,\"highWaterMark\",@getByIdDirectPrivate(strategy,\"highWaterMark\")),@putByIdDirectPrivate(this,\"start\",()=>@createReadableStreamController(this,underlyingSource,strategy));else if(isLazy){const autoAllocateChunkSize=underlyingSource.autoAllocateChunkSize;@putByIdDirectPrivate(this,\"highWaterMark\",@undefined),@putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@putByIdDirectPrivate(this,\"highWaterMark\",autoAllocateChunkSize||@getByIdDirectPrivate(strategy,\"highWaterMark\")),@putByIdDirectPrivate(this,\"start\",()=>{const instance=@lazyLoadStream(this,autoAllocateChunkSize);if(instance)@createReadableStreamController(this,instance,strategy)})}else @putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@putByIdDirectPrivate(this,\"highWaterMark\",@getByIdDirectPrivate(strategy,\"highWaterMark\")),@putByIdDirectPrivate(this,\"start\",@undefined),@createReadableStreamController(this,underlyingSource,strategy);return this})\n";
+/* ReadableByteStreamController.ts */
+// initializeReadableByteStreamController
+const JSC::ConstructAbility s_readableByteStreamControllerInitializeReadableByteStreamControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamControllerInitializeReadableByteStreamControllerCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamControllerInitializeReadableByteStreamControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamControllerInitializeReadableByteStreamControllerCodeLength = 325;
+static const JSC::Intrinsic s_readableByteStreamControllerInitializeReadableByteStreamControllerCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamControllerInitializeReadableByteStreamControllerCode = "(function (stream,underlyingByteSource,highWaterMark){\"use strict\";if(arguments.length!==4&&arguments[3]!==@isReadableStream)@throwTypeError(\"ReadableByteStreamController constructor should not be called directly\");return @privateInitializeReadableByteStreamController.@call(this,stream,underlyingByteSource,highWaterMark)})\n";
 
-// readableStreamToArray
-const JSC::ConstructAbility s_readableStreamReadableStreamToArrayCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamReadableStreamToArrayCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamReadableStreamToArrayCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamReadableStreamToArrayCodeLength = 238;
-static const JSC::Intrinsic s_readableStreamReadableStreamToArrayCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamReadableStreamToArrayCode = "(function (stream){\"use strict\";var underlyingSource=@getByIdDirectPrivate(stream,\"underlyingSource\");if(underlyingSource!==@undefined)return @readableStreamToArrayDirect(stream,underlyingSource);return @readableStreamIntoArray(stream)})\n";
+// enqueue
+const JSC::ConstructAbility s_readableByteStreamControllerEnqueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamControllerEnqueueCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamControllerEnqueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamControllerEnqueueCodeLength = 578;
+static const JSC::Intrinsic s_readableByteStreamControllerEnqueueCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamControllerEnqueueCode = "(function (chunk){\"use strict\";if(!@isReadableByteStreamController(this))throw @makeThisTypeError(\"ReadableByteStreamController\",\"enqueue\");if(@getByIdDirectPrivate(this,\"closeRequested\"))@throwTypeError(\"ReadableByteStreamController is requested to close\");if(@getByIdDirectPrivate(@getByIdDirectPrivate(this,\"controlledReadableStream\"),\"state\")!==@streamReadable)@throwTypeError(\"ReadableStream is not readable\");if(!@isObject(chunk)||!@ArrayBuffer.@isView(chunk))@throwTypeError(\"Provided chunk is not a TypedArray\");return @readableByteStreamControllerEnqueue(this,chunk)})\n";
 
-// readableStreamToText
-const JSC::ConstructAbility s_readableStreamReadableStreamToTextCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamReadableStreamToTextCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamReadableStreamToTextCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamReadableStreamToTextCodeLength = 236;
-static const JSC::Intrinsic s_readableStreamReadableStreamToTextCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamReadableStreamToTextCode = "(function (stream){\"use strict\";var underlyingSource=@getByIdDirectPrivate(stream,\"underlyingSource\");if(underlyingSource!==@undefined)return @readableStreamToTextDirect(stream,underlyingSource);return @readableStreamIntoText(stream)})\n";
+// error
+const JSC::ConstructAbility s_readableByteStreamControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamControllerErrorCodeLength = 344;
+static const JSC::Intrinsic s_readableByteStreamControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamControllerErrorCode = "(function (error){\"use strict\";if(!@isReadableByteStreamController(this))throw @makeThisTypeError(\"ReadableByteStreamController\",\"error\");if(@getByIdDirectPrivate(@getByIdDirectPrivate(this,\"controlledReadableStream\"),\"state\")!==@streamReadable)@throwTypeError(\"ReadableStream is not readable\");@readableByteStreamControllerError(this,error)})\n";
 
-// readableStreamToArrayBuffer
-const JSC::ConstructAbility s_readableStreamReadableStreamToArrayBufferCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamReadableStreamToArrayBufferCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamReadableStreamToArrayBufferCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamReadableStreamToArrayBufferCodeLength = 355;
-static const JSC::Intrinsic s_readableStreamReadableStreamToArrayBufferCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamReadableStreamToArrayBufferCode = "(function (stream){\"use strict\";var underlyingSource=@getByIdDirectPrivate(stream,\"underlyingSource\");if(underlyingSource!==@undefined)return @readableStreamToArrayBufferDirect(stream,underlyingSource);var result=@Bun.readableStreamToArray(stream);if(@isPromise(result))return result.then(@Bun.concatArrayBuffers);return @Bun.concatArrayBuffers(result)})\n";
+// close
+const JSC::ConstructAbility s_readableByteStreamControllerCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamControllerCloseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamControllerCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamControllerCloseCodeLength = 433;
+static const JSC::Intrinsic s_readableByteStreamControllerCloseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamControllerCloseCode = "(function (){\"use strict\";if(!@isReadableByteStreamController(this))throw @makeThisTypeError(\"ReadableByteStreamController\",\"close\");if(@getByIdDirectPrivate(this,\"closeRequested\"))@throwTypeError(\"Close has already been requested\");if(@getByIdDirectPrivate(@getByIdDirectPrivate(this,\"controlledReadableStream\"),\"state\")!==@streamReadable)@throwTypeError(\"ReadableStream is not readable\");@readableByteStreamControllerClose(this)})\n";
 
-// readableStreamToFormData
-const JSC::ConstructAbility s_readableStreamReadableStreamToFormDataCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamReadableStreamToFormDataCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamReadableStreamToFormDataCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamReadableStreamToFormDataCodeLength = 142;
-static const JSC::Intrinsic s_readableStreamReadableStreamToFormDataCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamReadableStreamToFormDataCode = "(function (stream,contentType){\"use strict\";return @Bun.readableStreamToBlob(stream).then((blob)=>{return FormData.from(blob,contentType)})})\n";
+// byobRequest
+const JSC::ConstructAbility s_readableByteStreamControllerByobRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamControllerByobRequestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamControllerByobRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamControllerByobRequestCodeLength = 651;
+static const JSC::Intrinsic s_readableByteStreamControllerByobRequestCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamControllerByobRequestCode = "(function (){\"use strict\";if(!@isReadableByteStreamController(this))throw @makeGetterTypeError(\"ReadableByteStreamController\",\"byobRequest\");var request=@getByIdDirectPrivate(this,\"byobRequest\");if(request===@undefined){var pending=@getByIdDirectPrivate(this,\"pendingPullIntos\");const firstDescriptor=pending.peek();if(firstDescriptor){const view=new @Uint8Array(firstDescriptor.buffer,firstDescriptor.byteOffset+firstDescriptor.bytesFilled,firstDescriptor.byteLength-firstDescriptor.bytesFilled);@putByIdDirectPrivate(this,\"byobRequest\",new @ReadableStreamBYOBRequest(this,view,@isReadableStream))}}return @getByIdDirectPrivate(this,\"byobRequest\")})\n";
 
-// readableStreamToJSON
-const JSC::ConstructAbility s_readableStreamReadableStreamToJSONCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamReadableStreamToJSONCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamReadableStreamToJSONCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamReadableStreamToJSONCodeLength = 104;
-static const JSC::Intrinsic s_readableStreamReadableStreamToJSONCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamReadableStreamToJSONCode = "(function (stream){\"use strict\";return @Bun.readableStreamToText(stream).@then(globalThis.JSON.parse)})\n";
-
-// readableStreamToBlob
-const JSC::ConstructAbility s_readableStreamReadableStreamToBlobCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamReadableStreamToBlobCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamReadableStreamToBlobCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamReadableStreamToBlobCodeLength = 126;
-static const JSC::Intrinsic s_readableStreamReadableStreamToBlobCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamReadableStreamToBlobCode = "(function (stream){\"use strict\";return @Promise.resolve(@Bun.readableStreamToArray(stream)).@then((array)=>new Blob(array))})\n";
-
-// consumeReadableStream
-const JSC::ConstructAbility s_readableStreamConsumeReadableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamConsumeReadableStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamConsumeReadableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamConsumeReadableStreamCodeLength = 2131;
-static const JSC::Intrinsic s_readableStreamConsumeReadableStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamConsumeReadableStreamCode = "(function (nativePtr,nativeType,inputStream){\"use strict\";const symbol=globalThis.Symbol.for(\"Bun.consumeReadableStreamPrototype\");var cached=globalThis[symbol];if(!cached)cached=globalThis[symbol]=[];var Prototype=cached[nativeType];if(Prototype===@undefined){var[doRead,doError,doReadMany,doClose,onClose,deinit]=globalThis[globalThis.Symbol.for('Bun.lazy')](nativeType);Prototype=class NativeReadableStreamSink{handleError;handleClosed;processResult;constructor(reader,ptr){this.#ptr=ptr,this.#reader=reader,this.#didClose=!1,this.handleError=this._handleError.bind(this),this.handleClosed=this._handleClosed.bind(this),this.processResult=this._processResult.bind(this),reader.closed.then(this.handleClosed,this.handleError)}_handleClosed(){if(this.#didClose)return;this.#didClose=!0;var ptr=this.#ptr;this.#ptr=0,doClose(ptr),deinit(ptr)}_handleError(error){if(this.#didClose)return;this.#didClose=!0;var ptr=this.#ptr;this.#ptr=0,doError(ptr,error),deinit(ptr)}#ptr;#didClose=!1;#reader;_handleReadMany({value,done,size}){if(done){this.handleClosed();return}if(this.#didClose)return;doReadMany(this.#ptr,value,done,size)}read(){if(!this.#ptr)return @throwTypeError(\"ReadableStreamSink is already closed\");return this.processResult(this.#reader.read())}_processResult(result){if(result&&@isPromise(result)){if(@getPromiseInternalField(result,@promiseFieldFlags)&@promiseStateFulfilled){const fulfilledValue=@getPromiseInternalField(result,@promiseFieldReactionsOrResult);if(fulfilledValue)result=fulfilledValue}}if(result&&@isPromise(result))return result.then(this.processResult,this.handleError),null;if(result.done)return this.handleClosed(),0;else if(result.value)return result.value;else return-1}readMany(){if(!this.#ptr)return @throwTypeError(\"ReadableStreamSink is already closed\");return this.processResult(this.#reader.readMany())}};const minlength=nativeType+1;if(cached.length<minlength)cached.length=minlength;@putByValDirect(cached,nativeType,Prototype)}if(@isReadableStreamLocked(inputStream))@throwTypeError(\"Cannot start reading from a locked stream\");return new Prototype(inputStream.getReader(),nativePtr)})\n";
-
-// createEmptyReadableStream
-const JSC::ConstructAbility s_readableStreamCreateEmptyReadableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamCreateEmptyReadableStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamCreateEmptyReadableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamCreateEmptyReadableStreamCodeLength = 114;
-static const JSC::Intrinsic s_readableStreamCreateEmptyReadableStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamCreateEmptyReadableStreamCode = "(function (){\"use strict\";var stream=new @ReadableStream({pull(){}});return @readableStreamClose(stream),stream})\n";
-
-// createNativeReadableStream
-const JSC::ConstructAbility s_readableStreamCreateNativeReadableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamCreateNativeReadableStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamCreateNativeReadableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamCreateNativeReadableStreamCodeLength = 181;
-static const JSC::Intrinsic s_readableStreamCreateNativeReadableStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamCreateNativeReadableStreamCode = "(function (nativePtr,nativeType,autoAllocateChunkSize){\"use strict\";return new @ReadableStream({@lazy:!0,@bunNativeType:nativeType,@bunNativePtr:nativePtr,autoAllocateChunkSize})})\n";
-
-// cancel
-const JSC::ConstructAbility s_readableStreamCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamCancelCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamCancelCodeLength = 276;
-static const JSC::Intrinsic s_readableStreamCancelCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamCancelCode = "(function (reason){\"use strict\";if(!@isReadableStream(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStream\",\"cancel\"));if(@isReadableStreamLocked(this))return @Promise.@reject(@makeTypeError(\"ReadableStream is locked\"));return @readableStreamCancel(this,reason)})\n";
-
-// getReader
-const JSC::ConstructAbility s_readableStreamGetReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamGetReaderCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamGetReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamGetReaderCodeLength = 506;
-static const JSC::Intrinsic s_readableStreamGetReaderCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamGetReaderCode = "(function (options){\"use strict\";if(!@isReadableStream(this))throw @makeThisTypeError(\"ReadableStream\",\"getReader\");const mode=@toDictionary(options,{},\"ReadableStream.getReader takes an object as first argument\").mode;if(mode===@undefined){var start_=@getByIdDirectPrivate(this,\"start\");if(start_)@putByIdDirectPrivate(this,\"start\",@undefined),start_();return new @ReadableStreamDefaultReader(this)}if(mode==\"byob\")return new @ReadableStreamBYOBReader(this);@throwTypeError(\"Invalid mode is specified\")})\n";
-
-// pipeThrough
-const JSC::ConstructAbility s_readableStreamPipeThroughCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamPipeThroughCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamPipeThroughCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamPipeThroughCodeLength = 1162;
-static const JSC::Intrinsic s_readableStreamPipeThroughCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamPipeThroughCode = "(function (streams,options){\"use strict\";const transforms=streams,readable=transforms.readable;if(!@isReadableStream(readable))throw @makeTypeError(\"readable should be ReadableStream\");const writable=transforms.writable,internalWritable=@getInternalWritableStream(writable);if(!@isWritableStream(internalWritable))throw @makeTypeError(\"writable should be WritableStream\");let preventClose=!1,preventAbort=!1,preventCancel=!1,signal;if(!@isUndefinedOrNull(options)){if(!@isObject(options))throw @makeTypeError(\"options must be an object\");if(preventAbort=!!options.preventAbort,preventCancel=!!options.preventCancel,preventClose=!!options.preventClose,signal=options.signal,signal!==@undefined&&!@isAbortSignal(signal))throw @makeTypeError(\"options.signal must be AbortSignal\")}if(!@isReadableStream(this))throw @makeThisTypeError(\"ReadableStream\",\"pipeThrough\");if(@isReadableStreamLocked(this))throw @makeTypeError(\"ReadableStream is locked\");if(@isWritableStreamLocked(internalWritable))throw @makeTypeError(\"WritableStream is locked\");return @readableStreamPipeToWritableStream(this,internalWritable,preventClose,preventAbort,preventCancel,signal),readable})\n";
-
-// pipeTo
-const JSC::ConstructAbility s_readableStreamPipeToCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamPipeToCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamPipeToCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamPipeToCodeLength = 1175;
-static const JSC::Intrinsic s_readableStreamPipeToCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamPipeToCode = "(function (destination){\"use strict\";if(!@isReadableStream(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStream\",\"pipeTo\"));if(@isReadableStreamLocked(this))return @Promise.@reject(@makeTypeError(\"ReadableStream is locked\"));let options=@argument(1),preventClose=!1,preventAbort=!1,preventCancel=!1,signal;if(!@isUndefinedOrNull(options)){if(!@isObject(options))return @Promise.@reject(@makeTypeError(\"options must be an object\"));try{preventAbort=!!options.preventAbort,preventCancel=!!options.preventCancel,preventClose=!!options.preventClose,signal=options.signal}catch(e){return @Promise.@reject(e)}if(signal!==@undefined&&!@isAbortSignal(signal))return @Promise.@reject(@makeTypeError(\"options.signal must be AbortSignal\"))}const internalDestination=@getInternalWritableStream(destination);if(!@isWritableStream(internalDestination))return @Promise.@reject(@makeTypeError(\"ReadableStream pipeTo requires a WritableStream\"));if(@isWritableStreamLocked(internalDestination))return @Promise.@reject(@makeTypeError(\"WritableStream is locked\"));return @readableStreamPipeToWritableStream(this,internalDestination,preventClose,preventAbort,preventCancel,signal)})\n";
-
-// tee
-const JSC::ConstructAbility s_readableStreamTeeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamTeeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamTeeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamTeeCodeLength = 140;
-static const JSC::Intrinsic s_readableStreamTeeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamTeeCode = "(function (){\"use strict\";if(!@isReadableStream(this))throw @makeThisTypeError(\"ReadableStream\",\"tee\");return @readableStreamTee(this,!1)})\n";
-
-// locked
-const JSC::ConstructAbility s_readableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamLockedCodeLength = 147;
-static const JSC::Intrinsic s_readableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamLockedCode = "(function (){\"use strict\";if(!@isReadableStream(this))throw @makeGetterTypeError(\"ReadableStream\",\"locked\");return @isReadableStreamLocked(this)})\n";
-
-// values
-const JSC::ConstructAbility s_readableStreamValuesCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamValuesCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamValuesCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_readableStreamValuesCodeLength = 165;
-static const JSC::Intrinsic s_readableStreamValuesCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamValuesCode = "(function (options){\"use strict\";var prototype=@ReadableStream.prototype;return @readableStreamDefineLazyIterators(prototype),prototype.values.@call(this,options)})\n";
-
-// lazyAsyncIterator
-const JSC::ConstructAbility s_readableStreamLazyAsyncIteratorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_readableStreamLazyAsyncIteratorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_readableStreamLazyAsyncIteratorCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
-const int s_readableStreamLazyAsyncIteratorCodeLength = 176;
-static const JSC::Intrinsic s_readableStreamLazyAsyncIteratorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_readableStreamLazyAsyncIteratorCode = "(function (){\"use strict\";var prototype=@ReadableStream.prototype;return @readableStreamDefineLazyIterators(prototype),prototype[globalThis.Symbol.asyncIterator].@call(this)})\n";
+// desiredSize
+const JSC::ConstructAbility s_readableByteStreamControllerDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamControllerDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamControllerDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamControllerDesiredSizeCodeLength = 200;
+static const JSC::Intrinsic s_readableByteStreamControllerDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamControllerDesiredSizeCode = "(function (){\"use strict\";if(!@isReadableByteStreamController(this))throw @makeGetterTypeError(\"ReadableByteStreamController\",\"desiredSize\");return @readableByteStreamControllerGetDesiredSize(this)})\n";
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 {\
     JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().readableStreamBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableStreamBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+    return clientData->builtinFunctions().readableByteStreamControllerBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableByteStreamControllerBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
 }
-WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_READABLEBYTESTREAMCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
-/* BundlerPlugin.ts */
-// runSetupFunction
-const JSC::ConstructAbility s_bundlerPluginRunSetupFunctionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_bundlerPluginRunSetupFunctionCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_bundlerPluginRunSetupFunctionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_bundlerPluginRunSetupFunctionCodeLength = 3224;
-static const JSC::Intrinsic s_bundlerPluginRunSetupFunctionCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_bundlerPluginRunSetupFunctionCode = "(function (setup,config){\"use strict\";var onLoadPlugins=new Map,onResolvePlugins=new Map;function validate(filterObject,callback,map){if(!filterObject||!@isObject(filterObject))@throwTypeError('Expected an object with \"filter\" RegExp');if(!callback||!@isCallable(callback))@throwTypeError(\"callback must be a function\");var{filter,namespace=\"file\"}=filterObject;if(!filter)@throwTypeError('Expected an object with \"filter\" RegExp');if(!@isRegExpObject(filter))@throwTypeError(\"filter must be a RegExp\");if(namespace&&typeof namespace!==\"string\")@throwTypeError(\"namespace must be a string\");if((namespace\?.length\?\?0)===0)namespace=\"file\";if(!/^([/@a-zA-Z0-9_\\\\-]+)$/.test(namespace))@throwTypeError(\"namespace can only contain $a-zA-Z0-9_\\\\-\");var callbacks=map.@get(namespace);if(!callbacks)map.@set(namespace,[[filter,callback]]);else @arrayPush(callbacks,[filter,callback])}function onLoad(filterObject,callback){validate(filterObject,callback,onLoadPlugins)}function onResolve(filterObject,callback){validate(filterObject,callback,onResolvePlugins)}const processSetupResult=()=>{var anyOnLoad=!1,anyOnResolve=!1;for(var[namespace,callbacks]of onLoadPlugins.entries())for(var[filter]of callbacks)this.addFilter(filter,namespace,1),anyOnLoad=!0;for(var[namespace,callbacks]of onResolvePlugins.entries())for(var[filter]of callbacks)this.addFilter(filter,namespace,0),anyOnResolve=!0;if(anyOnResolve){var onResolveObject=this.onResolve;if(!onResolveObject)this.onResolve=onResolvePlugins;else for(var[namespace,callbacks]of onResolvePlugins.entries()){var existing=onResolveObject.@get(namespace);if(!existing)onResolveObject.@set(namespace,callbacks);else onResolveObject.@set(namespace,existing.concat(callbacks))}}if(anyOnLoad){var onLoadObject=this.onLoad;if(!onLoadObject)this.onLoad=onLoadPlugins;else for(var[namespace,callbacks]of onLoadPlugins.entries()){var existing=onLoadObject.@get(namespace);if(!existing)onLoadObject.@set(namespace,callbacks);else onLoadObject.@set(namespace,existing.concat(callbacks))}}return anyOnLoad||anyOnResolve};var setupResult=setup({config,onDispose:()=>@throwTypeError(\"@{@2} is not implemented yet. See https://github.com/oven-sh/bun/issues/@1\"),onEnd:()=>@throwTypeError(\"@{@2} is not implemented yet. See https://github.com/oven-sh/bun/issues/@1\"),onLoad,onResolve,onStart:()=>@throwTypeError(\"@{@2} is not implemented yet. See https://github.com/oven-sh/bun/issues/@1\"),resolve:()=>@throwTypeError(\"@{@2} is not implemented yet. See https://github.com/oven-sh/bun/issues/@1\"),initialOptions:{...config,bundle:!0,entryPoints:config.entrypoints\?\?config.entryPoints\?\?[],minify:typeof config.minify===\"boolean\"\?config.minify:!1,minifyIdentifiers:config.minify===!0||config.minify\?.identifiers,minifyWhitespace:config.minify===!0||config.minify\?.whitespace,minifySyntax:config.minify===!0||config.minify\?.syntax,outbase:config.root,platform:config.target===\"bun\"\?\"node\":config.target},esbuild:{}});if(setupResult&&@isPromise(setupResult))if(@getPromiseInternalField(setupResult,@promiseFieldFlags)&@promiseStateFulfilled)setupResult=@getPromiseInternalField(setupResult,@promiseFieldReactionsOrResult);else return setupResult.@then(processSetupResult);return processSetupResult()})\n";
+/* UtilInspect.ts */
+// getStylizeWithColor
+const JSC::ConstructAbility s_utilInspectGetStylizeWithColorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_utilInspectGetStylizeWithColorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_utilInspectGetStylizeWithColorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_utilInspectGetStylizeWithColorCodeLength = 261;
+static const JSC::Intrinsic s_utilInspectGetStylizeWithColorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_utilInspectGetStylizeWithColorCode = "(function (inspect){\"use strict\";return function stylizeWithColor(str,styleType){const style=inspect.styles[styleType];if(style!==@undefined){const color=inspect.colors[style];if(color!==@undefined)return`\\x1B[${color[0]}m${str}\\x1B[${color[1]}m`}return str}})\n";
 
-// runOnResolvePlugins
-const JSC::ConstructAbility s_bundlerPluginRunOnResolvePluginsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_bundlerPluginRunOnResolvePluginsCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_bundlerPluginRunOnResolvePluginsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_bundlerPluginRunOnResolvePluginsCodeLength = 2359;
-static const JSC::Intrinsic s_bundlerPluginRunOnResolvePluginsCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_bundlerPluginRunOnResolvePluginsCode = "(function (specifier,inputNamespace,importer,internalID,kindId){\"use strict\";const kind=[\"entry-point\",\"import-statement\",\"require-call\",\"dynamic-import\",\"require-resolve\",\"import-rule\",\"url-token\",\"internal\"][kindId];var promiseResult=(async(inputPath,inputNamespace2,importer2,kind2)=>{var{onResolve,onLoad}=this,results=onResolve.@get(inputNamespace2);if(!results)return this.onResolveAsync(internalID,null,null,null),null;for(let[filter,callback]of results)if(filter.test(inputPath)){var result=callback({path:inputPath,importer:importer2,namespace:inputNamespace2,kind:kind2});while(result&&@isPromise(result)&&(@getPromiseInternalField(result,@promiseFieldFlags)&@promiseStateMask)===@promiseStateFulfilled)result=@getPromiseInternalField(result,@promiseFieldReactionsOrResult);if(result&&@isPromise(result))result=await result;if(!result||!@isObject(result))continue;var{path,namespace:userNamespace=inputNamespace2,external}=result;if(typeof path!==\"string\"||typeof userNamespace!==\"string\")@throwTypeError(\"onResolve plugins must return an object with a string 'path' and string 'loader' field\");if(!path)continue;if(!userNamespace)userNamespace=inputNamespace2;if(typeof external!==\"boolean\"&&!@isUndefinedOrNull(external))@throwTypeError('onResolve plugins \"external\" field must be boolean or unspecified');if(!external){if(userNamespace===\"file\"){if(process.platform!==\"win32\"){if(path[0]!==\"/\"||path.includes(\"..\"))@throwTypeError('onResolve plugin \"path\" must be absolute when the namespace is \"file\"')}}if(userNamespace===\"dataurl\"){if(!path.startsWith(\"data:\"))@throwTypeError('onResolve plugin \"path\" must start with \"data:\" when the namespace is \"dataurl\"')}if(userNamespace&&userNamespace!==\"file\"&&(!onLoad||!onLoad.@has(userNamespace)))@throwTypeError(`Expected onLoad plugin for namespace ${userNamespace} to exist`)}return this.onResolveAsync(internalID,path,userNamespace,external),null}return this.onResolveAsync(internalID,null,null,null),null})(specifier,inputNamespace,importer,kind);while(promiseResult&&@isPromise(promiseResult)&&(@getPromiseInternalField(promiseResult,@promiseFieldFlags)&@promiseStateMask)===@promiseStateFulfilled)promiseResult=@getPromiseInternalField(promiseResult,@promiseFieldReactionsOrResult);if(promiseResult&&@isPromise(promiseResult))promiseResult.then(()=>{},(e)=>{this.addError(internalID,e,0)})})\n";
-
-// runOnLoadPlugins
-const JSC::ConstructAbility s_bundlerPluginRunOnLoadPluginsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_bundlerPluginRunOnLoadPluginsCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_bundlerPluginRunOnLoadPluginsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_bundlerPluginRunOnLoadPluginsCodeLength = 1835;
-static const JSC::Intrinsic s_bundlerPluginRunOnLoadPluginsCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_bundlerPluginRunOnLoadPluginsCode = "(function (internalID,path,namespace,defaultLoaderId){\"use strict\";const LOADERS_MAP={jsx:0,js:1,ts:2,tsx:3,css:4,file:5,json:6,toml:7,wasm:8,napi:9,base64:10,dataurl:11,text:12},loaderName=[\"jsx\",\"js\",\"ts\",\"tsx\",\"css\",\"file\",\"json\",\"toml\",\"wasm\",\"napi\",\"base64\",\"dataurl\",\"text\"][defaultLoaderId];var promiseResult=(async(internalID2,path2,namespace2,defaultLoader)=>{var results=this.onLoad.@get(namespace2);if(!results)return this.onLoadAsync(internalID2,null,null),null;for(let[filter,callback]of results)if(filter.test(path2)){var result=callback({path:path2,namespace:namespace2,loader:defaultLoader});while(result&&@isPromise(result)&&(@getPromiseInternalField(result,@promiseFieldFlags)&@promiseStateMask)===@promiseStateFulfilled)result=@getPromiseInternalField(result,@promiseFieldReactionsOrResult);if(result&&@isPromise(result))result=await result;if(!result||!@isObject(result))continue;var{contents,loader=defaultLoader}=result;if(typeof contents!==\"string\"&&!@isTypedArrayView(contents))@throwTypeError('onLoad plugins must return an object with \"contents\" as a string or Uint8Array');if(typeof loader!==\"string\")@throwTypeError('onLoad plugins must return an object with \"loader\" as a string');const chosenLoader=LOADERS_MAP[loader];if(chosenLoader===@undefined)@throwTypeError(`Loader ${loader} is not supported.`);return this.onLoadAsync(internalID2,contents,chosenLoader),null}return this.onLoadAsync(internalID2,null,null),null})(internalID,path,namespace,loaderName);while(promiseResult&&@isPromise(promiseResult)&&(@getPromiseInternalField(promiseResult,@promiseFieldFlags)&@promiseStateMask)===@promiseStateFulfilled)promiseResult=@getPromiseInternalField(promiseResult,@promiseFieldReactionsOrResult);if(promiseResult&&@isPromise(promiseResult))promiseResult.then(()=>{},(e)=>{this.addError(internalID,e,1)})})\n";
+// stylizeWithNoColor
+const JSC::ConstructAbility s_utilInspectStylizeWithNoColorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_utilInspectStylizeWithNoColorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_utilInspectStylizeWithNoColorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_utilInspectStylizeWithNoColorCodeLength = 42;
+static const JSC::Intrinsic s_utilInspectStylizeWithNoColorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_utilInspectStylizeWithNoColorCode = "(function (str){\"use strict\";return str})\n";
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 {\
     JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().bundlerPluginBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().bundlerPluginBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+    return clientData->builtinFunctions().utilInspectBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().utilInspectBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
 }
-WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+#undef DEFINE_BUILTIN_GENERATOR
+
+/* ConsoleObject.ts */
+// asyncIterator
+const JSC::ConstructAbility s_consoleObjectAsyncIteratorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_consoleObjectAsyncIteratorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_consoleObjectAsyncIteratorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_consoleObjectAsyncIteratorCodeLength = 949;
+static const JSC::Intrinsic s_consoleObjectAsyncIteratorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_consoleObjectAsyncIteratorCode = "(function (){\"use strict\";const Iterator=async function*ConsoleAsyncIterator(){var reader=@Bun.stdin.stream().getReader(),decoder=new globalThis.TextDecoder(\"utf-8\",{fatal:!1}),deferredError,indexOf=@Bun.indexOfLine;try{while(!0){var done,value,pendingChunk;const firstResult=reader.readMany();if(@isPromise(firstResult))({done,value}=await firstResult);else({done,value}=firstResult);if(done){if(pendingChunk)yield decoder.decode(pendingChunk);return}var actualChunk;for(let chunk of value){if(actualChunk=chunk,pendingChunk)actualChunk=@Buffer.concat([pendingChunk,chunk]),pendingChunk=null;var last=0,i=indexOf(actualChunk,last);while(i!==-1)yield decoder.decode(actualChunk.subarray(last,i)),last=i+1,i=indexOf(actualChunk,last);pendingChunk=actualChunk.subarray(last)}}}catch(e){deferredError=e}finally{if(reader.releaseLock(),deferredError)throw deferredError}},symbol=globalThis.Symbol.asyncIterator;return this[symbol]=Iterator,Iterator()})\n";
+
+// write
+const JSC::ConstructAbility s_consoleObjectWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_consoleObjectWriteCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_consoleObjectWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_consoleObjectWriteCodeLength = 392;
+static const JSC::Intrinsic s_consoleObjectWriteCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_consoleObjectWriteCode = "(function (input){\"use strict\";var writer=@getByIdDirectPrivate(this,\"writer\");if(!writer){var length=@toLength(input\?.length\?\?0);writer=@Bun.stdout.writer({highWaterMark:length>65536\?length:65536}),@putByIdDirectPrivate(this,\"writer\",writer)}var wrote=writer.write(input);const count=@argumentCount();for(var i=1;i<count;i++)wrote+=writer.write(@argument(i));return writer.flush(!0),wrote})\n";
+
+#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
+{\
+    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
+    return clientData->builtinFunctions().consoleObjectBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().consoleObjectBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+}
+WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+#undef DEFINE_BUILTIN_GENERATOR
+
+/* ReadableStreamInternals.ts */
+// readableStreamReaderGenericInitialize
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamReaderGenericInitializeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamReaderGenericInitializeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamReaderGenericInitializeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamReaderGenericInitializeCodeLength = 584;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamReaderGenericInitializeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamReaderGenericInitializeCode = "(function (reader,stream){\"use strict\";if(@putByIdDirectPrivate(reader,\"ownerReadableStream\",stream),@putByIdDirectPrivate(stream,\"reader\",reader),@getByIdDirectPrivate(stream,\"state\")===@streamReadable)@putByIdDirectPrivate(reader,\"closedPromiseCapability\",@newPromiseCapability(@Promise));else if(@getByIdDirectPrivate(stream,\"state\")===@streamClosed)@putByIdDirectPrivate(reader,\"closedPromiseCapability\",{promise:@Promise.@resolve()});else @putByIdDirectPrivate(reader,\"closedPromiseCapability\",{promise:@newHandledRejectedPromise(@getByIdDirectPrivate(stream,\"storedError\"))})})\n";
+
+// privateInitializeReadableStreamDefaultController
+const JSC::ConstructAbility s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCodeLength = 755;
+static const JSC::Intrinsic s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsPrivateInitializeReadableStreamDefaultControllerCode = "(function (stream,underlyingSource,size,highWaterMark){\"use strict\";if(!@isReadableStream(stream))@throwTypeError(\"ReadableStreamDefaultController needs a ReadableStream\");if(@getByIdDirectPrivate(stream,\"readableStreamController\")!==null)@throwTypeError(\"ReadableStream already has a controller\");return @putByIdDirectPrivate(this,\"controlledReadableStream\",stream),@putByIdDirectPrivate(this,\"underlyingSource\",underlyingSource),@putByIdDirectPrivate(this,\"queue\",@newQueue()),@putByIdDirectPrivate(this,\"started\",-1),@putByIdDirectPrivate(this,\"closeRequested\",!1),@putByIdDirectPrivate(this,\"pullAgain\",!1),@putByIdDirectPrivate(this,\"pulling\",!1),@putByIdDirectPrivate(this,\"strategy\",@validateAndNormalizeQueuingStrategy(size,highWaterMark)),this})\n";
+
+// readableStreamDefaultControllerError
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefaultControllerErrorCodeLength = 273;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefaultControllerErrorCode = "(function (controller,error){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(@getByIdDirectPrivate(stream,\"state\")!==@streamReadable)return;@putByIdDirectPrivate(controller,\"queue\",@newQueue()),@readableStreamError(stream,error)})\n";
+
+// readableStreamPipeTo
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamPipeToCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamPipeToCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamPipeToCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamPipeToCodeLength = 469;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamPipeToCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamPipeToCode = "(function (stream,sink){\"use strict\";const reader=new @ReadableStreamDefaultReader(stream);@getByIdDirectPrivate(reader,\"closedPromiseCapability\").promise.@then(()=>{},(e)=>{sink.error(e)});function doPipe(){@readableStreamDefaultReaderRead(reader).@then(function(result){if(result.done){sink.close();return}try{sink.enqueue(result.value)}catch(e){sink.error(\"ReadableStream chunk enqueueing in the sink failed\");return}doPipe()},function(e){sink.error(e)})}doPipe()})\n";
+
+// acquireReadableStreamDefaultReader
+const JSC::ConstructAbility s_readableStreamInternalsAcquireReadableStreamDefaultReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsAcquireReadableStreamDefaultReaderCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsAcquireReadableStreamDefaultReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsAcquireReadableStreamDefaultReaderCodeLength = 159;
+static const JSC::Intrinsic s_readableStreamInternalsAcquireReadableStreamDefaultReaderCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsAcquireReadableStreamDefaultReaderCode = "(function (stream){\"use strict\";var start=@getByIdDirectPrivate(stream,\"start\");if(start)start.@call(stream);return new @ReadableStreamDefaultReader(stream)})\n";
+
+// setupReadableStreamDefaultController
+const JSC::ConstructAbility s_readableStreamInternalsSetupReadableStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsSetupReadableStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsSetupReadableStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsSetupReadableStreamDefaultControllerCodeLength = 1105;
+static const JSC::Intrinsic s_readableStreamInternalsSetupReadableStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsSetupReadableStreamDefaultControllerCode = "(function (stream,underlyingSource,size,highWaterMark,startMethod,pullMethod,cancelMethod){\"use strict\";const controller=new @ReadableStreamDefaultController(stream,underlyingSource,size,highWaterMark,@isReadableStream);var asyncContext=stream.@asyncContext;const pullAlgorithm=()=>@promiseInvokeOrNoopMethod(underlyingSource,pullMethod,[controller]),cancelAlgorithm=asyncContext\?(reason)=>{var prev=@getInternalField(@asyncContext,0);@putInternalField(@asyncContext,0,asyncContext);var result=@promiseInvokeOrNoopMethod(underlyingSource,cancelMethod,[reason]);return @putInternalField(@asyncContext,0,prev),result}:(reason)=>@promiseInvokeOrNoopMethod(underlyingSource,cancelMethod,[reason]);@putByIdDirectPrivate(controller,\"pullAlgorithm\",pullAlgorithm),@putByIdDirectPrivate(controller,\"cancelAlgorithm\",cancelAlgorithm),@putByIdDirectPrivate(controller,\"pull\",@readableStreamDefaultControllerPull),@putByIdDirectPrivate(controller,\"cancel\",@readableStreamDefaultControllerCancel),@putByIdDirectPrivate(stream,\"readableStreamController\",controller),@readableStreamDefaultControllerStart(controller)})\n";
+
+// createReadableStreamController
+const JSC::ConstructAbility s_readableStreamInternalsCreateReadableStreamControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsCreateReadableStreamControllerCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsCreateReadableStreamControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsCreateReadableStreamControllerCodeLength = 946;
+static const JSC::Intrinsic s_readableStreamInternalsCreateReadableStreamControllerCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsCreateReadableStreamControllerCode = "(function (stream,underlyingSource,strategy){\"use strict\";const type=underlyingSource.type,typeString=@toString(type);if(typeString===\"bytes\"){if(strategy.highWaterMark===@undefined)strategy.highWaterMark=0;if(strategy.size!==@undefined)@throwRangeError(\"Strategy for a ReadableByteStreamController cannot have a size\");@putByIdDirectPrivate(stream,\"readableStreamController\",new @ReadableByteStreamController(stream,underlyingSource,strategy.highWaterMark,@isReadableStream))}else if(typeString===\"direct\"){var highWaterMark=strategy\?.highWaterMark;@initializeArrayBufferStream.@call(stream,underlyingSource,highWaterMark)}else if(type===@undefined){if(strategy.highWaterMark===@undefined)strategy.highWaterMark=1;@setupReadableStreamDefaultController(stream,underlyingSource,strategy.size,strategy.highWaterMark,underlyingSource.start,underlyingSource.pull,underlyingSource.cancel)}else @throwRangeError(\"Invalid type for underlying source\")})\n";
+
+// readableStreamDefaultControllerStart
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerStartCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerStartCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerStartCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefaultControllerStartCodeLength = 518;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerStartCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefaultControllerStartCode = "(function (controller){\"use strict\";if(@getByIdDirectPrivate(controller,\"started\")!==-1)return;const underlyingSource=@getByIdDirectPrivate(controller,\"underlyingSource\"),startMethod=underlyingSource.start;@putByIdDirectPrivate(controller,\"started\",0),@promiseInvokeOrNoopMethodNoCatch(underlyingSource,startMethod,[controller]).@then(()=>{@putByIdDirectPrivate(controller,\"started\",1),@readableStreamDefaultControllerCallPullIfNeeded(controller)},(error)=>{@readableStreamDefaultControllerError(controller,error)})})\n";
+
+// readableStreamPipeToWritableStream
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamPipeToWritableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamPipeToWritableStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamPipeToWritableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamPipeToWritableStreamCodeLength = 2022;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamPipeToWritableStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamPipeToWritableStreamCode = "(function (source,destination,preventClose,preventAbort,preventCancel,signal){\"use strict\";if(@getByIdDirectPrivate(source,\"underlyingByteSource\")!==@undefined)return @Promise.@reject(\"Piping to a readable bytestream is not supported\");let pipeState={source,destination,preventAbort,preventCancel,preventClose,signal};if(pipeState.reader=@acquireReadableStreamDefaultReader(source),pipeState.writer=@acquireWritableStreamDefaultWriter(destination),@putByIdDirectPrivate(source,\"disturbed\",!0),pipeState.finalized=!1,pipeState.shuttingDown=!1,pipeState.promiseCapability=@newPromiseCapability(@Promise),pipeState.pendingReadPromiseCapability=@newPromiseCapability(@Promise),pipeState.pendingReadPromiseCapability.resolve.@call(),pipeState.pendingWritePromise=@Promise.@resolve(),signal!==@undefined){const algorithm=(reason)=>{if(pipeState.finalized)return;@pipeToShutdownWithAction(pipeState,()=>{const promiseDestination=!pipeState.preventAbort&&@getByIdDirectPrivate(pipeState.destination,\"state\")===\"writable\"\?@writableStreamAbort(pipeState.destination,reason):@Promise.@resolve(),promiseSource=!pipeState.preventCancel&&@getByIdDirectPrivate(pipeState.source,\"state\")===@streamReadable\?@readableStreamCancel(pipeState.source,reason):@Promise.@resolve();let promiseCapability=@newPromiseCapability(@Promise),shouldWait=!0,handleResolvedPromise=()=>{if(shouldWait){shouldWait=!1;return}promiseCapability.resolve.@call()},handleRejectedPromise=(e)=>{promiseCapability.reject.@call(@undefined,e)};return promiseDestination.@then(handleResolvedPromise,handleRejectedPromise),promiseSource.@then(handleResolvedPromise,handleRejectedPromise),promiseCapability.promise},reason)};if(@whenSignalAborted(signal,algorithm))return pipeState.promiseCapability.promise}return @pipeToErrorsMustBePropagatedForward(pipeState),@pipeToErrorsMustBePropagatedBackward(pipeState),@pipeToClosingMustBePropagatedForward(pipeState),@pipeToClosingMustBePropagatedBackward(pipeState),@pipeToLoop(pipeState),pipeState.promiseCapability.promise})\n";
+
+// pipeToLoop
+const JSC::ConstructAbility s_readableStreamInternalsPipeToLoopCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsPipeToLoopCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsPipeToLoopCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsPipeToLoopCodeLength = 152;
+static const JSC::Intrinsic s_readableStreamInternalsPipeToLoopCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsPipeToLoopCode = "(function (pipeState){\"use strict\";if(pipeState.shuttingDown)return;@pipeToDoReadWrite(pipeState).@then((result)=>{if(result)@pipeToLoop(pipeState)})})\n";
+
+// pipeToDoReadWrite
+const JSC::ConstructAbility s_readableStreamInternalsPipeToDoReadWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsPipeToDoReadWriteCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsPipeToDoReadWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsPipeToDoReadWriteCodeLength = 840;
+static const JSC::Intrinsic s_readableStreamInternalsPipeToDoReadWriteCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsPipeToDoReadWriteCode = "(function (pipeState){\"use strict\";return pipeState.pendingReadPromiseCapability=@newPromiseCapability(@Promise),@getByIdDirectPrivate(pipeState.writer,\"readyPromise\").promise.@then(()=>{if(pipeState.shuttingDown){pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,!1);return}@readableStreamDefaultReaderRead(pipeState.reader).@then((result)=>{const canWrite=!result.done&&@getByIdDirectPrivate(pipeState.writer,\"stream\")!==@undefined;if(pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,canWrite),!canWrite)return;pipeState.pendingWritePromise=@writableStreamDefaultWriterWrite(pipeState.writer,result.value)},(e)=>{pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,!1)})},(e)=>{pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,!1)}),pipeState.pendingReadPromiseCapability.promise})\n";
+
+// pipeToErrorsMustBePropagatedForward
+const JSC::ConstructAbility s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCodeLength = 539;
+static const JSC::Intrinsic s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsPipeToErrorsMustBePropagatedForwardCode = "(function (pipeState){\"use strict\";const action=()=>{pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,!1);const error=@getByIdDirectPrivate(pipeState.source,\"storedError\");if(!pipeState.preventAbort){@pipeToShutdownWithAction(pipeState,()=>@writableStreamAbort(pipeState.destination,error),error);return}@pipeToShutdown(pipeState,error)};if(@getByIdDirectPrivate(pipeState.source,\"state\")===@streamErrored){action();return}@getByIdDirectPrivate(pipeState.reader,\"closedPromiseCapability\").promise.@then(@undefined,action)})\n";
+
+// pipeToErrorsMustBePropagatedBackward
+const JSC::ConstructAbility s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCodeLength = 463;
+static const JSC::Intrinsic s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsPipeToErrorsMustBePropagatedBackwardCode = "(function (pipeState){\"use strict\";const action=()=>{const error=@getByIdDirectPrivate(pipeState.destination,\"storedError\");if(!pipeState.preventCancel){@pipeToShutdownWithAction(pipeState,()=>@readableStreamCancel(pipeState.source,error),error);return}@pipeToShutdown(pipeState,error)};if(@getByIdDirectPrivate(pipeState.destination,\"state\")===\"errored\"){action();return}@getByIdDirectPrivate(pipeState.writer,\"closedPromise\").promise.@then(@undefined,action)})\n";
+
+// pipeToClosingMustBePropagatedForward
+const JSC::ConstructAbility s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCodeLength = 482;
+static const JSC::Intrinsic s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsPipeToClosingMustBePropagatedForwardCode = "(function (pipeState){\"use strict\";const action=()=>{if(pipeState.pendingReadPromiseCapability.resolve.@call(@undefined,!1),!pipeState.preventClose){@pipeToShutdownWithAction(pipeState,()=>@writableStreamDefaultWriterCloseWithErrorPropagation(pipeState.writer));return}@pipeToShutdown(pipeState)};if(@getByIdDirectPrivate(pipeState.source,\"state\")===@streamClosed){action();return}@getByIdDirectPrivate(pipeState.reader,\"closedPromiseCapability\").promise.@then(action,@undefined)})\n";
+
+// pipeToClosingMustBePropagatedBackward
+const JSC::ConstructAbility s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCodeLength = 396;
+static const JSC::Intrinsic s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsPipeToClosingMustBePropagatedBackwardCode = "(function (pipeState){\"use strict\";if(!@writableStreamCloseQueuedOrInFlight(pipeState.destination)&&@getByIdDirectPrivate(pipeState.destination,\"state\")!==\"closed\")return;const error=@makeTypeError(\"closing is propagated backward\");if(!pipeState.preventCancel){@pipeToShutdownWithAction(pipeState,()=>@readableStreamCancel(pipeState.source,error),error);return}@pipeToShutdown(pipeState,error)})\n";
+
+// pipeToShutdownWithAction
+const JSC::ConstructAbility s_readableStreamInternalsPipeToShutdownWithActionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsPipeToShutdownWithActionCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsPipeToShutdownWithActionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsPipeToShutdownWithActionCodeLength = 605;
+static const JSC::Intrinsic s_readableStreamInternalsPipeToShutdownWithActionCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsPipeToShutdownWithActionCode = "(function (pipeState,action){\"use strict\";if(pipeState.shuttingDown)return;pipeState.shuttingDown=!0;const hasError=arguments.length>2,error=arguments[2],finalize=()=>{action().@then(()=>{if(hasError)@pipeToFinalize(pipeState,error);else @pipeToFinalize(pipeState)},(e)=>{@pipeToFinalize(pipeState,e)})};if(@getByIdDirectPrivate(pipeState.destination,\"state\")===\"writable\"&&!@writableStreamCloseQueuedOrInFlight(pipeState.destination)){pipeState.pendingReadPromiseCapability.promise.@then(()=>{pipeState.pendingWritePromise.@then(finalize,finalize)},(e)=>@pipeToFinalize(pipeState,e));return}finalize()})\n";
+
+// pipeToShutdown
+const JSC::ConstructAbility s_readableStreamInternalsPipeToShutdownCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsPipeToShutdownCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsPipeToShutdownCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsPipeToShutdownCodeLength = 540;
+static const JSC::Intrinsic s_readableStreamInternalsPipeToShutdownCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsPipeToShutdownCode = "(function (pipeState){\"use strict\";if(pipeState.shuttingDown)return;pipeState.shuttingDown=!0;const hasError=arguments.length>1,error=arguments[1],finalize=()=>{if(hasError)@pipeToFinalize(pipeState,error);else @pipeToFinalize(pipeState)};if(@getByIdDirectPrivate(pipeState.destination,\"state\")===\"writable\"&&!@writableStreamCloseQueuedOrInFlight(pipeState.destination)){pipeState.pendingReadPromiseCapability.promise.@then(()=>{pipeState.pendingWritePromise.@then(finalize,finalize)},(e)=>@pipeToFinalize(pipeState,e));return}finalize()})\n";
+
+// pipeToFinalize
+const JSC::ConstructAbility s_readableStreamInternalsPipeToFinalizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsPipeToFinalizeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsPipeToFinalizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsPipeToFinalizeCodeLength = 305;
+static const JSC::Intrinsic s_readableStreamInternalsPipeToFinalizeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsPipeToFinalizeCode = "(function (pipeState){\"use strict\";if(@writableStreamDefaultWriterRelease(pipeState.writer),@readableStreamReaderGenericRelease(pipeState.reader),pipeState.finalized=!0,arguments.length>1)pipeState.promiseCapability.reject.@call(@undefined,arguments[1]);else pipeState.promiseCapability.resolve.@call()})\n";
+
+// readableStreamTee
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamTeeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamTeeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamTeeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamTeeCodeLength = 1383;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamTeeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamTeeCode = "(function (stream,shouldClone){\"use strict\";var start_=@getByIdDirectPrivate(stream,\"start\");if(start_)@putByIdDirectPrivate(stream,\"start\",@undefined),start_();const reader=new @ReadableStreamDefaultReader(stream),teeState={closedOrErrored:!1,canceled1:!1,canceled2:!1,reason1:@undefined,reason2:@undefined};teeState.cancelPromiseCapability=@newPromiseCapability(@Promise);const pullFunction=@readableStreamTeePullFunction(teeState,reader,shouldClone),branch1Source={};@putByIdDirectPrivate(branch1Source,\"pull\",pullFunction),@putByIdDirectPrivate(branch1Source,\"cancel\",@readableStreamTeeBranch1CancelFunction(teeState,stream));const branch2Source={};@putByIdDirectPrivate(branch2Source,\"pull\",pullFunction),@putByIdDirectPrivate(branch2Source,\"cancel\",@readableStreamTeeBranch2CancelFunction(teeState,stream));const branch1=new @ReadableStream(branch1Source),branch2=new @ReadableStream(branch2Source);return @getByIdDirectPrivate(reader,\"closedPromiseCapability\").promise.@then(@undefined,function(e){if(teeState.closedOrErrored)return;if(@readableStreamDefaultControllerError(branch1.@readableStreamController,e),@readableStreamDefaultControllerError(branch2.@readableStreamController,e),teeState.closedOrErrored=!0,!teeState.canceled1||!teeState.canceled2)teeState.cancelPromiseCapability.resolve.@call()}),teeState.branch1=branch1,teeState.branch2=branch2,[branch1,branch2]})\n";
+
+// readableStreamTeePullFunction
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamTeePullFunctionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamTeePullFunctionCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamTeePullFunctionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamTeePullFunctionCodeLength = 866;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamTeePullFunctionCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamTeePullFunctionCode = "(function (teeState,reader,shouldClone){\"use strict\";return function(){@Promise.prototype.@then.@call(@readableStreamDefaultReaderRead(reader),function(result){if(result.done&&!teeState.closedOrErrored){if(!teeState.canceled1)@readableStreamDefaultControllerClose(teeState.branch1.@readableStreamController);if(!teeState.canceled2)@readableStreamDefaultControllerClose(teeState.branch2.@readableStreamController);if(teeState.closedOrErrored=!0,!teeState.canceled1||!teeState.canceled2)teeState.cancelPromiseCapability.resolve.@call()}if(teeState.closedOrErrored)return;if(!teeState.canceled1)@readableStreamDefaultControllerEnqueue(teeState.branch1.@readableStreamController,result.value);if(!teeState.canceled2)@readableStreamDefaultControllerEnqueue(teeState.branch2.@readableStreamController,shouldClone\?@structuredCloneForStream(result.value):result.value)})}})\n";
+
+// readableStreamTeeBranch1CancelFunction
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCodeLength = 330;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamTeeBranch1CancelFunctionCode = "(function (teeState,stream){\"use strict\";return function(r){if(teeState.canceled1=!0,teeState.reason1=r,teeState.canceled2)@readableStreamCancel(stream,[teeState.reason1,teeState.reason2]).@then(teeState.cancelPromiseCapability.@resolve,teeState.cancelPromiseCapability.@reject);return teeState.cancelPromiseCapability.promise}})\n";
+
+// readableStreamTeeBranch2CancelFunction
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCodeLength = 330;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamTeeBranch2CancelFunctionCode = "(function (teeState,stream){\"use strict\";return function(r){if(teeState.canceled2=!0,teeState.reason2=r,teeState.canceled1)@readableStreamCancel(stream,[teeState.reason1,teeState.reason2]).@then(teeState.cancelPromiseCapability.@resolve,teeState.cancelPromiseCapability.@reject);return teeState.cancelPromiseCapability.promise}})\n";
+
+// isReadableStream
+const JSC::ConstructAbility s_readableStreamInternalsIsReadableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsIsReadableStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsIsReadableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsIsReadableStreamCodeLength = 130;
+static const JSC::Intrinsic s_readableStreamInternalsIsReadableStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsIsReadableStreamCode = "(function (stream){\"use strict\";return @isObject(stream)&&@getByIdDirectPrivate(stream,\"readableStreamController\")!==@undefined})\n";
+
+// isReadableStreamDefaultReader
+const JSC::ConstructAbility s_readableStreamInternalsIsReadableStreamDefaultReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsIsReadableStreamDefaultReaderCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsIsReadableStreamDefaultReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsIsReadableStreamDefaultReaderCodeLength = 107;
+static const JSC::Intrinsic s_readableStreamInternalsIsReadableStreamDefaultReaderCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsIsReadableStreamDefaultReaderCode = "(function (reader){\"use strict\";return @isObject(reader)&&!!@getByIdDirectPrivate(reader,\"readRequests\")})\n";
+
+// isReadableStreamDefaultController
+const JSC::ConstructAbility s_readableStreamInternalsIsReadableStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsIsReadableStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsIsReadableStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsIsReadableStreamDefaultControllerCodeLength = 123;
+static const JSC::Intrinsic s_readableStreamInternalsIsReadableStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsIsReadableStreamDefaultControllerCode = "(function (controller){\"use strict\";return @isObject(controller)&&!!@getByIdDirectPrivate(controller,\"underlyingSource\")})\n";
+
+// readDirectStream
+const JSC::ConstructAbility s_readableStreamInternalsReadDirectStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadDirectStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadDirectStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadDirectStreamCodeLength = 1281;
+static const JSC::Intrinsic s_readableStreamInternalsReadDirectStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadDirectStreamCode = "(function (stream,sink,underlyingSource){\"use strict\";@putByIdDirectPrivate(stream,\"underlyingSource\",@undefined),@putByIdDirectPrivate(stream,\"start\",@undefined);function close(stream2,reason){if(reason&&underlyingSource\?.cancel){try{var prom=underlyingSource.cancel(reason);@markPromiseAsHandled(prom)}catch(e){}underlyingSource=@undefined}if(stream2){if(@putByIdDirectPrivate(stream2,\"readableStreamController\",@undefined),@putByIdDirectPrivate(stream2,\"reader\",@undefined),reason)@putByIdDirectPrivate(stream2,\"state\",@streamErrored),@putByIdDirectPrivate(stream2,\"storedError\",reason);else @putByIdDirectPrivate(stream2,\"state\",@streamClosed);stream2=@undefined}}if(!underlyingSource.pull){close();return}if(!@isCallable(underlyingSource.pull)){close(),@throwTypeError(\"pull is not a function\");return}@putByIdDirectPrivate(stream,\"readableStreamController\",sink);const highWaterMark=@getByIdDirectPrivate(stream,\"highWaterMark\");sink.start({highWaterMark:!highWaterMark||highWaterMark<64\?64:highWaterMark}),@startDirectStream.@call(sink,stream,underlyingSource.pull,close,stream.@asyncContext),@putByIdDirectPrivate(stream,\"reader\",{});var maybePromise=underlyingSource.pull(sink);if(sink=@undefined,maybePromise&&@isPromise(maybePromise))return maybePromise.@then(()=>{})})\n";
+
+// assignToStream
+const JSC::ConstructAbility s_readableStreamInternalsAssignToStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsAssignToStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsAssignToStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
+const int s_readableStreamInternalsAssignToStreamCodeLength = 318;
+static const JSC::Intrinsic s_readableStreamInternalsAssignToStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsAssignToStreamCode = "(function (stream,sink){\"use strict\";var underlyingSource=@getByIdDirectPrivate(stream,\"underlyingSource\");if(underlyingSource)try{return @readDirectStream(stream,sink,underlyingSource)}catch(e){throw e}finally{underlyingSource=@undefined,stream=@undefined,sink=@undefined}return @readStreamIntoSink(stream,sink,!0)})\n";
+
+// readStreamIntoSink
+const JSC::ConstructAbility s_readableStreamInternalsReadStreamIntoSinkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadStreamIntoSinkCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadStreamIntoSinkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadStreamIntoSinkCodeLength = 1943;
+static const JSC::Intrinsic s_readableStreamInternalsReadStreamIntoSinkCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadStreamIntoSinkCode = "(async function (stream,sink,isNative){\"use strict\";var didClose=!1,didThrow=!1;try{var reader=stream.getReader(),many=reader.readMany();if(many&&@isPromise(many))many=await many;if(many.done)return didClose=!0,sink.end();var wroteCount=many.value.length;const highWaterMark=@getByIdDirectPrivate(stream,\"highWaterMark\");if(isNative)@startDirectStream.@call(sink,stream,@undefined,()=>!didThrow&&@markPromiseAsHandled(stream.cancel()),stream.@asyncContext);sink.start({highWaterMark:highWaterMark||0});for(var i=0,values=many.value,length=many.value.length;i<length;i++)sink.write(values[i]);var streamState=@getByIdDirectPrivate(stream,\"state\");if(streamState===@streamClosed)return didClose=!0,sink.end();while(!0){var{value,done}=await reader.read();if(done)return didClose=!0,sink.end();sink.write(value)}}catch(e){didThrow=!0;try{reader=@undefined;const prom=stream.cancel(e);@markPromiseAsHandled(prom)}catch(j){}if(sink&&!didClose){didClose=!0;try{sink.close(e)}catch(j){throw new globalThis.AggregateError([e,j])}}throw e}finally{if(reader){try{reader.releaseLock()}catch(e){}reader=@undefined}sink=@undefined;var streamState=@getByIdDirectPrivate(stream,\"state\");if(stream){var readableStreamController=@getByIdDirectPrivate(stream,\"readableStreamController\");if(readableStreamController){if(@getByIdDirectPrivate(readableStreamController,\"underlyingSource\"))@putByIdDirectPrivate(readableStreamController,\"underlyingSource\",@undefined);if(@getByIdDirectPrivate(readableStreamController,\"controlledReadableStream\"))@putByIdDirectPrivate(readableStreamController,\"controlledReadableStream\",@undefined);if(@putByIdDirectPrivate(stream,\"readableStreamController\",null),@getByIdDirectPrivate(stream,\"underlyingSource\"))@putByIdDirectPrivate(stream,\"underlyingSource\",@undefined);readableStreamController=@undefined}if(!didThrow&&streamState!==@streamClosed&&streamState!==@streamErrored)@readableStreamClose(stream);stream=@undefined}}})\n";
+
+// handleDirectStreamError
+const JSC::ConstructAbility s_readableStreamInternalsHandleDirectStreamErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsHandleDirectStreamErrorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsHandleDirectStreamErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsHandleDirectStreamErrorCodeLength = 584;
+static const JSC::Intrinsic s_readableStreamInternalsHandleDirectStreamErrorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsHandleDirectStreamErrorCode = "(function (e){\"use strict\";var controller=this,sink=controller.@sink;if(sink){@putByIdDirectPrivate(controller,\"sink\",@undefined);try{sink.close(e)}catch(f){}}if(this.error=this.flush=this.write=this.close=this.end=@onReadableStreamDirectControllerClosed,typeof this.@underlyingSource.close===\"function\")try{this.@underlyingSource.close.@call(this.@underlyingSource,e)}catch(e2){}try{var pend=controller._pendingRead;if(pend)controller._pendingRead=@undefined,@rejectPromise(pend,e)}catch(f){}var stream=controller.@controlledReadableStream;if(stream)@readableStreamError(stream,e)})\n";
+
+// handleDirectStreamErrorReject
+const JSC::ConstructAbility s_readableStreamInternalsHandleDirectStreamErrorRejectCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsHandleDirectStreamErrorRejectCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsHandleDirectStreamErrorRejectCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsHandleDirectStreamErrorRejectCodeLength = 95;
+static const JSC::Intrinsic s_readableStreamInternalsHandleDirectStreamErrorRejectCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsHandleDirectStreamErrorRejectCode = "(function (e){\"use strict\";return @handleDirectStreamError.@call(this,e),@Promise.@reject(e)})\n";
+
+// onPullDirectStream
+const JSC::ConstructAbility s_readableStreamInternalsOnPullDirectStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsOnPullDirectStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsOnPullDirectStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsOnPullDirectStreamCodeLength = 1356;
+static const JSC::Intrinsic s_readableStreamInternalsOnPullDirectStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsOnPullDirectStreamCode = "(function (controller){\"use strict\";var stream=controller.@controlledReadableStream;if(!stream||@getByIdDirectPrivate(stream,\"state\")!==@streamReadable)return;if(controller._deferClose===-1)return;controller._deferClose=-1,controller._deferFlush=-1;var deferClose,deferFlush,asyncContext=stream.@asyncContext;if(asyncContext){var prev=@getInternalField(@asyncContext,0);@putInternalField(@asyncContext,0,asyncContext)}try{var result=controller.@underlyingSource.pull(controller);if(result&&@isPromise(result)){if(controller._handleError===@undefined)controller._handleError=@handleDirectStreamErrorReject.bind(controller);@Promise.prototype.catch.@call(result,controller._handleError)}}catch(e){return @handleDirectStreamErrorReject.@call(controller,e)}finally{if(deferClose=controller._deferClose,deferFlush=controller._deferFlush,controller._deferFlush=controller._deferClose=0,asyncContext)@putInternalField(@asyncContext,0,prev)}var promiseToReturn;if(controller._pendingRead===@undefined)controller._pendingRead=promiseToReturn=@newPromise();else promiseToReturn=@readableStreamAddReadRequest(stream);if(deferClose===1){var reason=controller._deferCloseReason;return controller._deferCloseReason=@undefined,@onCloseDirectStream.@call(controller,reason),promiseToReturn}if(deferFlush===1)@onFlushDirectStream.@call(controller);return promiseToReturn})\n";
+
+// noopDoneFunction
+const JSC::ConstructAbility s_readableStreamInternalsNoopDoneFunctionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsNoopDoneFunctionCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsNoopDoneFunctionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsNoopDoneFunctionCodeLength = 81;
+static const JSC::Intrinsic s_readableStreamInternalsNoopDoneFunctionCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsNoopDoneFunctionCode = "(function (){\"use strict\";return @Promise.@resolve({value:@undefined,done:!0})})\n";
+
+// onReadableStreamDirectControllerClosed
+const JSC::ConstructAbility s_readableStreamInternalsOnReadableStreamDirectControllerClosedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsOnReadableStreamDirectControllerClosedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsOnReadableStreamDirectControllerClosedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsOnReadableStreamDirectControllerClosedCodeLength = 98;
+static const JSC::Intrinsic s_readableStreamInternalsOnReadableStreamDirectControllerClosedCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsOnReadableStreamDirectControllerClosedCode = "(function (reason){\"use strict\";@throwTypeError(\"ReadableStreamDirectController is now closed\")})\n";
+
+// onCloseDirectStream
+const JSC::ConstructAbility s_readableStreamInternalsOnCloseDirectStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsOnCloseDirectStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsOnCloseDirectStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsOnCloseDirectStreamCodeLength = 1696;
+static const JSC::Intrinsic s_readableStreamInternalsOnCloseDirectStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsOnCloseDirectStreamCode = "(function (reason){\"use strict\";var stream=this.@controlledReadableStream;if(!stream||@getByIdDirectPrivate(stream,\"state\")!==@streamReadable)return;if(this._deferClose!==0){this._deferClose=1,this._deferCloseReason=reason;return}if(@putByIdDirectPrivate(stream,\"state\",@streamClosing),typeof this.@underlyingSource.close===\"function\")try{this.@underlyingSource.close.@call(this.@underlyingSource,reason)}catch(e){}var flushed;try{flushed=this.@sink.end(),@putByIdDirectPrivate(this,\"sink\",@undefined)}catch(e){if(this._pendingRead){var read=this._pendingRead;this._pendingRead=@undefined,@rejectPromise(read,e)}@readableStreamError(stream,e);return}this.error=this.flush=this.write=this.close=this.end=@onReadableStreamDirectControllerClosed;var reader=@getByIdDirectPrivate(stream,\"reader\");if(reader&&@isReadableStreamDefaultReader(reader)){var _pendingRead=this._pendingRead;if(_pendingRead&&@isPromise(_pendingRead)&&flushed\?.byteLength){this._pendingRead=@undefined,@fulfillPromise(_pendingRead,{value:flushed,done:!1}),@readableStreamClose(stream);return}}if(flushed\?.byteLength){var requests=@getByIdDirectPrivate(reader,\"readRequests\");if(requests\?.isNotEmpty()){@readableStreamFulfillReadRequest(stream,flushed,!1),@readableStreamClose(stream);return}@putByIdDirectPrivate(stream,\"state\",@streamReadable),this.@pull=()=>{var thisResult=@createFulfilledPromise({value:flushed,done:!1});return flushed=@undefined,@readableStreamClose(stream),stream=@undefined,thisResult}}else if(this._pendingRead){var read=this._pendingRead;this._pendingRead=@undefined,@putByIdDirectPrivate(this,\"pull\",@noopDoneFunction),@fulfillPromise(read,{value:@undefined,done:!0})}@readableStreamClose(stream)})\n";
+
+// onFlushDirectStream
+const JSC::ConstructAbility s_readableStreamInternalsOnFlushDirectStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsOnFlushDirectStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsOnFlushDirectStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsOnFlushDirectStreamCodeLength = 722;
+static const JSC::Intrinsic s_readableStreamInternalsOnFlushDirectStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsOnFlushDirectStreamCode = "(function (){\"use strict\";var stream=this.@controlledReadableStream,reader=@getByIdDirectPrivate(stream,\"reader\");if(!reader||!@isReadableStreamDefaultReader(reader))return;var _pendingRead=this._pendingRead;if(this._pendingRead=@undefined,_pendingRead&&@isPromise(_pendingRead)){var flushed=this.@sink.flush();if(flushed\?.byteLength)this._pendingRead=@getByIdDirectPrivate(stream,\"readRequests\")\?.shift(),@fulfillPromise(_pendingRead,{value:flushed,done:!1});else this._pendingRead=_pendingRead}else if(@getByIdDirectPrivate(stream,\"readRequests\")\?.isNotEmpty()){var flushed=this.@sink.flush();if(flushed\?.byteLength)@readableStreamFulfillReadRequest(stream,flushed,!1)}else if(this._deferFlush===-1)this._deferFlush=1})\n";
+
+// createTextStream
+const JSC::ConstructAbility s_readableStreamInternalsCreateTextStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsCreateTextStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsCreateTextStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsCreateTextStreamCodeLength = 1479;
+static const JSC::Intrinsic s_readableStreamInternalsCreateTextStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsCreateTextStreamCode = "(function (highWaterMark){\"use strict\";var sink,array=[],hasString=!1,hasBuffer=!1,rope=\"\",estimatedLength=@toLength(0),capability=@newPromiseCapability(@Promise),calledDone=!1;return sink={start(){},write(chunk){if(typeof chunk===\"string\"){var chunkLength=@toLength(chunk.length);if(chunkLength>0)rope+=chunk,hasString=!0,estimatedLength+=chunkLength;return chunkLength}if(!chunk||!(@ArrayBuffer.@isView(chunk)||chunk instanceof @ArrayBuffer))@throwTypeError(\"Expected text, ArrayBuffer or ArrayBufferView\");const byteLength=@toLength(chunk.byteLength);if(byteLength>0)if(hasBuffer=!0,rope.length>0)@arrayPush(array,rope,chunk),rope=\"\";else @arrayPush(array,chunk);return estimatedLength+=byteLength,byteLength},flush(){return 0},end(){if(calledDone)return\"\";return sink.fulfill()},fulfill(){calledDone=!0;const result=sink.finishInternal();return @fulfillPromise(capability.promise,result),result},finishInternal(){if(!hasString&&!hasBuffer)return\"\";if(hasString&&!hasBuffer)return rope;if(hasBuffer&&!hasString)return new globalThis.TextDecoder().decode(@Bun.concatArrayBuffers(array));var arrayBufferSink=new @Bun.ArrayBufferSink;arrayBufferSink.start({highWaterMark:estimatedLength,asUint8Array:!0});for(let item of array)arrayBufferSink.write(item);if(array.length=0,rope.length>0)arrayBufferSink.write(rope),rope=\"\";return new globalThis.TextDecoder().decode(arrayBufferSink.end())},close(){try{if(!calledDone)calledDone=!0,sink.fulfill()}catch(e){}}},[sink,capability]})\n";
+
+// initializeTextStream
+const JSC::ConstructAbility s_readableStreamInternalsInitializeTextStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsInitializeTextStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsInitializeTextStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsInitializeTextStreamCodeLength = 685;
+static const JSC::Intrinsic s_readableStreamInternalsInitializeTextStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsInitializeTextStreamCode = "(function (underlyingSource,highWaterMark){\"use strict\";var[sink,closingPromise]=@createTextStream(highWaterMark),controller={@underlyingSource:underlyingSource,@pull:@onPullDirectStream,@controlledReadableStream:this,@sink:sink,close:@onCloseDirectStream,write:sink.write,error:@handleDirectStreamError,end:@onCloseDirectStream,@close:@onCloseDirectStream,flush:@onFlushDirectStream,_pendingRead:@undefined,_deferClose:0,_deferFlush:0,_deferCloseReason:@undefined,_handleError:@undefined};return @putByIdDirectPrivate(this,\"readableStreamController\",controller),@putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@putByIdDirectPrivate(this,\"start\",@undefined),closingPromise})\n";
+
+// initializeArrayStream
+const JSC::ConstructAbility s_readableStreamInternalsInitializeArrayStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsInitializeArrayStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsInitializeArrayStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsInitializeArrayStreamCodeLength = 990;
+static const JSC::Intrinsic s_readableStreamInternalsInitializeArrayStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsInitializeArrayStreamCode = "(function (underlyingSource,highWaterMark){\"use strict\";var array=[],closingPromise=@newPromiseCapability(@Promise),calledDone=!1;function fulfill(){return calledDone=!0,closingPromise.resolve.@call(@undefined,array),array}var sink={start(){},write(chunk){return @arrayPush(array,chunk),chunk.byteLength||chunk.length},flush(){return 0},end(){if(calledDone)return[];return fulfill()},close(){if(!calledDone)fulfill()}},controller={@underlyingSource:underlyingSource,@pull:@onPullDirectStream,@controlledReadableStream:this,@sink:sink,close:@onCloseDirectStream,write:sink.write,error:@handleDirectStreamError,end:@onCloseDirectStream,@close:@onCloseDirectStream,flush:@onFlushDirectStream,_pendingRead:@undefined,_deferClose:0,_deferFlush:0,_deferCloseReason:@undefined,_handleError:@undefined};return @putByIdDirectPrivate(this,\"readableStreamController\",controller),@putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@putByIdDirectPrivate(this,\"start\",@undefined),closingPromise})\n";
+
+// initializeArrayBufferStream
+const JSC::ConstructAbility s_readableStreamInternalsInitializeArrayBufferStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsInitializeArrayBufferStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsInitializeArrayBufferStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsInitializeArrayBufferStreamCodeLength = 793;
+static const JSC::Intrinsic s_readableStreamInternalsInitializeArrayBufferStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsInitializeArrayBufferStreamCode = "(function (underlyingSource,highWaterMark){\"use strict\";var opts=highWaterMark&&typeof highWaterMark===\"number\"\?{highWaterMark,stream:!0,asUint8Array:!0}:{stream:!0,asUint8Array:!0},sink=new @Bun.ArrayBufferSink;sink.start(opts);var controller={@underlyingSource:underlyingSource,@pull:@onPullDirectStream,@controlledReadableStream:this,@sink:sink,close:@onCloseDirectStream,write:sink.write.bind(sink),error:@handleDirectStreamError,end:@onCloseDirectStream,@close:@onCloseDirectStream,flush:@onFlushDirectStream,_pendingRead:@undefined,_deferClose:0,_deferFlush:0,_deferCloseReason:@undefined,_handleError:@undefined};@putByIdDirectPrivate(this,\"readableStreamController\",controller),@putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@putByIdDirectPrivate(this,\"start\",@undefined)})\n";
+
+// readableStreamError
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamErrorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamErrorCodeLength = 895;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamErrorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamErrorCode = "(function (stream,error){\"use strict\";@putByIdDirectPrivate(stream,\"state\",@streamErrored),@putByIdDirectPrivate(stream,\"storedError\",error);const reader=@getByIdDirectPrivate(stream,\"reader\");if(!reader)return;if(@isReadableStreamDefaultReader(reader)){const requests=@getByIdDirectPrivate(reader,\"readRequests\");@putByIdDirectPrivate(reader,\"readRequests\",@createFIFO());for(var request=requests.shift();request;request=requests.shift())@rejectPromise(request,error)}else{const requests=@getByIdDirectPrivate(reader,\"readIntoRequests\");@putByIdDirectPrivate(reader,\"readIntoRequests\",@createFIFO());for(var request=requests.shift();request;request=requests.shift())@rejectPromise(request,error)}@getByIdDirectPrivate(reader,\"closedPromiseCapability\").reject.@call(@undefined,error);const promise=@getByIdDirectPrivate(reader,\"closedPromiseCapability\").promise;@markPromiseAsHandled(promise)})\n";
+
+// readableStreamDefaultControllerShouldCallPull
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCodeLength = 518;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefaultControllerShouldCallPullCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(!@readableStreamDefaultControllerCanCloseOrEnqueue(controller))return!1;if(@getByIdDirectPrivate(controller,\"started\")!==1)return!1;if((!@isReadableStreamLocked(stream)||!@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\")\?.isNotEmpty())&&@readableStreamDefaultControllerGetDesiredSize(controller)<=0)return!1;return @readableStreamDefaultControllerGetDesiredSize(controller)>0})\n";
+
+// readableStreamDefaultControllerCallPullIfNeeded
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCodeLength = 961;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefaultControllerCallPullIfNeededCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(!@readableStreamDefaultControllerCanCloseOrEnqueue(controller))return;if(@getByIdDirectPrivate(controller,\"started\")!==1)return;if((!@isReadableStreamLocked(stream)||!@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\")\?.isNotEmpty())&&@readableStreamDefaultControllerGetDesiredSize(controller)<=0)return;if(@getByIdDirectPrivate(controller,\"pulling\")){@putByIdDirectPrivate(controller,\"pullAgain\",!0);return}@putByIdDirectPrivate(controller,\"pulling\",!0),@getByIdDirectPrivate(controller,\"pullAlgorithm\").@call(@undefined).@then(function(){if(@putByIdDirectPrivate(controller,\"pulling\",!1),@getByIdDirectPrivate(controller,\"pullAgain\"))@putByIdDirectPrivate(controller,\"pullAgain\",!1),@readableStreamDefaultControllerCallPullIfNeeded(controller)},function(error){@readableStreamDefaultControllerError(controller,error)})})\n";
+
+// isReadableStreamLocked
+const JSC::ConstructAbility s_readableStreamInternalsIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsIsReadableStreamLockedCodeLength = 81;
+static const JSC::Intrinsic s_readableStreamInternalsIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsIsReadableStreamLockedCode = "(function (stream){\"use strict\";return!!@getByIdDirectPrivate(stream,\"reader\")})\n";
+
+// readableStreamDefaultControllerGetDesiredSize
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCodeLength = 341;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefaultControllerGetDesiredSizeCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\"),state=@getByIdDirectPrivate(stream,\"state\");if(state===@streamErrored)return null;if(state===@streamClosed)return 0;return @getByIdDirectPrivate(controller,\"strategy\").highWaterMark-@getByIdDirectPrivate(controller,\"queue\").size})\n";
+
+// readableStreamReaderGenericCancel
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamReaderGenericCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamReaderGenericCancelCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamReaderGenericCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamReaderGenericCancelCodeLength = 150;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamReaderGenericCancelCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamReaderGenericCancelCode = "(function (reader,reason){\"use strict\";const stream=@getByIdDirectPrivate(reader,\"ownerReadableStream\");return @readableStreamCancel(stream,reason)})\n";
+
+// readableStreamCancel
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamCancelCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamCancelCodeLength = 634;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamCancelCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamCancelCode = "(function (stream,reason){\"use strict\";@putByIdDirectPrivate(stream,\"disturbed\",!0);const state=@getByIdDirectPrivate(stream,\"state\");if(state===@streamClosed)return @Promise.@resolve();if(state===@streamErrored)return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));@readableStreamClose(stream);var controller=@getByIdDirectPrivate(stream,\"readableStreamController\"),cancel=controller.@cancel;if(cancel)return cancel(controller,reason).@then(function(){});var close=controller.close;if(close)return @Promise.@resolve(controller.close(reason));@throwTypeError(\"ReadableStreamController has no cancel or close method\")})\n";
+
+// readableStreamDefaultControllerCancel
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerCancelCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefaultControllerCancelCodeLength = 183;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerCancelCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefaultControllerCancelCode = "(function (controller,reason){\"use strict\";return @putByIdDirectPrivate(controller,\"queue\",@newQueue()),@getByIdDirectPrivate(controller,\"cancelAlgorithm\").@call(@undefined,reason)})\n";
+
+// readableStreamDefaultControllerPull
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerPullCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerPullCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerPullCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefaultControllerPullCodeLength = 632;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerPullCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefaultControllerPullCode = "(function (controller){\"use strict\";var queue=@getByIdDirectPrivate(controller,\"queue\");if(queue.content.isNotEmpty()){const chunk=@dequeueValue(queue);if(@getByIdDirectPrivate(controller,\"closeRequested\")&&queue.content.isEmpty())@readableStreamClose(@getByIdDirectPrivate(controller,\"controlledReadableStream\"));else @readableStreamDefaultControllerCallPullIfNeeded(controller);return @createFulfilledPromise({value:chunk,done:!1})}const pendingPromise=@readableStreamAddReadRequest(@getByIdDirectPrivate(controller,\"controlledReadableStream\"));return @readableStreamDefaultControllerCallPullIfNeeded(controller),pendingPromise})\n";
+
+// readableStreamDefaultControllerClose
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerCloseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefaultControllerCloseCodeLength = 240;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerCloseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefaultControllerCloseCode = "(function (controller){\"use strict\";if(@putByIdDirectPrivate(controller,\"closeRequested\",!0),@getByIdDirectPrivate(controller,\"queue\")\?.content\?.isEmpty())@readableStreamClose(@getByIdDirectPrivate(controller,\"controlledReadableStream\"))})\n";
+
+// readableStreamClose
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamCloseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamCloseCodeLength = 643;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamCloseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamCloseCode = "(function (stream){\"use strict\";if(@putByIdDirectPrivate(stream,\"state\",@streamClosed),!@getByIdDirectPrivate(stream,\"reader\"))return;if(@isReadableStreamDefaultReader(@getByIdDirectPrivate(stream,\"reader\"))){const requests=@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\");if(requests.isNotEmpty()){@putByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\",@createFIFO());for(var request=requests.shift();request;request=requests.shift())@fulfillPromise(request,{value:@undefined,done:!0})}}@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"closedPromiseCapability\").resolve.@call()})\n";
+
+// readableStreamFulfillReadRequest
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamFulfillReadRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamFulfillReadRequestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamFulfillReadRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamFulfillReadRequestCodeLength = 196;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamFulfillReadRequestCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamFulfillReadRequestCode = "(function (stream,chunk,done){\"use strict\";const readRequest=@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\").shift();@fulfillPromise(readRequest,{value:chunk,done})})\n";
+
+// readableStreamDefaultControllerEnqueue
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCodeLength = 741;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefaultControllerEnqueueCode = "(function (controller,chunk){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(@isReadableStreamLocked(stream)&&@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\")\?.isNotEmpty()){@readableStreamFulfillReadRequest(stream,chunk,!1),@readableStreamDefaultControllerCallPullIfNeeded(controller);return}try{let chunkSize=1;if(@getByIdDirectPrivate(controller,\"strategy\").size!==@undefined)chunkSize=@getByIdDirectPrivate(controller,\"strategy\").size(chunk);@enqueueValueWithSize(@getByIdDirectPrivate(controller,\"queue\"),chunk,chunkSize)}catch(error){throw @readableStreamDefaultControllerError(controller,error),error}@readableStreamDefaultControllerCallPullIfNeeded(controller)})\n";
+
+// readableStreamDefaultReaderRead
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultReaderReadCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultReaderReadCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultReaderReadCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefaultReaderReadCodeLength = 495;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultReaderReadCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefaultReaderReadCode = "(function (reader){\"use strict\";const stream=@getByIdDirectPrivate(reader,\"ownerReadableStream\"),state=@getByIdDirectPrivate(stream,\"state\");if(@putByIdDirectPrivate(stream,\"disturbed\",!0),state===@streamClosed)return @createFulfilledPromise({value:@undefined,done:!0});if(state===@streamErrored)return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));return @getByIdDirectPrivate(stream,\"readableStreamController\").@pull(@getByIdDirectPrivate(stream,\"readableStreamController\"))})\n";
+
+// readableStreamAddReadRequest
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamAddReadRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamAddReadRequestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamAddReadRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamAddReadRequestCodeLength = 180;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamAddReadRequestCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamAddReadRequestCode = "(function (stream){\"use strict\";const readRequest=@newPromise();return @getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\").push(readRequest),readRequest})\n";
+
+// isReadableStreamDisturbed
+const JSC::ConstructAbility s_readableStreamInternalsIsReadableStreamDisturbedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsIsReadableStreamDisturbedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsIsReadableStreamDisturbedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsIsReadableStreamDisturbedCodeLength = 83;
+static const JSC::Intrinsic s_readableStreamInternalsIsReadableStreamDisturbedCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsIsReadableStreamDisturbedCode = "(function (stream){\"use strict\";return @getByIdDirectPrivate(stream,\"disturbed\")})\n";
+
+// readableStreamReaderGenericRelease
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamReaderGenericReleaseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamReaderGenericReleaseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamReaderGenericReleaseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamReaderGenericReleaseCodeLength = 707;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamReaderGenericReleaseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamReaderGenericReleaseCode = "(function (reader){\"use strict\";if(@getByIdDirectPrivate(@getByIdDirectPrivate(reader,\"ownerReadableStream\"),\"state\")===@streamReadable)@getByIdDirectPrivate(reader,\"closedPromiseCapability\").reject.@call(@undefined,@makeTypeError(\"releasing lock of reader whose stream is still in readable state\"));else @putByIdDirectPrivate(reader,\"closedPromiseCapability\",{promise:@newHandledRejectedPromise(@makeTypeError(\"reader released lock\"))});const promise=@getByIdDirectPrivate(reader,\"closedPromiseCapability\").promise;@markPromiseAsHandled(promise),@putByIdDirectPrivate(@getByIdDirectPrivate(reader,\"ownerReadableStream\"),\"reader\",@undefined),@putByIdDirectPrivate(reader,\"ownerReadableStream\",@undefined)})\n";
+
+// readableStreamDefaultControllerCanCloseOrEnqueue
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCodeLength = 207;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefaultControllerCanCloseOrEnqueueCode = "(function (controller){\"use strict\";return!@getByIdDirectPrivate(controller,\"closeRequested\")&&@getByIdDirectPrivate(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),\"state\")===@streamReadable})\n";
+
+// lazyLoadStream
+const JSC::ConstructAbility s_readableStreamInternalsLazyLoadStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsLazyLoadStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsLazyLoadStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsLazyLoadStreamCodeLength = 2994;
+static const JSC::Intrinsic s_readableStreamInternalsLazyLoadStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsLazyLoadStreamCode = "(function (stream,autoAllocateChunkSize){\"use strict\";var nativeType=@getByIdDirectPrivate(stream,\"bunNativeType\"),nativePtr=@getByIdDirectPrivate(stream,\"bunNativePtr\"),Prototype=@lazyStreamPrototypeMap.@get(nativeType);if(Prototype===@undefined){let handleNativeReadableStreamPromiseResult2=function(val){var{c,v}=this;this.c=@undefined,this.v=@undefined,handleResult(val,c,v)},callClose2=function(controller){try{if(@getByIdDirectPrivate(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),\"state\")===@streamReadable)controller.close()}catch(e){globalThis.reportError(e)}},createResult2=function(tag,controller,view,closer2){closer2[0]=!1;var result;try{result=pull(tag,view,closer2)}catch(err){return controller.error(err)}return handleResult(result,controller,view)};var handleNativeReadableStreamPromiseResult=handleNativeReadableStreamPromiseResult2,callClose=callClose2,createResult=createResult2,[pull,start,cancel,setClose,deinit,setRefOrUnref,drain]=@lazyLoad(nativeType),closer=[!1],handleResult;handleResult=function handleResult(result,controller,view){if(result&&@isPromise(result))return result.then(handleNativeReadableStreamPromiseResult2.bind({c:controller,v:view}),(err)=>controller.error(err));else if(typeof result===\"number\")if(view&&view.byteLength===result&&view.buffer===controller.byobRequest\?.view\?.buffer)controller.byobRequest.respondWithNewView(view);else controller.byobRequest.respond(result);else if(result.constructor===@Uint8Array)controller.enqueue(result);if(closer[0]||result===!1)@enqueueJob(callClose2,controller),closer[0]=!1};const registry=deinit\?new FinalizationRegistry(deinit):null;Prototype=class NativeReadableStreamSource{constructor(tag,autoAllocateChunkSize2,drainValue2){if(this.#tag=tag,this.#cancellationToken={},this.pull=this.#pull.bind(this),this.cancel=this.#cancel.bind(this),this.autoAllocateChunkSize=autoAllocateChunkSize2,drainValue2!==@undefined)this.start=(controller)=>{controller.enqueue(drainValue2)};if(registry)registry.register(this,tag,this.#cancellationToken)}#cancellationToken;pull;cancel;start;#tag;type=\"bytes\";autoAllocateChunkSize=0;static startSync=start;#pull(controller){var tag=this.#tag;if(!tag){controller.close();return}createResult2(tag,controller,controller.byobRequest.view,closer)}#cancel(reason){var tag=this.#tag;registry&&registry.unregister(this.#cancellationToken),setRefOrUnref&&setRefOrUnref(tag,!1),cancel(tag,reason)}static deinit=deinit;static drain=drain},@lazyStreamPrototypeMap.@set(nativeType,Prototype)}const chunkSize=Prototype.startSync(nativePtr,autoAllocateChunkSize);var drainValue;const{drain:drainFn,deinit:deinitFn}=Prototype;if(drainFn)drainValue=drainFn(nativePtr);if(chunkSize===0){if(deinit&&nativePtr&&@enqueueJob(deinit,nativePtr),(drainValue\?.byteLength\?\?0)>0)return{start(controller){controller.enqueue(drainValue),controller.close()},type:\"bytes\"};return{start(controller){controller.close()},type:\"bytes\"}}return new Prototype(nativePtr,chunkSize,drainValue)})\n";
+
+// readableStreamIntoArray
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamIntoArrayCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamIntoArrayCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamIntoArrayCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamIntoArrayCodeLength = 427;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamIntoArrayCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamIntoArrayCode = "(function (stream){\"use strict\";var reader=stream.getReader(),manyResult=reader.readMany();async function processManyResult(result){if(result.done)return[];var chunks=result.value||[];while(!0){var thisResult=await reader.read();if(thisResult.done)break;chunks=chunks.concat(thisResult.value)}return chunks}if(manyResult&&@isPromise(manyResult))return manyResult.@then(processManyResult);return processManyResult(manyResult)})\n";
+
+// readableStreamIntoText
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamIntoTextCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamIntoTextCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamIntoTextCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamIntoTextCodeLength = 272;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamIntoTextCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamIntoTextCode = "(function (stream){\"use strict\";const[textStream,closer]=@createTextStream(@getByIdDirectPrivate(stream,\"highWaterMark\")),prom=@readStreamIntoSink(stream,textStream,!1);if(prom&&@isPromise(prom))return @Promise.@resolve(prom).@then(closer.promise);return closer.promise})\n";
+
+// readableStreamToArrayBufferDirect
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamToArrayBufferDirectCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamToArrayBufferDirectCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamToArrayBufferDirectCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamToArrayBufferDirectCodeLength = 1079;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamToArrayBufferDirectCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamToArrayBufferDirectCode = "(function (stream,underlyingSource){\"use strict\";var sink=new @Bun.ArrayBufferSink;@putByIdDirectPrivate(stream,\"underlyingSource\",@undefined);var highWaterMark=@getByIdDirectPrivate(stream,\"highWaterMark\");sink.start(highWaterMark\?{highWaterMark}:{});var capability=@newPromiseCapability(@Promise),ended=!1,pull=underlyingSource.pull,close=underlyingSource.close,controller={start(){},close(reason){if(!ended){if(ended=!0,close)close();@fulfillPromise(capability.promise,sink.end())}},end(){if(!ended){if(ended=!0,close)close();@fulfillPromise(capability.promise,sink.end())}},flush(){return 0},write:sink.write.bind(sink)},didError=!1;try{const firstPull=pull(controller);if(firstPull&&@isObject(firstPull)&&@isPromise(firstPull))return async function(controller2,promise2,pull2){while(!ended)await pull2(controller2);return await promise2}(controller,promise,pull);return capability.promise}catch(e){return didError=!0,@readableStreamError(stream,e),@Promise.@reject(e)}finally{if(!didError&&stream)@readableStreamClose(stream);controller=close=sink=pull=stream=@undefined}})\n";
+
+// readableStreamToTextDirect
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamToTextDirectCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamToTextDirectCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamToTextDirectCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamToTextDirectCodeLength = 388;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamToTextDirectCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamToTextDirectCode = "(async function (stream,underlyingSource){\"use strict\";const capability=@initializeTextStream.@call(stream,underlyingSource,@undefined);var reader=stream.getReader();while(@getByIdDirectPrivate(stream,\"state\")===@streamReadable){var thisResult=await reader.read();if(thisResult.done)break}try{reader.releaseLock()}catch(e){}return reader=@undefined,stream=@undefined,capability.promise})\n";
+
+// readableStreamToArrayDirect
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamToArrayDirectCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamToArrayDirectCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamToArrayDirectCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamToArrayDirectCodeLength = 484;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamToArrayDirectCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamToArrayDirectCode = "(async function (stream,underlyingSource){\"use strict\";const capability=@initializeArrayStream.@call(stream,underlyingSource,@undefined);underlyingSource=@undefined;var reader=stream.getReader();try{while(@getByIdDirectPrivate(stream,\"state\")===@streamReadable){var thisResult=await reader.read();if(thisResult.done)break}try{reader.releaseLock()}catch(e){}return reader=@undefined,@Promise.@resolve(capability.promise)}catch(e){throw e}finally{stream=@undefined,reader=@undefined}})\n";
+
+// readableStreamDefineLazyIterators
+const JSC::ConstructAbility s_readableStreamInternalsReadableStreamDefineLazyIteratorsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInternalsReadableStreamDefineLazyIteratorsCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInternalsReadableStreamDefineLazyIteratorsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInternalsReadableStreamDefineLazyIteratorsCodeLength = 921;
+static const JSC::Intrinsic s_readableStreamInternalsReadableStreamDefineLazyIteratorsCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInternalsReadableStreamDefineLazyIteratorsCode = "(function (prototype){\"use strict\";var asyncIterator=globalThis.Symbol.asyncIterator,ReadableStreamAsyncIterator=async function*ReadableStreamAsyncIterator(stream,preventCancel){var reader=stream.getReader(),deferredError;try{while(!0){var done,value;const firstResult=reader.readMany();if(@isPromise(firstResult))({done,value}=await firstResult);else({done,value}=firstResult);if(done)return;yield*value}}catch(e){deferredError=e}finally{if(reader.releaseLock(),!preventCancel)stream.cancel(deferredError);if(deferredError)throw deferredError}},createAsyncIterator=function asyncIterator(){return ReadableStreamAsyncIterator(this,!1)},createValues=function values({preventCancel=!1}={preventCancel:!1}){return ReadableStreamAsyncIterator(this,preventCancel)};return @Object.@defineProperty(prototype,asyncIterator,{value:createAsyncIterator}),@Object.@defineProperty(prototype,\"values\",{value:createValues}),prototype})\n";
+
+#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
+{\
+    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
+    return clientData->builtinFunctions().readableStreamInternalsBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableStreamInternalsBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+}
+WEBCORE_FOREACH_READABLESTREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+#undef DEFINE_BUILTIN_GENERATOR
+
+/* TransformStreamDefaultController.ts */
+// initializeTransformStreamDefaultController
+const JSC::ConstructAbility s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeLength = 40;
+static const JSC::Intrinsic s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCode = "(function (){\"use strict\";return this})\n";
+
+// desiredSize
+const JSC::ConstructAbility s_transformStreamDefaultControllerDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_transformStreamDefaultControllerDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_transformStreamDefaultControllerDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_transformStreamDefaultControllerDesiredSizeCodeLength = 397;
+static const JSC::Intrinsic s_transformStreamDefaultControllerDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_transformStreamDefaultControllerDesiredSizeCode = "(function (){\"use strict\";if(!@isTransformStreamDefaultController(this))throw @makeThisTypeError(\"TransformStreamDefaultController\",\"enqueue\");const stream=@getByIdDirectPrivate(this,\"stream\"),readable=@getByIdDirectPrivate(stream,\"readable\"),readableController=@getByIdDirectPrivate(readable,\"readableStreamController\");return @readableStreamDefaultControllerGetDesiredSize(readableController)})\n";
+
+// enqueue
+const JSC::ConstructAbility s_transformStreamDefaultControllerEnqueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_transformStreamDefaultControllerEnqueueCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_transformStreamDefaultControllerEnqueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_transformStreamDefaultControllerEnqueueCodeLength = 203;
+static const JSC::Intrinsic s_transformStreamDefaultControllerEnqueueCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_transformStreamDefaultControllerEnqueueCode = "(function (chunk){\"use strict\";if(!@isTransformStreamDefaultController(this))throw @makeThisTypeError(\"TransformStreamDefaultController\",\"enqueue\");@transformStreamDefaultControllerEnqueue(this,chunk)})\n";
+
+// error
+const JSC::ConstructAbility s_transformStreamDefaultControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_transformStreamDefaultControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_transformStreamDefaultControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_transformStreamDefaultControllerErrorCodeLength = 191;
+static const JSC::Intrinsic s_transformStreamDefaultControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_transformStreamDefaultControllerErrorCode = "(function (e){\"use strict\";if(!@isTransformStreamDefaultController(this))throw @makeThisTypeError(\"TransformStreamDefaultController\",\"error\");@transformStreamDefaultControllerError(this,e)})\n";
+
+// terminate
+const JSC::ConstructAbility s_transformStreamDefaultControllerTerminateCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_transformStreamDefaultControllerTerminateCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_transformStreamDefaultControllerTerminateCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_transformStreamDefaultControllerTerminateCodeLength = 196;
+static const JSC::Intrinsic s_transformStreamDefaultControllerTerminateCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_transformStreamDefaultControllerTerminateCode = "(function (){\"use strict\";if(!@isTransformStreamDefaultController(this))throw @makeThisTypeError(\"TransformStreamDefaultController\",\"terminate\");@transformStreamDefaultControllerTerminate(this)})\n";
+
+#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
+{\
+    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
+    return clientData->builtinFunctions().transformStreamDefaultControllerBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().transformStreamDefaultControllerBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+}
+WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+#undef DEFINE_BUILTIN_GENERATOR
+
+/* ReadableStreamBYOBReader.ts */
+// initializeReadableStreamBYOBReader
+const JSC::ConstructAbility s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeLength = 510;
+static const JSC::Intrinsic s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCode = "(function (stream){\"use strict\";if(!@isReadableStream(stream))@throwTypeError(\"ReadableStreamBYOBReader needs a ReadableStream\");if(!@isReadableByteStreamController(@getByIdDirectPrivate(stream,\"readableStreamController\")))@throwTypeError(\"ReadableStreamBYOBReader needs a ReadableByteStreamController\");if(@isReadableStreamLocked(stream))@throwTypeError(\"ReadableStream is locked\");return @readableStreamReaderGenericInitialize(this,stream),@putByIdDirectPrivate(this,\"readIntoRequests\",@createFIFO()),this})\n";
+
+// cancel
+const JSC::ConstructAbility s_readableStreamBYOBReaderCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamBYOBReaderCancelCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamBYOBReaderCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamBYOBReaderCancelCodeLength = 361;
+static const JSC::Intrinsic s_readableStreamBYOBReaderCancelCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamBYOBReaderCancelCode = "(function (reason){\"use strict\";if(!@isReadableStreamBYOBReader(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStreamBYOBReader\",\"cancel\"));if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return @Promise.@reject(@makeTypeError(\"cancel() called on a reader owned by no readable stream\"));return @readableStreamReaderGenericCancel(this,reason)})\n";
+
+// read
+const JSC::ConstructAbility s_readableStreamBYOBReaderReadCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamBYOBReaderReadCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamBYOBReaderReadCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamBYOBReaderReadCodeLength = 663;
+static const JSC::Intrinsic s_readableStreamBYOBReaderReadCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamBYOBReaderReadCode = "(function (view){\"use strict\";if(!@isReadableStreamBYOBReader(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStreamBYOBReader\",\"read\"));if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return @Promise.@reject(@makeTypeError(\"read() called on a reader owned by no readable stream\"));if(!@isObject(view))return @Promise.@reject(@makeTypeError(\"Provided view is not an object\"));if(!@ArrayBuffer.@isView(view))return @Promise.@reject(@makeTypeError(\"Provided view is not an ArrayBufferView\"));if(view.byteLength===0)return @Promise.@reject(@makeTypeError(\"Provided view cannot have a 0 byteLength\"));return @readableStreamBYOBReaderRead(this,view)})\n";
+
+// releaseLock
+const JSC::ConstructAbility s_readableStreamBYOBReaderReleaseLockCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamBYOBReaderReleaseLockCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamBYOBReaderReleaseLockCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamBYOBReaderReleaseLockCodeLength = 382;
+static const JSC::Intrinsic s_readableStreamBYOBReaderReleaseLockCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamBYOBReaderReleaseLockCode = "(function (){\"use strict\";if(!@isReadableStreamBYOBReader(this))throw @makeThisTypeError(\"ReadableStreamBYOBReader\",\"releaseLock\");if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return;if(@getByIdDirectPrivate(this,\"readIntoRequests\")\?.isNotEmpty())@throwTypeError(\"There are still pending read requests, cannot release the lock\");@readableStreamReaderGenericRelease(this)})\n";
+
+// closed
+const JSC::ConstructAbility s_readableStreamBYOBReaderClosedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamBYOBReaderClosedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamBYOBReaderClosedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamBYOBReaderClosedCodeLength = 218;
+static const JSC::Intrinsic s_readableStreamBYOBReaderClosedCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamBYOBReaderClosedCode = "(function (){\"use strict\";if(!@isReadableStreamBYOBReader(this))return @Promise.@reject(@makeGetterTypeError(\"ReadableStreamBYOBReader\",\"closed\"));return @getByIdDirectPrivate(this,\"closedPromiseCapability\").promise})\n";
+
+#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
+{\
+    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
+    return clientData->builtinFunctions().readableStreamBYOBReaderBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableStreamBYOBReaderBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+}
+WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+#undef DEFINE_BUILTIN_GENERATOR
+
+/* JSBufferConstructor.ts */
+// from
+const JSC::ConstructAbility s_jsBufferConstructorFromCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_jsBufferConstructorFromCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_jsBufferConstructorFromCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_jsBufferConstructorFromCodeLength = 1274;
+static const JSC::Intrinsic s_jsBufferConstructorFromCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_jsBufferConstructorFromCode = "(function (items){\"use strict\";if(@isUndefinedOrNull(items))@throwTypeError(\"The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object.\");if(typeof items===\"string\"||typeof items===\"object\"&&(@isTypedArrayView(items)||items instanceof @ArrayBuffer||items instanceof SharedArrayBuffer||items instanceof @String))switch(@argumentCount()){case 1:return new @Buffer(items);case 2:return new @Buffer(items,@argument(1));default:return new @Buffer(items,@argument(1),@argument(2))}var arrayLike=@toObject(items,\"The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object.\");if(!@isJSArray(arrayLike)){const toPrimitive=@tryGetByIdWithWellKnownSymbol(items,\"toPrimitive\");if(toPrimitive){const primitive=toPrimitive.@call(items,\"string\");if(typeof primitive===\"string\")switch(@argumentCount()){case 1:return new @Buffer(primitive);case 2:return new @Buffer(primitive,@argument(1));default:return new @Buffer(primitive,@argument(1),@argument(2))}}if(!(\"length\"in arrayLike)||@isCallable(arrayLike))@throwTypeError(\"The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object.\")}return new @Buffer(@Uint8Array.from(arrayLike).buffer)})\n";
+
+// isBuffer
+const JSC::ConstructAbility s_jsBufferConstructorIsBufferCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_jsBufferConstructorIsBufferCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_jsBufferConstructorIsBufferCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_jsBufferConstructorIsBufferCodeLength = 75;
+static const JSC::Intrinsic s_jsBufferConstructorIsBufferCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_jsBufferConstructorIsBufferCode = "(function (bufferlike){\"use strict\";return bufferlike instanceof @Buffer})\n";
+
+#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
+{\
+    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
+    return clientData->builtinFunctions().jsBufferConstructorBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().jsBufferConstructorBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+}
+WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+#undef DEFINE_BUILTIN_GENERATOR
+
+/* ReadableStreamDefaultReader.ts */
+// initializeReadableStreamDefaultReader
+const JSC::ConstructAbility s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeLength = 334;
+static const JSC::Intrinsic s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCode = "(function (stream){\"use strict\";if(!@isReadableStream(stream))@throwTypeError(\"ReadableStreamDefaultReader needs a ReadableStream\");if(@isReadableStreamLocked(stream))@throwTypeError(\"ReadableStream is locked\");return @readableStreamReaderGenericInitialize(this,stream),@putByIdDirectPrivate(this,\"readRequests\",@createFIFO()),this})\n";
+
+// cancel
+const JSC::ConstructAbility s_readableStreamDefaultReaderCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamDefaultReaderCancelCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamDefaultReaderCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamDefaultReaderCancelCodeLength = 367;
+static const JSC::Intrinsic s_readableStreamDefaultReaderCancelCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamDefaultReaderCancelCode = "(function (reason){\"use strict\";if(!@isReadableStreamDefaultReader(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStreamDefaultReader\",\"cancel\"));if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return @Promise.@reject(@makeTypeError(\"cancel() called on a reader owned by no readable stream\"));return @readableStreamReaderGenericCancel(this,reason)})\n";
+
+// readMany
+const JSC::ConstructAbility s_readableStreamDefaultReaderReadManyCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamDefaultReaderReadManyCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamDefaultReaderReadManyCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamDefaultReaderReadManyCodeLength = 3230;
+static const JSC::Intrinsic s_readableStreamDefaultReaderReadManyCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamDefaultReaderReadManyCode = "(function (){\"use strict\";if(!@isReadableStreamDefaultReader(this))@throwTypeError(\"ReadableStreamDefaultReader.readMany() should not be called directly\");const stream=@getByIdDirectPrivate(this,\"ownerReadableStream\");if(!stream)@throwTypeError(\"readMany() called on a reader owned by no readable stream\");const state=@getByIdDirectPrivate(stream,\"state\");if(@putByIdDirectPrivate(stream,\"disturbed\",!0),state===@streamClosed)return{value:[],size:0,done:!0};else if(state===@streamErrored)throw @getByIdDirectPrivate(stream,\"storedError\");var controller=@getByIdDirectPrivate(stream,\"readableStreamController\"),queue=@getByIdDirectPrivate(controller,\"queue\");if(!queue)return controller.@pull(controller).@then(function({done,value}){return done\?{done:!0,value:[],size:0}:{value:[value],size:1,done:!1}});const content=queue.content;var size=queue.size,values=content.toArray(!1),length=values.length;if(length>0){var outValues=@newArrayWithSize(length);if(@isReadableByteStreamController(controller)){{const buf=values[0];if(!(@ArrayBuffer.@isView(buf)||buf instanceof @ArrayBuffer))@putByValDirect(outValues,0,new @Uint8Array(buf.buffer,buf.byteOffset,buf.byteLength));else @putByValDirect(outValues,0,buf)}for(var i=1;i<length;i++){const buf=values[i];if(!(@ArrayBuffer.@isView(buf)||buf instanceof @ArrayBuffer))@putByValDirect(outValues,i,new @Uint8Array(buf.buffer,buf.byteOffset,buf.byteLength));else @putByValDirect(outValues,i,buf)}}else{@putByValDirect(outValues,0,values[0].value);for(var i=1;i<length;i++)@putByValDirect(outValues,i,values[i].value)}if(@resetQueue(@getByIdDirectPrivate(controller,\"queue\")),@getByIdDirectPrivate(controller,\"closeRequested\"))@readableStreamClose(@getByIdDirectPrivate(controller,\"controlledReadableStream\"));else if(@isReadableStreamDefaultController(controller))@readableStreamDefaultControllerCallPullIfNeeded(controller);else if(@isReadableByteStreamController(controller))@readableByteStreamControllerCallPullIfNeeded(controller);return{value:outValues,size,done:!1}}var onPullMany=(result)=>{if(result.done)return{value:[],size:0,done:!0};var controller2=@getByIdDirectPrivate(stream,\"readableStreamController\"),queue2=@getByIdDirectPrivate(controller2,\"queue\"),value=[result.value].concat(queue2.content.toArray(!1)),length2=value.length;if(@isReadableByteStreamController(controller2))for(var i2=0;i2<length2;i2++){const buf=value[i2];if(!(@ArrayBuffer.@isView(buf)||buf instanceof @ArrayBuffer)){const{buffer,byteOffset,byteLength}=buf;@putByValDirect(value,i2,new @Uint8Array(buffer,byteOffset,byteLength))}}else for(var i2=1;i2<length2;i2++)@putByValDirect(value,i2,value[i2].value);var size2=queue2.size;if(@resetQueue(queue2),@getByIdDirectPrivate(controller2,\"closeRequested\"))@readableStreamClose(@getByIdDirectPrivate(controller2,\"controlledReadableStream\"));else if(@isReadableStreamDefaultController(controller2))@readableStreamDefaultControllerCallPullIfNeeded(controller2);else if(@isReadableByteStreamController(controller2))@readableByteStreamControllerCallPullIfNeeded(controller2);return{value,size:size2,done:!1}},pullResult=controller.@pull(controller);if(pullResult&&@isPromise(pullResult))return pullResult.@then(onPullMany);return onPullMany(pullResult)})\n";
+
+// read
+const JSC::ConstructAbility s_readableStreamDefaultReaderReadCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamDefaultReaderReadCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamDefaultReaderReadCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamDefaultReaderReadCodeLength = 348;
+static const JSC::Intrinsic s_readableStreamDefaultReaderReadCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamDefaultReaderReadCode = "(function (){\"use strict\";if(!@isReadableStreamDefaultReader(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStreamDefaultReader\",\"read\"));if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return @Promise.@reject(@makeTypeError(\"read() called on a reader owned by no readable stream\"));return @readableStreamDefaultReaderRead(this)})\n";
+
+// releaseLock
+const JSC::ConstructAbility s_readableStreamDefaultReaderReleaseLockCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamDefaultReaderReleaseLockCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamDefaultReaderReleaseLockCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamDefaultReaderReleaseLockCodeLength = 384;
+static const JSC::Intrinsic s_readableStreamDefaultReaderReleaseLockCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamDefaultReaderReleaseLockCode = "(function (){\"use strict\";if(!@isReadableStreamDefaultReader(this))throw @makeThisTypeError(\"ReadableStreamDefaultReader\",\"releaseLock\");if(!@getByIdDirectPrivate(this,\"ownerReadableStream\"))return;if(@getByIdDirectPrivate(this,\"readRequests\")\?.isNotEmpty())@throwTypeError(\"There are still pending read requests, cannot release the lock\");@readableStreamReaderGenericRelease(this)})\n";
+
+// closed
+const JSC::ConstructAbility s_readableStreamDefaultReaderClosedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamDefaultReaderClosedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamDefaultReaderClosedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamDefaultReaderClosedCodeLength = 224;
+static const JSC::Intrinsic s_readableStreamDefaultReaderClosedCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamDefaultReaderClosedCode = "(function (){\"use strict\";if(!@isReadableStreamDefaultReader(this))return @Promise.@reject(@makeGetterTypeError(\"ReadableStreamDefaultReader\",\"closed\"));return @getByIdDirectPrivate(this,\"closedPromiseCapability\").promise})\n";
+
+#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
+{\
+    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
+    return clientData->builtinFunctions().readableStreamDefaultReaderBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableStreamDefaultReaderBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+}
+WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
 /* StreamInternals.ts */
@@ -2417,456 +2259,358 @@ JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
-/* TransformStreamDefaultController.ts */
-// initializeTransformStreamDefaultController
-const JSC::ConstructAbility s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeLength = 40;
-static const JSC::Intrinsic s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCode = "(function (){\"use strict\";return this})\n";
+/* ImportMetaObject.ts */
+// loadCJS2ESM
+const JSC::ConstructAbility s_importMetaObjectLoadCJS2ESMCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_importMetaObjectLoadCJS2ESMCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_importMetaObjectLoadCJS2ESMCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_importMetaObjectLoadCJS2ESMCodeLength = 2214;
+static const JSC::Intrinsic s_importMetaObjectLoadCJS2ESMCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_importMetaObjectLoadCJS2ESMCode = "(function (resolvedSpecifier){\"use strict\";var loader=@Loader,queue=@createFIFO(),key=resolvedSpecifier;while(key){var entry=loader.registry.@get(key);if((entry\?.state\?\?0)<=@ModuleFetch)@fulfillModuleSync(key),entry=loader.registry.@get(key);var sourceCodeObject=@getPromiseInternalField(entry.fetch,@promiseFieldReactionsOrResult),moduleRecordPromise=loader.parseModule(key,sourceCodeObject),mod=entry.module;if(moduleRecordPromise&&@isPromise(moduleRecordPromise)){var reactionsOrResult=@getPromiseInternalField(moduleRecordPromise,@promiseFieldReactionsOrResult),flags=@getPromiseInternalField(moduleRecordPromise,@promiseFieldFlags),state=flags&@promiseStateMask;if(state===@promiseStatePending||reactionsOrResult&&@isPromise(reactionsOrResult))@throwTypeError(`require() async module \"${key}\" is unsupported. use \"await import()\" instead.`);else if(state===@promiseStateRejected){if(!reactionsOrResult\?.message)@throwTypeError(`${reactionsOrResult+\"\"\?reactionsOrResult:\"An error occurred\"} occurred while parsing module \\\"${key}\\\"`);throw reactionsOrResult}entry.module=mod=reactionsOrResult}else if(moduleRecordPromise&&!mod)entry.module=mod=moduleRecordPromise;@setStateToMax(entry,@ModuleLink);var dependenciesMap=mod.dependenciesMap,requestedModules=loader.requestedModules(mod),dependencies=@newArrayWithSize(requestedModules.length);for(var i=0,length=requestedModules.length;i<length;++i){var depName=requestedModules[i],depKey=depName[0]===\"/\"\?depName:loader.resolve(depName,key),depEntry=loader.ensureRegistered(depKey);if(depEntry.state<@ModuleLink)queue.push(depKey);@putByValDirect(dependencies,i,depEntry),dependenciesMap.@set(depName,depEntry)}entry.dependencies=dependencies,entry.instantiate=@Promise.@resolve(entry),entry.satisfy=@Promise.@resolve(entry),entry.isSatisfied=!0,key=queue.shift();while(key&&(loader.registry.@get(key)\?.state\?\?@ModuleFetch)>=@ModuleLink)key=queue.shift()}var linkAndEvaluateResult=loader.linkAndEvaluateModule(resolvedSpecifier,@undefined);if(linkAndEvaluateResult&&@isPromise(linkAndEvaluateResult))@throwTypeError(`require() async module \\\"${resolvedSpecifier}\\\" is unsupported. use \"await import()\" instead.`);return loader.registry.@get(resolvedSpecifier)})\n";
 
-// desiredSize
-const JSC::ConstructAbility s_transformStreamDefaultControllerDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_transformStreamDefaultControllerDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_transformStreamDefaultControllerDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_transformStreamDefaultControllerDesiredSizeCodeLength = 397;
-static const JSC::Intrinsic s_transformStreamDefaultControllerDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_transformStreamDefaultControllerDesiredSizeCode = "(function (){\"use strict\";if(!@isTransformStreamDefaultController(this))throw @makeThisTypeError(\"TransformStreamDefaultController\",\"enqueue\");const stream=@getByIdDirectPrivate(this,\"stream\"),readable=@getByIdDirectPrivate(stream,\"readable\"),readableController=@getByIdDirectPrivate(readable,\"readableStreamController\");return @readableStreamDefaultControllerGetDesiredSize(readableController)})\n";
+// requireESM
+const JSC::ConstructAbility s_importMetaObjectRequireESMCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_importMetaObjectRequireESMCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_importMetaObjectRequireESMCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_importMetaObjectRequireESMCodeLength = 364;
+static const JSC::Intrinsic s_importMetaObjectRequireESMCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_importMetaObjectRequireESMCode = "(function (resolved){\"use strict\";var entry=@Loader.registry.@get(resolved);if(!entry||!entry.evaluated)entry=@loadCJS2ESM(resolved);if(!entry||!entry.evaluated||!entry.module)@throwTypeError(`require() failed to evaluate module \"${resolved}\". This is an internal consistentency error.`);var exports=@Loader.getModuleNamespaceObject(entry.module);return exports})\n";
 
-// enqueue
-const JSC::ConstructAbility s_transformStreamDefaultControllerEnqueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_transformStreamDefaultControllerEnqueueCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_transformStreamDefaultControllerEnqueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_transformStreamDefaultControllerEnqueueCodeLength = 203;
-static const JSC::Intrinsic s_transformStreamDefaultControllerEnqueueCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_transformStreamDefaultControllerEnqueueCode = "(function (chunk){\"use strict\";if(!@isTransformStreamDefaultController(this))throw @makeThisTypeError(\"TransformStreamDefaultController\",\"enqueue\");@transformStreamDefaultControllerEnqueue(this,chunk)})\n";
+// internalRequire
+const JSC::ConstructAbility s_importMetaObjectInternalRequireCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_importMetaObjectInternalRequireCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_importMetaObjectInternalRequireCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_importMetaObjectInternalRequireCodeLength = 857;
+static const JSC::Intrinsic s_importMetaObjectInternalRequireCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_importMetaObjectInternalRequireCode = "(function (id){\"use strict\";var cached=@requireMap.@get(id);const last5=id.substring(id.length-5);if(cached)return cached.exports;if(last5===\".json\"){var fs=globalThis[Symbol.for(\"_fs\")]||=@Bun.fs(),exports=JSON.parse(fs.readFileSync(id,\"utf8\"));return @requireMap.@set(id,@createCommonJSModule(id,exports,!0)),exports}else if(last5===\".node\"){const module=@createCommonJSModule(id,{},!0);return process.dlopen(module,id),@requireMap.@set(id,module),module.exports}else if(last5===\".toml\"){var fs=globalThis[Symbol.for(\"_fs\")]||=@Bun.fs(),exports=@Bun.TOML.parse(fs.readFileSync(id,\"utf8\"));return @requireMap.@set(id,@createCommonJSModule(id,exports,!0)),exports}else{var exports=@requireESM(id);const cachedModule=@requireMap.@get(id);if(cachedModule)return cachedModule.exports;return @requireMap.@set(id,@createCommonJSModule(id,exports,!0)),exports}})\n";
 
-// error
-const JSC::ConstructAbility s_transformStreamDefaultControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_transformStreamDefaultControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_transformStreamDefaultControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_transformStreamDefaultControllerErrorCodeLength = 191;
-static const JSC::Intrinsic s_transformStreamDefaultControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_transformStreamDefaultControllerErrorCode = "(function (e){\"use strict\";if(!@isTransformStreamDefaultController(this))throw @makeThisTypeError(\"TransformStreamDefaultController\",\"error\");@transformStreamDefaultControllerError(this,e)})\n";
+// createRequireCache
+const JSC::ConstructAbility s_importMetaObjectCreateRequireCacheCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_importMetaObjectCreateRequireCacheCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_importMetaObjectCreateRequireCacheCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_importMetaObjectCreateRequireCacheCodeLength = 978;
+static const JSC::Intrinsic s_importMetaObjectCreateRequireCacheCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_importMetaObjectCreateRequireCacheCode = "(function (){\"use strict\";var moduleMap=new Map,inner={};return new Proxy(inner,{get(target,key){const entry=@requireMap.@get(key);if(entry)return entry;const esm=@Loader.registry.@get(key);if(esm\?.evaluated){const namespace=@Loader.getModuleNamespaceObject(esm.module),mod=@createCommonJSModule(key,namespace,!0);return @requireMap.@set(key,mod),mod}return inner[key]},set(target,key,value){return @requireMap.@set(key,value),!0},has(target,key){return @requireMap.@has(key)||@Loader.registry.@has(key)},deleteProperty(target,key){return moduleMap.@delete(key),@requireMap.@delete(key),@Loader.registry.@delete(key),!0},ownKeys(target){var array=[...@requireMap.@keys()];const registryKeys=[...@Loader.registry.@keys()];for(let key of registryKeys)if(!array.includes(key))@arrayPush(array,key);return array},getPrototypeOf(target){return null},getOwnPropertyDescriptor(target,key){if(@requireMap.@has(key)||@Loader.registry.@has(key))return{configurable:!0,enumerable:!0}}})})\n";
 
-// terminate
-const JSC::ConstructAbility s_transformStreamDefaultControllerTerminateCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_transformStreamDefaultControllerTerminateCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_transformStreamDefaultControllerTerminateCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_transformStreamDefaultControllerTerminateCodeLength = 196;
-static const JSC::Intrinsic s_transformStreamDefaultControllerTerminateCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_transformStreamDefaultControllerTerminateCode = "(function (){\"use strict\";if(!@isTransformStreamDefaultController(this))throw @makeThisTypeError(\"TransformStreamDefaultController\",\"terminate\");@transformStreamDefaultControllerTerminate(this)})\n";
+// main
+const JSC::ConstructAbility s_importMetaObjectMainCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_importMetaObjectMainCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_importMetaObjectMainCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_importMetaObjectMainCodeLength = 76;
+static const JSC::Intrinsic s_importMetaObjectMainCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_importMetaObjectMainCode = "(function (){\"use strict\";return this.path===@Bun.main&&@Bun.isMainThread})\n";
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 {\
     JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().transformStreamDefaultControllerBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().transformStreamDefaultControllerBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+    return clientData->builtinFunctions().importMetaObjectBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().importMetaObjectBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
 }
-WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
-/* WritableStreamInternals.ts */
-// isWritableStream
-const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsIsWritableStreamCodeLength = 109;
-static const JSC::Intrinsic s_writableStreamInternalsIsWritableStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsIsWritableStreamCode = "(function (stream){\"use strict\";return @isObject(stream)&&!!@getByIdDirectPrivate(stream,\"underlyingSink\")})\n";
+/* CountQueuingStrategy.ts */
+// highWaterMark
+const JSC::ConstructAbility s_countQueuingStrategyHighWaterMarkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_countQueuingStrategyHighWaterMarkCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_countQueuingStrategyHighWaterMarkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_countQueuingStrategyHighWaterMarkCodeLength = 241;
+static const JSC::Intrinsic s_countQueuingStrategyHighWaterMarkCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_countQueuingStrategyHighWaterMarkCode = "(function (){\"use strict\";const highWaterMark=@getByIdDirectPrivate(this,\"highWaterMark\");if(highWaterMark===@undefined)@throwTypeError(\"CountQueuingStrategy.highWaterMark getter called on incompatible |this| value.\");return highWaterMark})\n";
 
-// isWritableStreamDefaultWriter
-const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamDefaultWriterCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamDefaultWriterCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamDefaultWriterCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsIsWritableStreamDefaultWriterCodeLength = 108;
-static const JSC::Intrinsic s_writableStreamInternalsIsWritableStreamDefaultWriterCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsIsWritableStreamDefaultWriterCode = "(function (writer){\"use strict\";return @isObject(writer)&&!!@getByIdDirectPrivate(writer,\"closedPromise\")})\n";
+// size
+const JSC::ConstructAbility s_countQueuingStrategySizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_countQueuingStrategySizeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_countQueuingStrategySizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_countQueuingStrategySizeCodeLength = 37;
+static const JSC::Intrinsic s_countQueuingStrategySizeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_countQueuingStrategySizeCode = "(function (){\"use strict\";return 1})\n";
 
-// acquireWritableStreamDefaultWriter
-const JSC::ConstructAbility s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeLength = 82;
-static const JSC::Intrinsic s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsAcquireWritableStreamDefaultWriterCode = "(function (stream){\"use strict\";return new @WritableStreamDefaultWriter(stream)})\n";
-
-// createWritableStream
-const JSC::ConstructAbility s_writableStreamInternalsCreateWritableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsCreateWritableStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsCreateWritableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsCreateWritableStreamCodeLength = 453;
-static const JSC::Intrinsic s_writableStreamInternalsCreateWritableStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsCreateWritableStreamCode = "(function (startAlgorithm,writeAlgorithm,closeAlgorithm,abortAlgorithm,highWaterMark,sizeAlgorithm){\"use strict\";const internalStream={};@initializeWritableStreamSlots(internalStream,{});const controller=new @WritableStreamDefaultController;return @setUpWritableStreamDefaultController(internalStream,controller,startAlgorithm,writeAlgorithm,closeAlgorithm,abortAlgorithm,highWaterMark,sizeAlgorithm),@createWritableStreamFromInternal(internalStream)})\n";
-
-// createInternalWritableStreamFromUnderlyingSink
-const JSC::ConstructAbility s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeLength = 1388;
-static const JSC::Intrinsic s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCode = "(function (underlyingSink,strategy){\"use strict\";const stream={};if(underlyingSink===@undefined)underlyingSink={};if(strategy===@undefined)strategy={};if(!@isObject(underlyingSink))@throwTypeError(\"WritableStream constructor takes an object as first argument\");if(\"type\"in underlyingSink)@throwRangeError(\"Invalid type is specified\");const sizeAlgorithm=@extractSizeAlgorithm(strategy),highWaterMark=@extractHighWaterMark(strategy,1),underlyingSinkDict={};if(\"start\"in underlyingSink){if(underlyingSinkDict.start=underlyingSink.start,typeof underlyingSinkDict.start!==\"function\")@throwTypeError(\"underlyingSink.start should be a function\")}if(\"write\"in underlyingSink){if(underlyingSinkDict.write=underlyingSink.write,typeof underlyingSinkDict.write!==\"function\")@throwTypeError(\"underlyingSink.write should be a function\")}if(\"close\"in underlyingSink){if(underlyingSinkDict.close=underlyingSink.close,typeof underlyingSinkDict.close!==\"function\")@throwTypeError(\"underlyingSink.close should be a function\")}if(\"abort\"in underlyingSink){if(underlyingSinkDict.abort=underlyingSink.abort,typeof underlyingSinkDict.abort!==\"function\")@throwTypeError(\"underlyingSink.abort should be a function\")}return @initializeWritableStreamSlots(stream,underlyingSink),@setUpWritableStreamDefaultControllerFromUnderlyingSink(stream,underlyingSink,underlyingSinkDict,highWaterMark,sizeAlgorithm),stream})\n";
-
-// initializeWritableStreamSlots
-const JSC::ConstructAbility s_writableStreamInternalsInitializeWritableStreamSlotsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsInitializeWritableStreamSlotsCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsInitializeWritableStreamSlotsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsInitializeWritableStreamSlotsCodeLength = 674;
-static const JSC::Intrinsic s_writableStreamInternalsInitializeWritableStreamSlotsCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsInitializeWritableStreamSlotsCode = "(function (stream,underlyingSink){\"use strict\";@putByIdDirectPrivate(stream,\"state\",\"writable\"),@putByIdDirectPrivate(stream,\"storedError\",@undefined),@putByIdDirectPrivate(stream,\"writer\",@undefined),@putByIdDirectPrivate(stream,\"controller\",@undefined),@putByIdDirectPrivate(stream,\"inFlightWriteRequest\",@undefined),@putByIdDirectPrivate(stream,\"closeRequest\",@undefined),@putByIdDirectPrivate(stream,\"inFlightCloseRequest\",@undefined),@putByIdDirectPrivate(stream,\"pendingAbortRequest\",@undefined),@putByIdDirectPrivate(stream,\"writeRequests\",@createFIFO()),@putByIdDirectPrivate(stream,\"backpressure\",!1),@putByIdDirectPrivate(stream,\"underlyingSink\",underlyingSink)})\n";
-
-// writableStreamCloseForBindings
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseForBindingsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseForBindingsCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseForBindingsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamCloseForBindingsCodeLength = 390;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamCloseForBindingsCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamCloseForBindingsCode = "(function (stream){\"use strict\";if(@isWritableStreamLocked(stream))return @Promise.@reject(@makeTypeError(\"WritableStream.close method can only be used on non locked WritableStream\"));if(@writableStreamCloseQueuedOrInFlight(stream))return @Promise.@reject(@makeTypeError(\"WritableStream.close method can only be used on a being close WritableStream\"));return @writableStreamClose(stream)})\n";
-
-// writableStreamAbortForBindings
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAbortForBindingsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAbortForBindingsCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAbortForBindingsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamAbortForBindingsCodeLength = 236;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamAbortForBindingsCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamAbortForBindingsCode = "(function (stream,reason){\"use strict\";if(@isWritableStreamLocked(stream))return @Promise.@reject(@makeTypeError(\"WritableStream.abort method can only be used on non locked WritableStream\"));return @writableStreamAbort(stream,reason)})\n";
-
-// isWritableStreamLocked
-const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsIsWritableStreamLockedCodeLength = 93;
-static const JSC::Intrinsic s_writableStreamInternalsIsWritableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsIsWritableStreamLockedCode = "(function (stream){\"use strict\";return @getByIdDirectPrivate(stream,\"writer\")!==@undefined})\n";
-
-// setUpWritableStreamDefaultWriter
-const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeLength = 1249;
-static const JSC::Intrinsic s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsSetUpWritableStreamDefaultWriterCode = "(function (writer,stream){\"use strict\";if(@isWritableStreamLocked(stream))@throwTypeError(\"WritableStream is locked\");@putByIdDirectPrivate(writer,\"stream\",stream),@putByIdDirectPrivate(stream,\"writer\",writer);const readyPromiseCapability=@newPromiseCapability(@Promise),closedPromiseCapability=@newPromiseCapability(@Promise);@putByIdDirectPrivate(writer,\"readyPromise\",readyPromiseCapability),@putByIdDirectPrivate(writer,\"closedPromise\",closedPromiseCapability);const state=@getByIdDirectPrivate(stream,\"state\");if(state===\"writable\"){if(@writableStreamCloseQueuedOrInFlight(stream)||!@getByIdDirectPrivate(stream,\"backpressure\"))readyPromiseCapability.resolve.@call()}else if(state===\"erroring\")readyPromiseCapability.reject.@call(@undefined,@getByIdDirectPrivate(stream,\"storedError\")),@markPromiseAsHandled(readyPromiseCapability.promise);else if(state===\"closed\")readyPromiseCapability.resolve.@call(),closedPromiseCapability.resolve.@call();else{const storedError=@getByIdDirectPrivate(stream,\"storedError\");readyPromiseCapability.reject.@call(@undefined,storedError),@markPromiseAsHandled(readyPromiseCapability.promise),closedPromiseCapability.reject.@call(@undefined,storedError),@markPromiseAsHandled(closedPromiseCapability.promise)}})\n";
-
-// writableStreamAbort
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAbortCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAbortCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAbortCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamAbortCodeLength = 679;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamAbortCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamAbortCode = "(function (stream,reason){\"use strict\";const state=@getByIdDirectPrivate(stream,\"state\");if(state===\"closed\"||state===\"errored\")return @Promise.@resolve();const pendingAbortRequest=@getByIdDirectPrivate(stream,\"pendingAbortRequest\");if(pendingAbortRequest!==@undefined)return pendingAbortRequest.promise.promise;let wasAlreadyErroring=!1;if(state===\"erroring\")wasAlreadyErroring=!0,reason=@undefined;const abortPromiseCapability=@newPromiseCapability(@Promise);if(@putByIdDirectPrivate(stream,\"pendingAbortRequest\",{promise:abortPromiseCapability,reason,wasAlreadyErroring}),!wasAlreadyErroring)@writableStreamStartErroring(stream,reason);return abortPromiseCapability.promise})\n";
-
-// writableStreamClose
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamCloseCodeLength = 674;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamCloseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamCloseCode = "(function (stream){\"use strict\";const state=@getByIdDirectPrivate(stream,\"state\");if(state===\"closed\"||state===\"errored\")return @Promise.@reject(@makeTypeError(\"Cannot close a writable stream that is closed or errored\"));const closePromiseCapability=@newPromiseCapability(@Promise);@putByIdDirectPrivate(stream,\"closeRequest\",closePromiseCapability);const writer=@getByIdDirectPrivate(stream,\"writer\");if(writer!==@undefined&&@getByIdDirectPrivate(stream,\"backpressure\")&&state===\"writable\")@getByIdDirectPrivate(writer,\"readyPromise\").resolve.@call();return @writableStreamDefaultControllerClose(@getByIdDirectPrivate(stream,\"controller\")),closePromiseCapability.promise})\n";
-
-// writableStreamAddWriteRequest
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAddWriteRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAddWriteRequestCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAddWriteRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamAddWriteRequestCodeLength = 208;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamAddWriteRequestCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamAddWriteRequestCode = "(function (stream){\"use strict\";const writePromiseCapability=@newPromiseCapability(@Promise);return @getByIdDirectPrivate(stream,\"writeRequests\").push(writePromiseCapability),writePromiseCapability.promise})\n";
-
-// writableStreamCloseQueuedOrInFlight
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeLength = 166;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCode = "(function (stream){\"use strict\";return @getByIdDirectPrivate(stream,\"closeRequest\")!==@undefined||@getByIdDirectPrivate(stream,\"inFlightCloseRequest\")!==@undefined})\n";
-
-// writableStreamDealWithRejection
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDealWithRejectionCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDealWithRejectionCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDealWithRejectionCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDealWithRejectionCodeLength = 183;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDealWithRejectionCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDealWithRejectionCode = "(function (stream,error){\"use strict\";if(@getByIdDirectPrivate(stream,\"state\")===\"writable\"){@writableStreamStartErroring(stream,error);return}@writableStreamFinishErroring(stream)})\n";
-
-// writableStreamFinishErroring
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishErroringCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishErroringCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishErroringCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamFinishErroringCodeLength = 1193;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamFinishErroringCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamFinishErroringCode = "(function (stream){\"use strict\";@putByIdDirectPrivate(stream,\"state\",\"errored\");const controller=@getByIdDirectPrivate(stream,\"controller\");@getByIdDirectPrivate(controller,\"errorSteps\").@call();const storedError=@getByIdDirectPrivate(stream,\"storedError\"),requests=@getByIdDirectPrivate(stream,\"writeRequests\");for(var request=requests.shift();request;request=requests.shift())request.reject.@call(@undefined,storedError);@putByIdDirectPrivate(stream,\"writeRequests\",@createFIFO());const abortRequest=@getByIdDirectPrivate(stream,\"pendingAbortRequest\");if(abortRequest===@undefined){@writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);return}if(@putByIdDirectPrivate(stream,\"pendingAbortRequest\",@undefined),abortRequest.wasAlreadyErroring){abortRequest.promise.reject.@call(@undefined,storedError),@writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);return}@getByIdDirectPrivate(controller,\"abortSteps\").@call(@undefined,abortRequest.reason).@then(()=>{abortRequest.promise.resolve.@call(),@writableStreamRejectCloseAndClosedPromiseIfNeeded(stream)},(reason)=>{abortRequest.promise.reject.@call(@undefined,reason),@writableStreamRejectCloseAndClosedPromiseIfNeeded(stream)})})\n";
-
-// writableStreamFinishInFlightClose
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeLength = 661;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamFinishInFlightCloseCode = "(function (stream){\"use strict\";if(@getByIdDirectPrivate(stream,\"inFlightCloseRequest\").resolve.@call(),@putByIdDirectPrivate(stream,\"inFlightCloseRequest\",@undefined),@getByIdDirectPrivate(stream,\"state\")===\"erroring\"){@putByIdDirectPrivate(stream,\"storedError\",@undefined);const abortRequest=@getByIdDirectPrivate(stream,\"pendingAbortRequest\");if(abortRequest!==@undefined)abortRequest.promise.resolve.@call(),@putByIdDirectPrivate(stream,\"pendingAbortRequest\",@undefined)}@putByIdDirectPrivate(stream,\"state\",\"closed\");const writer=@getByIdDirectPrivate(stream,\"writer\");if(writer!==@undefined)@getByIdDirectPrivate(writer,\"closedPromise\").resolve.@call()})\n";
-
-// writableStreamFinishInFlightCloseWithError
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeLength = 494;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCode = "(function (stream,error){\"use strict\";@getByIdDirectPrivate(stream,\"inFlightCloseRequest\").reject.@call(@undefined,error),@putByIdDirectPrivate(stream,\"inFlightCloseRequest\",@undefined);const state=@getByIdDirectPrivate(stream,\"state\"),abortRequest=@getByIdDirectPrivate(stream,\"pendingAbortRequest\");if(abortRequest!==@undefined)abortRequest.promise.reject.@call(@undefined,error),@putByIdDirectPrivate(stream,\"pendingAbortRequest\",@undefined);@writableStreamDealWithRejection(stream,error)})\n";
-
-// writableStreamFinishInFlightWrite
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeLength = 167;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamFinishInFlightWriteCode = "(function (stream){\"use strict\";@getByIdDirectPrivate(stream,\"inFlightWriteRequest\").resolve.@call(),@putByIdDirectPrivate(stream,\"inFlightWriteRequest\",@undefined)})\n";
-
-// writableStreamFinishInFlightWriteWithError
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeLength = 285;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCode = "(function (stream,error){\"use strict\";@getByIdDirectPrivate(stream,\"inFlightWriteRequest\").reject.@call(@undefined,error),@putByIdDirectPrivate(stream,\"inFlightWriteRequest\",@undefined);const state=@getByIdDirectPrivate(stream,\"state\");@writableStreamDealWithRejection(stream,error)})\n";
-
-// writableStreamHasOperationMarkedInFlight
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeLength = 174;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCode = "(function (stream){\"use strict\";return @getByIdDirectPrivate(stream,\"inFlightWriteRequest\")!==@undefined||@getByIdDirectPrivate(stream,\"inFlightCloseRequest\")!==@undefined})\n";
-
-// writableStreamMarkCloseRequestInFlight
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeLength = 220;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCode = "(function (stream){\"use strict\";const closeRequest=@getByIdDirectPrivate(stream,\"closeRequest\");@putByIdDirectPrivate(stream,\"inFlightCloseRequest\",closeRequest),@putByIdDirectPrivate(stream,\"closeRequest\",@undefined)})\n";
-
-// writableStreamMarkFirstWriteRequestInFlight
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeLength = 173;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCode = "(function (stream){\"use strict\";const writeRequest=@getByIdDirectPrivate(stream,\"writeRequests\").shift();@putByIdDirectPrivate(stream,\"inFlightWriteRequest\",writeRequest)})\n";
-
-// writableStreamRejectCloseAndClosedPromiseIfNeeded
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeLength = 528;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCode = "(function (stream){\"use strict\";const storedError=@getByIdDirectPrivate(stream,\"storedError\"),closeRequest=@getByIdDirectPrivate(stream,\"closeRequest\");if(closeRequest!==@undefined)closeRequest.reject.@call(@undefined,storedError),@putByIdDirectPrivate(stream,\"closeRequest\",@undefined);const writer=@getByIdDirectPrivate(stream,\"writer\");if(writer!==@undefined){const closedPromise=@getByIdDirectPrivate(writer,\"closedPromise\");closedPromise.reject.@call(@undefined,storedError),@markPromiseAsHandled(closedPromise.promise)}})\n";
-
-// writableStreamStartErroring
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamStartErroringCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamStartErroringCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamStartErroringCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamStartErroringCodeLength = 487;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamStartErroringCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamStartErroringCode = "(function (stream,reason){\"use strict\";const controller=@getByIdDirectPrivate(stream,\"controller\");@putByIdDirectPrivate(stream,\"state\",\"erroring\"),@putByIdDirectPrivate(stream,\"storedError\",reason);const writer=@getByIdDirectPrivate(stream,\"writer\");if(writer!==@undefined)@writableStreamDefaultWriterEnsureReadyPromiseRejected(writer,reason);if(!@writableStreamHasOperationMarkedInFlight(stream)&&@getByIdDirectPrivate(controller,\"started\")===1)@writableStreamFinishErroring(stream)})\n";
-
-// writableStreamUpdateBackpressure
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamUpdateBackpressureCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamUpdateBackpressureCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamUpdateBackpressureCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamUpdateBackpressureCodeLength = 400;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamUpdateBackpressureCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamUpdateBackpressureCode = "(function (stream,backpressure){\"use strict\";const writer=@getByIdDirectPrivate(stream,\"writer\");if(writer!==@undefined&&backpressure!==@getByIdDirectPrivate(stream,\"backpressure\"))if(backpressure)@putByIdDirectPrivate(writer,\"readyPromise\",@newPromiseCapability(@Promise));else @getByIdDirectPrivate(writer,\"readyPromise\").resolve.@call();@putByIdDirectPrivate(stream,\"backpressure\",backpressure)})\n";
-
-// writableStreamDefaultWriterAbort
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeLength = 136;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultWriterAbortCode = "(function (writer,reason){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\");return @writableStreamAbort(stream,reason)})\n";
-
-// writableStreamDefaultWriterClose
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeLength = 122;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultWriterCloseCode = "(function (writer){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\");return @writableStreamClose(stream)})\n";
-
-// writableStreamDefaultWriterCloseWithErrorPropagation
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeLength = 362;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCode = "(function (writer){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\"),state=@getByIdDirectPrivate(stream,\"state\");if(@writableStreamCloseQueuedOrInFlight(stream)||state===\"closed\")return @Promise.@resolve();if(state===\"errored\")return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));return @writableStreamDefaultWriterClose(writer)})\n";
-
-// writableStreamDefaultWriterEnsureClosedPromiseRejected
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeLength = 529;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCode = "(function (writer,error){\"use strict\";let closedPromiseCapability=@getByIdDirectPrivate(writer,\"closedPromise\"),closedPromise=closedPromiseCapability.promise;if((@getPromiseInternalField(closedPromise,@promiseFieldFlags)&@promiseStateMask)!==@promiseStatePending)closedPromiseCapability=@newPromiseCapability(@Promise),closedPromise=closedPromiseCapability.promise,@putByIdDirectPrivate(writer,\"closedPromise\",closedPromiseCapability);closedPromiseCapability.reject.@call(@undefined,error),@markPromiseAsHandled(closedPromise)})\n";
-
-// writableStreamDefaultWriterEnsureReadyPromiseRejected
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeLength = 517;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCode = "(function (writer,error){\"use strict\";let readyPromiseCapability=@getByIdDirectPrivate(writer,\"readyPromise\"),readyPromise=readyPromiseCapability.promise;if((@getPromiseInternalField(readyPromise,@promiseFieldFlags)&@promiseStateMask)!==@promiseStatePending)readyPromiseCapability=@newPromiseCapability(@Promise),readyPromise=readyPromiseCapability.promise,@putByIdDirectPrivate(writer,\"readyPromise\",readyPromiseCapability);readyPromiseCapability.reject.@call(@undefined,error),@markPromiseAsHandled(readyPromise)})\n";
-
-// writableStreamDefaultWriterGetDesiredSize
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeLength = 310;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCode = "(function (writer){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\"),state=@getByIdDirectPrivate(stream,\"state\");if(state===\"errored\"||state===\"erroring\")return null;if(state===\"closed\")return 0;return @writableStreamDefaultControllerGetDesiredSize(@getByIdDirectPrivate(stream,\"controller\"))})\n";
-
-// writableStreamDefaultWriterRelease
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeLength = 408;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultWriterReleaseCode = "(function (writer){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\"),releasedError=@makeTypeError(\"writableStreamDefaultWriterRelease\");@writableStreamDefaultWriterEnsureReadyPromiseRejected(writer,releasedError),@writableStreamDefaultWriterEnsureClosedPromiseRejected(writer,releasedError),@putByIdDirectPrivate(stream,\"writer\",@undefined),@putByIdDirectPrivate(writer,\"stream\",@undefined)})\n";
-
-// writableStreamDefaultWriterWrite
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeLength = 982;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultWriterWriteCode = "(function (writer,chunk){\"use strict\";const stream=@getByIdDirectPrivate(writer,\"stream\"),controller=@getByIdDirectPrivate(stream,\"controller\"),chunkSize=@writableStreamDefaultControllerGetChunkSize(controller,chunk);if(stream!==@getByIdDirectPrivate(writer,\"stream\"))return @Promise.@reject(@makeTypeError(\"writer is not stream's writer\"));const state=@getByIdDirectPrivate(stream,\"state\");if(state===\"errored\")return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));if(@writableStreamCloseQueuedOrInFlight(stream)||state===\"closed\")return @Promise.@reject(@makeTypeError(\"stream is closing or closed\"));if(@writableStreamCloseQueuedOrInFlight(stream)||state===\"closed\")return @Promise.@reject(@makeTypeError(\"stream is closing or closed\"));if(state===\"erroring\")return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));const promise=@writableStreamAddWriteRequest(stream);return @writableStreamDefaultControllerWrite(controller,chunk,chunkSize),promise})\n";
-
-// setUpWritableStreamDefaultController
-const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeLength = 921;
-static const JSC::Intrinsic s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsSetUpWritableStreamDefaultControllerCode = "(function (stream,controller,startAlgorithm,writeAlgorithm,closeAlgorithm,abortAlgorithm,highWaterMark,sizeAlgorithm){\"use strict\";@putByIdDirectPrivate(controller,\"stream\",stream),@putByIdDirectPrivate(stream,\"controller\",controller),@resetQueue(@getByIdDirectPrivate(controller,\"queue\")),@putByIdDirectPrivate(controller,\"started\",-1),@putByIdDirectPrivate(controller,\"startAlgorithm\",startAlgorithm),@putByIdDirectPrivate(controller,\"strategySizeAlgorithm\",sizeAlgorithm),@putByIdDirectPrivate(controller,\"strategyHWM\",highWaterMark),@putByIdDirectPrivate(controller,\"writeAlgorithm\",writeAlgorithm),@putByIdDirectPrivate(controller,\"closeAlgorithm\",closeAlgorithm),@putByIdDirectPrivate(controller,\"abortAlgorithm\",abortAlgorithm);const backpressure=@writableStreamDefaultControllerGetBackpressure(controller);@writableStreamUpdateBackpressure(stream,backpressure),@writableStreamDefaultControllerStart(controller)})\n";
-
-// writableStreamDefaultControllerStart
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerStartCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerStartCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerStartCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerStartCodeLength = 710;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerStartCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerStartCode = "(function (controller){\"use strict\";if(@getByIdDirectPrivate(controller,\"started\")!==-1)return;@putByIdDirectPrivate(controller,\"started\",0);const startAlgorithm=@getByIdDirectPrivate(controller,\"startAlgorithm\");@putByIdDirectPrivate(controller,\"startAlgorithm\",@undefined);const stream=@getByIdDirectPrivate(controller,\"stream\");return @Promise.@resolve(startAlgorithm.@call()).@then(()=>{const state=@getByIdDirectPrivate(stream,\"state\");@putByIdDirectPrivate(controller,\"started\",1),@writableStreamDefaultControllerAdvanceQueueIfNeeded(controller)},(error)=>{const state=@getByIdDirectPrivate(stream,\"state\");@putByIdDirectPrivate(controller,\"started\",1),@writableStreamDealWithRejection(stream,error)})})\n";
-
-// setUpWritableStreamDefaultControllerFromUnderlyingSink
-const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeLength = 1127;
-static const JSC::Intrinsic s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCode = "(function (stream,underlyingSink,underlyingSinkDict,highWaterMark,sizeAlgorithm){\"use strict\";const controller=new @WritableStreamDefaultController;let startAlgorithm=()=>{},writeAlgorithm=()=>{return @Promise.@resolve()},closeAlgorithm=()=>{return @Promise.@resolve()},abortAlgorithm=()=>{return @Promise.@resolve()};if(\"start\"in underlyingSinkDict){const startMethod=underlyingSinkDict.start;startAlgorithm=()=>@promiseInvokeOrNoopMethodNoCatch(underlyingSink,startMethod,[controller])}if(\"write\"in underlyingSinkDict){const writeMethod=underlyingSinkDict.write;writeAlgorithm=(chunk)=>@promiseInvokeOrNoopMethod(underlyingSink,writeMethod,[chunk,controller])}if(\"close\"in underlyingSinkDict){const closeMethod=underlyingSinkDict.close;closeAlgorithm=()=>@promiseInvokeOrNoopMethod(underlyingSink,closeMethod,[])}if(\"abort\"in underlyingSinkDict){const abortMethod=underlyingSinkDict.abort;abortAlgorithm=(reason)=>@promiseInvokeOrNoopMethod(underlyingSink,abortMethod,[reason])}@setUpWritableStreamDefaultController(stream,controller,startAlgorithm,writeAlgorithm,closeAlgorithm,abortAlgorithm,highWaterMark,sizeAlgorithm)})\n";
-
-// writableStreamDefaultControllerAdvanceQueueIfNeeded
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeLength = 609;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"stream\");if(@getByIdDirectPrivate(controller,\"started\")!==1)return;if(@getByIdDirectPrivate(stream,\"inFlightWriteRequest\")!==@undefined)return;if(@getByIdDirectPrivate(stream,\"state\")===\"erroring\"){@writableStreamFinishErroring(stream);return}const queue=@getByIdDirectPrivate(controller,\"queue\");if(queue.content\?.isEmpty()\?\?!1)return;const value=@peekQueueValue(queue);if(value===@isCloseSentinel)@writableStreamDefaultControllerProcessClose(controller);else @writableStreamDefaultControllerProcessWrite(controller,value)})\n";
-
-// isCloseSentinel
-const JSC::ConstructAbility s_writableStreamInternalsIsCloseSentinelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsIsCloseSentinelCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsIsCloseSentinelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsIsCloseSentinelCodeLength = 29;
-static const JSC::Intrinsic s_writableStreamInternalsIsCloseSentinelCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsIsCloseSentinelCode = "(function (){\"use strict\";})\n";
-
-// writableStreamDefaultControllerClearAlgorithms
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeLength = 293;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCode = "(function (controller){\"use strict\";@putByIdDirectPrivate(controller,\"writeAlgorithm\",@undefined),@putByIdDirectPrivate(controller,\"closeAlgorithm\",@undefined),@putByIdDirectPrivate(controller,\"abortAlgorithm\",@undefined),@putByIdDirectPrivate(controller,\"strategySizeAlgorithm\",@undefined)})\n";
-
-// writableStreamDefaultControllerClose
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeLength = 187;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerCloseCode = "(function (controller){\"use strict\";@enqueueValueWithSize(@getByIdDirectPrivate(controller,\"queue\"),@isCloseSentinel,0),@writableStreamDefaultControllerAdvanceQueueIfNeeded(controller)})\n";
-
-// writableStreamDefaultControllerError
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeLength = 203;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerErrorCode = "(function (controller,error){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"stream\");@writableStreamDefaultControllerClearAlgorithms(controller),@writableStreamStartErroring(stream,error)})\n";
-
-// writableStreamDefaultControllerErrorIfNeeded
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeLength = 210;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCode = "(function (controller,error){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"stream\");if(@getByIdDirectPrivate(stream,\"state\")===\"writable\")@writableStreamDefaultControllerError(controller,error)})\n";
-
-// writableStreamDefaultControllerGetBackpressure
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeLength = 107;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCode = "(function (controller){\"use strict\";return @writableStreamDefaultControllerGetDesiredSize(controller)<=0})\n";
-
-// writableStreamDefaultControllerGetChunkSize
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeLength = 216;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCode = "(function (controller,chunk){\"use strict\";try{return @getByIdDirectPrivate(controller,\"strategySizeAlgorithm\").@call(@undefined,chunk)}catch(e){return @writableStreamDefaultControllerErrorIfNeeded(controller,e),1}})\n";
-
-// writableStreamDefaultControllerGetDesiredSize
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeLength = 140;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCode = "(function (controller){\"use strict\";return @getByIdDirectPrivate(controller,\"strategyHWM\")-@getByIdDirectPrivate(controller,\"queue\").size})\n";
-
-// writableStreamDefaultControllerProcessClose
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeLength = 485;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"stream\");@writableStreamMarkCloseRequestInFlight(stream),@dequeueValue(@getByIdDirectPrivate(controller,\"queue\"));const sinkClosePromise=@getByIdDirectPrivate(controller,\"closeAlgorithm\").@call();@writableStreamDefaultControllerClearAlgorithms(controller),sinkClosePromise.@then(()=>{@writableStreamFinishInFlightClose(stream)},(reason)=>{@writableStreamFinishInFlightCloseWithError(stream,reason)})})\n";
-
-// writableStreamDefaultControllerProcessWrite
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeLength = 845;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCode = "(function (controller,chunk){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"stream\");@writableStreamMarkFirstWriteRequestInFlight(stream),@getByIdDirectPrivate(controller,\"writeAlgorithm\").@call(@undefined,chunk).@then(()=>{@writableStreamFinishInFlightWrite(stream);const state=@getByIdDirectPrivate(stream,\"state\");if(@dequeueValue(@getByIdDirectPrivate(controller,\"queue\")),!@writableStreamCloseQueuedOrInFlight(stream)&&state===\"writable\"){const backpressure=@writableStreamDefaultControllerGetBackpressure(controller);@writableStreamUpdateBackpressure(stream,backpressure)}@writableStreamDefaultControllerAdvanceQueueIfNeeded(controller)},(reason)=>{if(@getByIdDirectPrivate(stream,\"state\")===\"writable\")@writableStreamDefaultControllerClearAlgorithms(controller);@writableStreamFinishInFlightWriteWithError(stream,reason)})})\n";
-
-// writableStreamDefaultControllerWrite
-const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeLength = 578;
-static const JSC::Intrinsic s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_writableStreamInternalsWritableStreamDefaultControllerWriteCode = "(function (controller,chunk,chunkSize){\"use strict\";try{@enqueueValueWithSize(@getByIdDirectPrivate(controller,\"queue\"),chunk,chunkSize);const stream=@getByIdDirectPrivate(controller,\"stream\"),state=@getByIdDirectPrivate(stream,\"state\");if(!@writableStreamCloseQueuedOrInFlight(stream)&&state===\"writable\"){const backpressure=@writableStreamDefaultControllerGetBackpressure(controller);@writableStreamUpdateBackpressure(stream,backpressure)}@writableStreamDefaultControllerAdvanceQueueIfNeeded(controller)}catch(e){@writableStreamDefaultControllerErrorIfNeeded(controller,e)}})\n";
+// initializeCountQueuingStrategy
+const JSC::ConstructAbility s_countQueuingStrategyInitializeCountQueuingStrategyCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_countQueuingStrategyInitializeCountQueuingStrategyCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_countQueuingStrategyInitializeCountQueuingStrategyCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_countQueuingStrategyInitializeCountQueuingStrategyCodeLength = 139;
+static const JSC::Intrinsic s_countQueuingStrategyInitializeCountQueuingStrategyCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_countQueuingStrategyInitializeCountQueuingStrategyCode = "(function (parameters){\"use strict\";@putByIdDirectPrivate(this,\"highWaterMark\",@extractHighWaterMarkFromQueuingStrategyInit(parameters))})\n";
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 {\
     JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().writableStreamInternalsBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().writableStreamInternalsBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+    return clientData->builtinFunctions().countQueuingStrategyBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().countQueuingStrategyBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
 }
-WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+#undef DEFINE_BUILTIN_GENERATOR
+
+/* ReadableStreamBYOBRequest.ts */
+// initializeReadableStreamBYOBRequest
+const JSC::ConstructAbility s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeLength = 267;
+static const JSC::Intrinsic s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCode = "(function (controller,view){\"use strict\";if(arguments.length!==3&&arguments[2]!==@isReadableStream)@throwTypeError(\"ReadableStreamBYOBRequest constructor should not be called directly\");return @privateInitializeReadableStreamBYOBRequest.@call(this,controller,view)})\n";
+
+// respond
+const JSC::ConstructAbility s_readableStreamBYOBRequestRespondCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamBYOBRequestRespondCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamBYOBRequestRespondCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamBYOBRequestRespondCodeLength = 452;
+static const JSC::Intrinsic s_readableStreamBYOBRequestRespondCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamBYOBRequestRespondCode = "(function (bytesWritten){\"use strict\";if(!@isReadableStreamBYOBRequest(this))throw @makeThisTypeError(\"ReadableStreamBYOBRequest\",\"respond\");if(@getByIdDirectPrivate(this,\"associatedReadableByteStreamController\")===@undefined)@throwTypeError(\"ReadableStreamBYOBRequest.associatedReadableByteStreamController is undefined\");return @readableByteStreamControllerRespond(@getByIdDirectPrivate(this,\"associatedReadableByteStreamController\"),bytesWritten)})\n";
+
+// respondWithNewView
+const JSC::ConstructAbility s_readableStreamBYOBRequestRespondWithNewViewCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamBYOBRequestRespondWithNewViewCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamBYOBRequestRespondWithNewViewCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamBYOBRequestRespondWithNewViewCodeLength = 607;
+static const JSC::Intrinsic s_readableStreamBYOBRequestRespondWithNewViewCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamBYOBRequestRespondWithNewViewCode = "(function (view){\"use strict\";if(!@isReadableStreamBYOBRequest(this))throw @makeThisTypeError(\"ReadableStreamBYOBRequest\",\"respond\");if(@getByIdDirectPrivate(this,\"associatedReadableByteStreamController\")===@undefined)@throwTypeError(\"ReadableStreamBYOBRequest.associatedReadableByteStreamController is undefined\");if(!@isObject(view))@throwTypeError(\"Provided view is not an object\");if(!@ArrayBuffer.@isView(view))@throwTypeError(\"Provided view is not an ArrayBufferView\");return @readableByteStreamControllerRespondWithNewView(@getByIdDirectPrivate(this,\"associatedReadableByteStreamController\"),view)})\n";
+
+// view
+const JSC::ConstructAbility s_readableStreamBYOBRequestViewCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamBYOBRequestViewCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamBYOBRequestViewCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamBYOBRequestViewCodeLength = 172;
+static const JSC::Intrinsic s_readableStreamBYOBRequestViewCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamBYOBRequestViewCode = "(function (){\"use strict\";if(!@isReadableStreamBYOBRequest(this))throw @makeGetterTypeError(\"ReadableStreamBYOBRequest\",\"view\");return @getByIdDirectPrivate(this,\"view\")})\n";
+
+#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
+{\
+    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
+    return clientData->builtinFunctions().readableStreamBYOBRequestBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableStreamBYOBRequestBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+}
+WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+#undef DEFINE_BUILTIN_GENERATOR
+
+/* WritableStreamDefaultWriter.ts */
+// initializeWritableStreamDefaultWriter
+const JSC::ConstructAbility s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeLength = 301;
+static const JSC::Intrinsic s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCode = "(function (stream){\"use strict\";const internalStream=@getInternalWritableStream(stream);if(internalStream)stream=internalStream;if(!@isWritableStream(stream))@throwTypeError(\"WritableStreamDefaultWriter constructor takes a WritableStream\");return @setUpWritableStreamDefaultWriter(this,stream),this})\n";
+
+// closed
+const JSC::ConstructAbility s_writableStreamDefaultWriterClosedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamDefaultWriterClosedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamDefaultWriterClosedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamDefaultWriterClosedCodeLength = 214;
+static const JSC::Intrinsic s_writableStreamDefaultWriterClosedCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamDefaultWriterClosedCode = "(function (){\"use strict\";if(!@isWritableStreamDefaultWriter(this))return @Promise.@reject(@makeGetterTypeError(\"WritableStreamDefaultWriter\",\"closed\"));return @getByIdDirectPrivate(this,\"closedPromise\").promise})\n";
+
+// desiredSize
+const JSC::ConstructAbility s_writableStreamDefaultWriterDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamDefaultWriterDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamDefaultWriterDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamDefaultWriterDesiredSizeCodeLength = 309;
+static const JSC::Intrinsic s_writableStreamDefaultWriterDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamDefaultWriterDesiredSizeCode = "(function (){\"use strict\";if(!@isWritableStreamDefaultWriter(this))throw @makeThisTypeError(\"WritableStreamDefaultWriter\",\"desiredSize\");if(@getByIdDirectPrivate(this,\"stream\")===@undefined)@throwTypeError(\"WritableStreamDefaultWriter has no stream\");return @writableStreamDefaultWriterGetDesiredSize(this)})\n";
+
+// ready
+const JSC::ConstructAbility s_writableStreamDefaultWriterReadyCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamDefaultWriterReadyCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamDefaultWriterReadyCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamDefaultWriterReadyCodeLength = 210;
+static const JSC::Intrinsic s_writableStreamDefaultWriterReadyCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamDefaultWriterReadyCode = "(function (){\"use strict\";if(!@isWritableStreamDefaultWriter(this))return @Promise.@reject(@makeThisTypeError(\"WritableStreamDefaultWriter\",\"ready\"));return @getByIdDirectPrivate(this,\"readyPromise\").promise})\n";
+
+// abort
+const JSC::ConstructAbility s_writableStreamDefaultWriterAbortCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamDefaultWriterAbortCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamDefaultWriterAbortCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamDefaultWriterAbortCodeLength = 350;
+static const JSC::Intrinsic s_writableStreamDefaultWriterAbortCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamDefaultWriterAbortCode = "(function (reason){\"use strict\";if(!@isWritableStreamDefaultWriter(this))return @Promise.@reject(@makeThisTypeError(\"WritableStreamDefaultWriter\",\"abort\"));if(@getByIdDirectPrivate(this,\"stream\")===@undefined)return @Promise.@reject(@makeTypeError(\"WritableStreamDefaultWriter has no stream\"));return @writableStreamDefaultWriterAbort(this,reason)})\n";
+
+// close
+const JSC::ConstructAbility s_writableStreamDefaultWriterCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamDefaultWriterCloseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamDefaultWriterCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamDefaultWriterCloseCodeLength = 492;
+static const JSC::Intrinsic s_writableStreamDefaultWriterCloseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamDefaultWriterCloseCode = "(function (){\"use strict\";if(!@isWritableStreamDefaultWriter(this))return @Promise.@reject(@makeThisTypeError(\"WritableStreamDefaultWriter\",\"close\"));const stream=@getByIdDirectPrivate(this,\"stream\");if(stream===@undefined)return @Promise.@reject(@makeTypeError(\"WritableStreamDefaultWriter has no stream\"));if(@writableStreamCloseQueuedOrInFlight(stream))return @Promise.@reject(@makeTypeError(\"WritableStreamDefaultWriter is being closed\"));return @writableStreamDefaultWriterClose(this)})\n";
+
+// releaseLock
+const JSC::ConstructAbility s_writableStreamDefaultWriterReleaseLockCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamDefaultWriterReleaseLockCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamDefaultWriterReleaseLockCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamDefaultWriterReleaseLockCodeLength = 241;
+static const JSC::Intrinsic s_writableStreamDefaultWriterReleaseLockCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamDefaultWriterReleaseLockCode = "(function (){\"use strict\";if(!@isWritableStreamDefaultWriter(this))throw @makeThisTypeError(\"WritableStreamDefaultWriter\",\"releaseLock\");if(@getByIdDirectPrivate(this,\"stream\")===@undefined)return;@writableStreamDefaultWriterRelease(this)})\n";
+
+// write
+const JSC::ConstructAbility s_writableStreamDefaultWriterWriteCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamDefaultWriterWriteCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamDefaultWriterWriteCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamDefaultWriterWriteCodeLength = 348;
+static const JSC::Intrinsic s_writableStreamDefaultWriterWriteCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamDefaultWriterWriteCode = "(function (chunk){\"use strict\";if(!@isWritableStreamDefaultWriter(this))return @Promise.@reject(@makeThisTypeError(\"WritableStreamDefaultWriter\",\"write\"));if(@getByIdDirectPrivate(this,\"stream\")===@undefined)return @Promise.@reject(@makeTypeError(\"WritableStreamDefaultWriter has no stream\"));return @writableStreamDefaultWriterWrite(this,chunk)})\n";
+
+#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
+{\
+    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
+    return clientData->builtinFunctions().writableStreamDefaultWriterBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().writableStreamDefaultWriterBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+}
+WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+#undef DEFINE_BUILTIN_GENERATOR
+
+/* ReadableStream.ts */
+// initializeReadableStream
+const JSC::ConstructAbility s_readableStreamInitializeReadableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamInitializeReadableStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamInitializeReadableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamInitializeReadableStreamCodeLength = 2702;
+static const JSC::Intrinsic s_readableStreamInitializeReadableStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamInitializeReadableStreamCode = "(function (underlyingSource,strategy){\"use strict\";if(underlyingSource===@undefined)underlyingSource={@bunNativeType:0,@bunNativePtr:0,@lazy:!1};if(strategy===@undefined)strategy={};if(!@isObject(underlyingSource))@throwTypeError(\"ReadableStream constructor takes an object as first argument\");if(strategy!==@undefined&&!@isObject(strategy))@throwTypeError(\"ReadableStream constructor takes an object as second argument, if any\");@putByIdDirectPrivate(this,\"state\",@streamReadable),@putByIdDirectPrivate(this,\"reader\",@undefined),@putByIdDirectPrivate(this,\"storedError\",@undefined),@putByIdDirectPrivate(this,\"disturbed\",!1),@putByIdDirectPrivate(this,\"readableStreamController\",null),@putByIdDirectPrivate(this,\"bunNativeType\",@getByIdDirectPrivate(underlyingSource,\"bunNativeType\")\?\?0),@putByIdDirectPrivate(this,\"bunNativePtr\",@getByIdDirectPrivate(underlyingSource,\"bunNativePtr\")\?\?0),@putByIdDirectPrivate(this,\"asyncContext\",@getInternalField(@asyncContext,0));const isDirect=underlyingSource.type===\"direct\",isUnderlyingSourceLazy=!!underlyingSource.@lazy,isLazy=isDirect||isUnderlyingSourceLazy;if(@getByIdDirectPrivate(underlyingSource,\"pull\")!==@undefined&&!isLazy){const size=@getByIdDirectPrivate(strategy,\"size\"),highWaterMark=@getByIdDirectPrivate(strategy,\"highWaterMark\");return @putByIdDirectPrivate(this,\"highWaterMark\",highWaterMark),@putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@setupReadableStreamDefaultController(this,underlyingSource,size,highWaterMark!==@undefined\?highWaterMark:1,@getByIdDirectPrivate(underlyingSource,\"start\"),@getByIdDirectPrivate(underlyingSource,\"pull\"),@getByIdDirectPrivate(underlyingSource,\"cancel\")),this}if(isDirect)@putByIdDirectPrivate(this,\"underlyingSource\",underlyingSource),@putByIdDirectPrivate(this,\"highWaterMark\",@getByIdDirectPrivate(strategy,\"highWaterMark\")),@putByIdDirectPrivate(this,\"start\",()=>@createReadableStreamController(this,underlyingSource,strategy));else if(isLazy){const autoAllocateChunkSize=underlyingSource.autoAllocateChunkSize;@putByIdDirectPrivate(this,\"highWaterMark\",@undefined),@putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@putByIdDirectPrivate(this,\"highWaterMark\",autoAllocateChunkSize||@getByIdDirectPrivate(strategy,\"highWaterMark\")),@putByIdDirectPrivate(this,\"start\",()=>{const instance=@lazyLoadStream(this,autoAllocateChunkSize);if(instance)@createReadableStreamController(this,instance,strategy)})}else @putByIdDirectPrivate(this,\"underlyingSource\",@undefined),@putByIdDirectPrivate(this,\"highWaterMark\",@getByIdDirectPrivate(strategy,\"highWaterMark\")),@putByIdDirectPrivate(this,\"start\",@undefined),@createReadableStreamController(this,underlyingSource,strategy);return this})\n";
+
+// readableStreamToArray
+const JSC::ConstructAbility s_readableStreamReadableStreamToArrayCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamReadableStreamToArrayCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamReadableStreamToArrayCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
+const int s_readableStreamReadableStreamToArrayCodeLength = 238;
+static const JSC::Intrinsic s_readableStreamReadableStreamToArrayCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamReadableStreamToArrayCode = "(function (stream){\"use strict\";var underlyingSource=@getByIdDirectPrivate(stream,\"underlyingSource\");if(underlyingSource!==@undefined)return @readableStreamToArrayDirect(stream,underlyingSource);return @readableStreamIntoArray(stream)})\n";
+
+// readableStreamToText
+const JSC::ConstructAbility s_readableStreamReadableStreamToTextCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamReadableStreamToTextCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamReadableStreamToTextCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
+const int s_readableStreamReadableStreamToTextCodeLength = 236;
+static const JSC::Intrinsic s_readableStreamReadableStreamToTextCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamReadableStreamToTextCode = "(function (stream){\"use strict\";var underlyingSource=@getByIdDirectPrivate(stream,\"underlyingSource\");if(underlyingSource!==@undefined)return @readableStreamToTextDirect(stream,underlyingSource);return @readableStreamIntoText(stream)})\n";
+
+// readableStreamToArrayBuffer
+const JSC::ConstructAbility s_readableStreamReadableStreamToArrayBufferCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamReadableStreamToArrayBufferCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamReadableStreamToArrayBufferCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
+const int s_readableStreamReadableStreamToArrayBufferCodeLength = 355;
+static const JSC::Intrinsic s_readableStreamReadableStreamToArrayBufferCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamReadableStreamToArrayBufferCode = "(function (stream){\"use strict\";var underlyingSource=@getByIdDirectPrivate(stream,\"underlyingSource\");if(underlyingSource!==@undefined)return @readableStreamToArrayBufferDirect(stream,underlyingSource);var result=@Bun.readableStreamToArray(stream);if(@isPromise(result))return result.then(@Bun.concatArrayBuffers);return @Bun.concatArrayBuffers(result)})\n";
+
+// readableStreamToFormData
+const JSC::ConstructAbility s_readableStreamReadableStreamToFormDataCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamReadableStreamToFormDataCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamReadableStreamToFormDataCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
+const int s_readableStreamReadableStreamToFormDataCodeLength = 142;
+static const JSC::Intrinsic s_readableStreamReadableStreamToFormDataCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamReadableStreamToFormDataCode = "(function (stream,contentType){\"use strict\";return @Bun.readableStreamToBlob(stream).then((blob)=>{return FormData.from(blob,contentType)})})\n";
+
+// readableStreamToJSON
+const JSC::ConstructAbility s_readableStreamReadableStreamToJSONCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamReadableStreamToJSONCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamReadableStreamToJSONCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
+const int s_readableStreamReadableStreamToJSONCodeLength = 104;
+static const JSC::Intrinsic s_readableStreamReadableStreamToJSONCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamReadableStreamToJSONCode = "(function (stream){\"use strict\";return @Bun.readableStreamToText(stream).@then(globalThis.JSON.parse)})\n";
+
+// readableStreamToBlob
+const JSC::ConstructAbility s_readableStreamReadableStreamToBlobCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamReadableStreamToBlobCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamReadableStreamToBlobCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
+const int s_readableStreamReadableStreamToBlobCodeLength = 126;
+static const JSC::Intrinsic s_readableStreamReadableStreamToBlobCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamReadableStreamToBlobCode = "(function (stream){\"use strict\";return @Promise.resolve(@Bun.readableStreamToArray(stream)).@then((array)=>new Blob(array))})\n";
+
+// consumeReadableStream
+const JSC::ConstructAbility s_readableStreamConsumeReadableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamConsumeReadableStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamConsumeReadableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
+const int s_readableStreamConsumeReadableStreamCodeLength = 2131;
+static const JSC::Intrinsic s_readableStreamConsumeReadableStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamConsumeReadableStreamCode = "(function (nativePtr,nativeType,inputStream){\"use strict\";const symbol=globalThis.Symbol.for(\"Bun.consumeReadableStreamPrototype\");var cached=globalThis[symbol];if(!cached)cached=globalThis[symbol]=[];var Prototype=cached[nativeType];if(Prototype===@undefined){var[doRead,doError,doReadMany,doClose,onClose,deinit]=globalThis[globalThis.Symbol.for('Bun.lazy')](nativeType);Prototype=class NativeReadableStreamSink{handleError;handleClosed;processResult;constructor(reader,ptr){this.#ptr=ptr,this.#reader=reader,this.#didClose=!1,this.handleError=this._handleError.bind(this),this.handleClosed=this._handleClosed.bind(this),this.processResult=this._processResult.bind(this),reader.closed.then(this.handleClosed,this.handleError)}_handleClosed(){if(this.#didClose)return;this.#didClose=!0;var ptr=this.#ptr;this.#ptr=0,doClose(ptr),deinit(ptr)}_handleError(error){if(this.#didClose)return;this.#didClose=!0;var ptr=this.#ptr;this.#ptr=0,doError(ptr,error),deinit(ptr)}#ptr;#didClose=!1;#reader;_handleReadMany({value,done,size}){if(done){this.handleClosed();return}if(this.#didClose)return;doReadMany(this.#ptr,value,done,size)}read(){if(!this.#ptr)return @throwTypeError(\"ReadableStreamSink is already closed\");return this.processResult(this.#reader.read())}_processResult(result){if(result&&@isPromise(result)){if(@getPromiseInternalField(result,@promiseFieldFlags)&@promiseStateFulfilled){const fulfilledValue=@getPromiseInternalField(result,@promiseFieldReactionsOrResult);if(fulfilledValue)result=fulfilledValue}}if(result&&@isPromise(result))return result.then(this.processResult,this.handleError),null;if(result.done)return this.handleClosed(),0;else if(result.value)return result.value;else return-1}readMany(){if(!this.#ptr)return @throwTypeError(\"ReadableStreamSink is already closed\");return this.processResult(this.#reader.readMany())}};const minlength=nativeType+1;if(cached.length<minlength)cached.length=minlength;@putByValDirect(cached,nativeType,Prototype)}if(@isReadableStreamLocked(inputStream))@throwTypeError(\"Cannot start reading from a locked stream\");return new Prototype(inputStream.getReader(),nativePtr)})\n";
+
+// createEmptyReadableStream
+const JSC::ConstructAbility s_readableStreamCreateEmptyReadableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamCreateEmptyReadableStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamCreateEmptyReadableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
+const int s_readableStreamCreateEmptyReadableStreamCodeLength = 114;
+static const JSC::Intrinsic s_readableStreamCreateEmptyReadableStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamCreateEmptyReadableStreamCode = "(function (){\"use strict\";var stream=new @ReadableStream({pull(){}});return @readableStreamClose(stream),stream})\n";
+
+// createNativeReadableStream
+const JSC::ConstructAbility s_readableStreamCreateNativeReadableStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamCreateNativeReadableStreamCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamCreateNativeReadableStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
+const int s_readableStreamCreateNativeReadableStreamCodeLength = 181;
+static const JSC::Intrinsic s_readableStreamCreateNativeReadableStreamCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamCreateNativeReadableStreamCode = "(function (nativePtr,nativeType,autoAllocateChunkSize){\"use strict\";return new @ReadableStream({@lazy:!0,@bunNativeType:nativeType,@bunNativePtr:nativePtr,autoAllocateChunkSize})})\n";
+
+// cancel
+const JSC::ConstructAbility s_readableStreamCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamCancelCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamCancelCodeLength = 276;
+static const JSC::Intrinsic s_readableStreamCancelCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamCancelCode = "(function (reason){\"use strict\";if(!@isReadableStream(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStream\",\"cancel\"));if(@isReadableStreamLocked(this))return @Promise.@reject(@makeTypeError(\"ReadableStream is locked\"));return @readableStreamCancel(this,reason)})\n";
+
+// getReader
+const JSC::ConstructAbility s_readableStreamGetReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamGetReaderCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamGetReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamGetReaderCodeLength = 506;
+static const JSC::Intrinsic s_readableStreamGetReaderCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamGetReaderCode = "(function (options){\"use strict\";if(!@isReadableStream(this))throw @makeThisTypeError(\"ReadableStream\",\"getReader\");const mode=@toDictionary(options,{},\"ReadableStream.getReader takes an object as first argument\").mode;if(mode===@undefined){var start_=@getByIdDirectPrivate(this,\"start\");if(start_)@putByIdDirectPrivate(this,\"start\",@undefined),start_();return new @ReadableStreamDefaultReader(this)}if(mode==\"byob\")return new @ReadableStreamBYOBReader(this);@throwTypeError(\"Invalid mode is specified\")})\n";
+
+// pipeThrough
+const JSC::ConstructAbility s_readableStreamPipeThroughCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamPipeThroughCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamPipeThroughCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamPipeThroughCodeLength = 1162;
+static const JSC::Intrinsic s_readableStreamPipeThroughCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamPipeThroughCode = "(function (streams,options){\"use strict\";const transforms=streams,readable=transforms.readable;if(!@isReadableStream(readable))throw @makeTypeError(\"readable should be ReadableStream\");const writable=transforms.writable,internalWritable=@getInternalWritableStream(writable);if(!@isWritableStream(internalWritable))throw @makeTypeError(\"writable should be WritableStream\");let preventClose=!1,preventAbort=!1,preventCancel=!1,signal;if(!@isUndefinedOrNull(options)){if(!@isObject(options))throw @makeTypeError(\"options must be an object\");if(preventAbort=!!options.preventAbort,preventCancel=!!options.preventCancel,preventClose=!!options.preventClose,signal=options.signal,signal!==@undefined&&!@isAbortSignal(signal))throw @makeTypeError(\"options.signal must be AbortSignal\")}if(!@isReadableStream(this))throw @makeThisTypeError(\"ReadableStream\",\"pipeThrough\");if(@isReadableStreamLocked(this))throw @makeTypeError(\"ReadableStream is locked\");if(@isWritableStreamLocked(internalWritable))throw @makeTypeError(\"WritableStream is locked\");return @readableStreamPipeToWritableStream(this,internalWritable,preventClose,preventAbort,preventCancel,signal),readable})\n";
+
+// pipeTo
+const JSC::ConstructAbility s_readableStreamPipeToCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamPipeToCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamPipeToCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamPipeToCodeLength = 1175;
+static const JSC::Intrinsic s_readableStreamPipeToCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamPipeToCode = "(function (destination){\"use strict\";if(!@isReadableStream(this))return @Promise.@reject(@makeThisTypeError(\"ReadableStream\",\"pipeTo\"));if(@isReadableStreamLocked(this))return @Promise.@reject(@makeTypeError(\"ReadableStream is locked\"));let options=@argument(1),preventClose=!1,preventAbort=!1,preventCancel=!1,signal;if(!@isUndefinedOrNull(options)){if(!@isObject(options))return @Promise.@reject(@makeTypeError(\"options must be an object\"));try{preventAbort=!!options.preventAbort,preventCancel=!!options.preventCancel,preventClose=!!options.preventClose,signal=options.signal}catch(e){return @Promise.@reject(e)}if(signal!==@undefined&&!@isAbortSignal(signal))return @Promise.@reject(@makeTypeError(\"options.signal must be AbortSignal\"))}const internalDestination=@getInternalWritableStream(destination);if(!@isWritableStream(internalDestination))return @Promise.@reject(@makeTypeError(\"ReadableStream pipeTo requires a WritableStream\"));if(@isWritableStreamLocked(internalDestination))return @Promise.@reject(@makeTypeError(\"WritableStream is locked\"));return @readableStreamPipeToWritableStream(this,internalDestination,preventClose,preventAbort,preventCancel,signal)})\n";
+
+// tee
+const JSC::ConstructAbility s_readableStreamTeeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamTeeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamTeeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamTeeCodeLength = 140;
+static const JSC::Intrinsic s_readableStreamTeeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamTeeCode = "(function (){\"use strict\";if(!@isReadableStream(this))throw @makeThisTypeError(\"ReadableStream\",\"tee\");return @readableStreamTee(this,!1)})\n";
+
+// locked
+const JSC::ConstructAbility s_readableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamLockedCodeLength = 147;
+static const JSC::Intrinsic s_readableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamLockedCode = "(function (){\"use strict\";if(!@isReadableStream(this))throw @makeGetterTypeError(\"ReadableStream\",\"locked\");return @isReadableStreamLocked(this)})\n";
+
+// values
+const JSC::ConstructAbility s_readableStreamValuesCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamValuesCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamValuesCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableStreamValuesCodeLength = 165;
+static const JSC::Intrinsic s_readableStreamValuesCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamValuesCode = "(function (options){\"use strict\";var prototype=@ReadableStream.prototype;return @readableStreamDefineLazyIterators(prototype),prototype.values.@call(this,options)})\n";
+
+// lazyAsyncIterator
+const JSC::ConstructAbility s_readableStreamLazyAsyncIteratorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableStreamLazyAsyncIteratorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableStreamLazyAsyncIteratorCodeImplementationVisibility = JSC::ImplementationVisibility::Private;
+const int s_readableStreamLazyAsyncIteratorCodeLength = 176;
+static const JSC::Intrinsic s_readableStreamLazyAsyncIteratorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableStreamLazyAsyncIteratorCode = "(function (){\"use strict\";var prototype=@ReadableStream.prototype;return @readableStreamDefineLazyIterators(prototype),prototype[globalThis.Symbol.asyncIterator].@call(this)})\n";
+
+#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
+{\
+    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
+    return clientData->builtinFunctions().readableStreamBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableStreamBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+}
+WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
 /* ReadableStreamDefaultController.ts */
@@ -2919,38 +2663,328 @@ JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
-/* CountQueuingStrategy.ts */
-// highWaterMark
-const JSC::ConstructAbility s_countQueuingStrategyHighWaterMarkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_countQueuingStrategyHighWaterMarkCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_countQueuingStrategyHighWaterMarkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_countQueuingStrategyHighWaterMarkCodeLength = 241;
-static const JSC::Intrinsic s_countQueuingStrategyHighWaterMarkCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_countQueuingStrategyHighWaterMarkCode = "(function (){\"use strict\";const highWaterMark=@getByIdDirectPrivate(this,\"highWaterMark\");if(highWaterMark===@undefined)@throwTypeError(\"CountQueuingStrategy.highWaterMark getter called on incompatible |this| value.\");return highWaterMark})\n";
+/* ReadableByteStreamInternals.ts */
+// privateInitializeReadableByteStreamController
+const JSC::ConstructAbility s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCodeLength = 1896;
+static const JSC::Intrinsic s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCode = "(function (stream,underlyingByteSource,highWaterMark){\"use strict\";if(!@isReadableStream(stream))@throwTypeError(\"ReadableByteStreamController needs a ReadableStream\");if(@getByIdDirectPrivate(stream,\"readableStreamController\")!==null)@throwTypeError(\"ReadableStream already has a controller\");@putByIdDirectPrivate(this,\"controlledReadableStream\",stream),@putByIdDirectPrivate(this,\"underlyingByteSource\",underlyingByteSource),@putByIdDirectPrivate(this,\"pullAgain\",!1),@putByIdDirectPrivate(this,\"pulling\",!1),@readableByteStreamControllerClearPendingPullIntos(this),@putByIdDirectPrivate(this,\"queue\",@newQueue()),@putByIdDirectPrivate(this,\"started\",0),@putByIdDirectPrivate(this,\"closeRequested\",!1);let hwm=@toNumber(highWaterMark);if(hwm!==hwm||hwm<0)@throwRangeError(\"highWaterMark value is negative or not a number\");@putByIdDirectPrivate(this,\"strategyHWM\",hwm);let autoAllocateChunkSize=underlyingByteSource.autoAllocateChunkSize;if(autoAllocateChunkSize!==@undefined){if(autoAllocateChunkSize=@toNumber(autoAllocateChunkSize),autoAllocateChunkSize<=0||autoAllocateChunkSize===@Infinity||autoAllocateChunkSize===-@Infinity)@throwRangeError(\"autoAllocateChunkSize value is negative or equal to positive or negative infinity\")}@putByIdDirectPrivate(this,\"autoAllocateChunkSize\",autoAllocateChunkSize),@putByIdDirectPrivate(this,\"pendingPullIntos\",@createFIFO());const controller=this;return @promiseInvokeOrNoopNoCatch(@getByIdDirectPrivate(controller,\"underlyingByteSource\"),\"start\",[controller]).@then(()=>{@putByIdDirectPrivate(controller,\"started\",1),@readableByteStreamControllerCallPullIfNeeded(controller)},(error)=>{if(@getByIdDirectPrivate(stream,\"state\")===@streamReadable)@readableByteStreamControllerError(controller,error)}),@putByIdDirectPrivate(this,\"cancel\",@readableByteStreamControllerCancel),@putByIdDirectPrivate(this,\"pull\",@readableByteStreamControllerPull),this})\n";
 
-// size
-const JSC::ConstructAbility s_countQueuingStrategySizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_countQueuingStrategySizeCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_countQueuingStrategySizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_countQueuingStrategySizeCodeLength = 37;
-static const JSC::Intrinsic s_countQueuingStrategySizeCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_countQueuingStrategySizeCode = "(function (){\"use strict\";return 1})\n";
+// readableStreamByteStreamControllerStart
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCodeLength = 91;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableStreamByteStreamControllerStartCode = "(function (controller){\"use strict\";@putByIdDirectPrivate(controller,\"start\",@undefined)})\n";
 
-// initializeCountQueuingStrategy
-const JSC::ConstructAbility s_countQueuingStrategyInitializeCountQueuingStrategyCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_countQueuingStrategyInitializeCountQueuingStrategyCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_countQueuingStrategyInitializeCountQueuingStrategyCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_countQueuingStrategyInitializeCountQueuingStrategyCodeLength = 139;
-static const JSC::Intrinsic s_countQueuingStrategyInitializeCountQueuingStrategyCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_countQueuingStrategyInitializeCountQueuingStrategyCode = "(function (parameters){\"use strict\";@putByIdDirectPrivate(this,\"highWaterMark\",@extractHighWaterMarkFromQueuingStrategyInit(parameters))})\n";
+// privateInitializeReadableStreamBYOBRequest
+const JSC::ConstructAbility s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCodeLength = 163;
+static const JSC::Intrinsic s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsPrivateInitializeReadableStreamBYOBRequestCode = "(function (controller,view){\"use strict\";@putByIdDirectPrivate(this,\"associatedReadableByteStreamController\",controller),@putByIdDirectPrivate(this,\"view\",view)})\n";
+
+// isReadableByteStreamController
+const JSC::ConstructAbility s_readableByteStreamInternalsIsReadableByteStreamControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsIsReadableByteStreamControllerCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsIsReadableByteStreamControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsIsReadableByteStreamControllerCodeLength = 127;
+static const JSC::Intrinsic s_readableByteStreamInternalsIsReadableByteStreamControllerCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsIsReadableByteStreamControllerCode = "(function (controller){\"use strict\";return @isObject(controller)&&!!@getByIdDirectPrivate(controller,\"underlyingByteSource\")})\n";
+
+// isReadableStreamBYOBRequest
+const JSC::ConstructAbility s_readableByteStreamInternalsIsReadableStreamBYOBRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsIsReadableStreamBYOBRequestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsIsReadableStreamBYOBRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsIsReadableStreamBYOBRequestCodeLength = 148;
+static const JSC::Intrinsic s_readableByteStreamInternalsIsReadableStreamBYOBRequestCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsIsReadableStreamBYOBRequestCode = "(function (byobRequest){\"use strict\";return @isObject(byobRequest)&&!!@getByIdDirectPrivate(byobRequest,\"associatedReadableByteStreamController\")})\n";
+
+// isReadableStreamBYOBReader
+const JSC::ConstructAbility s_readableByteStreamInternalsIsReadableStreamBYOBReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsIsReadableStreamBYOBReaderCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsIsReadableStreamBYOBReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsIsReadableStreamBYOBReaderCodeLength = 111;
+static const JSC::Intrinsic s_readableByteStreamInternalsIsReadableStreamBYOBReaderCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsIsReadableStreamBYOBReaderCode = "(function (reader){\"use strict\";return @isObject(reader)&&!!@getByIdDirectPrivate(reader,\"readIntoRequests\")})\n";
+
+// readableByteStreamControllerCancel
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerCancelCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerCancelCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerCancelCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerCancelCodeLength = 336;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerCancelCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerCancelCode = "(function (controller,reason){\"use strict\";var pendingPullIntos=@getByIdDirectPrivate(controller,\"pendingPullIntos\"),first=pendingPullIntos.peek();if(first)first.bytesFilled=0;return @putByIdDirectPrivate(controller,\"queue\",@newQueue()),@promiseInvokeOrNoop(@getByIdDirectPrivate(controller,\"underlyingByteSource\"),\"cancel\",[reason])})\n";
+
+// readableByteStreamControllerError
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerErrorCodeLength = 242;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerErrorCode = "(function (controller,e){\"use strict\";@readableByteStreamControllerClearPendingPullIntos(controller),@putByIdDirectPrivate(controller,\"queue\",@newQueue()),@readableStreamError(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),e)})\n";
+
+// readableByteStreamControllerClose
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerCloseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerCloseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerCloseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerCloseCodeLength = 473;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerCloseCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerCloseCode = "(function (controller){\"use strict\";if(@getByIdDirectPrivate(controller,\"queue\").size>0){@putByIdDirectPrivate(controller,\"closeRequested\",!0);return}var first=@getByIdDirectPrivate(controller,\"pendingPullIntos\")\?.peek();if(first){if(first.bytesFilled>0){const e=@makeTypeError(\"Close requested while there remain pending bytes\");throw @readableByteStreamControllerError(controller,e),e}}@readableStreamClose(@getByIdDirectPrivate(controller,\"controlledReadableStream\"))})\n";
+
+// readableByteStreamControllerClearPendingPullIntos
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCodeLength = 281;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerClearPendingPullIntosCode = "(function (controller){\"use strict\";@readableByteStreamControllerInvalidateBYOBRequest(controller);var existing=@getByIdDirectPrivate(controller,\"pendingPullIntos\");if(existing!==@undefined)existing.clear();else @putByIdDirectPrivate(controller,\"pendingPullIntos\",@createFIFO())})\n";
+
+// readableByteStreamControllerGetDesiredSize
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCodeLength = 330;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerGetDesiredSizeCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\"),state=@getByIdDirectPrivate(stream,\"state\");if(state===@streamErrored)return null;if(state===@streamClosed)return 0;return @getByIdDirectPrivate(controller,\"strategyHWM\")-@getByIdDirectPrivate(controller,\"queue\").size})\n";
+
+// readableStreamHasBYOBReader
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamHasBYOBReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamHasBYOBReaderCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamHasBYOBReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableStreamHasBYOBReaderCodeLength = 150;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamHasBYOBReaderCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableStreamHasBYOBReaderCode = "(function (stream){\"use strict\";const reader=@getByIdDirectPrivate(stream,\"reader\");return reader!==@undefined&&@isReadableStreamBYOBReader(reader)})\n";
+
+// readableStreamHasDefaultReader
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamHasDefaultReaderCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamHasDefaultReaderCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamHasDefaultReaderCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableStreamHasDefaultReaderCodeLength = 153;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamHasDefaultReaderCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableStreamHasDefaultReaderCode = "(function (stream){\"use strict\";const reader=@getByIdDirectPrivate(stream,\"reader\");return reader!==@undefined&&@isReadableStreamDefaultReader(reader)})\n";
+
+// readableByteStreamControllerHandleQueueDrain
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCodeLength = 287;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerHandleQueueDrainCode = "(function (controller){\"use strict\";if(!@getByIdDirectPrivate(controller,\"queue\").size&&@getByIdDirectPrivate(controller,\"closeRequested\"))@readableStreamClose(@getByIdDirectPrivate(controller,\"controlledReadableStream\"));else @readableByteStreamControllerCallPullIfNeeded(controller)})\n";
+
+// readableByteStreamControllerPull
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerPullCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerPullCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerPullCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerPullCodeLength = 1169;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerPullCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerPullCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(@getByIdDirectPrivate(controller,\"queue\").content\?.isNotEmpty()){const entry=@getByIdDirectPrivate(controller,\"queue\").content.shift();@getByIdDirectPrivate(controller,\"queue\").size-=entry.byteLength,@readableByteStreamControllerHandleQueueDrain(controller);let view;try{view=new @Uint8Array(entry.buffer,entry.byteOffset,entry.byteLength)}catch(error){return @Promise.@reject(error)}return @createFulfilledPromise({value:view,done:!1})}if(@getByIdDirectPrivate(controller,\"autoAllocateChunkSize\")!==@undefined){let buffer;try{buffer=@createUninitializedArrayBuffer(@getByIdDirectPrivate(controller,\"autoAllocateChunkSize\"))}catch(error){return @Promise.@reject(error)}const pullIntoDescriptor={buffer,byteOffset:0,byteLength:@getByIdDirectPrivate(controller,\"autoAllocateChunkSize\"),bytesFilled:0,elementSize:1,ctor:@Uint8Array,readerType:\"default\"};@getByIdDirectPrivate(controller,\"pendingPullIntos\").push(pullIntoDescriptor)}const promise=@readableStreamAddReadRequest(stream);return @readableByteStreamControllerCallPullIfNeeded(controller),promise})\n";
+
+// readableByteStreamControllerShouldCallPull
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCodeLength = 709;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerShouldCallPullCode = "(function (controller){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(@getByIdDirectPrivate(stream,\"state\")!==@streamReadable)return!1;if(@getByIdDirectPrivate(controller,\"closeRequested\"))return!1;if(!(@getByIdDirectPrivate(controller,\"started\")>0))return!1;const reader=@getByIdDirectPrivate(stream,\"reader\");if(reader&&(@getByIdDirectPrivate(reader,\"readRequests\")\?.isNotEmpty()||!!@getByIdDirectPrivate(reader,\"bunNativePtr\")))return!0;if(@readableStreamHasBYOBReader(stream)&&@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readIntoRequests\")\?.isNotEmpty())return!0;if(@readableByteStreamControllerGetDesiredSize(controller)>0)return!0;return!1})\n";
+
+// readableByteStreamControllerCallPullIfNeeded
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCodeLength = 748;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerCallPullIfNeededCode = "(function (controller){\"use strict\";if(!@readableByteStreamControllerShouldCallPull(controller))return;if(@getByIdDirectPrivate(controller,\"pulling\")){@putByIdDirectPrivate(controller,\"pullAgain\",!0);return}@putByIdDirectPrivate(controller,\"pulling\",!0),@promiseInvokeOrNoop(@getByIdDirectPrivate(controller,\"underlyingByteSource\"),\"pull\",[controller]).@then(()=>{if(@putByIdDirectPrivate(controller,\"pulling\",!1),@getByIdDirectPrivate(controller,\"pullAgain\"))@putByIdDirectPrivate(controller,\"pullAgain\",!1),@readableByteStreamControllerCallPullIfNeeded(controller)},(error)=>{if(@getByIdDirectPrivate(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),\"state\")===@streamReadable)@readableByteStreamControllerError(controller,error)})})\n";
+
+// transferBufferToCurrentRealm
+const JSC::ConstructAbility s_readableByteStreamInternalsTransferBufferToCurrentRealmCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsTransferBufferToCurrentRealmCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsTransferBufferToCurrentRealmCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsTransferBufferToCurrentRealmCodeLength = 48;
+static const JSC::Intrinsic s_readableByteStreamInternalsTransferBufferToCurrentRealmCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsTransferBufferToCurrentRealmCode = "(function (buffer){\"use strict\";return buffer})\n";
+
+// readableStreamReaderKind
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamReaderKindCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamReaderKindCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamReaderKindCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableStreamReaderKindCodeLength = 208;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamReaderKindCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableStreamReaderKindCode = "(function (reader){\"use strict\";if(@getByIdDirectPrivate(reader,\"readRequests\"))return @getByIdDirectPrivate(reader,\"bunNativePtr\")\?3:1;if(@getByIdDirectPrivate(reader,\"readIntoRequests\"))return 2;return 0})\n";
+
+// readableByteStreamControllerEnqueue
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCodeLength = 1036;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerEnqueueCode = "(function (controller,chunk){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");switch(@getByIdDirectPrivate(stream,\"reader\")\?@readableStreamReaderKind(@getByIdDirectPrivate(stream,\"reader\")):0){case 1:{if(!@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readRequests\")\?.isNotEmpty())@readableByteStreamControllerEnqueueChunk(controller,@transferBufferToCurrentRealm(chunk.buffer),chunk.byteOffset,chunk.byteLength);else{const transferredView=chunk.constructor===@Uint8Array\?chunk:new @Uint8Array(chunk.buffer,chunk.byteOffset,chunk.byteLength);@readableStreamFulfillReadRequest(stream,transferredView,!1)}break}case 2:{@readableByteStreamControllerEnqueueChunk(controller,@transferBufferToCurrentRealm(chunk.buffer),chunk.byteOffset,chunk.byteLength),@readableByteStreamControllerProcessPullDescriptors(controller);break}case 3:break;default:{@readableByteStreamControllerEnqueueChunk(controller,@transferBufferToCurrentRealm(chunk.buffer),chunk.byteOffset,chunk.byteLength);break}}})\n";
+
+// readableByteStreamControllerEnqueueChunk
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCodeLength = 213;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerEnqueueChunkCode = "(function (controller,buffer,byteOffset,byteLength){\"use strict\";@getByIdDirectPrivate(controller,\"queue\").content.push({buffer,byteOffset,byteLength}),@getByIdDirectPrivate(controller,\"queue\").size+=byteLength})\n";
+
+// readableByteStreamControllerRespondWithNewView
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCodeLength = 463;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerRespondWithNewViewCode = "(function (controller,view){\"use strict\";let firstDescriptor=@getByIdDirectPrivate(controller,\"pendingPullIntos\").peek();if(firstDescriptor.byteOffset+firstDescriptor.bytesFilled!==view.byteOffset)@throwRangeError(\"Invalid value for view.byteOffset\");if(firstDescriptor.byteLength!==view.byteLength)@throwRangeError(\"Invalid value for view.byteLength\");firstDescriptor.buffer=view.buffer,@readableByteStreamControllerRespondInternal(controller,view.byteLength)})\n";
+
+// readableByteStreamControllerRespond
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerRespondCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerRespondCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerRespondCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerRespondCodeLength = 287;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerRespondCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerRespondCode = "(function (controller,bytesWritten){\"use strict\";if(bytesWritten=@toNumber(bytesWritten),bytesWritten!==bytesWritten||bytesWritten===@Infinity||bytesWritten<0)@throwRangeError(\"bytesWritten has an incorrect value\");@readableByteStreamControllerRespondInternal(controller,bytesWritten)})\n";
+
+// readableByteStreamControllerRespondInternal
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCodeLength = 534;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerRespondInternalCode = "(function (controller,bytesWritten){\"use strict\";let firstDescriptor=@getByIdDirectPrivate(controller,\"pendingPullIntos\").peek(),stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");if(@getByIdDirectPrivate(stream,\"state\")===@streamClosed){if(bytesWritten!==0)@throwTypeError(\"bytesWritten is different from 0 even though stream is closed\");@readableByteStreamControllerRespondInClosedState(controller,firstDescriptor)}else @readableByteStreamControllerRespondInReadableState(controller,bytesWritten,firstDescriptor)})\n";
+
+// readableByteStreamControllerRespondInReadableState
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCodeLength = 1110;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerRespondInReadableStateCode = "(function (controller,bytesWritten,pullIntoDescriptor){\"use strict\";if(pullIntoDescriptor.bytesFilled+bytesWritten>pullIntoDescriptor.byteLength)@throwRangeError(\"bytesWritten value is too great\");if(@readableByteStreamControllerInvalidateBYOBRequest(controller),pullIntoDescriptor.bytesFilled+=bytesWritten,pullIntoDescriptor.bytesFilled<pullIntoDescriptor.elementSize)return;@readableByteStreamControllerShiftPendingDescriptor(controller);const remainderSize=pullIntoDescriptor.bytesFilled%pullIntoDescriptor.elementSize;if(remainderSize>0){const end=pullIntoDescriptor.byteOffset+pullIntoDescriptor.bytesFilled,remainder=@cloneArrayBuffer(pullIntoDescriptor.buffer,end-remainderSize,remainderSize);@readableByteStreamControllerEnqueueChunk(controller,remainder,0,remainder.byteLength)}pullIntoDescriptor.buffer=@transferBufferToCurrentRealm(pullIntoDescriptor.buffer),pullIntoDescriptor.bytesFilled-=remainderSize,@readableByteStreamControllerCommitDescriptor(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),pullIntoDescriptor),@readableByteStreamControllerProcessPullDescriptors(controller)})\n";
+
+// readableByteStreamControllerRespondInClosedState
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCodeLength = 596;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerRespondInClosedStateCode = "(function (controller,firstDescriptor){\"use strict\";if(firstDescriptor.buffer=@transferBufferToCurrentRealm(firstDescriptor.buffer),@readableStreamHasBYOBReader(@getByIdDirectPrivate(controller,\"controlledReadableStream\")))while(@getByIdDirectPrivate(@getByIdDirectPrivate(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),\"reader\"),\"readIntoRequests\")\?.isNotEmpty()){let pullIntoDescriptor=@readableByteStreamControllerShiftPendingDescriptor(controller);@readableByteStreamControllerCommitDescriptor(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),pullIntoDescriptor)}})\n";
+
+// readableByteStreamControllerProcessPullDescriptors
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCodeLength = 534;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerProcessPullDescriptorsCode = "(function (controller){\"use strict\";while(@getByIdDirectPrivate(controller,\"pendingPullIntos\").isNotEmpty()){if(@getByIdDirectPrivate(controller,\"queue\").size===0)return;let pullIntoDescriptor=@getByIdDirectPrivate(controller,\"pendingPullIntos\").peek();if(@readableByteStreamControllerFillDescriptorFromQueue(controller,pullIntoDescriptor))@readableByteStreamControllerShiftPendingDescriptor(controller),@readableByteStreamControllerCommitDescriptor(@getByIdDirectPrivate(controller,\"controlledReadableStream\"),pullIntoDescriptor)}})\n";
+
+// readableByteStreamControllerFillDescriptorFromQueue
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCodeLength = 1538;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerFillDescriptorFromQueueCode = "(function (controller,pullIntoDescriptor){\"use strict\";const currentAlignedBytes=pullIntoDescriptor.bytesFilled-pullIntoDescriptor.bytesFilled%pullIntoDescriptor.elementSize,maxBytesToCopy=@getByIdDirectPrivate(controller,\"queue\").size<pullIntoDescriptor.byteLength-pullIntoDescriptor.bytesFilled\?@getByIdDirectPrivate(controller,\"queue\").size:pullIntoDescriptor.byteLength-pullIntoDescriptor.bytesFilled,maxBytesFilled=pullIntoDescriptor.bytesFilled+maxBytesToCopy,maxAlignedBytes=maxBytesFilled-maxBytesFilled%pullIntoDescriptor.elementSize;let totalBytesToCopyRemaining=maxBytesToCopy,ready=!1;if(maxAlignedBytes>currentAlignedBytes)totalBytesToCopyRemaining=maxAlignedBytes-pullIntoDescriptor.bytesFilled,ready=!0;while(totalBytesToCopyRemaining>0){let headOfQueue=@getByIdDirectPrivate(controller,\"queue\").content.peek();const bytesToCopy=totalBytesToCopyRemaining<headOfQueue.byteLength\?totalBytesToCopyRemaining:headOfQueue.byteLength,destStart=pullIntoDescriptor.byteOffset+pullIntoDescriptor.bytesFilled;if(new @Uint8Array(pullIntoDescriptor.buffer).set(new @Uint8Array(headOfQueue.buffer,headOfQueue.byteOffset,bytesToCopy),destStart),headOfQueue.byteLength===bytesToCopy)@getByIdDirectPrivate(controller,\"queue\").content.shift();else headOfQueue.byteOffset+=bytesToCopy,headOfQueue.byteLength-=bytesToCopy;@getByIdDirectPrivate(controller,\"queue\").size-=bytesToCopy,@readableByteStreamControllerInvalidateBYOBRequest(controller),pullIntoDescriptor.bytesFilled+=bytesToCopy,totalBytesToCopyRemaining-=bytesToCopy}return ready})\n";
+
+// readableByteStreamControllerShiftPendingDescriptor
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCodeLength = 195;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerShiftPendingDescriptorCode = "(function (controller){\"use strict\";let descriptor=@getByIdDirectPrivate(controller,\"pendingPullIntos\").shift();return @readableByteStreamControllerInvalidateBYOBRequest(controller),descriptor})\n";
+
+// readableByteStreamControllerInvalidateBYOBRequest
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCodeLength = 374;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerInvalidateBYOBRequestCode = "(function (controller){\"use strict\";if(@getByIdDirectPrivate(controller,\"byobRequest\")===@undefined)return;const byobRequest=@getByIdDirectPrivate(controller,\"byobRequest\");@putByIdDirectPrivate(byobRequest,\"associatedReadableByteStreamController\",@undefined),@putByIdDirectPrivate(byobRequest,\"view\",@undefined),@putByIdDirectPrivate(controller,\"byobRequest\",@undefined)})\n";
+
+// readableByteStreamControllerCommitDescriptor
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCodeLength = 382;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerCommitDescriptorCode = "(function (stream,pullIntoDescriptor){\"use strict\";let done=!1;if(@getByIdDirectPrivate(stream,\"state\")===@streamClosed)done=!0;let filledView=@readableByteStreamControllerConvertDescriptor(pullIntoDescriptor);if(pullIntoDescriptor.readerType===\"default\")@readableStreamFulfillReadRequest(stream,filledView,done);else @readableStreamFulfillReadIntoRequest(stream,filledView,done)})\n";
+
+// readableByteStreamControllerConvertDescriptor
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCodeLength = 200;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerConvertDescriptorCode = "(function (pullIntoDescriptor){\"use strict\";return new pullIntoDescriptor.ctor(pullIntoDescriptor.buffer,pullIntoDescriptor.byteOffset,pullIntoDescriptor.bytesFilled/pullIntoDescriptor.elementSize)})\n";
+
+// readableStreamFulfillReadIntoRequest
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCodeLength = 208;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableStreamFulfillReadIntoRequestCode = "(function (stream,chunk,done){\"use strict\";const readIntoRequest=@getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readIntoRequests\").shift();@fulfillPromise(readIntoRequest,{value:chunk,done})})\n";
+
+// readableStreamBYOBReaderRead
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamBYOBReaderReadCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamBYOBReaderReadCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamBYOBReaderReadCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableStreamBYOBReaderReadCodeLength = 384;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamBYOBReaderReadCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableStreamBYOBReaderReadCode = "(function (reader,view){\"use strict\";const stream=@getByIdDirectPrivate(reader,\"ownerReadableStream\");if(@putByIdDirectPrivate(stream,\"disturbed\",!0),@getByIdDirectPrivate(stream,\"state\")===@streamErrored)return @Promise.@reject(@getByIdDirectPrivate(stream,\"storedError\"));return @readableByteStreamControllerPullInto(@getByIdDirectPrivate(stream,\"readableStreamController\"),view)})\n";
+
+// readableByteStreamControllerPullInto
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCodeLength = 1659;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableByteStreamControllerPullIntoCode = "(function (controller,view){\"use strict\";const stream=@getByIdDirectPrivate(controller,\"controlledReadableStream\");let elementSize=1;if(view.BYTES_PER_ELEMENT!==@undefined)elementSize=view.BYTES_PER_ELEMENT;const ctor=view.constructor,pullIntoDescriptor={buffer:view.buffer,byteOffset:view.byteOffset,byteLength:view.byteLength,bytesFilled:0,elementSize,ctor,readerType:\"byob\"};var pending=@getByIdDirectPrivate(controller,\"pendingPullIntos\");if(pending\?.isNotEmpty())return pullIntoDescriptor.buffer=@transferBufferToCurrentRealm(pullIntoDescriptor.buffer),pending.push(pullIntoDescriptor),@readableStreamAddReadIntoRequest(stream);if(@getByIdDirectPrivate(stream,\"state\")===@streamClosed){const emptyView=new ctor(pullIntoDescriptor.buffer,pullIntoDescriptor.byteOffset,0);return @createFulfilledPromise({value:emptyView,done:!0})}if(@getByIdDirectPrivate(controller,\"queue\").size>0){if(@readableByteStreamControllerFillDescriptorFromQueue(controller,pullIntoDescriptor)){const filledView=@readableByteStreamControllerConvertDescriptor(pullIntoDescriptor);return @readableByteStreamControllerHandleQueueDrain(controller),@createFulfilledPromise({value:filledView,done:!1})}if(@getByIdDirectPrivate(controller,\"closeRequested\")){const e=@makeTypeError(\"Closing stream has been requested\");return @readableByteStreamControllerError(controller,e),@Promise.@reject(e)}}pullIntoDescriptor.buffer=@transferBufferToCurrentRealm(pullIntoDescriptor.buffer),@getByIdDirectPrivate(controller,\"pendingPullIntos\").push(pullIntoDescriptor);const promise=@readableStreamAddReadIntoRequest(stream);return @readableByteStreamControllerCallPullIfNeeded(controller),promise})\n";
+
+// readableStreamAddReadIntoRequest
+const JSC::ConstructAbility s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCodeLength = 184;
+static const JSC::Intrinsic s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_readableByteStreamInternalsReadableStreamAddReadIntoRequestCode = "(function (stream){\"use strict\";const readRequest=@newPromise();return @getByIdDirectPrivate(@getByIdDirectPrivate(stream,\"reader\"),\"readIntoRequests\").push(readRequest),readRequest})\n";
 
 #define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
 JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 {\
     JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().countQueuingStrategyBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().countQueuingStrategyBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+    return clientData->builtinFunctions().readableByteStreamInternalsBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().readableByteStreamInternalsBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
 }
-WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_READABLEBYTESTREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
+#undef DEFINE_BUILTIN_GENERATOR
+
+/* WritableStreamDefaultController.ts */
+// initializeWritableStreamDefaultController
+const JSC::ConstructAbility s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeLength = 388;
+static const JSC::Intrinsic s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCode = "(function (){\"use strict\";return @putByIdDirectPrivate(this,\"queue\",@newQueue()),@putByIdDirectPrivate(this,\"abortSteps\",(reason)=>{const result=@getByIdDirectPrivate(this,\"abortAlgorithm\").@call(@undefined,reason);return @writableStreamDefaultControllerClearAlgorithms(this),result}),@putByIdDirectPrivate(this,\"errorSteps\",()=>{@resetQueue(@getByIdDirectPrivate(this,\"queue\"))}),this})\n";
+
+// error
+const JSC::ConstructAbility s_writableStreamDefaultControllerErrorCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
+const JSC::ConstructorKind s_writableStreamDefaultControllerErrorCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_writableStreamDefaultControllerErrorCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const int s_writableStreamDefaultControllerErrorCodeLength = 311;
+static const JSC::Intrinsic s_writableStreamDefaultControllerErrorCodeIntrinsic = JSC::NoIntrinsic;
+const char* const s_writableStreamDefaultControllerErrorCode = "(function (e){\"use strict\";if(@getByIdDirectPrivate(this,\"abortSteps\")===@undefined)throw @makeThisTypeError(\"WritableStreamDefaultController\",\"error\");const stream=@getByIdDirectPrivate(this,\"stream\");if(@getByIdDirectPrivate(stream,\"state\")!==\"writable\")return;@writableStreamDefaultControllerError(this,e)})\n";
+
+#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
+{\
+    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
+    return clientData->builtinFunctions().writableStreamDefaultControllerBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().writableStreamDefaultControllerBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
+}
+WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
 /* EventSource.ts */
@@ -2971,49 +3005,15 @@ JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
 WEBCORE_FOREACH_EVENTSOURCE_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
 #undef DEFINE_BUILTIN_GENERATOR
 
-/* ProcessObjectInternals.ts */
-// binding
-const JSC::ConstructAbility s_processObjectInternalsBindingCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_processObjectInternalsBindingCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_processObjectInternalsBindingCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_processObjectInternalsBindingCodeLength = 511;
-static const JSC::Intrinsic s_processObjectInternalsBindingCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_processObjectInternalsBindingCode = "(function (bindingName){\"use strict\";if(bindingName===\"constants\")return @processBindingConstants;const issue={fs:3546,buffer:2020,natives:2254,uv:2891}[bindingName];if(issue)throw new Error(`process.binding(\"${bindingName}\") is not implemented in Bun. Track the status & thumbs up the issue: https://github.com/oven-sh/bun/issues/${issue}`);@throwTypeError(`process.binding(\"${bindingName}\") is not implemented in Bun. If that breaks something, please file an issue and include a reproducible code sample.`)})\n";
-
-// getStdioWriteStream
-const JSC::ConstructAbility s_processObjectInternalsGetStdioWriteStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_processObjectInternalsGetStdioWriteStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_processObjectInternalsGetStdioWriteStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_processObjectInternalsGetStdioWriteStreamCodeLength = 621;
-static const JSC::Intrinsic s_processObjectInternalsGetStdioWriteStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_processObjectInternalsGetStdioWriteStreamCode = "(function (fd){\"use strict\";const stream=(@getInternalField(@internalModuleRegistry,42)||@createInternalModuleById(42)).WriteStream(fd);if(process.on(\"SIGWINCH\",()=>{stream._refreshSize()}),fd===1)stream.destroySoon=stream.destroy,stream._destroy=function(err,cb){if(cb(err),this._undestroy(),!this._writableState.emitClose)process.nextTick(()=>{this.emit(\"close\")})};else if(fd===2)stream.destroySoon=stream.destroy,stream._destroy=function(err,cb){if(cb(err),this._undestroy(),!this._writableState.emitClose)process.nextTick(()=>{this.emit(\"close\")})};return stream._type=\"tty\",stream._isStdio=!0,stream.fd=fd,stream})\n";
-
-// getStdinStream
-const JSC::ConstructAbility s_processObjectInternalsGetStdinStreamCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
-const JSC::ConstructorKind s_processObjectInternalsGetStdinStreamCodeConstructorKind = JSC::ConstructorKind::None;
-const JSC::ImplementationVisibility s_processObjectInternalsGetStdinStreamCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
-const int s_processObjectInternalsGetStdinStreamCodeLength = 1386;
-static const JSC::Intrinsic s_processObjectInternalsGetStdinStreamCodeIntrinsic = JSC::NoIntrinsic;
-const char* const s_processObjectInternalsGetStdinStreamCode = "(function (fd){\"use strict\";var reader,readerRef;function ref(){reader\?\?=@Bun.stdin.stream().getReader(),readerRef\?\?=setInterval(()=>{},1<<30)}function unref(){if(readerRef)clearInterval(readerRef),readerRef=@undefined;if(reader)reader.cancel(),reader=@undefined}const stream=new((@getInternalField(@internalModuleRegistry,42))||(@createInternalModuleById(42))).ReadStream(fd),originalOn=stream.on;stream.on=function(event,listener){if(event===\"readable\")ref();return originalOn.call(this,event,listener)},stream.fd=fd;const originalPause=stream.pause;stream.pause=function(){return unref(),originalPause.call(this)};const originalResume=stream.resume;stream.resume=function(){return ref(),originalResume.call(this)};async function internalRead(stream2){try{var done,value;const read=reader\?.readMany();if(@isPromise(read))({done,value}=await read);else({done,value}=read);if(!done){stream2.push(value[0]);const length=value.length;for(let i=1;i<length;i++)stream2.push(value[i])}else stream2.emit(\"end\"),stream2.pause()}catch(err){stream2.destroy(err)}}return stream._read=function(size){internalRead(this)},stream.on(\"resume\",()=>{ref(),stream._undestroy()}),stream._readableState.reading=!1,stream.on(\"pause\",()=>{process.nextTick(()=>{if(!stream.readableFlowing)stream._readableState.reading=!1})}),stream.on(\"close\",()=>{process.nextTick(()=>{stream.destroy(),unref()})}),stream})\n";
-
-#define DEFINE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-JSC::FunctionExecutable* codeName##Generator(JSC::VM& vm) \
-{\
-    JSVMClientData* clientData = static_cast<JSVMClientData*>(vm.clientData); \
-    return clientData->builtinFunctions().processObjectInternalsBuiltins().codeName##Executable()->link(vm, nullptr, clientData->builtinFunctions().processObjectInternalsBuiltins().codeName##Source(), std::nullopt, s_##codeName##Intrinsic); \
-}
-WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_GENERATOR)
-#undef DEFINE_BUILTIN_GENERATOR
-
 
 
 JSBuiltinInternalFunctions::JSBuiltinInternalFunctions(JSC::VM& vm)
     : m_vm(vm)
+    , m_writableStreamInternals(vm)
     , m_transformStreamInternals(vm)
     , m_readableStreamInternals(vm)
-    , m_readableByteStreamInternals(vm)
     , m_streamInternals(vm)
-    , m_writableStreamInternals(vm)
+    , m_readableByteStreamInternals(vm)
 
 {
     UNUSED_PARAM(vm);
@@ -3022,11 +3022,11 @@ JSBuiltinInternalFunctions::JSBuiltinInternalFunctions(JSC::VM& vm)
 template<typename Visitor>
 void JSBuiltinInternalFunctions::visit(Visitor& visitor)
 {
+    m_writableStreamInternals.visit(visitor);
     m_transformStreamInternals.visit(visitor);
     m_readableStreamInternals.visit(visitor);
-    m_readableByteStreamInternals.visit(visitor);
     m_streamInternals.visit(visitor);
-    m_writableStreamInternals.visit(visitor);
+    m_readableByteStreamInternals.visit(visitor);
 
     UNUSED_PARAM(visitor);
 }
@@ -3037,15 +3037,20 @@ template void JSBuiltinInternalFunctions::visit(SlotVisitor&);
 SUPPRESS_ASAN void JSBuiltinInternalFunctions::initialize(Zig::GlobalObject& globalObject)
 {
     UNUSED_PARAM(globalObject);
+    m_writableStreamInternals.init(globalObject);
     m_transformStreamInternals.init(globalObject);
     m_readableStreamInternals.init(globalObject);
-    m_readableByteStreamInternals.init(globalObject);
     m_streamInternals.init(globalObject);
-    m_writableStreamInternals.init(globalObject);
+    m_readableByteStreamInternals.init(globalObject);
 
     JSVMClientData& clientData = *static_cast<JSVMClientData*>(m_vm.clientData);
     Zig::GlobalObject::GlobalPropertyInfo staticGlobals[] = {
 #define DECLARE_GLOBAL_STATIC(name) \
+    Zig::GlobalObject::GlobalPropertyInfo( \
+        clientData.builtinFunctions().writableStreamInternalsBuiltins().name##PrivateName(), writableStreamInternals().m_##name##Function.get() , JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly),
+    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_GLOBAL_STATIC)
+  #undef DECLARE_GLOBAL_STATIC
+  #define DECLARE_GLOBAL_STATIC(name) \
     Zig::GlobalObject::GlobalPropertyInfo( \
         clientData.builtinFunctions().transformStreamInternalsBuiltins().name##PrivateName(), transformStreamInternals().m_##name##Function.get() , JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly),
     WEBCORE_FOREACH_TRANSFORMSTREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_GLOBAL_STATIC)
@@ -3057,18 +3062,13 @@ SUPPRESS_ASAN void JSBuiltinInternalFunctions::initialize(Zig::GlobalObject& glo
   #undef DECLARE_GLOBAL_STATIC
   #define DECLARE_GLOBAL_STATIC(name) \
     Zig::GlobalObject::GlobalPropertyInfo( \
-        clientData.builtinFunctions().readableByteStreamInternalsBuiltins().name##PrivateName(), readableByteStreamInternals().m_##name##Function.get() , JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly),
-    WEBCORE_FOREACH_READABLEBYTESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_GLOBAL_STATIC)
-  #undef DECLARE_GLOBAL_STATIC
-  #define DECLARE_GLOBAL_STATIC(name) \
-    Zig::GlobalObject::GlobalPropertyInfo( \
         clientData.builtinFunctions().streamInternalsBuiltins().name##PrivateName(), streamInternals().m_##name##Function.get() , JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly),
     WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_GLOBAL_STATIC)
   #undef DECLARE_GLOBAL_STATIC
   #define DECLARE_GLOBAL_STATIC(name) \
     Zig::GlobalObject::GlobalPropertyInfo( \
-        clientData.builtinFunctions().writableStreamInternalsBuiltins().name##PrivateName(), writableStreamInternals().m_##name##Function.get() , JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly),
-    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_GLOBAL_STATIC)
+        clientData.builtinFunctions().readableByteStreamInternalsBuiltins().name##PrivateName(), readableByteStreamInternals().m_##name##Function.get() , JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly),
+    WEBCORE_FOREACH_READABLEBYTESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_GLOBAL_STATIC)
   #undef DECLARE_GLOBAL_STATIC
   
     };

--- a/src/js/out/WebCoreJSBuiltins.d.ts
+++ b/src/js/out/WebCoreJSBuiltins.d.ts
@@ -2,6 +2,57 @@
 // Do not edit by hand.
 type RemoveThis<F> = F extends (this: infer T, ...args: infer A) => infer R ? (...args: A) => R : F;
 
+// WritableStreamInternals.ts
+declare const $isWritableStream: RemoveThis<typeof import("../builtins/WritableStreamInternals")["isWritableStream"]>;
+declare const $isWritableStreamDefaultWriter: RemoveThis<typeof import("../builtins/WritableStreamInternals")["isWritableStreamDefaultWriter"]>;
+declare const $acquireWritableStreamDefaultWriter: RemoveThis<typeof import("../builtins/WritableStreamInternals")["acquireWritableStreamDefaultWriter"]>;
+declare const $createWritableStream: RemoveThis<typeof import("../builtins/WritableStreamInternals")["createWritableStream"]>;
+declare const $createInternalWritableStreamFromUnderlyingSink: RemoveThis<typeof import("../builtins/WritableStreamInternals")["createInternalWritableStreamFromUnderlyingSink"]>;
+declare const $initializeWritableStreamSlots: RemoveThis<typeof import("../builtins/WritableStreamInternals")["initializeWritableStreamSlots"]>;
+declare const $writableStreamCloseForBindings: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamCloseForBindings"]>;
+declare const $writableStreamAbortForBindings: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamAbortForBindings"]>;
+declare const $isWritableStreamLocked: RemoveThis<typeof import("../builtins/WritableStreamInternals")["isWritableStreamLocked"]>;
+declare const $setUpWritableStreamDefaultWriter: RemoveThis<typeof import("../builtins/WritableStreamInternals")["setUpWritableStreamDefaultWriter"]>;
+declare const $writableStreamAbort: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamAbort"]>;
+declare const $writableStreamClose: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamClose"]>;
+declare const $writableStreamAddWriteRequest: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamAddWriteRequest"]>;
+declare const $writableStreamCloseQueuedOrInFlight: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamCloseQueuedOrInFlight"]>;
+declare const $writableStreamDealWithRejection: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDealWithRejection"]>;
+declare const $writableStreamFinishErroring: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamFinishErroring"]>;
+declare const $writableStreamFinishInFlightClose: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamFinishInFlightClose"]>;
+declare const $writableStreamFinishInFlightCloseWithError: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamFinishInFlightCloseWithError"]>;
+declare const $writableStreamFinishInFlightWrite: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamFinishInFlightWrite"]>;
+declare const $writableStreamFinishInFlightWriteWithError: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamFinishInFlightWriteWithError"]>;
+declare const $writableStreamHasOperationMarkedInFlight: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamHasOperationMarkedInFlight"]>;
+declare const $writableStreamMarkCloseRequestInFlight: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamMarkCloseRequestInFlight"]>;
+declare const $writableStreamMarkFirstWriteRequestInFlight: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamMarkFirstWriteRequestInFlight"]>;
+declare const $writableStreamRejectCloseAndClosedPromiseIfNeeded: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamRejectCloseAndClosedPromiseIfNeeded"]>;
+declare const $writableStreamStartErroring: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamStartErroring"]>;
+declare const $writableStreamUpdateBackpressure: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamUpdateBackpressure"]>;
+declare const $writableStreamDefaultWriterAbort: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterAbort"]>;
+declare const $writableStreamDefaultWriterClose: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterClose"]>;
+declare const $writableStreamDefaultWriterCloseWithErrorPropagation: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterCloseWithErrorPropagation"]>;
+declare const $writableStreamDefaultWriterEnsureClosedPromiseRejected: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterEnsureClosedPromiseRejected"]>;
+declare const $writableStreamDefaultWriterEnsureReadyPromiseRejected: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterEnsureReadyPromiseRejected"]>;
+declare const $writableStreamDefaultWriterGetDesiredSize: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterGetDesiredSize"]>;
+declare const $writableStreamDefaultWriterRelease: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterRelease"]>;
+declare const $writableStreamDefaultWriterWrite: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterWrite"]>;
+declare const $setUpWritableStreamDefaultController: RemoveThis<typeof import("../builtins/WritableStreamInternals")["setUpWritableStreamDefaultController"]>;
+declare const $writableStreamDefaultControllerStart: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerStart"]>;
+declare const $setUpWritableStreamDefaultControllerFromUnderlyingSink: RemoveThis<typeof import("../builtins/WritableStreamInternals")["setUpWritableStreamDefaultControllerFromUnderlyingSink"]>;
+declare const $writableStreamDefaultControllerAdvanceQueueIfNeeded: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerAdvanceQueueIfNeeded"]>;
+declare const $isCloseSentinel: RemoveThis<typeof import("../builtins/WritableStreamInternals")["isCloseSentinel"]>;
+declare const $writableStreamDefaultControllerClearAlgorithms: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerClearAlgorithms"]>;
+declare const $writableStreamDefaultControllerClose: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerClose"]>;
+declare const $writableStreamDefaultControllerError: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerError"]>;
+declare const $writableStreamDefaultControllerErrorIfNeeded: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerErrorIfNeeded"]>;
+declare const $writableStreamDefaultControllerGetBackpressure: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerGetBackpressure"]>;
+declare const $writableStreamDefaultControllerGetChunkSize: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerGetChunkSize"]>;
+declare const $writableStreamDefaultControllerGetDesiredSize: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerGetDesiredSize"]>;
+declare const $writableStreamDefaultControllerProcessClose: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerProcessClose"]>;
+declare const $writableStreamDefaultControllerProcessWrite: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerProcessWrite"]>;
+declare const $writableStreamDefaultControllerWrite: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerWrite"]>;
+
 // TransformStreamInternals.ts
 declare const $isTransformStream: RemoveThis<typeof import("../builtins/TransformStreamInternals")["isTransformStream"]>;
 declare const $isTransformStreamDefaultController: RemoveThis<typeof import("../builtins/TransformStreamInternals")["isTransformStreamDefaultController"]>;
@@ -88,6 +139,27 @@ declare const $readableStreamToTextDirect: RemoveThis<typeof import("../builtins
 declare const $readableStreamToArrayDirect: RemoveThis<typeof import("../builtins/ReadableStreamInternals")["readableStreamToArrayDirect"]>;
 declare const $readableStreamDefineLazyIterators: RemoveThis<typeof import("../builtins/ReadableStreamInternals")["readableStreamDefineLazyIterators"]>;
 
+// StreamInternals.ts
+declare const $markPromiseAsHandled: RemoveThis<typeof import("../builtins/StreamInternals")["markPromiseAsHandled"]>;
+declare const $shieldingPromiseResolve: RemoveThis<typeof import("../builtins/StreamInternals")["shieldingPromiseResolve"]>;
+declare const $promiseInvokeOrNoopMethodNoCatch: RemoveThis<typeof import("../builtins/StreamInternals")["promiseInvokeOrNoopMethodNoCatch"]>;
+declare const $promiseInvokeOrNoopNoCatch: RemoveThis<typeof import("../builtins/StreamInternals")["promiseInvokeOrNoopNoCatch"]>;
+declare const $promiseInvokeOrNoopMethod: RemoveThis<typeof import("../builtins/StreamInternals")["promiseInvokeOrNoopMethod"]>;
+declare const $promiseInvokeOrNoop: RemoveThis<typeof import("../builtins/StreamInternals")["promiseInvokeOrNoop"]>;
+declare const $promiseInvokeOrFallbackOrNoop: RemoveThis<typeof import("../builtins/StreamInternals")["promiseInvokeOrFallbackOrNoop"]>;
+declare const $validateAndNormalizeQueuingStrategy: RemoveThis<typeof import("../builtins/StreamInternals")["validateAndNormalizeQueuingStrategy"]>;
+declare const $createFIFO: RemoveThis<typeof import("../builtins/StreamInternals")["createFIFO"]>;
+declare const $newQueue: RemoveThis<typeof import("../builtins/StreamInternals")["newQueue"]>;
+declare const $dequeueValue: RemoveThis<typeof import("../builtins/StreamInternals")["dequeueValue"]>;
+declare const $enqueueValueWithSize: RemoveThis<typeof import("../builtins/StreamInternals")["enqueueValueWithSize"]>;
+declare const $peekQueueValue: RemoveThis<typeof import("../builtins/StreamInternals")["peekQueueValue"]>;
+declare const $resetQueue: RemoveThis<typeof import("../builtins/StreamInternals")["resetQueue"]>;
+declare const $extractSizeAlgorithm: RemoveThis<typeof import("../builtins/StreamInternals")["extractSizeAlgorithm"]>;
+declare const $extractHighWaterMark: RemoveThis<typeof import("../builtins/StreamInternals")["extractHighWaterMark"]>;
+declare const $extractHighWaterMarkFromQueuingStrategyInit: RemoveThis<typeof import("../builtins/StreamInternals")["extractHighWaterMarkFromQueuingStrategyInit"]>;
+declare const $createFulfilledPromise: RemoveThis<typeof import("../builtins/StreamInternals")["createFulfilledPromise"]>;
+declare const $toDictionary: RemoveThis<typeof import("../builtins/StreamInternals")["toDictionary"]>;
+
 // ReadableByteStreamInternals.ts
 declare const $privateInitializeReadableByteStreamController: RemoveThis<typeof import("../builtins/ReadableByteStreamInternals")["privateInitializeReadableByteStreamController"]>;
 declare const $readableStreamByteStreamControllerStart: RemoveThis<typeof import("../builtins/ReadableByteStreamInternals")["readableStreamByteStreamControllerStart"]>;
@@ -125,75 +197,3 @@ declare const $readableStreamFulfillReadIntoRequest: RemoveThis<typeof import(".
 declare const $readableStreamBYOBReaderRead: RemoveThis<typeof import("../builtins/ReadableByteStreamInternals")["readableStreamBYOBReaderRead"]>;
 declare const $readableByteStreamControllerPullInto: RemoveThis<typeof import("../builtins/ReadableByteStreamInternals")["readableByteStreamControllerPullInto"]>;
 declare const $readableStreamAddReadIntoRequest: RemoveThis<typeof import("../builtins/ReadableByteStreamInternals")["readableStreamAddReadIntoRequest"]>;
-
-// StreamInternals.ts
-declare const $markPromiseAsHandled: RemoveThis<typeof import("../builtins/StreamInternals")["markPromiseAsHandled"]>;
-declare const $shieldingPromiseResolve: RemoveThis<typeof import("../builtins/StreamInternals")["shieldingPromiseResolve"]>;
-declare const $promiseInvokeOrNoopMethodNoCatch: RemoveThis<typeof import("../builtins/StreamInternals")["promiseInvokeOrNoopMethodNoCatch"]>;
-declare const $promiseInvokeOrNoopNoCatch: RemoveThis<typeof import("../builtins/StreamInternals")["promiseInvokeOrNoopNoCatch"]>;
-declare const $promiseInvokeOrNoopMethod: RemoveThis<typeof import("../builtins/StreamInternals")["promiseInvokeOrNoopMethod"]>;
-declare const $promiseInvokeOrNoop: RemoveThis<typeof import("../builtins/StreamInternals")["promiseInvokeOrNoop"]>;
-declare const $promiseInvokeOrFallbackOrNoop: RemoveThis<typeof import("../builtins/StreamInternals")["promiseInvokeOrFallbackOrNoop"]>;
-declare const $validateAndNormalizeQueuingStrategy: RemoveThis<typeof import("../builtins/StreamInternals")["validateAndNormalizeQueuingStrategy"]>;
-declare const $createFIFO: RemoveThis<typeof import("../builtins/StreamInternals")["createFIFO"]>;
-declare const $newQueue: RemoveThis<typeof import("../builtins/StreamInternals")["newQueue"]>;
-declare const $dequeueValue: RemoveThis<typeof import("../builtins/StreamInternals")["dequeueValue"]>;
-declare const $enqueueValueWithSize: RemoveThis<typeof import("../builtins/StreamInternals")["enqueueValueWithSize"]>;
-declare const $peekQueueValue: RemoveThis<typeof import("../builtins/StreamInternals")["peekQueueValue"]>;
-declare const $resetQueue: RemoveThis<typeof import("../builtins/StreamInternals")["resetQueue"]>;
-declare const $extractSizeAlgorithm: RemoveThis<typeof import("../builtins/StreamInternals")["extractSizeAlgorithm"]>;
-declare const $extractHighWaterMark: RemoveThis<typeof import("../builtins/StreamInternals")["extractHighWaterMark"]>;
-declare const $extractHighWaterMarkFromQueuingStrategyInit: RemoveThis<typeof import("../builtins/StreamInternals")["extractHighWaterMarkFromQueuingStrategyInit"]>;
-declare const $createFulfilledPromise: RemoveThis<typeof import("../builtins/StreamInternals")["createFulfilledPromise"]>;
-declare const $toDictionary: RemoveThis<typeof import("../builtins/StreamInternals")["toDictionary"]>;
-
-// WritableStreamInternals.ts
-declare const $isWritableStream: RemoveThis<typeof import("../builtins/WritableStreamInternals")["isWritableStream"]>;
-declare const $isWritableStreamDefaultWriter: RemoveThis<typeof import("../builtins/WritableStreamInternals")["isWritableStreamDefaultWriter"]>;
-declare const $acquireWritableStreamDefaultWriter: RemoveThis<typeof import("../builtins/WritableStreamInternals")["acquireWritableStreamDefaultWriter"]>;
-declare const $createWritableStream: RemoveThis<typeof import("../builtins/WritableStreamInternals")["createWritableStream"]>;
-declare const $createInternalWritableStreamFromUnderlyingSink: RemoveThis<typeof import("../builtins/WritableStreamInternals")["createInternalWritableStreamFromUnderlyingSink"]>;
-declare const $initializeWritableStreamSlots: RemoveThis<typeof import("../builtins/WritableStreamInternals")["initializeWritableStreamSlots"]>;
-declare const $writableStreamCloseForBindings: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamCloseForBindings"]>;
-declare const $writableStreamAbortForBindings: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamAbortForBindings"]>;
-declare const $isWritableStreamLocked: RemoveThis<typeof import("../builtins/WritableStreamInternals")["isWritableStreamLocked"]>;
-declare const $setUpWritableStreamDefaultWriter: RemoveThis<typeof import("../builtins/WritableStreamInternals")["setUpWritableStreamDefaultWriter"]>;
-declare const $writableStreamAbort: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamAbort"]>;
-declare const $writableStreamClose: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamClose"]>;
-declare const $writableStreamAddWriteRequest: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamAddWriteRequest"]>;
-declare const $writableStreamCloseQueuedOrInFlight: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamCloseQueuedOrInFlight"]>;
-declare const $writableStreamDealWithRejection: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDealWithRejection"]>;
-declare const $writableStreamFinishErroring: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamFinishErroring"]>;
-declare const $writableStreamFinishInFlightClose: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamFinishInFlightClose"]>;
-declare const $writableStreamFinishInFlightCloseWithError: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamFinishInFlightCloseWithError"]>;
-declare const $writableStreamFinishInFlightWrite: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamFinishInFlightWrite"]>;
-declare const $writableStreamFinishInFlightWriteWithError: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamFinishInFlightWriteWithError"]>;
-declare const $writableStreamHasOperationMarkedInFlight: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamHasOperationMarkedInFlight"]>;
-declare const $writableStreamMarkCloseRequestInFlight: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamMarkCloseRequestInFlight"]>;
-declare const $writableStreamMarkFirstWriteRequestInFlight: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamMarkFirstWriteRequestInFlight"]>;
-declare const $writableStreamRejectCloseAndClosedPromiseIfNeeded: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamRejectCloseAndClosedPromiseIfNeeded"]>;
-declare const $writableStreamStartErroring: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamStartErroring"]>;
-declare const $writableStreamUpdateBackpressure: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamUpdateBackpressure"]>;
-declare const $writableStreamDefaultWriterAbort: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterAbort"]>;
-declare const $writableStreamDefaultWriterClose: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterClose"]>;
-declare const $writableStreamDefaultWriterCloseWithErrorPropagation: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterCloseWithErrorPropagation"]>;
-declare const $writableStreamDefaultWriterEnsureClosedPromiseRejected: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterEnsureClosedPromiseRejected"]>;
-declare const $writableStreamDefaultWriterEnsureReadyPromiseRejected: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterEnsureReadyPromiseRejected"]>;
-declare const $writableStreamDefaultWriterGetDesiredSize: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterGetDesiredSize"]>;
-declare const $writableStreamDefaultWriterRelease: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterRelease"]>;
-declare const $writableStreamDefaultWriterWrite: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultWriterWrite"]>;
-declare const $setUpWritableStreamDefaultController: RemoveThis<typeof import("../builtins/WritableStreamInternals")["setUpWritableStreamDefaultController"]>;
-declare const $writableStreamDefaultControllerStart: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerStart"]>;
-declare const $setUpWritableStreamDefaultControllerFromUnderlyingSink: RemoveThis<typeof import("../builtins/WritableStreamInternals")["setUpWritableStreamDefaultControllerFromUnderlyingSink"]>;
-declare const $writableStreamDefaultControllerAdvanceQueueIfNeeded: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerAdvanceQueueIfNeeded"]>;
-declare const $isCloseSentinel: RemoveThis<typeof import("../builtins/WritableStreamInternals")["isCloseSentinel"]>;
-declare const $writableStreamDefaultControllerClearAlgorithms: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerClearAlgorithms"]>;
-declare const $writableStreamDefaultControllerClose: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerClose"]>;
-declare const $writableStreamDefaultControllerError: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerError"]>;
-declare const $writableStreamDefaultControllerErrorIfNeeded: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerErrorIfNeeded"]>;
-declare const $writableStreamDefaultControllerGetBackpressure: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerGetBackpressure"]>;
-declare const $writableStreamDefaultControllerGetChunkSize: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerGetChunkSize"]>;
-declare const $writableStreamDefaultControllerGetDesiredSize: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerGetDesiredSize"]>;
-declare const $writableStreamDefaultControllerProcessClose: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerProcessClose"]>;
-declare const $writableStreamDefaultControllerProcessWrite: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerProcessWrite"]>;
-declare const $writableStreamDefaultControllerWrite: RemoveThis<typeof import("../builtins/WritableStreamInternals")["writableStreamDefaultControllerWrite"]>;

--- a/src/js/out/WebCoreJSBuiltins.h
+++ b/src/js/out/WebCoreJSBuiltins.h
@@ -15,114 +15,59 @@ class FunctionExecutable;
 }
 
 namespace WebCore {
-/* WritableStreamDefaultWriter.ts */
-// initializeWritableStreamDefaultWriter
-#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_INITIALIZEWRITABLESTREAMDEFAULTWRITER 1
-extern const char* const s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCode;
-extern const int s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeLength;
-extern const JSC::ConstructAbility s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeImplementationVisibility;
+/* BundlerPlugin.ts */
+// runSetupFunction
+#define WEBCORE_BUILTIN_BUNDLERPLUGIN_RUNSETUPFUNCTION 1
+extern const char* const s_bundlerPluginRunSetupFunctionCode;
+extern const int s_bundlerPluginRunSetupFunctionCodeLength;
+extern const JSC::ConstructAbility s_bundlerPluginRunSetupFunctionCodeConstructAbility;
+extern const JSC::ConstructorKind s_bundlerPluginRunSetupFunctionCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_bundlerPluginRunSetupFunctionCodeImplementationVisibility;
 
-// closed
-#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_CLOSED 1
-extern const char* const s_writableStreamDefaultWriterClosedCode;
-extern const int s_writableStreamDefaultWriterClosedCodeLength;
-extern const JSC::ConstructAbility s_writableStreamDefaultWriterClosedCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamDefaultWriterClosedCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterClosedCodeImplementationVisibility;
+// runOnResolvePlugins
+#define WEBCORE_BUILTIN_BUNDLERPLUGIN_RUNONRESOLVEPLUGINS 1
+extern const char* const s_bundlerPluginRunOnResolvePluginsCode;
+extern const int s_bundlerPluginRunOnResolvePluginsCodeLength;
+extern const JSC::ConstructAbility s_bundlerPluginRunOnResolvePluginsCodeConstructAbility;
+extern const JSC::ConstructorKind s_bundlerPluginRunOnResolvePluginsCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_bundlerPluginRunOnResolvePluginsCodeImplementationVisibility;
 
-// desiredSize
-#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_DESIREDSIZE 1
-extern const char* const s_writableStreamDefaultWriterDesiredSizeCode;
-extern const int s_writableStreamDefaultWriterDesiredSizeCodeLength;
-extern const JSC::ConstructAbility s_writableStreamDefaultWriterDesiredSizeCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamDefaultWriterDesiredSizeCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterDesiredSizeCodeImplementationVisibility;
+// runOnLoadPlugins
+#define WEBCORE_BUILTIN_BUNDLERPLUGIN_RUNONLOADPLUGINS 1
+extern const char* const s_bundlerPluginRunOnLoadPluginsCode;
+extern const int s_bundlerPluginRunOnLoadPluginsCodeLength;
+extern const JSC::ConstructAbility s_bundlerPluginRunOnLoadPluginsCodeConstructAbility;
+extern const JSC::ConstructorKind s_bundlerPluginRunOnLoadPluginsCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_bundlerPluginRunOnLoadPluginsCodeImplementationVisibility;
 
-// ready
-#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_READY 1
-extern const char* const s_writableStreamDefaultWriterReadyCode;
-extern const int s_writableStreamDefaultWriterReadyCodeLength;
-extern const JSC::ConstructAbility s_writableStreamDefaultWriterReadyCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamDefaultWriterReadyCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterReadyCodeImplementationVisibility;
+#define WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_DATA(macro) \
+    macro(runSetupFunction, bundlerPluginRunSetupFunction, 2) \
+    macro(runOnResolvePlugins, bundlerPluginRunOnResolvePlugins, 5) \
+    macro(runOnLoadPlugins, bundlerPluginRunOnLoadPlugins, 4) \
 
-// abort
-#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_ABORT 1
-extern const char* const s_writableStreamDefaultWriterAbortCode;
-extern const int s_writableStreamDefaultWriterAbortCodeLength;
-extern const JSC::ConstructAbility s_writableStreamDefaultWriterAbortCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamDefaultWriterAbortCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterAbortCodeImplementationVisibility;
+#define WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(macro) \
+    macro(bundlerPluginRunSetupFunctionCode, runSetupFunction, ASCIILiteral(), s_bundlerPluginRunSetupFunctionCodeLength) \
+    macro(bundlerPluginRunOnResolvePluginsCode, runOnResolvePlugins, ASCIILiteral(), s_bundlerPluginRunOnResolvePluginsCodeLength) \
+    macro(bundlerPluginRunOnLoadPluginsCode, runOnLoadPlugins, ASCIILiteral(), s_bundlerPluginRunOnLoadPluginsCodeLength) \
 
-// close
-#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_CLOSE 1
-extern const char* const s_writableStreamDefaultWriterCloseCode;
-extern const int s_writableStreamDefaultWriterCloseCodeLength;
-extern const JSC::ConstructAbility s_writableStreamDefaultWriterCloseCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamDefaultWriterCloseCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterCloseCodeImplementationVisibility;
-
-// releaseLock
-#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_RELEASELOCK 1
-extern const char* const s_writableStreamDefaultWriterReleaseLockCode;
-extern const int s_writableStreamDefaultWriterReleaseLockCodeLength;
-extern const JSC::ConstructAbility s_writableStreamDefaultWriterReleaseLockCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamDefaultWriterReleaseLockCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterReleaseLockCodeImplementationVisibility;
-
-// write
-#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_WRITE 1
-extern const char* const s_writableStreamDefaultWriterWriteCode;
-extern const int s_writableStreamDefaultWriterWriteCodeLength;
-extern const JSC::ConstructAbility s_writableStreamDefaultWriterWriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamDefaultWriterWriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterWriteCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_DATA(macro) \
-    macro(initializeWritableStreamDefaultWriter, writableStreamDefaultWriterInitializeWritableStreamDefaultWriter, 1) \
-    macro(closed, writableStreamDefaultWriterClosed, 0) \
-    macro(desiredSize, writableStreamDefaultWriterDesiredSize, 0) \
-    macro(ready, writableStreamDefaultWriterReady, 0) \
-    macro(abort, writableStreamDefaultWriterAbort, 1) \
-    macro(close, writableStreamDefaultWriterClose, 0) \
-    macro(releaseLock, writableStreamDefaultWriterReleaseLock, 0) \
-    macro(write, writableStreamDefaultWriterWrite, 1) \
-
-#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(macro) \
-    macro(writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCode, initializeWritableStreamDefaultWriter, ASCIILiteral(), s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeLength) \
-    macro(writableStreamDefaultWriterClosedCode, closed, "get closed"_s, s_writableStreamDefaultWriterClosedCodeLength) \
-    macro(writableStreamDefaultWriterDesiredSizeCode, desiredSize, "get desiredSize"_s, s_writableStreamDefaultWriterDesiredSizeCodeLength) \
-    macro(writableStreamDefaultWriterReadyCode, ready, "get ready"_s, s_writableStreamDefaultWriterReadyCodeLength) \
-    macro(writableStreamDefaultWriterAbortCode, abort, ASCIILiteral(), s_writableStreamDefaultWriterAbortCodeLength) \
-    macro(writableStreamDefaultWriterCloseCode, close, ASCIILiteral(), s_writableStreamDefaultWriterCloseCodeLength) \
-    macro(writableStreamDefaultWriterReleaseLockCode, releaseLock, ASCIILiteral(), s_writableStreamDefaultWriterReleaseLockCodeLength) \
-    macro(writableStreamDefaultWriterWriteCode, write, ASCIILiteral(), s_writableStreamDefaultWriterWriteCodeLength) \
-
-#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_FUNCTION_NAME(macro) \
-    macro(initializeWritableStreamDefaultWriter) \
-    macro(closed) \
-    macro(desiredSize) \
-    macro(ready) \
-    macro(abort) \
-    macro(close) \
-    macro(releaseLock) \
-    macro(write) \
+#define WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_FUNCTION_NAME(macro) \
+    macro(runSetupFunction) \
+    macro(runOnResolvePlugins) \
+    macro(runOnLoadPlugins) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
     JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
 
-WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
 #undef DECLARE_BUILTIN_GENERATOR
 
-class WritableStreamDefaultWriterBuiltinsWrapper : private JSC::WeakHandleOwner {
+class BundlerPluginBuiltinsWrapper : private JSC::WeakHandleOwner {
 public:
-    explicit WritableStreamDefaultWriterBuiltinsWrapper(JSC::VM& vm)
+    explicit BundlerPluginBuiltinsWrapper(JSC::VM& vm)
         : m_vm(vm)
-        WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+        WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
 #define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+        WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
 #undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
     {
     }
@@ -130,28 +75,28 @@ public:
 #define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
     JSC::UnlinkedFunctionExecutable* name##Executable(); \
     const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+    WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
 #undef EXPOSE_BUILTIN_EXECUTABLES
 
-    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+    WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
 
     void exportNames();
 
 private:
     JSC::VM& m_vm;
 
-    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+    WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
 
 #define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
     JSC::SourceCode m_##name##Source;\
     JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+    WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
 #undef DECLARE_BUILTIN_SOURCE_MEMBERS
 
 };
 
 #define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* WritableStreamDefaultWriterBuiltinsWrapper::name##Executable() \
+inline JSC::UnlinkedFunctionExecutable* BundlerPluginBuiltinsWrapper::name##Executable() \
 {\
     if (!m_##name##Executable) {\
         JSC::Identifier executableName = functionName##PublicName();\
@@ -161,57 +106,68 @@ inline JSC::UnlinkedFunctionExecutable* WritableStreamDefaultWriterBuiltinsWrapp
     }\
     return m_##name##Executable.get();\
 }
-WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
 #undef DEFINE_BUILTIN_EXECUTABLES
 
-inline void WritableStreamDefaultWriterBuiltinsWrapper::exportNames()
+inline void BundlerPluginBuiltinsWrapper::exportNames()
 {
 #define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+    WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
 #undef EXPORT_FUNCTION_NAME
 }
-/* ConsoleObject.ts */
-// asyncIterator
-#define WEBCORE_BUILTIN_CONSOLEOBJECT_ASYNCITERATOR 1
-extern const char* const s_consoleObjectAsyncIteratorCode;
-extern const int s_consoleObjectAsyncIteratorCodeLength;
-extern const JSC::ConstructAbility s_consoleObjectAsyncIteratorCodeConstructAbility;
-extern const JSC::ConstructorKind s_consoleObjectAsyncIteratorCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_consoleObjectAsyncIteratorCodeImplementationVisibility;
+/* ByteLengthQueuingStrategy.ts */
+// highWaterMark
+#define WEBCORE_BUILTIN_BYTELENGTHQUEUINGSTRATEGY_HIGHWATERMARK 1
+extern const char* const s_byteLengthQueuingStrategyHighWaterMarkCode;
+extern const int s_byteLengthQueuingStrategyHighWaterMarkCodeLength;
+extern const JSC::ConstructAbility s_byteLengthQueuingStrategyHighWaterMarkCodeConstructAbility;
+extern const JSC::ConstructorKind s_byteLengthQueuingStrategyHighWaterMarkCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_byteLengthQueuingStrategyHighWaterMarkCodeImplementationVisibility;
 
-// write
-#define WEBCORE_BUILTIN_CONSOLEOBJECT_WRITE 1
-extern const char* const s_consoleObjectWriteCode;
-extern const int s_consoleObjectWriteCodeLength;
-extern const JSC::ConstructAbility s_consoleObjectWriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_consoleObjectWriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_consoleObjectWriteCodeImplementationVisibility;
+// size
+#define WEBCORE_BUILTIN_BYTELENGTHQUEUINGSTRATEGY_SIZE 1
+extern const char* const s_byteLengthQueuingStrategySizeCode;
+extern const int s_byteLengthQueuingStrategySizeCodeLength;
+extern const JSC::ConstructAbility s_byteLengthQueuingStrategySizeCodeConstructAbility;
+extern const JSC::ConstructorKind s_byteLengthQueuingStrategySizeCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_byteLengthQueuingStrategySizeCodeImplementationVisibility;
 
-#define WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_DATA(macro) \
-    macro(asyncIterator, consoleObjectAsyncIterator, 0) \
-    macro(write, consoleObjectWrite, 1) \
+// initializeByteLengthQueuingStrategy
+#define WEBCORE_BUILTIN_BYTELENGTHQUEUINGSTRATEGY_INITIALIZEBYTELENGTHQUEUINGSTRATEGY 1
+extern const char* const s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCode;
+extern const int s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeLength;
+extern const JSC::ConstructAbility s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeConstructAbility;
+extern const JSC::ConstructorKind s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeImplementationVisibility;
 
-#define WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(macro) \
-    macro(consoleObjectAsyncIteratorCode, asyncIterator, "[Symbol.asyncIterator]"_s, s_consoleObjectAsyncIteratorCodeLength) \
-    macro(consoleObjectWriteCode, write, ASCIILiteral(), s_consoleObjectWriteCodeLength) \
+#define WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_DATA(macro) \
+    macro(highWaterMark, byteLengthQueuingStrategyHighWaterMark, 0) \
+    macro(size, byteLengthQueuingStrategySize, 1) \
+    macro(initializeByteLengthQueuingStrategy, byteLengthQueuingStrategyInitializeByteLengthQueuingStrategy, 1) \
 
-#define WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_FUNCTION_NAME(macro) \
-    macro(asyncIterator) \
-    macro(write) \
+#define WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(macro) \
+    macro(byteLengthQueuingStrategyHighWaterMarkCode, highWaterMark, "get highWaterMark"_s, s_byteLengthQueuingStrategyHighWaterMarkCodeLength) \
+    macro(byteLengthQueuingStrategySizeCode, size, ASCIILiteral(), s_byteLengthQueuingStrategySizeCodeLength) \
+    macro(byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCode, initializeByteLengthQueuingStrategy, ASCIILiteral(), s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeLength) \
+
+#define WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(macro) \
+    macro(highWaterMark) \
+    macro(size) \
+    macro(initializeByteLengthQueuingStrategy) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
     JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
 
-WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
 #undef DECLARE_BUILTIN_GENERATOR
 
-class ConsoleObjectBuiltinsWrapper : private JSC::WeakHandleOwner {
+class ByteLengthQueuingStrategyBuiltinsWrapper : private JSC::WeakHandleOwner {
 public:
-    explicit ConsoleObjectBuiltinsWrapper(JSC::VM& vm)
+    explicit ByteLengthQueuingStrategyBuiltinsWrapper(JSC::VM& vm)
         : m_vm(vm)
-        WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+        WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
 #define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+        WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
 #undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
     {
     }
@@ -219,28 +175,28 @@ public:
 #define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
     JSC::UnlinkedFunctionExecutable* name##Executable(); \
     const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+    WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
 #undef EXPOSE_BUILTIN_EXECUTABLES
 
-    WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+    WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
 
     void exportNames();
 
 private:
     JSC::VM& m_vm;
 
-    WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+    WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
 
 #define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
     JSC::SourceCode m_##name##Source;\
     JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+    WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
 #undef DECLARE_BUILTIN_SOURCE_MEMBERS
 
 };
 
 #define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* ConsoleObjectBuiltinsWrapper::name##Executable() \
+inline JSC::UnlinkedFunctionExecutable* ByteLengthQueuingStrategyBuiltinsWrapper::name##Executable() \
 {\
     if (!m_##name##Executable) {\
         JSC::Identifier executableName = functionName##PublicName();\
@@ -250,16 +206,656 @@ inline JSC::UnlinkedFunctionExecutable* ConsoleObjectBuiltinsWrapper::name##Exec
     }\
     return m_##name##Executable.get();\
 }
-WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
 #undef DEFINE_BUILTIN_EXECUTABLES
 
-inline void ConsoleObjectBuiltinsWrapper::exportNames()
+inline void ByteLengthQueuingStrategyBuiltinsWrapper::exportNames()
 {
 #define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+    WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
 #undef EXPORT_FUNCTION_NAME
 }
-/* TransformStreamInternals.ts */
+/* WritableStreamInternals.ts */
+// isWritableStream
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_ISWRITABLESTREAM 1
+extern const char* const s_writableStreamInternalsIsWritableStreamCode;
+extern const int s_writableStreamInternalsIsWritableStreamCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamCodeImplementationVisibility;
+
+// isWritableStreamDefaultWriter
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_ISWRITABLESTREAMDEFAULTWRITER 1
+extern const char* const s_writableStreamInternalsIsWritableStreamDefaultWriterCode;
+extern const int s_writableStreamInternalsIsWritableStreamDefaultWriterCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamDefaultWriterCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamDefaultWriterCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamDefaultWriterCodeImplementationVisibility;
+
+// acquireWritableStreamDefaultWriter
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_ACQUIREWRITABLESTREAMDEFAULTWRITER 1
+extern const char* const s_writableStreamInternalsAcquireWritableStreamDefaultWriterCode;
+extern const int s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeImplementationVisibility;
+
+// createWritableStream
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_CREATEWRITABLESTREAM 1
+extern const char* const s_writableStreamInternalsCreateWritableStreamCode;
+extern const int s_writableStreamInternalsCreateWritableStreamCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsCreateWritableStreamCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsCreateWritableStreamCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsCreateWritableStreamCodeImplementationVisibility;
+
+// createInternalWritableStreamFromUnderlyingSink
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_CREATEINTERNALWRITABLESTREAMFROMUNDERLYINGSINK 1
+extern const char* const s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCode;
+extern const int s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeImplementationVisibility;
+
+// initializeWritableStreamSlots
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_INITIALIZEWRITABLESTREAMSLOTS 1
+extern const char* const s_writableStreamInternalsInitializeWritableStreamSlotsCode;
+extern const int s_writableStreamInternalsInitializeWritableStreamSlotsCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsInitializeWritableStreamSlotsCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsInitializeWritableStreamSlotsCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsInitializeWritableStreamSlotsCodeImplementationVisibility;
+
+// writableStreamCloseForBindings
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMCLOSEFORBINDINGS 1
+extern const char* const s_writableStreamInternalsWritableStreamCloseForBindingsCode;
+extern const int s_writableStreamInternalsWritableStreamCloseForBindingsCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseForBindingsCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseForBindingsCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseForBindingsCodeImplementationVisibility;
+
+// writableStreamAbortForBindings
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMABORTFORBINDINGS 1
+extern const char* const s_writableStreamInternalsWritableStreamAbortForBindingsCode;
+extern const int s_writableStreamInternalsWritableStreamAbortForBindingsCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAbortForBindingsCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAbortForBindingsCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAbortForBindingsCodeImplementationVisibility;
+
+// isWritableStreamLocked
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_ISWRITABLESTREAMLOCKED 1
+extern const char* const s_writableStreamInternalsIsWritableStreamLockedCode;
+extern const int s_writableStreamInternalsIsWritableStreamLockedCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamLockedCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamLockedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamLockedCodeImplementationVisibility;
+
+// setUpWritableStreamDefaultWriter
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_SETUPWRITABLESTREAMDEFAULTWRITER 1
+extern const char* const s_writableStreamInternalsSetUpWritableStreamDefaultWriterCode;
+extern const int s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeImplementationVisibility;
+
+// writableStreamAbort
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMABORT 1
+extern const char* const s_writableStreamInternalsWritableStreamAbortCode;
+extern const int s_writableStreamInternalsWritableStreamAbortCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAbortCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAbortCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAbortCodeImplementationVisibility;
+
+// writableStreamClose
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMCLOSE 1
+extern const char* const s_writableStreamInternalsWritableStreamCloseCode;
+extern const int s_writableStreamInternalsWritableStreamCloseCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseCodeImplementationVisibility;
+
+// writableStreamAddWriteRequest
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMADDWRITEREQUEST 1
+extern const char* const s_writableStreamInternalsWritableStreamAddWriteRequestCode;
+extern const int s_writableStreamInternalsWritableStreamAddWriteRequestCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAddWriteRequestCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAddWriteRequestCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAddWriteRequestCodeImplementationVisibility;
+
+// writableStreamCloseQueuedOrInFlight
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMCLOSEQUEUEDORINFLIGHT 1
+extern const char* const s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCode;
+extern const int s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeImplementationVisibility;
+
+// writableStreamDealWithRejection
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEALWITHREJECTION 1
+extern const char* const s_writableStreamInternalsWritableStreamDealWithRejectionCode;
+extern const int s_writableStreamInternalsWritableStreamDealWithRejectionCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDealWithRejectionCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDealWithRejectionCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDealWithRejectionCodeImplementationVisibility;
+
+// writableStreamFinishErroring
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMFINISHERRORING 1
+extern const char* const s_writableStreamInternalsWritableStreamFinishErroringCode;
+extern const int s_writableStreamInternalsWritableStreamFinishErroringCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishErroringCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishErroringCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishErroringCodeImplementationVisibility;
+
+// writableStreamFinishInFlightClose
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMFINISHINFLIGHTCLOSE 1
+extern const char* const s_writableStreamInternalsWritableStreamFinishInFlightCloseCode;
+extern const int s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeImplementationVisibility;
+
+// writableStreamFinishInFlightCloseWithError
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMFINISHINFLIGHTCLOSEWITHERROR 1
+extern const char* const s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCode;
+extern const int s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeImplementationVisibility;
+
+// writableStreamFinishInFlightWrite
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMFINISHINFLIGHTWRITE 1
+extern const char* const s_writableStreamInternalsWritableStreamFinishInFlightWriteCode;
+extern const int s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeImplementationVisibility;
+
+// writableStreamFinishInFlightWriteWithError
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMFINISHINFLIGHTWRITEWITHERROR 1
+extern const char* const s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCode;
+extern const int s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeImplementationVisibility;
+
+// writableStreamHasOperationMarkedInFlight
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMHASOPERATIONMARKEDINFLIGHT 1
+extern const char* const s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCode;
+extern const int s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeImplementationVisibility;
+
+// writableStreamMarkCloseRequestInFlight
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMMARKCLOSEREQUESTINFLIGHT 1
+extern const char* const s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCode;
+extern const int s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeImplementationVisibility;
+
+// writableStreamMarkFirstWriteRequestInFlight
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMMARKFIRSTWRITEREQUESTINFLIGHT 1
+extern const char* const s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCode;
+extern const int s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeImplementationVisibility;
+
+// writableStreamRejectCloseAndClosedPromiseIfNeeded
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMREJECTCLOSEANDCLOSEDPROMISEIFNEEDED 1
+extern const char* const s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCode;
+extern const int s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeImplementationVisibility;
+
+// writableStreamStartErroring
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMSTARTERRORING 1
+extern const char* const s_writableStreamInternalsWritableStreamStartErroringCode;
+extern const int s_writableStreamInternalsWritableStreamStartErroringCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamStartErroringCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamStartErroringCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamStartErroringCodeImplementationVisibility;
+
+// writableStreamUpdateBackpressure
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMUPDATEBACKPRESSURE 1
+extern const char* const s_writableStreamInternalsWritableStreamUpdateBackpressureCode;
+extern const int s_writableStreamInternalsWritableStreamUpdateBackpressureCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamUpdateBackpressureCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamUpdateBackpressureCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamUpdateBackpressureCodeImplementationVisibility;
+
+// writableStreamDefaultWriterAbort
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERABORT 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterAbortCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeImplementationVisibility;
+
+// writableStreamDefaultWriterClose
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERCLOSE 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterCloseCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeImplementationVisibility;
+
+// writableStreamDefaultWriterCloseWithErrorPropagation
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERCLOSEWITHERRORPROPAGATION 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeImplementationVisibility;
+
+// writableStreamDefaultWriterEnsureClosedPromiseRejected
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERENSURECLOSEDPROMISEREJECTED 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeImplementationVisibility;
+
+// writableStreamDefaultWriterEnsureReadyPromiseRejected
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERENSUREREADYPROMISEREJECTED 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeImplementationVisibility;
+
+// writableStreamDefaultWriterGetDesiredSize
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERGETDESIREDSIZE 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeImplementationVisibility;
+
+// writableStreamDefaultWriterRelease
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERRELEASE 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterReleaseCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeImplementationVisibility;
+
+// writableStreamDefaultWriterWrite
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERWRITE 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterWriteCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeImplementationVisibility;
+
+// setUpWritableStreamDefaultController
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_SETUPWRITABLESTREAMDEFAULTCONTROLLER 1
+extern const char* const s_writableStreamInternalsSetUpWritableStreamDefaultControllerCode;
+extern const int s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeImplementationVisibility;
+
+// writableStreamDefaultControllerStart
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERSTART 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerStartCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerStartCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerStartCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerStartCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerStartCodeImplementationVisibility;
+
+// setUpWritableStreamDefaultControllerFromUnderlyingSink
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_SETUPWRITABLESTREAMDEFAULTCONTROLLERFROMUNDERLYINGSINK 1
+extern const char* const s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCode;
+extern const int s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeImplementationVisibility;
+
+// writableStreamDefaultControllerAdvanceQueueIfNeeded
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERADVANCEQUEUEIFNEEDED 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeImplementationVisibility;
+
+// isCloseSentinel
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_ISCLOSESENTINEL 1
+extern const char* const s_writableStreamInternalsIsCloseSentinelCode;
+extern const int s_writableStreamInternalsIsCloseSentinelCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsIsCloseSentinelCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsIsCloseSentinelCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsIsCloseSentinelCodeImplementationVisibility;
+
+// writableStreamDefaultControllerClearAlgorithms
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERCLEARALGORITHMS 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeImplementationVisibility;
+
+// writableStreamDefaultControllerClose
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERCLOSE 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerCloseCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeImplementationVisibility;
+
+// writableStreamDefaultControllerError
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERERROR 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerErrorCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeImplementationVisibility;
+
+// writableStreamDefaultControllerErrorIfNeeded
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERERRORIFNEEDED 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeImplementationVisibility;
+
+// writableStreamDefaultControllerGetBackpressure
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERGETBACKPRESSURE 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeImplementationVisibility;
+
+// writableStreamDefaultControllerGetChunkSize
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERGETCHUNKSIZE 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeImplementationVisibility;
+
+// writableStreamDefaultControllerGetDesiredSize
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERGETDESIREDSIZE 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeImplementationVisibility;
+
+// writableStreamDefaultControllerProcessClose
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERPROCESSCLOSE 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeImplementationVisibility;
+
+// writableStreamDefaultControllerProcessWrite
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERPROCESSWRITE 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeImplementationVisibility;
+
+// writableStreamDefaultControllerWrite
+#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERWRITE 1
+extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerWriteCode;
+extern const int s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeLength;
+extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_DATA(macro) \
+    macro(isWritableStream, writableStreamInternalsIsWritableStream, 1) \
+    macro(isWritableStreamDefaultWriter, writableStreamInternalsIsWritableStreamDefaultWriter, 1) \
+    macro(acquireWritableStreamDefaultWriter, writableStreamInternalsAcquireWritableStreamDefaultWriter, 1) \
+    macro(createWritableStream, writableStreamInternalsCreateWritableStream, 7) \
+    macro(createInternalWritableStreamFromUnderlyingSink, writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSink, 2) \
+    macro(initializeWritableStreamSlots, writableStreamInternalsInitializeWritableStreamSlots, 2) \
+    macro(writableStreamCloseForBindings, writableStreamInternalsWritableStreamCloseForBindings, 1) \
+    macro(writableStreamAbortForBindings, writableStreamInternalsWritableStreamAbortForBindings, 2) \
+    macro(isWritableStreamLocked, writableStreamInternalsIsWritableStreamLocked, 1) \
+    macro(setUpWritableStreamDefaultWriter, writableStreamInternalsSetUpWritableStreamDefaultWriter, 2) \
+    macro(writableStreamAbort, writableStreamInternalsWritableStreamAbort, 2) \
+    macro(writableStreamClose, writableStreamInternalsWritableStreamClose, 1) \
+    macro(writableStreamAddWriteRequest, writableStreamInternalsWritableStreamAddWriteRequest, 1) \
+    macro(writableStreamCloseQueuedOrInFlight, writableStreamInternalsWritableStreamCloseQueuedOrInFlight, 1) \
+    macro(writableStreamDealWithRejection, writableStreamInternalsWritableStreamDealWithRejection, 2) \
+    macro(writableStreamFinishErroring, writableStreamInternalsWritableStreamFinishErroring, 1) \
+    macro(writableStreamFinishInFlightClose, writableStreamInternalsWritableStreamFinishInFlightClose, 1) \
+    macro(writableStreamFinishInFlightCloseWithError, writableStreamInternalsWritableStreamFinishInFlightCloseWithError, 2) \
+    macro(writableStreamFinishInFlightWrite, writableStreamInternalsWritableStreamFinishInFlightWrite, 1) \
+    macro(writableStreamFinishInFlightWriteWithError, writableStreamInternalsWritableStreamFinishInFlightWriteWithError, 2) \
+    macro(writableStreamHasOperationMarkedInFlight, writableStreamInternalsWritableStreamHasOperationMarkedInFlight, 1) \
+    macro(writableStreamMarkCloseRequestInFlight, writableStreamInternalsWritableStreamMarkCloseRequestInFlight, 1) \
+    macro(writableStreamMarkFirstWriteRequestInFlight, writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlight, 1) \
+    macro(writableStreamRejectCloseAndClosedPromiseIfNeeded, writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeeded, 1) \
+    macro(writableStreamStartErroring, writableStreamInternalsWritableStreamStartErroring, 2) \
+    macro(writableStreamUpdateBackpressure, writableStreamInternalsWritableStreamUpdateBackpressure, 2) \
+    macro(writableStreamDefaultWriterAbort, writableStreamInternalsWritableStreamDefaultWriterAbort, 2) \
+    macro(writableStreamDefaultWriterClose, writableStreamInternalsWritableStreamDefaultWriterClose, 1) \
+    macro(writableStreamDefaultWriterCloseWithErrorPropagation, writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagation, 1) \
+    macro(writableStreamDefaultWriterEnsureClosedPromiseRejected, writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejected, 2) \
+    macro(writableStreamDefaultWriterEnsureReadyPromiseRejected, writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejected, 2) \
+    macro(writableStreamDefaultWriterGetDesiredSize, writableStreamInternalsWritableStreamDefaultWriterGetDesiredSize, 1) \
+    macro(writableStreamDefaultWriterRelease, writableStreamInternalsWritableStreamDefaultWriterRelease, 1) \
+    macro(writableStreamDefaultWriterWrite, writableStreamInternalsWritableStreamDefaultWriterWrite, 2) \
+    macro(setUpWritableStreamDefaultController, writableStreamInternalsSetUpWritableStreamDefaultController, 9) \
+    macro(writableStreamDefaultControllerStart, writableStreamInternalsWritableStreamDefaultControllerStart, 1) \
+    macro(setUpWritableStreamDefaultControllerFromUnderlyingSink, writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSink, 6) \
+    macro(writableStreamDefaultControllerAdvanceQueueIfNeeded, writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeeded, 1) \
+    macro(isCloseSentinel, writableStreamInternalsIsCloseSentinel, 0) \
+    macro(writableStreamDefaultControllerClearAlgorithms, writableStreamInternalsWritableStreamDefaultControllerClearAlgorithms, 1) \
+    macro(writableStreamDefaultControllerClose, writableStreamInternalsWritableStreamDefaultControllerClose, 1) \
+    macro(writableStreamDefaultControllerError, writableStreamInternalsWritableStreamDefaultControllerError, 2) \
+    macro(writableStreamDefaultControllerErrorIfNeeded, writableStreamInternalsWritableStreamDefaultControllerErrorIfNeeded, 2) \
+    macro(writableStreamDefaultControllerGetBackpressure, writableStreamInternalsWritableStreamDefaultControllerGetBackpressure, 1) \
+    macro(writableStreamDefaultControllerGetChunkSize, writableStreamInternalsWritableStreamDefaultControllerGetChunkSize, 2) \
+    macro(writableStreamDefaultControllerGetDesiredSize, writableStreamInternalsWritableStreamDefaultControllerGetDesiredSize, 1) \
+    macro(writableStreamDefaultControllerProcessClose, writableStreamInternalsWritableStreamDefaultControllerProcessClose, 1) \
+    macro(writableStreamDefaultControllerProcessWrite, writableStreamInternalsWritableStreamDefaultControllerProcessWrite, 2) \
+    macro(writableStreamDefaultControllerWrite, writableStreamInternalsWritableStreamDefaultControllerWrite, 3) \
+
+#define WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(macro) \
+    macro(writableStreamInternalsIsWritableStreamCode, isWritableStream, ASCIILiteral(), s_writableStreamInternalsIsWritableStreamCodeLength) \
+    macro(writableStreamInternalsIsWritableStreamDefaultWriterCode, isWritableStreamDefaultWriter, ASCIILiteral(), s_writableStreamInternalsIsWritableStreamDefaultWriterCodeLength) \
+    macro(writableStreamInternalsAcquireWritableStreamDefaultWriterCode, acquireWritableStreamDefaultWriter, ASCIILiteral(), s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeLength) \
+    macro(writableStreamInternalsCreateWritableStreamCode, createWritableStream, ASCIILiteral(), s_writableStreamInternalsCreateWritableStreamCodeLength) \
+    macro(writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCode, createInternalWritableStreamFromUnderlyingSink, ASCIILiteral(), s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeLength) \
+    macro(writableStreamInternalsInitializeWritableStreamSlotsCode, initializeWritableStreamSlots, ASCIILiteral(), s_writableStreamInternalsInitializeWritableStreamSlotsCodeLength) \
+    macro(writableStreamInternalsWritableStreamCloseForBindingsCode, writableStreamCloseForBindings, ASCIILiteral(), s_writableStreamInternalsWritableStreamCloseForBindingsCodeLength) \
+    macro(writableStreamInternalsWritableStreamAbortForBindingsCode, writableStreamAbortForBindings, ASCIILiteral(), s_writableStreamInternalsWritableStreamAbortForBindingsCodeLength) \
+    macro(writableStreamInternalsIsWritableStreamLockedCode, isWritableStreamLocked, ASCIILiteral(), s_writableStreamInternalsIsWritableStreamLockedCodeLength) \
+    macro(writableStreamInternalsSetUpWritableStreamDefaultWriterCode, setUpWritableStreamDefaultWriter, ASCIILiteral(), s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeLength) \
+    macro(writableStreamInternalsWritableStreamAbortCode, writableStreamAbort, ASCIILiteral(), s_writableStreamInternalsWritableStreamAbortCodeLength) \
+    macro(writableStreamInternalsWritableStreamCloseCode, writableStreamClose, ASCIILiteral(), s_writableStreamInternalsWritableStreamCloseCodeLength) \
+    macro(writableStreamInternalsWritableStreamAddWriteRequestCode, writableStreamAddWriteRequest, ASCIILiteral(), s_writableStreamInternalsWritableStreamAddWriteRequestCodeLength) \
+    macro(writableStreamInternalsWritableStreamCloseQueuedOrInFlightCode, writableStreamCloseQueuedOrInFlight, ASCIILiteral(), s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeLength) \
+    macro(writableStreamInternalsWritableStreamDealWithRejectionCode, writableStreamDealWithRejection, ASCIILiteral(), s_writableStreamInternalsWritableStreamDealWithRejectionCodeLength) \
+    macro(writableStreamInternalsWritableStreamFinishErroringCode, writableStreamFinishErroring, ASCIILiteral(), s_writableStreamInternalsWritableStreamFinishErroringCodeLength) \
+    macro(writableStreamInternalsWritableStreamFinishInFlightCloseCode, writableStreamFinishInFlightClose, ASCIILiteral(), s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeLength) \
+    macro(writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCode, writableStreamFinishInFlightCloseWithError, ASCIILiteral(), s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeLength) \
+    macro(writableStreamInternalsWritableStreamFinishInFlightWriteCode, writableStreamFinishInFlightWrite, ASCIILiteral(), s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeLength) \
+    macro(writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCode, writableStreamFinishInFlightWriteWithError, ASCIILiteral(), s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeLength) \
+    macro(writableStreamInternalsWritableStreamHasOperationMarkedInFlightCode, writableStreamHasOperationMarkedInFlight, ASCIILiteral(), s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeLength) \
+    macro(writableStreamInternalsWritableStreamMarkCloseRequestInFlightCode, writableStreamMarkCloseRequestInFlight, ASCIILiteral(), s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeLength) \
+    macro(writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCode, writableStreamMarkFirstWriteRequestInFlight, ASCIILiteral(), s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeLength) \
+    macro(writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCode, writableStreamRejectCloseAndClosedPromiseIfNeeded, ASCIILiteral(), s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeLength) \
+    macro(writableStreamInternalsWritableStreamStartErroringCode, writableStreamStartErroring, ASCIILiteral(), s_writableStreamInternalsWritableStreamStartErroringCodeLength) \
+    macro(writableStreamInternalsWritableStreamUpdateBackpressureCode, writableStreamUpdateBackpressure, ASCIILiteral(), s_writableStreamInternalsWritableStreamUpdateBackpressureCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultWriterAbortCode, writableStreamDefaultWriterAbort, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultWriterCloseCode, writableStreamDefaultWriterClose, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCode, writableStreamDefaultWriterCloseWithErrorPropagation, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCode, writableStreamDefaultWriterEnsureClosedPromiseRejected, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCode, writableStreamDefaultWriterEnsureReadyPromiseRejected, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCode, writableStreamDefaultWriterGetDesiredSize, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultWriterReleaseCode, writableStreamDefaultWriterRelease, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultWriterWriteCode, writableStreamDefaultWriterWrite, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeLength) \
+    macro(writableStreamInternalsSetUpWritableStreamDefaultControllerCode, setUpWritableStreamDefaultController, ASCIILiteral(), s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerStartCode, writableStreamDefaultControllerStart, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerStartCodeLength) \
+    macro(writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCode, setUpWritableStreamDefaultControllerFromUnderlyingSink, ASCIILiteral(), s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCode, writableStreamDefaultControllerAdvanceQueueIfNeeded, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeLength) \
+    macro(writableStreamInternalsIsCloseSentinelCode, isCloseSentinel, ASCIILiteral(), s_writableStreamInternalsIsCloseSentinelCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCode, writableStreamDefaultControllerClearAlgorithms, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerCloseCode, writableStreamDefaultControllerClose, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerErrorCode, writableStreamDefaultControllerError, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCode, writableStreamDefaultControllerErrorIfNeeded, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCode, writableStreamDefaultControllerGetBackpressure, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCode, writableStreamDefaultControllerGetChunkSize, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCode, writableStreamDefaultControllerGetDesiredSize, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerProcessCloseCode, writableStreamDefaultControllerProcessClose, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerProcessWriteCode, writableStreamDefaultControllerProcessWrite, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeLength) \
+    macro(writableStreamInternalsWritableStreamDefaultControllerWriteCode, writableStreamDefaultControllerWrite, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeLength) \
+
+#define WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(macro) \
+    macro(isWritableStream) \
+    macro(isWritableStreamDefaultWriter) \
+    macro(acquireWritableStreamDefaultWriter) \
+    macro(createWritableStream) \
+    macro(createInternalWritableStreamFromUnderlyingSink) \
+    macro(initializeWritableStreamSlots) \
+    macro(writableStreamCloseForBindings) \
+    macro(writableStreamAbortForBindings) \
+    macro(isWritableStreamLocked) \
+    macro(setUpWritableStreamDefaultWriter) \
+    macro(writableStreamAbort) \
+    macro(writableStreamClose) \
+    macro(writableStreamAddWriteRequest) \
+    macro(writableStreamCloseQueuedOrInFlight) \
+    macro(writableStreamDealWithRejection) \
+    macro(writableStreamFinishErroring) \
+    macro(writableStreamFinishInFlightClose) \
+    macro(writableStreamFinishInFlightCloseWithError) \
+    macro(writableStreamFinishInFlightWrite) \
+    macro(writableStreamFinishInFlightWriteWithError) \
+    macro(writableStreamHasOperationMarkedInFlight) \
+    macro(writableStreamMarkCloseRequestInFlight) \
+    macro(writableStreamMarkFirstWriteRequestInFlight) \
+    macro(writableStreamRejectCloseAndClosedPromiseIfNeeded) \
+    macro(writableStreamStartErroring) \
+    macro(writableStreamUpdateBackpressure) \
+    macro(writableStreamDefaultWriterAbort) \
+    macro(writableStreamDefaultWriterClose) \
+    macro(writableStreamDefaultWriterCloseWithErrorPropagation) \
+    macro(writableStreamDefaultWriterEnsureClosedPromiseRejected) \
+    macro(writableStreamDefaultWriterEnsureReadyPromiseRejected) \
+    macro(writableStreamDefaultWriterGetDesiredSize) \
+    macro(writableStreamDefaultWriterRelease) \
+    macro(writableStreamDefaultWriterWrite) \
+    macro(setUpWritableStreamDefaultController) \
+    macro(writableStreamDefaultControllerStart) \
+    macro(setUpWritableStreamDefaultControllerFromUnderlyingSink) \
+    macro(writableStreamDefaultControllerAdvanceQueueIfNeeded) \
+    macro(isCloseSentinel) \
+    macro(writableStreamDefaultControllerClearAlgorithms) \
+    macro(writableStreamDefaultControllerClose) \
+    macro(writableStreamDefaultControllerError) \
+    macro(writableStreamDefaultControllerErrorIfNeeded) \
+    macro(writableStreamDefaultControllerGetBackpressure) \
+    macro(writableStreamDefaultControllerGetChunkSize) \
+    macro(writableStreamDefaultControllerGetDesiredSize) \
+    macro(writableStreamDefaultControllerProcessClose) \
+    macro(writableStreamDefaultControllerProcessWrite) \
+    macro(writableStreamDefaultControllerWrite) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class WritableStreamInternalsBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit WritableStreamInternalsBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* WritableStreamInternalsBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void WritableStreamInternalsBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+class WritableStreamInternalsBuiltinFunctions {
+public:
+    explicit WritableStreamInternalsBuiltinFunctions(JSC::VM& vm) : m_vm(vm) { }
+
+    void init(JSC::JSGlobalObject&);
+    template<typename Visitor> void visit(Visitor&);
+
+public:
+    JSC::VM& m_vm;
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(functionName) \
+    JSC::WriteBarrier<JSC::JSFunction> m_##functionName##Function;
+    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+};
+
+inline void WritableStreamInternalsBuiltinFunctions::init(JSC::JSGlobalObject& globalObject)
+{
+#define EXPORT_FUNCTION(codeName, functionName, overriddenName, length) \
+    m_##functionName##Function.set(m_vm, &globalObject, JSC::JSFunction::create(m_vm, codeName##Generator(m_vm), &globalObject));
+    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(EXPORT_FUNCTION)
+#undef EXPORT_FUNCTION
+}
+
+template<typename Visitor>
+inline void WritableStreamInternalsBuiltinFunctions::visit(Visitor& visitor)
+{
+#define VISIT_FUNCTION(name) visitor.append(m_##name##Function);
+    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(VISIT_FUNCTION)
+#undef VISIT_FUNCTION
+}
+
+template void WritableStreamInternalsBuiltinFunctions::visit(JSC::AbstractSlotVisitor&);
+template void WritableStreamInternalsBuiltinFunctions::visit(JSC::SlotVisitor&);
+    /* TransformStreamInternals.ts */
 // isTransformStream
 #define WEBCORE_BUILTIN_TRANSFORMSTREAMINTERNALS_ISTRANSFORMSTREAM 1
 extern const char* const s_transformStreamInternalsIsTransformStreamCode;
@@ -558,70 +1154,59 @@ inline void TransformStreamInternalsBuiltinFunctions::visit(Visitor& visitor)
 
 template void TransformStreamInternalsBuiltinFunctions::visit(JSC::AbstractSlotVisitor&);
 template void TransformStreamInternalsBuiltinFunctions::visit(JSC::SlotVisitor&);
-    /* ReadableStreamBYOBRequest.ts */
-// initializeReadableStreamBYOBRequest
-#define WEBCORE_BUILTIN_READABLESTREAMBYOBREQUEST_INITIALIZEREADABLESTREAMBYOBREQUEST 1
-extern const char* const s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCode;
-extern const int s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeLength;
-extern const JSC::ConstructAbility s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeImplementationVisibility;
+    /* ProcessObjectInternals.ts */
+// binding
+#define WEBCORE_BUILTIN_PROCESSOBJECTINTERNALS_BINDING 1
+extern const char* const s_processObjectInternalsBindingCode;
+extern const int s_processObjectInternalsBindingCodeLength;
+extern const JSC::ConstructAbility s_processObjectInternalsBindingCodeConstructAbility;
+extern const JSC::ConstructorKind s_processObjectInternalsBindingCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_processObjectInternalsBindingCodeImplementationVisibility;
 
-// respond
-#define WEBCORE_BUILTIN_READABLESTREAMBYOBREQUEST_RESPOND 1
-extern const char* const s_readableStreamBYOBRequestRespondCode;
-extern const int s_readableStreamBYOBRequestRespondCodeLength;
-extern const JSC::ConstructAbility s_readableStreamBYOBRequestRespondCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamBYOBRequestRespondCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamBYOBRequestRespondCodeImplementationVisibility;
+// getStdioWriteStream
+#define WEBCORE_BUILTIN_PROCESSOBJECTINTERNALS_GETSTDIOWRITESTREAM 1
+extern const char* const s_processObjectInternalsGetStdioWriteStreamCode;
+extern const int s_processObjectInternalsGetStdioWriteStreamCodeLength;
+extern const JSC::ConstructAbility s_processObjectInternalsGetStdioWriteStreamCodeConstructAbility;
+extern const JSC::ConstructorKind s_processObjectInternalsGetStdioWriteStreamCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_processObjectInternalsGetStdioWriteStreamCodeImplementationVisibility;
 
-// respondWithNewView
-#define WEBCORE_BUILTIN_READABLESTREAMBYOBREQUEST_RESPONDWITHNEWVIEW 1
-extern const char* const s_readableStreamBYOBRequestRespondWithNewViewCode;
-extern const int s_readableStreamBYOBRequestRespondWithNewViewCodeLength;
-extern const JSC::ConstructAbility s_readableStreamBYOBRequestRespondWithNewViewCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamBYOBRequestRespondWithNewViewCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamBYOBRequestRespondWithNewViewCodeImplementationVisibility;
+// getStdinStream
+#define WEBCORE_BUILTIN_PROCESSOBJECTINTERNALS_GETSTDINSTREAM 1
+extern const char* const s_processObjectInternalsGetStdinStreamCode;
+extern const int s_processObjectInternalsGetStdinStreamCodeLength;
+extern const JSC::ConstructAbility s_processObjectInternalsGetStdinStreamCodeConstructAbility;
+extern const JSC::ConstructorKind s_processObjectInternalsGetStdinStreamCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_processObjectInternalsGetStdinStreamCodeImplementationVisibility;
 
-// view
-#define WEBCORE_BUILTIN_READABLESTREAMBYOBREQUEST_VIEW 1
-extern const char* const s_readableStreamBYOBRequestViewCode;
-extern const int s_readableStreamBYOBRequestViewCodeLength;
-extern const JSC::ConstructAbility s_readableStreamBYOBRequestViewCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamBYOBRequestViewCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamBYOBRequestViewCodeImplementationVisibility;
+#define WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_DATA(macro) \
+    macro(binding, processObjectInternalsBinding, 1) \
+    macro(getStdioWriteStream, processObjectInternalsGetStdioWriteStream, 1) \
+    macro(getStdinStream, processObjectInternalsGetStdinStream, 1) \
 
-#define WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_DATA(macro) \
-    macro(initializeReadableStreamBYOBRequest, readableStreamBYOBRequestInitializeReadableStreamBYOBRequest, 2) \
-    macro(respond, readableStreamBYOBRequestRespond, 1) \
-    macro(respondWithNewView, readableStreamBYOBRequestRespondWithNewView, 1) \
-    macro(view, readableStreamBYOBRequestView, 0) \
+#define WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(macro) \
+    macro(processObjectInternalsBindingCode, binding, ASCIILiteral(), s_processObjectInternalsBindingCodeLength) \
+    macro(processObjectInternalsGetStdioWriteStreamCode, getStdioWriteStream, ASCIILiteral(), s_processObjectInternalsGetStdioWriteStreamCodeLength) \
+    macro(processObjectInternalsGetStdinStreamCode, getStdinStream, ASCIILiteral(), s_processObjectInternalsGetStdinStreamCodeLength) \
 
-#define WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(macro) \
-    macro(readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCode, initializeReadableStreamBYOBRequest, ASCIILiteral(), s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeLength) \
-    macro(readableStreamBYOBRequestRespondCode, respond, ASCIILiteral(), s_readableStreamBYOBRequestRespondCodeLength) \
-    macro(readableStreamBYOBRequestRespondWithNewViewCode, respondWithNewView, ASCIILiteral(), s_readableStreamBYOBRequestRespondWithNewViewCodeLength) \
-    macro(readableStreamBYOBRequestViewCode, view, "get view"_s, s_readableStreamBYOBRequestViewCodeLength) \
-
-#define WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_FUNCTION_NAME(macro) \
-    macro(initializeReadableStreamBYOBRequest) \
-    macro(respond) \
-    macro(respondWithNewView) \
-    macro(view) \
+#define WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_FUNCTION_NAME(macro) \
+    macro(binding) \
+    macro(getStdioWriteStream) \
+    macro(getStdinStream) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
     JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
 
-WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
 #undef DECLARE_BUILTIN_GENERATOR
 
-class ReadableStreamBYOBRequestBuiltinsWrapper : private JSC::WeakHandleOwner {
+class ProcessObjectInternalsBuiltinsWrapper : private JSC::WeakHandleOwner {
 public:
-    explicit ReadableStreamBYOBRequestBuiltinsWrapper(JSC::VM& vm)
+    explicit ProcessObjectInternalsBuiltinsWrapper(JSC::VM& vm)
         : m_vm(vm)
-        WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+        WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
 #define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+        WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
 #undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
     {
     }
@@ -629,28 +1214,28 @@ public:
 #define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
     JSC::UnlinkedFunctionExecutable* name##Executable(); \
     const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+    WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
 #undef EXPOSE_BUILTIN_EXECUTABLES
 
-    WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+    WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
 
     void exportNames();
 
 private:
     JSC::VM& m_vm;
 
-    WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+    WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
 
 #define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
     JSC::SourceCode m_##name##Source;\
     JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+    WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
 #undef DECLARE_BUILTIN_SOURCE_MEMBERS
 
 };
 
 #define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* ReadableStreamBYOBRequestBuiltinsWrapper::name##Executable() \
+inline JSC::UnlinkedFunctionExecutable* ProcessObjectInternalsBuiltinsWrapper::name##Executable() \
 {\
     if (!m_##name##Executable) {\
         JSC::Identifier executableName = functionName##PublicName();\
@@ -660,90 +1245,68 @@ inline JSC::UnlinkedFunctionExecutable* ReadableStreamBYOBRequestBuiltinsWrapper
     }\
     return m_##name##Executable.get();\
 }
-WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
 #undef DEFINE_BUILTIN_EXECUTABLES
 
-inline void ReadableStreamBYOBRequestBuiltinsWrapper::exportNames()
+inline void ProcessObjectInternalsBuiltinsWrapper::exportNames()
 {
 #define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+    WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
 #undef EXPORT_FUNCTION_NAME
 }
-/* ReadableStreamBYOBReader.ts */
-// initializeReadableStreamBYOBReader
-#define WEBCORE_BUILTIN_READABLESTREAMBYOBREADER_INITIALIZEREADABLESTREAMBYOBREADER 1
-extern const char* const s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCode;
-extern const int s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeLength;
-extern const JSC::ConstructAbility s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeImplementationVisibility;
+/* TransformStream.ts */
+// initializeTransformStream
+#define WEBCORE_BUILTIN_TRANSFORMSTREAM_INITIALIZETRANSFORMSTREAM 1
+extern const char* const s_transformStreamInitializeTransformStreamCode;
+extern const int s_transformStreamInitializeTransformStreamCodeLength;
+extern const JSC::ConstructAbility s_transformStreamInitializeTransformStreamCodeConstructAbility;
+extern const JSC::ConstructorKind s_transformStreamInitializeTransformStreamCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_transformStreamInitializeTransformStreamCodeImplementationVisibility;
 
-// cancel
-#define WEBCORE_BUILTIN_READABLESTREAMBYOBREADER_CANCEL 1
-extern const char* const s_readableStreamBYOBReaderCancelCode;
-extern const int s_readableStreamBYOBReaderCancelCodeLength;
-extern const JSC::ConstructAbility s_readableStreamBYOBReaderCancelCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamBYOBReaderCancelCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamBYOBReaderCancelCodeImplementationVisibility;
+// readable
+#define WEBCORE_BUILTIN_TRANSFORMSTREAM_READABLE 1
+extern const char* const s_transformStreamReadableCode;
+extern const int s_transformStreamReadableCodeLength;
+extern const JSC::ConstructAbility s_transformStreamReadableCodeConstructAbility;
+extern const JSC::ConstructorKind s_transformStreamReadableCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_transformStreamReadableCodeImplementationVisibility;
 
-// read
-#define WEBCORE_BUILTIN_READABLESTREAMBYOBREADER_READ 1
-extern const char* const s_readableStreamBYOBReaderReadCode;
-extern const int s_readableStreamBYOBReaderReadCodeLength;
-extern const JSC::ConstructAbility s_readableStreamBYOBReaderReadCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamBYOBReaderReadCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamBYOBReaderReadCodeImplementationVisibility;
+// writable
+#define WEBCORE_BUILTIN_TRANSFORMSTREAM_WRITABLE 1
+extern const char* const s_transformStreamWritableCode;
+extern const int s_transformStreamWritableCodeLength;
+extern const JSC::ConstructAbility s_transformStreamWritableCodeConstructAbility;
+extern const JSC::ConstructorKind s_transformStreamWritableCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_transformStreamWritableCodeImplementationVisibility;
 
-// releaseLock
-#define WEBCORE_BUILTIN_READABLESTREAMBYOBREADER_RELEASELOCK 1
-extern const char* const s_readableStreamBYOBReaderReleaseLockCode;
-extern const int s_readableStreamBYOBReaderReleaseLockCodeLength;
-extern const JSC::ConstructAbility s_readableStreamBYOBReaderReleaseLockCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamBYOBReaderReleaseLockCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamBYOBReaderReleaseLockCodeImplementationVisibility;
+#define WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_DATA(macro) \
+    macro(initializeTransformStream, transformStreamInitializeTransformStream, 0) \
+    macro(readable, transformStreamReadable, 0) \
+    macro(writable, transformStreamWritable, 0) \
 
-// closed
-#define WEBCORE_BUILTIN_READABLESTREAMBYOBREADER_CLOSED 1
-extern const char* const s_readableStreamBYOBReaderClosedCode;
-extern const int s_readableStreamBYOBReaderClosedCodeLength;
-extern const JSC::ConstructAbility s_readableStreamBYOBReaderClosedCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamBYOBReaderClosedCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamBYOBReaderClosedCodeImplementationVisibility;
+#define WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(macro) \
+    macro(transformStreamInitializeTransformStreamCode, initializeTransformStream, ASCIILiteral(), s_transformStreamInitializeTransformStreamCodeLength) \
+    macro(transformStreamReadableCode, readable, "get readable"_s, s_transformStreamReadableCodeLength) \
+    macro(transformStreamWritableCode, writable, ASCIILiteral(), s_transformStreamWritableCodeLength) \
 
-#define WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_DATA(macro) \
-    macro(initializeReadableStreamBYOBReader, readableStreamBYOBReaderInitializeReadableStreamBYOBReader, 1) \
-    macro(cancel, readableStreamBYOBReaderCancel, 1) \
-    macro(read, readableStreamBYOBReaderRead, 1) \
-    macro(releaseLock, readableStreamBYOBReaderReleaseLock, 0) \
-    macro(closed, readableStreamBYOBReaderClosed, 0) \
-
-#define WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(macro) \
-    macro(readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCode, initializeReadableStreamBYOBReader, ASCIILiteral(), s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeLength) \
-    macro(readableStreamBYOBReaderCancelCode, cancel, ASCIILiteral(), s_readableStreamBYOBReaderCancelCodeLength) \
-    macro(readableStreamBYOBReaderReadCode, read, ASCIILiteral(), s_readableStreamBYOBReaderReadCodeLength) \
-    macro(readableStreamBYOBReaderReleaseLockCode, releaseLock, ASCIILiteral(), s_readableStreamBYOBReaderReleaseLockCodeLength) \
-    macro(readableStreamBYOBReaderClosedCode, closed, "get closed"_s, s_readableStreamBYOBReaderClosedCodeLength) \
-
-#define WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_FUNCTION_NAME(macro) \
-    macro(initializeReadableStreamBYOBReader) \
-    macro(cancel) \
-    macro(read) \
-    macro(releaseLock) \
-    macro(closed) \
+#define WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_FUNCTION_NAME(macro) \
+    macro(initializeTransformStream) \
+    macro(readable) \
+    macro(writable) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
     JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
 
-WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
 #undef DECLARE_BUILTIN_GENERATOR
 
-class ReadableStreamBYOBReaderBuiltinsWrapper : private JSC::WeakHandleOwner {
+class TransformStreamBuiltinsWrapper : private JSC::WeakHandleOwner {
 public:
-    explicit ReadableStreamBYOBReaderBuiltinsWrapper(JSC::VM& vm)
+    explicit TransformStreamBuiltinsWrapper(JSC::VM& vm)
         : m_vm(vm)
-        WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+        WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
 #define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+        WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
 #undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
     {
     }
@@ -751,28 +1314,28 @@ public:
 #define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
     JSC::UnlinkedFunctionExecutable* name##Executable(); \
     const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+    WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
 #undef EXPOSE_BUILTIN_EXECUTABLES
 
-    WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+    WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
 
     void exportNames();
 
 private:
     JSC::VM& m_vm;
 
-    WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+    WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
 
 #define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
     JSC::SourceCode m_##name##Source;\
     JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+    WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
 #undef DECLARE_BUILTIN_SOURCE_MEMBERS
 
 };
 
 #define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* ReadableStreamBYOBReaderBuiltinsWrapper::name##Executable() \
+inline JSC::UnlinkedFunctionExecutable* TransformStreamBuiltinsWrapper::name##Executable() \
 {\
     if (!m_##name##Executable) {\
         JSC::Identifier executableName = functionName##PublicName();\
@@ -782,102 +1345,13 @@ inline JSC::UnlinkedFunctionExecutable* ReadableStreamBYOBReaderBuiltinsWrapper:
     }\
     return m_##name##Executable.get();\
 }
-WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
 #undef DEFINE_BUILTIN_EXECUTABLES
 
-inline void ReadableStreamBYOBReaderBuiltinsWrapper::exportNames()
+inline void TransformStreamBuiltinsWrapper::exportNames()
 {
 #define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-/* WritableStreamDefaultController.ts */
-// initializeWritableStreamDefaultController
-#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTCONTROLLER_INITIALIZEWRITABLESTREAMDEFAULTCONTROLLER 1
-extern const char* const s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCode;
-extern const int s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeLength;
-extern const JSC::ConstructAbility s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeImplementationVisibility;
-
-// error
-#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTCONTROLLER_ERROR 1
-extern const char* const s_writableStreamDefaultControllerErrorCode;
-extern const int s_writableStreamDefaultControllerErrorCodeLength;
-extern const JSC::ConstructAbility s_writableStreamDefaultControllerErrorCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamDefaultControllerErrorCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamDefaultControllerErrorCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_DATA(macro) \
-    macro(initializeWritableStreamDefaultController, writableStreamDefaultControllerInitializeWritableStreamDefaultController, 0) \
-    macro(error, writableStreamDefaultControllerError, 1) \
-
-#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(macro) \
-    macro(writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCode, initializeWritableStreamDefaultController, ASCIILiteral(), s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeLength) \
-    macro(writableStreamDefaultControllerErrorCode, error, ASCIILiteral(), s_writableStreamDefaultControllerErrorCodeLength) \
-
-#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(macro) \
-    macro(initializeWritableStreamDefaultController) \
-    macro(error) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class WritableStreamDefaultControllerBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit WritableStreamDefaultControllerBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* WritableStreamDefaultControllerBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void WritableStreamDefaultControllerBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+    WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
 #undef EXPORT_FUNCTION_NAME
 }
 /* Module.ts */
@@ -989,6 +1463,799 @@ inline void ModuleBuiltinsWrapper::exportNames()
 {
 #define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
     WEBCORE_FOREACH_MODULE_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+/* JSBufferPrototype.ts */
+// setBigUint64
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_SETBIGUINT64 1
+extern const char* const s_jsBufferPrototypeSetBigUint64Code;
+extern const int s_jsBufferPrototypeSetBigUint64CodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeSetBigUint64CodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeSetBigUint64CodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeSetBigUint64CodeImplementationVisibility;
+
+// readInt8
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINT8 1
+extern const char* const s_jsBufferPrototypeReadInt8Code;
+extern const int s_jsBufferPrototypeReadInt8CodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadInt8CodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadInt8CodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadInt8CodeImplementationVisibility;
+
+// readUInt8
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINT8 1
+extern const char* const s_jsBufferPrototypeReadUInt8Code;
+extern const int s_jsBufferPrototypeReadUInt8CodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadUInt8CodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadUInt8CodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUInt8CodeImplementationVisibility;
+
+// readInt16LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINT16LE 1
+extern const char* const s_jsBufferPrototypeReadInt16LECode;
+extern const int s_jsBufferPrototypeReadInt16LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadInt16LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadInt16LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadInt16LECodeImplementationVisibility;
+
+// readInt16BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINT16BE 1
+extern const char* const s_jsBufferPrototypeReadInt16BECode;
+extern const int s_jsBufferPrototypeReadInt16BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadInt16BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadInt16BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadInt16BECodeImplementationVisibility;
+
+// readUInt16LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINT16LE 1
+extern const char* const s_jsBufferPrototypeReadUInt16LECode;
+extern const int s_jsBufferPrototypeReadUInt16LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadUInt16LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadUInt16LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUInt16LECodeImplementationVisibility;
+
+// readUInt16BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINT16BE 1
+extern const char* const s_jsBufferPrototypeReadUInt16BECode;
+extern const int s_jsBufferPrototypeReadUInt16BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadUInt16BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadUInt16BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUInt16BECodeImplementationVisibility;
+
+// readInt32LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINT32LE 1
+extern const char* const s_jsBufferPrototypeReadInt32LECode;
+extern const int s_jsBufferPrototypeReadInt32LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadInt32LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadInt32LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadInt32LECodeImplementationVisibility;
+
+// readInt32BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINT32BE 1
+extern const char* const s_jsBufferPrototypeReadInt32BECode;
+extern const int s_jsBufferPrototypeReadInt32BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadInt32BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadInt32BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadInt32BECodeImplementationVisibility;
+
+// readUInt32LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINT32LE 1
+extern const char* const s_jsBufferPrototypeReadUInt32LECode;
+extern const int s_jsBufferPrototypeReadUInt32LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadUInt32LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadUInt32LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUInt32LECodeImplementationVisibility;
+
+// readUInt32BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINT32BE 1
+extern const char* const s_jsBufferPrototypeReadUInt32BECode;
+extern const int s_jsBufferPrototypeReadUInt32BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadUInt32BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadUInt32BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUInt32BECodeImplementationVisibility;
+
+// readIntLE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINTLE 1
+extern const char* const s_jsBufferPrototypeReadIntLECode;
+extern const int s_jsBufferPrototypeReadIntLECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadIntLECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadIntLECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadIntLECodeImplementationVisibility;
+
+// readIntBE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINTBE 1
+extern const char* const s_jsBufferPrototypeReadIntBECode;
+extern const int s_jsBufferPrototypeReadIntBECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadIntBECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadIntBECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadIntBECodeImplementationVisibility;
+
+// readUIntLE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINTLE 1
+extern const char* const s_jsBufferPrototypeReadUIntLECode;
+extern const int s_jsBufferPrototypeReadUIntLECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadUIntLECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadUIntLECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUIntLECodeImplementationVisibility;
+
+// readUIntBE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINTBE 1
+extern const char* const s_jsBufferPrototypeReadUIntBECode;
+extern const int s_jsBufferPrototypeReadUIntBECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadUIntBECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadUIntBECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUIntBECodeImplementationVisibility;
+
+// readFloatLE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READFLOATLE 1
+extern const char* const s_jsBufferPrototypeReadFloatLECode;
+extern const int s_jsBufferPrototypeReadFloatLECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadFloatLECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadFloatLECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadFloatLECodeImplementationVisibility;
+
+// readFloatBE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READFLOATBE 1
+extern const char* const s_jsBufferPrototypeReadFloatBECode;
+extern const int s_jsBufferPrototypeReadFloatBECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadFloatBECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadFloatBECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadFloatBECodeImplementationVisibility;
+
+// readDoubleLE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READDOUBLELE 1
+extern const char* const s_jsBufferPrototypeReadDoubleLECode;
+extern const int s_jsBufferPrototypeReadDoubleLECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadDoubleLECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadDoubleLECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadDoubleLECodeImplementationVisibility;
+
+// readDoubleBE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READDOUBLEBE 1
+extern const char* const s_jsBufferPrototypeReadDoubleBECode;
+extern const int s_jsBufferPrototypeReadDoubleBECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadDoubleBECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadDoubleBECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadDoubleBECodeImplementationVisibility;
+
+// readBigInt64LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READBIGINT64LE 1
+extern const char* const s_jsBufferPrototypeReadBigInt64LECode;
+extern const int s_jsBufferPrototypeReadBigInt64LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadBigInt64LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadBigInt64LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadBigInt64LECodeImplementationVisibility;
+
+// readBigInt64BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READBIGINT64BE 1
+extern const char* const s_jsBufferPrototypeReadBigInt64BECode;
+extern const int s_jsBufferPrototypeReadBigInt64BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadBigInt64BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadBigInt64BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadBigInt64BECodeImplementationVisibility;
+
+// readBigUInt64LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READBIGUINT64LE 1
+extern const char* const s_jsBufferPrototypeReadBigUInt64LECode;
+extern const int s_jsBufferPrototypeReadBigUInt64LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadBigUInt64LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadBigUInt64LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadBigUInt64LECodeImplementationVisibility;
+
+// readBigUInt64BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READBIGUINT64BE 1
+extern const char* const s_jsBufferPrototypeReadBigUInt64BECode;
+extern const int s_jsBufferPrototypeReadBigUInt64BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeReadBigUInt64BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeReadBigUInt64BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadBigUInt64BECodeImplementationVisibility;
+
+// writeInt8
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINT8 1
+extern const char* const s_jsBufferPrototypeWriteInt8Code;
+extern const int s_jsBufferPrototypeWriteInt8CodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteInt8CodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteInt8CodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteInt8CodeImplementationVisibility;
+
+// writeUInt8
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINT8 1
+extern const char* const s_jsBufferPrototypeWriteUInt8Code;
+extern const int s_jsBufferPrototypeWriteUInt8CodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUInt8CodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUInt8CodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUInt8CodeImplementationVisibility;
+
+// writeInt16LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINT16LE 1
+extern const char* const s_jsBufferPrototypeWriteInt16LECode;
+extern const int s_jsBufferPrototypeWriteInt16LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteInt16LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteInt16LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteInt16LECodeImplementationVisibility;
+
+// writeInt16BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINT16BE 1
+extern const char* const s_jsBufferPrototypeWriteInt16BECode;
+extern const int s_jsBufferPrototypeWriteInt16BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteInt16BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteInt16BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteInt16BECodeImplementationVisibility;
+
+// writeUInt16LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINT16LE 1
+extern const char* const s_jsBufferPrototypeWriteUInt16LECode;
+extern const int s_jsBufferPrototypeWriteUInt16LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUInt16LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUInt16LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUInt16LECodeImplementationVisibility;
+
+// writeUInt16BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINT16BE 1
+extern const char* const s_jsBufferPrototypeWriteUInt16BECode;
+extern const int s_jsBufferPrototypeWriteUInt16BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUInt16BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUInt16BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUInt16BECodeImplementationVisibility;
+
+// writeInt32LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINT32LE 1
+extern const char* const s_jsBufferPrototypeWriteInt32LECode;
+extern const int s_jsBufferPrototypeWriteInt32LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteInt32LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteInt32LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteInt32LECodeImplementationVisibility;
+
+// writeInt32BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINT32BE 1
+extern const char* const s_jsBufferPrototypeWriteInt32BECode;
+extern const int s_jsBufferPrototypeWriteInt32BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteInt32BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteInt32BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteInt32BECodeImplementationVisibility;
+
+// writeUInt32LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINT32LE 1
+extern const char* const s_jsBufferPrototypeWriteUInt32LECode;
+extern const int s_jsBufferPrototypeWriteUInt32LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUInt32LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUInt32LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUInt32LECodeImplementationVisibility;
+
+// writeUInt32BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINT32BE 1
+extern const char* const s_jsBufferPrototypeWriteUInt32BECode;
+extern const int s_jsBufferPrototypeWriteUInt32BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUInt32BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUInt32BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUInt32BECodeImplementationVisibility;
+
+// writeIntLE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINTLE 1
+extern const char* const s_jsBufferPrototypeWriteIntLECode;
+extern const int s_jsBufferPrototypeWriteIntLECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteIntLECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteIntLECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteIntLECodeImplementationVisibility;
+
+// writeIntBE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINTBE 1
+extern const char* const s_jsBufferPrototypeWriteIntBECode;
+extern const int s_jsBufferPrototypeWriteIntBECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteIntBECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteIntBECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteIntBECodeImplementationVisibility;
+
+// writeUIntLE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINTLE 1
+extern const char* const s_jsBufferPrototypeWriteUIntLECode;
+extern const int s_jsBufferPrototypeWriteUIntLECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUIntLECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUIntLECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUIntLECodeImplementationVisibility;
+
+// writeUIntBE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINTBE 1
+extern const char* const s_jsBufferPrototypeWriteUIntBECode;
+extern const int s_jsBufferPrototypeWriteUIntBECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUIntBECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUIntBECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUIntBECodeImplementationVisibility;
+
+// writeFloatLE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEFLOATLE 1
+extern const char* const s_jsBufferPrototypeWriteFloatLECode;
+extern const int s_jsBufferPrototypeWriteFloatLECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteFloatLECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteFloatLECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteFloatLECodeImplementationVisibility;
+
+// writeFloatBE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEFLOATBE 1
+extern const char* const s_jsBufferPrototypeWriteFloatBECode;
+extern const int s_jsBufferPrototypeWriteFloatBECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteFloatBECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteFloatBECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteFloatBECodeImplementationVisibility;
+
+// writeDoubleLE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEDOUBLELE 1
+extern const char* const s_jsBufferPrototypeWriteDoubleLECode;
+extern const int s_jsBufferPrototypeWriteDoubleLECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteDoubleLECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteDoubleLECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteDoubleLECodeImplementationVisibility;
+
+// writeDoubleBE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEDOUBLEBE 1
+extern const char* const s_jsBufferPrototypeWriteDoubleBECode;
+extern const int s_jsBufferPrototypeWriteDoubleBECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteDoubleBECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteDoubleBECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteDoubleBECodeImplementationVisibility;
+
+// writeBigInt64LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEBIGINT64LE 1
+extern const char* const s_jsBufferPrototypeWriteBigInt64LECode;
+extern const int s_jsBufferPrototypeWriteBigInt64LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteBigInt64LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteBigInt64LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteBigInt64LECodeImplementationVisibility;
+
+// writeBigInt64BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEBIGINT64BE 1
+extern const char* const s_jsBufferPrototypeWriteBigInt64BECode;
+extern const int s_jsBufferPrototypeWriteBigInt64BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteBigInt64BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteBigInt64BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteBigInt64BECodeImplementationVisibility;
+
+// writeBigUInt64LE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEBIGUINT64LE 1
+extern const char* const s_jsBufferPrototypeWriteBigUInt64LECode;
+extern const int s_jsBufferPrototypeWriteBigUInt64LECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteBigUInt64LECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteBigUInt64LECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteBigUInt64LECodeImplementationVisibility;
+
+// writeBigUInt64BE
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEBIGUINT64BE 1
+extern const char* const s_jsBufferPrototypeWriteBigUInt64BECode;
+extern const int s_jsBufferPrototypeWriteBigUInt64BECodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeWriteBigUInt64BECodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeWriteBigUInt64BECodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteBigUInt64BECodeImplementationVisibility;
+
+// utf8Write
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UTF8WRITE 1
+extern const char* const s_jsBufferPrototypeUtf8WriteCode;
+extern const int s_jsBufferPrototypeUtf8WriteCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeUtf8WriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeUtf8WriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeUtf8WriteCodeImplementationVisibility;
+
+// ucs2Write
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UCS2WRITE 1
+extern const char* const s_jsBufferPrototypeUcs2WriteCode;
+extern const int s_jsBufferPrototypeUcs2WriteCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeUcs2WriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeUcs2WriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeUcs2WriteCodeImplementationVisibility;
+
+// utf16leWrite
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UTF16LEWRITE 1
+extern const char* const s_jsBufferPrototypeUtf16leWriteCode;
+extern const int s_jsBufferPrototypeUtf16leWriteCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeUtf16leWriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeUtf16leWriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeUtf16leWriteCodeImplementationVisibility;
+
+// latin1Write
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_LATIN1WRITE 1
+extern const char* const s_jsBufferPrototypeLatin1WriteCode;
+extern const int s_jsBufferPrototypeLatin1WriteCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeLatin1WriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeLatin1WriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeLatin1WriteCodeImplementationVisibility;
+
+// asciiWrite
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_ASCIIWRITE 1
+extern const char* const s_jsBufferPrototypeAsciiWriteCode;
+extern const int s_jsBufferPrototypeAsciiWriteCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeAsciiWriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeAsciiWriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeAsciiWriteCodeImplementationVisibility;
+
+// base64Write
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_BASE64WRITE 1
+extern const char* const s_jsBufferPrototypeBase64WriteCode;
+extern const int s_jsBufferPrototypeBase64WriteCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeBase64WriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeBase64WriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeBase64WriteCodeImplementationVisibility;
+
+// base64urlWrite
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_BASE64URLWRITE 1
+extern const char* const s_jsBufferPrototypeBase64urlWriteCode;
+extern const int s_jsBufferPrototypeBase64urlWriteCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeBase64urlWriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeBase64urlWriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeBase64urlWriteCodeImplementationVisibility;
+
+// hexWrite
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_HEXWRITE 1
+extern const char* const s_jsBufferPrototypeHexWriteCode;
+extern const int s_jsBufferPrototypeHexWriteCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeHexWriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeHexWriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeHexWriteCodeImplementationVisibility;
+
+// utf8Slice
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UTF8SLICE 1
+extern const char* const s_jsBufferPrototypeUtf8SliceCode;
+extern const int s_jsBufferPrototypeUtf8SliceCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeUtf8SliceCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeUtf8SliceCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeUtf8SliceCodeImplementationVisibility;
+
+// ucs2Slice
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UCS2SLICE 1
+extern const char* const s_jsBufferPrototypeUcs2SliceCode;
+extern const int s_jsBufferPrototypeUcs2SliceCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeUcs2SliceCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeUcs2SliceCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeUcs2SliceCodeImplementationVisibility;
+
+// utf16leSlice
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UTF16LESLICE 1
+extern const char* const s_jsBufferPrototypeUtf16leSliceCode;
+extern const int s_jsBufferPrototypeUtf16leSliceCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeUtf16leSliceCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeUtf16leSliceCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeUtf16leSliceCodeImplementationVisibility;
+
+// latin1Slice
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_LATIN1SLICE 1
+extern const char* const s_jsBufferPrototypeLatin1SliceCode;
+extern const int s_jsBufferPrototypeLatin1SliceCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeLatin1SliceCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeLatin1SliceCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeLatin1SliceCodeImplementationVisibility;
+
+// asciiSlice
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_ASCIISLICE 1
+extern const char* const s_jsBufferPrototypeAsciiSliceCode;
+extern const int s_jsBufferPrototypeAsciiSliceCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeAsciiSliceCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeAsciiSliceCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeAsciiSliceCodeImplementationVisibility;
+
+// base64Slice
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_BASE64SLICE 1
+extern const char* const s_jsBufferPrototypeBase64SliceCode;
+extern const int s_jsBufferPrototypeBase64SliceCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeBase64SliceCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeBase64SliceCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeBase64SliceCodeImplementationVisibility;
+
+// base64urlSlice
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_BASE64URLSLICE 1
+extern const char* const s_jsBufferPrototypeBase64urlSliceCode;
+extern const int s_jsBufferPrototypeBase64urlSliceCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeBase64urlSliceCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeBase64urlSliceCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeBase64urlSliceCodeImplementationVisibility;
+
+// hexSlice
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_HEXSLICE 1
+extern const char* const s_jsBufferPrototypeHexSliceCode;
+extern const int s_jsBufferPrototypeHexSliceCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeHexSliceCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeHexSliceCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeHexSliceCodeImplementationVisibility;
+
+// toJSON
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_TOJSON 1
+extern const char* const s_jsBufferPrototypeToJSONCode;
+extern const int s_jsBufferPrototypeToJSONCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeToJSONCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeToJSONCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeToJSONCodeImplementationVisibility;
+
+// slice
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_SLICE 1
+extern const char* const s_jsBufferPrototypeSliceCode;
+extern const int s_jsBufferPrototypeSliceCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeSliceCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeSliceCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeSliceCodeImplementationVisibility;
+
+// parent
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_PARENT 1
+extern const char* const s_jsBufferPrototypeParentCode;
+extern const int s_jsBufferPrototypeParentCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeParentCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeParentCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeParentCodeImplementationVisibility;
+
+// offset
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_OFFSET 1
+extern const char* const s_jsBufferPrototypeOffsetCode;
+extern const int s_jsBufferPrototypeOffsetCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeOffsetCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeOffsetCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeOffsetCodeImplementationVisibility;
+
+// inspect
+#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_INSPECT 1
+extern const char* const s_jsBufferPrototypeInspectCode;
+extern const int s_jsBufferPrototypeInspectCodeLength;
+extern const JSC::ConstructAbility s_jsBufferPrototypeInspectCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferPrototypeInspectCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferPrototypeInspectCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_DATA(macro) \
+    macro(setBigUint64, jsBufferPrototypeSetBigUint64, 3) \
+    macro(readInt8, jsBufferPrototypeReadInt8, 1) \
+    macro(readUInt8, jsBufferPrototypeReadUInt8, 1) \
+    macro(readInt16LE, jsBufferPrototypeReadInt16LE, 1) \
+    macro(readInt16BE, jsBufferPrototypeReadInt16BE, 1) \
+    macro(readUInt16LE, jsBufferPrototypeReadUInt16LE, 1) \
+    macro(readUInt16BE, jsBufferPrototypeReadUInt16BE, 1) \
+    macro(readInt32LE, jsBufferPrototypeReadInt32LE, 1) \
+    macro(readInt32BE, jsBufferPrototypeReadInt32BE, 1) \
+    macro(readUInt32LE, jsBufferPrototypeReadUInt32LE, 1) \
+    macro(readUInt32BE, jsBufferPrototypeReadUInt32BE, 1) \
+    macro(readIntLE, jsBufferPrototypeReadIntLE, 2) \
+    macro(readIntBE, jsBufferPrototypeReadIntBE, 2) \
+    macro(readUIntLE, jsBufferPrototypeReadUIntLE, 2) \
+    macro(readUIntBE, jsBufferPrototypeReadUIntBE, 2) \
+    macro(readFloatLE, jsBufferPrototypeReadFloatLE, 1) \
+    macro(readFloatBE, jsBufferPrototypeReadFloatBE, 1) \
+    macro(readDoubleLE, jsBufferPrototypeReadDoubleLE, 1) \
+    macro(readDoubleBE, jsBufferPrototypeReadDoubleBE, 1) \
+    macro(readBigInt64LE, jsBufferPrototypeReadBigInt64LE, 1) \
+    macro(readBigInt64BE, jsBufferPrototypeReadBigInt64BE, 1) \
+    macro(readBigUInt64LE, jsBufferPrototypeReadBigUInt64LE, 1) \
+    macro(readBigUInt64BE, jsBufferPrototypeReadBigUInt64BE, 1) \
+    macro(writeInt8, jsBufferPrototypeWriteInt8, 2) \
+    macro(writeUInt8, jsBufferPrototypeWriteUInt8, 2) \
+    macro(writeInt16LE, jsBufferPrototypeWriteInt16LE, 2) \
+    macro(writeInt16BE, jsBufferPrototypeWriteInt16BE, 2) \
+    macro(writeUInt16LE, jsBufferPrototypeWriteUInt16LE, 2) \
+    macro(writeUInt16BE, jsBufferPrototypeWriteUInt16BE, 2) \
+    macro(writeInt32LE, jsBufferPrototypeWriteInt32LE, 2) \
+    macro(writeInt32BE, jsBufferPrototypeWriteInt32BE, 2) \
+    macro(writeUInt32LE, jsBufferPrototypeWriteUInt32LE, 2) \
+    macro(writeUInt32BE, jsBufferPrototypeWriteUInt32BE, 2) \
+    macro(writeIntLE, jsBufferPrototypeWriteIntLE, 3) \
+    macro(writeIntBE, jsBufferPrototypeWriteIntBE, 3) \
+    macro(writeUIntLE, jsBufferPrototypeWriteUIntLE, 3) \
+    macro(writeUIntBE, jsBufferPrototypeWriteUIntBE, 3) \
+    macro(writeFloatLE, jsBufferPrototypeWriteFloatLE, 2) \
+    macro(writeFloatBE, jsBufferPrototypeWriteFloatBE, 2) \
+    macro(writeDoubleLE, jsBufferPrototypeWriteDoubleLE, 2) \
+    macro(writeDoubleBE, jsBufferPrototypeWriteDoubleBE, 2) \
+    macro(writeBigInt64LE, jsBufferPrototypeWriteBigInt64LE, 2) \
+    macro(writeBigInt64BE, jsBufferPrototypeWriteBigInt64BE, 2) \
+    macro(writeBigUInt64LE, jsBufferPrototypeWriteBigUInt64LE, 2) \
+    macro(writeBigUInt64BE, jsBufferPrototypeWriteBigUInt64BE, 2) \
+    macro(utf8Write, jsBufferPrototypeUtf8Write, 3) \
+    macro(ucs2Write, jsBufferPrototypeUcs2Write, 3) \
+    macro(utf16leWrite, jsBufferPrototypeUtf16leWrite, 3) \
+    macro(latin1Write, jsBufferPrototypeLatin1Write, 3) \
+    macro(asciiWrite, jsBufferPrototypeAsciiWrite, 3) \
+    macro(base64Write, jsBufferPrototypeBase64Write, 3) \
+    macro(base64urlWrite, jsBufferPrototypeBase64urlWrite, 3) \
+    macro(hexWrite, jsBufferPrototypeHexWrite, 3) \
+    macro(utf8Slice, jsBufferPrototypeUtf8Slice, 2) \
+    macro(ucs2Slice, jsBufferPrototypeUcs2Slice, 2) \
+    macro(utf16leSlice, jsBufferPrototypeUtf16leSlice, 2) \
+    macro(latin1Slice, jsBufferPrototypeLatin1Slice, 2) \
+    macro(asciiSlice, jsBufferPrototypeAsciiSlice, 2) \
+    macro(base64Slice, jsBufferPrototypeBase64Slice, 2) \
+    macro(base64urlSlice, jsBufferPrototypeBase64urlSlice, 2) \
+    macro(hexSlice, jsBufferPrototypeHexSlice, 2) \
+    macro(toJSON, jsBufferPrototypeToJSON, 0) \
+    macro(slice, jsBufferPrototypeSlice, 2) \
+    macro(parent, jsBufferPrototypeParent, 0) \
+    macro(offset, jsBufferPrototypeOffset, 0) \
+    macro(inspect, jsBufferPrototypeInspect, 2) \
+
+#define WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(macro) \
+    macro(jsBufferPrototypeSetBigUint64Code, setBigUint64, ASCIILiteral(), s_jsBufferPrototypeSetBigUint64CodeLength) \
+    macro(jsBufferPrototypeReadInt8Code, readInt8, ASCIILiteral(), s_jsBufferPrototypeReadInt8CodeLength) \
+    macro(jsBufferPrototypeReadUInt8Code, readUInt8, ASCIILiteral(), s_jsBufferPrototypeReadUInt8CodeLength) \
+    macro(jsBufferPrototypeReadInt16LECode, readInt16LE, ASCIILiteral(), s_jsBufferPrototypeReadInt16LECodeLength) \
+    macro(jsBufferPrototypeReadInt16BECode, readInt16BE, ASCIILiteral(), s_jsBufferPrototypeReadInt16BECodeLength) \
+    macro(jsBufferPrototypeReadUInt16LECode, readUInt16LE, ASCIILiteral(), s_jsBufferPrototypeReadUInt16LECodeLength) \
+    macro(jsBufferPrototypeReadUInt16BECode, readUInt16BE, ASCIILiteral(), s_jsBufferPrototypeReadUInt16BECodeLength) \
+    macro(jsBufferPrototypeReadInt32LECode, readInt32LE, ASCIILiteral(), s_jsBufferPrototypeReadInt32LECodeLength) \
+    macro(jsBufferPrototypeReadInt32BECode, readInt32BE, ASCIILiteral(), s_jsBufferPrototypeReadInt32BECodeLength) \
+    macro(jsBufferPrototypeReadUInt32LECode, readUInt32LE, ASCIILiteral(), s_jsBufferPrototypeReadUInt32LECodeLength) \
+    macro(jsBufferPrototypeReadUInt32BECode, readUInt32BE, ASCIILiteral(), s_jsBufferPrototypeReadUInt32BECodeLength) \
+    macro(jsBufferPrototypeReadIntLECode, readIntLE, ASCIILiteral(), s_jsBufferPrototypeReadIntLECodeLength) \
+    macro(jsBufferPrototypeReadIntBECode, readIntBE, ASCIILiteral(), s_jsBufferPrototypeReadIntBECodeLength) \
+    macro(jsBufferPrototypeReadUIntLECode, readUIntLE, ASCIILiteral(), s_jsBufferPrototypeReadUIntLECodeLength) \
+    macro(jsBufferPrototypeReadUIntBECode, readUIntBE, ASCIILiteral(), s_jsBufferPrototypeReadUIntBECodeLength) \
+    macro(jsBufferPrototypeReadFloatLECode, readFloatLE, ASCIILiteral(), s_jsBufferPrototypeReadFloatLECodeLength) \
+    macro(jsBufferPrototypeReadFloatBECode, readFloatBE, ASCIILiteral(), s_jsBufferPrototypeReadFloatBECodeLength) \
+    macro(jsBufferPrototypeReadDoubleLECode, readDoubleLE, ASCIILiteral(), s_jsBufferPrototypeReadDoubleLECodeLength) \
+    macro(jsBufferPrototypeReadDoubleBECode, readDoubleBE, ASCIILiteral(), s_jsBufferPrototypeReadDoubleBECodeLength) \
+    macro(jsBufferPrototypeReadBigInt64LECode, readBigInt64LE, ASCIILiteral(), s_jsBufferPrototypeReadBigInt64LECodeLength) \
+    macro(jsBufferPrototypeReadBigInt64BECode, readBigInt64BE, ASCIILiteral(), s_jsBufferPrototypeReadBigInt64BECodeLength) \
+    macro(jsBufferPrototypeReadBigUInt64LECode, readBigUInt64LE, ASCIILiteral(), s_jsBufferPrototypeReadBigUInt64LECodeLength) \
+    macro(jsBufferPrototypeReadBigUInt64BECode, readBigUInt64BE, ASCIILiteral(), s_jsBufferPrototypeReadBigUInt64BECodeLength) \
+    macro(jsBufferPrototypeWriteInt8Code, writeInt8, ASCIILiteral(), s_jsBufferPrototypeWriteInt8CodeLength) \
+    macro(jsBufferPrototypeWriteUInt8Code, writeUInt8, ASCIILiteral(), s_jsBufferPrototypeWriteUInt8CodeLength) \
+    macro(jsBufferPrototypeWriteInt16LECode, writeInt16LE, ASCIILiteral(), s_jsBufferPrototypeWriteInt16LECodeLength) \
+    macro(jsBufferPrototypeWriteInt16BECode, writeInt16BE, ASCIILiteral(), s_jsBufferPrototypeWriteInt16BECodeLength) \
+    macro(jsBufferPrototypeWriteUInt16LECode, writeUInt16LE, ASCIILiteral(), s_jsBufferPrototypeWriteUInt16LECodeLength) \
+    macro(jsBufferPrototypeWriteUInt16BECode, writeUInt16BE, ASCIILiteral(), s_jsBufferPrototypeWriteUInt16BECodeLength) \
+    macro(jsBufferPrototypeWriteInt32LECode, writeInt32LE, ASCIILiteral(), s_jsBufferPrototypeWriteInt32LECodeLength) \
+    macro(jsBufferPrototypeWriteInt32BECode, writeInt32BE, ASCIILiteral(), s_jsBufferPrototypeWriteInt32BECodeLength) \
+    macro(jsBufferPrototypeWriteUInt32LECode, writeUInt32LE, ASCIILiteral(), s_jsBufferPrototypeWriteUInt32LECodeLength) \
+    macro(jsBufferPrototypeWriteUInt32BECode, writeUInt32BE, ASCIILiteral(), s_jsBufferPrototypeWriteUInt32BECodeLength) \
+    macro(jsBufferPrototypeWriteIntLECode, writeIntLE, ASCIILiteral(), s_jsBufferPrototypeWriteIntLECodeLength) \
+    macro(jsBufferPrototypeWriteIntBECode, writeIntBE, ASCIILiteral(), s_jsBufferPrototypeWriteIntBECodeLength) \
+    macro(jsBufferPrototypeWriteUIntLECode, writeUIntLE, ASCIILiteral(), s_jsBufferPrototypeWriteUIntLECodeLength) \
+    macro(jsBufferPrototypeWriteUIntBECode, writeUIntBE, ASCIILiteral(), s_jsBufferPrototypeWriteUIntBECodeLength) \
+    macro(jsBufferPrototypeWriteFloatLECode, writeFloatLE, ASCIILiteral(), s_jsBufferPrototypeWriteFloatLECodeLength) \
+    macro(jsBufferPrototypeWriteFloatBECode, writeFloatBE, ASCIILiteral(), s_jsBufferPrototypeWriteFloatBECodeLength) \
+    macro(jsBufferPrototypeWriteDoubleLECode, writeDoubleLE, ASCIILiteral(), s_jsBufferPrototypeWriteDoubleLECodeLength) \
+    macro(jsBufferPrototypeWriteDoubleBECode, writeDoubleBE, ASCIILiteral(), s_jsBufferPrototypeWriteDoubleBECodeLength) \
+    macro(jsBufferPrototypeWriteBigInt64LECode, writeBigInt64LE, ASCIILiteral(), s_jsBufferPrototypeWriteBigInt64LECodeLength) \
+    macro(jsBufferPrototypeWriteBigInt64BECode, writeBigInt64BE, ASCIILiteral(), s_jsBufferPrototypeWriteBigInt64BECodeLength) \
+    macro(jsBufferPrototypeWriteBigUInt64LECode, writeBigUInt64LE, ASCIILiteral(), s_jsBufferPrototypeWriteBigUInt64LECodeLength) \
+    macro(jsBufferPrototypeWriteBigUInt64BECode, writeBigUInt64BE, ASCIILiteral(), s_jsBufferPrototypeWriteBigUInt64BECodeLength) \
+    macro(jsBufferPrototypeUtf8WriteCode, utf8Write, ASCIILiteral(), s_jsBufferPrototypeUtf8WriteCodeLength) \
+    macro(jsBufferPrototypeUcs2WriteCode, ucs2Write, ASCIILiteral(), s_jsBufferPrototypeUcs2WriteCodeLength) \
+    macro(jsBufferPrototypeUtf16leWriteCode, utf16leWrite, ASCIILiteral(), s_jsBufferPrototypeUtf16leWriteCodeLength) \
+    macro(jsBufferPrototypeLatin1WriteCode, latin1Write, ASCIILiteral(), s_jsBufferPrototypeLatin1WriteCodeLength) \
+    macro(jsBufferPrototypeAsciiWriteCode, asciiWrite, ASCIILiteral(), s_jsBufferPrototypeAsciiWriteCodeLength) \
+    macro(jsBufferPrototypeBase64WriteCode, base64Write, ASCIILiteral(), s_jsBufferPrototypeBase64WriteCodeLength) \
+    macro(jsBufferPrototypeBase64urlWriteCode, base64urlWrite, ASCIILiteral(), s_jsBufferPrototypeBase64urlWriteCodeLength) \
+    macro(jsBufferPrototypeHexWriteCode, hexWrite, ASCIILiteral(), s_jsBufferPrototypeHexWriteCodeLength) \
+    macro(jsBufferPrototypeUtf8SliceCode, utf8Slice, ASCIILiteral(), s_jsBufferPrototypeUtf8SliceCodeLength) \
+    macro(jsBufferPrototypeUcs2SliceCode, ucs2Slice, ASCIILiteral(), s_jsBufferPrototypeUcs2SliceCodeLength) \
+    macro(jsBufferPrototypeUtf16leSliceCode, utf16leSlice, ASCIILiteral(), s_jsBufferPrototypeUtf16leSliceCodeLength) \
+    macro(jsBufferPrototypeLatin1SliceCode, latin1Slice, ASCIILiteral(), s_jsBufferPrototypeLatin1SliceCodeLength) \
+    macro(jsBufferPrototypeAsciiSliceCode, asciiSlice, ASCIILiteral(), s_jsBufferPrototypeAsciiSliceCodeLength) \
+    macro(jsBufferPrototypeBase64SliceCode, base64Slice, ASCIILiteral(), s_jsBufferPrototypeBase64SliceCodeLength) \
+    macro(jsBufferPrototypeBase64urlSliceCode, base64urlSlice, ASCIILiteral(), s_jsBufferPrototypeBase64urlSliceCodeLength) \
+    macro(jsBufferPrototypeHexSliceCode, hexSlice, ASCIILiteral(), s_jsBufferPrototypeHexSliceCodeLength) \
+    macro(jsBufferPrototypeToJSONCode, toJSON, ASCIILiteral(), s_jsBufferPrototypeToJSONCodeLength) \
+    macro(jsBufferPrototypeSliceCode, slice, ASCIILiteral(), s_jsBufferPrototypeSliceCodeLength) \
+    macro(jsBufferPrototypeParentCode, parent, "get parent"_s, s_jsBufferPrototypeParentCodeLength) \
+    macro(jsBufferPrototypeOffsetCode, offset, "get offset"_s, s_jsBufferPrototypeOffsetCodeLength) \
+    macro(jsBufferPrototypeInspectCode, inspect, ASCIILiteral(), s_jsBufferPrototypeInspectCodeLength) \
+
+#define WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_FUNCTION_NAME(macro) \
+    macro(setBigUint64) \
+    macro(readInt8) \
+    macro(readUInt8) \
+    macro(readInt16LE) \
+    macro(readInt16BE) \
+    macro(readUInt16LE) \
+    macro(readUInt16BE) \
+    macro(readInt32LE) \
+    macro(readInt32BE) \
+    macro(readUInt32LE) \
+    macro(readUInt32BE) \
+    macro(readIntLE) \
+    macro(readIntBE) \
+    macro(readUIntLE) \
+    macro(readUIntBE) \
+    macro(readFloatLE) \
+    macro(readFloatBE) \
+    macro(readDoubleLE) \
+    macro(readDoubleBE) \
+    macro(readBigInt64LE) \
+    macro(readBigInt64BE) \
+    macro(readBigUInt64LE) \
+    macro(readBigUInt64BE) \
+    macro(writeInt8) \
+    macro(writeUInt8) \
+    macro(writeInt16LE) \
+    macro(writeInt16BE) \
+    macro(writeUInt16LE) \
+    macro(writeUInt16BE) \
+    macro(writeInt32LE) \
+    macro(writeInt32BE) \
+    macro(writeUInt32LE) \
+    macro(writeUInt32BE) \
+    macro(writeIntLE) \
+    macro(writeIntBE) \
+    macro(writeUIntLE) \
+    macro(writeUIntBE) \
+    macro(writeFloatLE) \
+    macro(writeFloatBE) \
+    macro(writeDoubleLE) \
+    macro(writeDoubleBE) \
+    macro(writeBigInt64LE) \
+    macro(writeBigInt64BE) \
+    macro(writeBigUInt64LE) \
+    macro(writeBigUInt64BE) \
+    macro(utf8Write) \
+    macro(ucs2Write) \
+    macro(utf16leWrite) \
+    macro(latin1Write) \
+    macro(asciiWrite) \
+    macro(base64Write) \
+    macro(base64urlWrite) \
+    macro(hexWrite) \
+    macro(utf8Slice) \
+    macro(ucs2Slice) \
+    macro(utf16leSlice) \
+    macro(latin1Slice) \
+    macro(asciiSlice) \
+    macro(base64Slice) \
+    macro(base64urlSlice) \
+    macro(hexSlice) \
+    macro(toJSON) \
+    macro(slice) \
+    macro(parent) \
+    macro(offset) \
+    macro(inspect) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class JSBufferPrototypeBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit JSBufferPrototypeBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* JSBufferPrototypeBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void JSBufferPrototypeBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
 #undef EXPORT_FUNCTION_NAME
 }
 /* ReadableByteStreamController.ts */
@@ -1124,92 +2391,48 @@ inline void ReadableByteStreamControllerBuiltinsWrapper::exportNames()
     WEBCORE_FOREACH_READABLEBYTESTREAMCONTROLLER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
 #undef EXPORT_FUNCTION_NAME
 }
-/* ReadableStreamDefaultReader.ts */
-// initializeReadableStreamDefaultReader
-#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_INITIALIZEREADABLESTREAMDEFAULTREADER 1
-extern const char* const s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCode;
-extern const int s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeLength;
-extern const JSC::ConstructAbility s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeImplementationVisibility;
+/* UtilInspect.ts */
+// getStylizeWithColor
+#define WEBCORE_BUILTIN_UTILINSPECT_GETSTYLIZEWITHCOLOR 1
+extern const char* const s_utilInspectGetStylizeWithColorCode;
+extern const int s_utilInspectGetStylizeWithColorCodeLength;
+extern const JSC::ConstructAbility s_utilInspectGetStylizeWithColorCodeConstructAbility;
+extern const JSC::ConstructorKind s_utilInspectGetStylizeWithColorCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_utilInspectGetStylizeWithColorCodeImplementationVisibility;
 
-// cancel
-#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_CANCEL 1
-extern const char* const s_readableStreamDefaultReaderCancelCode;
-extern const int s_readableStreamDefaultReaderCancelCodeLength;
-extern const JSC::ConstructAbility s_readableStreamDefaultReaderCancelCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamDefaultReaderCancelCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderCancelCodeImplementationVisibility;
+// stylizeWithNoColor
+#define WEBCORE_BUILTIN_UTILINSPECT_STYLIZEWITHNOCOLOR 1
+extern const char* const s_utilInspectStylizeWithNoColorCode;
+extern const int s_utilInspectStylizeWithNoColorCodeLength;
+extern const JSC::ConstructAbility s_utilInspectStylizeWithNoColorCodeConstructAbility;
+extern const JSC::ConstructorKind s_utilInspectStylizeWithNoColorCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_utilInspectStylizeWithNoColorCodeImplementationVisibility;
 
-// readMany
-#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_READMANY 1
-extern const char* const s_readableStreamDefaultReaderReadManyCode;
-extern const int s_readableStreamDefaultReaderReadManyCodeLength;
-extern const JSC::ConstructAbility s_readableStreamDefaultReaderReadManyCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamDefaultReaderReadManyCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderReadManyCodeImplementationVisibility;
+#define WEBCORE_FOREACH_UTILINSPECT_BUILTIN_DATA(macro) \
+    macro(getStylizeWithColor, utilInspectGetStylizeWithColor, 1) \
+    macro(stylizeWithNoColor, utilInspectStylizeWithNoColor, 1) \
 
-// read
-#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_READ 1
-extern const char* const s_readableStreamDefaultReaderReadCode;
-extern const int s_readableStreamDefaultReaderReadCodeLength;
-extern const JSC::ConstructAbility s_readableStreamDefaultReaderReadCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamDefaultReaderReadCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderReadCodeImplementationVisibility;
+#define WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(macro) \
+    macro(utilInspectGetStylizeWithColorCode, getStylizeWithColor, ASCIILiteral(), s_utilInspectGetStylizeWithColorCodeLength) \
+    macro(utilInspectStylizeWithNoColorCode, stylizeWithNoColor, ASCIILiteral(), s_utilInspectStylizeWithNoColorCodeLength) \
 
-// releaseLock
-#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_RELEASELOCK 1
-extern const char* const s_readableStreamDefaultReaderReleaseLockCode;
-extern const int s_readableStreamDefaultReaderReleaseLockCodeLength;
-extern const JSC::ConstructAbility s_readableStreamDefaultReaderReleaseLockCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamDefaultReaderReleaseLockCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderReleaseLockCodeImplementationVisibility;
-
-// closed
-#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_CLOSED 1
-extern const char* const s_readableStreamDefaultReaderClosedCode;
-extern const int s_readableStreamDefaultReaderClosedCodeLength;
-extern const JSC::ConstructAbility s_readableStreamDefaultReaderClosedCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamDefaultReaderClosedCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderClosedCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_DATA(macro) \
-    macro(initializeReadableStreamDefaultReader, readableStreamDefaultReaderInitializeReadableStreamDefaultReader, 1) \
-    macro(cancel, readableStreamDefaultReaderCancel, 1) \
-    macro(readMany, readableStreamDefaultReaderReadMany, 0) \
-    macro(read, readableStreamDefaultReaderRead, 0) \
-    macro(releaseLock, readableStreamDefaultReaderReleaseLock, 0) \
-    macro(closed, readableStreamDefaultReaderClosed, 0) \
-
-#define WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(macro) \
-    macro(readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCode, initializeReadableStreamDefaultReader, ASCIILiteral(), s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeLength) \
-    macro(readableStreamDefaultReaderCancelCode, cancel, ASCIILiteral(), s_readableStreamDefaultReaderCancelCodeLength) \
-    macro(readableStreamDefaultReaderReadManyCode, readMany, ASCIILiteral(), s_readableStreamDefaultReaderReadManyCodeLength) \
-    macro(readableStreamDefaultReaderReadCode, read, ASCIILiteral(), s_readableStreamDefaultReaderReadCodeLength) \
-    macro(readableStreamDefaultReaderReleaseLockCode, releaseLock, ASCIILiteral(), s_readableStreamDefaultReaderReleaseLockCodeLength) \
-    macro(readableStreamDefaultReaderClosedCode, closed, "get closed"_s, s_readableStreamDefaultReaderClosedCodeLength) \
-
-#define WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_FUNCTION_NAME(macro) \
-    macro(initializeReadableStreamDefaultReader) \
-    macro(cancel) \
-    macro(readMany) \
-    macro(read) \
-    macro(releaseLock) \
-    macro(closed) \
+#define WEBCORE_FOREACH_UTILINSPECT_BUILTIN_FUNCTION_NAME(macro) \
+    macro(getStylizeWithColor) \
+    macro(stylizeWithNoColor) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
     JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
 
-WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
 #undef DECLARE_BUILTIN_GENERATOR
 
-class ReadableStreamDefaultReaderBuiltinsWrapper : private JSC::WeakHandleOwner {
+class UtilInspectBuiltinsWrapper : private JSC::WeakHandleOwner {
 public:
-    explicit ReadableStreamDefaultReaderBuiltinsWrapper(JSC::VM& vm)
+    explicit UtilInspectBuiltinsWrapper(JSC::VM& vm)
         : m_vm(vm)
-        WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+        WEBCORE_FOREACH_UTILINSPECT_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
 #define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+        WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
 #undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
     {
     }
@@ -1217,28 +2440,28 @@ public:
 #define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
     JSC::UnlinkedFunctionExecutable* name##Executable(); \
     const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+    WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
 #undef EXPOSE_BUILTIN_EXECUTABLES
 
-    WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+    WEBCORE_FOREACH_UTILINSPECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
 
     void exportNames();
 
 private:
     JSC::VM& m_vm;
 
-    WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+    WEBCORE_FOREACH_UTILINSPECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
 
 #define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
     JSC::SourceCode m_##name##Source;\
     JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+    WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
 #undef DECLARE_BUILTIN_SOURCE_MEMBERS
 
 };
 
 #define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* ReadableStreamDefaultReaderBuiltinsWrapper::name##Executable() \
+inline JSC::UnlinkedFunctionExecutable* UtilInspectBuiltinsWrapper::name##Executable() \
 {\
     if (!m_##name##Executable) {\
         JSC::Identifier executableName = functionName##PublicName();\
@@ -1248,68 +2471,57 @@ inline JSC::UnlinkedFunctionExecutable* ReadableStreamDefaultReaderBuiltinsWrapp
     }\
     return m_##name##Executable.get();\
 }
-WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
 #undef DEFINE_BUILTIN_EXECUTABLES
 
-inline void ReadableStreamDefaultReaderBuiltinsWrapper::exportNames()
+inline void UtilInspectBuiltinsWrapper::exportNames()
 {
 #define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+    WEBCORE_FOREACH_UTILINSPECT_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
 #undef EXPORT_FUNCTION_NAME
 }
-/* ByteLengthQueuingStrategy.ts */
-// highWaterMark
-#define WEBCORE_BUILTIN_BYTELENGTHQUEUINGSTRATEGY_HIGHWATERMARK 1
-extern const char* const s_byteLengthQueuingStrategyHighWaterMarkCode;
-extern const int s_byteLengthQueuingStrategyHighWaterMarkCodeLength;
-extern const JSC::ConstructAbility s_byteLengthQueuingStrategyHighWaterMarkCodeConstructAbility;
-extern const JSC::ConstructorKind s_byteLengthQueuingStrategyHighWaterMarkCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_byteLengthQueuingStrategyHighWaterMarkCodeImplementationVisibility;
+/* ConsoleObject.ts */
+// asyncIterator
+#define WEBCORE_BUILTIN_CONSOLEOBJECT_ASYNCITERATOR 1
+extern const char* const s_consoleObjectAsyncIteratorCode;
+extern const int s_consoleObjectAsyncIteratorCodeLength;
+extern const JSC::ConstructAbility s_consoleObjectAsyncIteratorCodeConstructAbility;
+extern const JSC::ConstructorKind s_consoleObjectAsyncIteratorCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_consoleObjectAsyncIteratorCodeImplementationVisibility;
 
-// size
-#define WEBCORE_BUILTIN_BYTELENGTHQUEUINGSTRATEGY_SIZE 1
-extern const char* const s_byteLengthQueuingStrategySizeCode;
-extern const int s_byteLengthQueuingStrategySizeCodeLength;
-extern const JSC::ConstructAbility s_byteLengthQueuingStrategySizeCodeConstructAbility;
-extern const JSC::ConstructorKind s_byteLengthQueuingStrategySizeCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_byteLengthQueuingStrategySizeCodeImplementationVisibility;
+// write
+#define WEBCORE_BUILTIN_CONSOLEOBJECT_WRITE 1
+extern const char* const s_consoleObjectWriteCode;
+extern const int s_consoleObjectWriteCodeLength;
+extern const JSC::ConstructAbility s_consoleObjectWriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_consoleObjectWriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_consoleObjectWriteCodeImplementationVisibility;
 
-// initializeByteLengthQueuingStrategy
-#define WEBCORE_BUILTIN_BYTELENGTHQUEUINGSTRATEGY_INITIALIZEBYTELENGTHQUEUINGSTRATEGY 1
-extern const char* const s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCode;
-extern const int s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeLength;
-extern const JSC::ConstructAbility s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeConstructAbility;
-extern const JSC::ConstructorKind s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeImplementationVisibility;
+#define WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_DATA(macro) \
+    macro(asyncIterator, consoleObjectAsyncIterator, 0) \
+    macro(write, consoleObjectWrite, 1) \
 
-#define WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_DATA(macro) \
-    macro(highWaterMark, byteLengthQueuingStrategyHighWaterMark, 0) \
-    macro(size, byteLengthQueuingStrategySize, 1) \
-    macro(initializeByteLengthQueuingStrategy, byteLengthQueuingStrategyInitializeByteLengthQueuingStrategy, 1) \
+#define WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(macro) \
+    macro(consoleObjectAsyncIteratorCode, asyncIterator, "[Symbol.asyncIterator]"_s, s_consoleObjectAsyncIteratorCodeLength) \
+    macro(consoleObjectWriteCode, write, ASCIILiteral(), s_consoleObjectWriteCodeLength) \
 
-#define WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(macro) \
-    macro(byteLengthQueuingStrategyHighWaterMarkCode, highWaterMark, "get highWaterMark"_s, s_byteLengthQueuingStrategyHighWaterMarkCodeLength) \
-    macro(byteLengthQueuingStrategySizeCode, size, ASCIILiteral(), s_byteLengthQueuingStrategySizeCodeLength) \
-    macro(byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCode, initializeByteLengthQueuingStrategy, ASCIILiteral(), s_byteLengthQueuingStrategyInitializeByteLengthQueuingStrategyCodeLength) \
-
-#define WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(macro) \
-    macro(highWaterMark) \
-    macro(size) \
-    macro(initializeByteLengthQueuingStrategy) \
+#define WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_FUNCTION_NAME(macro) \
+    macro(asyncIterator) \
+    macro(write) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
     JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
 
-WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
 #undef DECLARE_BUILTIN_GENERATOR
 
-class ByteLengthQueuingStrategyBuiltinsWrapper : private JSC::WeakHandleOwner {
+class ConsoleObjectBuiltinsWrapper : private JSC::WeakHandleOwner {
 public:
-    explicit ByteLengthQueuingStrategyBuiltinsWrapper(JSC::VM& vm)
+    explicit ConsoleObjectBuiltinsWrapper(JSC::VM& vm)
         : m_vm(vm)
-        WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+        WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
 #define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+        WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
 #undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
     {
     }
@@ -1317,28 +2529,28 @@ public:
 #define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
     JSC::UnlinkedFunctionExecutable* name##Executable(); \
     const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+    WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
 #undef EXPOSE_BUILTIN_EXECUTABLES
 
-    WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+    WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
 
     void exportNames();
 
 private:
     JSC::VM& m_vm;
 
-    WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+    WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
 
 #define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
     JSC::SourceCode m_##name##Source;\
     JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+    WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
 #undef DECLARE_BUILTIN_SOURCE_MEMBERS
 
 };
 
 #define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* ByteLengthQueuingStrategyBuiltinsWrapper::name##Executable() \
+inline JSC::UnlinkedFunctionExecutable* ConsoleObjectBuiltinsWrapper::name##Executable() \
 {\
     if (!m_##name##Executable) {\
         JSC::Identifier executableName = functionName##PublicName();\
@@ -1348,324 +2560,13 @@ inline JSC::UnlinkedFunctionExecutable* ByteLengthQueuingStrategyBuiltinsWrapper
     }\
     return m_##name##Executable.get();\
 }
-WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
 #undef DEFINE_BUILTIN_EXECUTABLES
 
-inline void ByteLengthQueuingStrategyBuiltinsWrapper::exportNames()
+inline void ConsoleObjectBuiltinsWrapper::exportNames()
 {
 #define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_BYTELENGTHQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-/* JSBufferConstructor.ts */
-// from
-#define WEBCORE_BUILTIN_JSBUFFERCONSTRUCTOR_FROM 1
-extern const char* const s_jsBufferConstructorFromCode;
-extern const int s_jsBufferConstructorFromCodeLength;
-extern const JSC::ConstructAbility s_jsBufferConstructorFromCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferConstructorFromCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferConstructorFromCodeImplementationVisibility;
-
-// isBuffer
-#define WEBCORE_BUILTIN_JSBUFFERCONSTRUCTOR_ISBUFFER 1
-extern const char* const s_jsBufferConstructorIsBufferCode;
-extern const int s_jsBufferConstructorIsBufferCodeLength;
-extern const JSC::ConstructAbility s_jsBufferConstructorIsBufferCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferConstructorIsBufferCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferConstructorIsBufferCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_DATA(macro) \
-    macro(from, jsBufferConstructorFrom, 1) \
-    macro(isBuffer, jsBufferConstructorIsBuffer, 1) \
-
-#define WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(macro) \
-    macro(jsBufferConstructorFromCode, from, ASCIILiteral(), s_jsBufferConstructorFromCodeLength) \
-    macro(jsBufferConstructorIsBufferCode, isBuffer, ASCIILiteral(), s_jsBufferConstructorIsBufferCodeLength) \
-
-#define WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_FUNCTION_NAME(macro) \
-    macro(from) \
-    macro(isBuffer) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class JSBufferConstructorBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit JSBufferConstructorBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* JSBufferConstructorBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void JSBufferConstructorBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-/* ImportMetaObject.ts */
-// loadCJS2ESM
-#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_LOADCJS2ESM 1
-extern const char* const s_importMetaObjectLoadCJS2ESMCode;
-extern const int s_importMetaObjectLoadCJS2ESMCodeLength;
-extern const JSC::ConstructAbility s_importMetaObjectLoadCJS2ESMCodeConstructAbility;
-extern const JSC::ConstructorKind s_importMetaObjectLoadCJS2ESMCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_importMetaObjectLoadCJS2ESMCodeImplementationVisibility;
-
-// requireESM
-#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_REQUIREESM 1
-extern const char* const s_importMetaObjectRequireESMCode;
-extern const int s_importMetaObjectRequireESMCodeLength;
-extern const JSC::ConstructAbility s_importMetaObjectRequireESMCodeConstructAbility;
-extern const JSC::ConstructorKind s_importMetaObjectRequireESMCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_importMetaObjectRequireESMCodeImplementationVisibility;
-
-// internalRequire
-#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_INTERNALREQUIRE 1
-extern const char* const s_importMetaObjectInternalRequireCode;
-extern const int s_importMetaObjectInternalRequireCodeLength;
-extern const JSC::ConstructAbility s_importMetaObjectInternalRequireCodeConstructAbility;
-extern const JSC::ConstructorKind s_importMetaObjectInternalRequireCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_importMetaObjectInternalRequireCodeImplementationVisibility;
-
-// createRequireCache
-#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_CREATEREQUIRECACHE 1
-extern const char* const s_importMetaObjectCreateRequireCacheCode;
-extern const int s_importMetaObjectCreateRequireCacheCodeLength;
-extern const JSC::ConstructAbility s_importMetaObjectCreateRequireCacheCodeConstructAbility;
-extern const JSC::ConstructorKind s_importMetaObjectCreateRequireCacheCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_importMetaObjectCreateRequireCacheCodeImplementationVisibility;
-
-// main
-#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_MAIN 1
-extern const char* const s_importMetaObjectMainCode;
-extern const int s_importMetaObjectMainCodeLength;
-extern const JSC::ConstructAbility s_importMetaObjectMainCodeConstructAbility;
-extern const JSC::ConstructorKind s_importMetaObjectMainCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_importMetaObjectMainCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_DATA(macro) \
-    macro(loadCJS2ESM, importMetaObjectLoadCJS2ESM, 1) \
-    macro(requireESM, importMetaObjectRequireESM, 1) \
-    macro(internalRequire, importMetaObjectInternalRequire, 1) \
-    macro(createRequireCache, importMetaObjectCreateRequireCache, 0) \
-    macro(main, importMetaObjectMain, 0) \
-
-#define WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(macro) \
-    macro(importMetaObjectLoadCJS2ESMCode, loadCJS2ESM, ASCIILiteral(), s_importMetaObjectLoadCJS2ESMCodeLength) \
-    macro(importMetaObjectRequireESMCode, requireESM, ASCIILiteral(), s_importMetaObjectRequireESMCodeLength) \
-    macro(importMetaObjectInternalRequireCode, internalRequire, ASCIILiteral(), s_importMetaObjectInternalRequireCodeLength) \
-    macro(importMetaObjectCreateRequireCacheCode, createRequireCache, ASCIILiteral(), s_importMetaObjectCreateRequireCacheCodeLength) \
-    macro(importMetaObjectMainCode, main, "get main"_s, s_importMetaObjectMainCodeLength) \
-
-#define WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_FUNCTION_NAME(macro) \
-    macro(loadCJS2ESM) \
-    macro(requireESM) \
-    macro(internalRequire) \
-    macro(createRequireCache) \
-    macro(main) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class ImportMetaObjectBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit ImportMetaObjectBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* ImportMetaObjectBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void ImportMetaObjectBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-/* TransformStream.ts */
-// initializeTransformStream
-#define WEBCORE_BUILTIN_TRANSFORMSTREAM_INITIALIZETRANSFORMSTREAM 1
-extern const char* const s_transformStreamInitializeTransformStreamCode;
-extern const int s_transformStreamInitializeTransformStreamCodeLength;
-extern const JSC::ConstructAbility s_transformStreamInitializeTransformStreamCodeConstructAbility;
-extern const JSC::ConstructorKind s_transformStreamInitializeTransformStreamCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_transformStreamInitializeTransformStreamCodeImplementationVisibility;
-
-// readable
-#define WEBCORE_BUILTIN_TRANSFORMSTREAM_READABLE 1
-extern const char* const s_transformStreamReadableCode;
-extern const int s_transformStreamReadableCodeLength;
-extern const JSC::ConstructAbility s_transformStreamReadableCodeConstructAbility;
-extern const JSC::ConstructorKind s_transformStreamReadableCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_transformStreamReadableCodeImplementationVisibility;
-
-// writable
-#define WEBCORE_BUILTIN_TRANSFORMSTREAM_WRITABLE 1
-extern const char* const s_transformStreamWritableCode;
-extern const int s_transformStreamWritableCodeLength;
-extern const JSC::ConstructAbility s_transformStreamWritableCodeConstructAbility;
-extern const JSC::ConstructorKind s_transformStreamWritableCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_transformStreamWritableCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_DATA(macro) \
-    macro(initializeTransformStream, transformStreamInitializeTransformStream, 0) \
-    macro(readable, transformStreamReadable, 0) \
-    macro(writable, transformStreamWritable, 0) \
-
-#define WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(macro) \
-    macro(transformStreamInitializeTransformStreamCode, initializeTransformStream, ASCIILiteral(), s_transformStreamInitializeTransformStreamCodeLength) \
-    macro(transformStreamReadableCode, readable, "get readable"_s, s_transformStreamReadableCodeLength) \
-    macro(transformStreamWritableCode, writable, ASCIILiteral(), s_transformStreamWritableCodeLength) \
-
-#define WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_FUNCTION_NAME(macro) \
-    macro(initializeTransformStream) \
-    macro(readable) \
-    macro(writable) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class TransformStreamBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit TransformStreamBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* TransformStreamBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void TransformStreamBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_TRANSFORMSTREAM_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+    WEBCORE_FOREACH_CONSOLEOBJECT_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
 #undef EXPORT_FUNCTION_NAME
 }
 /* ReadableStreamInternals.ts */
@@ -2473,7 +3374,1658 @@ inline void ReadableStreamInternalsBuiltinFunctions::visit(Visitor& visitor)
 
 template void ReadableStreamInternalsBuiltinFunctions::visit(JSC::AbstractSlotVisitor&);
 template void ReadableStreamInternalsBuiltinFunctions::visit(JSC::SlotVisitor&);
-    /* ReadableByteStreamInternals.ts */
+    /* TransformStreamDefaultController.ts */
+// initializeTransformStreamDefaultController
+#define WEBCORE_BUILTIN_TRANSFORMSTREAMDEFAULTCONTROLLER_INITIALIZETRANSFORMSTREAMDEFAULTCONTROLLER 1
+extern const char* const s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCode;
+extern const int s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeLength;
+extern const JSC::ConstructAbility s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeConstructAbility;
+extern const JSC::ConstructorKind s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeImplementationVisibility;
+
+// desiredSize
+#define WEBCORE_BUILTIN_TRANSFORMSTREAMDEFAULTCONTROLLER_DESIREDSIZE 1
+extern const char* const s_transformStreamDefaultControllerDesiredSizeCode;
+extern const int s_transformStreamDefaultControllerDesiredSizeCodeLength;
+extern const JSC::ConstructAbility s_transformStreamDefaultControllerDesiredSizeCodeConstructAbility;
+extern const JSC::ConstructorKind s_transformStreamDefaultControllerDesiredSizeCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_transformStreamDefaultControllerDesiredSizeCodeImplementationVisibility;
+
+// enqueue
+#define WEBCORE_BUILTIN_TRANSFORMSTREAMDEFAULTCONTROLLER_ENQUEUE 1
+extern const char* const s_transformStreamDefaultControllerEnqueueCode;
+extern const int s_transformStreamDefaultControllerEnqueueCodeLength;
+extern const JSC::ConstructAbility s_transformStreamDefaultControllerEnqueueCodeConstructAbility;
+extern const JSC::ConstructorKind s_transformStreamDefaultControllerEnqueueCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_transformStreamDefaultControllerEnqueueCodeImplementationVisibility;
+
+// error
+#define WEBCORE_BUILTIN_TRANSFORMSTREAMDEFAULTCONTROLLER_ERROR 1
+extern const char* const s_transformStreamDefaultControllerErrorCode;
+extern const int s_transformStreamDefaultControllerErrorCodeLength;
+extern const JSC::ConstructAbility s_transformStreamDefaultControllerErrorCodeConstructAbility;
+extern const JSC::ConstructorKind s_transformStreamDefaultControllerErrorCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_transformStreamDefaultControllerErrorCodeImplementationVisibility;
+
+// terminate
+#define WEBCORE_BUILTIN_TRANSFORMSTREAMDEFAULTCONTROLLER_TERMINATE 1
+extern const char* const s_transformStreamDefaultControllerTerminateCode;
+extern const int s_transformStreamDefaultControllerTerminateCodeLength;
+extern const JSC::ConstructAbility s_transformStreamDefaultControllerTerminateCodeConstructAbility;
+extern const JSC::ConstructorKind s_transformStreamDefaultControllerTerminateCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_transformStreamDefaultControllerTerminateCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_DATA(macro) \
+    macro(initializeTransformStreamDefaultController, transformStreamDefaultControllerInitializeTransformStreamDefaultController, 0) \
+    macro(desiredSize, transformStreamDefaultControllerDesiredSize, 0) \
+    macro(enqueue, transformStreamDefaultControllerEnqueue, 1) \
+    macro(error, transformStreamDefaultControllerError, 1) \
+    macro(terminate, transformStreamDefaultControllerTerminate, 0) \
+
+#define WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(macro) \
+    macro(transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCode, initializeTransformStreamDefaultController, ASCIILiteral(), s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeLength) \
+    macro(transformStreamDefaultControllerDesiredSizeCode, desiredSize, "get desiredSize"_s, s_transformStreamDefaultControllerDesiredSizeCodeLength) \
+    macro(transformStreamDefaultControllerEnqueueCode, enqueue, ASCIILiteral(), s_transformStreamDefaultControllerEnqueueCodeLength) \
+    macro(transformStreamDefaultControllerErrorCode, error, ASCIILiteral(), s_transformStreamDefaultControllerErrorCodeLength) \
+    macro(transformStreamDefaultControllerTerminateCode, terminate, ASCIILiteral(), s_transformStreamDefaultControllerTerminateCodeLength) \
+
+#define WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(macro) \
+    macro(initializeTransformStreamDefaultController) \
+    macro(desiredSize) \
+    macro(enqueue) \
+    macro(error) \
+    macro(terminate) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class TransformStreamDefaultControllerBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit TransformStreamDefaultControllerBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* TransformStreamDefaultControllerBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void TransformStreamDefaultControllerBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+/* ReadableStreamBYOBReader.ts */
+// initializeReadableStreamBYOBReader
+#define WEBCORE_BUILTIN_READABLESTREAMBYOBREADER_INITIALIZEREADABLESTREAMBYOBREADER 1
+extern const char* const s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCode;
+extern const int s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeLength;
+extern const JSC::ConstructAbility s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeImplementationVisibility;
+
+// cancel
+#define WEBCORE_BUILTIN_READABLESTREAMBYOBREADER_CANCEL 1
+extern const char* const s_readableStreamBYOBReaderCancelCode;
+extern const int s_readableStreamBYOBReaderCancelCodeLength;
+extern const JSC::ConstructAbility s_readableStreamBYOBReaderCancelCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamBYOBReaderCancelCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamBYOBReaderCancelCodeImplementationVisibility;
+
+// read
+#define WEBCORE_BUILTIN_READABLESTREAMBYOBREADER_READ 1
+extern const char* const s_readableStreamBYOBReaderReadCode;
+extern const int s_readableStreamBYOBReaderReadCodeLength;
+extern const JSC::ConstructAbility s_readableStreamBYOBReaderReadCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamBYOBReaderReadCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamBYOBReaderReadCodeImplementationVisibility;
+
+// releaseLock
+#define WEBCORE_BUILTIN_READABLESTREAMBYOBREADER_RELEASELOCK 1
+extern const char* const s_readableStreamBYOBReaderReleaseLockCode;
+extern const int s_readableStreamBYOBReaderReleaseLockCodeLength;
+extern const JSC::ConstructAbility s_readableStreamBYOBReaderReleaseLockCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamBYOBReaderReleaseLockCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamBYOBReaderReleaseLockCodeImplementationVisibility;
+
+// closed
+#define WEBCORE_BUILTIN_READABLESTREAMBYOBREADER_CLOSED 1
+extern const char* const s_readableStreamBYOBReaderClosedCode;
+extern const int s_readableStreamBYOBReaderClosedCodeLength;
+extern const JSC::ConstructAbility s_readableStreamBYOBReaderClosedCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamBYOBReaderClosedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamBYOBReaderClosedCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_DATA(macro) \
+    macro(initializeReadableStreamBYOBReader, readableStreamBYOBReaderInitializeReadableStreamBYOBReader, 1) \
+    macro(cancel, readableStreamBYOBReaderCancel, 1) \
+    macro(read, readableStreamBYOBReaderRead, 1) \
+    macro(releaseLock, readableStreamBYOBReaderReleaseLock, 0) \
+    macro(closed, readableStreamBYOBReaderClosed, 0) \
+
+#define WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(macro) \
+    macro(readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCode, initializeReadableStreamBYOBReader, ASCIILiteral(), s_readableStreamBYOBReaderInitializeReadableStreamBYOBReaderCodeLength) \
+    macro(readableStreamBYOBReaderCancelCode, cancel, ASCIILiteral(), s_readableStreamBYOBReaderCancelCodeLength) \
+    macro(readableStreamBYOBReaderReadCode, read, ASCIILiteral(), s_readableStreamBYOBReaderReadCodeLength) \
+    macro(readableStreamBYOBReaderReleaseLockCode, releaseLock, ASCIILiteral(), s_readableStreamBYOBReaderReleaseLockCodeLength) \
+    macro(readableStreamBYOBReaderClosedCode, closed, "get closed"_s, s_readableStreamBYOBReaderClosedCodeLength) \
+
+#define WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_FUNCTION_NAME(macro) \
+    macro(initializeReadableStreamBYOBReader) \
+    macro(cancel) \
+    macro(read) \
+    macro(releaseLock) \
+    macro(closed) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class ReadableStreamBYOBReaderBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit ReadableStreamBYOBReaderBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* ReadableStreamBYOBReaderBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void ReadableStreamBYOBReaderBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_READABLESTREAMBYOBREADER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+/* JSBufferConstructor.ts */
+// from
+#define WEBCORE_BUILTIN_JSBUFFERCONSTRUCTOR_FROM 1
+extern const char* const s_jsBufferConstructorFromCode;
+extern const int s_jsBufferConstructorFromCodeLength;
+extern const JSC::ConstructAbility s_jsBufferConstructorFromCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferConstructorFromCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferConstructorFromCodeImplementationVisibility;
+
+// isBuffer
+#define WEBCORE_BUILTIN_JSBUFFERCONSTRUCTOR_ISBUFFER 1
+extern const char* const s_jsBufferConstructorIsBufferCode;
+extern const int s_jsBufferConstructorIsBufferCodeLength;
+extern const JSC::ConstructAbility s_jsBufferConstructorIsBufferCodeConstructAbility;
+extern const JSC::ConstructorKind s_jsBufferConstructorIsBufferCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_jsBufferConstructorIsBufferCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_DATA(macro) \
+    macro(from, jsBufferConstructorFrom, 1) \
+    macro(isBuffer, jsBufferConstructorIsBuffer, 1) \
+
+#define WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(macro) \
+    macro(jsBufferConstructorFromCode, from, ASCIILiteral(), s_jsBufferConstructorFromCodeLength) \
+    macro(jsBufferConstructorIsBufferCode, isBuffer, ASCIILiteral(), s_jsBufferConstructorIsBufferCodeLength) \
+
+#define WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_FUNCTION_NAME(macro) \
+    macro(from) \
+    macro(isBuffer) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class JSBufferConstructorBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit JSBufferConstructorBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* JSBufferConstructorBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void JSBufferConstructorBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_JSBUFFERCONSTRUCTOR_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+/* ReadableStreamDefaultReader.ts */
+// initializeReadableStreamDefaultReader
+#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_INITIALIZEREADABLESTREAMDEFAULTREADER 1
+extern const char* const s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCode;
+extern const int s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeLength;
+extern const JSC::ConstructAbility s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeImplementationVisibility;
+
+// cancel
+#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_CANCEL 1
+extern const char* const s_readableStreamDefaultReaderCancelCode;
+extern const int s_readableStreamDefaultReaderCancelCodeLength;
+extern const JSC::ConstructAbility s_readableStreamDefaultReaderCancelCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamDefaultReaderCancelCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderCancelCodeImplementationVisibility;
+
+// readMany
+#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_READMANY 1
+extern const char* const s_readableStreamDefaultReaderReadManyCode;
+extern const int s_readableStreamDefaultReaderReadManyCodeLength;
+extern const JSC::ConstructAbility s_readableStreamDefaultReaderReadManyCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamDefaultReaderReadManyCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderReadManyCodeImplementationVisibility;
+
+// read
+#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_READ 1
+extern const char* const s_readableStreamDefaultReaderReadCode;
+extern const int s_readableStreamDefaultReaderReadCodeLength;
+extern const JSC::ConstructAbility s_readableStreamDefaultReaderReadCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamDefaultReaderReadCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderReadCodeImplementationVisibility;
+
+// releaseLock
+#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_RELEASELOCK 1
+extern const char* const s_readableStreamDefaultReaderReleaseLockCode;
+extern const int s_readableStreamDefaultReaderReleaseLockCodeLength;
+extern const JSC::ConstructAbility s_readableStreamDefaultReaderReleaseLockCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamDefaultReaderReleaseLockCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderReleaseLockCodeImplementationVisibility;
+
+// closed
+#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTREADER_CLOSED 1
+extern const char* const s_readableStreamDefaultReaderClosedCode;
+extern const int s_readableStreamDefaultReaderClosedCodeLength;
+extern const JSC::ConstructAbility s_readableStreamDefaultReaderClosedCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamDefaultReaderClosedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamDefaultReaderClosedCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_DATA(macro) \
+    macro(initializeReadableStreamDefaultReader, readableStreamDefaultReaderInitializeReadableStreamDefaultReader, 1) \
+    macro(cancel, readableStreamDefaultReaderCancel, 1) \
+    macro(readMany, readableStreamDefaultReaderReadMany, 0) \
+    macro(read, readableStreamDefaultReaderRead, 0) \
+    macro(releaseLock, readableStreamDefaultReaderReleaseLock, 0) \
+    macro(closed, readableStreamDefaultReaderClosed, 0) \
+
+#define WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(macro) \
+    macro(readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCode, initializeReadableStreamDefaultReader, ASCIILiteral(), s_readableStreamDefaultReaderInitializeReadableStreamDefaultReaderCodeLength) \
+    macro(readableStreamDefaultReaderCancelCode, cancel, ASCIILiteral(), s_readableStreamDefaultReaderCancelCodeLength) \
+    macro(readableStreamDefaultReaderReadManyCode, readMany, ASCIILiteral(), s_readableStreamDefaultReaderReadManyCodeLength) \
+    macro(readableStreamDefaultReaderReadCode, read, ASCIILiteral(), s_readableStreamDefaultReaderReadCodeLength) \
+    macro(readableStreamDefaultReaderReleaseLockCode, releaseLock, ASCIILiteral(), s_readableStreamDefaultReaderReleaseLockCodeLength) \
+    macro(readableStreamDefaultReaderClosedCode, closed, "get closed"_s, s_readableStreamDefaultReaderClosedCodeLength) \
+
+#define WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_FUNCTION_NAME(macro) \
+    macro(initializeReadableStreamDefaultReader) \
+    macro(cancel) \
+    macro(readMany) \
+    macro(read) \
+    macro(releaseLock) \
+    macro(closed) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class ReadableStreamDefaultReaderBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit ReadableStreamDefaultReaderBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* ReadableStreamDefaultReaderBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void ReadableStreamDefaultReaderBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_READABLESTREAMDEFAULTREADER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+/* StreamInternals.ts */
+// markPromiseAsHandled
+#define WEBCORE_BUILTIN_STREAMINTERNALS_MARKPROMISEASHANDLED 1
+extern const char* const s_streamInternalsMarkPromiseAsHandledCode;
+extern const int s_streamInternalsMarkPromiseAsHandledCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsMarkPromiseAsHandledCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsMarkPromiseAsHandledCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsMarkPromiseAsHandledCodeImplementationVisibility;
+
+// shieldingPromiseResolve
+#define WEBCORE_BUILTIN_STREAMINTERNALS_SHIELDINGPROMISERESOLVE 1
+extern const char* const s_streamInternalsShieldingPromiseResolveCode;
+extern const int s_streamInternalsShieldingPromiseResolveCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsShieldingPromiseResolveCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsShieldingPromiseResolveCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsShieldingPromiseResolveCodeImplementationVisibility;
+
+// promiseInvokeOrNoopMethodNoCatch
+#define WEBCORE_BUILTIN_STREAMINTERNALS_PROMISEINVOKEORNOOPMETHODNOCATCH 1
+extern const char* const s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCode;
+extern const int s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCodeImplementationVisibility;
+
+// promiseInvokeOrNoopNoCatch
+#define WEBCORE_BUILTIN_STREAMINTERNALS_PROMISEINVOKEORNOOPNOCATCH 1
+extern const char* const s_streamInternalsPromiseInvokeOrNoopNoCatchCode;
+extern const int s_streamInternalsPromiseInvokeOrNoopNoCatchCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsPromiseInvokeOrNoopNoCatchCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsPromiseInvokeOrNoopNoCatchCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsPromiseInvokeOrNoopNoCatchCodeImplementationVisibility;
+
+// promiseInvokeOrNoopMethod
+#define WEBCORE_BUILTIN_STREAMINTERNALS_PROMISEINVOKEORNOOPMETHOD 1
+extern const char* const s_streamInternalsPromiseInvokeOrNoopMethodCode;
+extern const int s_streamInternalsPromiseInvokeOrNoopMethodCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsPromiseInvokeOrNoopMethodCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsPromiseInvokeOrNoopMethodCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsPromiseInvokeOrNoopMethodCodeImplementationVisibility;
+
+// promiseInvokeOrNoop
+#define WEBCORE_BUILTIN_STREAMINTERNALS_PROMISEINVOKEORNOOP 1
+extern const char* const s_streamInternalsPromiseInvokeOrNoopCode;
+extern const int s_streamInternalsPromiseInvokeOrNoopCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsPromiseInvokeOrNoopCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsPromiseInvokeOrNoopCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsPromiseInvokeOrNoopCodeImplementationVisibility;
+
+// promiseInvokeOrFallbackOrNoop
+#define WEBCORE_BUILTIN_STREAMINTERNALS_PROMISEINVOKEORFALLBACKORNOOP 1
+extern const char* const s_streamInternalsPromiseInvokeOrFallbackOrNoopCode;
+extern const int s_streamInternalsPromiseInvokeOrFallbackOrNoopCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsPromiseInvokeOrFallbackOrNoopCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsPromiseInvokeOrFallbackOrNoopCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsPromiseInvokeOrFallbackOrNoopCodeImplementationVisibility;
+
+// validateAndNormalizeQueuingStrategy
+#define WEBCORE_BUILTIN_STREAMINTERNALS_VALIDATEANDNORMALIZEQUEUINGSTRATEGY 1
+extern const char* const s_streamInternalsValidateAndNormalizeQueuingStrategyCode;
+extern const int s_streamInternalsValidateAndNormalizeQueuingStrategyCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsValidateAndNormalizeQueuingStrategyCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsValidateAndNormalizeQueuingStrategyCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsValidateAndNormalizeQueuingStrategyCodeImplementationVisibility;
+
+// createFIFO
+#define WEBCORE_BUILTIN_STREAMINTERNALS_CREATEFIFO 1
+extern const char* const s_streamInternalsCreateFIFOCode;
+extern const int s_streamInternalsCreateFIFOCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsCreateFIFOCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsCreateFIFOCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsCreateFIFOCodeImplementationVisibility;
+
+// newQueue
+#define WEBCORE_BUILTIN_STREAMINTERNALS_NEWQUEUE 1
+extern const char* const s_streamInternalsNewQueueCode;
+extern const int s_streamInternalsNewQueueCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsNewQueueCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsNewQueueCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsNewQueueCodeImplementationVisibility;
+
+// dequeueValue
+#define WEBCORE_BUILTIN_STREAMINTERNALS_DEQUEUEVALUE 1
+extern const char* const s_streamInternalsDequeueValueCode;
+extern const int s_streamInternalsDequeueValueCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsDequeueValueCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsDequeueValueCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsDequeueValueCodeImplementationVisibility;
+
+// enqueueValueWithSize
+#define WEBCORE_BUILTIN_STREAMINTERNALS_ENQUEUEVALUEWITHSIZE 1
+extern const char* const s_streamInternalsEnqueueValueWithSizeCode;
+extern const int s_streamInternalsEnqueueValueWithSizeCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsEnqueueValueWithSizeCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsEnqueueValueWithSizeCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsEnqueueValueWithSizeCodeImplementationVisibility;
+
+// peekQueueValue
+#define WEBCORE_BUILTIN_STREAMINTERNALS_PEEKQUEUEVALUE 1
+extern const char* const s_streamInternalsPeekQueueValueCode;
+extern const int s_streamInternalsPeekQueueValueCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsPeekQueueValueCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsPeekQueueValueCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsPeekQueueValueCodeImplementationVisibility;
+
+// resetQueue
+#define WEBCORE_BUILTIN_STREAMINTERNALS_RESETQUEUE 1
+extern const char* const s_streamInternalsResetQueueCode;
+extern const int s_streamInternalsResetQueueCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsResetQueueCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsResetQueueCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsResetQueueCodeImplementationVisibility;
+
+// extractSizeAlgorithm
+#define WEBCORE_BUILTIN_STREAMINTERNALS_EXTRACTSIZEALGORITHM 1
+extern const char* const s_streamInternalsExtractSizeAlgorithmCode;
+extern const int s_streamInternalsExtractSizeAlgorithmCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsExtractSizeAlgorithmCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsExtractSizeAlgorithmCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsExtractSizeAlgorithmCodeImplementationVisibility;
+
+// extractHighWaterMark
+#define WEBCORE_BUILTIN_STREAMINTERNALS_EXTRACTHIGHWATERMARK 1
+extern const char* const s_streamInternalsExtractHighWaterMarkCode;
+extern const int s_streamInternalsExtractHighWaterMarkCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsExtractHighWaterMarkCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsExtractHighWaterMarkCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsExtractHighWaterMarkCodeImplementationVisibility;
+
+// extractHighWaterMarkFromQueuingStrategyInit
+#define WEBCORE_BUILTIN_STREAMINTERNALS_EXTRACTHIGHWATERMARKFROMQUEUINGSTRATEGYINIT 1
+extern const char* const s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCode;
+extern const int s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCodeImplementationVisibility;
+
+// createFulfilledPromise
+#define WEBCORE_BUILTIN_STREAMINTERNALS_CREATEFULFILLEDPROMISE 1
+extern const char* const s_streamInternalsCreateFulfilledPromiseCode;
+extern const int s_streamInternalsCreateFulfilledPromiseCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsCreateFulfilledPromiseCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsCreateFulfilledPromiseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsCreateFulfilledPromiseCodeImplementationVisibility;
+
+// toDictionary
+#define WEBCORE_BUILTIN_STREAMINTERNALS_TODICTIONARY 1
+extern const char* const s_streamInternalsToDictionaryCode;
+extern const int s_streamInternalsToDictionaryCodeLength;
+extern const JSC::ConstructAbility s_streamInternalsToDictionaryCodeConstructAbility;
+extern const JSC::ConstructorKind s_streamInternalsToDictionaryCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_streamInternalsToDictionaryCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_DATA(macro) \
+    macro(markPromiseAsHandled, streamInternalsMarkPromiseAsHandled, 1) \
+    macro(shieldingPromiseResolve, streamInternalsShieldingPromiseResolve, 1) \
+    macro(promiseInvokeOrNoopMethodNoCatch, streamInternalsPromiseInvokeOrNoopMethodNoCatch, 3) \
+    macro(promiseInvokeOrNoopNoCatch, streamInternalsPromiseInvokeOrNoopNoCatch, 3) \
+    macro(promiseInvokeOrNoopMethod, streamInternalsPromiseInvokeOrNoopMethod, 3) \
+    macro(promiseInvokeOrNoop, streamInternalsPromiseInvokeOrNoop, 3) \
+    macro(promiseInvokeOrFallbackOrNoop, streamInternalsPromiseInvokeOrFallbackOrNoop, 5) \
+    macro(validateAndNormalizeQueuingStrategy, streamInternalsValidateAndNormalizeQueuingStrategy, 2) \
+    macro(createFIFO, streamInternalsCreateFIFO, 0) \
+    macro(newQueue, streamInternalsNewQueue, 0) \
+    macro(dequeueValue, streamInternalsDequeueValue, 1) \
+    macro(enqueueValueWithSize, streamInternalsEnqueueValueWithSize, 3) \
+    macro(peekQueueValue, streamInternalsPeekQueueValue, 1) \
+    macro(resetQueue, streamInternalsResetQueue, 1) \
+    macro(extractSizeAlgorithm, streamInternalsExtractSizeAlgorithm, 1) \
+    macro(extractHighWaterMark, streamInternalsExtractHighWaterMark, 2) \
+    macro(extractHighWaterMarkFromQueuingStrategyInit, streamInternalsExtractHighWaterMarkFromQueuingStrategyInit, 1) \
+    macro(createFulfilledPromise, streamInternalsCreateFulfilledPromise, 1) \
+    macro(toDictionary, streamInternalsToDictionary, 3) \
+
+#define WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(macro) \
+    macro(streamInternalsMarkPromiseAsHandledCode, markPromiseAsHandled, ASCIILiteral(), s_streamInternalsMarkPromiseAsHandledCodeLength) \
+    macro(streamInternalsShieldingPromiseResolveCode, shieldingPromiseResolve, ASCIILiteral(), s_streamInternalsShieldingPromiseResolveCodeLength) \
+    macro(streamInternalsPromiseInvokeOrNoopMethodNoCatchCode, promiseInvokeOrNoopMethodNoCatch, ASCIILiteral(), s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCodeLength) \
+    macro(streamInternalsPromiseInvokeOrNoopNoCatchCode, promiseInvokeOrNoopNoCatch, ASCIILiteral(), s_streamInternalsPromiseInvokeOrNoopNoCatchCodeLength) \
+    macro(streamInternalsPromiseInvokeOrNoopMethodCode, promiseInvokeOrNoopMethod, ASCIILiteral(), s_streamInternalsPromiseInvokeOrNoopMethodCodeLength) \
+    macro(streamInternalsPromiseInvokeOrNoopCode, promiseInvokeOrNoop, ASCIILiteral(), s_streamInternalsPromiseInvokeOrNoopCodeLength) \
+    macro(streamInternalsPromiseInvokeOrFallbackOrNoopCode, promiseInvokeOrFallbackOrNoop, ASCIILiteral(), s_streamInternalsPromiseInvokeOrFallbackOrNoopCodeLength) \
+    macro(streamInternalsValidateAndNormalizeQueuingStrategyCode, validateAndNormalizeQueuingStrategy, ASCIILiteral(), s_streamInternalsValidateAndNormalizeQueuingStrategyCodeLength) \
+    macro(streamInternalsCreateFIFOCode, createFIFO, ASCIILiteral(), s_streamInternalsCreateFIFOCodeLength) \
+    macro(streamInternalsNewQueueCode, newQueue, ASCIILiteral(), s_streamInternalsNewQueueCodeLength) \
+    macro(streamInternalsDequeueValueCode, dequeueValue, ASCIILiteral(), s_streamInternalsDequeueValueCodeLength) \
+    macro(streamInternalsEnqueueValueWithSizeCode, enqueueValueWithSize, ASCIILiteral(), s_streamInternalsEnqueueValueWithSizeCodeLength) \
+    macro(streamInternalsPeekQueueValueCode, peekQueueValue, ASCIILiteral(), s_streamInternalsPeekQueueValueCodeLength) \
+    macro(streamInternalsResetQueueCode, resetQueue, ASCIILiteral(), s_streamInternalsResetQueueCodeLength) \
+    macro(streamInternalsExtractSizeAlgorithmCode, extractSizeAlgorithm, ASCIILiteral(), s_streamInternalsExtractSizeAlgorithmCodeLength) \
+    macro(streamInternalsExtractHighWaterMarkCode, extractHighWaterMark, ASCIILiteral(), s_streamInternalsExtractHighWaterMarkCodeLength) \
+    macro(streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCode, extractHighWaterMarkFromQueuingStrategyInit, ASCIILiteral(), s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCodeLength) \
+    macro(streamInternalsCreateFulfilledPromiseCode, createFulfilledPromise, ASCIILiteral(), s_streamInternalsCreateFulfilledPromiseCodeLength) \
+    macro(streamInternalsToDictionaryCode, toDictionary, ASCIILiteral(), s_streamInternalsToDictionaryCodeLength) \
+
+#define WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(macro) \
+    macro(markPromiseAsHandled) \
+    macro(shieldingPromiseResolve) \
+    macro(promiseInvokeOrNoopMethodNoCatch) \
+    macro(promiseInvokeOrNoopNoCatch) \
+    macro(promiseInvokeOrNoopMethod) \
+    macro(promiseInvokeOrNoop) \
+    macro(promiseInvokeOrFallbackOrNoop) \
+    macro(validateAndNormalizeQueuingStrategy) \
+    macro(createFIFO) \
+    macro(newQueue) \
+    macro(dequeueValue) \
+    macro(enqueueValueWithSize) \
+    macro(peekQueueValue) \
+    macro(resetQueue) \
+    macro(extractSizeAlgorithm) \
+    macro(extractHighWaterMark) \
+    macro(extractHighWaterMarkFromQueuingStrategyInit) \
+    macro(createFulfilledPromise) \
+    macro(toDictionary) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class StreamInternalsBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit StreamInternalsBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* StreamInternalsBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void StreamInternalsBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+class StreamInternalsBuiltinFunctions {
+public:
+    explicit StreamInternalsBuiltinFunctions(JSC::VM& vm) : m_vm(vm) { }
+
+    void init(JSC::JSGlobalObject&);
+    template<typename Visitor> void visit(Visitor&);
+
+public:
+    JSC::VM& m_vm;
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(functionName) \
+    JSC::WriteBarrier<JSC::JSFunction> m_##functionName##Function;
+    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+};
+
+inline void StreamInternalsBuiltinFunctions::init(JSC::JSGlobalObject& globalObject)
+{
+#define EXPORT_FUNCTION(codeName, functionName, overriddenName, length) \
+    m_##functionName##Function.set(m_vm, &globalObject, JSC::JSFunction::create(m_vm, codeName##Generator(m_vm), &globalObject));
+    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(EXPORT_FUNCTION)
+#undef EXPORT_FUNCTION
+}
+
+template<typename Visitor>
+inline void StreamInternalsBuiltinFunctions::visit(Visitor& visitor)
+{
+#define VISIT_FUNCTION(name) visitor.append(m_##name##Function);
+    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(VISIT_FUNCTION)
+#undef VISIT_FUNCTION
+}
+
+template void StreamInternalsBuiltinFunctions::visit(JSC::AbstractSlotVisitor&);
+template void StreamInternalsBuiltinFunctions::visit(JSC::SlotVisitor&);
+    /* ImportMetaObject.ts */
+// loadCJS2ESM
+#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_LOADCJS2ESM 1
+extern const char* const s_importMetaObjectLoadCJS2ESMCode;
+extern const int s_importMetaObjectLoadCJS2ESMCodeLength;
+extern const JSC::ConstructAbility s_importMetaObjectLoadCJS2ESMCodeConstructAbility;
+extern const JSC::ConstructorKind s_importMetaObjectLoadCJS2ESMCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_importMetaObjectLoadCJS2ESMCodeImplementationVisibility;
+
+// requireESM
+#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_REQUIREESM 1
+extern const char* const s_importMetaObjectRequireESMCode;
+extern const int s_importMetaObjectRequireESMCodeLength;
+extern const JSC::ConstructAbility s_importMetaObjectRequireESMCodeConstructAbility;
+extern const JSC::ConstructorKind s_importMetaObjectRequireESMCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_importMetaObjectRequireESMCodeImplementationVisibility;
+
+// internalRequire
+#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_INTERNALREQUIRE 1
+extern const char* const s_importMetaObjectInternalRequireCode;
+extern const int s_importMetaObjectInternalRequireCodeLength;
+extern const JSC::ConstructAbility s_importMetaObjectInternalRequireCodeConstructAbility;
+extern const JSC::ConstructorKind s_importMetaObjectInternalRequireCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_importMetaObjectInternalRequireCodeImplementationVisibility;
+
+// createRequireCache
+#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_CREATEREQUIRECACHE 1
+extern const char* const s_importMetaObjectCreateRequireCacheCode;
+extern const int s_importMetaObjectCreateRequireCacheCodeLength;
+extern const JSC::ConstructAbility s_importMetaObjectCreateRequireCacheCodeConstructAbility;
+extern const JSC::ConstructorKind s_importMetaObjectCreateRequireCacheCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_importMetaObjectCreateRequireCacheCodeImplementationVisibility;
+
+// main
+#define WEBCORE_BUILTIN_IMPORTMETAOBJECT_MAIN 1
+extern const char* const s_importMetaObjectMainCode;
+extern const int s_importMetaObjectMainCodeLength;
+extern const JSC::ConstructAbility s_importMetaObjectMainCodeConstructAbility;
+extern const JSC::ConstructorKind s_importMetaObjectMainCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_importMetaObjectMainCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_DATA(macro) \
+    macro(loadCJS2ESM, importMetaObjectLoadCJS2ESM, 1) \
+    macro(requireESM, importMetaObjectRequireESM, 1) \
+    macro(internalRequire, importMetaObjectInternalRequire, 1) \
+    macro(createRequireCache, importMetaObjectCreateRequireCache, 0) \
+    macro(main, importMetaObjectMain, 0) \
+
+#define WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(macro) \
+    macro(importMetaObjectLoadCJS2ESMCode, loadCJS2ESM, ASCIILiteral(), s_importMetaObjectLoadCJS2ESMCodeLength) \
+    macro(importMetaObjectRequireESMCode, requireESM, ASCIILiteral(), s_importMetaObjectRequireESMCodeLength) \
+    macro(importMetaObjectInternalRequireCode, internalRequire, ASCIILiteral(), s_importMetaObjectInternalRequireCodeLength) \
+    macro(importMetaObjectCreateRequireCacheCode, createRequireCache, ASCIILiteral(), s_importMetaObjectCreateRequireCacheCodeLength) \
+    macro(importMetaObjectMainCode, main, "get main"_s, s_importMetaObjectMainCodeLength) \
+
+#define WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_FUNCTION_NAME(macro) \
+    macro(loadCJS2ESM) \
+    macro(requireESM) \
+    macro(internalRequire) \
+    macro(createRequireCache) \
+    macro(main) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class ImportMetaObjectBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit ImportMetaObjectBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* ImportMetaObjectBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void ImportMetaObjectBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_IMPORTMETAOBJECT_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+/* CountQueuingStrategy.ts */
+// highWaterMark
+#define WEBCORE_BUILTIN_COUNTQUEUINGSTRATEGY_HIGHWATERMARK 1
+extern const char* const s_countQueuingStrategyHighWaterMarkCode;
+extern const int s_countQueuingStrategyHighWaterMarkCodeLength;
+extern const JSC::ConstructAbility s_countQueuingStrategyHighWaterMarkCodeConstructAbility;
+extern const JSC::ConstructorKind s_countQueuingStrategyHighWaterMarkCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_countQueuingStrategyHighWaterMarkCodeImplementationVisibility;
+
+// size
+#define WEBCORE_BUILTIN_COUNTQUEUINGSTRATEGY_SIZE 1
+extern const char* const s_countQueuingStrategySizeCode;
+extern const int s_countQueuingStrategySizeCodeLength;
+extern const JSC::ConstructAbility s_countQueuingStrategySizeCodeConstructAbility;
+extern const JSC::ConstructorKind s_countQueuingStrategySizeCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_countQueuingStrategySizeCodeImplementationVisibility;
+
+// initializeCountQueuingStrategy
+#define WEBCORE_BUILTIN_COUNTQUEUINGSTRATEGY_INITIALIZECOUNTQUEUINGSTRATEGY 1
+extern const char* const s_countQueuingStrategyInitializeCountQueuingStrategyCode;
+extern const int s_countQueuingStrategyInitializeCountQueuingStrategyCodeLength;
+extern const JSC::ConstructAbility s_countQueuingStrategyInitializeCountQueuingStrategyCodeConstructAbility;
+extern const JSC::ConstructorKind s_countQueuingStrategyInitializeCountQueuingStrategyCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_countQueuingStrategyInitializeCountQueuingStrategyCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_DATA(macro) \
+    macro(highWaterMark, countQueuingStrategyHighWaterMark, 0) \
+    macro(size, countQueuingStrategySize, 0) \
+    macro(initializeCountQueuingStrategy, countQueuingStrategyInitializeCountQueuingStrategy, 1) \
+
+#define WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(macro) \
+    macro(countQueuingStrategyHighWaterMarkCode, highWaterMark, "get highWaterMark"_s, s_countQueuingStrategyHighWaterMarkCodeLength) \
+    macro(countQueuingStrategySizeCode, size, ASCIILiteral(), s_countQueuingStrategySizeCodeLength) \
+    macro(countQueuingStrategyInitializeCountQueuingStrategyCode, initializeCountQueuingStrategy, ASCIILiteral(), s_countQueuingStrategyInitializeCountQueuingStrategyCodeLength) \
+
+#define WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(macro) \
+    macro(highWaterMark) \
+    macro(size) \
+    macro(initializeCountQueuingStrategy) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class CountQueuingStrategyBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit CountQueuingStrategyBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* CountQueuingStrategyBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void CountQueuingStrategyBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+/* ReadableStreamBYOBRequest.ts */
+// initializeReadableStreamBYOBRequest
+#define WEBCORE_BUILTIN_READABLESTREAMBYOBREQUEST_INITIALIZEREADABLESTREAMBYOBREQUEST 1
+extern const char* const s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCode;
+extern const int s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeLength;
+extern const JSC::ConstructAbility s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeImplementationVisibility;
+
+// respond
+#define WEBCORE_BUILTIN_READABLESTREAMBYOBREQUEST_RESPOND 1
+extern const char* const s_readableStreamBYOBRequestRespondCode;
+extern const int s_readableStreamBYOBRequestRespondCodeLength;
+extern const JSC::ConstructAbility s_readableStreamBYOBRequestRespondCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamBYOBRequestRespondCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamBYOBRequestRespondCodeImplementationVisibility;
+
+// respondWithNewView
+#define WEBCORE_BUILTIN_READABLESTREAMBYOBREQUEST_RESPONDWITHNEWVIEW 1
+extern const char* const s_readableStreamBYOBRequestRespondWithNewViewCode;
+extern const int s_readableStreamBYOBRequestRespondWithNewViewCodeLength;
+extern const JSC::ConstructAbility s_readableStreamBYOBRequestRespondWithNewViewCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamBYOBRequestRespondWithNewViewCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamBYOBRequestRespondWithNewViewCodeImplementationVisibility;
+
+// view
+#define WEBCORE_BUILTIN_READABLESTREAMBYOBREQUEST_VIEW 1
+extern const char* const s_readableStreamBYOBRequestViewCode;
+extern const int s_readableStreamBYOBRequestViewCodeLength;
+extern const JSC::ConstructAbility s_readableStreamBYOBRequestViewCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamBYOBRequestViewCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamBYOBRequestViewCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_DATA(macro) \
+    macro(initializeReadableStreamBYOBRequest, readableStreamBYOBRequestInitializeReadableStreamBYOBRequest, 2) \
+    macro(respond, readableStreamBYOBRequestRespond, 1) \
+    macro(respondWithNewView, readableStreamBYOBRequestRespondWithNewView, 1) \
+    macro(view, readableStreamBYOBRequestView, 0) \
+
+#define WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(macro) \
+    macro(readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCode, initializeReadableStreamBYOBRequest, ASCIILiteral(), s_readableStreamBYOBRequestInitializeReadableStreamBYOBRequestCodeLength) \
+    macro(readableStreamBYOBRequestRespondCode, respond, ASCIILiteral(), s_readableStreamBYOBRequestRespondCodeLength) \
+    macro(readableStreamBYOBRequestRespondWithNewViewCode, respondWithNewView, ASCIILiteral(), s_readableStreamBYOBRequestRespondWithNewViewCodeLength) \
+    macro(readableStreamBYOBRequestViewCode, view, "get view"_s, s_readableStreamBYOBRequestViewCodeLength) \
+
+#define WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_FUNCTION_NAME(macro) \
+    macro(initializeReadableStreamBYOBRequest) \
+    macro(respond) \
+    macro(respondWithNewView) \
+    macro(view) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class ReadableStreamBYOBRequestBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit ReadableStreamBYOBRequestBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* ReadableStreamBYOBRequestBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void ReadableStreamBYOBRequestBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_READABLESTREAMBYOBREQUEST_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+/* WritableStreamDefaultWriter.ts */
+// initializeWritableStreamDefaultWriter
+#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_INITIALIZEWRITABLESTREAMDEFAULTWRITER 1
+extern const char* const s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCode;
+extern const int s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeLength;
+extern const JSC::ConstructAbility s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeImplementationVisibility;
+
+// closed
+#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_CLOSED 1
+extern const char* const s_writableStreamDefaultWriterClosedCode;
+extern const int s_writableStreamDefaultWriterClosedCodeLength;
+extern const JSC::ConstructAbility s_writableStreamDefaultWriterClosedCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamDefaultWriterClosedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterClosedCodeImplementationVisibility;
+
+// desiredSize
+#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_DESIREDSIZE 1
+extern const char* const s_writableStreamDefaultWriterDesiredSizeCode;
+extern const int s_writableStreamDefaultWriterDesiredSizeCodeLength;
+extern const JSC::ConstructAbility s_writableStreamDefaultWriterDesiredSizeCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamDefaultWriterDesiredSizeCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterDesiredSizeCodeImplementationVisibility;
+
+// ready
+#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_READY 1
+extern const char* const s_writableStreamDefaultWriterReadyCode;
+extern const int s_writableStreamDefaultWriterReadyCodeLength;
+extern const JSC::ConstructAbility s_writableStreamDefaultWriterReadyCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamDefaultWriterReadyCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterReadyCodeImplementationVisibility;
+
+// abort
+#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_ABORT 1
+extern const char* const s_writableStreamDefaultWriterAbortCode;
+extern const int s_writableStreamDefaultWriterAbortCodeLength;
+extern const JSC::ConstructAbility s_writableStreamDefaultWriterAbortCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamDefaultWriterAbortCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterAbortCodeImplementationVisibility;
+
+// close
+#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_CLOSE 1
+extern const char* const s_writableStreamDefaultWriterCloseCode;
+extern const int s_writableStreamDefaultWriterCloseCodeLength;
+extern const JSC::ConstructAbility s_writableStreamDefaultWriterCloseCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamDefaultWriterCloseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterCloseCodeImplementationVisibility;
+
+// releaseLock
+#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_RELEASELOCK 1
+extern const char* const s_writableStreamDefaultWriterReleaseLockCode;
+extern const int s_writableStreamDefaultWriterReleaseLockCodeLength;
+extern const JSC::ConstructAbility s_writableStreamDefaultWriterReleaseLockCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamDefaultWriterReleaseLockCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterReleaseLockCodeImplementationVisibility;
+
+// write
+#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTWRITER_WRITE 1
+extern const char* const s_writableStreamDefaultWriterWriteCode;
+extern const int s_writableStreamDefaultWriterWriteCodeLength;
+extern const JSC::ConstructAbility s_writableStreamDefaultWriterWriteCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamDefaultWriterWriteCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamDefaultWriterWriteCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_DATA(macro) \
+    macro(initializeWritableStreamDefaultWriter, writableStreamDefaultWriterInitializeWritableStreamDefaultWriter, 1) \
+    macro(closed, writableStreamDefaultWriterClosed, 0) \
+    macro(desiredSize, writableStreamDefaultWriterDesiredSize, 0) \
+    macro(ready, writableStreamDefaultWriterReady, 0) \
+    macro(abort, writableStreamDefaultWriterAbort, 1) \
+    macro(close, writableStreamDefaultWriterClose, 0) \
+    macro(releaseLock, writableStreamDefaultWriterReleaseLock, 0) \
+    macro(write, writableStreamDefaultWriterWrite, 1) \
+
+#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(macro) \
+    macro(writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCode, initializeWritableStreamDefaultWriter, ASCIILiteral(), s_writableStreamDefaultWriterInitializeWritableStreamDefaultWriterCodeLength) \
+    macro(writableStreamDefaultWriterClosedCode, closed, "get closed"_s, s_writableStreamDefaultWriterClosedCodeLength) \
+    macro(writableStreamDefaultWriterDesiredSizeCode, desiredSize, "get desiredSize"_s, s_writableStreamDefaultWriterDesiredSizeCodeLength) \
+    macro(writableStreamDefaultWriterReadyCode, ready, "get ready"_s, s_writableStreamDefaultWriterReadyCodeLength) \
+    macro(writableStreamDefaultWriterAbortCode, abort, ASCIILiteral(), s_writableStreamDefaultWriterAbortCodeLength) \
+    macro(writableStreamDefaultWriterCloseCode, close, ASCIILiteral(), s_writableStreamDefaultWriterCloseCodeLength) \
+    macro(writableStreamDefaultWriterReleaseLockCode, releaseLock, ASCIILiteral(), s_writableStreamDefaultWriterReleaseLockCodeLength) \
+    macro(writableStreamDefaultWriterWriteCode, write, ASCIILiteral(), s_writableStreamDefaultWriterWriteCodeLength) \
+
+#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_FUNCTION_NAME(macro) \
+    macro(initializeWritableStreamDefaultWriter) \
+    macro(closed) \
+    macro(desiredSize) \
+    macro(ready) \
+    macro(abort) \
+    macro(close) \
+    macro(releaseLock) \
+    macro(write) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class WritableStreamDefaultWriterBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit WritableStreamDefaultWriterBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* WritableStreamDefaultWriterBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void WritableStreamDefaultWriterBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTWRITER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+/* ReadableStream.ts */
+// initializeReadableStream
+#define WEBCORE_BUILTIN_READABLESTREAM_INITIALIZEREADABLESTREAM 1
+extern const char* const s_readableStreamInitializeReadableStreamCode;
+extern const int s_readableStreamInitializeReadableStreamCodeLength;
+extern const JSC::ConstructAbility s_readableStreamInitializeReadableStreamCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamInitializeReadableStreamCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamInitializeReadableStreamCodeImplementationVisibility;
+
+// readableStreamToArray
+#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOARRAY 1
+extern const char* const s_readableStreamReadableStreamToArrayCode;
+extern const int s_readableStreamReadableStreamToArrayCodeLength;
+extern const JSC::ConstructAbility s_readableStreamReadableStreamToArrayCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamReadableStreamToArrayCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToArrayCodeImplementationVisibility;
+
+// readableStreamToText
+#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOTEXT 1
+extern const char* const s_readableStreamReadableStreamToTextCode;
+extern const int s_readableStreamReadableStreamToTextCodeLength;
+extern const JSC::ConstructAbility s_readableStreamReadableStreamToTextCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamReadableStreamToTextCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToTextCodeImplementationVisibility;
+
+// readableStreamToArrayBuffer
+#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOARRAYBUFFER 1
+extern const char* const s_readableStreamReadableStreamToArrayBufferCode;
+extern const int s_readableStreamReadableStreamToArrayBufferCodeLength;
+extern const JSC::ConstructAbility s_readableStreamReadableStreamToArrayBufferCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamReadableStreamToArrayBufferCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToArrayBufferCodeImplementationVisibility;
+
+// readableStreamToFormData
+#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOFORMDATA 1
+extern const char* const s_readableStreamReadableStreamToFormDataCode;
+extern const int s_readableStreamReadableStreamToFormDataCodeLength;
+extern const JSC::ConstructAbility s_readableStreamReadableStreamToFormDataCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamReadableStreamToFormDataCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToFormDataCodeImplementationVisibility;
+
+// readableStreamToJSON
+#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOJSON 1
+extern const char* const s_readableStreamReadableStreamToJSONCode;
+extern const int s_readableStreamReadableStreamToJSONCodeLength;
+extern const JSC::ConstructAbility s_readableStreamReadableStreamToJSONCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamReadableStreamToJSONCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToJSONCodeImplementationVisibility;
+
+// readableStreamToBlob
+#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOBLOB 1
+extern const char* const s_readableStreamReadableStreamToBlobCode;
+extern const int s_readableStreamReadableStreamToBlobCodeLength;
+extern const JSC::ConstructAbility s_readableStreamReadableStreamToBlobCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamReadableStreamToBlobCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToBlobCodeImplementationVisibility;
+
+// consumeReadableStream
+#define WEBCORE_BUILTIN_READABLESTREAM_CONSUMEREADABLESTREAM 1
+extern const char* const s_readableStreamConsumeReadableStreamCode;
+extern const int s_readableStreamConsumeReadableStreamCodeLength;
+extern const JSC::ConstructAbility s_readableStreamConsumeReadableStreamCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamConsumeReadableStreamCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamConsumeReadableStreamCodeImplementationVisibility;
+
+// createEmptyReadableStream
+#define WEBCORE_BUILTIN_READABLESTREAM_CREATEEMPTYREADABLESTREAM 1
+extern const char* const s_readableStreamCreateEmptyReadableStreamCode;
+extern const int s_readableStreamCreateEmptyReadableStreamCodeLength;
+extern const JSC::ConstructAbility s_readableStreamCreateEmptyReadableStreamCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamCreateEmptyReadableStreamCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamCreateEmptyReadableStreamCodeImplementationVisibility;
+
+// createNativeReadableStream
+#define WEBCORE_BUILTIN_READABLESTREAM_CREATENATIVEREADABLESTREAM 1
+extern const char* const s_readableStreamCreateNativeReadableStreamCode;
+extern const int s_readableStreamCreateNativeReadableStreamCodeLength;
+extern const JSC::ConstructAbility s_readableStreamCreateNativeReadableStreamCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamCreateNativeReadableStreamCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamCreateNativeReadableStreamCodeImplementationVisibility;
+
+// cancel
+#define WEBCORE_BUILTIN_READABLESTREAM_CANCEL 1
+extern const char* const s_readableStreamCancelCode;
+extern const int s_readableStreamCancelCodeLength;
+extern const JSC::ConstructAbility s_readableStreamCancelCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamCancelCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamCancelCodeImplementationVisibility;
+
+// getReader
+#define WEBCORE_BUILTIN_READABLESTREAM_GETREADER 1
+extern const char* const s_readableStreamGetReaderCode;
+extern const int s_readableStreamGetReaderCodeLength;
+extern const JSC::ConstructAbility s_readableStreamGetReaderCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamGetReaderCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamGetReaderCodeImplementationVisibility;
+
+// pipeThrough
+#define WEBCORE_BUILTIN_READABLESTREAM_PIPETHROUGH 1
+extern const char* const s_readableStreamPipeThroughCode;
+extern const int s_readableStreamPipeThroughCodeLength;
+extern const JSC::ConstructAbility s_readableStreamPipeThroughCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamPipeThroughCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamPipeThroughCodeImplementationVisibility;
+
+// pipeTo
+#define WEBCORE_BUILTIN_READABLESTREAM_PIPETO 1
+extern const char* const s_readableStreamPipeToCode;
+extern const int s_readableStreamPipeToCodeLength;
+extern const JSC::ConstructAbility s_readableStreamPipeToCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamPipeToCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamPipeToCodeImplementationVisibility;
+
+// tee
+#define WEBCORE_BUILTIN_READABLESTREAM_TEE 1
+extern const char* const s_readableStreamTeeCode;
+extern const int s_readableStreamTeeCodeLength;
+extern const JSC::ConstructAbility s_readableStreamTeeCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamTeeCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamTeeCodeImplementationVisibility;
+
+// locked
+#define WEBCORE_BUILTIN_READABLESTREAM_LOCKED 1
+extern const char* const s_readableStreamLockedCode;
+extern const int s_readableStreamLockedCodeLength;
+extern const JSC::ConstructAbility s_readableStreamLockedCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamLockedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamLockedCodeImplementationVisibility;
+
+// values
+#define WEBCORE_BUILTIN_READABLESTREAM_VALUES 1
+extern const char* const s_readableStreamValuesCode;
+extern const int s_readableStreamValuesCodeLength;
+extern const JSC::ConstructAbility s_readableStreamValuesCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamValuesCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamValuesCodeImplementationVisibility;
+
+// lazyAsyncIterator
+#define WEBCORE_BUILTIN_READABLESTREAM_LAZYASYNCITERATOR 1
+extern const char* const s_readableStreamLazyAsyncIteratorCode;
+extern const int s_readableStreamLazyAsyncIteratorCodeLength;
+extern const JSC::ConstructAbility s_readableStreamLazyAsyncIteratorCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamLazyAsyncIteratorCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamLazyAsyncIteratorCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_READABLESTREAM_BUILTIN_DATA(macro) \
+    macro(initializeReadableStream, readableStreamInitializeReadableStream, 3) \
+    macro(readableStreamToArray, readableStreamReadableStreamToArray, 1) \
+    macro(readableStreamToText, readableStreamReadableStreamToText, 1) \
+    macro(readableStreamToArrayBuffer, readableStreamReadableStreamToArrayBuffer, 1) \
+    macro(readableStreamToFormData, readableStreamReadableStreamToFormData, 3) \
+    macro(readableStreamToJSON, readableStreamReadableStreamToJSON, 1) \
+    macro(readableStreamToBlob, readableStreamReadableStreamToBlob, 1) \
+    macro(consumeReadableStream, readableStreamConsumeReadableStream, 3) \
+    macro(createEmptyReadableStream, readableStreamCreateEmptyReadableStream, 0) \
+    macro(createNativeReadableStream, readableStreamCreateNativeReadableStream, 3) \
+    macro(cancel, readableStreamCancel, 1) \
+    macro(getReader, readableStreamGetReader, 1) \
+    macro(pipeThrough, readableStreamPipeThrough, 2) \
+    macro(pipeTo, readableStreamPipeTo, 1) \
+    macro(tee, readableStreamTee, 0) \
+    macro(locked, readableStreamLocked, 0) \
+    macro(values, readableStreamValues, 1) \
+    macro(lazyAsyncIterator, readableStreamLazyAsyncIterator, 0) \
+
+#define WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(macro) \
+    macro(readableStreamInitializeReadableStreamCode, initializeReadableStream, ASCIILiteral(), s_readableStreamInitializeReadableStreamCodeLength) \
+    macro(readableStreamReadableStreamToArrayCode, readableStreamToArray, ASCIILiteral(), s_readableStreamReadableStreamToArrayCodeLength) \
+    macro(readableStreamReadableStreamToTextCode, readableStreamToText, ASCIILiteral(), s_readableStreamReadableStreamToTextCodeLength) \
+    macro(readableStreamReadableStreamToArrayBufferCode, readableStreamToArrayBuffer, ASCIILiteral(), s_readableStreamReadableStreamToArrayBufferCodeLength) \
+    macro(readableStreamReadableStreamToFormDataCode, readableStreamToFormData, ASCIILiteral(), s_readableStreamReadableStreamToFormDataCodeLength) \
+    macro(readableStreamReadableStreamToJSONCode, readableStreamToJSON, ASCIILiteral(), s_readableStreamReadableStreamToJSONCodeLength) \
+    macro(readableStreamReadableStreamToBlobCode, readableStreamToBlob, ASCIILiteral(), s_readableStreamReadableStreamToBlobCodeLength) \
+    macro(readableStreamConsumeReadableStreamCode, consumeReadableStream, ASCIILiteral(), s_readableStreamConsumeReadableStreamCodeLength) \
+    macro(readableStreamCreateEmptyReadableStreamCode, createEmptyReadableStream, ASCIILiteral(), s_readableStreamCreateEmptyReadableStreamCodeLength) \
+    macro(readableStreamCreateNativeReadableStreamCode, createNativeReadableStream, ASCIILiteral(), s_readableStreamCreateNativeReadableStreamCodeLength) \
+    macro(readableStreamCancelCode, cancel, ASCIILiteral(), s_readableStreamCancelCodeLength) \
+    macro(readableStreamGetReaderCode, getReader, ASCIILiteral(), s_readableStreamGetReaderCodeLength) \
+    macro(readableStreamPipeThroughCode, pipeThrough, ASCIILiteral(), s_readableStreamPipeThroughCodeLength) \
+    macro(readableStreamPipeToCode, pipeTo, ASCIILiteral(), s_readableStreamPipeToCodeLength) \
+    macro(readableStreamTeeCode, tee, ASCIILiteral(), s_readableStreamTeeCodeLength) \
+    macro(readableStreamLockedCode, locked, "get locked"_s, s_readableStreamLockedCodeLength) \
+    macro(readableStreamValuesCode, values, ASCIILiteral(), s_readableStreamValuesCodeLength) \
+    macro(readableStreamLazyAsyncIteratorCode, lazyAsyncIterator, ASCIILiteral(), s_readableStreamLazyAsyncIteratorCodeLength) \
+
+#define WEBCORE_FOREACH_READABLESTREAM_BUILTIN_FUNCTION_NAME(macro) \
+    macro(initializeReadableStream) \
+    macro(readableStreamToArray) \
+    macro(readableStreamToText) \
+    macro(readableStreamToArrayBuffer) \
+    macro(readableStreamToFormData) \
+    macro(readableStreamToJSON) \
+    macro(readableStreamToBlob) \
+    macro(consumeReadableStream) \
+    macro(createEmptyReadableStream) \
+    macro(createNativeReadableStream) \
+    macro(cancel) \
+    macro(getReader) \
+    macro(pipeThrough) \
+    macro(pipeTo) \
+    macro(tee) \
+    macro(locked) \
+    macro(values) \
+    macro(lazyAsyncIterator) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class ReadableStreamBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit ReadableStreamBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_READABLESTREAM_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_READABLESTREAM_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_READABLESTREAM_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* ReadableStreamBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void ReadableStreamBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_READABLESTREAM_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+/* ReadableStreamDefaultController.ts */
+// initializeReadableStreamDefaultController
+#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTCONTROLLER_INITIALIZEREADABLESTREAMDEFAULTCONTROLLER 1
+extern const char* const s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCode;
+extern const int s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCodeLength;
+extern const JSC::ConstructAbility s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCodeImplementationVisibility;
+
+// enqueue
+#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTCONTROLLER_ENQUEUE 1
+extern const char* const s_readableStreamDefaultControllerEnqueueCode;
+extern const int s_readableStreamDefaultControllerEnqueueCodeLength;
+extern const JSC::ConstructAbility s_readableStreamDefaultControllerEnqueueCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamDefaultControllerEnqueueCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamDefaultControllerEnqueueCodeImplementationVisibility;
+
+// error
+#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTCONTROLLER_ERROR 1
+extern const char* const s_readableStreamDefaultControllerErrorCode;
+extern const int s_readableStreamDefaultControllerErrorCodeLength;
+extern const JSC::ConstructAbility s_readableStreamDefaultControllerErrorCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamDefaultControllerErrorCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamDefaultControllerErrorCodeImplementationVisibility;
+
+// close
+#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTCONTROLLER_CLOSE 1
+extern const char* const s_readableStreamDefaultControllerCloseCode;
+extern const int s_readableStreamDefaultControllerCloseCodeLength;
+extern const JSC::ConstructAbility s_readableStreamDefaultControllerCloseCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamDefaultControllerCloseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamDefaultControllerCloseCodeImplementationVisibility;
+
+// desiredSize
+#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTCONTROLLER_DESIREDSIZE 1
+extern const char* const s_readableStreamDefaultControllerDesiredSizeCode;
+extern const int s_readableStreamDefaultControllerDesiredSizeCodeLength;
+extern const JSC::ConstructAbility s_readableStreamDefaultControllerDesiredSizeCodeConstructAbility;
+extern const JSC::ConstructorKind s_readableStreamDefaultControllerDesiredSizeCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_readableStreamDefaultControllerDesiredSizeCodeImplementationVisibility;
+
+#define WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_DATA(macro) \
+    macro(initializeReadableStreamDefaultController, readableStreamDefaultControllerInitializeReadableStreamDefaultController, 4) \
+    macro(enqueue, readableStreamDefaultControllerEnqueue, 1) \
+    macro(error, readableStreamDefaultControllerError, 1) \
+    macro(close, readableStreamDefaultControllerClose, 0) \
+    macro(desiredSize, readableStreamDefaultControllerDesiredSize, 0) \
+
+#define WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(macro) \
+    macro(readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCode, initializeReadableStreamDefaultController, ASCIILiteral(), s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCodeLength) \
+    macro(readableStreamDefaultControllerEnqueueCode, enqueue, ASCIILiteral(), s_readableStreamDefaultControllerEnqueueCodeLength) \
+    macro(readableStreamDefaultControllerErrorCode, error, ASCIILiteral(), s_readableStreamDefaultControllerErrorCodeLength) \
+    macro(readableStreamDefaultControllerCloseCode, close, ASCIILiteral(), s_readableStreamDefaultControllerCloseCodeLength) \
+    macro(readableStreamDefaultControllerDesiredSizeCode, desiredSize, "get desiredSize"_s, s_readableStreamDefaultControllerDesiredSizeCodeLength) \
+
+#define WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(macro) \
+    macro(initializeReadableStreamDefaultController) \
+    macro(enqueue) \
+    macro(error) \
+    macro(close) \
+    macro(desiredSize) \
+
+#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
+    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
+
+WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+#undef DECLARE_BUILTIN_GENERATOR
+
+class ReadableStreamDefaultControllerBuiltinsWrapper : private JSC::WeakHandleOwner {
+public:
+    explicit ReadableStreamDefaultControllerBuiltinsWrapper(JSC::VM& vm)
+        : m_vm(vm)
+        WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
+        WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
+    {
+    }
+
+#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+    JSC::UnlinkedFunctionExecutable* name##Executable(); \
+    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
+    WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+#undef EXPOSE_BUILTIN_EXECUTABLES
+
+    WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+
+    void exportNames();
+
+private:
+    JSC::VM& m_vm;
+
+    WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+
+#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
+    JSC::SourceCode m_##name##Source;\
+    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
+    WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+#undef DECLARE_BUILTIN_SOURCE_MEMBERS
+
+};
+
+#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
+inline JSC::UnlinkedFunctionExecutable* ReadableStreamDefaultControllerBuiltinsWrapper::name##Executable() \
+{\
+    if (!m_##name##Executable) {\
+        JSC::Identifier executableName = functionName##PublicName();\
+        if (overriddenName)\
+            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+    }\
+    return m_##name##Executable.get();\
+}
+WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+#undef DEFINE_BUILTIN_EXECUTABLES
+
+inline void ReadableStreamDefaultControllerBuiltinsWrapper::exportNames()
+{
+#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
+    WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+#undef EXPORT_FUNCTION_NAME
+}
+/* ReadableByteStreamInternals.ts */
 // privateInitializeReadableByteStreamController
 #define WEBCORE_BUILTIN_READABLEBYTESTREAMINTERNALS_PRIVATEINITIALIZEREADABLEBYTESTREAMCONTROLLER 1
 extern const char* const s_readableByteStreamInternalsPrivateInitializeReadableByteStreamControllerCode;
@@ -2970,1638 +5522,48 @@ inline void ReadableByteStreamInternalsBuiltinFunctions::visit(Visitor& visitor)
 
 template void ReadableByteStreamInternalsBuiltinFunctions::visit(JSC::AbstractSlotVisitor&);
 template void ReadableByteStreamInternalsBuiltinFunctions::visit(JSC::SlotVisitor&);
-    /* UtilInspect.ts */
-// getStylizeWithColor
-#define WEBCORE_BUILTIN_UTILINSPECT_GETSTYLIZEWITHCOLOR 1
-extern const char* const s_utilInspectGetStylizeWithColorCode;
-extern const int s_utilInspectGetStylizeWithColorCodeLength;
-extern const JSC::ConstructAbility s_utilInspectGetStylizeWithColorCodeConstructAbility;
-extern const JSC::ConstructorKind s_utilInspectGetStylizeWithColorCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_utilInspectGetStylizeWithColorCodeImplementationVisibility;
-
-// stylizeWithNoColor
-#define WEBCORE_BUILTIN_UTILINSPECT_STYLIZEWITHNOCOLOR 1
-extern const char* const s_utilInspectStylizeWithNoColorCode;
-extern const int s_utilInspectStylizeWithNoColorCodeLength;
-extern const JSC::ConstructAbility s_utilInspectStylizeWithNoColorCodeConstructAbility;
-extern const JSC::ConstructorKind s_utilInspectStylizeWithNoColorCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_utilInspectStylizeWithNoColorCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_UTILINSPECT_BUILTIN_DATA(macro) \
-    macro(getStylizeWithColor, utilInspectGetStylizeWithColor, 1) \
-    macro(stylizeWithNoColor, utilInspectStylizeWithNoColor, 1) \
-
-#define WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(macro) \
-    macro(utilInspectGetStylizeWithColorCode, getStylizeWithColor, ASCIILiteral(), s_utilInspectGetStylizeWithColorCodeLength) \
-    macro(utilInspectStylizeWithNoColorCode, stylizeWithNoColor, ASCIILiteral(), s_utilInspectStylizeWithNoColorCodeLength) \
-
-#define WEBCORE_FOREACH_UTILINSPECT_BUILTIN_FUNCTION_NAME(macro) \
-    macro(getStylizeWithColor) \
-    macro(stylizeWithNoColor) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class UtilInspectBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit UtilInspectBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_UTILINSPECT_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_UTILINSPECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_UTILINSPECT_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* UtilInspectBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_UTILINSPECT_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void UtilInspectBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_UTILINSPECT_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-/* JSBufferPrototype.ts */
-// setBigUint64
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_SETBIGUINT64 1
-extern const char* const s_jsBufferPrototypeSetBigUint64Code;
-extern const int s_jsBufferPrototypeSetBigUint64CodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeSetBigUint64CodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeSetBigUint64CodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeSetBigUint64CodeImplementationVisibility;
-
-// readInt8
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINT8 1
-extern const char* const s_jsBufferPrototypeReadInt8Code;
-extern const int s_jsBufferPrototypeReadInt8CodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadInt8CodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadInt8CodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadInt8CodeImplementationVisibility;
-
-// readUInt8
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINT8 1
-extern const char* const s_jsBufferPrototypeReadUInt8Code;
-extern const int s_jsBufferPrototypeReadUInt8CodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadUInt8CodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadUInt8CodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUInt8CodeImplementationVisibility;
-
-// readInt16LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINT16LE 1
-extern const char* const s_jsBufferPrototypeReadInt16LECode;
-extern const int s_jsBufferPrototypeReadInt16LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadInt16LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadInt16LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadInt16LECodeImplementationVisibility;
-
-// readInt16BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINT16BE 1
-extern const char* const s_jsBufferPrototypeReadInt16BECode;
-extern const int s_jsBufferPrototypeReadInt16BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadInt16BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadInt16BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadInt16BECodeImplementationVisibility;
-
-// readUInt16LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINT16LE 1
-extern const char* const s_jsBufferPrototypeReadUInt16LECode;
-extern const int s_jsBufferPrototypeReadUInt16LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadUInt16LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadUInt16LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUInt16LECodeImplementationVisibility;
-
-// readUInt16BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINT16BE 1
-extern const char* const s_jsBufferPrototypeReadUInt16BECode;
-extern const int s_jsBufferPrototypeReadUInt16BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadUInt16BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadUInt16BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUInt16BECodeImplementationVisibility;
-
-// readInt32LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINT32LE 1
-extern const char* const s_jsBufferPrototypeReadInt32LECode;
-extern const int s_jsBufferPrototypeReadInt32LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadInt32LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadInt32LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadInt32LECodeImplementationVisibility;
-
-// readInt32BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINT32BE 1
-extern const char* const s_jsBufferPrototypeReadInt32BECode;
-extern const int s_jsBufferPrototypeReadInt32BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadInt32BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadInt32BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadInt32BECodeImplementationVisibility;
-
-// readUInt32LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINT32LE 1
-extern const char* const s_jsBufferPrototypeReadUInt32LECode;
-extern const int s_jsBufferPrototypeReadUInt32LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadUInt32LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadUInt32LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUInt32LECodeImplementationVisibility;
-
-// readUInt32BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINT32BE 1
-extern const char* const s_jsBufferPrototypeReadUInt32BECode;
-extern const int s_jsBufferPrototypeReadUInt32BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadUInt32BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadUInt32BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUInt32BECodeImplementationVisibility;
-
-// readIntLE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINTLE 1
-extern const char* const s_jsBufferPrototypeReadIntLECode;
-extern const int s_jsBufferPrototypeReadIntLECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadIntLECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadIntLECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadIntLECodeImplementationVisibility;
-
-// readIntBE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READINTBE 1
-extern const char* const s_jsBufferPrototypeReadIntBECode;
-extern const int s_jsBufferPrototypeReadIntBECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadIntBECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadIntBECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadIntBECodeImplementationVisibility;
-
-// readUIntLE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINTLE 1
-extern const char* const s_jsBufferPrototypeReadUIntLECode;
-extern const int s_jsBufferPrototypeReadUIntLECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadUIntLECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadUIntLECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUIntLECodeImplementationVisibility;
-
-// readUIntBE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READUINTBE 1
-extern const char* const s_jsBufferPrototypeReadUIntBECode;
-extern const int s_jsBufferPrototypeReadUIntBECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadUIntBECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadUIntBECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadUIntBECodeImplementationVisibility;
-
-// readFloatLE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READFLOATLE 1
-extern const char* const s_jsBufferPrototypeReadFloatLECode;
-extern const int s_jsBufferPrototypeReadFloatLECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadFloatLECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadFloatLECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadFloatLECodeImplementationVisibility;
-
-// readFloatBE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READFLOATBE 1
-extern const char* const s_jsBufferPrototypeReadFloatBECode;
-extern const int s_jsBufferPrototypeReadFloatBECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadFloatBECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadFloatBECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadFloatBECodeImplementationVisibility;
-
-// readDoubleLE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READDOUBLELE 1
-extern const char* const s_jsBufferPrototypeReadDoubleLECode;
-extern const int s_jsBufferPrototypeReadDoubleLECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadDoubleLECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadDoubleLECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadDoubleLECodeImplementationVisibility;
-
-// readDoubleBE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READDOUBLEBE 1
-extern const char* const s_jsBufferPrototypeReadDoubleBECode;
-extern const int s_jsBufferPrototypeReadDoubleBECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadDoubleBECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadDoubleBECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadDoubleBECodeImplementationVisibility;
-
-// readBigInt64LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READBIGINT64LE 1
-extern const char* const s_jsBufferPrototypeReadBigInt64LECode;
-extern const int s_jsBufferPrototypeReadBigInt64LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadBigInt64LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadBigInt64LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadBigInt64LECodeImplementationVisibility;
-
-// readBigInt64BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READBIGINT64BE 1
-extern const char* const s_jsBufferPrototypeReadBigInt64BECode;
-extern const int s_jsBufferPrototypeReadBigInt64BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadBigInt64BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadBigInt64BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadBigInt64BECodeImplementationVisibility;
-
-// readBigUInt64LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READBIGUINT64LE 1
-extern const char* const s_jsBufferPrototypeReadBigUInt64LECode;
-extern const int s_jsBufferPrototypeReadBigUInt64LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadBigUInt64LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadBigUInt64LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadBigUInt64LECodeImplementationVisibility;
-
-// readBigUInt64BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_READBIGUINT64BE 1
-extern const char* const s_jsBufferPrototypeReadBigUInt64BECode;
-extern const int s_jsBufferPrototypeReadBigUInt64BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeReadBigUInt64BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeReadBigUInt64BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeReadBigUInt64BECodeImplementationVisibility;
-
-// writeInt8
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINT8 1
-extern const char* const s_jsBufferPrototypeWriteInt8Code;
-extern const int s_jsBufferPrototypeWriteInt8CodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteInt8CodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteInt8CodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteInt8CodeImplementationVisibility;
-
-// writeUInt8
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINT8 1
-extern const char* const s_jsBufferPrototypeWriteUInt8Code;
-extern const int s_jsBufferPrototypeWriteUInt8CodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUInt8CodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUInt8CodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUInt8CodeImplementationVisibility;
-
-// writeInt16LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINT16LE 1
-extern const char* const s_jsBufferPrototypeWriteInt16LECode;
-extern const int s_jsBufferPrototypeWriteInt16LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteInt16LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteInt16LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteInt16LECodeImplementationVisibility;
-
-// writeInt16BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINT16BE 1
-extern const char* const s_jsBufferPrototypeWriteInt16BECode;
-extern const int s_jsBufferPrototypeWriteInt16BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteInt16BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteInt16BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteInt16BECodeImplementationVisibility;
-
-// writeUInt16LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINT16LE 1
-extern const char* const s_jsBufferPrototypeWriteUInt16LECode;
-extern const int s_jsBufferPrototypeWriteUInt16LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUInt16LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUInt16LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUInt16LECodeImplementationVisibility;
-
-// writeUInt16BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINT16BE 1
-extern const char* const s_jsBufferPrototypeWriteUInt16BECode;
-extern const int s_jsBufferPrototypeWriteUInt16BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUInt16BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUInt16BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUInt16BECodeImplementationVisibility;
-
-// writeInt32LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINT32LE 1
-extern const char* const s_jsBufferPrototypeWriteInt32LECode;
-extern const int s_jsBufferPrototypeWriteInt32LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteInt32LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteInt32LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteInt32LECodeImplementationVisibility;
-
-// writeInt32BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINT32BE 1
-extern const char* const s_jsBufferPrototypeWriteInt32BECode;
-extern const int s_jsBufferPrototypeWriteInt32BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteInt32BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteInt32BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteInt32BECodeImplementationVisibility;
-
-// writeUInt32LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINT32LE 1
-extern const char* const s_jsBufferPrototypeWriteUInt32LECode;
-extern const int s_jsBufferPrototypeWriteUInt32LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUInt32LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUInt32LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUInt32LECodeImplementationVisibility;
-
-// writeUInt32BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINT32BE 1
-extern const char* const s_jsBufferPrototypeWriteUInt32BECode;
-extern const int s_jsBufferPrototypeWriteUInt32BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUInt32BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUInt32BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUInt32BECodeImplementationVisibility;
-
-// writeIntLE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINTLE 1
-extern const char* const s_jsBufferPrototypeWriteIntLECode;
-extern const int s_jsBufferPrototypeWriteIntLECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteIntLECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteIntLECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteIntLECodeImplementationVisibility;
-
-// writeIntBE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEINTBE 1
-extern const char* const s_jsBufferPrototypeWriteIntBECode;
-extern const int s_jsBufferPrototypeWriteIntBECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteIntBECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteIntBECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteIntBECodeImplementationVisibility;
-
-// writeUIntLE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINTLE 1
-extern const char* const s_jsBufferPrototypeWriteUIntLECode;
-extern const int s_jsBufferPrototypeWriteUIntLECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUIntLECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUIntLECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUIntLECodeImplementationVisibility;
-
-// writeUIntBE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEUINTBE 1
-extern const char* const s_jsBufferPrototypeWriteUIntBECode;
-extern const int s_jsBufferPrototypeWriteUIntBECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteUIntBECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteUIntBECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteUIntBECodeImplementationVisibility;
-
-// writeFloatLE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEFLOATLE 1
-extern const char* const s_jsBufferPrototypeWriteFloatLECode;
-extern const int s_jsBufferPrototypeWriteFloatLECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteFloatLECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteFloatLECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteFloatLECodeImplementationVisibility;
-
-// writeFloatBE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEFLOATBE 1
-extern const char* const s_jsBufferPrototypeWriteFloatBECode;
-extern const int s_jsBufferPrototypeWriteFloatBECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteFloatBECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteFloatBECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteFloatBECodeImplementationVisibility;
-
-// writeDoubleLE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEDOUBLELE 1
-extern const char* const s_jsBufferPrototypeWriteDoubleLECode;
-extern const int s_jsBufferPrototypeWriteDoubleLECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteDoubleLECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteDoubleLECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteDoubleLECodeImplementationVisibility;
-
-// writeDoubleBE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEDOUBLEBE 1
-extern const char* const s_jsBufferPrototypeWriteDoubleBECode;
-extern const int s_jsBufferPrototypeWriteDoubleBECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteDoubleBECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteDoubleBECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteDoubleBECodeImplementationVisibility;
-
-// writeBigInt64LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEBIGINT64LE 1
-extern const char* const s_jsBufferPrototypeWriteBigInt64LECode;
-extern const int s_jsBufferPrototypeWriteBigInt64LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteBigInt64LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteBigInt64LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteBigInt64LECodeImplementationVisibility;
-
-// writeBigInt64BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEBIGINT64BE 1
-extern const char* const s_jsBufferPrototypeWriteBigInt64BECode;
-extern const int s_jsBufferPrototypeWriteBigInt64BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteBigInt64BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteBigInt64BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteBigInt64BECodeImplementationVisibility;
-
-// writeBigUInt64LE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEBIGUINT64LE 1
-extern const char* const s_jsBufferPrototypeWriteBigUInt64LECode;
-extern const int s_jsBufferPrototypeWriteBigUInt64LECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteBigUInt64LECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteBigUInt64LECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteBigUInt64LECodeImplementationVisibility;
-
-// writeBigUInt64BE
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_WRITEBIGUINT64BE 1
-extern const char* const s_jsBufferPrototypeWriteBigUInt64BECode;
-extern const int s_jsBufferPrototypeWriteBigUInt64BECodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeWriteBigUInt64BECodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeWriteBigUInt64BECodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeWriteBigUInt64BECodeImplementationVisibility;
-
-// utf8Write
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UTF8WRITE 1
-extern const char* const s_jsBufferPrototypeUtf8WriteCode;
-extern const int s_jsBufferPrototypeUtf8WriteCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeUtf8WriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeUtf8WriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeUtf8WriteCodeImplementationVisibility;
-
-// ucs2Write
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UCS2WRITE 1
-extern const char* const s_jsBufferPrototypeUcs2WriteCode;
-extern const int s_jsBufferPrototypeUcs2WriteCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeUcs2WriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeUcs2WriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeUcs2WriteCodeImplementationVisibility;
-
-// utf16leWrite
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UTF16LEWRITE 1
-extern const char* const s_jsBufferPrototypeUtf16leWriteCode;
-extern const int s_jsBufferPrototypeUtf16leWriteCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeUtf16leWriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeUtf16leWriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeUtf16leWriteCodeImplementationVisibility;
-
-// latin1Write
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_LATIN1WRITE 1
-extern const char* const s_jsBufferPrototypeLatin1WriteCode;
-extern const int s_jsBufferPrototypeLatin1WriteCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeLatin1WriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeLatin1WriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeLatin1WriteCodeImplementationVisibility;
-
-// asciiWrite
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_ASCIIWRITE 1
-extern const char* const s_jsBufferPrototypeAsciiWriteCode;
-extern const int s_jsBufferPrototypeAsciiWriteCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeAsciiWriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeAsciiWriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeAsciiWriteCodeImplementationVisibility;
-
-// base64Write
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_BASE64WRITE 1
-extern const char* const s_jsBufferPrototypeBase64WriteCode;
-extern const int s_jsBufferPrototypeBase64WriteCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeBase64WriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeBase64WriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeBase64WriteCodeImplementationVisibility;
-
-// base64urlWrite
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_BASE64URLWRITE 1
-extern const char* const s_jsBufferPrototypeBase64urlWriteCode;
-extern const int s_jsBufferPrototypeBase64urlWriteCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeBase64urlWriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeBase64urlWriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeBase64urlWriteCodeImplementationVisibility;
-
-// hexWrite
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_HEXWRITE 1
-extern const char* const s_jsBufferPrototypeHexWriteCode;
-extern const int s_jsBufferPrototypeHexWriteCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeHexWriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeHexWriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeHexWriteCodeImplementationVisibility;
-
-// utf8Slice
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UTF8SLICE 1
-extern const char* const s_jsBufferPrototypeUtf8SliceCode;
-extern const int s_jsBufferPrototypeUtf8SliceCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeUtf8SliceCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeUtf8SliceCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeUtf8SliceCodeImplementationVisibility;
-
-// ucs2Slice
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UCS2SLICE 1
-extern const char* const s_jsBufferPrototypeUcs2SliceCode;
-extern const int s_jsBufferPrototypeUcs2SliceCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeUcs2SliceCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeUcs2SliceCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeUcs2SliceCodeImplementationVisibility;
-
-// utf16leSlice
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_UTF16LESLICE 1
-extern const char* const s_jsBufferPrototypeUtf16leSliceCode;
-extern const int s_jsBufferPrototypeUtf16leSliceCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeUtf16leSliceCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeUtf16leSliceCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeUtf16leSliceCodeImplementationVisibility;
-
-// latin1Slice
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_LATIN1SLICE 1
-extern const char* const s_jsBufferPrototypeLatin1SliceCode;
-extern const int s_jsBufferPrototypeLatin1SliceCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeLatin1SliceCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeLatin1SliceCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeLatin1SliceCodeImplementationVisibility;
-
-// asciiSlice
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_ASCIISLICE 1
-extern const char* const s_jsBufferPrototypeAsciiSliceCode;
-extern const int s_jsBufferPrototypeAsciiSliceCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeAsciiSliceCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeAsciiSliceCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeAsciiSliceCodeImplementationVisibility;
-
-// base64Slice
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_BASE64SLICE 1
-extern const char* const s_jsBufferPrototypeBase64SliceCode;
-extern const int s_jsBufferPrototypeBase64SliceCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeBase64SliceCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeBase64SliceCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeBase64SliceCodeImplementationVisibility;
-
-// base64urlSlice
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_BASE64URLSLICE 1
-extern const char* const s_jsBufferPrototypeBase64urlSliceCode;
-extern const int s_jsBufferPrototypeBase64urlSliceCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeBase64urlSliceCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeBase64urlSliceCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeBase64urlSliceCodeImplementationVisibility;
-
-// hexSlice
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_HEXSLICE 1
-extern const char* const s_jsBufferPrototypeHexSliceCode;
-extern const int s_jsBufferPrototypeHexSliceCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeHexSliceCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeHexSliceCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeHexSliceCodeImplementationVisibility;
-
-// toJSON
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_TOJSON 1
-extern const char* const s_jsBufferPrototypeToJSONCode;
-extern const int s_jsBufferPrototypeToJSONCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeToJSONCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeToJSONCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeToJSONCodeImplementationVisibility;
-
-// slice
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_SLICE 1
-extern const char* const s_jsBufferPrototypeSliceCode;
-extern const int s_jsBufferPrototypeSliceCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeSliceCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeSliceCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeSliceCodeImplementationVisibility;
-
-// parent
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_PARENT 1
-extern const char* const s_jsBufferPrototypeParentCode;
-extern const int s_jsBufferPrototypeParentCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeParentCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeParentCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeParentCodeImplementationVisibility;
-
-// offset
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_OFFSET 1
-extern const char* const s_jsBufferPrototypeOffsetCode;
-extern const int s_jsBufferPrototypeOffsetCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeOffsetCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeOffsetCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeOffsetCodeImplementationVisibility;
-
-// inspect
-#define WEBCORE_BUILTIN_JSBUFFERPROTOTYPE_INSPECT 1
-extern const char* const s_jsBufferPrototypeInspectCode;
-extern const int s_jsBufferPrototypeInspectCodeLength;
-extern const JSC::ConstructAbility s_jsBufferPrototypeInspectCodeConstructAbility;
-extern const JSC::ConstructorKind s_jsBufferPrototypeInspectCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_jsBufferPrototypeInspectCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_DATA(macro) \
-    macro(setBigUint64, jsBufferPrototypeSetBigUint64, 3) \
-    macro(readInt8, jsBufferPrototypeReadInt8, 1) \
-    macro(readUInt8, jsBufferPrototypeReadUInt8, 1) \
-    macro(readInt16LE, jsBufferPrototypeReadInt16LE, 1) \
-    macro(readInt16BE, jsBufferPrototypeReadInt16BE, 1) \
-    macro(readUInt16LE, jsBufferPrototypeReadUInt16LE, 1) \
-    macro(readUInt16BE, jsBufferPrototypeReadUInt16BE, 1) \
-    macro(readInt32LE, jsBufferPrototypeReadInt32LE, 1) \
-    macro(readInt32BE, jsBufferPrototypeReadInt32BE, 1) \
-    macro(readUInt32LE, jsBufferPrototypeReadUInt32LE, 1) \
-    macro(readUInt32BE, jsBufferPrototypeReadUInt32BE, 1) \
-    macro(readIntLE, jsBufferPrototypeReadIntLE, 2) \
-    macro(readIntBE, jsBufferPrototypeReadIntBE, 2) \
-    macro(readUIntLE, jsBufferPrototypeReadUIntLE, 2) \
-    macro(readUIntBE, jsBufferPrototypeReadUIntBE, 2) \
-    macro(readFloatLE, jsBufferPrototypeReadFloatLE, 1) \
-    macro(readFloatBE, jsBufferPrototypeReadFloatBE, 1) \
-    macro(readDoubleLE, jsBufferPrototypeReadDoubleLE, 1) \
-    macro(readDoubleBE, jsBufferPrototypeReadDoubleBE, 1) \
-    macro(readBigInt64LE, jsBufferPrototypeReadBigInt64LE, 1) \
-    macro(readBigInt64BE, jsBufferPrototypeReadBigInt64BE, 1) \
-    macro(readBigUInt64LE, jsBufferPrototypeReadBigUInt64LE, 1) \
-    macro(readBigUInt64BE, jsBufferPrototypeReadBigUInt64BE, 1) \
-    macro(writeInt8, jsBufferPrototypeWriteInt8, 2) \
-    macro(writeUInt8, jsBufferPrototypeWriteUInt8, 2) \
-    macro(writeInt16LE, jsBufferPrototypeWriteInt16LE, 2) \
-    macro(writeInt16BE, jsBufferPrototypeWriteInt16BE, 2) \
-    macro(writeUInt16LE, jsBufferPrototypeWriteUInt16LE, 2) \
-    macro(writeUInt16BE, jsBufferPrototypeWriteUInt16BE, 2) \
-    macro(writeInt32LE, jsBufferPrototypeWriteInt32LE, 2) \
-    macro(writeInt32BE, jsBufferPrototypeWriteInt32BE, 2) \
-    macro(writeUInt32LE, jsBufferPrototypeWriteUInt32LE, 2) \
-    macro(writeUInt32BE, jsBufferPrototypeWriteUInt32BE, 2) \
-    macro(writeIntLE, jsBufferPrototypeWriteIntLE, 3) \
-    macro(writeIntBE, jsBufferPrototypeWriteIntBE, 3) \
-    macro(writeUIntLE, jsBufferPrototypeWriteUIntLE, 3) \
-    macro(writeUIntBE, jsBufferPrototypeWriteUIntBE, 3) \
-    macro(writeFloatLE, jsBufferPrototypeWriteFloatLE, 2) \
-    macro(writeFloatBE, jsBufferPrototypeWriteFloatBE, 2) \
-    macro(writeDoubleLE, jsBufferPrototypeWriteDoubleLE, 2) \
-    macro(writeDoubleBE, jsBufferPrototypeWriteDoubleBE, 2) \
-    macro(writeBigInt64LE, jsBufferPrototypeWriteBigInt64LE, 2) \
-    macro(writeBigInt64BE, jsBufferPrototypeWriteBigInt64BE, 2) \
-    macro(writeBigUInt64LE, jsBufferPrototypeWriteBigUInt64LE, 2) \
-    macro(writeBigUInt64BE, jsBufferPrototypeWriteBigUInt64BE, 2) \
-    macro(utf8Write, jsBufferPrototypeUtf8Write, 3) \
-    macro(ucs2Write, jsBufferPrototypeUcs2Write, 3) \
-    macro(utf16leWrite, jsBufferPrototypeUtf16leWrite, 3) \
-    macro(latin1Write, jsBufferPrototypeLatin1Write, 3) \
-    macro(asciiWrite, jsBufferPrototypeAsciiWrite, 3) \
-    macro(base64Write, jsBufferPrototypeBase64Write, 3) \
-    macro(base64urlWrite, jsBufferPrototypeBase64urlWrite, 3) \
-    macro(hexWrite, jsBufferPrototypeHexWrite, 3) \
-    macro(utf8Slice, jsBufferPrototypeUtf8Slice, 2) \
-    macro(ucs2Slice, jsBufferPrototypeUcs2Slice, 2) \
-    macro(utf16leSlice, jsBufferPrototypeUtf16leSlice, 2) \
-    macro(latin1Slice, jsBufferPrototypeLatin1Slice, 2) \
-    macro(asciiSlice, jsBufferPrototypeAsciiSlice, 2) \
-    macro(base64Slice, jsBufferPrototypeBase64Slice, 2) \
-    macro(base64urlSlice, jsBufferPrototypeBase64urlSlice, 2) \
-    macro(hexSlice, jsBufferPrototypeHexSlice, 2) \
-    macro(toJSON, jsBufferPrototypeToJSON, 0) \
-    macro(slice, jsBufferPrototypeSlice, 2) \
-    macro(parent, jsBufferPrototypeParent, 0) \
-    macro(offset, jsBufferPrototypeOffset, 0) \
-    macro(inspect, jsBufferPrototypeInspect, 2) \
-
-#define WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(macro) \
-    macro(jsBufferPrototypeSetBigUint64Code, setBigUint64, ASCIILiteral(), s_jsBufferPrototypeSetBigUint64CodeLength) \
-    macro(jsBufferPrototypeReadInt8Code, readInt8, ASCIILiteral(), s_jsBufferPrototypeReadInt8CodeLength) \
-    macro(jsBufferPrototypeReadUInt8Code, readUInt8, ASCIILiteral(), s_jsBufferPrototypeReadUInt8CodeLength) \
-    macro(jsBufferPrototypeReadInt16LECode, readInt16LE, ASCIILiteral(), s_jsBufferPrototypeReadInt16LECodeLength) \
-    macro(jsBufferPrototypeReadInt16BECode, readInt16BE, ASCIILiteral(), s_jsBufferPrototypeReadInt16BECodeLength) \
-    macro(jsBufferPrototypeReadUInt16LECode, readUInt16LE, ASCIILiteral(), s_jsBufferPrototypeReadUInt16LECodeLength) \
-    macro(jsBufferPrototypeReadUInt16BECode, readUInt16BE, ASCIILiteral(), s_jsBufferPrototypeReadUInt16BECodeLength) \
-    macro(jsBufferPrototypeReadInt32LECode, readInt32LE, ASCIILiteral(), s_jsBufferPrototypeReadInt32LECodeLength) \
-    macro(jsBufferPrototypeReadInt32BECode, readInt32BE, ASCIILiteral(), s_jsBufferPrototypeReadInt32BECodeLength) \
-    macro(jsBufferPrototypeReadUInt32LECode, readUInt32LE, ASCIILiteral(), s_jsBufferPrototypeReadUInt32LECodeLength) \
-    macro(jsBufferPrototypeReadUInt32BECode, readUInt32BE, ASCIILiteral(), s_jsBufferPrototypeReadUInt32BECodeLength) \
-    macro(jsBufferPrototypeReadIntLECode, readIntLE, ASCIILiteral(), s_jsBufferPrototypeReadIntLECodeLength) \
-    macro(jsBufferPrototypeReadIntBECode, readIntBE, ASCIILiteral(), s_jsBufferPrototypeReadIntBECodeLength) \
-    macro(jsBufferPrototypeReadUIntLECode, readUIntLE, ASCIILiteral(), s_jsBufferPrototypeReadUIntLECodeLength) \
-    macro(jsBufferPrototypeReadUIntBECode, readUIntBE, ASCIILiteral(), s_jsBufferPrototypeReadUIntBECodeLength) \
-    macro(jsBufferPrototypeReadFloatLECode, readFloatLE, ASCIILiteral(), s_jsBufferPrototypeReadFloatLECodeLength) \
-    macro(jsBufferPrototypeReadFloatBECode, readFloatBE, ASCIILiteral(), s_jsBufferPrototypeReadFloatBECodeLength) \
-    macro(jsBufferPrototypeReadDoubleLECode, readDoubleLE, ASCIILiteral(), s_jsBufferPrototypeReadDoubleLECodeLength) \
-    macro(jsBufferPrototypeReadDoubleBECode, readDoubleBE, ASCIILiteral(), s_jsBufferPrototypeReadDoubleBECodeLength) \
-    macro(jsBufferPrototypeReadBigInt64LECode, readBigInt64LE, ASCIILiteral(), s_jsBufferPrototypeReadBigInt64LECodeLength) \
-    macro(jsBufferPrototypeReadBigInt64BECode, readBigInt64BE, ASCIILiteral(), s_jsBufferPrototypeReadBigInt64BECodeLength) \
-    macro(jsBufferPrototypeReadBigUInt64LECode, readBigUInt64LE, ASCIILiteral(), s_jsBufferPrototypeReadBigUInt64LECodeLength) \
-    macro(jsBufferPrototypeReadBigUInt64BECode, readBigUInt64BE, ASCIILiteral(), s_jsBufferPrototypeReadBigUInt64BECodeLength) \
-    macro(jsBufferPrototypeWriteInt8Code, writeInt8, ASCIILiteral(), s_jsBufferPrototypeWriteInt8CodeLength) \
-    macro(jsBufferPrototypeWriteUInt8Code, writeUInt8, ASCIILiteral(), s_jsBufferPrototypeWriteUInt8CodeLength) \
-    macro(jsBufferPrototypeWriteInt16LECode, writeInt16LE, ASCIILiteral(), s_jsBufferPrototypeWriteInt16LECodeLength) \
-    macro(jsBufferPrototypeWriteInt16BECode, writeInt16BE, ASCIILiteral(), s_jsBufferPrototypeWriteInt16BECodeLength) \
-    macro(jsBufferPrototypeWriteUInt16LECode, writeUInt16LE, ASCIILiteral(), s_jsBufferPrototypeWriteUInt16LECodeLength) \
-    macro(jsBufferPrototypeWriteUInt16BECode, writeUInt16BE, ASCIILiteral(), s_jsBufferPrototypeWriteUInt16BECodeLength) \
-    macro(jsBufferPrototypeWriteInt32LECode, writeInt32LE, ASCIILiteral(), s_jsBufferPrototypeWriteInt32LECodeLength) \
-    macro(jsBufferPrototypeWriteInt32BECode, writeInt32BE, ASCIILiteral(), s_jsBufferPrototypeWriteInt32BECodeLength) \
-    macro(jsBufferPrototypeWriteUInt32LECode, writeUInt32LE, ASCIILiteral(), s_jsBufferPrototypeWriteUInt32LECodeLength) \
-    macro(jsBufferPrototypeWriteUInt32BECode, writeUInt32BE, ASCIILiteral(), s_jsBufferPrototypeWriteUInt32BECodeLength) \
-    macro(jsBufferPrototypeWriteIntLECode, writeIntLE, ASCIILiteral(), s_jsBufferPrototypeWriteIntLECodeLength) \
-    macro(jsBufferPrototypeWriteIntBECode, writeIntBE, ASCIILiteral(), s_jsBufferPrototypeWriteIntBECodeLength) \
-    macro(jsBufferPrototypeWriteUIntLECode, writeUIntLE, ASCIILiteral(), s_jsBufferPrototypeWriteUIntLECodeLength) \
-    macro(jsBufferPrototypeWriteUIntBECode, writeUIntBE, ASCIILiteral(), s_jsBufferPrototypeWriteUIntBECodeLength) \
-    macro(jsBufferPrototypeWriteFloatLECode, writeFloatLE, ASCIILiteral(), s_jsBufferPrototypeWriteFloatLECodeLength) \
-    macro(jsBufferPrototypeWriteFloatBECode, writeFloatBE, ASCIILiteral(), s_jsBufferPrototypeWriteFloatBECodeLength) \
-    macro(jsBufferPrototypeWriteDoubleLECode, writeDoubleLE, ASCIILiteral(), s_jsBufferPrototypeWriteDoubleLECodeLength) \
-    macro(jsBufferPrototypeWriteDoubleBECode, writeDoubleBE, ASCIILiteral(), s_jsBufferPrototypeWriteDoubleBECodeLength) \
-    macro(jsBufferPrototypeWriteBigInt64LECode, writeBigInt64LE, ASCIILiteral(), s_jsBufferPrototypeWriteBigInt64LECodeLength) \
-    macro(jsBufferPrototypeWriteBigInt64BECode, writeBigInt64BE, ASCIILiteral(), s_jsBufferPrototypeWriteBigInt64BECodeLength) \
-    macro(jsBufferPrototypeWriteBigUInt64LECode, writeBigUInt64LE, ASCIILiteral(), s_jsBufferPrototypeWriteBigUInt64LECodeLength) \
-    macro(jsBufferPrototypeWriteBigUInt64BECode, writeBigUInt64BE, ASCIILiteral(), s_jsBufferPrototypeWriteBigUInt64BECodeLength) \
-    macro(jsBufferPrototypeUtf8WriteCode, utf8Write, ASCIILiteral(), s_jsBufferPrototypeUtf8WriteCodeLength) \
-    macro(jsBufferPrototypeUcs2WriteCode, ucs2Write, ASCIILiteral(), s_jsBufferPrototypeUcs2WriteCodeLength) \
-    macro(jsBufferPrototypeUtf16leWriteCode, utf16leWrite, ASCIILiteral(), s_jsBufferPrototypeUtf16leWriteCodeLength) \
-    macro(jsBufferPrototypeLatin1WriteCode, latin1Write, ASCIILiteral(), s_jsBufferPrototypeLatin1WriteCodeLength) \
-    macro(jsBufferPrototypeAsciiWriteCode, asciiWrite, ASCIILiteral(), s_jsBufferPrototypeAsciiWriteCodeLength) \
-    macro(jsBufferPrototypeBase64WriteCode, base64Write, ASCIILiteral(), s_jsBufferPrototypeBase64WriteCodeLength) \
-    macro(jsBufferPrototypeBase64urlWriteCode, base64urlWrite, ASCIILiteral(), s_jsBufferPrototypeBase64urlWriteCodeLength) \
-    macro(jsBufferPrototypeHexWriteCode, hexWrite, ASCIILiteral(), s_jsBufferPrototypeHexWriteCodeLength) \
-    macro(jsBufferPrototypeUtf8SliceCode, utf8Slice, ASCIILiteral(), s_jsBufferPrototypeUtf8SliceCodeLength) \
-    macro(jsBufferPrototypeUcs2SliceCode, ucs2Slice, ASCIILiteral(), s_jsBufferPrototypeUcs2SliceCodeLength) \
-    macro(jsBufferPrototypeUtf16leSliceCode, utf16leSlice, ASCIILiteral(), s_jsBufferPrototypeUtf16leSliceCodeLength) \
-    macro(jsBufferPrototypeLatin1SliceCode, latin1Slice, ASCIILiteral(), s_jsBufferPrototypeLatin1SliceCodeLength) \
-    macro(jsBufferPrototypeAsciiSliceCode, asciiSlice, ASCIILiteral(), s_jsBufferPrototypeAsciiSliceCodeLength) \
-    macro(jsBufferPrototypeBase64SliceCode, base64Slice, ASCIILiteral(), s_jsBufferPrototypeBase64SliceCodeLength) \
-    macro(jsBufferPrototypeBase64urlSliceCode, base64urlSlice, ASCIILiteral(), s_jsBufferPrototypeBase64urlSliceCodeLength) \
-    macro(jsBufferPrototypeHexSliceCode, hexSlice, ASCIILiteral(), s_jsBufferPrototypeHexSliceCodeLength) \
-    macro(jsBufferPrototypeToJSONCode, toJSON, ASCIILiteral(), s_jsBufferPrototypeToJSONCodeLength) \
-    macro(jsBufferPrototypeSliceCode, slice, ASCIILiteral(), s_jsBufferPrototypeSliceCodeLength) \
-    macro(jsBufferPrototypeParentCode, parent, "get parent"_s, s_jsBufferPrototypeParentCodeLength) \
-    macro(jsBufferPrototypeOffsetCode, offset, "get offset"_s, s_jsBufferPrototypeOffsetCodeLength) \
-    macro(jsBufferPrototypeInspectCode, inspect, ASCIILiteral(), s_jsBufferPrototypeInspectCodeLength) \
-
-#define WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_FUNCTION_NAME(macro) \
-    macro(setBigUint64) \
-    macro(readInt8) \
-    macro(readUInt8) \
-    macro(readInt16LE) \
-    macro(readInt16BE) \
-    macro(readUInt16LE) \
-    macro(readUInt16BE) \
-    macro(readInt32LE) \
-    macro(readInt32BE) \
-    macro(readUInt32LE) \
-    macro(readUInt32BE) \
-    macro(readIntLE) \
-    macro(readIntBE) \
-    macro(readUIntLE) \
-    macro(readUIntBE) \
-    macro(readFloatLE) \
-    macro(readFloatBE) \
-    macro(readDoubleLE) \
-    macro(readDoubleBE) \
-    macro(readBigInt64LE) \
-    macro(readBigInt64BE) \
-    macro(readBigUInt64LE) \
-    macro(readBigUInt64BE) \
-    macro(writeInt8) \
-    macro(writeUInt8) \
-    macro(writeInt16LE) \
-    macro(writeInt16BE) \
-    macro(writeUInt16LE) \
-    macro(writeUInt16BE) \
-    macro(writeInt32LE) \
-    macro(writeInt32BE) \
-    macro(writeUInt32LE) \
-    macro(writeUInt32BE) \
-    macro(writeIntLE) \
-    macro(writeIntBE) \
-    macro(writeUIntLE) \
-    macro(writeUIntBE) \
-    macro(writeFloatLE) \
-    macro(writeFloatBE) \
-    macro(writeDoubleLE) \
-    macro(writeDoubleBE) \
-    macro(writeBigInt64LE) \
-    macro(writeBigInt64BE) \
-    macro(writeBigUInt64LE) \
-    macro(writeBigUInt64BE) \
-    macro(utf8Write) \
-    macro(ucs2Write) \
-    macro(utf16leWrite) \
-    macro(latin1Write) \
-    macro(asciiWrite) \
-    macro(base64Write) \
-    macro(base64urlWrite) \
-    macro(hexWrite) \
-    macro(utf8Slice) \
-    macro(ucs2Slice) \
-    macro(utf16leSlice) \
-    macro(latin1Slice) \
-    macro(asciiSlice) \
-    macro(base64Slice) \
-    macro(base64urlSlice) \
-    macro(hexSlice) \
-    macro(toJSON) \
-    macro(slice) \
-    macro(parent) \
-    macro(offset) \
-    macro(inspect) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class JSBufferPrototypeBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit JSBufferPrototypeBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* JSBufferPrototypeBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void JSBufferPrototypeBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_JSBUFFERPROTOTYPE_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-/* ReadableStream.ts */
-// initializeReadableStream
-#define WEBCORE_BUILTIN_READABLESTREAM_INITIALIZEREADABLESTREAM 1
-extern const char* const s_readableStreamInitializeReadableStreamCode;
-extern const int s_readableStreamInitializeReadableStreamCodeLength;
-extern const JSC::ConstructAbility s_readableStreamInitializeReadableStreamCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamInitializeReadableStreamCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamInitializeReadableStreamCodeImplementationVisibility;
-
-// readableStreamToArray
-#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOARRAY 1
-extern const char* const s_readableStreamReadableStreamToArrayCode;
-extern const int s_readableStreamReadableStreamToArrayCodeLength;
-extern const JSC::ConstructAbility s_readableStreamReadableStreamToArrayCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamReadableStreamToArrayCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToArrayCodeImplementationVisibility;
-
-// readableStreamToText
-#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOTEXT 1
-extern const char* const s_readableStreamReadableStreamToTextCode;
-extern const int s_readableStreamReadableStreamToTextCodeLength;
-extern const JSC::ConstructAbility s_readableStreamReadableStreamToTextCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamReadableStreamToTextCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToTextCodeImplementationVisibility;
-
-// readableStreamToArrayBuffer
-#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOARRAYBUFFER 1
-extern const char* const s_readableStreamReadableStreamToArrayBufferCode;
-extern const int s_readableStreamReadableStreamToArrayBufferCodeLength;
-extern const JSC::ConstructAbility s_readableStreamReadableStreamToArrayBufferCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamReadableStreamToArrayBufferCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToArrayBufferCodeImplementationVisibility;
-
-// readableStreamToFormData
-#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOFORMDATA 1
-extern const char* const s_readableStreamReadableStreamToFormDataCode;
-extern const int s_readableStreamReadableStreamToFormDataCodeLength;
-extern const JSC::ConstructAbility s_readableStreamReadableStreamToFormDataCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamReadableStreamToFormDataCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToFormDataCodeImplementationVisibility;
-
-// readableStreamToJSON
-#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOJSON 1
-extern const char* const s_readableStreamReadableStreamToJSONCode;
-extern const int s_readableStreamReadableStreamToJSONCodeLength;
-extern const JSC::ConstructAbility s_readableStreamReadableStreamToJSONCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamReadableStreamToJSONCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToJSONCodeImplementationVisibility;
-
-// readableStreamToBlob
-#define WEBCORE_BUILTIN_READABLESTREAM_READABLESTREAMTOBLOB 1
-extern const char* const s_readableStreamReadableStreamToBlobCode;
-extern const int s_readableStreamReadableStreamToBlobCodeLength;
-extern const JSC::ConstructAbility s_readableStreamReadableStreamToBlobCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamReadableStreamToBlobCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamReadableStreamToBlobCodeImplementationVisibility;
-
-// consumeReadableStream
-#define WEBCORE_BUILTIN_READABLESTREAM_CONSUMEREADABLESTREAM 1
-extern const char* const s_readableStreamConsumeReadableStreamCode;
-extern const int s_readableStreamConsumeReadableStreamCodeLength;
-extern const JSC::ConstructAbility s_readableStreamConsumeReadableStreamCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamConsumeReadableStreamCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamConsumeReadableStreamCodeImplementationVisibility;
-
-// createEmptyReadableStream
-#define WEBCORE_BUILTIN_READABLESTREAM_CREATEEMPTYREADABLESTREAM 1
-extern const char* const s_readableStreamCreateEmptyReadableStreamCode;
-extern const int s_readableStreamCreateEmptyReadableStreamCodeLength;
-extern const JSC::ConstructAbility s_readableStreamCreateEmptyReadableStreamCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamCreateEmptyReadableStreamCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamCreateEmptyReadableStreamCodeImplementationVisibility;
-
-// createNativeReadableStream
-#define WEBCORE_BUILTIN_READABLESTREAM_CREATENATIVEREADABLESTREAM 1
-extern const char* const s_readableStreamCreateNativeReadableStreamCode;
-extern const int s_readableStreamCreateNativeReadableStreamCodeLength;
-extern const JSC::ConstructAbility s_readableStreamCreateNativeReadableStreamCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamCreateNativeReadableStreamCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamCreateNativeReadableStreamCodeImplementationVisibility;
-
-// cancel
-#define WEBCORE_BUILTIN_READABLESTREAM_CANCEL 1
-extern const char* const s_readableStreamCancelCode;
-extern const int s_readableStreamCancelCodeLength;
-extern const JSC::ConstructAbility s_readableStreamCancelCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamCancelCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamCancelCodeImplementationVisibility;
-
-// getReader
-#define WEBCORE_BUILTIN_READABLESTREAM_GETREADER 1
-extern const char* const s_readableStreamGetReaderCode;
-extern const int s_readableStreamGetReaderCodeLength;
-extern const JSC::ConstructAbility s_readableStreamGetReaderCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamGetReaderCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamGetReaderCodeImplementationVisibility;
-
-// pipeThrough
-#define WEBCORE_BUILTIN_READABLESTREAM_PIPETHROUGH 1
-extern const char* const s_readableStreamPipeThroughCode;
-extern const int s_readableStreamPipeThroughCodeLength;
-extern const JSC::ConstructAbility s_readableStreamPipeThroughCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamPipeThroughCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamPipeThroughCodeImplementationVisibility;
-
-// pipeTo
-#define WEBCORE_BUILTIN_READABLESTREAM_PIPETO 1
-extern const char* const s_readableStreamPipeToCode;
-extern const int s_readableStreamPipeToCodeLength;
-extern const JSC::ConstructAbility s_readableStreamPipeToCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamPipeToCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamPipeToCodeImplementationVisibility;
-
-// tee
-#define WEBCORE_BUILTIN_READABLESTREAM_TEE 1
-extern const char* const s_readableStreamTeeCode;
-extern const int s_readableStreamTeeCodeLength;
-extern const JSC::ConstructAbility s_readableStreamTeeCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamTeeCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamTeeCodeImplementationVisibility;
-
-// locked
-#define WEBCORE_BUILTIN_READABLESTREAM_LOCKED 1
-extern const char* const s_readableStreamLockedCode;
-extern const int s_readableStreamLockedCodeLength;
-extern const JSC::ConstructAbility s_readableStreamLockedCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamLockedCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamLockedCodeImplementationVisibility;
-
-// values
-#define WEBCORE_BUILTIN_READABLESTREAM_VALUES 1
-extern const char* const s_readableStreamValuesCode;
-extern const int s_readableStreamValuesCodeLength;
-extern const JSC::ConstructAbility s_readableStreamValuesCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamValuesCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamValuesCodeImplementationVisibility;
-
-// lazyAsyncIterator
-#define WEBCORE_BUILTIN_READABLESTREAM_LAZYASYNCITERATOR 1
-extern const char* const s_readableStreamLazyAsyncIteratorCode;
-extern const int s_readableStreamLazyAsyncIteratorCodeLength;
-extern const JSC::ConstructAbility s_readableStreamLazyAsyncIteratorCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamLazyAsyncIteratorCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamLazyAsyncIteratorCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_READABLESTREAM_BUILTIN_DATA(macro) \
-    macro(initializeReadableStream, readableStreamInitializeReadableStream, 3) \
-    macro(readableStreamToArray, readableStreamReadableStreamToArray, 1) \
-    macro(readableStreamToText, readableStreamReadableStreamToText, 1) \
-    macro(readableStreamToArrayBuffer, readableStreamReadableStreamToArrayBuffer, 1) \
-    macro(readableStreamToFormData, readableStreamReadableStreamToFormData, 3) \
-    macro(readableStreamToJSON, readableStreamReadableStreamToJSON, 1) \
-    macro(readableStreamToBlob, readableStreamReadableStreamToBlob, 1) \
-    macro(consumeReadableStream, readableStreamConsumeReadableStream, 3) \
-    macro(createEmptyReadableStream, readableStreamCreateEmptyReadableStream, 0) \
-    macro(createNativeReadableStream, readableStreamCreateNativeReadableStream, 3) \
-    macro(cancel, readableStreamCancel, 1) \
-    macro(getReader, readableStreamGetReader, 1) \
-    macro(pipeThrough, readableStreamPipeThrough, 2) \
-    macro(pipeTo, readableStreamPipeTo, 1) \
-    macro(tee, readableStreamTee, 0) \
-    macro(locked, readableStreamLocked, 0) \
-    macro(values, readableStreamValues, 1) \
-    macro(lazyAsyncIterator, readableStreamLazyAsyncIterator, 0) \
-
-#define WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(macro) \
-    macro(readableStreamInitializeReadableStreamCode, initializeReadableStream, ASCIILiteral(), s_readableStreamInitializeReadableStreamCodeLength) \
-    macro(readableStreamReadableStreamToArrayCode, readableStreamToArray, ASCIILiteral(), s_readableStreamReadableStreamToArrayCodeLength) \
-    macro(readableStreamReadableStreamToTextCode, readableStreamToText, ASCIILiteral(), s_readableStreamReadableStreamToTextCodeLength) \
-    macro(readableStreamReadableStreamToArrayBufferCode, readableStreamToArrayBuffer, ASCIILiteral(), s_readableStreamReadableStreamToArrayBufferCodeLength) \
-    macro(readableStreamReadableStreamToFormDataCode, readableStreamToFormData, ASCIILiteral(), s_readableStreamReadableStreamToFormDataCodeLength) \
-    macro(readableStreamReadableStreamToJSONCode, readableStreamToJSON, ASCIILiteral(), s_readableStreamReadableStreamToJSONCodeLength) \
-    macro(readableStreamReadableStreamToBlobCode, readableStreamToBlob, ASCIILiteral(), s_readableStreamReadableStreamToBlobCodeLength) \
-    macro(readableStreamConsumeReadableStreamCode, consumeReadableStream, ASCIILiteral(), s_readableStreamConsumeReadableStreamCodeLength) \
-    macro(readableStreamCreateEmptyReadableStreamCode, createEmptyReadableStream, ASCIILiteral(), s_readableStreamCreateEmptyReadableStreamCodeLength) \
-    macro(readableStreamCreateNativeReadableStreamCode, createNativeReadableStream, ASCIILiteral(), s_readableStreamCreateNativeReadableStreamCodeLength) \
-    macro(readableStreamCancelCode, cancel, ASCIILiteral(), s_readableStreamCancelCodeLength) \
-    macro(readableStreamGetReaderCode, getReader, ASCIILiteral(), s_readableStreamGetReaderCodeLength) \
-    macro(readableStreamPipeThroughCode, pipeThrough, ASCIILiteral(), s_readableStreamPipeThroughCodeLength) \
-    macro(readableStreamPipeToCode, pipeTo, ASCIILiteral(), s_readableStreamPipeToCodeLength) \
-    macro(readableStreamTeeCode, tee, ASCIILiteral(), s_readableStreamTeeCodeLength) \
-    macro(readableStreamLockedCode, locked, "get locked"_s, s_readableStreamLockedCodeLength) \
-    macro(readableStreamValuesCode, values, ASCIILiteral(), s_readableStreamValuesCodeLength) \
-    macro(readableStreamLazyAsyncIteratorCode, lazyAsyncIterator, ASCIILiteral(), s_readableStreamLazyAsyncIteratorCodeLength) \
-
-#define WEBCORE_FOREACH_READABLESTREAM_BUILTIN_FUNCTION_NAME(macro) \
-    macro(initializeReadableStream) \
-    macro(readableStreamToArray) \
-    macro(readableStreamToText) \
-    macro(readableStreamToArrayBuffer) \
-    macro(readableStreamToFormData) \
-    macro(readableStreamToJSON) \
-    macro(readableStreamToBlob) \
-    macro(consumeReadableStream) \
-    macro(createEmptyReadableStream) \
-    macro(createNativeReadableStream) \
-    macro(cancel) \
-    macro(getReader) \
-    macro(pipeThrough) \
-    macro(pipeTo) \
-    macro(tee) \
-    macro(locked) \
-    macro(values) \
-    macro(lazyAsyncIterator) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class ReadableStreamBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit ReadableStreamBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_READABLESTREAM_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_READABLESTREAM_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_READABLESTREAM_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* ReadableStreamBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_READABLESTREAM_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void ReadableStreamBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_READABLESTREAM_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-/* BundlerPlugin.ts */
-// runSetupFunction
-#define WEBCORE_BUILTIN_BUNDLERPLUGIN_RUNSETUPFUNCTION 1
-extern const char* const s_bundlerPluginRunSetupFunctionCode;
-extern const int s_bundlerPluginRunSetupFunctionCodeLength;
-extern const JSC::ConstructAbility s_bundlerPluginRunSetupFunctionCodeConstructAbility;
-extern const JSC::ConstructorKind s_bundlerPluginRunSetupFunctionCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_bundlerPluginRunSetupFunctionCodeImplementationVisibility;
-
-// runOnResolvePlugins
-#define WEBCORE_BUILTIN_BUNDLERPLUGIN_RUNONRESOLVEPLUGINS 1
-extern const char* const s_bundlerPluginRunOnResolvePluginsCode;
-extern const int s_bundlerPluginRunOnResolvePluginsCodeLength;
-extern const JSC::ConstructAbility s_bundlerPluginRunOnResolvePluginsCodeConstructAbility;
-extern const JSC::ConstructorKind s_bundlerPluginRunOnResolvePluginsCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_bundlerPluginRunOnResolvePluginsCodeImplementationVisibility;
-
-// runOnLoadPlugins
-#define WEBCORE_BUILTIN_BUNDLERPLUGIN_RUNONLOADPLUGINS 1
-extern const char* const s_bundlerPluginRunOnLoadPluginsCode;
-extern const int s_bundlerPluginRunOnLoadPluginsCodeLength;
-extern const JSC::ConstructAbility s_bundlerPluginRunOnLoadPluginsCodeConstructAbility;
-extern const JSC::ConstructorKind s_bundlerPluginRunOnLoadPluginsCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_bundlerPluginRunOnLoadPluginsCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_DATA(macro) \
-    macro(runSetupFunction, bundlerPluginRunSetupFunction, 2) \
-    macro(runOnResolvePlugins, bundlerPluginRunOnResolvePlugins, 5) \
-    macro(runOnLoadPlugins, bundlerPluginRunOnLoadPlugins, 4) \
-
-#define WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(macro) \
-    macro(bundlerPluginRunSetupFunctionCode, runSetupFunction, ASCIILiteral(), s_bundlerPluginRunSetupFunctionCodeLength) \
-    macro(bundlerPluginRunOnResolvePluginsCode, runOnResolvePlugins, ASCIILiteral(), s_bundlerPluginRunOnResolvePluginsCodeLength) \
-    macro(bundlerPluginRunOnLoadPluginsCode, runOnLoadPlugins, ASCIILiteral(), s_bundlerPluginRunOnLoadPluginsCodeLength) \
-
-#define WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_FUNCTION_NAME(macro) \
-    macro(runSetupFunction) \
-    macro(runOnResolvePlugins) \
-    macro(runOnLoadPlugins) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class BundlerPluginBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit BundlerPluginBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* BundlerPluginBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void BundlerPluginBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_BUNDLERPLUGIN_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-/* StreamInternals.ts */
-// markPromiseAsHandled
-#define WEBCORE_BUILTIN_STREAMINTERNALS_MARKPROMISEASHANDLED 1
-extern const char* const s_streamInternalsMarkPromiseAsHandledCode;
-extern const int s_streamInternalsMarkPromiseAsHandledCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsMarkPromiseAsHandledCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsMarkPromiseAsHandledCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsMarkPromiseAsHandledCodeImplementationVisibility;
-
-// shieldingPromiseResolve
-#define WEBCORE_BUILTIN_STREAMINTERNALS_SHIELDINGPROMISERESOLVE 1
-extern const char* const s_streamInternalsShieldingPromiseResolveCode;
-extern const int s_streamInternalsShieldingPromiseResolveCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsShieldingPromiseResolveCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsShieldingPromiseResolveCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsShieldingPromiseResolveCodeImplementationVisibility;
-
-// promiseInvokeOrNoopMethodNoCatch
-#define WEBCORE_BUILTIN_STREAMINTERNALS_PROMISEINVOKEORNOOPMETHODNOCATCH 1
-extern const char* const s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCode;
-extern const int s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCodeImplementationVisibility;
-
-// promiseInvokeOrNoopNoCatch
-#define WEBCORE_BUILTIN_STREAMINTERNALS_PROMISEINVOKEORNOOPNOCATCH 1
-extern const char* const s_streamInternalsPromiseInvokeOrNoopNoCatchCode;
-extern const int s_streamInternalsPromiseInvokeOrNoopNoCatchCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsPromiseInvokeOrNoopNoCatchCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsPromiseInvokeOrNoopNoCatchCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsPromiseInvokeOrNoopNoCatchCodeImplementationVisibility;
-
-// promiseInvokeOrNoopMethod
-#define WEBCORE_BUILTIN_STREAMINTERNALS_PROMISEINVOKEORNOOPMETHOD 1
-extern const char* const s_streamInternalsPromiseInvokeOrNoopMethodCode;
-extern const int s_streamInternalsPromiseInvokeOrNoopMethodCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsPromiseInvokeOrNoopMethodCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsPromiseInvokeOrNoopMethodCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsPromiseInvokeOrNoopMethodCodeImplementationVisibility;
-
-// promiseInvokeOrNoop
-#define WEBCORE_BUILTIN_STREAMINTERNALS_PROMISEINVOKEORNOOP 1
-extern const char* const s_streamInternalsPromiseInvokeOrNoopCode;
-extern const int s_streamInternalsPromiseInvokeOrNoopCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsPromiseInvokeOrNoopCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsPromiseInvokeOrNoopCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsPromiseInvokeOrNoopCodeImplementationVisibility;
-
-// promiseInvokeOrFallbackOrNoop
-#define WEBCORE_BUILTIN_STREAMINTERNALS_PROMISEINVOKEORFALLBACKORNOOP 1
-extern const char* const s_streamInternalsPromiseInvokeOrFallbackOrNoopCode;
-extern const int s_streamInternalsPromiseInvokeOrFallbackOrNoopCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsPromiseInvokeOrFallbackOrNoopCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsPromiseInvokeOrFallbackOrNoopCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsPromiseInvokeOrFallbackOrNoopCodeImplementationVisibility;
-
-// validateAndNormalizeQueuingStrategy
-#define WEBCORE_BUILTIN_STREAMINTERNALS_VALIDATEANDNORMALIZEQUEUINGSTRATEGY 1
-extern const char* const s_streamInternalsValidateAndNormalizeQueuingStrategyCode;
-extern const int s_streamInternalsValidateAndNormalizeQueuingStrategyCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsValidateAndNormalizeQueuingStrategyCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsValidateAndNormalizeQueuingStrategyCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsValidateAndNormalizeQueuingStrategyCodeImplementationVisibility;
-
-// createFIFO
-#define WEBCORE_BUILTIN_STREAMINTERNALS_CREATEFIFO 1
-extern const char* const s_streamInternalsCreateFIFOCode;
-extern const int s_streamInternalsCreateFIFOCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsCreateFIFOCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsCreateFIFOCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsCreateFIFOCodeImplementationVisibility;
-
-// newQueue
-#define WEBCORE_BUILTIN_STREAMINTERNALS_NEWQUEUE 1
-extern const char* const s_streamInternalsNewQueueCode;
-extern const int s_streamInternalsNewQueueCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsNewQueueCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsNewQueueCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsNewQueueCodeImplementationVisibility;
-
-// dequeueValue
-#define WEBCORE_BUILTIN_STREAMINTERNALS_DEQUEUEVALUE 1
-extern const char* const s_streamInternalsDequeueValueCode;
-extern const int s_streamInternalsDequeueValueCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsDequeueValueCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsDequeueValueCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsDequeueValueCodeImplementationVisibility;
-
-// enqueueValueWithSize
-#define WEBCORE_BUILTIN_STREAMINTERNALS_ENQUEUEVALUEWITHSIZE 1
-extern const char* const s_streamInternalsEnqueueValueWithSizeCode;
-extern const int s_streamInternalsEnqueueValueWithSizeCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsEnqueueValueWithSizeCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsEnqueueValueWithSizeCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsEnqueueValueWithSizeCodeImplementationVisibility;
-
-// peekQueueValue
-#define WEBCORE_BUILTIN_STREAMINTERNALS_PEEKQUEUEVALUE 1
-extern const char* const s_streamInternalsPeekQueueValueCode;
-extern const int s_streamInternalsPeekQueueValueCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsPeekQueueValueCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsPeekQueueValueCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsPeekQueueValueCodeImplementationVisibility;
-
-// resetQueue
-#define WEBCORE_BUILTIN_STREAMINTERNALS_RESETQUEUE 1
-extern const char* const s_streamInternalsResetQueueCode;
-extern const int s_streamInternalsResetQueueCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsResetQueueCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsResetQueueCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsResetQueueCodeImplementationVisibility;
-
-// extractSizeAlgorithm
-#define WEBCORE_BUILTIN_STREAMINTERNALS_EXTRACTSIZEALGORITHM 1
-extern const char* const s_streamInternalsExtractSizeAlgorithmCode;
-extern const int s_streamInternalsExtractSizeAlgorithmCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsExtractSizeAlgorithmCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsExtractSizeAlgorithmCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsExtractSizeAlgorithmCodeImplementationVisibility;
-
-// extractHighWaterMark
-#define WEBCORE_BUILTIN_STREAMINTERNALS_EXTRACTHIGHWATERMARK 1
-extern const char* const s_streamInternalsExtractHighWaterMarkCode;
-extern const int s_streamInternalsExtractHighWaterMarkCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsExtractHighWaterMarkCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsExtractHighWaterMarkCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsExtractHighWaterMarkCodeImplementationVisibility;
-
-// extractHighWaterMarkFromQueuingStrategyInit
-#define WEBCORE_BUILTIN_STREAMINTERNALS_EXTRACTHIGHWATERMARKFROMQUEUINGSTRATEGYINIT 1
-extern const char* const s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCode;
-extern const int s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCodeImplementationVisibility;
-
-// createFulfilledPromise
-#define WEBCORE_BUILTIN_STREAMINTERNALS_CREATEFULFILLEDPROMISE 1
-extern const char* const s_streamInternalsCreateFulfilledPromiseCode;
-extern const int s_streamInternalsCreateFulfilledPromiseCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsCreateFulfilledPromiseCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsCreateFulfilledPromiseCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsCreateFulfilledPromiseCodeImplementationVisibility;
-
-// toDictionary
-#define WEBCORE_BUILTIN_STREAMINTERNALS_TODICTIONARY 1
-extern const char* const s_streamInternalsToDictionaryCode;
-extern const int s_streamInternalsToDictionaryCodeLength;
-extern const JSC::ConstructAbility s_streamInternalsToDictionaryCodeConstructAbility;
-extern const JSC::ConstructorKind s_streamInternalsToDictionaryCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_streamInternalsToDictionaryCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_DATA(macro) \
-    macro(markPromiseAsHandled, streamInternalsMarkPromiseAsHandled, 1) \
-    macro(shieldingPromiseResolve, streamInternalsShieldingPromiseResolve, 1) \
-    macro(promiseInvokeOrNoopMethodNoCatch, streamInternalsPromiseInvokeOrNoopMethodNoCatch, 3) \
-    macro(promiseInvokeOrNoopNoCatch, streamInternalsPromiseInvokeOrNoopNoCatch, 3) \
-    macro(promiseInvokeOrNoopMethod, streamInternalsPromiseInvokeOrNoopMethod, 3) \
-    macro(promiseInvokeOrNoop, streamInternalsPromiseInvokeOrNoop, 3) \
-    macro(promiseInvokeOrFallbackOrNoop, streamInternalsPromiseInvokeOrFallbackOrNoop, 5) \
-    macro(validateAndNormalizeQueuingStrategy, streamInternalsValidateAndNormalizeQueuingStrategy, 2) \
-    macro(createFIFO, streamInternalsCreateFIFO, 0) \
-    macro(newQueue, streamInternalsNewQueue, 0) \
-    macro(dequeueValue, streamInternalsDequeueValue, 1) \
-    macro(enqueueValueWithSize, streamInternalsEnqueueValueWithSize, 3) \
-    macro(peekQueueValue, streamInternalsPeekQueueValue, 1) \
-    macro(resetQueue, streamInternalsResetQueue, 1) \
-    macro(extractSizeAlgorithm, streamInternalsExtractSizeAlgorithm, 1) \
-    macro(extractHighWaterMark, streamInternalsExtractHighWaterMark, 2) \
-    macro(extractHighWaterMarkFromQueuingStrategyInit, streamInternalsExtractHighWaterMarkFromQueuingStrategyInit, 1) \
-    macro(createFulfilledPromise, streamInternalsCreateFulfilledPromise, 1) \
-    macro(toDictionary, streamInternalsToDictionary, 3) \
-
-#define WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(macro) \
-    macro(streamInternalsMarkPromiseAsHandledCode, markPromiseAsHandled, ASCIILiteral(), s_streamInternalsMarkPromiseAsHandledCodeLength) \
-    macro(streamInternalsShieldingPromiseResolveCode, shieldingPromiseResolve, ASCIILiteral(), s_streamInternalsShieldingPromiseResolveCodeLength) \
-    macro(streamInternalsPromiseInvokeOrNoopMethodNoCatchCode, promiseInvokeOrNoopMethodNoCatch, ASCIILiteral(), s_streamInternalsPromiseInvokeOrNoopMethodNoCatchCodeLength) \
-    macro(streamInternalsPromiseInvokeOrNoopNoCatchCode, promiseInvokeOrNoopNoCatch, ASCIILiteral(), s_streamInternalsPromiseInvokeOrNoopNoCatchCodeLength) \
-    macro(streamInternalsPromiseInvokeOrNoopMethodCode, promiseInvokeOrNoopMethod, ASCIILiteral(), s_streamInternalsPromiseInvokeOrNoopMethodCodeLength) \
-    macro(streamInternalsPromiseInvokeOrNoopCode, promiseInvokeOrNoop, ASCIILiteral(), s_streamInternalsPromiseInvokeOrNoopCodeLength) \
-    macro(streamInternalsPromiseInvokeOrFallbackOrNoopCode, promiseInvokeOrFallbackOrNoop, ASCIILiteral(), s_streamInternalsPromiseInvokeOrFallbackOrNoopCodeLength) \
-    macro(streamInternalsValidateAndNormalizeQueuingStrategyCode, validateAndNormalizeQueuingStrategy, ASCIILiteral(), s_streamInternalsValidateAndNormalizeQueuingStrategyCodeLength) \
-    macro(streamInternalsCreateFIFOCode, createFIFO, ASCIILiteral(), s_streamInternalsCreateFIFOCodeLength) \
-    macro(streamInternalsNewQueueCode, newQueue, ASCIILiteral(), s_streamInternalsNewQueueCodeLength) \
-    macro(streamInternalsDequeueValueCode, dequeueValue, ASCIILiteral(), s_streamInternalsDequeueValueCodeLength) \
-    macro(streamInternalsEnqueueValueWithSizeCode, enqueueValueWithSize, ASCIILiteral(), s_streamInternalsEnqueueValueWithSizeCodeLength) \
-    macro(streamInternalsPeekQueueValueCode, peekQueueValue, ASCIILiteral(), s_streamInternalsPeekQueueValueCodeLength) \
-    macro(streamInternalsResetQueueCode, resetQueue, ASCIILiteral(), s_streamInternalsResetQueueCodeLength) \
-    macro(streamInternalsExtractSizeAlgorithmCode, extractSizeAlgorithm, ASCIILiteral(), s_streamInternalsExtractSizeAlgorithmCodeLength) \
-    macro(streamInternalsExtractHighWaterMarkCode, extractHighWaterMark, ASCIILiteral(), s_streamInternalsExtractHighWaterMarkCodeLength) \
-    macro(streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCode, extractHighWaterMarkFromQueuingStrategyInit, ASCIILiteral(), s_streamInternalsExtractHighWaterMarkFromQueuingStrategyInitCodeLength) \
-    macro(streamInternalsCreateFulfilledPromiseCode, createFulfilledPromise, ASCIILiteral(), s_streamInternalsCreateFulfilledPromiseCodeLength) \
-    macro(streamInternalsToDictionaryCode, toDictionary, ASCIILiteral(), s_streamInternalsToDictionaryCodeLength) \
-
-#define WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(macro) \
-    macro(markPromiseAsHandled) \
-    macro(shieldingPromiseResolve) \
-    macro(promiseInvokeOrNoopMethodNoCatch) \
-    macro(promiseInvokeOrNoopNoCatch) \
-    macro(promiseInvokeOrNoopMethod) \
-    macro(promiseInvokeOrNoop) \
-    macro(promiseInvokeOrFallbackOrNoop) \
-    macro(validateAndNormalizeQueuingStrategy) \
-    macro(createFIFO) \
-    macro(newQueue) \
-    macro(dequeueValue) \
-    macro(enqueueValueWithSize) \
-    macro(peekQueueValue) \
-    macro(resetQueue) \
-    macro(extractSizeAlgorithm) \
-    macro(extractHighWaterMark) \
-    macro(extractHighWaterMarkFromQueuingStrategyInit) \
-    macro(createFulfilledPromise) \
-    macro(toDictionary) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class StreamInternalsBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit StreamInternalsBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* StreamInternalsBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void StreamInternalsBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-class StreamInternalsBuiltinFunctions {
-public:
-    explicit StreamInternalsBuiltinFunctions(JSC::VM& vm) : m_vm(vm) { }
-
-    void init(JSC::JSGlobalObject&);
-    template<typename Visitor> void visit(Visitor&);
-
-public:
-    JSC::VM& m_vm;
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(functionName) \
-    JSC::WriteBarrier<JSC::JSFunction> m_##functionName##Function;
-    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-};
-
-inline void StreamInternalsBuiltinFunctions::init(JSC::JSGlobalObject& globalObject)
-{
-#define EXPORT_FUNCTION(codeName, functionName, overriddenName, length) \
-    m_##functionName##Function.set(m_vm, &globalObject, JSC::JSFunction::create(m_vm, codeName##Generator(m_vm), &globalObject));
-    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_CODE(EXPORT_FUNCTION)
-#undef EXPORT_FUNCTION
-}
-
-template<typename Visitor>
-inline void StreamInternalsBuiltinFunctions::visit(Visitor& visitor)
-{
-#define VISIT_FUNCTION(name) visitor.append(m_##name##Function);
-    WEBCORE_FOREACH_STREAMINTERNALS_BUILTIN_FUNCTION_NAME(VISIT_FUNCTION)
-#undef VISIT_FUNCTION
-}
-
-template void StreamInternalsBuiltinFunctions::visit(JSC::AbstractSlotVisitor&);
-template void StreamInternalsBuiltinFunctions::visit(JSC::SlotVisitor&);
-    /* TransformStreamDefaultController.ts */
-// initializeTransformStreamDefaultController
-#define WEBCORE_BUILTIN_TRANSFORMSTREAMDEFAULTCONTROLLER_INITIALIZETRANSFORMSTREAMDEFAULTCONTROLLER 1
-extern const char* const s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCode;
-extern const int s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeLength;
-extern const JSC::ConstructAbility s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeConstructAbility;
-extern const JSC::ConstructorKind s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeImplementationVisibility;
-
-// desiredSize
-#define WEBCORE_BUILTIN_TRANSFORMSTREAMDEFAULTCONTROLLER_DESIREDSIZE 1
-extern const char* const s_transformStreamDefaultControllerDesiredSizeCode;
-extern const int s_transformStreamDefaultControllerDesiredSizeCodeLength;
-extern const JSC::ConstructAbility s_transformStreamDefaultControllerDesiredSizeCodeConstructAbility;
-extern const JSC::ConstructorKind s_transformStreamDefaultControllerDesiredSizeCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_transformStreamDefaultControllerDesiredSizeCodeImplementationVisibility;
-
-// enqueue
-#define WEBCORE_BUILTIN_TRANSFORMSTREAMDEFAULTCONTROLLER_ENQUEUE 1
-extern const char* const s_transformStreamDefaultControllerEnqueueCode;
-extern const int s_transformStreamDefaultControllerEnqueueCodeLength;
-extern const JSC::ConstructAbility s_transformStreamDefaultControllerEnqueueCodeConstructAbility;
-extern const JSC::ConstructorKind s_transformStreamDefaultControllerEnqueueCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_transformStreamDefaultControllerEnqueueCodeImplementationVisibility;
+    /* WritableStreamDefaultController.ts */
+// initializeWritableStreamDefaultController
+#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTCONTROLLER_INITIALIZEWRITABLESTREAMDEFAULTCONTROLLER 1
+extern const char* const s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCode;
+extern const int s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeLength;
+extern const JSC::ConstructAbility s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeImplementationVisibility;
 
 // error
-#define WEBCORE_BUILTIN_TRANSFORMSTREAMDEFAULTCONTROLLER_ERROR 1
-extern const char* const s_transformStreamDefaultControllerErrorCode;
-extern const int s_transformStreamDefaultControllerErrorCodeLength;
-extern const JSC::ConstructAbility s_transformStreamDefaultControllerErrorCodeConstructAbility;
-extern const JSC::ConstructorKind s_transformStreamDefaultControllerErrorCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_transformStreamDefaultControllerErrorCodeImplementationVisibility;
+#define WEBCORE_BUILTIN_WRITABLESTREAMDEFAULTCONTROLLER_ERROR 1
+extern const char* const s_writableStreamDefaultControllerErrorCode;
+extern const int s_writableStreamDefaultControllerErrorCodeLength;
+extern const JSC::ConstructAbility s_writableStreamDefaultControllerErrorCodeConstructAbility;
+extern const JSC::ConstructorKind s_writableStreamDefaultControllerErrorCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_writableStreamDefaultControllerErrorCodeImplementationVisibility;
 
-// terminate
-#define WEBCORE_BUILTIN_TRANSFORMSTREAMDEFAULTCONTROLLER_TERMINATE 1
-extern const char* const s_transformStreamDefaultControllerTerminateCode;
-extern const int s_transformStreamDefaultControllerTerminateCodeLength;
-extern const JSC::ConstructAbility s_transformStreamDefaultControllerTerminateCodeConstructAbility;
-extern const JSC::ConstructorKind s_transformStreamDefaultControllerTerminateCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_transformStreamDefaultControllerTerminateCodeImplementationVisibility;
+#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_DATA(macro) \
+    macro(initializeWritableStreamDefaultController, writableStreamDefaultControllerInitializeWritableStreamDefaultController, 0) \
+    macro(error, writableStreamDefaultControllerError, 1) \
 
-#define WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_DATA(macro) \
-    macro(initializeTransformStreamDefaultController, transformStreamDefaultControllerInitializeTransformStreamDefaultController, 0) \
-    macro(desiredSize, transformStreamDefaultControllerDesiredSize, 0) \
-    macro(enqueue, transformStreamDefaultControllerEnqueue, 1) \
-    macro(error, transformStreamDefaultControllerError, 1) \
-    macro(terminate, transformStreamDefaultControllerTerminate, 0) \
+#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(macro) \
+    macro(writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCode, initializeWritableStreamDefaultController, ASCIILiteral(), s_writableStreamDefaultControllerInitializeWritableStreamDefaultControllerCodeLength) \
+    macro(writableStreamDefaultControllerErrorCode, error, ASCIILiteral(), s_writableStreamDefaultControllerErrorCodeLength) \
 
-#define WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(macro) \
-    macro(transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCode, initializeTransformStreamDefaultController, ASCIILiteral(), s_transformStreamDefaultControllerInitializeTransformStreamDefaultControllerCodeLength) \
-    macro(transformStreamDefaultControllerDesiredSizeCode, desiredSize, "get desiredSize"_s, s_transformStreamDefaultControllerDesiredSizeCodeLength) \
-    macro(transformStreamDefaultControllerEnqueueCode, enqueue, ASCIILiteral(), s_transformStreamDefaultControllerEnqueueCodeLength) \
-    macro(transformStreamDefaultControllerErrorCode, error, ASCIILiteral(), s_transformStreamDefaultControllerErrorCodeLength) \
-    macro(transformStreamDefaultControllerTerminateCode, terminate, ASCIILiteral(), s_transformStreamDefaultControllerTerminateCodeLength) \
-
-#define WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(macro) \
-    macro(initializeTransformStreamDefaultController) \
-    macro(desiredSize) \
-    macro(enqueue) \
+#define WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(macro) \
+    macro(initializeWritableStreamDefaultController) \
     macro(error) \
-    macro(terminate) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
     JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
 
-WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
+WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
 #undef DECLARE_BUILTIN_GENERATOR
 
-class TransformStreamDefaultControllerBuiltinsWrapper : private JSC::WeakHandleOwner {
+class WritableStreamDefaultControllerBuiltinsWrapper : private JSC::WeakHandleOwner {
 public:
-    explicit TransformStreamDefaultControllerBuiltinsWrapper(JSC::VM& vm)
+    explicit WritableStreamDefaultControllerBuiltinsWrapper(JSC::VM& vm)
         : m_vm(vm)
-        WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
+        WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
 #define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
+        WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
 #undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
     {
     }
@@ -4609,28 +5571,28 @@ public:
 #define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
     JSC::UnlinkedFunctionExecutable* name##Executable(); \
     const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
+    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
 #undef EXPOSE_BUILTIN_EXECUTABLES
 
-    WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
+    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
 
     void exportNames();
 
 private:
     JSC::VM& m_vm;
 
-    WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
+    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
 
 #define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
     JSC::SourceCode m_##name##Source;\
     JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
+    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
 #undef DECLARE_BUILTIN_SOURCE_MEMBERS
 
 };
 
 #define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* TransformStreamDefaultControllerBuiltinsWrapper::name##Executable() \
+inline JSC::UnlinkedFunctionExecutable* WritableStreamDefaultControllerBuiltinsWrapper::name##Executable() \
 {\
     if (!m_##name##Executable) {\
         JSC::Identifier executableName = functionName##PublicName();\
@@ -4640,875 +5602,13 @@ inline JSC::UnlinkedFunctionExecutable* TransformStreamDefaultControllerBuiltins
     }\
     return m_##name##Executable.get();\
 }
-WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
+WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
 #undef DEFINE_BUILTIN_EXECUTABLES
 
-inline void TransformStreamDefaultControllerBuiltinsWrapper::exportNames()
+inline void WritableStreamDefaultControllerBuiltinsWrapper::exportNames()
 {
 #define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_TRANSFORMSTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-/* WritableStreamInternals.ts */
-// isWritableStream
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_ISWRITABLESTREAM 1
-extern const char* const s_writableStreamInternalsIsWritableStreamCode;
-extern const int s_writableStreamInternalsIsWritableStreamCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamCodeImplementationVisibility;
-
-// isWritableStreamDefaultWriter
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_ISWRITABLESTREAMDEFAULTWRITER 1
-extern const char* const s_writableStreamInternalsIsWritableStreamDefaultWriterCode;
-extern const int s_writableStreamInternalsIsWritableStreamDefaultWriterCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamDefaultWriterCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamDefaultWriterCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamDefaultWriterCodeImplementationVisibility;
-
-// acquireWritableStreamDefaultWriter
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_ACQUIREWRITABLESTREAMDEFAULTWRITER 1
-extern const char* const s_writableStreamInternalsAcquireWritableStreamDefaultWriterCode;
-extern const int s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeImplementationVisibility;
-
-// createWritableStream
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_CREATEWRITABLESTREAM 1
-extern const char* const s_writableStreamInternalsCreateWritableStreamCode;
-extern const int s_writableStreamInternalsCreateWritableStreamCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsCreateWritableStreamCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsCreateWritableStreamCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsCreateWritableStreamCodeImplementationVisibility;
-
-// createInternalWritableStreamFromUnderlyingSink
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_CREATEINTERNALWRITABLESTREAMFROMUNDERLYINGSINK 1
-extern const char* const s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCode;
-extern const int s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeImplementationVisibility;
-
-// initializeWritableStreamSlots
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_INITIALIZEWRITABLESTREAMSLOTS 1
-extern const char* const s_writableStreamInternalsInitializeWritableStreamSlotsCode;
-extern const int s_writableStreamInternalsInitializeWritableStreamSlotsCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsInitializeWritableStreamSlotsCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsInitializeWritableStreamSlotsCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsInitializeWritableStreamSlotsCodeImplementationVisibility;
-
-// writableStreamCloseForBindings
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMCLOSEFORBINDINGS 1
-extern const char* const s_writableStreamInternalsWritableStreamCloseForBindingsCode;
-extern const int s_writableStreamInternalsWritableStreamCloseForBindingsCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseForBindingsCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseForBindingsCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseForBindingsCodeImplementationVisibility;
-
-// writableStreamAbortForBindings
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMABORTFORBINDINGS 1
-extern const char* const s_writableStreamInternalsWritableStreamAbortForBindingsCode;
-extern const int s_writableStreamInternalsWritableStreamAbortForBindingsCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAbortForBindingsCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAbortForBindingsCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAbortForBindingsCodeImplementationVisibility;
-
-// isWritableStreamLocked
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_ISWRITABLESTREAMLOCKED 1
-extern const char* const s_writableStreamInternalsIsWritableStreamLockedCode;
-extern const int s_writableStreamInternalsIsWritableStreamLockedCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsIsWritableStreamLockedCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsIsWritableStreamLockedCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsIsWritableStreamLockedCodeImplementationVisibility;
-
-// setUpWritableStreamDefaultWriter
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_SETUPWRITABLESTREAMDEFAULTWRITER 1
-extern const char* const s_writableStreamInternalsSetUpWritableStreamDefaultWriterCode;
-extern const int s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeImplementationVisibility;
-
-// writableStreamAbort
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMABORT 1
-extern const char* const s_writableStreamInternalsWritableStreamAbortCode;
-extern const int s_writableStreamInternalsWritableStreamAbortCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAbortCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAbortCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAbortCodeImplementationVisibility;
-
-// writableStreamClose
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMCLOSE 1
-extern const char* const s_writableStreamInternalsWritableStreamCloseCode;
-extern const int s_writableStreamInternalsWritableStreamCloseCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseCodeImplementationVisibility;
-
-// writableStreamAddWriteRequest
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMADDWRITEREQUEST 1
-extern const char* const s_writableStreamInternalsWritableStreamAddWriteRequestCode;
-extern const int s_writableStreamInternalsWritableStreamAddWriteRequestCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamAddWriteRequestCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamAddWriteRequestCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamAddWriteRequestCodeImplementationVisibility;
-
-// writableStreamCloseQueuedOrInFlight
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMCLOSEQUEUEDORINFLIGHT 1
-extern const char* const s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCode;
-extern const int s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeImplementationVisibility;
-
-// writableStreamDealWithRejection
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEALWITHREJECTION 1
-extern const char* const s_writableStreamInternalsWritableStreamDealWithRejectionCode;
-extern const int s_writableStreamInternalsWritableStreamDealWithRejectionCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDealWithRejectionCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDealWithRejectionCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDealWithRejectionCodeImplementationVisibility;
-
-// writableStreamFinishErroring
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMFINISHERRORING 1
-extern const char* const s_writableStreamInternalsWritableStreamFinishErroringCode;
-extern const int s_writableStreamInternalsWritableStreamFinishErroringCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishErroringCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishErroringCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishErroringCodeImplementationVisibility;
-
-// writableStreamFinishInFlightClose
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMFINISHINFLIGHTCLOSE 1
-extern const char* const s_writableStreamInternalsWritableStreamFinishInFlightCloseCode;
-extern const int s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeImplementationVisibility;
-
-// writableStreamFinishInFlightCloseWithError
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMFINISHINFLIGHTCLOSEWITHERROR 1
-extern const char* const s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCode;
-extern const int s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeImplementationVisibility;
-
-// writableStreamFinishInFlightWrite
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMFINISHINFLIGHTWRITE 1
-extern const char* const s_writableStreamInternalsWritableStreamFinishInFlightWriteCode;
-extern const int s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeImplementationVisibility;
-
-// writableStreamFinishInFlightWriteWithError
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMFINISHINFLIGHTWRITEWITHERROR 1
-extern const char* const s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCode;
-extern const int s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeImplementationVisibility;
-
-// writableStreamHasOperationMarkedInFlight
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMHASOPERATIONMARKEDINFLIGHT 1
-extern const char* const s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCode;
-extern const int s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeImplementationVisibility;
-
-// writableStreamMarkCloseRequestInFlight
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMMARKCLOSEREQUESTINFLIGHT 1
-extern const char* const s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCode;
-extern const int s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeImplementationVisibility;
-
-// writableStreamMarkFirstWriteRequestInFlight
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMMARKFIRSTWRITEREQUESTINFLIGHT 1
-extern const char* const s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCode;
-extern const int s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeImplementationVisibility;
-
-// writableStreamRejectCloseAndClosedPromiseIfNeeded
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMREJECTCLOSEANDCLOSEDPROMISEIFNEEDED 1
-extern const char* const s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCode;
-extern const int s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeImplementationVisibility;
-
-// writableStreamStartErroring
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMSTARTERRORING 1
-extern const char* const s_writableStreamInternalsWritableStreamStartErroringCode;
-extern const int s_writableStreamInternalsWritableStreamStartErroringCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamStartErroringCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamStartErroringCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamStartErroringCodeImplementationVisibility;
-
-// writableStreamUpdateBackpressure
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMUPDATEBACKPRESSURE 1
-extern const char* const s_writableStreamInternalsWritableStreamUpdateBackpressureCode;
-extern const int s_writableStreamInternalsWritableStreamUpdateBackpressureCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamUpdateBackpressureCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamUpdateBackpressureCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamUpdateBackpressureCodeImplementationVisibility;
-
-// writableStreamDefaultWriterAbort
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERABORT 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterAbortCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeImplementationVisibility;
-
-// writableStreamDefaultWriterClose
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERCLOSE 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterCloseCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeImplementationVisibility;
-
-// writableStreamDefaultWriterCloseWithErrorPropagation
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERCLOSEWITHERRORPROPAGATION 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeImplementationVisibility;
-
-// writableStreamDefaultWriterEnsureClosedPromiseRejected
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERENSURECLOSEDPROMISEREJECTED 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeImplementationVisibility;
-
-// writableStreamDefaultWriterEnsureReadyPromiseRejected
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERENSUREREADYPROMISEREJECTED 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeImplementationVisibility;
-
-// writableStreamDefaultWriterGetDesiredSize
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERGETDESIREDSIZE 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeImplementationVisibility;
-
-// writableStreamDefaultWriterRelease
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERRELEASE 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterReleaseCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeImplementationVisibility;
-
-// writableStreamDefaultWriterWrite
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTWRITERWRITE 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultWriterWriteCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeImplementationVisibility;
-
-// setUpWritableStreamDefaultController
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_SETUPWRITABLESTREAMDEFAULTCONTROLLER 1
-extern const char* const s_writableStreamInternalsSetUpWritableStreamDefaultControllerCode;
-extern const int s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeImplementationVisibility;
-
-// writableStreamDefaultControllerStart
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERSTART 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerStartCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerStartCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerStartCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerStartCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerStartCodeImplementationVisibility;
-
-// setUpWritableStreamDefaultControllerFromUnderlyingSink
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_SETUPWRITABLESTREAMDEFAULTCONTROLLERFROMUNDERLYINGSINK 1
-extern const char* const s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCode;
-extern const int s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeImplementationVisibility;
-
-// writableStreamDefaultControllerAdvanceQueueIfNeeded
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERADVANCEQUEUEIFNEEDED 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeImplementationVisibility;
-
-// isCloseSentinel
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_ISCLOSESENTINEL 1
-extern const char* const s_writableStreamInternalsIsCloseSentinelCode;
-extern const int s_writableStreamInternalsIsCloseSentinelCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsIsCloseSentinelCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsIsCloseSentinelCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsIsCloseSentinelCodeImplementationVisibility;
-
-// writableStreamDefaultControllerClearAlgorithms
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERCLEARALGORITHMS 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeImplementationVisibility;
-
-// writableStreamDefaultControllerClose
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERCLOSE 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerCloseCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeImplementationVisibility;
-
-// writableStreamDefaultControllerError
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERERROR 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerErrorCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeImplementationVisibility;
-
-// writableStreamDefaultControllerErrorIfNeeded
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERERRORIFNEEDED 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeImplementationVisibility;
-
-// writableStreamDefaultControllerGetBackpressure
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERGETBACKPRESSURE 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeImplementationVisibility;
-
-// writableStreamDefaultControllerGetChunkSize
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERGETCHUNKSIZE 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeImplementationVisibility;
-
-// writableStreamDefaultControllerGetDesiredSize
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERGETDESIREDSIZE 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeImplementationVisibility;
-
-// writableStreamDefaultControllerProcessClose
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERPROCESSCLOSE 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeImplementationVisibility;
-
-// writableStreamDefaultControllerProcessWrite
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERPROCESSWRITE 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeImplementationVisibility;
-
-// writableStreamDefaultControllerWrite
-#define WEBCORE_BUILTIN_WRITABLESTREAMINTERNALS_WRITABLESTREAMDEFAULTCONTROLLERWRITE 1
-extern const char* const s_writableStreamInternalsWritableStreamDefaultControllerWriteCode;
-extern const int s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeLength;
-extern const JSC::ConstructAbility s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeConstructAbility;
-extern const JSC::ConstructorKind s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_DATA(macro) \
-    macro(isWritableStream, writableStreamInternalsIsWritableStream, 1) \
-    macro(isWritableStreamDefaultWriter, writableStreamInternalsIsWritableStreamDefaultWriter, 1) \
-    macro(acquireWritableStreamDefaultWriter, writableStreamInternalsAcquireWritableStreamDefaultWriter, 1) \
-    macro(createWritableStream, writableStreamInternalsCreateWritableStream, 7) \
-    macro(createInternalWritableStreamFromUnderlyingSink, writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSink, 2) \
-    macro(initializeWritableStreamSlots, writableStreamInternalsInitializeWritableStreamSlots, 2) \
-    macro(writableStreamCloseForBindings, writableStreamInternalsWritableStreamCloseForBindings, 1) \
-    macro(writableStreamAbortForBindings, writableStreamInternalsWritableStreamAbortForBindings, 2) \
-    macro(isWritableStreamLocked, writableStreamInternalsIsWritableStreamLocked, 1) \
-    macro(setUpWritableStreamDefaultWriter, writableStreamInternalsSetUpWritableStreamDefaultWriter, 2) \
-    macro(writableStreamAbort, writableStreamInternalsWritableStreamAbort, 2) \
-    macro(writableStreamClose, writableStreamInternalsWritableStreamClose, 1) \
-    macro(writableStreamAddWriteRequest, writableStreamInternalsWritableStreamAddWriteRequest, 1) \
-    macro(writableStreamCloseQueuedOrInFlight, writableStreamInternalsWritableStreamCloseQueuedOrInFlight, 1) \
-    macro(writableStreamDealWithRejection, writableStreamInternalsWritableStreamDealWithRejection, 2) \
-    macro(writableStreamFinishErroring, writableStreamInternalsWritableStreamFinishErroring, 1) \
-    macro(writableStreamFinishInFlightClose, writableStreamInternalsWritableStreamFinishInFlightClose, 1) \
-    macro(writableStreamFinishInFlightCloseWithError, writableStreamInternalsWritableStreamFinishInFlightCloseWithError, 2) \
-    macro(writableStreamFinishInFlightWrite, writableStreamInternalsWritableStreamFinishInFlightWrite, 1) \
-    macro(writableStreamFinishInFlightWriteWithError, writableStreamInternalsWritableStreamFinishInFlightWriteWithError, 2) \
-    macro(writableStreamHasOperationMarkedInFlight, writableStreamInternalsWritableStreamHasOperationMarkedInFlight, 1) \
-    macro(writableStreamMarkCloseRequestInFlight, writableStreamInternalsWritableStreamMarkCloseRequestInFlight, 1) \
-    macro(writableStreamMarkFirstWriteRequestInFlight, writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlight, 1) \
-    macro(writableStreamRejectCloseAndClosedPromiseIfNeeded, writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeeded, 1) \
-    macro(writableStreamStartErroring, writableStreamInternalsWritableStreamStartErroring, 2) \
-    macro(writableStreamUpdateBackpressure, writableStreamInternalsWritableStreamUpdateBackpressure, 2) \
-    macro(writableStreamDefaultWriterAbort, writableStreamInternalsWritableStreamDefaultWriterAbort, 2) \
-    macro(writableStreamDefaultWriterClose, writableStreamInternalsWritableStreamDefaultWriterClose, 1) \
-    macro(writableStreamDefaultWriterCloseWithErrorPropagation, writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagation, 1) \
-    macro(writableStreamDefaultWriterEnsureClosedPromiseRejected, writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejected, 2) \
-    macro(writableStreamDefaultWriterEnsureReadyPromiseRejected, writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejected, 2) \
-    macro(writableStreamDefaultWriterGetDesiredSize, writableStreamInternalsWritableStreamDefaultWriterGetDesiredSize, 1) \
-    macro(writableStreamDefaultWriterRelease, writableStreamInternalsWritableStreamDefaultWriterRelease, 1) \
-    macro(writableStreamDefaultWriterWrite, writableStreamInternalsWritableStreamDefaultWriterWrite, 2) \
-    macro(setUpWritableStreamDefaultController, writableStreamInternalsSetUpWritableStreamDefaultController, 9) \
-    macro(writableStreamDefaultControllerStart, writableStreamInternalsWritableStreamDefaultControllerStart, 1) \
-    macro(setUpWritableStreamDefaultControllerFromUnderlyingSink, writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSink, 6) \
-    macro(writableStreamDefaultControllerAdvanceQueueIfNeeded, writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeeded, 1) \
-    macro(isCloseSentinel, writableStreamInternalsIsCloseSentinel, 0) \
-    macro(writableStreamDefaultControllerClearAlgorithms, writableStreamInternalsWritableStreamDefaultControllerClearAlgorithms, 1) \
-    macro(writableStreamDefaultControllerClose, writableStreamInternalsWritableStreamDefaultControllerClose, 1) \
-    macro(writableStreamDefaultControllerError, writableStreamInternalsWritableStreamDefaultControllerError, 2) \
-    macro(writableStreamDefaultControllerErrorIfNeeded, writableStreamInternalsWritableStreamDefaultControllerErrorIfNeeded, 2) \
-    macro(writableStreamDefaultControllerGetBackpressure, writableStreamInternalsWritableStreamDefaultControllerGetBackpressure, 1) \
-    macro(writableStreamDefaultControllerGetChunkSize, writableStreamInternalsWritableStreamDefaultControllerGetChunkSize, 2) \
-    macro(writableStreamDefaultControllerGetDesiredSize, writableStreamInternalsWritableStreamDefaultControllerGetDesiredSize, 1) \
-    macro(writableStreamDefaultControllerProcessClose, writableStreamInternalsWritableStreamDefaultControllerProcessClose, 1) \
-    macro(writableStreamDefaultControllerProcessWrite, writableStreamInternalsWritableStreamDefaultControllerProcessWrite, 2) \
-    macro(writableStreamDefaultControllerWrite, writableStreamInternalsWritableStreamDefaultControllerWrite, 3) \
-
-#define WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(macro) \
-    macro(writableStreamInternalsIsWritableStreamCode, isWritableStream, ASCIILiteral(), s_writableStreamInternalsIsWritableStreamCodeLength) \
-    macro(writableStreamInternalsIsWritableStreamDefaultWriterCode, isWritableStreamDefaultWriter, ASCIILiteral(), s_writableStreamInternalsIsWritableStreamDefaultWriterCodeLength) \
-    macro(writableStreamInternalsAcquireWritableStreamDefaultWriterCode, acquireWritableStreamDefaultWriter, ASCIILiteral(), s_writableStreamInternalsAcquireWritableStreamDefaultWriterCodeLength) \
-    macro(writableStreamInternalsCreateWritableStreamCode, createWritableStream, ASCIILiteral(), s_writableStreamInternalsCreateWritableStreamCodeLength) \
-    macro(writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCode, createInternalWritableStreamFromUnderlyingSink, ASCIILiteral(), s_writableStreamInternalsCreateInternalWritableStreamFromUnderlyingSinkCodeLength) \
-    macro(writableStreamInternalsInitializeWritableStreamSlotsCode, initializeWritableStreamSlots, ASCIILiteral(), s_writableStreamInternalsInitializeWritableStreamSlotsCodeLength) \
-    macro(writableStreamInternalsWritableStreamCloseForBindingsCode, writableStreamCloseForBindings, ASCIILiteral(), s_writableStreamInternalsWritableStreamCloseForBindingsCodeLength) \
-    macro(writableStreamInternalsWritableStreamAbortForBindingsCode, writableStreamAbortForBindings, ASCIILiteral(), s_writableStreamInternalsWritableStreamAbortForBindingsCodeLength) \
-    macro(writableStreamInternalsIsWritableStreamLockedCode, isWritableStreamLocked, ASCIILiteral(), s_writableStreamInternalsIsWritableStreamLockedCodeLength) \
-    macro(writableStreamInternalsSetUpWritableStreamDefaultWriterCode, setUpWritableStreamDefaultWriter, ASCIILiteral(), s_writableStreamInternalsSetUpWritableStreamDefaultWriterCodeLength) \
-    macro(writableStreamInternalsWritableStreamAbortCode, writableStreamAbort, ASCIILiteral(), s_writableStreamInternalsWritableStreamAbortCodeLength) \
-    macro(writableStreamInternalsWritableStreamCloseCode, writableStreamClose, ASCIILiteral(), s_writableStreamInternalsWritableStreamCloseCodeLength) \
-    macro(writableStreamInternalsWritableStreamAddWriteRequestCode, writableStreamAddWriteRequest, ASCIILiteral(), s_writableStreamInternalsWritableStreamAddWriteRequestCodeLength) \
-    macro(writableStreamInternalsWritableStreamCloseQueuedOrInFlightCode, writableStreamCloseQueuedOrInFlight, ASCIILiteral(), s_writableStreamInternalsWritableStreamCloseQueuedOrInFlightCodeLength) \
-    macro(writableStreamInternalsWritableStreamDealWithRejectionCode, writableStreamDealWithRejection, ASCIILiteral(), s_writableStreamInternalsWritableStreamDealWithRejectionCodeLength) \
-    macro(writableStreamInternalsWritableStreamFinishErroringCode, writableStreamFinishErroring, ASCIILiteral(), s_writableStreamInternalsWritableStreamFinishErroringCodeLength) \
-    macro(writableStreamInternalsWritableStreamFinishInFlightCloseCode, writableStreamFinishInFlightClose, ASCIILiteral(), s_writableStreamInternalsWritableStreamFinishInFlightCloseCodeLength) \
-    macro(writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCode, writableStreamFinishInFlightCloseWithError, ASCIILiteral(), s_writableStreamInternalsWritableStreamFinishInFlightCloseWithErrorCodeLength) \
-    macro(writableStreamInternalsWritableStreamFinishInFlightWriteCode, writableStreamFinishInFlightWrite, ASCIILiteral(), s_writableStreamInternalsWritableStreamFinishInFlightWriteCodeLength) \
-    macro(writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCode, writableStreamFinishInFlightWriteWithError, ASCIILiteral(), s_writableStreamInternalsWritableStreamFinishInFlightWriteWithErrorCodeLength) \
-    macro(writableStreamInternalsWritableStreamHasOperationMarkedInFlightCode, writableStreamHasOperationMarkedInFlight, ASCIILiteral(), s_writableStreamInternalsWritableStreamHasOperationMarkedInFlightCodeLength) \
-    macro(writableStreamInternalsWritableStreamMarkCloseRequestInFlightCode, writableStreamMarkCloseRequestInFlight, ASCIILiteral(), s_writableStreamInternalsWritableStreamMarkCloseRequestInFlightCodeLength) \
-    macro(writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCode, writableStreamMarkFirstWriteRequestInFlight, ASCIILiteral(), s_writableStreamInternalsWritableStreamMarkFirstWriteRequestInFlightCodeLength) \
-    macro(writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCode, writableStreamRejectCloseAndClosedPromiseIfNeeded, ASCIILiteral(), s_writableStreamInternalsWritableStreamRejectCloseAndClosedPromiseIfNeededCodeLength) \
-    macro(writableStreamInternalsWritableStreamStartErroringCode, writableStreamStartErroring, ASCIILiteral(), s_writableStreamInternalsWritableStreamStartErroringCodeLength) \
-    macro(writableStreamInternalsWritableStreamUpdateBackpressureCode, writableStreamUpdateBackpressure, ASCIILiteral(), s_writableStreamInternalsWritableStreamUpdateBackpressureCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultWriterAbortCode, writableStreamDefaultWriterAbort, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterAbortCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultWriterCloseCode, writableStreamDefaultWriterClose, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterCloseCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCode, writableStreamDefaultWriterCloseWithErrorPropagation, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterCloseWithErrorPropagationCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCode, writableStreamDefaultWriterEnsureClosedPromiseRejected, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterEnsureClosedPromiseRejectedCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCode, writableStreamDefaultWriterEnsureReadyPromiseRejected, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterEnsureReadyPromiseRejectedCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCode, writableStreamDefaultWriterGetDesiredSize, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterGetDesiredSizeCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultWriterReleaseCode, writableStreamDefaultWriterRelease, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterReleaseCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultWriterWriteCode, writableStreamDefaultWriterWrite, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultWriterWriteCodeLength) \
-    macro(writableStreamInternalsSetUpWritableStreamDefaultControllerCode, setUpWritableStreamDefaultController, ASCIILiteral(), s_writableStreamInternalsSetUpWritableStreamDefaultControllerCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerStartCode, writableStreamDefaultControllerStart, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerStartCodeLength) \
-    macro(writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCode, setUpWritableStreamDefaultControllerFromUnderlyingSink, ASCIILiteral(), s_writableStreamInternalsSetUpWritableStreamDefaultControllerFromUnderlyingSinkCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCode, writableStreamDefaultControllerAdvanceQueueIfNeeded, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerAdvanceQueueIfNeededCodeLength) \
-    macro(writableStreamInternalsIsCloseSentinelCode, isCloseSentinel, ASCIILiteral(), s_writableStreamInternalsIsCloseSentinelCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCode, writableStreamDefaultControllerClearAlgorithms, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerClearAlgorithmsCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerCloseCode, writableStreamDefaultControllerClose, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerCloseCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerErrorCode, writableStreamDefaultControllerError, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerErrorCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCode, writableStreamDefaultControllerErrorIfNeeded, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerErrorIfNeededCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCode, writableStreamDefaultControllerGetBackpressure, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerGetBackpressureCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCode, writableStreamDefaultControllerGetChunkSize, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerGetChunkSizeCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCode, writableStreamDefaultControllerGetDesiredSize, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerGetDesiredSizeCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerProcessCloseCode, writableStreamDefaultControllerProcessClose, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerProcessCloseCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerProcessWriteCode, writableStreamDefaultControllerProcessWrite, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerProcessWriteCodeLength) \
-    macro(writableStreamInternalsWritableStreamDefaultControllerWriteCode, writableStreamDefaultControllerWrite, ASCIILiteral(), s_writableStreamInternalsWritableStreamDefaultControllerWriteCodeLength) \
-
-#define WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(macro) \
-    macro(isWritableStream) \
-    macro(isWritableStreamDefaultWriter) \
-    macro(acquireWritableStreamDefaultWriter) \
-    macro(createWritableStream) \
-    macro(createInternalWritableStreamFromUnderlyingSink) \
-    macro(initializeWritableStreamSlots) \
-    macro(writableStreamCloseForBindings) \
-    macro(writableStreamAbortForBindings) \
-    macro(isWritableStreamLocked) \
-    macro(setUpWritableStreamDefaultWriter) \
-    macro(writableStreamAbort) \
-    macro(writableStreamClose) \
-    macro(writableStreamAddWriteRequest) \
-    macro(writableStreamCloseQueuedOrInFlight) \
-    macro(writableStreamDealWithRejection) \
-    macro(writableStreamFinishErroring) \
-    macro(writableStreamFinishInFlightClose) \
-    macro(writableStreamFinishInFlightCloseWithError) \
-    macro(writableStreamFinishInFlightWrite) \
-    macro(writableStreamFinishInFlightWriteWithError) \
-    macro(writableStreamHasOperationMarkedInFlight) \
-    macro(writableStreamMarkCloseRequestInFlight) \
-    macro(writableStreamMarkFirstWriteRequestInFlight) \
-    macro(writableStreamRejectCloseAndClosedPromiseIfNeeded) \
-    macro(writableStreamStartErroring) \
-    macro(writableStreamUpdateBackpressure) \
-    macro(writableStreamDefaultWriterAbort) \
-    macro(writableStreamDefaultWriterClose) \
-    macro(writableStreamDefaultWriterCloseWithErrorPropagation) \
-    macro(writableStreamDefaultWriterEnsureClosedPromiseRejected) \
-    macro(writableStreamDefaultWriterEnsureReadyPromiseRejected) \
-    macro(writableStreamDefaultWriterGetDesiredSize) \
-    macro(writableStreamDefaultWriterRelease) \
-    macro(writableStreamDefaultWriterWrite) \
-    macro(setUpWritableStreamDefaultController) \
-    macro(writableStreamDefaultControllerStart) \
-    macro(setUpWritableStreamDefaultControllerFromUnderlyingSink) \
-    macro(writableStreamDefaultControllerAdvanceQueueIfNeeded) \
-    macro(isCloseSentinel) \
-    macro(writableStreamDefaultControllerClearAlgorithms) \
-    macro(writableStreamDefaultControllerClose) \
-    macro(writableStreamDefaultControllerError) \
-    macro(writableStreamDefaultControllerErrorIfNeeded) \
-    macro(writableStreamDefaultControllerGetBackpressure) \
-    macro(writableStreamDefaultControllerGetChunkSize) \
-    macro(writableStreamDefaultControllerGetDesiredSize) \
-    macro(writableStreamDefaultControllerProcessClose) \
-    macro(writableStreamDefaultControllerProcessWrite) \
-    macro(writableStreamDefaultControllerWrite) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class WritableStreamInternalsBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit WritableStreamInternalsBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* WritableStreamInternalsBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void WritableStreamInternalsBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-class WritableStreamInternalsBuiltinFunctions {
-public:
-    explicit WritableStreamInternalsBuiltinFunctions(JSC::VM& vm) : m_vm(vm) { }
-
-    void init(JSC::JSGlobalObject&);
-    template<typename Visitor> void visit(Visitor&);
-
-public:
-    JSC::VM& m_vm;
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(functionName) \
-    JSC::WriteBarrier<JSC::JSFunction> m_##functionName##Function;
-    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-};
-
-inline void WritableStreamInternalsBuiltinFunctions::init(JSC::JSGlobalObject& globalObject)
-{
-#define EXPORT_FUNCTION(codeName, functionName, overriddenName, length) \
-    m_##functionName##Function.set(m_vm, &globalObject, JSC::JSFunction::create(m_vm, codeName##Generator(m_vm), &globalObject));
-    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_CODE(EXPORT_FUNCTION)
-#undef EXPORT_FUNCTION
-}
-
-template<typename Visitor>
-inline void WritableStreamInternalsBuiltinFunctions::visit(Visitor& visitor)
-{
-#define VISIT_FUNCTION(name) visitor.append(m_##name##Function);
-    WEBCORE_FOREACH_WRITABLESTREAMINTERNALS_BUILTIN_FUNCTION_NAME(VISIT_FUNCTION)
-#undef VISIT_FUNCTION
-}
-
-template void WritableStreamInternalsBuiltinFunctions::visit(JSC::AbstractSlotVisitor&);
-template void WritableStreamInternalsBuiltinFunctions::visit(JSC::SlotVisitor&);
-    /* ReadableStreamDefaultController.ts */
-// initializeReadableStreamDefaultController
-#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTCONTROLLER_INITIALIZEREADABLESTREAMDEFAULTCONTROLLER 1
-extern const char* const s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCode;
-extern const int s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCodeLength;
-extern const JSC::ConstructAbility s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCodeImplementationVisibility;
-
-// enqueue
-#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTCONTROLLER_ENQUEUE 1
-extern const char* const s_readableStreamDefaultControllerEnqueueCode;
-extern const int s_readableStreamDefaultControllerEnqueueCodeLength;
-extern const JSC::ConstructAbility s_readableStreamDefaultControllerEnqueueCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamDefaultControllerEnqueueCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamDefaultControllerEnqueueCodeImplementationVisibility;
-
-// error
-#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTCONTROLLER_ERROR 1
-extern const char* const s_readableStreamDefaultControllerErrorCode;
-extern const int s_readableStreamDefaultControllerErrorCodeLength;
-extern const JSC::ConstructAbility s_readableStreamDefaultControllerErrorCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamDefaultControllerErrorCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamDefaultControllerErrorCodeImplementationVisibility;
-
-// close
-#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTCONTROLLER_CLOSE 1
-extern const char* const s_readableStreamDefaultControllerCloseCode;
-extern const int s_readableStreamDefaultControllerCloseCodeLength;
-extern const JSC::ConstructAbility s_readableStreamDefaultControllerCloseCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamDefaultControllerCloseCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamDefaultControllerCloseCodeImplementationVisibility;
-
-// desiredSize
-#define WEBCORE_BUILTIN_READABLESTREAMDEFAULTCONTROLLER_DESIREDSIZE 1
-extern const char* const s_readableStreamDefaultControllerDesiredSizeCode;
-extern const int s_readableStreamDefaultControllerDesiredSizeCodeLength;
-extern const JSC::ConstructAbility s_readableStreamDefaultControllerDesiredSizeCodeConstructAbility;
-extern const JSC::ConstructorKind s_readableStreamDefaultControllerDesiredSizeCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_readableStreamDefaultControllerDesiredSizeCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_DATA(macro) \
-    macro(initializeReadableStreamDefaultController, readableStreamDefaultControllerInitializeReadableStreamDefaultController, 4) \
-    macro(enqueue, readableStreamDefaultControllerEnqueue, 1) \
-    macro(error, readableStreamDefaultControllerError, 1) \
-    macro(close, readableStreamDefaultControllerClose, 0) \
-    macro(desiredSize, readableStreamDefaultControllerDesiredSize, 0) \
-
-#define WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(macro) \
-    macro(readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCode, initializeReadableStreamDefaultController, ASCIILiteral(), s_readableStreamDefaultControllerInitializeReadableStreamDefaultControllerCodeLength) \
-    macro(readableStreamDefaultControllerEnqueueCode, enqueue, ASCIILiteral(), s_readableStreamDefaultControllerEnqueueCodeLength) \
-    macro(readableStreamDefaultControllerErrorCode, error, ASCIILiteral(), s_readableStreamDefaultControllerErrorCodeLength) \
-    macro(readableStreamDefaultControllerCloseCode, close, ASCIILiteral(), s_readableStreamDefaultControllerCloseCodeLength) \
-    macro(readableStreamDefaultControllerDesiredSizeCode, desiredSize, "get desiredSize"_s, s_readableStreamDefaultControllerDesiredSizeCodeLength) \
-
-#define WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(macro) \
-    macro(initializeReadableStreamDefaultController) \
-    macro(enqueue) \
-    macro(error) \
-    macro(close) \
-    macro(desiredSize) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class ReadableStreamDefaultControllerBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit ReadableStreamDefaultControllerBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* ReadableStreamDefaultControllerBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void ReadableStreamDefaultControllerBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_READABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
-/* CountQueuingStrategy.ts */
-// highWaterMark
-#define WEBCORE_BUILTIN_COUNTQUEUINGSTRATEGY_HIGHWATERMARK 1
-extern const char* const s_countQueuingStrategyHighWaterMarkCode;
-extern const int s_countQueuingStrategyHighWaterMarkCodeLength;
-extern const JSC::ConstructAbility s_countQueuingStrategyHighWaterMarkCodeConstructAbility;
-extern const JSC::ConstructorKind s_countQueuingStrategyHighWaterMarkCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_countQueuingStrategyHighWaterMarkCodeImplementationVisibility;
-
-// size
-#define WEBCORE_BUILTIN_COUNTQUEUINGSTRATEGY_SIZE 1
-extern const char* const s_countQueuingStrategySizeCode;
-extern const int s_countQueuingStrategySizeCodeLength;
-extern const JSC::ConstructAbility s_countQueuingStrategySizeCodeConstructAbility;
-extern const JSC::ConstructorKind s_countQueuingStrategySizeCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_countQueuingStrategySizeCodeImplementationVisibility;
-
-// initializeCountQueuingStrategy
-#define WEBCORE_BUILTIN_COUNTQUEUINGSTRATEGY_INITIALIZECOUNTQUEUINGSTRATEGY 1
-extern const char* const s_countQueuingStrategyInitializeCountQueuingStrategyCode;
-extern const int s_countQueuingStrategyInitializeCountQueuingStrategyCodeLength;
-extern const JSC::ConstructAbility s_countQueuingStrategyInitializeCountQueuingStrategyCodeConstructAbility;
-extern const JSC::ConstructorKind s_countQueuingStrategyInitializeCountQueuingStrategyCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_countQueuingStrategyInitializeCountQueuingStrategyCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_DATA(macro) \
-    macro(highWaterMark, countQueuingStrategyHighWaterMark, 0) \
-    macro(size, countQueuingStrategySize, 0) \
-    macro(initializeCountQueuingStrategy, countQueuingStrategyInitializeCountQueuingStrategy, 1) \
-
-#define WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(macro) \
-    macro(countQueuingStrategyHighWaterMarkCode, highWaterMark, "get highWaterMark"_s, s_countQueuingStrategyHighWaterMarkCodeLength) \
-    macro(countQueuingStrategySizeCode, size, ASCIILiteral(), s_countQueuingStrategySizeCodeLength) \
-    macro(countQueuingStrategyInitializeCountQueuingStrategyCode, initializeCountQueuingStrategy, ASCIILiteral(), s_countQueuingStrategyInitializeCountQueuingStrategyCodeLength) \
-
-#define WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(macro) \
-    macro(highWaterMark) \
-    macro(size) \
-    macro(initializeCountQueuingStrategy) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class CountQueuingStrategyBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit CountQueuingStrategyBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* CountQueuingStrategyBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void CountQueuingStrategyBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_COUNTQUEUINGSTRATEGY_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
+    WEBCORE_FOREACH_WRITABLESTREAMDEFAULTCONTROLLER_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
 #undef EXPORT_FUNCTION_NAME
 }
 /* EventSource.ts */
@@ -5589,199 +5689,99 @@ inline void EventSourceBuiltinsWrapper::exportNames()
     WEBCORE_FOREACH_EVENTSOURCE_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
 #undef EXPORT_FUNCTION_NAME
 }
-/* ProcessObjectInternals.ts */
-// binding
-#define WEBCORE_BUILTIN_PROCESSOBJECTINTERNALS_BINDING 1
-extern const char* const s_processObjectInternalsBindingCode;
-extern const int s_processObjectInternalsBindingCodeLength;
-extern const JSC::ConstructAbility s_processObjectInternalsBindingCodeConstructAbility;
-extern const JSC::ConstructorKind s_processObjectInternalsBindingCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_processObjectInternalsBindingCodeImplementationVisibility;
-
-// getStdioWriteStream
-#define WEBCORE_BUILTIN_PROCESSOBJECTINTERNALS_GETSTDIOWRITESTREAM 1
-extern const char* const s_processObjectInternalsGetStdioWriteStreamCode;
-extern const int s_processObjectInternalsGetStdioWriteStreamCodeLength;
-extern const JSC::ConstructAbility s_processObjectInternalsGetStdioWriteStreamCodeConstructAbility;
-extern const JSC::ConstructorKind s_processObjectInternalsGetStdioWriteStreamCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_processObjectInternalsGetStdioWriteStreamCodeImplementationVisibility;
-
-// getStdinStream
-#define WEBCORE_BUILTIN_PROCESSOBJECTINTERNALS_GETSTDINSTREAM 1
-extern const char* const s_processObjectInternalsGetStdinStreamCode;
-extern const int s_processObjectInternalsGetStdinStreamCodeLength;
-extern const JSC::ConstructAbility s_processObjectInternalsGetStdinStreamCodeConstructAbility;
-extern const JSC::ConstructorKind s_processObjectInternalsGetStdinStreamCodeConstructorKind;
-extern const JSC::ImplementationVisibility s_processObjectInternalsGetStdinStreamCodeImplementationVisibility;
-
-#define WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_DATA(macro) \
-    macro(binding, processObjectInternalsBinding, 1) \
-    macro(getStdioWriteStream, processObjectInternalsGetStdioWriteStream, 1) \
-    macro(getStdinStream, processObjectInternalsGetStdinStream, 1) \
-
-#define WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(macro) \
-    macro(processObjectInternalsBindingCode, binding, ASCIILiteral(), s_processObjectInternalsBindingCodeLength) \
-    macro(processObjectInternalsGetStdioWriteStreamCode, getStdioWriteStream, ASCIILiteral(), s_processObjectInternalsGetStdioWriteStreamCodeLength) \
-    macro(processObjectInternalsGetStdinStreamCode, getStdinStream, ASCIILiteral(), s_processObjectInternalsGetStdinStreamCodeLength) \
-
-#define WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_FUNCTION_NAME(macro) \
-    macro(binding) \
-    macro(getStdioWriteStream) \
-    macro(getStdinStream) \
-
-#define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
-    JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
-
-WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_GENERATOR)
-#undef DECLARE_BUILTIN_GENERATOR
-
-class ProcessObjectInternalsBuiltinsWrapper : private JSC::WeakHandleOwner {
-public:
-    explicit ProcessObjectInternalsBuiltinsWrapper(JSC::VM& vm)
-        : m_vm(vm)
-        WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(s_##name, length), { }))
-        WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
-#undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
-    {
-    }
-
-#define EXPOSE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-    JSC::UnlinkedFunctionExecutable* name##Executable(); \
-    const JSC::SourceCode& name##Source() const { return m_##name##Source; }
-    WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(EXPOSE_BUILTIN_EXECUTABLES)
-#undef EXPOSE_BUILTIN_EXECUTABLES
-
-    WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
-
-    void exportNames();
-
-private:
-    JSC::VM& m_vm;
-
-    WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
-
-#define DECLARE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) \
-    JSC::SourceCode m_##name##Source;\
-    JSC::Weak<JSC::UnlinkedFunctionExecutable> m_##name##Executable;
-    WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(DECLARE_BUILTIN_SOURCE_MEMBERS)
-#undef DECLARE_BUILTIN_SOURCE_MEMBERS
-
-};
-
-#define DEFINE_BUILTIN_EXECUTABLES(name, functionName, overriddenName, length) \
-inline JSC::UnlinkedFunctionExecutable* ProcessObjectInternalsBuiltinsWrapper::name##Executable() \
-{\
-    if (!m_##name##Executable) {\
-        JSC::Identifier executableName = functionName##PublicName();\
-        if (overriddenName)\
-            executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
-    }\
-    return m_##name##Executable.get();\
-}
-WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_CODE(DEFINE_BUILTIN_EXECUTABLES)
-#undef DEFINE_BUILTIN_EXECUTABLES
-
-inline void ProcessObjectInternalsBuiltinsWrapper::exportNames()
-{
-#define EXPORT_FUNCTION_NAME(name) m_vm.propertyNames->appendExternalName(name##PublicName(), name##PrivateName());
-    WEBCORE_FOREACH_PROCESSOBJECTINTERNALS_BUILTIN_FUNCTION_NAME(EXPORT_FUNCTION_NAME)
-#undef EXPORT_FUNCTION_NAME
-}
 class JSBuiltinFunctions {
 public:
     explicit JSBuiltinFunctions(JSC::VM& vm)
         : m_vm(vm)
-        , m_writableStreamDefaultWriterBuiltins(m_vm)
-        , m_consoleObjectBuiltins(m_vm)
-        , m_transformStreamInternalsBuiltins(m_vm)
-        , m_readableStreamBYOBRequestBuiltins(m_vm)
-        , m_readableStreamBYOBReaderBuiltins(m_vm)
-        , m_writableStreamDefaultControllerBuiltins(m_vm)
-        , m_moduleBuiltins(m_vm)
-        , m_readableByteStreamControllerBuiltins(m_vm)
-        , m_readableStreamDefaultReaderBuiltins(m_vm)
-        , m_byteLengthQueuingStrategyBuiltins(m_vm)
-        , m_jsBufferConstructorBuiltins(m_vm)
-        , m_importMetaObjectBuiltins(m_vm)
-        , m_transformStreamBuiltins(m_vm)
-        , m_readableStreamInternalsBuiltins(m_vm)
-        , m_readableByteStreamInternalsBuiltins(m_vm)
-        , m_utilInspectBuiltins(m_vm)
-        , m_jsBufferPrototypeBuiltins(m_vm)
-        , m_readableStreamBuiltins(m_vm)
         , m_bundlerPluginBuiltins(m_vm)
-        , m_streamInternalsBuiltins(m_vm)
-        , m_transformStreamDefaultControllerBuiltins(m_vm)
+        , m_byteLengthQueuingStrategyBuiltins(m_vm)
         , m_writableStreamInternalsBuiltins(m_vm)
-        , m_readableStreamDefaultControllerBuiltins(m_vm)
-        , m_countQueuingStrategyBuiltins(m_vm)
-        , m_eventSourceBuiltins(m_vm)
+        , m_transformStreamInternalsBuiltins(m_vm)
         , m_processObjectInternalsBuiltins(m_vm)
+        , m_transformStreamBuiltins(m_vm)
+        , m_moduleBuiltins(m_vm)
+        , m_jsBufferPrototypeBuiltins(m_vm)
+        , m_readableByteStreamControllerBuiltins(m_vm)
+        , m_utilInspectBuiltins(m_vm)
+        , m_consoleObjectBuiltins(m_vm)
+        , m_readableStreamInternalsBuiltins(m_vm)
+        , m_transformStreamDefaultControllerBuiltins(m_vm)
+        , m_readableStreamBYOBReaderBuiltins(m_vm)
+        , m_jsBufferConstructorBuiltins(m_vm)
+        , m_readableStreamDefaultReaderBuiltins(m_vm)
+        , m_streamInternalsBuiltins(m_vm)
+        , m_importMetaObjectBuiltins(m_vm)
+        , m_countQueuingStrategyBuiltins(m_vm)
+        , m_readableStreamBYOBRequestBuiltins(m_vm)
+        , m_writableStreamDefaultWriterBuiltins(m_vm)
+        , m_readableStreamBuiltins(m_vm)
+        , m_readableStreamDefaultControllerBuiltins(m_vm)
+        , m_readableByteStreamInternalsBuiltins(m_vm)
+        , m_writableStreamDefaultControllerBuiltins(m_vm)
+        , m_eventSourceBuiltins(m_vm)
 
   {
+        m_writableStreamInternalsBuiltins.exportNames();
         m_transformStreamInternalsBuiltins.exportNames();
         m_readableStreamInternalsBuiltins.exportNames();
-        m_readableByteStreamInternalsBuiltins.exportNames();
         m_streamInternalsBuiltins.exportNames();
-        m_writableStreamInternalsBuiltins.exportNames();
+        m_readableByteStreamInternalsBuiltins.exportNames();
     }
-    WritableStreamDefaultWriterBuiltinsWrapper& writableStreamDefaultWriterBuiltins() { return m_writableStreamDefaultWriterBuiltins; }
-    ConsoleObjectBuiltinsWrapper& consoleObjectBuiltins() { return m_consoleObjectBuiltins; }
-    TransformStreamInternalsBuiltinsWrapper& transformStreamInternalsBuiltins() { return m_transformStreamInternalsBuiltins; }
-    ReadableStreamBYOBRequestBuiltinsWrapper& readableStreamBYOBRequestBuiltins() { return m_readableStreamBYOBRequestBuiltins; }
-    ReadableStreamBYOBReaderBuiltinsWrapper& readableStreamBYOBReaderBuiltins() { return m_readableStreamBYOBReaderBuiltins; }
-    WritableStreamDefaultControllerBuiltinsWrapper& writableStreamDefaultControllerBuiltins() { return m_writableStreamDefaultControllerBuiltins; }
-    ModuleBuiltinsWrapper& moduleBuiltins() { return m_moduleBuiltins; }
-    ReadableByteStreamControllerBuiltinsWrapper& readableByteStreamControllerBuiltins() { return m_readableByteStreamControllerBuiltins; }
-    ReadableStreamDefaultReaderBuiltinsWrapper& readableStreamDefaultReaderBuiltins() { return m_readableStreamDefaultReaderBuiltins; }
-    ByteLengthQueuingStrategyBuiltinsWrapper& byteLengthQueuingStrategyBuiltins() { return m_byteLengthQueuingStrategyBuiltins; }
-    JSBufferConstructorBuiltinsWrapper& jsBufferConstructorBuiltins() { return m_jsBufferConstructorBuiltins; }
-    ImportMetaObjectBuiltinsWrapper& importMetaObjectBuiltins() { return m_importMetaObjectBuiltins; }
-    TransformStreamBuiltinsWrapper& transformStreamBuiltins() { return m_transformStreamBuiltins; }
-    ReadableStreamInternalsBuiltinsWrapper& readableStreamInternalsBuiltins() { return m_readableStreamInternalsBuiltins; }
-    ReadableByteStreamInternalsBuiltinsWrapper& readableByteStreamInternalsBuiltins() { return m_readableByteStreamInternalsBuiltins; }
-    UtilInspectBuiltinsWrapper& utilInspectBuiltins() { return m_utilInspectBuiltins; }
-    JSBufferPrototypeBuiltinsWrapper& jsBufferPrototypeBuiltins() { return m_jsBufferPrototypeBuiltins; }
-    ReadableStreamBuiltinsWrapper& readableStreamBuiltins() { return m_readableStreamBuiltins; }
     BundlerPluginBuiltinsWrapper& bundlerPluginBuiltins() { return m_bundlerPluginBuiltins; }
-    StreamInternalsBuiltinsWrapper& streamInternalsBuiltins() { return m_streamInternalsBuiltins; }
-    TransformStreamDefaultControllerBuiltinsWrapper& transformStreamDefaultControllerBuiltins() { return m_transformStreamDefaultControllerBuiltins; }
+    ByteLengthQueuingStrategyBuiltinsWrapper& byteLengthQueuingStrategyBuiltins() { return m_byteLengthQueuingStrategyBuiltins; }
     WritableStreamInternalsBuiltinsWrapper& writableStreamInternalsBuiltins() { return m_writableStreamInternalsBuiltins; }
-    ReadableStreamDefaultControllerBuiltinsWrapper& readableStreamDefaultControllerBuiltins() { return m_readableStreamDefaultControllerBuiltins; }
-    CountQueuingStrategyBuiltinsWrapper& countQueuingStrategyBuiltins() { return m_countQueuingStrategyBuiltins; }
-    EventSourceBuiltinsWrapper& eventSourceBuiltins() { return m_eventSourceBuiltins; }
+    TransformStreamInternalsBuiltinsWrapper& transformStreamInternalsBuiltins() { return m_transformStreamInternalsBuiltins; }
     ProcessObjectInternalsBuiltinsWrapper& processObjectInternalsBuiltins() { return m_processObjectInternalsBuiltins; }
+    TransformStreamBuiltinsWrapper& transformStreamBuiltins() { return m_transformStreamBuiltins; }
+    ModuleBuiltinsWrapper& moduleBuiltins() { return m_moduleBuiltins; }
+    JSBufferPrototypeBuiltinsWrapper& jsBufferPrototypeBuiltins() { return m_jsBufferPrototypeBuiltins; }
+    ReadableByteStreamControllerBuiltinsWrapper& readableByteStreamControllerBuiltins() { return m_readableByteStreamControllerBuiltins; }
+    UtilInspectBuiltinsWrapper& utilInspectBuiltins() { return m_utilInspectBuiltins; }
+    ConsoleObjectBuiltinsWrapper& consoleObjectBuiltins() { return m_consoleObjectBuiltins; }
+    ReadableStreamInternalsBuiltinsWrapper& readableStreamInternalsBuiltins() { return m_readableStreamInternalsBuiltins; }
+    TransformStreamDefaultControllerBuiltinsWrapper& transformStreamDefaultControllerBuiltins() { return m_transformStreamDefaultControllerBuiltins; }
+    ReadableStreamBYOBReaderBuiltinsWrapper& readableStreamBYOBReaderBuiltins() { return m_readableStreamBYOBReaderBuiltins; }
+    JSBufferConstructorBuiltinsWrapper& jsBufferConstructorBuiltins() { return m_jsBufferConstructorBuiltins; }
+    ReadableStreamDefaultReaderBuiltinsWrapper& readableStreamDefaultReaderBuiltins() { return m_readableStreamDefaultReaderBuiltins; }
+    StreamInternalsBuiltinsWrapper& streamInternalsBuiltins() { return m_streamInternalsBuiltins; }
+    ImportMetaObjectBuiltinsWrapper& importMetaObjectBuiltins() { return m_importMetaObjectBuiltins; }
+    CountQueuingStrategyBuiltinsWrapper& countQueuingStrategyBuiltins() { return m_countQueuingStrategyBuiltins; }
+    ReadableStreamBYOBRequestBuiltinsWrapper& readableStreamBYOBRequestBuiltins() { return m_readableStreamBYOBRequestBuiltins; }
+    WritableStreamDefaultWriterBuiltinsWrapper& writableStreamDefaultWriterBuiltins() { return m_writableStreamDefaultWriterBuiltins; }
+    ReadableStreamBuiltinsWrapper& readableStreamBuiltins() { return m_readableStreamBuiltins; }
+    ReadableStreamDefaultControllerBuiltinsWrapper& readableStreamDefaultControllerBuiltins() { return m_readableStreamDefaultControllerBuiltins; }
+    ReadableByteStreamInternalsBuiltinsWrapper& readableByteStreamInternalsBuiltins() { return m_readableByteStreamInternalsBuiltins; }
+    WritableStreamDefaultControllerBuiltinsWrapper& writableStreamDefaultControllerBuiltins() { return m_writableStreamDefaultControllerBuiltins; }
+    EventSourceBuiltinsWrapper& eventSourceBuiltins() { return m_eventSourceBuiltins; }
 
 private:
     JSC::VM& m_vm;
-    WritableStreamDefaultWriterBuiltinsWrapper m_writableStreamDefaultWriterBuiltins;
-    ConsoleObjectBuiltinsWrapper m_consoleObjectBuiltins;
-    TransformStreamInternalsBuiltinsWrapper m_transformStreamInternalsBuiltins;
-    ReadableStreamBYOBRequestBuiltinsWrapper m_readableStreamBYOBRequestBuiltins;
-    ReadableStreamBYOBReaderBuiltinsWrapper m_readableStreamBYOBReaderBuiltins;
-    WritableStreamDefaultControllerBuiltinsWrapper m_writableStreamDefaultControllerBuiltins;
-    ModuleBuiltinsWrapper m_moduleBuiltins;
-    ReadableByteStreamControllerBuiltinsWrapper m_readableByteStreamControllerBuiltins;
-    ReadableStreamDefaultReaderBuiltinsWrapper m_readableStreamDefaultReaderBuiltins;
-    ByteLengthQueuingStrategyBuiltinsWrapper m_byteLengthQueuingStrategyBuiltins;
-    JSBufferConstructorBuiltinsWrapper m_jsBufferConstructorBuiltins;
-    ImportMetaObjectBuiltinsWrapper m_importMetaObjectBuiltins;
-    TransformStreamBuiltinsWrapper m_transformStreamBuiltins;
-    ReadableStreamInternalsBuiltinsWrapper m_readableStreamInternalsBuiltins;
-    ReadableByteStreamInternalsBuiltinsWrapper m_readableByteStreamInternalsBuiltins;
-    UtilInspectBuiltinsWrapper m_utilInspectBuiltins;
-    JSBufferPrototypeBuiltinsWrapper m_jsBufferPrototypeBuiltins;
-    ReadableStreamBuiltinsWrapper m_readableStreamBuiltins;
     BundlerPluginBuiltinsWrapper m_bundlerPluginBuiltins;
-    StreamInternalsBuiltinsWrapper m_streamInternalsBuiltins;
-    TransformStreamDefaultControllerBuiltinsWrapper m_transformStreamDefaultControllerBuiltins;
+    ByteLengthQueuingStrategyBuiltinsWrapper m_byteLengthQueuingStrategyBuiltins;
     WritableStreamInternalsBuiltinsWrapper m_writableStreamInternalsBuiltins;
-    ReadableStreamDefaultControllerBuiltinsWrapper m_readableStreamDefaultControllerBuiltins;
-    CountQueuingStrategyBuiltinsWrapper m_countQueuingStrategyBuiltins;
-    EventSourceBuiltinsWrapper m_eventSourceBuiltins;
+    TransformStreamInternalsBuiltinsWrapper m_transformStreamInternalsBuiltins;
     ProcessObjectInternalsBuiltinsWrapper m_processObjectInternalsBuiltins;
+    TransformStreamBuiltinsWrapper m_transformStreamBuiltins;
+    ModuleBuiltinsWrapper m_moduleBuiltins;
+    JSBufferPrototypeBuiltinsWrapper m_jsBufferPrototypeBuiltins;
+    ReadableByteStreamControllerBuiltinsWrapper m_readableByteStreamControllerBuiltins;
+    UtilInspectBuiltinsWrapper m_utilInspectBuiltins;
+    ConsoleObjectBuiltinsWrapper m_consoleObjectBuiltins;
+    ReadableStreamInternalsBuiltinsWrapper m_readableStreamInternalsBuiltins;
+    TransformStreamDefaultControllerBuiltinsWrapper m_transformStreamDefaultControllerBuiltins;
+    ReadableStreamBYOBReaderBuiltinsWrapper m_readableStreamBYOBReaderBuiltins;
+    JSBufferConstructorBuiltinsWrapper m_jsBufferConstructorBuiltins;
+    ReadableStreamDefaultReaderBuiltinsWrapper m_readableStreamDefaultReaderBuiltins;
+    StreamInternalsBuiltinsWrapper m_streamInternalsBuiltins;
+    ImportMetaObjectBuiltinsWrapper m_importMetaObjectBuiltins;
+    CountQueuingStrategyBuiltinsWrapper m_countQueuingStrategyBuiltins;
+    ReadableStreamBYOBRequestBuiltinsWrapper m_readableStreamBYOBRequestBuiltins;
+    WritableStreamDefaultWriterBuiltinsWrapper m_writableStreamDefaultWriterBuiltins;
+    ReadableStreamBuiltinsWrapper m_readableStreamBuiltins;
+    ReadableStreamDefaultControllerBuiltinsWrapper m_readableStreamDefaultControllerBuiltins;
+    ReadableByteStreamInternalsBuiltinsWrapper m_readableByteStreamInternalsBuiltins;
+    WritableStreamDefaultControllerBuiltinsWrapper m_writableStreamDefaultControllerBuiltins;
+    EventSourceBuiltinsWrapper m_eventSourceBuiltins;
 ;
 };
 
@@ -5791,19 +5791,19 @@ public:
 
     template<typename Visitor> void visit(Visitor&);
     void initialize(Zig::GlobalObject&);
+    WritableStreamInternalsBuiltinFunctions& writableStreamInternals() { return m_writableStreamInternals; }
     TransformStreamInternalsBuiltinFunctions& transformStreamInternals() { return m_transformStreamInternals; }
     ReadableStreamInternalsBuiltinFunctions& readableStreamInternals() { return m_readableStreamInternals; }
-    ReadableByteStreamInternalsBuiltinFunctions& readableByteStreamInternals() { return m_readableByteStreamInternals; }
     StreamInternalsBuiltinFunctions& streamInternals() { return m_streamInternals; }
-    WritableStreamInternalsBuiltinFunctions& writableStreamInternals() { return m_writableStreamInternals; }
+    ReadableByteStreamInternalsBuiltinFunctions& readableByteStreamInternals() { return m_readableByteStreamInternals; }
 
 private:
     JSC::VM& m_vm;
+    WritableStreamInternalsBuiltinFunctions m_writableStreamInternals;
     TransformStreamInternalsBuiltinFunctions m_transformStreamInternals;
     ReadableStreamInternalsBuiltinFunctions m_readableStreamInternals;
-    ReadableByteStreamInternalsBuiltinFunctions m_readableByteStreamInternals;
     StreamInternalsBuiltinFunctions m_streamInternals;
-    WritableStreamInternalsBuiltinFunctions m_writableStreamInternals;
+    ReadableByteStreamInternalsBuiltinFunctions m_readableByteStreamInternals;
 
 };
 


### PR DESCRIPTION
### What does this PR do?

these are diffs generated during a clean build from 908018a4df5b03168988993f0b664d9443fca381

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

https://bun.sh/docs/project/development#first-build

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
