### PR TITLE
fix(doc): Add "compilerOptions" to bun-types README.md

### DIFF
--- a/packages/bun-types/README.md
+++ b/packages/bun-types/README.md
@@ -21,9 +21,11 @@ Add this to your `tsconfig.json` or `jsconfig.json`:
 
 ```jsonc-diff
   {
-    
-+   "types": ["bun-types"],
-    
+    "compilerOptions": {
++     "types": ["bun-types"]
+      // other options...
+    }
+
     // other options...
   }
 ```


### PR DESCRIPTION
### What does this PR do?

This updates the documentation for how to add bun-types.
Reading the documentation on bun-types it was not clear to me that the tsconfig.ts needs to look like this:

```
{
  "compilerOptions": {
    "types": ["bun-types"]
  }
}
```

So i added the "compilerOptions" information.

- [ x ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)

### How did you verify your code works?

- [  x ] Checked the readme on my pr 

