### PR TITLE
docs: Made bun-types install as dev dependency in example

### DIFF
--- a/packages/bun-types/README.md
+++ b/packages/bun-types/README.md
@@ -12,7 +12,7 @@ Install the `bun-types` npm package:
 
 ```bash
 # yarn/npm/pnpm work too, "bun-types" is an ordinary npm package
-bun add bun-types
+bun add -d bun-types
 ```
 
 # Usage


### PR DESCRIPTION
### Made bun-types install as dev dependency in example

As bun-types only adds types and it is suggested in other places to be only installed as dev dependency the readme installation example should also do so
