### PR TITLE
`bun install` support private GitHub dependencies using oauth2

### DIFF
--- a/.github/workflows/bun-linux-build.yml
+++ b/.github/workflows/bun-linux-build.yml
@@ -192,6 +192,7 @@ jobs:
       - id: test
         name: Test (node runner)
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SMTP_SENDGRID_SENDER: ${{ secrets.SMTP_SENDGRID_SENDER }}
           TLS_MONGODB_DATABASE_URL: ${{ secrets.TLS_MONGODB_DATABASE_URL }}
           TLS_POSTGRES_DATABASE_URL: ${{ secrets.TLS_POSTGRES_DATABASE_URL }}

--- a/.github/workflows/bun-mac-aarch64.yml
+++ b/.github/workflows/bun-mac-aarch64.yml
@@ -431,6 +431,7 @@ jobs:
       - id: test
         name: Test (node runner)
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SMTP_SENDGRID_SENDER: ${{ secrets.SMTP_SENDGRID_SENDER }}
           TLS_MONGODB_DATABASE_URL: ${{ secrets.TLS_MONGODB_DATABASE_URL }}
           TLS_POSTGRES_DATABASE_URL: ${{ secrets.TLS_POSTGRES_DATABASE_URL }}

--- a/.github/workflows/bun-mac-x64-baseline.yml
+++ b/.github/workflows/bun-mac-x64-baseline.yml
@@ -435,6 +435,7 @@ jobs:
       - id: test
         name: Test (node runner)
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SMTP_SENDGRID_SENDER: ${{ secrets.SMTP_SENDGRID_SENDER }}
           TLS_MONGODB_DATABASE_URL: ${{ secrets.TLS_MONGODB_DATABASE_URL }}
           TLS_POSTGRES_DATABASE_URL: ${{ secrets.TLS_POSTGRES_DATABASE_URL }}

--- a/.github/workflows/bun-mac-x64.yml
+++ b/.github/workflows/bun-mac-x64.yml
@@ -437,6 +437,7 @@ jobs:
       - id: test
         name: Test (node runner)
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SMTP_SENDGRID_SENDER: ${{ secrets.SMTP_SENDGRID_SENDER }}
           TLS_MONGODB_DATABASE_URL: ${{ secrets.TLS_MONGODB_DATABASE_URL }}
           TLS_POSTGRES_DATABASE_URL: ${{ secrets.TLS_POSTGRES_DATABASE_URL }}

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -472,7 +472,7 @@ pub const Version = struct {
                 // hello/world
                 // hello.tar.gz
                 // https://github.com/user/repo
-                // https://oauth2:github_pat_token@github.com/user/repo
+                // https://oauth2:TOKEN@github.com/user/repo
                 'h' => {
                     if (strings.hasPrefixComptime(dependency, "http")) {
                         var url = dependency["http".len..];
@@ -490,8 +490,8 @@ pub const Version = struct {
                                 },
                                 else => {},
                             }
-                            if (strings.hasPrefixComptime(url, "oauth2:github_pat_")) {
-                                url = url["oauth2:github_pat_".len..];
+                            if (strings.hasPrefixComptime(url, "oauth2:")) {
+                                url = url["oauth2:".len..];
                                 for (url, 0..) |c, i| {
                                     if (c == '@' and i < url.len - 1) {
                                         url = url[i + 1 ..];
@@ -795,7 +795,7 @@ pub fn parseWithTag(
                             },
                             else => {},
                         }
-                        if (strings.hasPrefixComptime(url, "oauth2:github_pat_")) {
+                        if (strings.hasPrefixComptime(url, "oauth2:")) {
                             url = url["oauth2:".len..];
                             for (url, 0..) |c, i| {
                                 if (c == '@' and i < url.len - 1) {

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -490,8 +490,8 @@ pub const Version = struct {
                                 },
                                 else => {},
                             }
-                            if (strings.hasPrefixComptime(url, "oauth2:github_pat")) {
-                                url = url["oauth2:github_pat".len..];
+                            if (strings.hasPrefixComptime(url, "oauth2:github_pat_")) {
+                                url = url["oauth2:github_pat_".len..];
                                 for (url, 0..) |c, i| {
                                     if (c == '@' and i < url.len - 1) {
                                         url = url[i + 1 ..];
@@ -769,6 +769,7 @@ pub fn parseWithTag(
         .github => {
             var from_url = false;
             var input = dependency;
+            var oauth2: ?[]const u8 = null;
             if (strings.hasPrefixComptime(input, "github:")) {
                 input = input["github:".len..];
             } else if (strings.hasPrefixComptime(input, "git://github.com/")) {
@@ -794,10 +795,11 @@ pub fn parseWithTag(
                             },
                             else => {},
                         }
-                        if (strings.hasPrefixComptime(url, "oauth2:github_pat")) {
-                            url = url["oauth2:github_pat".len..];
+                        if (strings.hasPrefixComptime(url, "oauth2:github_pat_")) {
+                            url = url["oauth2:".len..];
                             for (url, 0..) |c, i| {
                                 if (c == '@' and i < url.len - 1) {
+                                    oauth2 = url[0..i];
                                     url = url[i + 1 ..];
                                     break;
                                 }
@@ -840,6 +842,7 @@ pub fn parseWithTag(
                         .owner = sliced.sub(input[0..slash_index]).value(),
                         .repo = sliced.sub(repo).value(),
                         .committish = if (hash_index == 0) String.from("") else sliced.sub(input[hash_index + 1 ..]).value(),
+                        .oauth2_token = if (oauth2) |token| sliced.sub(token).value() else .{},
                     },
                 },
                 .tag = .github,

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -472,6 +472,7 @@ pub const Version = struct {
                 // hello/world
                 // hello.tar.gz
                 // https://github.com/user/repo
+                // https://oauth2:github_pat_token@github.com/user/repo
                 'h' => {
                     if (strings.hasPrefixComptime(dependency, "http")) {
                         var url = dependency["http".len..];
@@ -488,6 +489,15 @@ pub const Version = struct {
                                     }
                                 },
                                 else => {},
+                            }
+                            if (strings.hasPrefixComptime(url, "oauth2:github_pat")) {
+                                url = url["oauth2:github_pat".len..];
+                                for (url, 0..) |c, i| {
+                                    if (c == '@' and i < url.len - 1) {
+                                        url = url[i + 1 ..];
+                                        break;
+                                    }
+                                }
                             }
                             if (strings.hasPrefixComptime(url, "github.com/")) {
                                 if (isGitHubRepoPath(url["github.com/".len..])) return .github;
@@ -783,6 +793,15 @@ pub fn parseWithTag(
                                 }
                             },
                             else => {},
+                        }
+                        if (strings.hasPrefixComptime(url, "oauth2:github_pat")) {
+                            url = url["oauth2:github_pat".len..];
+                            for (url, 0..) |c, i| {
+                                if (c == '@' and i < url.len - 1) {
+                                    url = url[i + 1 ..];
+                                    break;
+                                }
+                            }
                         }
                         if (strings.hasPrefixComptime(url, "github.com/")) {
                             input = url["github.com/".len..];

--- a/src/install/repository.zig
+++ b/src/install/repository.zig
@@ -26,6 +26,8 @@ pub const Repository = extern struct {
     committish: GitSHA = .{},
     resolved: GitSHA = .{},
     package_name: String = .{},
+    /// Used for GitHub package URLs with an oauth2 token
+    oauth2_token: String = .{},
 
     pub fn verify(this: *const Repository) void {
         this.owner.assertDefined();

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2851,7 +2851,7 @@ it("should handle GitHub URL in dependencies (git+https://github.com/user/repo.g
 });
 
 test.skipIf(process.env.GITHUB_TOKEN === undefined)(
-  "should handle GitHub OAuth2 URL in dependencies (https://oauth2:github_pat_TOKEN@github.com/user/repo)",
+  "should handle GitHub OAuth2 URL in dependencies (https://oauth2:TOKEN@github.com/user/repo)",
   async () => {
     const token = process.env.GITHUB_TOKEN;
     await writeFile(

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2850,7 +2850,7 @@ it("should handle GitHub URL in dependencies (git+https://github.com/user/repo.g
   await access(join(package_dir, "bun.lockb"));
 });
 
-test.skipIf(process.env.GITHUB_TOKEN !== undefined)(
+test.skipIf(process.env.GITHUB_TOKEN === undefined)(
   "should handle GitHub OAuth2 URL in dependencies (https://oauth2:github_pat_TOKEN@github.com/user/repo)",
   async () => {
     const token = process.env.GITHUB_TOKEN;


### PR DESCRIPTION
### What does this PR do?
Closes #3555
Adds support for dependencies using a OAuth2 GitHub URL. E.g.
```json
"dependencies": {
    "@biz/module": "https://oauth2:your_token_here@github.com/user/repo.git#master"
}
```
It's more of a workaround than I'd like, as dependency parsing and request header generation is mostly hardcoded for npm style workflows. This makes it hard to modify how dependencies are fetched through `bun install`.

The included test requires fetching a private GitHub repo using a real OAuth2 token.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
