### PR TITLE
Suggest appending shell completions to config

### DIFF
--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -346,7 +346,7 @@ pub const InstallCompletionsCommand = struct {
             }
 
             Output.printErrorln(
-                "Please either pipe it:\n   bun completions > /to/a/file\n\n Or pass a directory:\n\n   bun completions /my/completions/dir\n",
+                "Please either append it to your respective config file (.bashrc, .zshrc, etc):\n   bun completions >> ~/.bashrc\n   bun completions >> ~/.zshrc \n\n Pipe it:\n   bun completions > /to/a/file\n\n Or pass a directory:\n\n   bun completions /my/completions/dir\n",
                 .{},
             );
             Global.exit(fail_exit_code);


### PR DESCRIPTION
### What does this PR do?

This PR closes #5153 and suggests appending to a config file like .bashrc or .zshrc when `bun completions` fails (fails on WSL Ubuntu bash since none of these folders in [install_completions_command.zig](https://github.com/oven-sh/bun/blob/main/src/cli/install_completions_command.zig#L282) exist).

Now, when it fails, it will output

```bash
Please either append it to your respective config file (.bashrc, .zshrc, etc):
   bun completions >> ~/.bashrc
   bun completions >> ~/.zshrc 

 Pipe it:
   bun completions > /to/a/file

 Or pass a directory:

   bun completions /my/completions/dir
```
(the first line is a little long but it's just under the recommended 80 char limit)

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Printed the updated string and ran `bun completions >> ~/.bashrc` on WSL

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
