### PR TITLE
docs: Simplify Homebrew install command

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,8 +17,7 @@ $ npm install -g bun # the last `npm` command you'll ever need
 ```
 
 ```bash#Homebrew
-$ brew tap oven-sh/bun # for macOS and Linux
-$ brew install bun
+$ brew install oven-sh/bun/bun # for macOS and Linux
 ```
 
 ```bash#Docker


### PR DESCRIPTION
### What does this PR do?

Simplify the Homebrew install command to `brew install oven-sh/bun/bun`. Homebrew adds the tap automatically if you use this syntax.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
