### PR TITLE
fix ipv6 localhost fetch

### DIFF
--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -369,8 +369,17 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             debug("connect({s}, {d})", .{ host, port });
             var stack_fallback = std.heap.stackFallback(1024, bun.default_allocator);
             var allocator = stack_fallback.get();
-            var host_ = allocator.dupeZ(u8, host) catch return null;
-            defer allocator.free(host_);
+
+            var host_: ?[*:0]u8 = brk: {
+                // getaddrinfo expects `node` to be null if localhost
+                if (host.len < 6 and (bun.strings.eqlComptime(host, "[::1]") or bun.strings.eqlComptime(host, "[::]"))) {
+                    break :brk null;
+                }
+
+                break :brk allocator.dupeZ(u8, host) catch return null;
+            };
+
+            defer if (host_) |host__| allocator.free(host__[0..host.len]);
 
             var socket = us_socket_context_connect(comptime ssl_int, socket_ctx, host_, port, null, 0, @sizeOf(*anyopaque)) orelse return null;
             const socket_ = ThisSocket{ .socket = socket };

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -531,6 +531,20 @@ describe("fetch", () => {
     expect(response2.status).toBe(200);
     expect(await response2.text()).toBe("0");
   });
+
+  it("should work with ipv6 localhost", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response("Pass!");
+      },
+    });
+
+    const res = await fetch(`http://[::1]:${server.port}`);
+    expect(await res.text()).toBe("Pass!");
+
+    server.stop();
+  });
 });
 
 it("simultaneous HTTPS fetch", async () => {

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -540,7 +540,13 @@ describe("fetch", () => {
       },
     });
 
-    const res = await fetch(`http://[::1]:${server.port}`);
+    let res = await fetch(`http://[::1]:${server.port}`);
+    expect(await res.text()).toBe("Pass!");
+    res = await fetch(`http://[::]:${server.port}/`);
+    expect(await res.text()).toBe("Pass!");
+    res = await fetch(`http://[0:0:0:0:0:0:0:1]:${server.port}/`);
+    expect(await res.text()).toBe("Pass!");
+    res = await fetch(`http://[0000:0000:0000:0000:0000:0000:0000:0001]:${server.port}/`);
     expect(await res.text()).toBe("Pass!");
 
     server.stop();


### PR DESCRIPTION
### What does this PR do?
fixes #2941 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
added test and tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
