### PR TITLE
Fix error message typo in js_ast.zig

### DIFF
--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -425,7 +425,7 @@ pub const Binding = struct {
                 );
             },
             else => {
-                Global.panic("Interanl error", .{});
+                Global.panic("Internal error", .{});
             },
         }
     }


### PR DESCRIPTION
Noticed a small typo in one of the panic messages when looking through the AST code