### PR TITLE
fix: remove `.only` from `bun-server.test.ts` test case

### DIFF
--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 describe("Server", () => {
-  test.only("normlizes incoming request URLs", async () => {
+  test("normlizes incoming request URLs", async () => {
     const server = Bun.serve({
       fetch(request) {
         return new Response(request.url, {


### PR DESCRIPTION
### What does this PR do?

This updates the `bun-server.test.ts` test case which, I believe mistakenly, had a `.only` in it.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
- [x] Test changes

### How did you verify your code works?

I wrote automated tests
