### PR TITLE
docs: fix typos

### DIFF
--- a/docs/api/binary-data.md
+++ b/docs/api/binary-data.md
@@ -412,7 +412,7 @@ For complete documentation, refer to the [Node.js documentation](https://nodejs.
 
 `Blob` is a Web API commonly used for representing files. `Blob` was initially implemented in browsers (unlike `ArrayBuffer` which is part of JavaScript itself), but it is now supported in Node and Bun.
 
-It isn't common to directly create `Blob` instances. More often, you'll recieve instances of `Blob` from an external source (like an `<input type="file">` element in the browser) or library. That said, it is possible to create a `Blob` from one or more string or binary "blob parts".
+It isn't common to directly create `Blob` instances. More often, you'll receive instances of `Blob` from an external source (like an `<input type="file">` element in the browser) or library. That said, it is possible to create a `Blob` from one or more string or binary "blob parts".
 
 ```ts
 const blob = new Blob(["<html>Hello</html>"], {
@@ -507,7 +507,7 @@ for await (const chunk of stream) {
 }
 ```
 
-For a more complete discusson of streams in Bun, see [API > Streams](/docs/api/streams).
+For a more complete discussion of streams in Bun, see [API > Streams](/docs/api/streams).
 
 ## Conversion
 

--- a/docs/api/transpiler.md
+++ b/docs/api/transpiler.md
@@ -76,7 +76,7 @@ await transpiler.transform("<div>hi!</div>", "tsx");
 ```
 
 {% details summary="Nitty gritty" %}
-The `.tranform()` method runs the transpiler in Bun's worker threadpool, so if you run it 100 times, it will run it across `Math.floor($cpu_count * 0.8)` threads, without blocking the main JavaScript thread.
+The `.transform()` method runs the transpiler in Bun's worker threadpool, so if you run it 100 times, it will run it across `Math.floor($cpu_count * 0.8)` threads, without blocking the main JavaScript thread.
 
 If your code uses a macro, it will potentially spawn a new copy of Bun's JavaScript runtime environment in that new thread.
 {% /details %}

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -204,7 +204,7 @@ Bun.ArrayBufferSink;
 
 ## `Bun.deepEquals()`
 
-Nestedly checks if two objects are equivalent. This is used internally by `expect().toEqual()` in `bun:test`.
+Recursively checks if two objects are equivalent. This is used internally by `expect().toEqual()` in `bun:test`.
 
 ```ts
 const foo = { a: 1, b: 2, c: { d: 3 } };

--- a/docs/api/websockets.md
+++ b/docs/api/websockets.md
@@ -87,7 +87,7 @@ ws.send(new Uint8Array([1, 2, 3])); // TypedArray | DataView
 
 ### Headers
 
-Once the upgrade succeeds, Bun will send a `101 Switching Protocols` response per the [spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism). Additional `headers` can be attched to this `Response` in the call to `server.upgrade()`.
+Once the upgrade succeeds, Bun will send a `101 Switching Protocols` response per the [spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism). Additional `headers` can be attached to this `Response` in the call to `server.upgrade()`.
 
 ```ts
 Bun.serve({

--- a/docs/api/workers.md
+++ b/docs/api/workers.md
@@ -123,7 +123,7 @@ By default, an active `Worker` will keep the main (spawning) process alive, so a
 
 ### `worker.unref()`
 
-To stop a running worker from keeping the process alive, call `worker.unref()`. This decouples the lifetime of the worker to the lifetime of the main process, and is equivlent to what Node.js' `worker_threads` does.
+To stop a running worker from keeping the process alive, call `worker.unref()`. This decouples the lifetime of the worker to the lifetime of the main process, and is equivalent to what Node.js' `worker_threads` does.
 
 ```ts
 const worker = new Worker(new URL("worker.ts", import.meta.url).href);

--- a/docs/bundler/intro.md
+++ b/docs/bundler/intro.md
@@ -40,7 +40,7 @@ When a user visits this website, the files are loaded in the following order:
 
 This approach works, it requires three round-trip HTTP requests before the browser is ready to render the page. On slow internet connections, this may add up to a non-trivial delay.
 
-This example is extremely simplistic. A modern app may be loading dozens of modules from `node_modules`, each consisting of hundrends of files. Loading each of these files with a separate HTTP request becomes untenable very quickly. While most of these requests will be running in parallel, the number of round-trip requests can still be very high; plus, there are limits on how many simultaneous requests a browser can make.
+This example is extremely simplistic. A modern app may be loading dozens of modules from `node_modules`, each consisting of hundred of files. Loading each of these files with a separate HTTP request becomes untenable very quickly. While most of these requests will be running in parallel, the number of round-trip requests can still be very high; plus, there are limits on how many simultaneous requests a browser can make.
 
 {% callout %}
 Some recent advances like modulepreload and HTTP/3 are intended to solve some of these problems, but at the moment bundling is still the most performant approach.

--- a/docs/bundler/loaders.md
+++ b/docs/bundler/loaders.md
@@ -16,7 +16,7 @@ Parses the code and applies a set of default transforms, like dead-code eliminat
 
 **JavaScript + JSX.**. Default for `.js` and `.jsx`.
 
-Same as the `js` loader, but JSX syntax is supported. By default, JSX is downconverted to plain JavaScript; the details of how this is done depends on the `jsx*` compiler options in your `tsconfig.json`. Refer to the TypeScript documentation [on JSX](https://www.typescriptlang.org/docs/handbook/jsx.html) for more information.
+Same as the `js` loader, but JSX syntax is supported. By default, JSX is down-converted to plain JavaScript; the details of how this is done depends on the `jsx*` compiler options in your `tsconfig.json`. Refer to the TypeScript documentation [on JSX](https://www.typescriptlang.org/docs/handbook/jsx.html) for more information.
 
 ### `ts`
 

--- a/docs/bundler/macros.md
+++ b/docs/bundler/macros.md
@@ -129,7 +129,7 @@ if (returnFalse()) {
 }
 ```
 
-## Serializablility
+## Serializability
 
 Bun's transpiler needs to be able to serialize the result of the macro so it can be inlined into the AST. All JSON-compatible data structures are supported:
 

--- a/docs/bundler/vs-esbuild.md
+++ b/docs/bundler/vs-esbuild.md
@@ -125,7 +125,7 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 - `--target`
 - n/a
-- No supported. Bun's bundler performs no syntactic downleveling at this time.
+- No supported. Bun's bundler performs no syntactic down-leveling at this time.
 
 ---
 

--- a/docs/cli/bundler.md
+++ b/docs/cli/bundler.md
@@ -1,6 +1,6 @@
 Bundling is currently an important mechanism for building complex web apps.
 
-Modern apps typically consist of a large number of files and package dependencies. Despite the fact that modern browsers support [ES Module](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) imports, it's still too slow to fetch each file via inidividual HTTP requests. _Bundling_ is the process of concatenating several source files into a single large file that can be loaded in a single request.
+Modern apps typically consist of a large number of files and package dependencies. Despite the fact that modern browsers support [ES Module](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) imports, it's still too slow to fetch each file via individual HTTP requests. _Bundling_ is the process of concatenating several source files into a single large file that can be loaded in a single request.
 
 {% callout %}
 **On bundling** — Despite recent advances like [`modulepreload`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/modulepreload) and [HTTP/3](https://en.wikipedia.org/wiki/HTTP/3), bundling is still the most performant approach.

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -289,7 +289,7 @@ Bun supports a variety of protocols, including [`github`](https://docs.npmjs.com
 
 ## Tarball dependencies
 
-A package name can correspond to a publically hosted `.tgz` file. During `bun install`, Bun will download and install the package from the specified tarball URL, rather than from the package registry.
+A package name can correspond to a publicly hosted `.tgz` file. During `bun install`, Bun will download and install the package from the specified tarball URL, rather than from the package registry.
 
 ```json#package.json
 {

--- a/docs/guides/binary/blob-to-stream.md
+++ b/docs/guides/binary/blob-to-stream.md
@@ -2,7 +2,7 @@
 name: Convert a Blob to a ReadableStream
 ---
 
-The [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) class provides a number of methods for consuming its contents in different formats, inluding `.stream()`. This returns `Promise<ReadableStream>`.
+The [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) class provides a number of methods for consuming its contents in different formats, including `.stream()`. This returns `Promise<ReadableStream>`.
 
 ```ts
 const blob = new Blob(["hello world"]);

--- a/docs/guides/binary/blob-to-string.md
+++ b/docs/guides/binary/blob-to-string.md
@@ -2,7 +2,7 @@
 name: Convert a Blob to a string
 ---
 
-The [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) class provides a number of methods for consuming its contents in different formats, inluding `.text()`.
+The [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) class provides a number of methods for consuming its contents in different formats, including `.text()`.
 
 ```ts
 const blob = new Blob(["hello world"]);

--- a/docs/guides/http/file-uploads.md
+++ b/docs/guides/http/file-uploads.md
@@ -59,7 +59,7 @@ Listening on http://localhost:4000
 
 Our form will send a `POST` request to the `/action` endpoint with the form data. Let's handle that request in our server.
 
-First we use the [`.formData()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/formData) method on the incoming `Request` to asynchonously parse its contents to a `FormData` instance. Then we can use the [`.get()`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/get) method to extract the value of the `name` and `profilePicture` fields. Here `name` corresponds to a `string` and `profilePicture` is a `Blob`.
+First we use the [`.formData()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/formData) method on the incoming `Request` to asynchronously parse its contents to a `FormData` instance. Then we can use the [`.get()`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/get) method to extract the value of the `name` and `profilePicture` fields. Here `name` corresponds to a `string` and `profilePicture` is a `Blob`.
 
 Finally, we write the `Blob` to disk using [`Bun.write()`](/docs/api/file-io#writing-files-bun-write).
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -188,7 +188,7 @@ Bun supports a variety of protocols, including [`github`](https://docs.npmjs.com
 
 ## Tarball dependencies
 
-A package name can correspond to a publically hosted `.tgz` file. During `bun install`, Bun will download and install the package from the specified tarball URL, rather than from the package registry.
+A package name can correspond to a publicly hosted `.tgz` file. During `bun install`, Bun will download and install the package from the specified tarball URL, rather than from the package registry.
 
 ```json#package.json
 {

--- a/docs/nav.ts
+++ b/docs/nav.ts
@@ -166,7 +166,7 @@ export default {
 
     divider("Bundler"),
     page("bundler", "`Bun.build`", {
-      description: "Bundle code for comsumption in the browser with Bun's native bundler.",
+      description: "Bundle code for consumption in the browser with Bun's native bundler.",
     }),
     // page("bundler/intro", "How bundlers work", {
     //   description: "A visual introduction to bundling",

--- a/docs/runtime/configuration.md
+++ b/docs/runtime/configuration.md
@@ -10,7 +10,7 @@ You can also create a global configuration file at the following paths:
 - `$HOME/.bunfig.toml`
 - `$XDG_CONFIG_HOME/.bunfig.toml`
 
-If both a global and local `bunfig` are detected, the results are shallow-merged, with local overridding global. CLI flags will override `bunfig` setting where applicable.
+If both a global and local `bunfig` are detected, the results are shallow-merged, with local overriding global. CLI flags will override `bunfig` setting where applicable.
 
 ## Runtime
 


### PR DESCRIPTION
I tried to fix multiple typos among various files in the documentation 🚀 