### PR TITLE
WIP: fetch without lock

### DIFF
--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1392,60 +1392,6 @@ pub const Fetch = struct {
             if (this.http != null) {
                 HTTPClient.http_thread.scheduleShutdown(this.http.?);
             }
-
-            var ref = this.promise;
-
-            const promise_value = ref.valueOrEmpty();
-
-            defer ref.strong.deinit();
-
-            if (this.signal) |signal| {
-                this.signal = null;
-                signal.detach(this);
-            }
-            err.ensureStillAlive();
-
-            if (promise_value.isEmptyOrUndefinedOrNull()) {
-                log("abortListener no promise", .{});
-                if (this.readable_stream_ref.get()) |readable| {
-                    readable.ptr.Bytes.onData(
-                        .{
-                            .err = .{ .JSValue = err },
-                        },
-                        bun.default_allocator,
-                    );
-                    return;
-                }
-                if (this.response.get()) |response_js| {
-                    if (response_js.as(Response)) |response| {
-                        const body = response.body;
-                        if (body.value == .Locked) {
-                            if (body.value.Locked.readable) |readable| {
-                                readable.ptr.Bytes.onData(
-                                    .{
-                                        .err = .{ .JSValue = err },
-                                    },
-                                    bun.default_allocator,
-                                );
-                                return;
-                            }
-                        }
-
-                        response.body.value.toErrorInstance(err, globalThis);
-                        return;
-                    }
-                }
-
-                globalThis.throwValue(err);
-                return;
-            }
-
-            log("abortListener with promise", .{});
-
-            promise_value.ensureStillAlive();
-            const promise = promise_value.asAnyPromise() orelse return;
-
-            promise.reject(globalThis, err);
         }
 
         const FetchOptions = struct {

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -871,6 +871,15 @@ pub const Fetch = struct {
             if (!success) {
                 const err = this.onReject(result);
                 err.ensureStillAlive();
+                if (this.readable_stream_ref.get()) |readable| {
+                    readable.ptr.Bytes.onData(
+                        .{
+                            .err = .{ .JSValue = err },
+                        },
+                        bun.default_allocator,
+                    );
+                    return;
+                }
                 if (this.response.get()) |response_js| {
                     if (response_js.as(Response)) |response| {
                         const body = response.body;

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1378,13 +1378,12 @@ pub const Fetch = struct {
             return fetch_tasklet;
         }
 
-        pub fn abortListener(this: *FetchTasklet, err: JSValue) void {
+        pub fn abortListener(this: *FetchTasklet, reason: JSValue) void {
             log("abortListener", .{});
             const globalThis = this.global_this;
-            err.ensureStillAlive();
-            err.protect();
-            this.is_waiting_abort = true;
-            this.abort_reason = err;
+            reason.ensureStillAlive();
+            reason.protect();
+            this.abort_reason = reason;
 
             this.signal_store.aborted.store(true, .Monotonic);
             this.tracker.didCancel(globalThis);

--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -1324,7 +1324,6 @@ pub const InternalState = struct {
             reader.deinit();
         }
 
-        
         if (this.cloned_metadata != null) {
             this.cloned_metadata.?.deinit(allocator);
             this.cloned_metadata = null;

--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -1324,10 +1324,7 @@ pub const InternalState = struct {
             reader.deinit();
         }
 
-        // if we are holding a cloned_metadata we need to deinit it
-        // this should never happen because we should always return the metadata to the user
-        std.debug.assert(this.cloned_metadata == null);
-        // just in case we check and free to avoid leaks
+        
         if (this.cloned_metadata != null) {
             this.cloned_metadata.?.deinit(allocator);
             this.cloned_metadata = null;
@@ -2865,10 +2862,6 @@ fn fail(this: *HTTPClient, err: anyerror) void {
     if (this.signals.aborted != null) {
         _ = socket_async_http_abort_tracker.swapRemove(this.async_http_id);
     }
-
-    this.state.reset(this.allocator);
-    this.proxy_tunneling = false;
-
     this.state.request_stage = .fail;
     this.state.response_stage = .fail;
     this.state.fail = err;
@@ -2876,6 +2869,9 @@ fn fail(this: *HTTPClient, err: anyerror) void {
 
     const callback = this.result_callback;
     const result = this.toResult();
+    this.state.reset(this.allocator);
+    this.proxy_tunneling = false;
+
     callback.run(result);
 }
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Existing tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
