### PR TITLE
Move "Importing CJS from CJS" back out of low-level details section

### DIFF
--- a/docs/runtime/modules.md
+++ b/docs/runtime/modules.md
@@ -201,6 +201,12 @@ const myStuff = require("./my-commonjs.cjs");
 const { stuff } = require("./my-esm.mjs");
 ```
 
+### Importing CommonJS from CommonJS
+
+```ts
+const { stuff } = require("./my-commonjs.cjs");
+```
+
 #### Top-level await
 
 If you are using top-level await, you must use `import()` to import ESM modules from CommonJS modules.
@@ -217,14 +223,6 @@ const { stuff } = require("./my-esm.js");
 {% details summary="Low-level details of CommonJS interop in Bun" %}
 
 Bun's JavaScript runtime has native support for CommonJS. When Bun's JavaScript transpiler detects usages of `module.exports`, it treats the file as CommonJS. The module loader will then wrap the transpiled module in a function shaped like this:
-
-### Importing CommonJS from CommonJS
-
-You can `require()` CommonJS modules from CommonJS modules.
-
-```ts
-const { stuff } = require("./my-commonjs.cjs");
-```
 
 ```js
 (function (module, exports, require) {


### PR DESCRIPTION
### What does this PR do?

Move "Importing CJS from CJS" back out of low-level details section

This section appears to have been accidentally moved into the low-level details section in 5424ea3403df9cd4672290865f12b6f5b01cf2d0.

This fixes the example in the low-level details section, because the "Importing CJS from CJS" section is not the example code that the low-level details section is intended to provide.


<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

