### PR TITLE
transpiler should hoist dynamic member initialization into the constructor

### DIFF
--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -812,6 +812,24 @@ class Test extends Bar {
 }
                   `.trim(),
         ],
+        [
+          `class Test {
+            b = this.a;
+
+            constructor(private a: string) {}
+          }`,
+
+          `
+class Test {
+  a;
+  b;
+  constructor(a) {
+    this.a = a;
+    this.b = this.a;
+  }
+}
+                  `.trim(),
+        ],
       ];
 
       for (const [code, out] of fixtures) {


### PR DESCRIPTION
Issue: #4922 

### What does this PR do?

This adds a test case to demonstrate that the transpiler currently fails to hoist dynamic class member initialiation logic into the constructor.