### PR TITLE
`server.requestIp()`

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2332,6 +2332,25 @@ declare module "bun" {
     ): ServerWebSocketSendStatus;
 
     /**
+     * Returns the client IP address of the given Request.
+     *
+     * @param request The incoming request
+     *
+     * @returns An ipv6 address `string`, or `undefined` if it couldn't find one.
+     * @todo Return a `SocketAddress` object instead.
+     *
+     * @example
+     * ```js
+     * export default {
+     *  async fetch(request, server) {
+     *    return new Response(server.requestIp(request));
+     *  }
+     * }
+     * ```
+     */
+    requestIp(request: Request): string | undefined;
+
+    /**
      * How many requests are in-flight right now?
      */
     readonly pendingRequests: number;

--- a/src/bun.js/api/server.classes.ts
+++ b/src/bun.js/api/server.classes.ts
@@ -24,6 +24,10 @@ function generate(name) {
         fn: "doStop",
         length: 1,
       },
+      requestIp: {
+        fn: "doRequestIp",
+        length: 1,
+      },
       port: {
         getter: "getPort",
       },

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5845,13 +5845,11 @@ const SocketAddress = struct {
 
         if (addr.len == 4) {
             result.tag = .ipv4;
-            const ip = std.mem.readIntSlice(u32, addr, .Big);
-
             result.value = try std.fmt.allocPrint(allocator, "{d}.{d}.{d}.{d}", .{
-                (ip >> (8 * 3)) & 0xFF,
-                (ip >> (8 * 2)) & 0xFF,
-                (ip >> (8 * 1)) & 0xFF,
-                (ip >> (8 * 0)) & 0xFF,
+                addr[0],
+                addr[1],
+                addr[2],
+                addr[3],
             });
         } else if (addr.len == 16) {
             result.tag = .ipv6;
@@ -5859,6 +5857,7 @@ const SocketAddress = struct {
             const ip = std.mem.readIntSlice(u128, addr, .Big);
             const buf = try allocator.alloc(u8, 4 * 8 + 7); // 8 groups of 4 digits, seperated by 7 colons
 
+            // iterate through buf, printing 4 bits at a time from ip, and placing colons every 5 chars
             for (buf, 0..) |*c, i| {
                 if ((i + 1) % 5 == 0 and i != 0) {
                     c.* = ':';

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5829,6 +5829,60 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
     };
 }
 
+const SocketAddress = struct {
+    tag: Tag,
+    value: []const u8,
+
+    pub const Tag = enum {
+        ipv4,
+        ipv6,
+        // unix,
+    };
+
+    /// Parses address bytes into a text representation.
+    pub fn parse_binary(allocator: std.mem.Allocator, addr: []const u8) !SocketAddress {
+        var result = SocketAddress{ .tag = .ipv4, .value = undefined };
+
+        if (addr.len == 4) {
+            result.tag = .ipv4;
+            const ip = std.mem.readIntSlice(u32, addr, .Big);
+
+            result.value = try std.fmt.allocPrint(allocator, "{d}.{d}.{d}.{d}", .{
+                (ip >> (8 * 3)) & 0xFF,
+                (ip >> (8 * 2)) & 0xFF,
+                (ip >> (8 * 1)) & 0xFF,
+                (ip >> (8 * 0)) & 0xFF,
+            });
+        } else if (addr.len == 16) {
+            result.tag = .ipv6;
+
+            const ip = std.mem.readIntSlice(u128, addr, .Big);
+            const buf = try allocator.alloc(u8, 4 * 8 + 7); // 8 groups of 4 digits, seperated by 7 colons
+
+            for (buf, 0..) |*c, i| {
+                if ((i + 1) % 5 == 0 and i != 0) {
+                    c.* = ':';
+                    continue;
+                }
+
+                const shift = 124 - (i - @divFloor(i, 5)) * 4;
+                c.* = hex_from_bits(@truncate(ip >> @intCast(shift)));
+            }
+
+            result.value = buf;
+        } else return error.InvalidAddress;
+
+        return result;
+    }
+
+    inline fn hex_from_bits(b: u4) u8 {
+        return if (b < 10)
+            '0' + @as(u8, b)
+        else
+            'a' + @as(u8, b - 10);
+    }
+};
+
 pub const HTTPServer = NewServer(JSC.Codegen.JSHTTPServer, false, false);
 pub const HTTPSServer = NewServer(JSC.Codegen.JSHTTPSServer, true, false);
 pub const DebugHTTPServer = NewServer(JSC.Codegen.JSDebugHTTPServer, false, true);

--- a/src/bun.js/bindings/ZigGeneratedClasses.cpp
+++ b/src/bun.js/bindings/ZigGeneratedClasses.cpp
@@ -4197,6 +4197,9 @@ JSC_DECLARE_HOST_FUNCTION(DebugHTTPSServerPrototype__publishCallback);
 extern "C" EncodedJSValue DebugHTTPSServerPrototype__doReload(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC_DECLARE_HOST_FUNCTION(DebugHTTPSServerPrototype__reloadCallback);
 
+extern "C" EncodedJSValue DebugHTTPSServerPrototype__doRequestIp(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
+JSC_DECLARE_HOST_FUNCTION(DebugHTTPSServerPrototype__requestIpCallback);
+
 extern "C" EncodedJSValue DebugHTTPSServerPrototype__doStop(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC_DECLARE_HOST_FUNCTION(DebugHTTPSServerPrototype__stopCallback);
 
@@ -4216,6 +4219,7 @@ static const HashTableValue JSDebugHTTPSServerPrototypeTableValues[] = {
     { "protocol"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, DebugHTTPSServerPrototype__protocolGetterWrap, 0 } },
     { "publish"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, DebugHTTPSServerPrototype__publishCallback, 3 } },
     { "reload"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, DebugHTTPSServerPrototype__reloadCallback, 2 } },
+    { "requestIp"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, DebugHTTPSServerPrototype__requestIpCallback, 1 } },
     { "stop"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, DebugHTTPSServerPrototype__stopCallback, 1 } },
     { "upgrade"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, DebugHTTPSServerPrototype__upgradeCallback, 1 } }
 };
@@ -4438,6 +4442,34 @@ JSC_DEFINE_HOST_FUNCTION(DebugHTTPSServerPrototype__reloadCallback, (JSGlobalObj
 #endif
 
     return DebugHTTPSServerPrototype__doReload(thisObject->wrapped(), lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(DebugHTTPSServerPrototype__requestIpCallback, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+
+    JSDebugHTTPSServer* thisObject = jsDynamicCast<JSDebugHTTPSServer*>(callFrame->thisValue());
+
+    if (UNLIKELY(!thisObject)) {
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        throwVMTypeError(lexicalGlobalObject, throwScope, "Expected 'this' to be instanceof DebugHTTPSServer"_s);
+        return JSValue::encode({});
+    }
+
+    JSC::EnsureStillAliveScope thisArg = JSC::EnsureStillAliveScope(thisObject);
+
+#ifdef BUN_DEBUG
+    /** View the file name of the JS file that called this function
+     * from a debugger */
+    SourceOrigin sourceOrigin = callFrame->callerSourceOrigin(vm);
+    const char* fileName = sourceOrigin.string().utf8().data();
+    static const char* lastFileName = nullptr;
+    if (lastFileName != fileName) {
+        lastFileName = fileName;
+    }
+#endif
+
+    return DebugHTTPSServerPrototype__doRequestIp(thisObject->wrapped(), lexicalGlobalObject, callFrame);
 }
 
 JSC_DEFINE_HOST_FUNCTION(DebugHTTPSServerPrototype__stopCallback, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -4679,6 +4711,9 @@ JSC_DECLARE_HOST_FUNCTION(DebugHTTPServerPrototype__publishCallback);
 extern "C" EncodedJSValue DebugHTTPServerPrototype__doReload(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC_DECLARE_HOST_FUNCTION(DebugHTTPServerPrototype__reloadCallback);
 
+extern "C" EncodedJSValue DebugHTTPServerPrototype__doRequestIp(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
+JSC_DECLARE_HOST_FUNCTION(DebugHTTPServerPrototype__requestIpCallback);
+
 extern "C" EncodedJSValue DebugHTTPServerPrototype__doStop(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC_DECLARE_HOST_FUNCTION(DebugHTTPServerPrototype__stopCallback);
 
@@ -4698,6 +4733,7 @@ static const HashTableValue JSDebugHTTPServerPrototypeTableValues[] = {
     { "protocol"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, DebugHTTPServerPrototype__protocolGetterWrap, 0 } },
     { "publish"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, DebugHTTPServerPrototype__publishCallback, 3 } },
     { "reload"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, DebugHTTPServerPrototype__reloadCallback, 2 } },
+    { "requestIp"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, DebugHTTPServerPrototype__requestIpCallback, 1 } },
     { "stop"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, DebugHTTPServerPrototype__stopCallback, 1 } },
     { "upgrade"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, DebugHTTPServerPrototype__upgradeCallback, 1 } }
 };
@@ -4920,6 +4956,34 @@ JSC_DEFINE_HOST_FUNCTION(DebugHTTPServerPrototype__reloadCallback, (JSGlobalObje
 #endif
 
     return DebugHTTPServerPrototype__doReload(thisObject->wrapped(), lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(DebugHTTPServerPrototype__requestIpCallback, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+
+    JSDebugHTTPServer* thisObject = jsDynamicCast<JSDebugHTTPServer*>(callFrame->thisValue());
+
+    if (UNLIKELY(!thisObject)) {
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        throwVMTypeError(lexicalGlobalObject, throwScope, "Expected 'this' to be instanceof DebugHTTPServer"_s);
+        return JSValue::encode({});
+    }
+
+    JSC::EnsureStillAliveScope thisArg = JSC::EnsureStillAliveScope(thisObject);
+
+#ifdef BUN_DEBUG
+    /** View the file name of the JS file that called this function
+     * from a debugger */
+    SourceOrigin sourceOrigin = callFrame->callerSourceOrigin(vm);
+    const char* fileName = sourceOrigin.string().utf8().data();
+    static const char* lastFileName = nullptr;
+    if (lastFileName != fileName) {
+        lastFileName = fileName;
+    }
+#endif
+
+    return DebugHTTPServerPrototype__doRequestIp(thisObject->wrapped(), lexicalGlobalObject, callFrame);
 }
 
 JSC_DEFINE_HOST_FUNCTION(DebugHTTPServerPrototype__stopCallback, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -11452,6 +11516,9 @@ JSC_DECLARE_HOST_FUNCTION(HTTPSServerPrototype__publishCallback);
 extern "C" EncodedJSValue HTTPSServerPrototype__doReload(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC_DECLARE_HOST_FUNCTION(HTTPSServerPrototype__reloadCallback);
 
+extern "C" EncodedJSValue HTTPSServerPrototype__doRequestIp(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
+JSC_DECLARE_HOST_FUNCTION(HTTPSServerPrototype__requestIpCallback);
+
 extern "C" EncodedJSValue HTTPSServerPrototype__doStop(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC_DECLARE_HOST_FUNCTION(HTTPSServerPrototype__stopCallback);
 
@@ -11471,6 +11538,7 @@ static const HashTableValue JSHTTPSServerPrototypeTableValues[] = {
     { "protocol"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, HTTPSServerPrototype__protocolGetterWrap, 0 } },
     { "publish"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, HTTPSServerPrototype__publishCallback, 3 } },
     { "reload"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, HTTPSServerPrototype__reloadCallback, 2 } },
+    { "requestIp"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, HTTPSServerPrototype__requestIpCallback, 1 } },
     { "stop"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, HTTPSServerPrototype__stopCallback, 1 } },
     { "upgrade"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, HTTPSServerPrototype__upgradeCallback, 1 } }
 };
@@ -11693,6 +11761,34 @@ JSC_DEFINE_HOST_FUNCTION(HTTPSServerPrototype__reloadCallback, (JSGlobalObject *
 #endif
 
     return HTTPSServerPrototype__doReload(thisObject->wrapped(), lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(HTTPSServerPrototype__requestIpCallback, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+
+    JSHTTPSServer* thisObject = jsDynamicCast<JSHTTPSServer*>(callFrame->thisValue());
+
+    if (UNLIKELY(!thisObject)) {
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        throwVMTypeError(lexicalGlobalObject, throwScope, "Expected 'this' to be instanceof HTTPSServer"_s);
+        return JSValue::encode({});
+    }
+
+    JSC::EnsureStillAliveScope thisArg = JSC::EnsureStillAliveScope(thisObject);
+
+#ifdef BUN_DEBUG
+    /** View the file name of the JS file that called this function
+     * from a debugger */
+    SourceOrigin sourceOrigin = callFrame->callerSourceOrigin(vm);
+    const char* fileName = sourceOrigin.string().utf8().data();
+    static const char* lastFileName = nullptr;
+    if (lastFileName != fileName) {
+        lastFileName = fileName;
+    }
+#endif
+
+    return HTTPSServerPrototype__doRequestIp(thisObject->wrapped(), lexicalGlobalObject, callFrame);
 }
 
 JSC_DEFINE_HOST_FUNCTION(HTTPSServerPrototype__stopCallback, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -11934,6 +12030,9 @@ JSC_DECLARE_HOST_FUNCTION(HTTPServerPrototype__publishCallback);
 extern "C" EncodedJSValue HTTPServerPrototype__doReload(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC_DECLARE_HOST_FUNCTION(HTTPServerPrototype__reloadCallback);
 
+extern "C" EncodedJSValue HTTPServerPrototype__doRequestIp(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
+JSC_DECLARE_HOST_FUNCTION(HTTPServerPrototype__requestIpCallback);
+
 extern "C" EncodedJSValue HTTPServerPrototype__doStop(void* ptr, JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC_DECLARE_HOST_FUNCTION(HTTPServerPrototype__stopCallback);
 
@@ -11953,6 +12052,7 @@ static const HashTableValue JSHTTPServerPrototypeTableValues[] = {
     { "protocol"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, HTTPServerPrototype__protocolGetterWrap, 0 } },
     { "publish"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, HTTPServerPrototype__publishCallback, 3 } },
     { "reload"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, HTTPServerPrototype__reloadCallback, 2 } },
+    { "requestIp"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, HTTPServerPrototype__requestIpCallback, 1 } },
     { "stop"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, HTTPServerPrototype__stopCallback, 1 } },
     { "upgrade"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, HTTPServerPrototype__upgradeCallback, 1 } }
 };
@@ -12175,6 +12275,34 @@ JSC_DEFINE_HOST_FUNCTION(HTTPServerPrototype__reloadCallback, (JSGlobalObject * 
 #endif
 
     return HTTPServerPrototype__doReload(thisObject->wrapped(), lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(HTTPServerPrototype__requestIpCallback, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+
+    JSHTTPServer* thisObject = jsDynamicCast<JSHTTPServer*>(callFrame->thisValue());
+
+    if (UNLIKELY(!thisObject)) {
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        throwVMTypeError(lexicalGlobalObject, throwScope, "Expected 'this' to be instanceof HTTPServer"_s);
+        return JSValue::encode({});
+    }
+
+    JSC::EnsureStillAliveScope thisArg = JSC::EnsureStillAliveScope(thisObject);
+
+#ifdef BUN_DEBUG
+    /** View the file name of the JS file that called this function
+     * from a debugger */
+    SourceOrigin sourceOrigin = callFrame->callerSourceOrigin(vm);
+    const char* fileName = sourceOrigin.string().utf8().data();
+    static const char* lastFileName = nullptr;
+    if (lastFileName != fileName) {
+        lastFileName = fileName;
+    }
+#endif
+
+    return HTTPServerPrototype__doRequestIp(thisObject->wrapped(), lexicalGlobalObject, callFrame);
 }
 
 JSC_DEFINE_HOST_FUNCTION(HTTPServerPrototype__stopCallback, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/bun.js/bindings/generated_classes.zig
+++ b/src/bun.js/bindings/generated_classes.zig
@@ -1327,6 +1327,8 @@ pub const JSDebugHTTPSServer = struct {
             @compileLog("Expected DebugHTTPSServer.doPublish to be a callback but received " ++ @typeName(@TypeOf(DebugHTTPSServer.doPublish)));
         if (@TypeOf(DebugHTTPSServer.doReload) != CallbackType)
             @compileLog("Expected DebugHTTPSServer.doReload to be a callback but received " ++ @typeName(@TypeOf(DebugHTTPSServer.doReload)));
+        if (@TypeOf(DebugHTTPSServer.doRequestIp) != CallbackType)
+            @compileLog("Expected DebugHTTPSServer.doRequestIp to be a callback but received " ++ @typeName(@TypeOf(DebugHTTPSServer.doRequestIp)));
         if (@TypeOf(DebugHTTPSServer.doStop) != CallbackType)
             @compileLog("Expected DebugHTTPSServer.doStop to be a callback but received " ++ @typeName(@TypeOf(DebugHTTPSServer.doStop)));
         if (@TypeOf(DebugHTTPSServer.doUpgrade) != CallbackType)
@@ -1335,6 +1337,7 @@ pub const JSDebugHTTPSServer = struct {
             @export(DebugHTTPSServer.doFetch, .{ .name = "DebugHTTPSServerPrototype__doFetch" });
             @export(DebugHTTPSServer.doPublish, .{ .name = "DebugHTTPSServerPrototype__doPublish" });
             @export(DebugHTTPSServer.doReload, .{ .name = "DebugHTTPSServerPrototype__doReload" });
+            @export(DebugHTTPSServer.doRequestIp, .{ .name = "DebugHTTPSServerPrototype__doRequestIp" });
             @export(DebugHTTPSServer.doStop, .{ .name = "DebugHTTPSServerPrototype__doStop" });
             @export(DebugHTTPSServer.doUpgrade, .{ .name = "DebugHTTPSServerPrototype__doUpgrade" });
             @export(DebugHTTPSServer.finalize, .{ .name = "DebugHTTPSServerClass__finalize" });
@@ -1470,6 +1473,8 @@ pub const JSDebugHTTPServer = struct {
             @compileLog("Expected DebugHTTPServer.doPublish to be a callback but received " ++ @typeName(@TypeOf(DebugHTTPServer.doPublish)));
         if (@TypeOf(DebugHTTPServer.doReload) != CallbackType)
             @compileLog("Expected DebugHTTPServer.doReload to be a callback but received " ++ @typeName(@TypeOf(DebugHTTPServer.doReload)));
+        if (@TypeOf(DebugHTTPServer.doRequestIp) != CallbackType)
+            @compileLog("Expected DebugHTTPServer.doRequestIp to be a callback but received " ++ @typeName(@TypeOf(DebugHTTPServer.doRequestIp)));
         if (@TypeOf(DebugHTTPServer.doStop) != CallbackType)
             @compileLog("Expected DebugHTTPServer.doStop to be a callback but received " ++ @typeName(@TypeOf(DebugHTTPServer.doStop)));
         if (@TypeOf(DebugHTTPServer.doUpgrade) != CallbackType)
@@ -1478,6 +1483,7 @@ pub const JSDebugHTTPServer = struct {
             @export(DebugHTTPServer.doFetch, .{ .name = "DebugHTTPServerPrototype__doFetch" });
             @export(DebugHTTPServer.doPublish, .{ .name = "DebugHTTPServerPrototype__doPublish" });
             @export(DebugHTTPServer.doReload, .{ .name = "DebugHTTPServerPrototype__doReload" });
+            @export(DebugHTTPServer.doRequestIp, .{ .name = "DebugHTTPServerPrototype__doRequestIp" });
             @export(DebugHTTPServer.doStop, .{ .name = "DebugHTTPServerPrototype__doStop" });
             @export(DebugHTTPServer.doUpgrade, .{ .name = "DebugHTTPServerPrototype__doUpgrade" });
             @export(DebugHTTPServer.finalize, .{ .name = "DebugHTTPServerClass__finalize" });
@@ -3196,6 +3202,8 @@ pub const JSHTTPSServer = struct {
             @compileLog("Expected HTTPSServer.doPublish to be a callback but received " ++ @typeName(@TypeOf(HTTPSServer.doPublish)));
         if (@TypeOf(HTTPSServer.doReload) != CallbackType)
             @compileLog("Expected HTTPSServer.doReload to be a callback but received " ++ @typeName(@TypeOf(HTTPSServer.doReload)));
+        if (@TypeOf(HTTPSServer.doRequestIp) != CallbackType)
+            @compileLog("Expected HTTPSServer.doRequestIp to be a callback but received " ++ @typeName(@TypeOf(HTTPSServer.doRequestIp)));
         if (@TypeOf(HTTPSServer.doStop) != CallbackType)
             @compileLog("Expected HTTPSServer.doStop to be a callback but received " ++ @typeName(@TypeOf(HTTPSServer.doStop)));
         if (@TypeOf(HTTPSServer.doUpgrade) != CallbackType)
@@ -3204,6 +3212,7 @@ pub const JSHTTPSServer = struct {
             @export(HTTPSServer.doFetch, .{ .name = "HTTPSServerPrototype__doFetch" });
             @export(HTTPSServer.doPublish, .{ .name = "HTTPSServerPrototype__doPublish" });
             @export(HTTPSServer.doReload, .{ .name = "HTTPSServerPrototype__doReload" });
+            @export(HTTPSServer.doRequestIp, .{ .name = "HTTPSServerPrototype__doRequestIp" });
             @export(HTTPSServer.doStop, .{ .name = "HTTPSServerPrototype__doStop" });
             @export(HTTPSServer.doUpgrade, .{ .name = "HTTPSServerPrototype__doUpgrade" });
             @export(HTTPSServer.finalize, .{ .name = "HTTPSServerClass__finalize" });
@@ -3339,6 +3348,8 @@ pub const JSHTTPServer = struct {
             @compileLog("Expected HTTPServer.doPublish to be a callback but received " ++ @typeName(@TypeOf(HTTPServer.doPublish)));
         if (@TypeOf(HTTPServer.doReload) != CallbackType)
             @compileLog("Expected HTTPServer.doReload to be a callback but received " ++ @typeName(@TypeOf(HTTPServer.doReload)));
+        if (@TypeOf(HTTPServer.doRequestIp) != CallbackType)
+            @compileLog("Expected HTTPServer.doRequestIp to be a callback but received " ++ @typeName(@TypeOf(HTTPServer.doRequestIp)));
         if (@TypeOf(HTTPServer.doStop) != CallbackType)
             @compileLog("Expected HTTPServer.doStop to be a callback but received " ++ @typeName(@TypeOf(HTTPServer.doStop)));
         if (@TypeOf(HTTPServer.doUpgrade) != CallbackType)
@@ -3347,6 +3358,7 @@ pub const JSHTTPServer = struct {
             @export(HTTPServer.doFetch, .{ .name = "HTTPServerPrototype__doFetch" });
             @export(HTTPServer.doPublish, .{ .name = "HTTPServerPrototype__doPublish" });
             @export(HTTPServer.doReload, .{ .name = "HTTPServerPrototype__doReload" });
+            @export(HTTPServer.doRequestIp, .{ .name = "HTTPServerPrototype__doRequestIp" });
             @export(HTTPServer.doStop, .{ .name = "HTTPServerPrototype__doStop" });
             @export(HTTPServer.doUpgrade, .{ .name = "HTTPServerPrototype__doUpgrade" });
             @export(HTTPServer.finalize, .{ .name = "HTTPServerClass__finalize" });

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -994,6 +994,22 @@ extern "C"
     return value.length();
   }
 
+  size_t uws_res_get_remote_address_as_text(int ssl, uws_res_t *res, const char **dest)
+  {
+      if (ssl)
+      {
+          uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+          std::string_view value = uwsRes->getRemoteAddressAsText();
+          *dest = value.data();
+          return value.length();
+      }
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+
+      std::string_view value = uwsRes->getRemoteAddressAsText();
+      *dest = value.data();
+      return value.length();
+  }
+
   size_t uws_ws_get_remote_address_as_text(int ssl, uws_websocket_t *ws,
                                            const char **dest)
   {

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1786,6 +1786,9 @@ pub fn NewApp(comptime ssl: bool) type {
             pub fn getNativeHandle(res: *Response) i32 {
                 return @as(i32, @intCast(@intFromPtr(uws_res_get_native_handle(ssl_flag, res.downcast()))));
             }
+            pub fn getRemoteAddress(res: *Response, buf: *[*]const u8) usize {
+                return uws_res_get_remote_address(ssl_flag, res.downcast(), buf);
+            }
             pub fn getRemoteAddressAsText(res: *Response, buf: *[*]const u8) usize {
                 return uws_res_get_remote_address_as_text(ssl_flag, res.downcast(), buf);
             }
@@ -2072,6 +2075,7 @@ pub fn NewApp(comptime ssl: bool) type {
 extern fn uws_res_end_stream(ssl: i32, res: *uws_res, close_connection: bool) void;
 extern fn uws_res_prepare_for_sendfile(ssl: i32, res: *uws_res) void;
 extern fn uws_res_get_native_handle(ssl: i32, res: *uws_res) *Socket;
+extern fn uws_res_get_remote_address(ssl: i32, res: *uws_res, dest: *[*]const u8) usize;
 extern fn uws_res_get_remote_address_as_text(ssl: i32, res: *uws_res, dest: *[*]const u8) usize;
 extern fn uws_create_app(ssl: i32, options: us_bun_socket_context_options_t) *uws_app_t;
 extern fn uws_app_destroy(ssl: i32, app: *uws_app_t) void;

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1786,8 +1786,8 @@ pub fn NewApp(comptime ssl: bool) type {
             pub fn getNativeHandle(res: *Response) i32 {
                 return @as(i32, @intCast(@intFromPtr(uws_res_get_native_handle(ssl_flag, res.downcast()))));
             }
-            pub fn getRemoteAddressAsText(res: *Response, buf: []u8) usize {
-                return uws_res_get_remote_address_as_text(ssl_flag, res, buf);
+            pub fn getRemoteAddressAsText(res: *Response, buf: *[*]const u8) usize {
+                return uws_res_get_remote_address_as_text(ssl_flag, res.downcast(), buf);
             }
             pub fn onWritable(
                 res: *Response,

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1786,6 +1786,9 @@ pub fn NewApp(comptime ssl: bool) type {
             pub fn getNativeHandle(res: *Response) i32 {
                 return @as(i32, @intCast(@intFromPtr(uws_res_get_native_handle(ssl_flag, res.downcast()))));
             }
+            pub fn getRemoteAddressAsText(res: *Response, buf: []u8) usize {
+                return uws_res_get_remote_address_as_text(ssl_flag, res, buf);
+            }
             pub fn onWritable(
                 res: *Response,
                 comptime UserDataType: type,
@@ -2069,6 +2072,7 @@ pub fn NewApp(comptime ssl: bool) type {
 extern fn uws_res_end_stream(ssl: i32, res: *uws_res, close_connection: bool) void;
 extern fn uws_res_prepare_for_sendfile(ssl: i32, res: *uws_res) void;
 extern fn uws_res_get_native_handle(ssl: i32, res: *uws_res) *Socket;
+extern fn uws_res_get_remote_address_as_text(ssl: i32, res: *uws_res, dest: *[*]const u8) usize;
 extern fn uws_create_app(ssl: i32, options: us_bun_socket_context_options_t) *uws_app_t;
 extern fn uws_app_destroy(ssl: i32, app: *uws_app_t) void;
 extern fn uws_app_get(ssl: i32, app: *uws_app_t, pattern: [*c]const u8, handler: uws_method_handler, user_data: ?*anyopaque) void;

--- a/src/jsc.zig
+++ b/src/jsc.zig
@@ -38,6 +38,7 @@ pub const API = struct {
     pub const HTTPSServer = @import("./bun.js/api/server.zig").HTTPSServer;
     pub const DebugHTTPServer = @import("./bun.js/api/server.zig").DebugHTTPServer;
     pub const DebugHTTPSServer = @import("./bun.js/api/server.zig").DebugHTTPSServer;
+    pub const AnyRequestContext = @import("./bun.js/api/server.zig").AnyRequestContext;
     pub const Bun = @import("./bun.js/api/bun.zig");
     pub const FileSystemRouter = @import("./bun.js/api/filesystem_router.zig").FileSystemRouter;
     pub const MatchedRoute = @import("./bun.js/api/filesystem_router.zig").MatchedRoute;


### PR DESCRIPTION
### What does this PR do?
Closes #3540
Implements `server.requestIp(request)`, returning the origin IP address of a Request. 

Currently it just returns an ipv6 address string directly from UWS. The plan is to return a "SocketAddress" object, which will contain the address string and a value signaling what type it is.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

- [ ] I added TypeScript types for the new methods, getters, or setters

- [x] I ran `make codegen` to regenerate the C++ and Zig code
