### PR TITLE
[bun install] Add `-E` as alias of `--exact`

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5783,7 +5783,7 @@ pub const PackageManager = struct {
         clap.parseParam("-d, --dev                 Add dependency to \"devDependencies\"") catch unreachable,
         clap.parseParam("-D, --development") catch unreachable,
         clap.parseParam("--optional                        Add dependency to \"optionalDependencies\"") catch unreachable,
-        clap.parseParam("--exact                      Add the exact version instead of the ^range") catch unreachable,
+        clap.parseParam("-E, --exact                  Add the exact version instead of the ^range") catch unreachable,
         clap.parseParam("<POS> ...                         ") catch unreachable,
     };
 
@@ -5799,7 +5799,7 @@ pub const PackageManager = struct {
         clap.parseParam("-d, --dev                 Add dependency to \"devDependencies\"") catch unreachable,
         clap.parseParam("-D, --development") catch unreachable,
         clap.parseParam("--optional                        Add dependency to \"optionalDependencies\"") catch unreachable,
-        clap.parseParam("--exact                      Add the exact version instead of the ^range") catch unreachable,
+        clap.parseParam("-E, --exact                  Add the exact version instead of the ^range") catch unreachable,
         clap.parseParam("<POS> ...                         \"name\" or \"name@version\" of packages to install") catch unreachable,
     };
 

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -356,6 +356,61 @@ it("should add exact version", async () => {
   await access(join(package_dir, "bun.lockb"));
 });
 
+it("should add exact version with -E", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+    }),
+  );
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "-E", "BaR"],
+    cwd: package_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr).toBeDefined();
+  const err = await new Response(stderr).text();
+  expect(err).toContain("Saved lockfile");
+  expect(stdout).toBeDefined();
+  const out = await new Response(stdout).text();
+  expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+    "",
+    " installed BaR@0.0.2",
+    "",
+    "",
+    " 1 packages installed",
+  ]);
+  expect(await exited).toBe(0);
+  expect(urls.sort()).toEqual([`${root_url}/BaR`, `${root_url}/BaR-0.0.2.tgz`]);
+  expect(requested).toBe(2);
+  expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".cache", "BaR"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", "BaR"))).toEqual(["package.json"]);
+  expect(await file(join(package_dir, "node_modules", "BaR", "package.json")).json()).toEqual({
+    name: "bar",
+    version: "0.0.2",
+  });
+  expect(await file(join(package_dir, "package.json")).text()).toEqual(
+    JSON.stringify(
+      {
+        name: "foo",
+        version: "0.0.1",
+        dependencies: {
+          BaR: "0.0.2",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  await access(join(package_dir, "bun.lockb"));
+});
+
 it("should add dependency with specified semver", async () => {
   const urls: string[] = [];
   setHandler(


### PR DESCRIPTION
### What does this PR do?

`bun install` and `bun add` both support the `--exact` flag for pinning a dependency's version.
This adds a shorter `-E` flag as an alias, something that [npm](https://docs.npmjs.com/cli/v10/commands/npm-install#save-exact:~:text=additional%2C%20optional%20flags%3A-,%2DE%2C%20%2D%2Dsave%2Dexact,-%3A%20Saved%20dependencies%20will), [Yarn](https://yarnpkg.com/cli/add#options-E%2C-exact), and [pnpm](https://pnpm.io/cli/add#--save-exact--e) also support.

- [ ] Documentation or TypeScript types
  - There are a few examples of how to use `--exact` where it may be helpful to have examples for `-E` as well
  - I think it's fine to leave them as-is though
- [x] Code changes

### How did you verify your code works?

I've tested locally and confirmed that the flag works as expected:

![screenshot of `bun install zod -E` working locally](https://github.com/oven-sh/bun/assets/7608555/4c9e5ad0-752d-4737-9b8b-4bf5f3ade6ce)

There are existing tests for `--exact`. If it'd be useful, those could be duplicated to do the same assertions but with `-E` instead of `--exact. The only thing that'd test would be the CLI arg parsing though, not sure if that's useful.

- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
