### PR TITLE
Correct the configuration file names.

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -69,7 +69,7 @@ $ bun install --silent  # no logging
 ```
 
 {% details summary="Configuring behavior" %}
-The default behavior of `bun install` can be configured in `bun.toml`:
+The default behavior of `bun install` can be configured in `bunfig.toml`:
 
 ```toml
 [install]

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -69,7 +69,7 @@ $ bun install --silent  # no logging
 ```
 
 {% details summary="Configuring behavior" %}
-The default behavior of `bun install` can be configured in `bun.toml`:
+The default behavior of `bun install` can be configured in `bunfig.toml`:
 
 ```toml
 [install]


### PR DESCRIPTION
Bun stores configuration in these three places:

- `$XDG_CONFIG_HOME/.bunfig.toml`
- `$HOME/.bunfig.toml`
- `${pwd}/bunfig.toml`

The use of `bun.toml` is a documentation error.