### PR TITLE
chore(docs): include missing links to Node.js APIs

### DIFF
--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -94,7 +94,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:process`](https://nodejs.org/api/process.html)
 
-🟡 See `Globals > process`.
+🟡 See [`process`](#process) Global.
 
 ### [`node:punycode`](https://nodejs.org/api/punycode.html)
 
@@ -122,7 +122,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:sys`](https://nodejs.org/api/util.html)
 
-🟡 See `node:util`.
+🟡 See [`node:util`](#node-util).
 
 ### [`node:timers`](https://nodejs.org/api/timers.html)
 


### PR DESCRIPTION
### What does this PR do?

This PR adds some missing links to make it easy to jump to another section.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
