### PR TITLE
Update Svelte Kit Docs

### DIFF
--- a/docs/guides/ecosystem/sveltekit.md
+++ b/docs/guides/ecosystem/sveltekit.md
@@ -63,3 +63,58 @@ Visit [http://localhost:5173](http://localhost:5173/) in a browser to see the te
 ---
 
 If you edit and save `src/routes/+page.svelte`, you should see your changes hot-reloaded in the browser.
+
+---
+
+To build for production, you'll need to add the right sveltekit adapter. 
+
+`bun add -D svelte-adapter-bun`.
+
+Now, make the following changes to your `svelte.config.js`.
+
+```diff
+- import adapter from '@sveltejs/adapter-auto'
++ import adapter from 'svelte-adapter-bun';
+import { vitePreprocess } from '@sveltejs/kit/vite';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+        kit: {
+                adapter: adapter()
+        },
+        preprocess: vitePreprocess()
+};
+
+export default config;
+```
+
+---
+
+To build a production bundle for deployment execute `bun run build` in the root folder of your project.
+
+```sh
+$ vite build
+
+vite v4.4.9 building SSR bundle for production...
+transforming (60) node_modules/@sveltejs/kit/src/utils/escape.js
+
+✓ 98 modules transformed.
+Generated an empty chunk: "entries/endpoints/waitlist/_server.ts".
+
+vite v4.4.9 building for production...
+✓ 92 modules transformed.
+Generated an empty chunk: "7".
+.svelte-kit/output/client/_app/version.json                                     0.03 kB │ gzip:  0.05 kB
+
+...
+
+.svelte-kit/output/server/index.js                                             86.47 kB
+
+Run npm run preview to preview your production build locally.
+
+> Using svelte-adapter-bun
+  ✔ Start server with: bun ./build/index.js
+  ✔ done
+✓ built in 7.81s
+```
+

--- a/docs/guides/ecosystem/sveltekit.md
+++ b/docs/guides/ecosystem/sveltekit.md
@@ -66,23 +66,23 @@ If you edit and save `src/routes/+page.svelte`, you should see your changes hot-
 
 ---
 
-To build for production, you'll need to add the right sveltekit adapter. 
+To build for production, you'll need to add the right SvelteKit adapter. Currently we recommend the
 
 `bun add -D svelte-adapter-bun`.
 
 Now, make the following changes to your `svelte.config.js`.
 
-```diff
-- import adapter from '@sveltejs/adapter-auto'
-+ import adapter from 'svelte-adapter-bun';
-import { vitePreprocess } from '@sveltejs/kit/vite';
+```ts
+- import adapter from "@sveltejs/adapter-auto";
++ import adapter from "svelte-adapter-bun";
+import { vitePreprocess } from "@sveltejs/kit/vite";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-        kit: {
-                adapter: adapter()
-        },
-        preprocess: vitePreprocess()
+  kit: {
+    adapter: adapter(),
+  },
+  preprocess: vitePreprocess(),
 };
 
 export default config;
@@ -90,10 +90,11 @@ export default config;
 
 ---
 
-To build a production bundle for deployment execute `bun run build` in the root folder of your project.
+To build a production bundle:
 
 ```sh
-$ vite build
+$ bun run build
+ $ vite build
 
 vite v4.4.9 building SSR bundle for production...
 transforming (60) node_modules/@sveltejs/kit/src/utils/escape.js
@@ -104,11 +105,11 @@ Generated an empty chunk: "entries/endpoints/waitlist/_server.ts".
 vite v4.4.9 building for production...
 ✓ 92 modules transformed.
 Generated an empty chunk: "7".
-.svelte-kit/output/client/_app/version.json                                     0.03 kB │ gzip:  0.05 kB
+.svelte-kit/output/client/_app/version.json      0.03 kB │ gzip:  0.05 kB
 
 ...
 
-.svelte-kit/output/server/index.js                                             86.47 kB
+.svelte-kit/output/server/index.js               86.47 kB
 
 Run npm run preview to preview your production build locally.
 
@@ -117,4 +118,3 @@ Run npm run preview to preview your production build locally.
   ✔ done
 ✓ built in 7.81s
 ```
-


### PR DESCRIPTION
I added some guidance about how to build for production. Still WIP since I would like to add a more complete deployment guide.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
