### PR TITLE
Use `$XDG_CACHE_HOME/bun` instead of `$XDG_CACHE_HOME/.bun` (when the var is set).

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -4469,7 +4469,7 @@ pub const PackageManager = struct {
                 return try std.fs.cwd().makeOpenPathIterable(path, .{});
             }
 
-            if (orelse bun.getenvZ("HOME")) |home_dir| {
+            if (bun.getenvZ("HOME")) |home_dir| {
                 var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
                 var parts = [_]string{
                     ".bun",

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -3674,7 +3674,7 @@ pub const PackageManager = struct {
         }
 
         if (env.map.get("XDG_CACHE_HOME")) |dir| {
-            var parts = [_]string{ dir, ".bun/", "install/", "cache/" };
+            var parts = [_]string{ dir, "bun/", "install/", "cache/" };
             return CacheDir{ .path = Fs.FileSystem.instance.abs(&parts), .is_node_modules = false };
         }
 
@@ -4429,7 +4429,7 @@ pub const PackageManager = struct {
 
             if (bun.getenvZ("XDG_CACHE_HOME") orelse bun.getenvZ("HOME")) |home_dir| {
                 var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                var parts = [_]string{ ".bun", "install", "global" };
+                var parts = [_]string{ "bun", "install", "global" };
                 var path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
                 return try std.fs.cwd().makeOpenPathIterable(path, .{});
             }
@@ -4459,7 +4459,17 @@ pub const PackageManager = struct {
                 return try std.fs.cwd().makeOpenPathIterable(path, .{});
             }
 
-            if (bun.getenvZ("XDG_CACHE_HOME") orelse bun.getenvZ("HOME")) |home_dir| {
+            if (bun.getenvZ("XDG_CACHE_HOME")) |home_dir| {
+                var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+                var parts = [_]string{
+                    "bun",
+                    "bin",
+                };
+                var path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
+                return try std.fs.cwd().makeOpenPathIterable(path, .{});
+            }
+
+            if (orelse bun.getenvZ("HOME")) |home_dir| {
                 var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
                 var parts = [_]string{
                     ".bun",


### PR DESCRIPTION
This addresses the comment at https://github.com/oven-sh/bun/issues/1678#issuecomment-1668660285

> … I have yet to see see any other program use a `.` prefix for folders
> *inside* the XDG convention folders. This may cause the folder to be
> unexpectedly hidden when viewing it in a file explorer app or running
> `ls` without `-a`. (That is, someone may expect `~/.cache` to be
> hidden — but that all folders are visible once they are viewing that
> hidden folder.)

The only previous workaround would have been to set `$BUN_INSTALL`, but
that affects more than the cache directory (sort of defeating the point
of `$XDG_CACHE_HOME` in the first place).

Since this:

- only affects the subset of users who have explictly
opted into `$XDG_CACHE_HOME`, and
- only affects cache data, which is meant to be safe to abandon/lose at
  any moment,

… it shouldn't be harmful to leave the old directory lying around and
allow a new one to be created. But it would also be possible to (re)move the
existing directory with an additional change.

### What does this PR do?

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

This is an adaptation of existing code patterns — modifying a string in two places and forking an `if` statement into two copies.
I'm unable to build `bun` on my system at the moment, but this is as safe a change as I could author.
