### PR TITLE
docs: fix `--backend` options list on cache.md

### DIFF
--- a/docs/install/cache.md
+++ b/docs/install/cache.md
@@ -46,7 +46,7 @@ This behavior is configurable with the `--backend` flag, which is respected by a
 - **`clonefile`** Default on macOS.
 - **`clonefile_each_dir`**: Similar to `clonefile`, except it clones each file individually per directory. It is only available on macOS and tends to perform slower than `clonefile`.
 - **`copyfile`**: The fallback used when any of the above fail. It is the slowest option. On macOS, it uses `fcopyfile()`; on Linux it uses `copy_file_range()`.
-  **`symlink`**: Currently used only `file:` (and eventually `link:`) dependencies. To prevent infinite loops, it skips symlinking the `node_modules` folder.
+- **`symlink`**: Currently used only `file:` (and eventually `link:`) dependencies. To prevent infinite loops, it skips symlinking the `node_modules` folder.
 
 If you install with `--backend=symlink`, Node.js won't resolve node_modules of dependencies unless each dependency has its own `node_modules` folder or you pass `--preserve-symlinks` to `node`. See [Node.js documentation on `--preserve-symlinks`](https://nodejs.org/api/cli.html#--preserve-symlinks).
 


### PR DESCRIPTION
`symlink` wasn’t an item, it appeared the same as `copyfile`

### What does this PR do?

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

