### PR TITLE
Update http.js - Fix Methods Fallback naming

### DIFF
--- a/src/node-fallbacks/http.js
+++ b/src/node-fallbacks/http.js
@@ -9,5 +9,5 @@ export var {
   Agent,
   globalAgent,
   STATUS_CODES,
-  METHIDS,
+  METHODS,
 } = http;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This fixes the misspelling of METHODS from `node http`.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

- [x] I made the change directly in Github
