### PR TITLE
fix(bundler): Add a space before minified require

### DIFF
--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -2179,6 +2179,7 @@ fn NewPrinter(
                     }
                 },
                 .e_require_call_target => {
+                    p.printSpaceBeforeIdentifier();
                     p.addSourceMapping(expr.loc);
 
                     if (p.options.module_type == .cjs or !is_bun_platform) {
@@ -2188,6 +2189,7 @@ fn NewPrinter(
                     }
                 },
                 .e_require_resolve_call_target => {
+                    p.printSpaceBeforeIdentifier();
                     p.addSourceMapping(expr.loc);
 
                     if (p.options.module_type == .cjs or !is_bun_platform) {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -286,4 +286,25 @@ describe("bundler", () => {
       stdout: "PASS",
     },
   });
+  // https://github.com/oven-sh/bun/issues/5501
+  itBundled("minify/BunRequireStatement", {
+    files: {
+      "/entry.js": /* js */ `
+        export function test(ident) {
+          return require(ident);
+        }
+
+        test("fs");
+        console.log("PASS");
+      `,
+    },
+    minifyWhitespace: true,
+    minifySyntax: true,
+    minifyIdentifiers: true,
+    target: "bun",
+    backend: "cli",
+    run: {
+      stdout: "PASS",
+    },
+  });
 });


### PR DESCRIPTION
Fixes #5501

Ensures `require` and `resolve` statements are treated as an identifier with a space before them, so you don't end up with `returnrequire` in the minified output.

- [x] Code changes

### How did you verify your code works?

I wrote automated tests
