### PR TITLE
In `bunx`, always get latest version when @latest is explicitly passed

### DIFF
--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -279,65 +279,67 @@ pub const BunxCommand = struct {
 
         const passthrough = passthrough_list.items;
 
-        // Similar to "npx":
-        //
-        //  1. Try the bin in the current node_modules and then we try the bin in the global cache
-        if (bun.which(
-            &path_buf,
-            PATH_FOR_BIN_DIRS,
-            this_bundler.fs.top_level_dir,
-            initial_bin_name,
-        ) orelse bun.which(
-            &path_buf,
-            bunx_cache_dir,
-            this_bundler.fs.top_level_dir,
-            absolute_in_cache_dir,
-        )) |destination| {
-            const out = bun.asByteSlice(destination);
-            _ = try Run.runBinary(
-                ctx,
-                try this_bundler.fs.dirname_store.append(@TypeOf(out), out),
+        if (update_request.version.literal.isEmpty() or update_request.version.tag != .dist_tag) {
+            // Similar to "npx":
+            //
+            //  1. Try the bin in the current node_modules and then we try the bin in the global cache
+            if (bun.which(
+                &path_buf,
+                PATH_FOR_BIN_DIRS,
                 this_bundler.fs.top_level_dir,
-                this_bundler.env,
-                passthrough,
-            );
-            // we are done!
-            Global.exit(0);
-        }
-
-        // 2. The "bin" is possibly not the same as the package name, so we load the package.json to figure out what "bin" to use
-        if (getBinName(&this_bundler, bun.fdcast(root_dir_info.getFileDescriptor()), bunx_cache_dir, initial_bin_name)) |package_name_for_bin| {
-            // if we check the bin name and its actually the same, we don't need to check $PATH here again
-            if (!strings.eqlLong(package_name_for_bin, initial_bin_name, true)) {
-                absolute_in_cache_dir = std.fmt.bufPrint(&absolute_in_cache_dir_buf, "{s}/node_modules/.bin/{s}", .{ bunx_cache_dir, package_name_for_bin }) catch unreachable;
-
-                if (bun.which(
-                    &path_buf,
-                    PATH_FOR_BIN_DIRS,
+                initial_bin_name,
+            ) orelse bun.which(
+                &path_buf,
+                bunx_cache_dir,
+                this_bundler.fs.top_level_dir,
+                absolute_in_cache_dir,
+            )) |destination| {
+                const out = bun.asByteSlice(destination);
+                _ = try Run.runBinary(
+                    ctx,
+                    try this_bundler.fs.dirname_store.append(@TypeOf(out), out),
                     this_bundler.fs.top_level_dir,
-                    package_name_for_bin,
-                ) orelse bun.which(
-                    &path_buf,
-                    bunx_cache_dir,
-                    this_bundler.fs.top_level_dir,
-                    absolute_in_cache_dir,
-                )) |destination| {
-                    const out = bun.asByteSlice(destination);
-                    _ = try Run.runBinary(
-                        ctx,
-                        try this_bundler.fs.dirname_store.append(@TypeOf(out), out),
-                        this_bundler.fs.top_level_dir,
-                        this_bundler.env,
-                        passthrough,
-                    );
-                    // we are done!
-                    Global.exit(0);
-                }
+                    this_bundler.env,
+                    passthrough,
+                );
+                // we are done!
+                Global.exit(0);
             }
-        } else |err| {
-            if (err == error.NoBinFound) {
-                Output.prettyErrorln("<r><red>error<r><d>:<r> could not determine executable to run for package <r><b>{s}<r>", .{update_request.name});
-                Global.exit(1);
+
+            // 2. The "bin" is possibly not the same as the package name, so we load the package.json to figure out what "bin" to use
+            if (getBinName(&this_bundler, bun.fdcast(root_dir_info.getFileDescriptor()), bunx_cache_dir, initial_bin_name)) |package_name_for_bin| {
+                // if we check the bin name and its actually the same, we don't need to check $PATH here again
+                if (!strings.eqlLong(package_name_for_bin, initial_bin_name, true)) {
+                    absolute_in_cache_dir = std.fmt.bufPrint(&absolute_in_cache_dir_buf, "{s}/node_modules/.bin/{s}", .{ bunx_cache_dir, package_name_for_bin }) catch unreachable;
+
+                    if (bun.which(
+                        &path_buf,
+                        PATH_FOR_BIN_DIRS,
+                        this_bundler.fs.top_level_dir,
+                        package_name_for_bin,
+                    ) orelse bun.which(
+                        &path_buf,
+                        bunx_cache_dir,
+                        this_bundler.fs.top_level_dir,
+                        absolute_in_cache_dir,
+                    )) |destination| {
+                        const out = bun.asByteSlice(destination);
+                        _ = try Run.runBinary(
+                            ctx,
+                            try this_bundler.fs.dirname_store.append(@TypeOf(out), out),
+                            this_bundler.fs.top_level_dir,
+                            this_bundler.env,
+                            passthrough,
+                        );
+                        // we are done!
+                        Global.exit(0);
+                    }
+                }
+            } else |err| {
+                if (err == error.NoBinFound) {
+                    Output.prettyErrorln("<r><red>error<r><d>:<r> could not determine executable to run for package <r><b>{s}<r>", .{update_request.name});
+                    Global.exit(1);
+                }
             }
         }
 
@@ -353,13 +355,14 @@ pub const BunxCommand = struct {
 
         create_package_json: {
             // create package.json, but only if it doesn't exist
-            var package_json = bunx_install_dir.createFileZ("package.json", .{ .truncate = false }) catch break :create_package_json;
+            var package_json = bunx_install_dir.createFileZ("package.json", .{ .truncate = true }) catch break :create_package_json;
             defer package_json.close();
             package_json.writeAll("{}\n") catch {};
         }
 
         var args_buf = [_]string{
-            try std.fs.selfExePathAlloc(ctx.allocator), "add", "--no-summary", try std.fmt.allocPrint(
+            try std.fs.selfExePathAlloc(ctx.allocator), "add", "--no-summary",
+            try std.fmt.allocPrint(
                 ctx.allocator,
                 "{s}@{s}",
                 .{
@@ -367,8 +370,13 @@ pub const BunxCommand = struct {
                     display_version,
                 },
             ),
+            // disable the manifest cache when a tag is specified
+            // so that @latest is fetched from the registry
+            "--no-cache",
         };
-        var child_process = std.ChildProcess.init(&args_buf, default_allocator);
+        const argv_to_use: []const string = args_buf[0 .. args_buf.len - @as(usize, @intFromBool(update_request.version.tag != .dist_tag))];
+
+        var child_process = std.ChildProcess.init(argv_to_use, default_allocator);
         child_process.cwd = bunx_install_dir_path;
         child_process.cwd_dir = bunx_install_dir;
         const env_map = try this_bundler.env.map.cloneToEnvMap(ctx.allocator);


### PR DESCRIPTION
### What does this PR do?

Previously, `bunx create-t3-app@latest` would use the `/tmp/create-t3-app@latest...`  folder and rely on the OS tmpdir cache removal mechanism to know when to re-download. That's not soon enough. 

This makes it so the following:
```bash
bunx create-t3-app@latest
```

will always check versions from the registry, and possibly re-install it. 

It does not change the scenario when you do `bunx create-t3-app` by itself. That will still be cached for 1-3 days.

### How did you verify your code works?

Manual. Would be nice to have a test for this.