### PR TITLE
fix(node/fs.watch): Check first char before trimming event filenames

### DIFF
--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -286,17 +286,8 @@ pub const PathWatcherManager = struct {
                                 if (!(path.len == 1 and entry_point[0] == '/')) {
                                     path = path[entry_point.len..];
 
-                                    if (path.len == 0) {
-                                        while (path.len > 0) {
-                                            if (bun.strings.startsWithChar(path, '/')) {
-                                                path = path[1..];
-                                                break;
-                                            } else {
-                                                path = path[1..];
-                                            }
-                                        }
-                                    } else {
-                                        // Skip forward slash
+                                    // Skip leading slash
+                                    if (bun.strings.startsWithChar(path, '/')) {
                                         path = path[1..];
                                     }
                                 }

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -67,7 +67,7 @@ describe("fs.watch", () => {
     const root = path.join(testDir, "add-directory");
     try {
       fs.mkdirSync(root);
-    } catch {}
+    } catch { }
     let err: Error | undefined = undefined;
     const watcher = fs.watch(root, { signal: AbortSignal.timeout(3000) });
     watcher.on("change", (event, filename) => {
@@ -102,7 +102,7 @@ describe("fs.watch", () => {
     const root = path.join(testDir, "add-subdirectory");
     try {
       fs.mkdirSync(root);
-    } catch {}
+    } catch { }
     const subfolder = path.join(root, "subfolder");
     fs.mkdirSync(subfolder);
     const watcher = fs.watch(root, { recursive: true, signal: AbortSignal.timeout(3000) });
@@ -438,7 +438,7 @@ describe("fs.promises.watch", () => {
     const root = path.join(testDir, "add-promise-directory");
     try {
       fs.mkdirSync(root);
-    } catch {}
+    } catch { }
     let success = false;
     let err: Error | undefined = undefined;
     try {
@@ -480,7 +480,7 @@ describe("fs.promises.watch", () => {
     const root = path.join(testDir, "add-promise-subdirectory");
     try {
       fs.mkdirSync(root);
-    } catch {}
+    } catch { }
     const subfolder = path.join(root, "subfolder");
     fs.mkdirSync(subfolder);
     let success = false;


### PR DESCRIPTION
### What does this PR do?

Fixes #5442 

Adds a conditional to only trim the first character if it's a leading slash, because there might already be a trailing slash on the watch path, that we already strip from the start of the string.

Also removed some unreachable code while I was here.

- [x] Code changes

### How did you verify your code works?

I wrote automated tests

- [x] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
