### PR TITLE
fix(request) handle undefined/null/empty signal on request

### DIFF
--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -609,17 +609,18 @@ pub const Request = struct {
 
             if (!fields.contains(.signal)) {
                 if (value.get(globalThis, "signal")) |signal_| {
-                    fields.insert(.signal);
-
-                    if (AbortSignal.fromJS(signal_)) |signal| {
-                        //Keep it alive
-                        signal_.ensureStillAlive();
-                        req.signal = signal.ref();
-                    } else {
-                        globalThis.throw("Failed to construct 'Request': signal is not of type AbortSignal.", .{});
-                        req.finalizeWithoutDeinit();
-                        _ = req.body.unref();
-                        return null;
+                    if(!signal_.isEmptyOrUndefinedOrNull()) {
+                        fields.insert(.signal);
+                        if (AbortSignal.fromJS(signal_)) |signal| {
+                            //Keep it alive
+                            signal_.ensureStillAlive();
+                            req.signal = signal.ref();
+                        } else {
+                            globalThis.throw("Failed to construct 'Request': signal is not of type AbortSignal.", .{});
+                            req.finalizeWithoutDeinit();
+                            _ = req.body.unref();
+                            return null;
+                        }
                     }
                 }
             }

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -608,19 +608,17 @@ pub const Request = struct {
             }
 
             if (!fields.contains(.signal)) {
-                if (value.get(globalThis, "signal")) |signal_| {
-                    if(!signal_.isEmptyOrUndefinedOrNull()) {
-                        fields.insert(.signal);
-                        if (AbortSignal.fromJS(signal_)) |signal| {
-                            //Keep it alive
-                            signal_.ensureStillAlive();
-                            req.signal = signal.ref();
-                        } else {
-                            globalThis.throw("Failed to construct 'Request': signal is not of type AbortSignal.", .{});
-                            req.finalizeWithoutDeinit();
-                            _ = req.body.unref();
-                            return null;
-                        }
+                if (value.getTruthy(globalThis, "signal")) |signal_| {
+                    fields.insert(.signal);
+                    if (AbortSignal.fromJS(signal_)) |signal| {
+                        //Keep it alive
+                        signal_.ensureStillAlive();
+                        req.signal = signal.ref();
+                    } else {
+                        globalThis.throw("Failed to construct 'Request': signal is not of type AbortSignal.", .{});
+                        req.finalizeWithoutDeinit();
+                        _ = req.body.unref();
+                        return null;
                     }
                 }
             }

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "bun:test";
+
+test("request can receive undefined signal", async () => {
+  const request = new Request("http://example.com/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "text/bun;charset=utf-8",
+    },
+    body: "bun",
+    signal: undefined,
+  });
+  expect(request.method).toBe("POST");
+  // @ts-ignore
+  const clone = new Request(request);
+  expect(clone.method).toBe("POST");
+  expect(clone.headers.get("content-type")).toBe("text/bun;charset=utf-8");
+  expect(await request.text()).toBe("bun");
+  expect(await clone.text()).toBe("bun");
+});
+
+test("request can receive null signal", async () => {
+  const request = new Request("http://example.com/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "text/bun;charset=utf-8",
+    },
+    body: "bun",
+    signal: null,
+  });
+  expect(request.method).toBe("POST");
+  // @ts-ignore
+  const clone = new Request(request);
+  expect(clone.method).toBe("POST");
+  expect(clone.headers.get("content-type")).toBe("text/bun;charset=utf-8");
+  expect(await request.text()).toBe("bun");
+  expect(await clone.text()).toBe("bun");
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
My fix or improve on: https://github.com/oven-sh/bun/issues/5363 and fix https://github.com/oven-sh/bun/issues/5494
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
