### PR TITLE
docs typo: `loaders` -> `loader`

### DIFF
--- a/docs/runtime/configuration.md
+++ b/docs/runtime/configuration.md
@@ -37,7 +37,7 @@ logLevel = "debug" # "debug", "warn", "error"
 # This will probably change in a future release to be just regular TOML instead. It is a holdover from the CLI argument parsing.
 "process.env.bagel" = "'lox'"
 
-[loaders]
+[loader]
 # When loading a .bagel file, run the JS parser
 ".bagel" = "js"
 ```


### PR DESCRIPTION
### What does this PR do?

It should be `loader` instead of `loaders`. Close: #4377

https://github.com/oven-sh/bun/blob/18767906db0dd29b2d898f84a023d403c3084d6e/src/bunfig.zig#L686

In command line, we also use the `--loader`, no `--loaders`.


- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

