### PR TITLE
fix(docs): Fix the text that `bun run --bun` is the same as `bun`

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -26,7 +26,7 @@ $ bun run index.ts
 $ bun run index.tsx
 ```
 
-The "naked" `bun` command is equivalent to `bun run`.
+The "naked" `bun` command is equivalent to `bun run --bun`.
 
 ```bash
 $ bun index.tsx

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -26,10 +26,11 @@ $ bun run index.ts
 $ bun run index.tsx
 ```
 
-The "naked" `bun` command is equivalent to `bun run --bun`.
+Alternatively, you can omit the `run` keyword and use the "naked" command; it behaves identically.
 
 ```bash
 $ bun index.tsx
+$ bun index.js
 ```
 
 ### `--watch`


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Hello, I've just started using bun!
I was a bit puzzled by the different behavior between `bun` and `bun run` when dealing with files that have a shebang (the documentation states that the two commands should behave identically).
When I use the `--bun` option, the behavior becomes the same as expected. I think this might be a better approach. What do you think? (I've just started using bun, so I could be wrong).
P.S. This message was machine-translated, so I apologize if it's hard to understand.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
