### PR TITLE
Fix typo in http file upload example

### DIFF
--- a/docs/guides/http/file-uploads.md
+++ b/docs/guides/http/file-uploads.md
@@ -81,7 +81,7 @@ const server = Bun.serve({
 +   if (url.pathname === '/action') {
 +     const formdata = await req.formData();
 +     const name = formdata.get('name');
-+     const profilePicture = formdata.get('profilePicture');+
++     const profilePicture = formdata.get('profilePicture');
 +     if (!profilePicture) throw new Error('Must upload a profile picture.');
 +     // write profilePicture to disk
 +     await Bun.write('profilePicture.png', profilePicture);


### PR DESCRIPTION
### What does this PR do?

Remove the extra "+" at the end of a line in the example which causes a syntax error in the example. 


- [x] Documentation or TypeScript types