### PR TITLE
Add 'un' to package remove

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1158,6 +1158,7 @@ pub const Command = struct {
             RootCommandMatcher.case("r"),
             RootCommandMatcher.case("remove"),
             RootCommandMatcher.case("rm"),
+            RootCommandMatcher.case("un"),
             RootCommandMatcher.case("uninstall"),
             => .RemoveCommand,
 


### PR DESCRIPTION
### What does this PR do?
Adds an alias for `bun un` for `bun remove` to achieve full compatibility with the npm API, this is an extension of #2137, since it was a minor change i did not consider opening an issue and have dropped a comment on #2137

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Compiled it locally and created tried to run it as needed

```sh
un_test) cat package.json | jq
# {
#   "dependencies": {
#     "vite": "^4.4.9"
#   }
# }
```

Seemed to run ok on macOS with no issues
```sh
un_test) ../packages/debug-bun-darwin-aarch64/bun-debug un vite
[SYS] read(3, 4096) = 4096 (0.062ms)
[SYS] close(3)
bun remove v1.0.0_debug (589d236e)
[16.00ms] done
No packages! Deleted empty lockfile
```