### PR TITLE
fix checkout/build failure due to `src/deps/uws`

### DIFF
--- a/.scripts/write-versions.sh
+++ b/.scripts/write-versions.sh
@@ -7,11 +7,9 @@ LIBARCHIVE_VERSION=$(git rev-parse HEAD:./src/deps/libarchive)
 PICOHTTPPARSER_VERSION=$(git rev-parse HEAD:./src/deps/picohttpparser)
 BORINGSSL_VERSION=$(git rev-parse HEAD:./src/deps/boringssl)
 ZLIB_VERSION=$(git rev-parse HEAD:./src/deps/zlib)
-UWS_VERSION=$(git rev-parse HEAD:./src/deps/uws)
 LOLHTML=$(git rev-parse HEAD:./src/deps/lol-html)
 TINYCC=$(git rev-parse HEAD:./src/deps/tinycc)
 C_ARES=$(git rev-parse HEAD:./src/deps/c-ares)
-USOCKETS=$(cd src/deps/uws/uSockets && git rev-parse HEAD)
 
 rm -rf src/generated_versions_list.zig
 echo "// AUTO-GENERATED FILE. Created via .scripts/write-versions.sh" >src/generated_versions_list.zig
@@ -20,7 +18,6 @@ echo "pub const boringssl = \"$BORINGSSL_VERSION\";" >>src/generated_versions_li
 echo "pub const libarchive = \"$LIBARCHIVE_VERSION\";" >>src/generated_versions_list.zig
 echo "pub const mimalloc = \"$MIMALLOC_VERSION\";" >>src/generated_versions_list.zig
 echo "pub const picohttpparser = \"$PICOHTTPPARSER_VERSION\";" >>src/generated_versions_list.zig
-echo "pub const uws = \"$UWS_VERSION\";" >>src/generated_versions_list.zig
 echo "pub const webkit = \"$WEBKIT_VERSION\";" >>src/generated_versions_list.zig
 echo "pub const zig = @import(\"std\").fmt.comptimePrint(\"{}\", .{@import(\"builtin\").zig_version});" >>src/generated_versions_list.zig
 echo "pub const zlib = \"$ZLIB_VERSION\";" >>src/generated_versions_list.zig

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -2488,14 +2488,14 @@ pub const Process = struct {
     pub export const Bun__versions_libarchive: [*:0]const u8 = bun.Global.versions.libarchive;
     pub export const Bun__versions_mimalloc: [*:0]const u8 = bun.Global.versions.mimalloc;
     pub export const Bun__versions_picohttpparser: [*:0]const u8 = bun.Global.versions.picohttpparser;
-    pub export const Bun__versions_uws: [*:0]const u8 = bun.Global.versions.uws;
+    pub export const Bun__versions_uws: [*:0]const u8 = bun.Environment.git_sha;
     pub export const Bun__versions_webkit: [*:0]const u8 = bun.Global.versions.webkit;
     pub export const Bun__versions_zig: [*:0]const u8 = bun.Global.versions.zig;
     pub export const Bun__versions_zlib: [*:0]const u8 = bun.Global.versions.zlib;
     pub export const Bun__versions_tinycc: [*:0]const u8 = bun.Global.versions.tinycc;
     pub export const Bun__versions_lolhtml: [*:0]const u8 = bun.Global.versions.lolhtml;
     pub export const Bun__versions_c_ares: [*:0]const u8 = bun.Global.versions.c_ares;
-    pub export const Bun__versions_usockets: [*:0]const u8 = bun.Global.versions.usockets;
+    pub export const Bun__versions_usockets: [*:0]const u8 = bun.Environment.git_sha;
     pub export const Bun__version_sha: [*:0]const u8 = bun.Environment.git_sha;
 };
 

--- a/src/generated_versions_list.zig
+++ b/src/generated_versions_list.zig
@@ -2,13 +2,11 @@
 
 pub const boringssl = "b275c5ce1c88bc06f5a967026d3c0ce1df2be815";
 pub const libarchive = "dc321febde83dd0f31158e1be61a7aedda65e7a2";
-pub const mimalloc = "3c7079967a269027e438a2aac83197076d9fe09d";
+pub const mimalloc = "7968d4285043401bb36573374710d47a4081a063";
 pub const picohttpparser = "066d2b1e9ab820703db0837a7255d92d30f0c9f5";
-pub const uws = "70b1b9fc1341e8b791b42c5447f90505c2abe156";
-pub const webkit = "60d11703a533fd694cd1d6ddda04813eecb5d69f";
+pub const webkit = "a780bdf0255ae1a7ed15e4b3f31c14af705facae";
 pub const zig = @import("std").fmt.comptimePrint("{}", .{@import("builtin").zig_version});
 pub const zlib = "885674026394870b7e7a05b7bf1ec5eb7bd8a9c0";
 pub const tinycc = "2d3ad9e0d32194ad7fd867b66ebe218dcc8cb5cd";
-pub const lolhtml = "2681dcf0b3e6907111565199df8c43cc9aab7fe8";
+pub const lolhtml = "8d4c273ded322193d017042d1f48df2766b0f88b";
 pub const c_ares = "0e7a5dee0fbb04080750cf6eabbe89d8bae87faa";
-pub const usockets = "fafc241e8664243fc0c51d69684d5d02b9805134";

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -171,13 +171,11 @@ const versions = existsSync(generated_versions_list);
   // pub const libarchive = "dc321febde83dd0f31158e1be61a7aedda65e7a2";
   // pub const mimalloc = "3c7079967a269027e438a2aac83197076d9fe09d";
   // pub const picohttpparser = "066d2b1e9ab820703db0837a7255d92d30f0c9f5";
-  // pub const uws = "70b1b9fc1341e8b791b42c5447f90505c2abe156";
   // pub const webkit = "60d11703a533fd694cd1d6ddda04813eecb5d69f";
   // pub const zlib = "885674026394870b7e7a05b7bf1ec5eb7bd8a9c0";
   // pub const tinycc = "2d3ad9e0d32194ad7fd867b66ebe218dcc8cb5cd";
   // pub const lolhtml = "2eed349dcdfa4ff5c19fe7c6e501cfd687601033";
   // pub const c_ares = "0e7a5dee0fbb04080750cf6eabbe89d8bae87faa";
-  // pub const usockets = "fafc241e8664243fc0c51d69684d5d02b9805134";
   const versions = Object.fromEntries(
     readFileSync(generated_versions_list, "utf8")
       .split("\n")
@@ -185,15 +183,17 @@ const versions = existsSync(generated_versions_list);
       .map(line => line.split(" = "))
       .map(([name, hash]) => [name.slice(9).trim(), hash.slice(1, -2)]),
   );
-  versions.uwebsockets = versions.uws;
-  delete versions.uws;
-  versions["ares"] = versions.c_ares;
+  versions.ares = versions.c_ares;
   delete versions.c_ares;
 
   for (const name in versions) {
     expect(process.versions).toHaveProperty(name);
     expect(process.versions[name]).toBe(versions[name]);
   }
+
+  expect(process.versions).toHaveProperty("usockets");
+  expect(process.versions).toHaveProperty("uwebsockets");
+  expect(process.versions.usockets).toBe(process.versions.uwebsockets);
 });
 
 it("process.config", () => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fixes `git submodule sync` failure caused by presence of `src/deps/uws` in a85bd5d083b4f4010467640d6545bcd7df3d9ae6

In addition, fix up `.scripts/write-versions.sh` since it referenced the now-removed submodule, and short-circuit `process.versions[{"usockets", "uwebsockets"}]` to use `bun`'s SHA since they have now been internalised.
