### PR TITLE
modules documentation didn't have correct import example

### DIFF
--- a/docs/runtime/modules.md
+++ b/docs/runtime/modules.md
@@ -135,9 +135,9 @@ The biggest difference between CommonJS and ES Modules is that CommonJS modules 
 You can `import` any file or package, even `.cjs` files.
 
 ```ts
-const { foo } = require("./foo"); // extensions are optional
-const { bar } = require("./bar.mjs");
-const { baz } = require("./my-typescript.tsx");
+import { foo } from "./foo"; // extensions are optional
+import bar from "./bar.ts";
+import { stuff } from "./my-commonjs.cjs";
 ```
 
 ### Using `import` and `require()` together


### PR DESCRIPTION
### What does this PR do?

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

I noticed that the [modules documentation](https://bun.sh/docs/runtime/modules) doesn't include import example code in the imports section. 

![image](https://github.com/oven-sh/bun/assets/30512204/0913a02f-bc3e-4182-8816-8dec09b11776)

This PR replaces the screenshotted code block with:
```ts
import { foo } from "./foo"; // extensions are optional
import bar from "./bar.ts";
import { stuff } from "./my-commonjs.cjs";
```