### PR TITLE
Add support for async plugin `build.onResolve` at runtime

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -482,14 +482,9 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
 
         if (auto* promise = JSC::jsDynamicCast<JSPromise*>(result)) {
             switch (promise->status(vm)) {
+            case JSPromise::Status::Rejected:
             case JSPromise::Status::Pending: {
-                JSC::throwTypeError(globalObject, throwScope, "onResolve() doesn't support pending promises yet"_s);
-                return JSValue::encode({});
-            }
-            case JSPromise::Status::Rejected: {
-                promise->internalField(JSC::JSPromise::Field::Flags).set(vm, promise, jsNumber(static_cast<unsigned>(JSC::JSPromise::Status::Fulfilled)));
-                result = promise->result(vm);
-                return JSValue::encode(result);
+                return JSValue::encode(promise);
             }
             case JSPromise::Status::Fulfilled: {
                 result = promise->result(vm);

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -28,12 +28,25 @@ describe("bundler", () => {
   };
 
   itBundled("plugin/Resolve", {
-    todo: true,
     files: resolveFixture,
     // The bundler testing api has a shorthand where the plugins array can be
     // the `setup` function of one plugin.
     plugins(builder) {
       builder.onResolve({ filter: /\.magic$/ }, args => {
+        return {
+          path: path.resolve(path.dirname(args.importer), args.path.replace(/\.magic$/, ".ts")),
+        };
+      });
+    },
+    run: {
+      stdout: "foo",
+    },
+  });
+  itBundled("plugin/ResolveAsync", {
+    files: resolveFixture,
+    plugins(builder) {
+      builder.onResolve({ filter: /\.magic$/ }, async args => {
+        await new Promise(resolve => setTimeout(resolve, 10));
         return {
           path: path.resolve(path.dirname(args.importer), args.path.replace(/\.magic$/, ".ts")),
         };

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -46,7 +46,7 @@ describe("bundler", () => {
     files: resolveFixture,
     plugins(builder) {
       builder.onResolve({ filter: /\.magic$/ }, async args => {
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await Bun.sleep(10);
         return {
           path: path.resolve(path.dirname(args.importer), args.path.replace(/\.magic$/, ".ts")),
         };

--- a/test/js/bun/plugin/plugins.d.ts
+++ b/test/js/bun/plugin/plugins.d.ts
@@ -3,6 +3,8 @@ declare var laterCode: any;
 
 declare module "beep:*";
 declare module "async:*";
+declare module "resolve:*";
+declare module "async-resolve:*";
 declare module "asyncret:*";
 declare module "asyncfail:*";
 declare module "async-obj:*";

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -114,7 +114,7 @@ plugin({
   name: "async resolve",
   setup(builder) {
     builder.onResolve({ filter: /original/, namespace: "async-resolve" }, async () => {
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await Bun.sleep(10);
       return {
         path: "changed",
         namespace: "async-resolve",

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -279,7 +279,7 @@ describe("dynamic import", () => {
   });
 
   it("should change resolved import when onResolve is async", async () => {
-    const result = require("async-resolve:original");
+    const result = await import("async-resolve:original");
     expect(result.default).toBe("changed");
   });
 


### PR DESCRIPTION
### What does this PR do?

This PR addresses my issue outlined in #5314.

The problem with #5314 is that the Bun runtime does not allow plugins to handle asynchronous imports.
I personally need this feature, so I decided to create this PR to implement it for all the Bun users.
I also planed after this PR to create a Bun plugin capable of importing image and do some image operation before building and live.

Although I'm not really familiar with Zig, I have knowledge in C/C++ and Rust and I know how computer memory can been slow some time. So I try the best to not create any useless variable.
Please Verify I didn't anything is not idiomatic to Zig and will hurt de performance of Bun.

- [x] Code changes

### How did you verify your code works?

- [x] I have written some tests for the bundler for verify if it's still works.
- [x] I have written some tests for the runtime plugin to verify if I didn't broke the none async `builder.onResolve` and if the async `build.onResolve` work as expected
- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be ***(But since I'm not a zig expert so please verify)***
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed