### PR TITLE
fix(node/path): Prevent memory corruption in parse

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -2198,22 +2198,14 @@ pub const Path = struct {
         base.setOutputEncoding();
         name_.setOutputEncoding();
         ext.setOutputEncoding();
-        var entries = [10]JSC.ZigString{
-            JSC.ZigString.init("dir"),
-            JSC.ZigString.init("root"),
-            JSC.ZigString.init("base"),
-            JSC.ZigString.init("name"),
-            JSC.ZigString.init("ext"),
-            dir,
-            root,
-            base,
-            name_,
-            ext,
-        };
 
-        var keys: []JSC.ZigString = entries[0..5];
-        var values: []JSC.ZigString = entries[5..10];
-        return JSC.JSValue.fromEntries(globalThis, keys.ptr, values.ptr, 5, true);
+        var result = JSC.JSValue.createEmptyObject(globalThis, 5);
+        result.put(globalThis, JSC.ZigString.static("dir"), dir.toValueGC(globalThis));
+        result.put(globalThis, JSC.ZigString.static("root"), root.toValueGC(globalThis));
+        result.put(globalThis, JSC.ZigString.static("base"), base.toValueGC(globalThis));
+        result.put(globalThis, JSC.ZigString.static("name"), name_.toValueGC(globalThis));
+        result.put(globalThis, JSC.ZigString.static("ext"), ext.toValueGC(globalThis));
+        return result;
     }
     pub fn relative(globalThis: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(.C) JSC.JSValue {
         if (comptime is_bindgen) return JSC.JSValue.jsUndefined();

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -812,6 +812,17 @@ describe("path.parse and path.format", () => {
         name: "another_dir",
       },
     },
+    {
+      // https://github.com/oven-sh/bun/issues/4954
+      input: "/test/Ł.txt",
+      expected: {
+        root: "/",
+        dir: "/test",
+        base: "Ł.txt",
+        ext: ".txt",
+        name: "Ł",
+      },
+    }
   ];
   testCases.forEach(({ input, expected }) => {
     it(`case ${input}`, () => {


### PR DESCRIPTION
### What does this PR do?

Fixes #4954 

Corrects what seems to be a use-after-free memory issue in `node:path` `parse()`.

The added test case fails for the original poster of #4954 and for me on macOS x86_64.

Fix the issue by returning the strings via `toValueGC` so they can be freed at the right time in the JS side.

- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
