### PR TITLE
`bunx` doesn't work with the install of version 1.0.0

### DIFF
--- a/docs/guides/ecosystem/sveltekit.md
+++ b/docs/guides/ecosystem/sveltekit.md
@@ -2,10 +2,10 @@
 name: Build an app with SvelteKit and Bun
 ---
 
-Use `bunx` to scaffold your app with the `create-svelte` CLI. Answer the prompts to select a template and set up your development environment.
+Use `bun x` to scaffold your app with the `create-svelte` CLI. Answer the prompts to select a template and set up your development environment.
 
 ```sh
-$ bunx create-svelte my-app
+$ bun x create-svelte my-app
 ┌  Welcome to SvelteKit!
 │
 ◇  Which Svelte app template?


### PR DESCRIPTION
### What does this PR do?

Switches the `bunx` command to `bun x` because `bunx` isn't shipped with v1.0.0.

### How did you verify your code works?

Ran it and the project was created.