### PR TITLE
docs: fix typo in import.meta.resolve

### DIFF
--- a/docs/api/import-meta.md
+++ b/docs/api/import-meta.md
@@ -39,7 +39,7 @@ import.meta.resolveSync("zod")
 ---
 
 - `import.meta.resolve{Sync}`
-- Resolve a module specifier (e.g. `"zod"` or `"./file.tsx`) to an absolute path. While file would be imported if the specifier were imported from this file?
+- Resolve a module specifier (e.g. `"zod"` or `"./file.tsx"`) to an absolute path. While file would be imported if the specifier were imported from this file?
 
   ```ts
   import.meta.resolveSync("zod");


### PR DESCRIPTION
### What does this PR do?

This fixes a small punctuation typo in the docs for `import.meta.resolve`. It adds a missing quotation.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

- [x] The missing quotation is now present.