### PR TITLE
Bun.file replaced with file

### DIFF
--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -216,7 +216,7 @@ import { serve, file } from "bun";
 
 serve({
   fetch(req) {
-    return new Response(Bun.file("./hello.txt"));
+    return new Response(file("./hello.txt"));
   },
 });
 ```


### PR DESCRIPTION
Because the `file` has already been imported, there is no need to use `Bun.file`
