### PR TITLE
Remove `--save` from helptext

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5763,7 +5763,6 @@ pub const PackageManager = struct {
         clap.parseParam("-y, --yarn                        Write a yarn.lock file (yarn v1)") catch unreachable,
         clap.parseParam("-p, --production                  Don't install devDependencies") catch unreachable,
         clap.parseParam("--no-save                         Don't save a lockfile") catch unreachable,
-        clap.parseParam("--save                            Save to package.json") catch unreachable,
         clap.parseParam("--dry-run                         Don't install anything") catch unreachable,
         clap.parseParam("--lockfile <PATH>                  Store & load a lockfile at a specific filepath") catch unreachable,
         clap.parseParam("--frozen-lockfile                 Disallow changes to lockfile") catch unreachable,
@@ -5816,10 +5815,12 @@ pub const PackageManager = struct {
     };
 
     const link_params = install_params_ ++ [_]ParamType{
+        clap.parseParam("--save                            Add dependency to package.json") catch unreachable,
         clap.parseParam("<POS> ...                         \"name\" install package as a link") catch unreachable,
     };
 
     const unlink_params = install_params_ ++ [_]ParamType{
+        clap.parseParam("--save                            Add dependency to package.json") catch unreachable,
         clap.parseParam("<POS> ...                         \"name\" uninstall package as a link") catch unreachable,
     };
 

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1470,9 +1470,10 @@ it("should add dependencies to workspaces directly", async () => {
   expect(await file(join(package_dir, "node_modules", "foo", "package.json")).text()).toEqual(foo_package);
 });
 
-it("should redirect 'install --save X' to 'add'", async () => {
-  await installRedirectsToAdd(true);
-});
+// TODO: make un-recognized long flags no-ops
+// it("should redirect 'install --save X' to 'add'", async () => {
+//   await installRedirectsToAdd(true);
+// });
 
 it("should redirect 'install X --save' to 'add'", async () => {
   await installRedirectsToAdd(false);


### PR DESCRIPTION
### What does this PR do?

Currently `--save` is listed as a flag for `bun install|add|remove` even though it's a no-op.

This changes it to only appear in `link` and `unlink` where it does something

The existence of `--save` in the helptext also implied that Bun wouldn't update package.json by default which causes confusion

Per https://github.com/oven-sh/bun/pull/3277 there is a bug where Bun will stop parsing when it encounters an unrecognized long flag, so `bun install --save zod` will behave like `bun install`. This is true for all manner of unimplemented `npm` flags, and adding `--save` to support this use case isn't worth the confusion. Flags like `--save-dev` or more common anyway. 

Later we should refactor the args parsing to its easier to ignore unrecognized long flags and have more control over helptext, etc.
