### PR TITLE
decode regex if needed

### DIFF
--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -2538,7 +2538,10 @@ pub const E = struct {
     };
 
     pub const RegExp = struct {
-        value: string,
+        data: union(enum) {
+            raw: string,
+            decoded: std.ArrayList(u16),
+        },
 
         // This exists for JavaScript bindings
         // The RegExp constructor expects flags as a second argument.
@@ -2548,7 +2551,7 @@ pub const E = struct {
         //      ^
         flags_offset: ?u16 = null,
 
-        pub var empty = RegExp{ .value = "" };
+        pub var empty = RegExp{ .data = .{ .raw = "" } };
 
         pub fn pattern(this: RegExp) string {
 

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -2540,7 +2540,7 @@ pub const E = struct {
     pub const RegExp = struct {
         data: union(enum) {
             raw: string,
-            decoded: std.ArrayList(u16),
+            decoded: bun.BabyList(u16),
         },
 
         // This exists for JavaScript bindings

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -13122,7 +13122,7 @@ fn NewParser_(
                     return p.newExpr(
                         E.RegExp{
                             .data = .{
-                                .decoded = buf,
+                                .decoded = bun.BabyList(u16).init(buf.items),
                             },
                             .flags_offset = p.lexer.regex_flags_start,
                         },

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -3192,8 +3192,7 @@ fn NewPrinter(
                     p.print(raw);
                 },
                 .decoded => |decoded| {
-                    p.printUnquotedUTF16(decoded.items);
-                    decoded.deinit();
+                    p.printUnquotedUTF16(decoded.slice());
                 },
             }
 

--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -1973,6 +1973,11 @@ console.log(resolve.length)
       expectParseError("/x/msuygig", 'Duplicate flag "g" in regular expression');
     });
 
+    it("non-ascii regexp literals", () => {
+      var str = "🔴11 54 / 10,000";
+      expect(str.replace(/[🔵🔴,]+/g, "")).toBe("11 54 / 10000");
+    });
+
     it("identifier escapes", () => {
       expectPrinted_("var _\u0076\u0061\u0072", "var _var");
       expectParseError("var \u0076\u0061\u0072", 'Expected identifier but found "\u0076\u0061\u0072"');


### PR DESCRIPTION
### What does this PR do?
fixes #5132 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
added test and tested manually.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
