### PR TITLE
docs/run: Reference reserved keywords

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -26,7 +26,7 @@ $ bun run index.ts
 $ bun run index.tsx
 ```
 
-The "naked" `bun` command is equivalent to `bun run`.
+The "naked" `bun` command is equivalent to `bun run` (execpt for reserved keywords).
 
 ```bash
 $ bun index.tsx


### PR DESCRIPTION
Reference reserved keywords to clarify that bun run is not always the same as bun run <file>

Ideally, this reference would link to a list of reserved keywords. Is there such a list in the docs? I could only find https://github.com/oven-sh/bun/issues/4465.