### PR TITLE
fix(node/fetch): Make data URL fetch consistent with node

### DIFF
--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -93,6 +93,30 @@ describe("fetch data urls", () => {
     expect(blob.type).toBe("text/plain;charset=utf-8");
     expect(blob.text()).resolves.toBe("helloworld!");
   });
+  it("unstrict parsing of invalid URL characters", async () => {
+    var url = "data:application/json,{%7B%7D}";
+    var res = await fetch(url);
+    expect(res.status).toBe(200);
+    expect(res.statusText).toBe("OK");
+    expect(res.ok).toBe(true);
+
+    var blob = await res.blob();
+    expect(blob.size).toBe(4);
+    expect(blob.type).toBe("application/json;charset=utf-8");
+    expect(blob.text()).resolves.toBe("{{}}");
+  });
+  it("unstrict parsing of double percent characters", async () => {
+    var url = "data:application/json,{%%7B%7D%%}%%";
+    var res = await fetch(url);
+    expect(res.status).toBe(200);
+    expect(res.statusText).toBe("OK");
+    expect(res.ok).toBe(true);
+
+    var blob = await res.blob();
+    expect(blob.size).toBe(9);
+    expect(blob.type).toBe("application/json;charset=utf-8");
+    expect(blob.text()).resolves.toBe("{%{}%%}%%");
+  });
   it("data url (invalid)", async () => {
     var url = "data:Hello%2C%20World!";
     expect(async () => {


### PR DESCRIPTION
### What does this PR do?
Fixes #5073 

Implements a non-strict mode of the percent encoding decoder that instead of immediately throwing an error and using the original data when there is non-URL safe character in a data URL, it passes the non-URL safe characters through and only replaces the percent encoded elements.

`test.mjs`:
```
console.log(await fetch("data:application/json,{%7B%7D}").then((r) => r.text()));
console.log(await fetch("data:application/json,{%%7B%7D%%}%%").then((r) => r.text()));
console.log(await fetch("data:,%20%😀").then((r) => r.text()));
```

Node output:
```
{{}}
{%{}%%}%%
 %😀
```

Bun before this commit:
```
{%7B%7D}
{%%7B%7D%%}%%
%20%😀
```

After this commit, the output from Bun matches Node.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

- [x] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
