### PR TITLE
Update misleading documentation link

### DIFF
--- a/docs/guides/ecosystem/discordjs.md
+++ b/docs/guides/ecosystem/discordjs.md
@@ -74,4 +74,4 @@ Ready! Logged in as my-bot#1234
 
 ---
 
-You're up and running with a bare-bones Discord.js bot! This is a basic guide to setting up your bot with Bun; we recommend the [official Discord docs](https://discordjs.guide/) for complete information on the `discord.js` API.
+You're up and running with a bare-bones Discord.js bot! This is a basic guide to setting up your bot with Bun; we recommend the [official discord.js docs](https://discordjs.guide/) for complete information on the `discord.js` API.


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Updates discord.js documentation to correct a named link that previously could mislead people into thinking it's a link to a Discord website when it's a link to discord.js' documentation in reality.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

