### PR TITLE
[Docs] Use git's `--global` flag for lockfile diffs instead of manually editing config files.

### DIFF
--- a/docs/install/lockfile.md
+++ b/docs/install/lockfile.md
@@ -12,28 +12,18 @@ Run `bun install -y` to generate a Yarn-compatible `yarn.lock` (v1) that can be 
 
 To add to the global gitattributes file:
 
-- First try `$XDG_CONFIG_HOME/git/attributes`
-- If `$XDG_CONFIG_HOME` is not set, try `~/.config/git/attributes`
-
-For example, on macOS, add the following to `~/.config/git/attributes`:
-
-```
-*.lockb diff=lockb
-```
-
-Then add the following to `~/.gitconfig`:
-
-```
-[diff "lockb"]
-    textconv = bun
-    binary = true
-```
-
-To only add to the local gitattributes file:
+To enable diffing in the local gitattributes file (per-repository):
 
 ```sh
 $ git config diff.lockb.textconv bun
 $ git config diff.lockb.binary true
+```
+
+To enable diffing in the global gitattributes file (system-wide), use the `--global` option:
+
+```sh
+$ git config --global diff.lockb.textconv bun
+$ git config --global diff.lockb.binary true
 ```
 
 **Why this works:**


### PR DESCRIPTION
### What does this PR do?

This PR changes the method for enabling Bun lockfile diffs in git. Instead of manually modifying config files, the new method uses the git CLI's `--global` flag to change the global `.gitattributes` file. This should be easier, safer, and more cross-platform than manually modifying the config files. I also clarified that the "local" git-attributes file refers to a per-repository setting, while the global `.gitattributes` file refers to a system-wide setting.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
