### PR TITLE
Update simple.md

### DIFF
--- a/docs/guides/websocket/simple.md
+++ b/docs/guides/websocket/simple.md
@@ -29,5 +29,5 @@ const server = Bun.serve<{ authToken: string }>({
   },
 });
 
-console.log(`Listening on localhost:\${server.port}`);
+console.log(`Listening on localhost:${server.port}`);
 ```


### PR DESCRIPTION
Remove errant slash preventing the correct console log

Old:
<img width="390" alt="image" src="https://github.com/oven-sh/bun/assets/4225378/6edebe89-3b0d-466d-b6e5-3df8b8a1234f">

Fixed:
<img width="440" alt="image" src="https://github.com/oven-sh/bun/assets/4225378/0a2fc645-7854-4153-af06-a5aeb3a9a7c2">

### What does this PR do?

Fixes the websocket quick start guide output from `Listening on localhost:${server.port}` to `Listening on localhost:3000`

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes