### PR TITLE
fix(runtime): `fs.cp` edge cases

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -3557,7 +3557,7 @@ pub const NodeFS = struct {
                 };
 
                 if (!os.S.ISREG(stat_.mode)) {
-                    return Maybe(Return.CopyFile){ .err = .{ .errno = @intFromEnum(C.SystemErrno.ENOTSUP), .path = src } };
+                    return Maybe(Return.CopyFile){ .err = .{ .errno = @intFromEnum(C.SystemErrno.ENOTSUP) } };
                 }
 
                 // 64 KB is about the break-even point for clonefile() to be worth it

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5400,7 +5400,7 @@ pub const NodeFS = struct {
                     .PERM,
                     .INVAL,
                     => {
-                        @memcpy(this.sync_error_buf[0..src.len], dest);
+                        @memcpy(this.sync_error_buf[0..src.len], src);
                         return .{ .err = err.err.withPath(this.sync_error_buf[0..src.len]) };
                     },
                     // Other errors may be due to clonefile() not being supported

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -40,7 +40,9 @@ for (const [name, copy] of impls) {
         "from/a.txt": "a",
       });
 
-      await copyShouldThrow(basename + "/from", basename + "/result");
+      const e = await copyShouldThrow(basename + "/from", basename + "/result");
+      expect(e.code).toBe("EISDIR");
+      expect(e.path).toBe(basename + "/from");
     });
 
     test("recursive directory structure - no destination", async () => {
@@ -129,7 +131,12 @@ for (const [name, copy] of impls) {
         "result/a.txt": "win",
       });
 
-      await copyShouldThrow(basename + "/from/a.txt", basename + "/result/a.txt", { force: false, errorOnExist: true });
+      const e = await copyShouldThrow(basename + "/from/a.txt", basename + "/result/a.txt", {
+        force: false,
+        errorOnExist: true,
+      });
+      expect(e.code).toBe("EEXIST");
+      expect(e.path).toBe(basename + "/result/a.txt");
 
       assertContent(basename + "/result/a.txt", "win");
     });

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -3,7 +3,7 @@ import { describe, test, expect, jest } from "bun:test";
 import { tempDirWithFiles } from "harness";
 
 const impls = [
-  // ["cpSync", fs.cpSync],
+  ["cpSync", fs.cpSync],
   ["cp", fs.promises.cp],
 ] as const;
 

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -251,5 +251,31 @@ for (const [name, copy] of impls) {
         [basename + "/from/b.txt", basename + "/result/b.txt"],
       ]);
     });
+
+    test("trailing slash", async () => {
+      const basename = tempDirWithFiles("cp", {
+        "from/a.txt": "a",
+        "from/b.txt": "b",
+      });
+
+      await copy(basename + "/from/", basename + "/result/", { recursive: true });
+
+      assertContent(basename + "/result/a.txt", "a");
+      assertContent(basename + "/result/b.txt", "b");
+    });
+
+    test("copy directory will ensure directory exists", async () => {
+      const basename = tempDirWithFiles("cp", {
+        "from/a.txt": "a",
+        "from/b.txt": "b",
+      });
+
+      fs.mkdirSync(basename + "/result/");
+
+      await copy(basename + "/from/", basename + "/hello/world/", { recursive: true });
+
+      assertContent(basename + "/hello/world/a.txt", "a");
+      assertContent(basename + "/hello/world/b.txt", "b");
+    });
   });
 }


### PR DESCRIPTION
### What does this PR do?

Closes #4436 

- Error messages did not always contain the proper path.
- Fix a crash during one of the errors.
- `clonefile` path can `ENOENT` if there the destination directory doesnt exist.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
