### PR TITLE
Fix ZLS commit hash in the document

### DIFF
--- a/docs/project/development.md
+++ b/docs/project/development.md
@@ -285,26 +285,6 @@ The above will probably also need Zig and/or C++ code rebuilt.
 
 VSCode is the recommended IDE for working on Bun, as it has been configured. Once opening, you can run `Extensions: Show Recommended Extensions` to install the recommended extensions for Zig and C++. ZLS is automatically configured.
 
-### ZLS
-
-ZLS is the language server for Zig. The latest binary that the extension auto-updates may not function with the version of Zig that Bun uses. It may be more reliable to build ZLS from source:
-
-```bash
-$ git clone https://github.com/zigtools/zls
-$ cd zls
-$ git checkout 0.11.0
-$ zig build
-```
-
-Then add absolute paths to Zig and ZLS in your vscode config:
-
-```json
-{
-  "zig.zigPath": "/path/to/zig/install/zig",
-  "zig.zls.path": "/path/to/zls/zig-out/bin/zls"
-}
-```
-
 ## JavaScript builtins
 
 When you change anything in `src/js/builtins/*` or switch branches, run this:

--- a/docs/project/development.md
+++ b/docs/project/development.md
@@ -292,7 +292,7 @@ ZLS is the language server for Zig. The latest binary that the extension auto-up
 ```bash
 $ git clone https://github.com/zigtools/zls
 $ cd zls
-$ git checkout f91ff831f4959efcb7e648dba4f0132c296d26c0
+$ git checkout 0.11.0
 $ zig build
 ```
 


### PR DESCRIPTION
### What does this PR do?

Update the commit hash of `zls` in the document. This fixes https://github.com/oven-sh/bun/issues/5508.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
