### PR TITLE
Allow undefined as encoding in TextDecoder

### DIFF
--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -702,6 +702,8 @@ pub const TextDecoder = struct {
                     globalThis.throwInvalidArguments("Unsupported encoding label \"{s}\"", .{str.slice()});
                     return null;
                 }
+            } else if (arguments[0].isUndefined()) {
+                // undefined is used to mean "use the default encoding"
             } else {
                 globalThis.throwInvalidArguments("TextDecoder(encoding) label is invalid", .{});
                 return null;

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -253,6 +253,11 @@ describe("TextDecoder", () => {
     // expect(decoder.ignoreBOM).toBe(false); // currently the getter for ignoreBOM doesn't work and always returns undefined
   });
 
+  it("constructor should accept undefined as utf-8", () => {
+    const decoder = new TextDecoder(undefined, { fatal: true, ignoreBOM: false });
+    expect(decoder.encoding).toBe("utf-8");
+  })
+
   it("should throw on invalid input", () => {
     expect(() => {
       const decoder = new TextDecoder("utf-8", { fatal: 10, ignoreBOM: {} });


### PR DESCRIPTION

Resolves #5211

### What does this PR do?

This matches behavior in Node where undefined as first argument is considered utf-8

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
I wrote automated tests

If Zig files changed:

- [X] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I or my editor ran `zig fmt` on the changed files
- [X] I included a test for the new code, or an existing test covers it
- [X] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed