### PR TITLE
doc(guides): update sveltekit guide 

### DIFF
--- a/docs/guides/ecosystem/sveltekit.md
+++ b/docs/guides/ecosystem/sveltekit.md
@@ -5,7 +5,7 @@ name: Build an app with SvelteKit and Bun
 Use `bunx` to scaffold your app with the `create-svelte` CLI. Answer the prompts to select a template and set up your development environment.
 
 ```sh
-$ bunx create-svelte my-app
+$ bun create svelte@latest my-app
 ┌  Welcome to SvelteKit!
 │
 ◇  Which Svelte app template?

--- a/docs/guides/ecosystem/sveltekit.md
+++ b/docs/guides/ecosystem/sveltekit.md
@@ -2,7 +2,7 @@
 name: Build an app with SvelteKit and Bun
 ---
 
-Use `bunx` to scaffold your app with the `create-svelte` CLI. Answer the prompts to select a template and set up your development environment.
+Use `bun create` to scaffold your app with the `svelte` package. Answer the prompts to select a template and set up your development environment.
 
 ```sh
 $ bun create svelte@latest my-app


### PR DESCRIPTION
### What does this PR do?

Use `bun create svelte` instead of `bunx create-svelte`. 

This is to bring the documentation at par with the SvelteKit official doc to [create a project](https://kit.svelte.dev/docs/creating-a-project).

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes