### PR TITLE
get name if not provided in `FormData.append`

### DIFF
--- a/bench/snippets/cp-r.mjs
+++ b/bench/snippets/cp-r.mjs
@@ -1,4 +1,3 @@
 import { cp } from "fs/promises";
 
 await cp(process.argv[2], process.argv[3], { recursive: true });
-

--- a/src/bun.js/bindings/webcore/JSDOMFormData.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMFormData.cpp
@@ -286,6 +286,8 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append1Body(JSC
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.append(WTFMove(name), WTFMove(value)); })));
 }
 
+extern "C" BunString Blob__getFileNameString(void* impl);
+
 static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append2Body(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSDOMFormData>::ClassParameter castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
@@ -298,10 +300,6 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append2Body(JSC
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
     EnsureStillAliveScope argument1 = callFrame->uncheckedArgument(1);
 
-    EnsureStillAliveScope argument2 = callFrame->argument(2);
-    auto filename = argument2.value().isUndefined() ? String() : convert<IDLUSVString>(*lexicalGlobalObject, argument2.value());
-    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-
     RefPtr<Blob> blobValue = nullptr;
     if (argument1.value().inherits<JSBlob>()) {
         blobValue = Blob::create(argument1.value());
@@ -310,6 +308,10 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append2Body(JSC
     if (!blobValue) {
         throwTypeError(lexicalGlobalObject, throwScope, "Expected argument to be a Blob."_s);
     }
+    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
+
+    EnsureStillAliveScope argument2 = callFrame->argument(2);
+    auto filename = argument2.value().isUndefined() ? Bun::toWTFString(Blob__getFileNameString(blobValue->impl())) : convert<IDLUSVString>(*lexicalGlobalObject, argument2.value());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.append(WTFMove(name), WTFMove(blobValue), WTFMove(filename)); })));

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -510,11 +510,20 @@ pub const Blob = struct {
         this.finalize();
     }
 
+    export fn Blob__getFileNameString(this: *Blob) callconv(.C) bun.String {
+        if (this.getFileName()) |filename| {
+            return bun.String.fromBytes(filename);
+        }
+
+        return bun.String.empty;
+    }
+
     comptime {
         _ = Blob__dupeFromJS;
         _ = Blob__destroy;
         _ = Blob__dupe;
         _ = Blob__setAsFile;
+        _ = Blob__getFileNameString;
     }
 
     pub fn writeFormatForSize(size: usize, writer: anytype, comptime enable_ansi_colors: bool) !void {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -47,6 +47,25 @@ describe("FormData", () => {
     expect(formData.get("foo2").name).toBe("foo.txt");
   });
 
+  it("should use the correct filenames", async () => {
+    const blob = new Blob(["bar"]) as any;
+    const form = new FormData();
+    form.append("foo", blob);
+    expect(blob.name).toBeUndefined();
+
+    let b1 = form.get("foo") as any;
+    expect(blob.name).toBeUndefined();
+    expect(b1.name).toBeUndefined();
+
+    form.set("foo", b1, "foo.txt");
+    expect(blob.name).toBeUndefined();
+    expect(b1.name).toBeUndefined();
+
+    b1 = form.get("foo") as Blob;
+    expect(blob.name).toBeUndefined();
+    expect(b1.name).toBe("foo.txt");
+  });
+
   const multipartFormDataFixturesRawBody = [
     {
       name: "simple",

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -36,6 +36,17 @@ describe("FormData", () => {
     expect(formData.getAll("foo")[0]).toBe("bar");
   });
 
+  it("should get filename from file", async () => {
+    const blob = new Blob(["bar"]);
+    const formData = new FormData();
+    formData.append("foo", blob);
+    // @ts-expect-error
+    expect(formData.get("foo").name).toBeUndefined();
+    formData.append("foo2", new File([blob], "foo.txt"));
+    // @ts-expect-error
+    expect(formData.get("foo2").name).toBe("foo.txt");
+  });
+
   const multipartFormDataFixturesRawBody = [
     {
       name: "simple",


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
fixes #4396 
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

added tests and tested manually

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
