### PR TITLE
fix warnings during bun run publish-layer

### DIFF
--- a/packages/bun-lambda/package.json
+++ b/packages/bun-lambda/package.json
@@ -2,6 +2,7 @@
   "name": "bun-lambda",
   "private": true,
   "devDependencies": {
+    "@oclif/plugin-plugins": "^3.5.0",
     "bun-types": "^0.7.0",
     "jszip": "^3.10.1",
     "oclif": "^3.6.5",


### PR DESCRIPTION
When running `bun run publish-layer` the following warnings displayed:

```sh
$ bun scripts/publish-layer.ts
101 |     async load() {
102 |         this.type = this.options.type || 'core';
103 |         this.tag = this.options.tag;
104 |         const root = await findRoot(this.options.name, this.options.root);
105 |         if (!root)
106 |             throw new Error(`could not find package.json with ${(0, util_1.inspect)(this.options)}`);
                      ^
warn: could not find package.json with { type: 'dev',
```

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Added missing package @oclif/plugin-plugins to resolved warning
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

-->

- [x] I ran `bun run publish-layer` and verified layer was published
<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
