### PR TITLE
fix(console.log) fix printing long custom format

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2119,7 +2119,7 @@ pub const ZigConsoleClient = struct {
                         this.globalThis,
                         this.custom_formatted_object.function,
                         this.custom_formatted_object.this,
-                        this.max_depth - this.depth,
+                        if (this.depth > this.max_depth) 0 else this.max_depth - this.depth,
                         this.max_depth,
                         enable_ansi_colors,
                     );

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2119,7 +2119,7 @@ pub const ZigConsoleClient = struct {
                         this.globalThis,
                         this.custom_formatted_object.function,
                         this.custom_formatted_object.this,
-                        if (this.depth > this.max_depth) 0 else this.max_depth - this.depth,
+                        this.max_depth -| this.depth,
                         this.max_depth,
                         enable_ansi_colors,
                     );

--- a/test/js/third_party/mongodb/mongodb.test.ts
+++ b/test/js/third_party/mongodb/mongodb.test.ts
@@ -1,0 +1,29 @@
+import { test, expect, describe } from "bun:test";
+import { MongoClient } from "mongodb";
+
+const CONNECTION_STRING = process.env.TLS_MONGODB_DATABASE_URL;
+
+const it = CONNECTION_STRING ? test : test.skip;
+
+describe("mongodb", () => {
+  it("should connect and inpect", async () => {
+    const client = new MongoClient(CONNECTION_STRING as string);
+
+    const clientConnection = await client.connect();
+
+    try {
+      const db = client.db("oven");
+
+      const schema = db.collection("bun");
+
+      await schema.insertOne({ name: "bunny", version: 1.0 });
+      const result = await schema.find();
+      await schema.deleteOne({ name: "bunny" });
+      const text = Bun.inspect(result);
+
+      expect(text).toBeDefined();
+    } finally {
+      await clientConnection.close();
+    }
+  });
+});

--- a/test/js/third_party/mongodb/mongodb.test.ts
+++ b/test/js/third_party/mongodb/mongodb.test.ts
@@ -12,7 +12,7 @@ describe("mongodb", () => {
     const clientConnection = await client.connect();
 
     try {
-      const db = client.db("oven");
+      const db = client.db("bun");
 
       const schema = db.collection("bun");
 

--- a/test/js/third_party/mongodb/package.json
+++ b/test/js/third_party/mongodb/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "mongodb",
+  "dependencies": {
+    "mongodb": "6.0.0"
+   }
+}

--- a/test/package.json
+++ b/test/package.json
@@ -34,7 +34,8 @@
     "undici": "5.20.0",
     "vitest": "0.32.2",
     "webpack": "5.88.0",
-    "webpack-cli": "4.7.2"
+    "webpack-cli": "4.7.2",
+    "mongodb": "6.0.0"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
### What does this PR do?

This fix printing `.find()` result from `mongodb` package.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

Manually testing
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
