### PR TITLE
docs: update `net` node documentation

### DIFF
--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -78,7 +78,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:net`](https://nodejs.org/api/net.html)
 
-🟡 Missing `net.{get|set}DefaultAutoSelectFamily` `net.SocketAddress` `net.BlockList`.
+🟡 Missing `net.{get|set}DefaultAutoSelectFamily` `net.SocketAddress` `net.BlockList` `net.Server.ref()` `net.Server.unref()` `net.Socket.ref()` `net.Socket.unref()`.
 
 ### [`node:os`](https://nodejs.org/api/os.html)
 


### PR DESCRIPTION
### What does this PR do?

Update the Node APIs documentation which incorrectly indicates that `node:net` is fully implemented by while parts are missing.

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

None, it's a documentation change