### PR TITLE
feat(bun install): add backend option to bunfig.toml

### DIFF
--- a/docs/cli/bun-install.md
+++ b/docs/cli/bun-install.md
@@ -62,6 +62,9 @@ dev = true
 # Install peerDependencies (default: false)
 peer = false
 
+# Which installation strategy to use (default: null (uses the fastest syscalls for specific system), can be one of: hardlink, symlink, copyfile, and only on macOS: clonefile and clonefile_each_dir)
+backend = ""
+
 # When using `bun install -g`, install packages here
 globalDir = "~/.bun/install/global"
 
@@ -163,7 +166,7 @@ Environment variables have a higher priority than `bunfig.toml`.
 | BUN_CONFIG_SKIP_LOAD_LOCKFILE    | Don’t load a lockfile                                         |
 | BUN_CONFIG_SKIP_INSTALL_PACKAGES | Don’t install any packages                                    |
 
-Bun always tries to use the fastest available installation method for the target platform. On macOS, that’s `clonefile` and on Linux, that’s `hardlink`. You can change which installation method is used with the `--backend` flag. When unavailable or on error, `clonefile` and `hardlink` fallsback to a platform-specific implementation of copying files.
+Bun always tries to use the fastest available installation method for the target platform. On macOS, that’s `clonefile` and on Linux, that’s `hardlink`. You can change which installation method is used with the `--backend` flag or in [`bunfig.toml`](/docs/runtime/configuration) file. When unavailable or on error, `clonefile` and `hardlink` fallsback to a platform-specific implementation of copying files.
 
 Bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}`. Note that if the semver version has a `build` or a `pre` tag, it is replaced with a hash of that value instead. This is to reduce the chances of errors from long file paths, but unfortunately complicates figuring out where a package was installed on disk.
 

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -83,6 +83,9 @@ dev = true
 # whether to install peerDependencies
 peer = false
 
+# equivalent to `--backend` flag
+backend = ""
+
 # equivalent to `--production` flag
 production = false
 

--- a/docs/install/cache.md
+++ b/docs/install/cache.md
@@ -40,7 +40,7 @@ Since Bun uses hardlinks to "copy" a module into a project's `node_modules` dire
 This benefit does not extend to macOS, which uses `clonefile` for performance reasons.
 
 {% details summary="Installation strategies" %}
-This behavior is configurable with the `--backend` flag, which is respected by all of Bun's package management commands.
+This behavior is configurable with the `--backend` flag or in [`bunfig.toml`](/docs/runtime/configuration) file, which is respected by all of Bun's package management commands.
 
 - **`hardlink`**: Default on Linux.
 - **`clonefile`** Default on macOS.

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -83,6 +83,9 @@ dev = true
 # whether to install peerDependencies
 peer = false
 
+# equivalent to `--backend` flag
+backend = ""
+
 # equivalent to `--production` flag
 production = false
 

--- a/docs/runtime/configuration.md
+++ b/docs/runtime/configuration.md
@@ -73,6 +73,9 @@ dev = true
 # whether to install peerDependencies
 peer = false
 
+# equivalent to `--backend` flag (default: null (uses the fastest syscalls for specific system), can be one of: hardlink, symlink, copyfile, and only on macOS: clonefile and clonefile_each_dir)
+backend = ""
+
 # equivalent to `--production` flag
 production = false
 

--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -719,6 +719,7 @@ export interface BunInstall {
   global_bin_dir?: string;
   frozen_lockfile?: boolean;
   exact?: boolean;
+  backend?: string;
 }
 
 export interface ClientServerModule {

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -3038,6 +3038,10 @@ function decodeBunInstall(bb) {
         result["exact"] = !!bb.readByte();
         break;
 
+      case 21:
+        result["backend"] = bb.readString();
+        break;
+
       default:
         throw new Error("Attempted to parse invalid message");
     }
@@ -3169,6 +3173,12 @@ function encodeBunInstall(message, bb) {
   if (value != null) {
     bb.writeByte(20);
     bb.writeByte(value);
+  }
+
+  var value = message["backend"];
+  if (value != null) {
+    bb.writeByte(21);
+    bb.writeString(value);
   }
   bb.writeByte(0);
 }

--- a/src/api/schema.peechy
+++ b/src/api/schema.peechy
@@ -588,6 +588,7 @@ message BunInstall {
   string global_bin_dir = 18;
   bool frozen_lockfile = 19;
   bool exact = 20;
+  string backend = 21;
 }
 
 struct ClientServerModule {

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -2954,6 +2954,9 @@ pub const Api = struct {
                     20 => {
                         this.exact = try reader.readValue(bool);
                     },
+                    21 => {
+                        this.backend = try reader.readValue([]const u8);
+                    },
                     else => {
                         return error.InvalidMessage;
                     },
@@ -3042,6 +3045,10 @@ pub const Api = struct {
             if (this.exact) |exact| {
                 try writer.writeFieldID(20);
                 try writer.writeInt(@as(u8, @intFromBool(exact)));
+            }
+            if (this.backend) |backend| {
+                try writer.writeFieldID(21);
+                try writer.writeValue(@TypeOf(backend), backend);
             }
             try writer.endMessage();
         }

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -2882,6 +2882,9 @@ pub const Api = struct {
         /// exact
         exact: ?bool = null,
 
+        /// backend
+        backend: ?[]const u8 = null,
+
         pub fn decode(reader: anytype) anyerror!BunInstall {
             var this = std.mem.zeroes(BunInstall);
 

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -424,6 +424,12 @@ pub const Bunfig = struct {
                         }
                     }
 
+                    if (_bun.get("backend")) |backend| {
+                        if (backend.asString(allocator)) |value| {
+                            install.backend = value;
+                        }
+                    }
+
                     if (_bun.get("globalDir")) |dir| {
                         if (dir.asString(allocator)) |value| {
                             install.global_dir = value;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -4534,6 +4534,15 @@ pub const PackageManager = struct {
                     this.enable.exact_versions = exact;
                 }
 
+                if (bun_install.backend) |backend| {
+                    const specified_backend = PackageInstall.Method.map.get(backend);
+                    if (specified_backend) |method| {
+                        if (method.isSupported()) {
+                            PackageInstall.supported_method = method;
+                        }
+                    }
+                }
+
                 if (bun_install.production) |production| {
                     if (production) {
                         this.local_package_features.dev_dependencies = false;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

This adds a new option `backend` in the .bunfig.toml file. This is useful in case you want to trade dependency installation performance, for some space saving (especially on macOS).

- [x] Documentation
- [x] Code changes

### How did you verify your code works?

Tried setting different options in `$HOME/.bunfig.toml` and `project_src/bunfig.toml`.

```toml
[install]
backend = "symlink"
```
