### PR TITLE
`bun install` fix Git SSH URLs

### DIFF
--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -521,16 +521,6 @@ pub const Version = struct {
                         return .npm;
                     }
                 },
-                // ssh://user@example.com/user/repo
-                // ssh://user@example.com:user/repo
-                // ssh://example.com/user/repo
-                // ssh://example.com:user/repo
-                's' => {
-                    if (strings.hasPrefixComptime(dependency, "ssh://")) {
-                        return .git;
-                    }
-                },
-
                 // v1.2.3
                 // verilog
                 // verilog.tar.gz

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -412,6 +412,10 @@ pub const Version = struct {
                 // git_tarball.tgz
                 // github:user/repo
                 // git@example.com/repo.git
+                // git+ssh://user@example.com/repo.git
+                // git+file://user@example.com/repo.git
+                // git+http://user@example.com/repo.git
+                // git+https://user@example.com/repo.git
                 // git://user@example.com/repo.git
                 'g' => {
                     if (strings.hasPrefixComptime(dependency, "git")) {

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -413,6 +413,7 @@ pub const Version = struct {
                 // github:user/repo
                 // git@example.com/repo.git
                 // git+ssh://user@example.com/repo.git
+                // git+ssh://user@example.com:repo.git
                 // git+file://user@example.com/repo.git
                 // git+http://user@example.com/repo.git
                 // git+https://user@example.com/repo.git
@@ -520,6 +521,16 @@ pub const Version = struct {
                         return .npm;
                     }
                 },
+                // ssh://user@example.com/user/repo
+                // ssh://user@example.com:user/repo
+                // ssh://example.com/user/repo
+                // ssh://example.com:user/repo
+                's' => {
+                    if (strings.hasPrefixComptime(dependency, "ssh://")) {
+                        return .git;
+                    }
+                },
+
                 // v1.2.3
                 // verilog
                 // verilog.tar.gz

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -633,14 +633,14 @@ const Task = struct {
                 const name = this.request.git_clone.name.slice();
                 const url = this.request.git_clone.url.slice();
 
-                const dir = Repository.download(
+                const dir = Repository.download_try_https_first(
                     manager.allocator,
                     manager.env,
                     manager.log,
                     manager.getCacheDirectory().dir,
                     this.id,
                     name,
-                    Repository.normalize_to_git_url(url),
+                    url,
                 ) catch |err| {
                     this.err = err;
                     this.status = Status.fail;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -632,25 +632,15 @@ const Task = struct {
                 const manager = this.package_manager;
                 const name = this.request.git_clone.name.slice();
                 const url = this.request.git_clone.url.slice();
-                const dir = brk: {
-                    if (Repository.tryHTTPS(url)) |https| break :brk Repository.download(
-                        manager.allocator,
-                        manager.env,
-                        manager.log,
-                        manager.getCacheDirectory().dir,
-                        this.id,
-                        name,
-                        https,
-                    ) catch null;
-                    break :brk null;
-                } orelse Repository.download(
+
+                const dir = Repository.download(
                     manager.allocator,
                     manager.env,
                     manager.log,
                     manager.getCacheDirectory().dir,
                     this.id,
                     name,
-                    url,
+                    Repository.normalize_to_git_url(url),
                 ) catch |err| {
                     this.err = err;
                     this.status = Status.fail;

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -1027,6 +1027,20 @@ pub const Log = struct {
         });
     }
 
+    pub fn addErrorFmtWithNote(log: *Log, source: ?*const Source, l: Loc, allocator: std.mem.Allocator, comptime err: string, args: anytype, comptime note_fmt: string, note_args: anytype) !void {
+        @setCold(true);
+        log.errors += 1;
+
+        var notes = try allocator.alloc(Data, 1);
+        notes[0] = rangeData(null, Range.None, allocPrint(allocator, note_fmt, note_args) catch unreachable);
+
+        try log.addMsg(.{
+            .kind = .err,
+            .data = try rangeData(source, Range{ .loc = l }, allocPrint(allocator, err, args) catch unreachable).cloneLineText(log.clone_line_text, log.msgs.allocator),
+            .notes = notes,
+        });
+    }
+
     pub fn addZigErrorWithNote(log: *Log, allocator: std.mem.Allocator, err: anyerror, comptime noteFmt: string, args: anytype) !void {
         @setCold(true);
         log.errors += 1;

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -3427,13 +3427,13 @@ describe("Git URLs", () => {
       expect(stdout).toBeDefined();
       let out = await new Response(stdout).text();
       out = out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, ""); // remove timings
-      
+
       const has_sha = dep.commit_sha !== null;
       if (!has_sha) out = out.replace(/(\.git)?#[a-f0-9]+/, "$1"); // remove commit SHA
 
       const expected_out_url = dep.expected_out_url === null ? dep.url : dep.expected_out_url;
       expect(out.split(/\r?\n/)).toEqual([
-        ` + ${dep.name}@${expected_out_url}${has_sha ? ('#' + dep.commit_sha) : ""}`,
+        ` + ${dep.name}@${expected_out_url}${has_sha ? "#" + dep.commit_sha : ""}`,
         "",
         " 1 packages installed",
       ]);
@@ -3449,7 +3449,7 @@ describe("Git URLs", () => {
       expect(cache).not.toBeEmpty();
       if (has_sha) expect(cache).toContain(`@G@${dep.commit_sha}`);
       expect(await readdirSorted(join(package_dir, "node_modules", dep.name))).toContain("package.json");
-      
+
       const package_json = await file(join(package_dir, "node_modules", dep.name, "package.json")).json();
       expect(package_json.name).toBe(dep.name);
       await access(join(package_dir, "bun.lockb"));
@@ -3493,7 +3493,7 @@ describe("Git URLs", () => {
       expect(err.code).toBe("ENOENT");
     }
   });
-  
+
   it("should fail on invalid committish", async () => {
     const urls: string[] = [];
     setHandler(dummyRegistry(urls));
@@ -3533,7 +3533,7 @@ describe("Git URLs", () => {
       expect(err.code).toBe("ENOENT");
     }
   }, 20000);
-  
+
   it("should de-duplicate committish", async () => {
     const urls: string[] = [];
     setHandler(dummyRegistry(urls));
@@ -3620,7 +3620,7 @@ describe("Git URLs", () => {
     expect(ver_json.version).toBe("3.14.1");
     await access(join(package_dir, "bun.lockb"));
   }, 20000);
-  
+
   it("should handle Git URL with existing lockfile", async () => {
     const urls: string[] = [];
     setHandler(dummyRegistry(urls));
@@ -3762,7 +3762,7 @@ describe("Git URLs", () => {
         "upper-case",
       ].map(async dir => await rm(join(package_dir, "node_modules", dir), { force: true, recursive: true })),
     );
-  
+
     urls.length = 0;
     const {
       stdout: stdout3,
@@ -3816,7 +3816,6 @@ describe("Git URLs", () => {
     await access(join(package_dir, "bun.lockb"));
   }, 20000);
 });
-
 
 it("should prefer optionalDependencies over dependencies of the same name", async () => {
   const urls: string[] = [];

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -3340,6 +3340,11 @@ describe("Git URLs", () => {
       commit_sha: null,
     },
     {
+      url: "ssh://git@github.com:mishoo/UglifyJS.git",
+      expected_out_url: "git+ssh://git@github.com:mishoo/UglifyJS.git",
+      commit_sha: null,
+    },
+    {
       url: "github.com:mishoo/UglifyJS.git",
       expected_out_url: "git+ssh://github.com:mishoo/UglifyJS.git",
       commit_sha: null,
@@ -3349,11 +3354,11 @@ describe("Git URLs", () => {
       expected_out_url: "git+ssh://git@github.com:mishoo/UglifyJS.git",
       commit_sha: null,
     },
-    // {
-    //   url: "git://git@github.com/mishoo/UglifyJS.git",
-    //   expected_out_url: null,
-    //   commit_sha: null,
-    // },
+    {
+      url: "git://github.com/mishoo/UglifyJS.git",
+      expected_out_url: "github:mishoo/UglifyJS",
+      commit_sha: null,
+    },
     {
       url: "git+https://git@github.com/mishoo/UglifyJS.git#v3.14.1",
       expected_out_url: "git+https://git@github.com/mishoo/UglifyJS.git#e219a9a78a0d2251e4dcbd4bb9034207eb484fe8",
@@ -3395,7 +3400,7 @@ describe("Git URLs", () => {
       expect(stdout).toBeDefined();
       let out = await new Response(stdout).text();
       out = out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, ""); // remove timings
-      if (dep.commit_sha === null) out = out.replace(/(\.git)#[a-f0-9]+/, "$1"); // remove commit SHA
+      if (dep.commit_sha === null) out = out.replace(/(\.git)?#[a-f0-9]+/, "$1"); // remove commit SHA
 
       const expected_out_url = dep.expected_out_url === null ? dep.url : dep.expected_out_url;
       expect(out.split(/\r?\n/)).toEqual([

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -3344,12 +3344,6 @@ describe("Git URLs", () => {
     },
     {
       name: "uglify-js",
-      url: "ssh://git@github.com:mishoo/UglifyJS.git",
-      expected_out_url: "git+ssh://git@github.com:mishoo/UglifyJS.git",
-      commit_sha: null,
-    },
-    {
-      name: "uglify-js",
       url: "github.com:mishoo/UglifyJS.git",
       expected_out_url: "git+ssh://github.com:mishoo/UglifyJS.git",
       commit_sha: null,
@@ -3382,12 +3376,6 @@ describe("Git URLs", () => {
       name: "@gitlab-examples/semantic-release-npm",
       url: "git+ssh://git@gitlab.com:gitlab-examples/semantic-release-npm.git",
       expected_out_url: null,
-      commit_sha: null,
-    },
-    {
-      name: "@gitlab-examples/semantic-release-npm",
-      url: "ssh://git@gitlab.com:gitlab-examples/semantic-release-npm.git",
-      expected_out_url: "git+ssh://git@gitlab.com:gitlab-examples/semantic-release-npm.git",
       commit_sha: null,
     },
     {


### PR DESCRIPTION
### What does this PR do?

Closes #4068

`npm` allows SSH and SCP style URLs to have a `:` between the host and path, but `git` will not accept URLs like that. So we need to do a small conversion between the two.
E.g.  `git+ssh://git@example.com:path/to/repo` -> `git+ssh://git@example.com/path/to/repo`

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
I wrote automated tests

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
