### PR TITLE
Fix bug with bun build --compile failing to resolve node builtins

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1516,9 +1516,9 @@ pub const VirtualMachine = struct {
             ret.result = null;
             ret.path = specifier;
             return;
-        } else if (JSC.HardcodedModule.Map.get(specifier)) |result| {
+        } else if (JSC.HardcodedModule.Aliases.get(specifier, .bun)) |result| {
             ret.result = null;
-            ret.path = @as(string, @tagName(result));
+            ret.path = result.path;
             return;
         }
 

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -18,6 +18,9 @@ describe("bundler", () => {
     files: {
       "/entry.ts": `
         // testing random features of bun
+        import 'node:process';
+        import 'process';
+
         import { Database } from "bun:sqlite";
         import { serve } from 'bun';
         import { getRandomSeed } from 'bun:jsc';


### PR DESCRIPTION
### What does this PR do?

To fix webpack loading in bun, in 1.0 we renamed `node:process` and `node:*` aliases to their un-aliased counterparts (where relevant). When we did that, we missed continuing to support the aliased versions in bun build --compile.  

### How did you verify your code works?

Updated the bundler_compile test