### PR TITLE
fix(syscall): fix handling syscall errno

### DIFF
--- a/src/sys.zig
+++ b/src/sys.zig
@@ -257,8 +257,8 @@ pub fn getErrno(rc: anytype) bun.C.E {
     const Type = @TypeOf(rc);
 
     return switch (Type) {
-        comptime_int, usize => return std.os.linux.getErrno(@as(usize, rc)),
-        i32, c_int, isize => return std.os.errno(rc),
+        comptime_int, usize => std.os.linux.getErrno(@as(usize, rc)),
+        i32, c_int, isize => std.os.errno(rc),
         else => @compileError("Not implemented yet for type " ++ @typeName(Type)),
     };
 }

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -256,16 +256,11 @@ pub fn getErrno(rc: anytype) bun.C.E {
     if (comptime use_libc) return std.os.errno(rc);
     const Type = @TypeOf(rc);
 
-    switch (Type) {
+    return switch (Type) {
         comptime_int, usize => return std.os.linux.getErrno(@as(usize, rc)),
-        i32, c_int, isize => {
-            if (rc == -1) {
-                return std.os.errno(rc);
-            }
-            return std.os.linux.getErrno(@as(usize, @bitCast(@as(isize, rc))));
-        },
+        i32, c_int, isize => return std.os.errno(rc),
         else => @compileError("Not implemented yet for type " ++ @typeName(Type)),
-    }
+    };
 }
 
 // pub fn openOptionsFromFlagsWindows(flags: u32) windows.OpenFileOptions {

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -256,11 +256,16 @@ pub fn getErrno(rc: anytype) bun.C.E {
     if (comptime use_libc) return std.os.errno(rc);
     const Type = @TypeOf(rc);
 
-    return switch (Type) {
-        comptime_int, usize => std.os.linux.getErrno(@as(usize, rc)),
-        i32, c_int, isize => std.os.linux.getErrno(@as(usize, @bitCast(@as(isize, rc)))),
+    switch (Type) {
+        comptime_int, usize => return std.os.linux.getErrno(@as(usize, rc)),
+        i32, c_int, isize => {
+            if (rc == -1) {
+                return std.os.errno(rc);
+            }
+            return std.os.linux.getErrno(@as(usize, @bitCast(@as(isize, rc))));
+        },
         else => @compileError("Not implemented yet for type " ++ @typeName(Type)),
-    };
+    }
 }
 
 // pub fn openOptionsFromFlagsWindows(flags: u32) windows.OpenFileOptions {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2024,7 +2024,20 @@ it("BigIntStats", () => {
 
 it("test syscall errno, issue#4198", () => {
   const path = `${tmpdir()}/non-existent-${Date.now()}.txt`;
-  expect(() => unlinkSync(path)).toThrow("No such file or directory");
+  expect(() => openSync(path, "r")).toThrow("No such file or directory");
+  expect(() => readSync(2147483640, Buffer.alloc(0))).toThrow("Bad file number");
+  expect(() => readlinkSync(path)).toThrow("No such file or directory");
+  expect(() => realpathSync(path)).toThrow("No such file or directory");
+  expect(() => readFileSync(path)).toThrow("No such file or directory");
   expect(() => renameSync(path, `${path}.2`)).toThrow("No such file or directory");
-  expect(() => openSync(path)).toThrow("No such file or directory");
+  expect(() => statSync(path)).toThrow("No such file or directory");
+  expect(() => unlinkSync(path)).toThrow("No such file or directory");
+  expect(() => rmSync(path)).toThrow("No such file or directory");
+  expect(() => rmdirSync(path)).toThrow("No such file or directory");
+  expect(() => closeSync(2147483640)).toThrow("Bad file number");
+
+  mkdirSync(path);
+  expect(() => mkdirSync(path)).toThrow("File or folder exists");
+  expect(() => unlinkSync(path)).toThrow("Is a directory");
+  rmdirSync(path);
 });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -18,6 +18,7 @@ import fs, {
   rmSync,
   rmdir,
   rmdirSync,
+  renameSync,
   createReadStream,
   createWriteStream,
   promises,
@@ -2019,4 +2020,10 @@ it("BigIntStats", () => {
   expect(withBigInt.mtime.getTime()).toEqual(withoutBigInt.mtime.getTime());
   expect(withBigInt.ctime.getTime()).toEqual(withoutBigInt.ctime.getTime());
   expect(withBigInt.birthtime.getTime()).toEqual(withoutBigInt.birthtime.getTime());
+});
+
+it("test syscall errno, issue#4198", () => {
+  const path = `${tmpdir()}/non-existent-${Date.now()}.txt`;
+  expect(() => unlinkSync(path)).toThrow("No such file or directory");
+  expect(() => renameSync(path, `${path}.2`)).toThrow("No such file or directory");
 });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2026,4 +2026,5 @@ it("test syscall errno, issue#4198", () => {
   const path = `${tmpdir()}/non-existent-${Date.now()}.txt`;
   expect(() => unlinkSync(path)).toThrow("No such file or directory");
   expect(() => renameSync(path, `${path}.2`)).toThrow("No such file or directory");
+  expect(() => openSync(path)).toThrow("No such file or directory");
 });


### PR DESCRIPTION
### What does this PR do?

Close: #4198 


- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

## Explanation

### Why `unlinkSync` throws `EPERM`


https://github.com/oven-sh/bun/blob/5c43744bce358f132a63d5002baffd7647d47a76/src/sys.zig#L912-L921

`unlinkSync` uses the `sys.unlink` which behaves differently at compile time based on whether we link to `libc` or not.

https://ziglang.org/documentation/master/std/#A;std:os.system

![2023-09-03_22-46](https://github.com/oven-sh/bun/assets/9482395/26bc8d97-b823-4267-9dd7-0e83f00d1416)


If we link to `libc`, we use the `unlink` function from the C library. From `man 2 unlink`, we should read the `errno`

> RETURN VALUE
       On success, zero is returned.  On error, -1 is returned, and errno is set to indicate the error.

https://github.com/oven-sh/bun/blob/5c43744bce358f132a63d5002baffd7647d47a76/src/sys.zig#L247-L264

`-1` will be converted to `1` (`EPERM`), so we get a `Operation not permitted`.


### Why `open` work correctly before?


https://github.com/oven-sh/bun/blob/5c43744bce358f132a63d5002baffd7647d47a76/src/sys.zig#L419-L434


`Syscall.system.openat` is https://github.com/ziglang/zig/blob/62f727eedb2b8d8b8f922d52a0ff4218a92e6cff/lib/std/os/linux.zig#L750. This is not `libc` function, just a linux platform syscall.


### Why `unlinkSync` work on darwin?

On darwin, libc is linked, and the value directly from `std.os.errno` is used in `getErrno`.
