### PR TITLE
Fix bug with multiline string in CRLF terminated files (#4893)

### DIFF
--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -642,7 +642,7 @@ fn NewLexer_(
                         lexer.step();
 
                         // Handle Windows CRLF
-                        if (lexer.code_point == 'r' and comptime !is_json) {
+                        if (lexer.code_point == '\r' and comptime !is_json) {
                             lexer.step();
                             if (lexer.code_point == '\n') {
                                 lexer.step();

--- a/test/regression/issue/4893.test.ts
+++ b/test/regression/issue/4893.test.ts
@@ -1,0 +1,23 @@
+import { bunEnv, bunExe } from "harness";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+it("correctly handles CRLF multiline string in CRLF terminated files", async () => {
+  const testDir = mkdtempSync(join(tmpdir(), "issue4893-"));
+
+  // Clean up from prior runs if necessary
+  rmSync(testDir, { recursive: true, force: true });
+
+  // Create a directory with our test CRLF terminated file
+  mkdirSync(testDir, { recursive: true });
+  writeFileSync(join(testDir, "crlf.js"), '"a\\\r\nb"');
+
+  const { stdout, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "run", join(testDir, "crlf.js")],
+    env: bunEnv,
+    stderr: "inherit",
+  });
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

correctly handles escaped CRLF line endings in multiline strings

fixes https://github.com/oven-sh/bun/issues/4893

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I manually tested against three files
- terminated with CRLF
- terminated with CR
- terminated with LF

Pre change it errored on CRLF and passed on the other 2
Post change it passes on all 3

I also added an automated test for the failing CRLF scenario.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
