### PR TITLE
fix(path): Fix edge case in `path.relative`

### DIFF
--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -471,7 +471,7 @@ pub fn relativePlatform(from: []const u8, to: []const u8, comptime platform: Pla
         Fs.FileSystem.instance.top_level_dir,
         &relative_from_buf,
         &[_][]const u8{
-            normalizeStringBuf(from, relative_from_buf[1..], false, platform, true),
+            normalizeStringBuf(from, relative_from_buf[1..], true, platform, true),
         },
         platform,
     );
@@ -484,7 +484,7 @@ pub fn relativePlatform(from: []const u8, to: []const u8, comptime platform: Pla
         Fs.FileSystem.instance.top_level_dir,
         &relative_to_buf,
         &[_][]const u8{
-            normalizeStringBuf(to, relative_to_buf[1..], false, platform, true),
+            normalizeStringBuf(to, relative_to_buf[1..], true, platform, true),
         },
         platform,
     );

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -415,6 +415,9 @@ it("path.join", () => {
 
 it("path.relative", () => {
   const failures = [];
+  const cwd = process.cwd();
+  const cwdParent = path.dirname(cwd);
+  const parentIsRoot = cwdParent == "/";
 
   const relativeTests = [
     // [
@@ -477,6 +480,16 @@ it("path.relative", () => {
         ["/webp4ck-hot-middleware", "/webpack/buildin/module.js", "../webpack/buildin/module.js"],
         ["/webpack-hot-middleware", "/webp4ck/buildin/module.js", "../webp4ck/buildin/module.js"],
         ["/var/webpack-hot-middleware", "/var/webpack/buildin/module.js", "../webpack/buildin/module.js"],
+        ["/app/node_modules/pkg", "../static", `../../..${parentIsRoot ? "" : cwdParent}/static`],
+        ["/app/node_modules/pkg", "../../static", `../../..${parentIsRoot ? "" : path.dirname(cwdParent)}/static`],
+        ["/app", "../static", `..${parentIsRoot ? "" : cwdParent}/static`],
+        ["/app", "../".repeat(64) + "static", "../static"],
+        [".", "../static", cwd == "/" ? "static" : "../static"],
+        ["/", "../static", parentIsRoot ? "static" : `${cwdParent}/static`.slice(1)],
+        ["../", "../", ""],
+        ["../", "../../", parentIsRoot ? "" : ".."],
+        ["../../", "../", parentIsRoot ? "" : path.basename(cwdParent)],
+        ["../../", "../../", ""],
       ],
     ],
   ];


### PR DESCRIPTION


### What does this PR do?

Close: #4789


In Bun 0.1, this code will log an empty string, but node will log `..`.

```JavaScript
const path = require("path");

console.log(path.relative("../", "../../"));
```

This is because the parameter `allow_above_root` we passed is `false`.

https://github.com/oven-sh/bun/blob/d48ff53e4ec4cb49172e0e96ca9890446f971a0e/src/resolver/resolve_path.zig#L479-L490

In `normalizeStringGeneric` function, if `allow_above_root` is false, `../` will be converted to empty string. 



https://github.com/oven-sh/bun/blob/d48ff53e4ec4cb49172e0e96ca9890446f971a0e/src/resolver/resolve_path.zig#L535-L544

This also affects paths like `../static`, which will be converted into `static`. So in Bun, the result for the following code is `true`. Actually, it's comparing `static` and `static`.

```JavaScript
console.log(path.relative("../static", "../../static") == "");
```

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
