### PR TITLE
fix typo and grammar errors in bunfig.toml

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,8 +1,8 @@
 [test]
 # Large monorepos (like Bun) may want to specify the test directory more specifically 
-# By default, `bun test` scans every single folder recurisvely which, if you
-# have a gigantic submodule (like WebKit), it has to do lots of directory
+# By default, `bun test` scans every single folder recursively which, if you
+# have a gigantic submodule (like WebKit), requires lots of directory
 # traversals
 #
-# Instead, we can just make it scan only the test directory for Bun's runtime tests
+# Instead, we can only scan the test directory for Bun's runtime tests
 root = "test"


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

The explanation in the root bunfig.toml contained a typo and some grammar issues. This fixes them.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation

