### PR TITLE
Follow-up for workspace docs #5379 and #5229

### DIFF
--- a/docs/guides/install/workspaces.md
+++ b/docs/guides/install/workspaces.md
@@ -37,13 +37,13 @@ It's common to place all packages in a `packages` directory. The `"workspaces"` 
 
 ---
 
-To add one workspace as a dependency of another, modify its `package.json`. Here we're adding `stuff-a` as a dependency of `stuff-b`.
+To add dependencies between workspaces, use the `"workspace:*"` syntax. Here we're adding `stuff-a` as a dependency of `stuff-b`.
 
 ```json-diff#packages/stuff-b/package.json
 {
   "name": "stuff-b",
   "dependencies": {
-+   "stuff-a": "*"
++   "stuff-a": "workspace:*"
   }
 }
 ```


### PR DESCRIPTION
### What does this PR do?

This PR adds to the doc fixes in #5379 and #5229 by updating another workspace example to use `"workspace:*"` instead of `"*"`.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes