### PR TITLE
allocate task for `ThreadSafeFunction` 

### DIFF
--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -347,6 +347,10 @@ pub const ConcurrentTask = struct {
         return created;
     }
 
+    pub fn createFrom(task: anytype) *ConcurrentTask {
+        return create(Task.init(task));
+    }
+
     pub fn fromCallback(ptr: anytype, comptime callback: anytype) *ConcurrentTask {
         return create(ManagedTask.New(std.meta.Child(@TypeOf(ptr)), callback).init(ptr));
     }

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -93,6 +93,10 @@ pub const AsyncReaddirTask = struct {
         var node_fs = NodeFS{};
         this.result = node_fs.readdir(this.args, .promise);
 
+        if (this.result == .err) {
+            this.result.err.path = bun.default_allocator.dupe(u8, this.result.err.path) catch "";
+        }
+
         this.globalObject.bunVMConcurrently().eventLoop().enqueueTaskConcurrent(JSC.ConcurrentTask.fromCallback(this, runFromJSThread));
     }
 
@@ -370,6 +374,10 @@ pub const AsyncReadFileTask = struct {
         var node_fs = NodeFS{};
         this.result = node_fs.readFile(this.args, .promise);
 
+        if (this.result == .err) {
+            this.result.err.path = bun.default_allocator.dupe(u8, this.result.err.path) catch "";
+        }
+
         this.globalObject.bunVMConcurrently().eventLoop().enqueueTaskConcurrent(JSC.ConcurrentTask.fromCallback(this, runFromJSThread));
     }
 
@@ -459,6 +467,10 @@ pub const AsyncCopyFileTask = struct {
 
         var node_fs = NodeFS{};
         this.result = node_fs.copyFile(this.args, .promise);
+
+        if (this.result == .err) {
+            this.result.err.path = bun.default_allocator.dupe(u8, this.result.err.path) catch "";
+        }
 
         this.globalObject.bunVMConcurrently().eventLoop().enqueueTaskConcurrent(JSC.ConcurrentTask.fromCallback(this, runFromJSThread));
     }

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1215,7 +1215,6 @@ pub const ThreadSafeFunction = struct {
     owning_threads: std.AutoArrayHashMapUnmanaged(u64, void) = .{},
     owning_thread_lock: Lock = Lock.init(),
     event_loop: *JSC.EventLoop,
-    concurrent_task: JSC.ConcurrentTask = .{},
     concurrent_finalizer_task: JSC.ConcurrentTask = .{},
 
     env: napi_env,

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1323,7 +1323,7 @@ pub const ThreadSafeFunction = struct {
             }
         }
 
-        this.event_loop.enqueueTaskConcurrent(this.concurrent_task.from(this, .manual_deinit));
+        this.event_loop.enqueueTaskConcurrent(JSC.ConcurrentTask.createFrom(this));
     }
 
     pub fn finalize(opaq: *anyopaque) void {

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1215,7 +1215,6 @@ pub const ThreadSafeFunction = struct {
     owning_threads: std.AutoArrayHashMapUnmanaged(u64, void) = .{},
     owning_thread_lock: Lock = Lock.init(),
     event_loop: *JSC.EventLoop,
-    concurrent_finalizer_task: JSC.ConcurrentTask = .{},
 
     env: napi_env,
 
@@ -1371,7 +1370,7 @@ pub const ThreadSafeFunction = struct {
 
         if (this.owning_threads.count() == 0) {
             this.finalizer_task = JSC.AnyTask{ .ctx = this, .callback = finalize };
-            this.event_loop.enqueueTaskConcurrent(this.concurrent_finalizer_task.from(&this.finalizer_task, .manual_deinit));
+            this.event_loop.enqueueTaskConcurrent(JSC.ConcurrentTask.fromCallback(this, finalize));
             return;
         }
     }


### PR DESCRIPTION
### What does this PR do?
fixes file reloads when running `bun --bun run dev` in astro docs.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
