### PR TITLE
fix zlib deflate on fetch

### DIFF
--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -1155,9 +1155,9 @@ pub const InternalState = struct {
                     // TODO: add br support today we support gzip and deflate only
                     // zlib.MAX_WBITS = 15
                     // to (de-)compress deflate format, use wbits = -zlib.MAX_WBITS
-                    // to (de-)compress zlib format, use wbits = zlib.MAX_WBITS
+                    // to (de-)compress deflate format with headers we use wbits = 0 (we can detect the first byte using 120)
                     // to (de-)compress gzip format, use wbits = zlib.MAX_WBITS | 16
-                    .windowBits = if (this.encoding == Encoding.gzip) Zlib.MAX_WBITS | 16 else -Zlib.MAX_WBITS,
+                    .windowBits = if (this.encoding == Encoding.gzip) Zlib.MAX_WBITS | 16 else (if (buffer.len > 1 and buffer[0] == 120) 0 else -Zlib.MAX_WBITS),
                 },
             );
             this.zlib_reader = reader;

--- a/src/zlib.zig
+++ b/src/zlib.zig
@@ -442,8 +442,8 @@ pub const ZlibReaderArrayList = struct {
         // always free with `inflateEnd`
         if (this.state != State.End) {
             _ = inflateEnd(&this.zlib);
+            this.state = State.End;
         }
-        this.state = State.End;
     }
 
     pub fn init(

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -17,7 +17,7 @@ const smallText = Buffer.from("Hello".repeat(16));
 const empty = Buffer.alloc(0);
 
 describe("fetch() with streaming", () => {
-  it("can deflate with and without headers", async () => {
+  it("can deflate with and without headers #4478", async () => {
     let server: Server | null = null;
     try {
       server = Bun.serve({

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -44,12 +44,13 @@ describe("fetch() with streaming", () => {
         },
       });
       const url = `http://${server.hostname}:${server.port}/`;
-      expect(await (await fetch(`${url}with_headers`)).text()).toBe("Hello, World");
-      expect(await (await fetch(url)).text()).toBe("Hello, World");
+      expect(await fetch(`${url}with_headers`).then(res => res.text())).toBe("Hello, World");
+      expect(await fetch(url).then(res => res.text())).toBe("Hello, World");
     } finally {
       server?.stop();
     }
   });
+
   it("stream still works after response get out of scope", async () => {
     let server: Server | null = null;
     try {
@@ -500,12 +501,13 @@ describe("fetch() with streaming", () => {
     }
   }
 
-  type CompressionType = "no" | "gzip" | "deflate" | "br";
+  type CompressionType = "no" | "gzip" | "deflate" | "br" | "deflate_with_headers";
   type TestType = { headers: Record<string, string>; compression: CompressionType; skip?: boolean };
   const types: Array<TestType> = [
     { headers: {}, compression: "no" },
     { headers: { "Content-Encoding": "gzip" }, compression: "gzip" },
     { headers: { "Content-Encoding": "deflate" }, compression: "deflate" },
+    { headers: { "Content-Encoding": "deflate" }, compression: "deflate_with_headers" },
     // { headers: { "Content-Encoding": "br" }, compression: "br", skip: true }, // not implemented yet
   ];
 
@@ -515,6 +517,8 @@ describe("fetch() with streaming", () => {
         return Bun.gzipSync(data);
       case "deflate":
         return Bun.deflateSync(data);
+      case "deflate_with_headers":
+        return zlib.deflateSync(data);
       default:
         return data;
     }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix https://github.com/oven-sh/bun/issues/4478
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

 I wrote automated tests 

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
