### PR TITLE
fix(node:dns): fix crash and compatibility issues with `resolve`

### DIFF
--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1977,11 +1977,6 @@ pub const DNSResolver = struct {
             return .zero;
         };
 
-        if (name_str.length() == 0) {
-            globalThis.throwInvalidArgumentType("resolveSoa", "hostname", "non-empty string");
-            return .zero;
-        }
-
         const name = name_str.toSliceClone(globalThis, bun.default_allocator);
 
         var vm = globalThis.bunVM();
@@ -2038,11 +2033,6 @@ pub const DNSResolver = struct {
         const name_str = name_value.toStringOrNull(globalThis) orelse {
             return .zero;
         };
-
-        if (name_str.length() == 0) {
-            globalThis.throwInvalidArgumentType("resolveNs", "hostname", "non-empty string");
-            return .zero;
-        }
 
         const name = name_str.toSliceClone(globalThis, bun.default_allocator);
 


### PR DESCRIPTION
### What does this PR do?

#### 1. long string could lead to a segfault.

Segmentfault code: 

```JavaScript
const dns = require("node:dns");

dns.resolveCname("a".repeat(3000), (err, results) => {});
```

`null` should not be used here as it can lead to a crash. (Line 530)

https://github.com/oven-sh/bun/blob/3b2c0941e4b418dcf2bfbc5117da76338f45a90e/src/deps/c_ares.zig#L526-L541


#### 2. Fix a compatibility issue (`resolveNs` and `resolveSoa`)

```JavaScript
const dns = require("node:dns");
for (const f of [dns.resolveNs, dns.resolveSoa]) {
  f("", (err, results) => {
    console.log(f, results);
  });
}

// nodejs output
// [Function: bound queryNs] [
//   'h.root-servers.net',
//   'j.root-servers.net',
//   'k.root-servers.net',
//   'd.root-servers.net',
//   'b.root-servers.net',
//   'f.root-servers.net',
//   'l.root-servers.net',
//   'e.root-servers.net',
//   'i.root-servers.net',
//   'a.root-servers.net',
//   'm.root-servers.net',
//   'g.root-servers.net',
//   'c.root-servers.net'
// ]
// [Function: bound querySoa] {
//   nsname: 'a.root-servers.net',
//   hostmaster: 'nstld.verisign-grs.com',
//   serial: 2023091202,
//   refresh: 1800,
//   retry: 900,
//   expire: 604800,
//   minttl: 86400
// }
```

bun doesn't allow empty strings to be passed into these two functions.

---

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests



- [ ] I ran `make js` and committed the transpiled changes
- [x] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [x] I included a test for the new code, or an existing test covers it
- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
