### PR TITLE
add NODE_TLS_REJECT_UNAUTHORIZED for fetch/install/upgrade/create

### DIFF
--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1563,7 +1563,7 @@ pub const Fetch = struct {
 
         var url_proxy_buffer: []const u8 = undefined;
         var is_file_url = false;
-        var reject_unauthorized = true;
+        var reject_unauthorized = script_ctx.bundler.env.getTLSRejectUnauthorized();
         var check_server_identity: JSValue = .zero;
         // TODO: move this into a DRYer implementation
         // The status quo is very repetitive and very bug prone

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1879,6 +1879,8 @@ pub const Example = struct {
             HTTP.FetchRedirect.follow,
         );
         async_http.client.progress_node = progress;
+        async_http.client.reject_unauthorized = env_loader.getTLSRejectUnauthorized();
+
         const response = try async_http.sendSync(true);
 
         switch (response.status_code) {
@@ -1955,6 +1957,8 @@ pub const Example = struct {
             HTTP.FetchRedirect.follow,
         );
         async_http.client.progress_node = progress;
+        async_http.client.reject_unauthorized = env_loader.getTLSRejectUnauthorized();
+
         var response = try async_http.sendSync(true);
 
         switch (response.status_code) {
@@ -2043,6 +2047,7 @@ pub const Example = struct {
             HTTP.FetchRedirect.follow,
         );
         async_http.client.progress_node = progress;
+        async_http.client.reject_unauthorized = env_loader.getTLSRejectUnauthorized();
 
         refresher.maybeRefresh();
 
@@ -2084,6 +2089,7 @@ pub const Example = struct {
             null,
             HTTP.FetchRedirect.follow,
         );
+        async_http.client.reject_unauthorized = env_loader.getTLSRejectUnauthorized();
 
         if (Output.enable_ansi_colors) {
             async_http.client.progress_node = progress_node;

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -236,6 +236,8 @@ pub const UpgradeCommand = struct {
             null,
             HTTP.FetchRedirect.follow,
         );
+        async_http.client.reject_unauthorized = env_loader.getTLSRejectUnauthorized();
+
         if (!silent) async_http.client.progress_node = progress;
         const response = try async_http.sendSync(true);
 
@@ -481,6 +483,8 @@ pub const UpgradeCommand = struct {
             );
             async_http.client.timeout = timeout;
             async_http.client.progress_node = progress;
+            async_http.client.reject_unauthorized = env_loader.getTLSRejectUnauthorized();
+
             const response = try async_http.sendSync(true);
 
             switch (response.status_code) {

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -87,6 +87,15 @@ pub const Loader = struct {
         }
     }
 
+    pub fn getTLSRejectUnauthorized(this: *Loader) bool {
+        if (this.map.get("NODE_TLS_REJECT_UNAUTHORIZED")) |reject| {
+            if (strings.eql(reject, "0")) return false;
+            if (strings.eql(reject, "false")) return false;
+        }
+        // default: true
+        return true;
+    }
+
     pub fn getHttpProxy(this: *Loader, url: URL) ?URL {
         // TODO: When Web Worker support is added, make sure to intern these strings
         var http_proxy: ?URL = null;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -343,6 +343,8 @@ const NetworkTask = struct {
             HTTP.FetchRedirect.follow,
             null,
         );
+        this.http.client.reject_unauthorized = this.package_manager.tlsRejectUnauthorized();
+
         this.callback = .{
             .package_manifest = .{
                 .name = try strings.StringOrTinyString.initAppendIfNeeded(name, *FileSystem.FilenameStore, &FileSystem.FilenameStore.instance),
@@ -421,6 +423,8 @@ const NetworkTask = struct {
             HTTP.FetchRedirect.follow,
             null,
         );
+        this.http.client.reject_unauthorized = this.package_manager.tlsRejectUnauthorized();
+
         this.callback = .{ .extract = tarball };
     }
 };
@@ -1677,6 +1681,10 @@ pub const PackageManager = struct {
 
     pub fn httpProxy(this: *PackageManager, url: URL) ?URL {
         return this.env.getHttpProxy(url);
+    }
+
+    pub fn tlsRejectUnauthorized(this: *PackageManager) bool {
+        return this.env.getTLSRejectUnauthorized();
     }
 
     pub const WakeHandler = struct {

--- a/test/js/web/fetch/fetch-reject-authorized-env-fixture.js
+++ b/test/js/web/fetch/fetch-reject-authorized-env-fixture.js
@@ -1,0 +1,8 @@
+const { SERVER } = process.env;
+
+try {
+  const result = await fetch(SERVER).then(res => res.text());
+  if (result !== "Hello World") process.exit(2);
+} catch (err) {
+  process.exit(err.code === "ERR_TLS_CERT_ALTNAME_INVALID" ? 1 : 3);
+}


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
