### PR TITLE
export non-enumerable values

### DIFF
--- a/src/bun.js/bindings/CommonJSModuleRecord.cpp
+++ b/src/bun.js/bindings/CommonJSModuleRecord.cpp
@@ -556,7 +556,7 @@ void JSCommonJSModule::toSyntheticSource(JSC::JSGlobalObject* globalObject,
             if (canPerformFastEnumeration(structure)) {
                 exports->structure()->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
                     auto key = entry.key();
-                    if (key->isSymbol() || entry.attributes() & PropertyAttribute::Accessor || entry.attributes() & PropertyAttribute::CustomAccessor || key == esModuleMarker)
+                    if (key->isSymbol() || entry.attributes() & PropertyAttribute::DontEnum || key == esModuleMarker)
                         return true;
 
                     needsToAssignDefault = needsToAssignDefault && key != vm.propertyNames->defaultKeyword;
@@ -568,7 +568,7 @@ void JSCommonJSModule::toSyntheticSource(JSC::JSGlobalObject* globalObject,
                 });
             } else {
                 JSC::PropertyNameArray properties(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
-                exports->methodTable()->getOwnPropertyNames(exports, globalObject, properties, DontEnumPropertiesMode::Include);
+                exports->methodTable()->getOwnPropertyNames(exports, globalObject, properties, DontEnumPropertiesMode::Exclude);
                 if (catchScope.exception()) {
                     catchScope.clearExceptionExceptTermination();
                     return;
@@ -584,9 +584,6 @@ void JSCommonJSModule::toSyntheticSource(JSC::JSGlobalObject* globalObject,
 
                     JSC::PropertySlot slot(exports, PropertySlot::InternalMethodType::Get);
                     if (!exports->getPropertySlot(globalObject, property, slot))
-                        continue;
-
-                    if (slot.isAccessor() || slot.isUnset())
                         continue;
 
                     exportNames.append(property);
@@ -609,7 +606,7 @@ void JSCommonJSModule::toSyntheticSource(JSC::JSGlobalObject* globalObject,
         } else if (canPerformFastEnumeration(structure)) {
             exports->structure()->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
                 auto key = entry.key();
-                if (key->isSymbol() || key == vm.propertyNames->defaultKeyword || entry.attributes() & PropertyAttribute::Accessor || entry.attributes() & PropertyAttribute::CustomAccessor)
+                if (key->isSymbol() || entry.attributes() & PropertyAttribute::DontEnum || key == vm.propertyNames->defaultKeyword)
                     return true;
 
                 JSValue value = exports->getDirect(entry.offset());
@@ -620,7 +617,7 @@ void JSCommonJSModule::toSyntheticSource(JSC::JSGlobalObject* globalObject,
             });
         } else {
             JSC::PropertyNameArray properties(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
-            exports->methodTable()->getOwnPropertyNames(exports, globalObject, properties, DontEnumPropertiesMode::Include);
+            exports->methodTable()->getOwnPropertyNames(exports, globalObject, properties, DontEnumPropertiesMode::Exclude);
             if (catchScope.exception()) {
                 catchScope.clearExceptionExceptTermination();
                 return;
@@ -636,9 +633,6 @@ void JSCommonJSModule::toSyntheticSource(JSC::JSGlobalObject* globalObject,
 
                 JSC::PropertySlot slot(exports, PropertySlot::InternalMethodType::Get);
                 if (!exports->getPropertySlot(globalObject, property, slot))
-                    continue;
-
-                if (slot.isAccessor() || slot.isUnset())
                     continue;
 
                 exportNames.append(property);

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -12115,7 +12115,7 @@ fn NewParser_(
                 try p.lexer.next();
             }
 
-            if (args.items.len == 3 and need_to_check_for_enumerable and args.items[2].data == .e_object) {
+            if (need_to_check_for_enumerable and args.items.len == 3 and args.items[2].data == .e_object) {
                 var obj: *E.Object = args.items[2].data.e_object;
                 var prop_list = obj.properties.listManaged(p.allocator);
 
@@ -12136,6 +12136,7 @@ fn NewParser_(
                 }
 
                 if (!has_enumerable) {
+                    // Needs to be last. If there's a duplicate from a spread, it can be overwritten
                     try prop_list.append(Property{
                         .value = p.newExpr(E.Boolean{ .value = true }, logger.Loc.Empty),
                         .key = p.newExpr(E.String{ .data = "enumerable" }, logger.Loc.Empty),

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -286,4 +286,73 @@ describe("bundler", () => {
       stdout: "react\nreact\nreact\nreact\nundefined\nreact\nreact\nreact\nreact\nreact\nreact\n1 react\nreact\nreact",
     },
   });
+  for (const bundling of [true, false]) {
+    itBundled("cjs2esm/NonEnumerableModuleExports", {
+      files: {
+        "/entry.js": /* js */ `
+          import { foo } from "./foo.cjs";
+          import { bar } from "./bar.cjs";
+          console.log(foo, bar);
+        `,
+        "/foo.cjs": /* js */ `
+          Object.defineProperty(exports, "foo", {
+            enumerable: false,
+            value: 1,
+          });
+        `,
+        "/bar.cjs": /* js */ `
+          Object.defineProperty(exports, "__esModule", {
+            value: true,
+          });
+          Object.defineProperty(exports, "bar", {
+            enumerable: false,
+            value: 1
+          })
+        `,
+      },
+      bundling,
+      run: {
+        stdout: "1 1",
+      },
+    });
+  }
+  itBundled("cjs2esm/NonEnumerableModuleExportsAccessors", {
+    files: {
+      "/entry.js": /* js */ `
+          import { foo } from "./foo.cjs";
+          console.log(foo);
+        `,
+      "/foo.cjs": /* js */ `
+          Object.defineProperty(exports, "foo", {
+            enumerable: false,
+            get: () => 1,
+          });
+        `,
+    },
+    bundling: false,
+    run: {
+      error: "SyntaxError: Import named 'foo' not found in module",
+    },
+  });
+  itBundled("cjs2esm/NonEnumerableModuleExportsAccessors2", {
+    files: {
+      "/entry.js": /* js */ `
+          import { foo } from "./foo.cjs";
+          console.log(foo);
+        `,
+      "/foo.cjs": /* js */ `
+          Object.defineProperty(exports, "__esModule", {
+            value: true,
+          });
+          Object.defineProperty(exports, "foo", {
+            enumerable: false,
+            get: () => 1,
+          });
+        `,
+    },
+    bundling: false,
+    run: {
+      error: "SyntaxError: Import named 'foo' not found in module",
+    },
+  });
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
fixes #4432 
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
added tests. tested the slow paths manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
