### PR TITLE
Fix code typo in transpiler.md

### DIFF
--- a/docs/api/transpiler.md
+++ b/docs/api/transpiler.md
@@ -160,7 +160,6 @@ export const name = "hello";
 `;
 
 const result = transpiler.scanImports(code);
-`);
 ```
 
 ```json#Results


### PR DESCRIPTION
### What does this PR do?

There are some extra closing brackets at the end of the `scanImports` example. These cause a syntax error ("Unterminated string literal") when running the example.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

It didn't work before, now it does. I don't know if there's a procedure to automatically run example code from documentation.