### PR TITLE
Add navigator.platform polyfill

### DIFF
--- a/packages/bun-polyfills/src/global/index.ts
+++ b/packages/bun-polyfills/src/global/index.ts
@@ -13,10 +13,23 @@ Blob.prototype.json = async function json<T>(this: Blob): Promise<T> {
     }
 };
 
+function navigatorPlatform() {
+    const platform = os.platform();
+    switch (platform) {
+        case 'darwin':
+            return 'MacIntel';
+        case 'win32':
+            return 'Win32';
+        default:
+            return 'Linux';
+    }
+}
+
 //? navigator global object polyfill
 Reflect.set(globalThis, 'navigator', {
     userAgent: `Bun/${version}`,
     hardwareConcurrency: os.cpus().length,
+    platform: navigatorPlatform(),
 });
 
 //? method only available in Bun


### PR DESCRIPTION
### What does this PR do?

Some packages throw if `navigator` exists, but is missing the `platform` field: https://github.com/oven-sh/bun/issues/4588

This PR adds `navigator.platform`.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it
- [ ] I added TypeScript types for the new methods, getters, or setters