### PR TITLE
compat: Buffer: allow optional positional arguments to be undefined

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -864,26 +864,47 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSG
     size_t sourceEndInit = castedThis->byteLength();
     size_t sourceEnd = sourceEndInit;
 
+    JSValue targetStartValue = jsUndefined();
+    JSValue targetEndValue = jsUndefined();
+    JSValue sourceStartValue = jsUndefined();
+    JSValue sourceEndValue = jsUndefined();
+
     switch (callFrame->argumentCount()) {
     default:
-        sourceEnd = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(4));
-        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+        sourceEndValue = callFrame->uncheckedArgument(4);
         FALLTHROUGH;
     case 4:
-        sourceStart = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(3));
-        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+        sourceStartValue = callFrame->uncheckedArgument(3);
         FALLTHROUGH;
     case 3:
-        targetEnd = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(2));
-        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+        targetEndValue = callFrame->uncheckedArgument(2);
         FALLTHROUGH;
     case 2:
-        targetStart = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(1));
-        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+        targetStartValue = callFrame->uncheckedArgument(1);
         break;
     case 1:
     case 0:
         break;
+    }
+
+    if (!targetStartValue.isUndefined()) {
+        targetStart = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(1));
+        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+    }
+
+    if (!targetEndValue.isUndefined()) {
+        targetEnd = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(2));
+        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+    }
+
+    if (!sourceStartValue.isUndefined()) {
+        sourceStart = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(3));
+        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+    }
+
+    if (!sourceEndValue.isUndefined()) {
+        sourceEnd = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(4));
+        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
     }
 
     targetStart = std::min(targetStart, std::min(targetEnd, targetEndInit));

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -951,22 +951,38 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_copyBody(JSC::JSGlob
     size_t sourceEndInit = castedThis->byteLength();
     size_t sourceEnd = sourceEndInit;
 
+    JSValue targetStartValue = jsUndefined();
+    JSValue sourceStartValue = jsUndefined();
+    JSValue sourceEndValue = jsUndefined();
+
     switch (callFrame->argumentCount()) {
     default:
-        sourceEnd = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(3));
-        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+        sourceEndValue = callFrame->uncheckedArgument(3);
         FALLTHROUGH;
     case 3:
-        sourceStart = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(2));
-        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+        sourceStartValue = callFrame->uncheckedArgument(2);
         FALLTHROUGH;
     case 2:
-        targetStart = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(1));
-        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+        targetStartValue = callFrame->uncheckedArgument(1);
         break;
     case 1:
     case 0:
         break;
+    }
+
+    if (!targetStartValue.isUndefined()) {
+        targetStart = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(1));
+        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+    }
+
+    if (!sourceStartValue.isUndefined()) {
+        sourceStart = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(2));
+        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
+    }
+
+    if (!sourceEndValue.isUndefined()) {
+        sourceEnd = parseIndex(lexicalGlobalObject, throwScope, callFrame->uncheckedArgument(3));
+        RETURN_IF_EXCEPTION(throwScope, JSValue::encode(jsUndefined()));
     }
 
     targetStart = std::min(targetStart, targetEnd);


### PR DESCRIPTION
### What does this PR do?

SSIA.
Fixes `Buffer.prototype.copy()` and `Buffer.prototype.compare()` in the following cases:

<details>
  <summary>Buffer.prototype.copy()</summary>
  
  ```
  Welcome to Node.js v18.17.1.
  Type ".help" for more information.
  > Buffer.alloc(0).copy(Buffer.alloc(0), undefined)
  0
  ```
  
  ```
  Welcome to Bun v1.0.0
  Type ".help" for more information.
  > Buffer.alloc(0).copy(Buffer.alloc(0), undefined)
  1 | "use strict";void 0;Buffer.alloc(0).copy(Buffer.alloc(0), undefined);
                         ^
  TypeError: Expected number
  ```
</details>

<details>
  <summary>Buffer.prototype.compare()</summary>
  
  ```
  Welcome to Node.js v18.17.1.
  Type ".help" for more information.
  > Buffer.alloc(0).compare(Buffer.alloc(0), undefined)
  0
  ```
  
  ```
  Welcome to Bun v1.0.0
  Type ".help" for more information.
  > Buffer.alloc(0).compare(Buffer.alloc(0), undefined)
  1 | "use strict";void 0;Buffer.alloc(0).compare(Buffer.alloc(0), undefined);
                         ^
  TypeError: Expected number
  ```
</details>
