### PR TITLE
Clean up some edgecases with posix_spawn usage

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1467,7 +1467,7 @@ pub const Subprocess = struct {
             else
                 0;
             var fd: std.os.linux.fd_t = std.os.linux.pidfd_open(
-                pid,
+                @intCast(pid),
                 pidfd_flags,
             );
 
@@ -1476,7 +1476,7 @@ pub const Subprocess = struct {
                     .SUCCESS => break :brk @as(std.os.fd_t, @intCast(fd)),
                     .INTR => {
                         fd = std.os.linux.pidfd_open(
-                            pid,
+                            @intCast(pid),
                             pidfd_flags,
                         );
                         continue;
@@ -1485,7 +1485,7 @@ pub const Subprocess = struct {
                         if (err == .INVAL) {
                             if (pidfd_flags != 0) {
                                 fd = std.os.linux.pidfd_open(
-                                    pid,
+                                    @intCast(pid),
                                     0,
                                 );
                                 pidfd_flags = 0;

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1466,16 +1466,17 @@ pub const Subprocess = struct {
                 std.os.O.NONBLOCK
             else
                 0;
-            var fd: std.os.linux.fd_t = std.os.linux.pidfd_open(
+
+            var rc = std.os.linux.pidfd_open(
                 @intCast(pid),
                 pidfd_flags,
             );
 
             while (true) {
-                switch (std.os.linux.getErrno(fd)) {
-                    .SUCCESS => break :brk @as(std.os.fd_t, @intCast(fd)),
+                switch (std.os.linux.getErrno(rc)) {
+                    .SUCCESS => break :brk @as(std.os.fd_t, @intCast(rc)),
                     .INTR => {
-                        fd = std.os.linux.pidfd_open(
+                        rc = std.os.linux.pidfd_open(
                             @intCast(pid),
                             pidfd_flags,
                         );
@@ -1484,7 +1485,7 @@ pub const Subprocess = struct {
                     else => |err| {
                         if (err == .INVAL) {
                             if (pidfd_flags != 0) {
-                                fd = std.os.linux.pidfd_open(
+                                rc = std.os.linux.pidfd_open(
                                     @intCast(pid),
                                     0,
                                 );

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1474,7 +1474,13 @@ pub const Subprocess = struct {
             while (true) {
                 switch (std.os.linux.getErrno(fd)) {
                     .SUCCESS => break :brk @as(std.os.fd_t, @intCast(fd)),
-                    .INTR => continue,
+                    .INTR => {
+                        fd = std.os.linux.pidfd_open(
+                            pid,
+                            pidfd_flags,
+                        );
+                        continue;
+                    },
                     else => |err| {
                         if (err == .INVAL) {
                             if (pidfd_flags != 0) {

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1499,7 +1499,7 @@ pub const Subprocess = struct {
                                     \\"pidfd_open(2)" system call is not supported by your Linux kernel
                                     \\To fix this error, either:
                                     \\- Upgrade your Linux kernel to a newer version (current: {})
-                                    \\- Ensure the seccomp filter allows \"pidfd_open\"
+                                    \\- Ensure the seccomp filter allows "pidfd_open"
                                 ,
                                     .{
                                         kernel.fmt(""),

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1718,7 +1718,7 @@ pub const Subprocess = struct {
                 this.waitpid_err = err;
             },
             .result => |result| {
-                if (result.pid == pid) {
+                if (result.pid != 0) {
                     if (std.os.W.IFEXITED(result.status)) {
                         this.exit_code = @as(u8, @truncate(std.os.W.EXITSTATUS(result.status)));
                     }

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1462,25 +1462,54 @@ pub const Subprocess = struct {
             const kernel = @import("../../../analytics.zig").GenerateHeader.GeneratePlatform.kernelVersion();
 
             // pidfd_nonblock only supported in 5.10+
-            const pidfd_flags: u32 = if (!is_sync and kernel.orderWithoutTag(.{ .major = 5, .minor = 10, .patch = 0 }).compare(.gte))
+            var pidfd_flags: u32 = if (!is_sync and kernel.orderWithoutTag(.{ .major = 5, .minor = 10, .patch = 0 }).compare(.gte))
                 std.os.O.NONBLOCK
             else
                 0;
-
-            const fd = std.os.linux.pidfd_open(
+            var fd: std.os.linux.fd_t = std.os.linux.pidfd_open(
                 pid,
                 pidfd_flags,
             );
 
-            switch (std.os.linux.getErrno(fd)) {
-                .SUCCESS => break :brk @as(std.os.fd_t, @intCast(fd)),
-                else => |err| {
-                    globalThis.throwValue(bun.sys.Error.fromCode(err, .open).toJSC(globalThis));
-                    var status: u32 = 0;
-                    // ensure we don't leak the child process on error
-                    _ = std.os.linux.waitpid(pid, &status, 0);
-                    return .zero;
-                },
+            while (true) {
+                switch (std.os.linux.getErrno(fd)) {
+                    .SUCCESS => break :brk @as(std.os.fd_t, @intCast(fd)),
+                    .INTR => continue,
+                    else => |err| {
+                        if (err == .INVAL) {
+                            if (pidfd_flags != 0) {
+                                fd = std.os.linux.pidfd_open(
+                                    pid,
+                                    0,
+                                );
+                                pidfd_flags = 0;
+                                continue;
+                            }
+                        }
+
+                        const error_instance = brk2: {
+                            if (err == .NOSYS) {
+                                break :brk2 globalThis.createErrorInstance(
+                                    \\"pidfd_open(2)" system call is not supported by your Linux kernel
+                                    \\To fix this error, either:
+                                    \\- Upgrade your Linux kernel to a newer version (current: {})
+                                    \\- Ensure the seccomp filter allows \"pidfd_open\"
+                                ,
+                                    .{
+                                        kernel.fmt(""),
+                                    },
+                                );
+                            }
+
+                            break :brk2 bun.sys.Error.fromCode(err, .open).toJSC(globalThis);
+                        };
+                        globalThis.throwValue(error_instance);
+                        var status: u32 = 0;
+                        // ensure we don't leak the child process on error
+                        _ = std.os.linux.waitpid(pid, &status, 0);
+                        return .zero;
+                    },
+                }
             }
         };
 
@@ -1682,14 +1711,16 @@ pub const Subprocess = struct {
                 this.waitpid_err = err;
             },
             .result => |result| {
-                if (std.os.W.IFEXITED(result.status)) {
-                    this.exit_code = @as(u8, @truncate(std.os.W.EXITSTATUS(result.status)));
-                }
+                if (result.pid == pid) {
+                    if (std.os.W.IFEXITED(result.status)) {
+                        this.exit_code = @as(u8, @truncate(std.os.W.EXITSTATUS(result.status)));
+                    }
 
-                if (std.os.W.IFSIGNALED(result.status)) {
-                    this.signal_code = @as(SignalCode, @enumFromInt(@as(u8, @truncate(std.os.W.TERMSIG(result.status)))));
-                } else if (std.os.W.IFSTOPPED(result.status)) {
-                    this.signal_code = @as(SignalCode, @enumFromInt(@as(u8, @truncate(std.os.W.STOPSIG(result.status)))));
+                    if (std.os.W.IFSIGNALED(result.status)) {
+                        this.signal_code = @as(SignalCode, @enumFromInt(@as(u8, @truncate(std.os.W.TERMSIG(result.status)))));
+                    } else if (std.os.W.IFSTOPPED(result.status)) {
+                        this.signal_code = @as(SignalCode, @enumFromInt(@as(u8, @truncate(std.os.W.STOPSIG(result.status)))));
+                    }
                 }
 
                 if (!this.hasExited()) {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1250,7 +1250,15 @@ const PackageInstall = struct {
                             std.os.mkdirat(destination_dir_.dir.fd, entry.path, 0o755) catch {};
                         },
                         .file => {
-                            try std.os.linkat(entry.dir.dir.fd, entry.basename, destination_dir_.dir.fd, entry.path, 0);
+                            std.os.linkat(entry.dir.dir.fd, entry.basename, destination_dir_.dir.fd, entry.path, 0) catch |err| {
+                                if (err != error.PathAlreadyExists) {
+                                    return err;
+                                }
+
+                                std.os.unlinkat(destination_dir_.dir.fd, entry.path, 0) catch {};
+                                try std.os.linkat(entry.dir.dir.fd, entry.basename, destination_dir_.dir.fd, entry.path, 0);
+                            };
+
                             real_file_count += 1;
                         },
                         else => {},


### PR DESCRIPTION
### What does this PR do?

- When the linux kernel doesn't support `pidfd_open`, report a more informative error message 
- Handle EINTR when pidfd_open is called

- Check the pid returned by waitpid, per:
> waitpid(): on success, returns the process ID of the child whose
> state has changed; if WNOHANG was specified and one or more
> child(ren) specified by pid exist, but have not yet changed
> state, then 0 is returned.  On failure, -1 is returned.

### How did you verify your code works?

Existing tests are hopefully less flaky