### PR TITLE
docs(runtime): fix some typo.

### DIFF
--- a/docs/runtime/bunfig.md
+++ b/docs/runtime/bunfig.md
@@ -269,6 +269,9 @@ Valid values are:
 
 {% table %}
 
+- Value
+- Description
+
 ---
 
 - `"auto"`
@@ -277,12 +280,12 @@ Valid values are:
 ---
 
 - `"force"`
-- Always auto-install dependencies, even if `node_modules` exists
+- Always auto-install dependencies, even if `node_modules` exists.
 
 ---
 
 - `"disable"`
-- Never auto-install dependencies
+- Never auto-install dependencies.
 
 ---
 

--- a/docs/runtime/hot.md
+++ b/docs/runtime/hot.md
@@ -1,6 +1,6 @@
 Bun supports two kinds of automatic reloading via CLI flags:
 
-- `--watch` mode, which hard restarts Bun's process when imported files change/
+- `--watch` mode, which hard restarts Bun's process when imported files change.
 - `--hot` mode, which soft reloads the code (without restarting the process) when imported files change.
 
 ## `--watch` mode

--- a/docs/runtime/modules.md
+++ b/docs/runtime/modules.md
@@ -24,7 +24,7 @@ export function hello() {
 
 {% /codetabs %}
 
-When we run `index.ts`, it prints "Hello world".
+When we run `index.ts`, it prints "Hello world!".
 
 ```bash
 $ bun index.ts
@@ -197,7 +197,7 @@ Bun respects subpath [`"exports"`](https://nodejs.org/api/packages.html#subpath-
 
 Subpath imports and conditional imports work in conjunction with each other.
 
-```
+```json
 {
   "name": "foo",
   "exports": {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

fix some typo.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
