### PR TITLE
Fix `Buffer.from` to handle double-byte hex encoding strings

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -351,6 +351,7 @@ static EncodedJSValue constructFromEncoding(JSGlobalObject* lexicalGlobalObject,
         case WebCore::BufferEncodingType::utf8:
         case WebCore::BufferEncodingType::base64:
         case WebCore::BufferEncodingType::base64url:
+        case WebCore::BufferEncodingType::hex:
         case WebCore::BufferEncodingType::ascii:
         case WebCore::BufferEncodingType::latin1: {
             result = Bun__encoding__constructFromUTF16(lexicalGlobalObject, view.characters16(), view.length(), static_cast<uint8_t>(encoding));

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -2572,3 +2572,16 @@ it("construct buffer from UTF16, issue #3914", () => {
   const buf = Buffer.from(str, "latin1");
   expect(buf).toStrictEqual(raw);
 });
+
+it("construct buffer from hex, issue #4919", () => {
+  const data = "测试63e9f6c4b04fa8c80f3fb0ee";
+
+  const slice1 = data.substring(0, 2);
+  const slice2 = data.substring(2);
+
+  const buf1 = Buffer.from(slice1, "hex");
+  const buf2 = Buffer.from(slice2, "hex");
+
+  expect(buf1).toStrictEqual(Buffer.from([]));
+  expect(buf2).toStrictEqual(Buffer.from([0x63, 0xe9, 0xf6, 0xc4, 0xb0, 0x4f, 0xa8, 0xc8, 0x0f, 0x3f, 0xb0, 0xee]));
+});


### PR DESCRIPTION


### What does this PR do?

Close: #4919



- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests


<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
