### PR TITLE
Fix(fs): Fix the `dir` field parsing in `PathName`.

### DIFF
--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -79,4 +79,38 @@ describe("bun", () => {
       }
     });
   });
+
+  test("test bun . in different path, issue#4516", () => {
+    function expectSuccess(cwd: string, path: string) {
+      fs.writeFileSync(path, "console.log('Bun!')");
+      const p = Bun.spawnSync({
+        cmd: [bunExe(), "."],
+        cwd: cwd,
+        env: bunEnv,
+        stderr: "inherit",
+      });
+      expect(p.exitCode).toBe(0);
+    }
+    // Run `bun .` in /tmp
+    {
+      const cwd = tmpdir();
+      const path = `${cwd}/index.ts`;
+      try {
+        expectSuccess(cwd, path);
+      } finally {
+        fs.unlinkSync(path);
+      }
+    }
+    // Run `bun .` in /tmp/xxx
+    {
+      const cwd = `${tmpdir()}/bun-cli-test-${Date.now()}`;
+      fs.mkdirSync(cwd);
+      const path = `${cwd}/index.ts`;
+      try {
+        expectSuccess(cwd, path);
+      } finally {
+        fs.rmSync(cwd, { recursive: true });
+      }
+    }
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Close: #4516

If we passed a path like `/app/` into the `init` function of `PathName`, the parsed `dir` would be an empty string.

https://github.com/oven-sh/bun/blob/daaac7792cc348030d64a33087f1a41b3a3822cf/src/fs.zig#L1405-L1419

In above, we stop at first non-trailing slash, `i` could be `0` here, so `dir` is empty. 

https://github.com/oven-sh/bun/blob/daaac7792cc348030d64a33087f1a41b3a3822cf/src/fs.zig#L1385-L1396

`dirWithTrailingSlash` will return `./`.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?


I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->


- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
