### PR TITLE
Remove the ability to configure lockfile location.

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -92,12 +92,12 @@ _bun_completions() {
     PACKAGE_OPTIONS[REMOVE_OPTIONS_LONG]="";
     PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]="";
 
-    PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]="--config --yarn --production --frozen-lockfile --no-save --dry-run --lockfile --force --cache-dir --no-cache --silent --verbose --global --cwd --backend --link-native-bins --help";
+    PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --global --cwd --backend --link-native-bins --help";
     PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]="-c -y -p -f -g";
 
-    PM_OPTIONS[LONG_OPTIONS]="--config --yarn --production --frozen-lockfile --no-save --dry-run --lockfile --force --cache-dir --no-cache --silent --verbose --no-progress --no-summary --no-verify --ignore-scripts --global --cwd --backend --link-native-bins --help"
+    PM_OPTIONS[LONG_OPTIONS]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --no-progress --no-summary --no-verify --ignore-scripts --global --cwd --backend --link-native-bins --help"
     PM_OPTIONS[SHORT_OPTIONS]="-c -y -p -f -g"
-     
+
     local cur_word="${COMP_WORDS[${COMP_CWORD}]}";
     local prev="${COMP_WORDS[$(( COMP_CWORD - 1 ))]}";
 

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -55,7 +55,6 @@ _bun() {
                 '--no-save[]' \
                 '--dry-run[Don'"'"'t install anything]' \
                 '--force[Always request the latest versions from the registry & reinstall all dependenices]' \
-                '--lockfile[Store & load a lockfile at a specific filepath]:lockfile' \
                 '--cache-dir[Store & load cached data from a specific directory path]:cache-dir' \
                 '--no-cache[Ignore manifest cache entirely]' \
                 '--silent[Don'"'"'t output anything]' \
@@ -97,7 +96,6 @@ _bun() {
                 '--no-save[]' \
                 '--dry-run[Don'"'"'t install anything]' \
                 '--force[Always request the latest versions from the registry & reinstall all dependenices]' \
-                '--lockfile[Store & load a lockfile at a specific filepath]:lockfile' \
                 '--cache-dir[Store & load cached data from a specific directory path]:cache-dir' \
                 '--no-cache[Ignore manifest cache entirely]' \
                 '--silent[Don'"'"'t output anything]' \
@@ -133,7 +131,6 @@ _bun() {
                 '--no-save[]' \
                 '--dry-run[Don'"'"'t install anything]' \
                 '--force[Always request the latest versions from the registry & reinstall all dependenices]' \
-                '--lockfile[Store & load a lockfile at a specific filepath]:lockfile' \
                 '--cache-dir[Store & load cached data from a specific directory path]:cache-dir' \
                 '--no-cache[Ignore manifest cache entirely]' \
                 '--silent[Don'"'"'t output anything]' \
@@ -284,7 +281,6 @@ _bun() {
                 '--frozen-lockfile[Disallow changes to lockfile]' \
                 '--no-save[Do not save a lockfile]'
                 '--dry-run[Do not install anything]'
-                '--lockfile[Store & load a lockfile at a specific filepath]'
                 '-f[Always request the latest versions from the registry & reinstall all dependencies]'
                 '--force[Always request the latest versions from the registry & reinstall all dependencies]'
                 '--cache-dir[Store & load cached data from a specific directory path]'
@@ -540,7 +536,6 @@ _bun() {
                 '--no-save[]' \
                 '--dry-run[Don'"'"'t install anything]' \
                 '--force[Always request the latest versions from the registry & reinstall all dependenices]' \
-                '--lockfile[Store & load a lockfile at a specific filepath]:lockfile' \
                 '--cache-dir[Store & load cached data from a specific directory path]:cache-dir' \
                 '--no-cache[Ignore manifest cache entirely]' \
                 '--silent[Don'"'"'t output anything]' \
@@ -576,7 +571,6 @@ _bun() {
                 '-g[Remove a package globally]' \
                 '--global[Remove a package globally]' \
                 '--force[Always request the latest versions from the registry & reinstall all dependenices]' \
-                '--lockfile[Store & load a lockfile at a specific filepath]:lockfile' \
                 '--cache-dir[Store & load cached data from a specific directory path]:cache-dir' \
                 '--no-cache[Ignore manifest cache entirely]' \
                 '--silent[Don'"'"'t output anything]' \
@@ -642,7 +636,7 @@ _bun_run_param_script_completion() {
     local -a scripts_list
     IFS=$'\n' scripts_list=($(SHELL=zsh bun getcompletes s))
     IFS=$'\n' bins=($(SHELL=zsh bun getcompletes b))
-    
+
     _alternative "scripts:scripts:(($scripts_list))"
     _alternative "bin:bin:(($bins))"
     _alternative "files:file:_files -g '*.(js|ts|jsx|tsx|wasm)'"

--- a/completions/spec.yaml
+++ b/completions/spec.yaml
@@ -119,9 +119,6 @@ subcommands:
       - no-save --
       - dry-run -- "Don't install anything"
       - force -- "Always request the latest versions from the registry & reinstall all dependenices"
-      - name: lockfile
-        type: string
-        summary: "Store & load a lockfile at a specific filepath"
       - name: cache-dir
         type: string
         summary: "Store & load cached data from a specific directory path"
@@ -160,9 +157,6 @@ subcommands:
       - no-cache -- "Ignore manifest cache entirely"
       - silent -- "Don't output anything"
       - verbose -- "Excessively verbose logging"
-      - name: lockfile
-        type: string
-        summary: "Store & load a lockfile at a specific filepath"
       - name: cache-dir
         type: string
         summary: "Store & load cached data from a specific directory path"
@@ -198,9 +192,6 @@ subcommands:
       - no-save --
       - dry-run -- "Don't install anything"
       - force -- "Always request the latest versions from the registry & reinstall all dependenices"
-      - name: lockfile
-        type: string
-        summary: "Store & load a lockfile at a specific filepath"
       - name: cache-dir
         type: string
         summary: "Store & load cached data from a specific directory path"

--- a/docs/cli/bun-install.md
+++ b/docs/cli/bun-install.md
@@ -89,12 +89,6 @@ disableManifest = false
 # Note: it does not load the lockfile, it just converts bun.lockb into a yarn.lock
 print = "yarn"
 
-# Path to read bun.lockb from
-path = "bun.lockb"
-
-# Path to save bun.lockb to
-savePath = "bun.lockb"
-
 # Save the lockfile to disk
 save = true
 
@@ -142,8 +136,6 @@ export interface Cache {
 
 export interface Lockfile {
   print?: "yarn";
-  path: string;
-  savePath: string;
   save: boolean;
 }
 ```
@@ -156,7 +148,6 @@ Environment variables have a higher priority than `bunfig.toml`.
 | -------------------------------- | ------------------------------------------------------------- |
 | BUN_CONFIG_REGISTRY              | Set an npm registry (default: <https://registry.npmjs.org>)   |
 | BUN_CONFIG_TOKEN                 | Set an auth token (currently does nothing)                    |
-| BUN_CONFIG_LOCKFILE_SAVE_PATH    | File path to save the lockfile to (default: bun.lockb)        |
 | BUN_CONFIG_YARN_LOCKFILE         | Save a Yarn v1-style yarn.lock                                |
 | BUN_CONFIG_LINK_NATIVE_BINS      | Point `bin` in package.json to a platform-specific dependency |
 | BUN_CONFIG_SKIP_SAVE_LOCKFILE    | Don’t save a lockfile                                         |

--- a/docs/install/lockfile.md
+++ b/docs/install/lockfile.md
@@ -79,12 +79,6 @@ print = "yarn"
 ```toml
 [install.lockfile]
 
-# path to read bun.lockb from
-path = "bun.lockb"
-
-# path to save bun.lockb to
-savePath = "bun.lockb"
-
 # whether to save the lockfile to disk
 save = true
 

--- a/docs/runtime/configuration.md
+++ b/docs/runtime/configuration.md
@@ -148,12 +148,6 @@ To configure lockfile behavior:
 # path to read bun.lockb from
 path = "bun.lockb"
 
-# path to save bun.lockb to
-savePath = "bun.lockb"
-
-# whether to save the lockfile to disk
-save = true
-
 # whether to save a non-Bun lockfile alongside bun.lockb
 # only "yarn" is supported
 print = "yarn"

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -392,18 +392,6 @@ pub const Bunfig = struct {
                                 install.save_lockfile = value;
                             }
                         }
-
-                        if (lockfile_expr.get("path")) |lockfile| {
-                            if (lockfile.asString(allocator)) |value| {
-                                install.lockfile_path = value;
-                            }
-                        }
-
-                        if (lockfile_expr.get("savePath")) |lockfile| {
-                            if (lockfile.asString(allocator)) |value| {
-                                install.save_lockfile_path = value;
-                            }
-                        }
                     }
 
                     if (_bun.get("optional")) |optional| {


### PR DESCRIPTION
1. Enabling configuration of lockfile location at the global config level means that the lockfile isn't guaranteed consistent across a team. Currently, the only "safe" (read: assured consistent) way to use `bun` with multiple contributor teams requires setting that value in the local `bunfig.toml`.

2. Splitting the two values from each other enables a configuration where you can’t read after writing.

3. `env` priority is "correct" for `BUN_CONFIG_LOCKFILE_SAVE_PATH` but I don't feel like it should exist. It isn't used in the test suite, makes shared configuration impossible, and appears [semi-arbitrarily added](https://github.com/oven-sh/bun/commit/a765b13f526f5d379c7d2535f496fecd9a202add) two years ago in December 2021.

4. `--lockfile` introduces the same problem, and since it is per-execution, is _extremely_ difficult to ensure consistency. It also gets removed.

***

Approach notes:
- This does not change the peechy schema because I'm ~certain that isn't possible.
- I don't know what I don't know in Zig.
- I _think_ there are some other places that can be cleaned up because `lockfile_path` is now a static string.

***

Closes #5259