### PR TITLE
Add ~/.bun as option to install bash completions

### DIFF
--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -318,6 +318,14 @@ pub const InstallCompletionsCommand = struct {
                                     break :outer;
                             }
                         }
+                        {
+                            outer: {
+                                var paths = [_]string{ home_dir, "./.bun" };
+                                completions_dir = resolve_path.joinAbsString(cwd, &paths, .auto);
+                                break :found std.fs.openIterableDirAbsolute(completions_dir, .{}) catch
+                                    break :outer;
+                            }
+                        }
                     }
 
                     const dirs_to_try = [_]string{

--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -437,8 +437,7 @@ pub const InstallCompletionsCommand = struct {
                                 break :rc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :third;
                             }
                         }
-                    }
-                    else if (shell == .bash) {
+                    } else if (shell == .bash) {
                         first: {
                             if (bun.getenvZ("HOME")) |bdot_dir| {
                                 bun.copy(u8, &rc_filepath, bdot_dir);

--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -397,7 +397,7 @@ pub const InstallCompletionsCommand = struct {
             var rc_filepath: [bun.MAX_PATH_BYTES]u8 = undefined;
             const rc_string = if (shell == .bash) ".bashrc" else ".zshrc";
             const needs_to_tell_them_to_add_completions_file = brk: {
-                var dot_rc: std.fs.File = zshrc: {
+                var dot_rc: std.fs.File = rc: {
                     if (shell == .zsh){
                         first: {
 
@@ -414,7 +414,7 @@ pub const InstallCompletionsCommand = struct {
                                 bun.copy(u8, rc_filepath[zdot_dir.len..], "/.zshrc");
                                 rc_filepath[zdot_dir.len + "/.zshrc".len] = 0;
                                 var filepath = rc_filepath[0 .. zdot_dir.len + "/.zshrc".len :0];
-                                break :zshrc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :first;
+                                break :rc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :first;
                             }
                         }
 
@@ -424,7 +424,7 @@ pub const InstallCompletionsCommand = struct {
                                 bun.copy(u8, rc_filepath[zdot_dir.len..], "/.zshrc");
                                 rc_filepath[zdot_dir.len + "/.zshrc".len] = 0;
                                 var filepath = rc_filepath[0 .. zdot_dir.len + "/.zshrc".len :0];
-                                break :zshrc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :second;
+                                break :rc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :second;
                             }
                         }
 
@@ -434,7 +434,7 @@ pub const InstallCompletionsCommand = struct {
                                 bun.copy(u8, rc_filepath[zdot_dir.len..], "/.zshenv");
                                 rc_filepath[zdot_dir.len + "/.zshenv".len] = 0;
                                 var filepath = rc_filepath[0 .. zdot_dir.len + "/.zshenv".len :0];
-                                break :zshrc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :third;
+                                break :rc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :third;
                             }
                         }
                     }
@@ -445,7 +445,7 @@ pub const InstallCompletionsCommand = struct {
                                 bun.copy(u8, rc_filepath[bdot_dir.len..], "/.bashrc");
                                 rc_filepath[bdot_dir.len + "/.bashrc".len] = 0;
                                 var filepath = rc_filepath[0 .. bdot_dir.len + "/.bashrc".len :0];
-                                break :zshrc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :first;
+                                break :rc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :first;
                             }
                         }
                     }

--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -398,7 +398,7 @@ pub const InstallCompletionsCommand = struct {
             const rc_string = if (shell == .bash) ".bashrc" else ".zshrc";
             const needs_to_tell_them_to_add_completions_file = brk: {
                 var dot_rc: std.fs.File = rc: {
-                    if (shell == .zsh){
+                    if (shell == .zsh) {
                         first: {
 
                             // https://zsh.sourceforge.io/Intro/intro_3.html
@@ -438,7 +438,7 @@ pub const InstallCompletionsCommand = struct {
                             }
                         }
                     }
-                    if (shell == .bash){
+                    if (shell == .bash) {
                         first: {
                             if (bun.getenvZ("HOME")) |bdot_dir| {
                                 bun.copy(u8, &rc_filepath, bdot_dir);
@@ -450,9 +450,7 @@ pub const InstallCompletionsCommand = struct {
                         }
                     }
 
-
-
-                    break :brk true;         
+                    break :brk true;
                 };
                 defer dot_rc.close();
                 var buf = allocator.alloc(

--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -438,7 +438,7 @@ pub const InstallCompletionsCommand = struct {
                             }
                         }
                     }
-                    if (shell == .bash) {
+                    else if (shell == .bash) {
                         first: {
                             if (bun.getenvZ("HOME")) |bdot_dir| {
                                 bun.copy(u8, &rc_filepath, bdot_dir);

--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -487,7 +487,7 @@ pub const InstallCompletionsCommand = struct {
             };
 
             if (needs_to_tell_them_to_add_completions_file) {
-                Output.prettyErrorln("<r>To enable completions, add this to your \"{s}\":\n      <b>[ -s \"{s}\" ] && source \"{s}\"", .{
+                Output.prettyErrorln("<r>To enable completions, add this to your {s}:\n      <b>[ -s \"{s}\" ] && source \"{s}\"", .{
                     rc_string,
                     completions_path,
                     completions_path,


### PR DESCRIPTION
### What does this PR do?
Bash completions weren't working on WSL2, so I made it like zsh. For bash, this PR makes `bun completions` look for another folder ~/.bun to install bun.completions.bash into. Then, it checks whether to add bun.completions.bash to ~/.bashrc. This is what works for [zsh currently](https://github.com/oven-sh/bun/issues/5153#issuecomment-1716632068). This is needed because for bash, [it only checks for folders that only exist](https://github.com/oven-sh/bun/blob/main/src/cli/install_completions_command.zig#L282) if user has installed `bash-completions`.



<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Manual test on WSL Ubuntu and Mac.

For Macs, [bun.bash](https://github.com/oven-sh/bun/blob/687e31dc3a16e76926f0eb06155c5357741b05ab/completions/bun.bash) uses features added in bash 4.0 or above, so I had to
```bash
brew install bash
chsh -s /usr/local/bin/bash # to change $SHELL from zsh
```

 to test. Preinstalled bash is only 3.x.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:
-->
- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
