### PR TITLE
Make the link to application clickable in the terminal

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,14 +39,14 @@ const server = Bun.serve({
   },
 });
 
-console.log(`Listening on http://localhost:${server.port}...`);
+console.log(`Listening on http://localhost:${server.port} ...`);
 ```
 
 Run the file from your shell.
 
 ```bash
 $ bun index.ts
-Listening at http://localhost:3000...
+Listening at http://localhost:3000 ...
 ```
 
 Visit [http://localhost:3000](http://localhost:3000) to test the server. You should see a simple page that says "Bun!".


### PR DESCRIPTION
### What does this PR do?

Terminals like iTerm require valid URL to make them clickable.  Adding a space to make link clickable in terminal. 

Similar problem is on https://bun.sh/, where protocol is missing.

### How did you verify your code works?

Cosmetic change. Tested on macOS with iTerm.