### PR TITLE
fix: `ArrayBufferConstructor` type signature

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -3507,8 +3507,9 @@ interface CallSite {
 }
 
 interface ArrayBufferConstructor {
-  new (params: { byteLength: number; maxByteLength?: number }): ArrayBuffer;
+  new (byteLength: number, options: { maxByteLength?: number }): ArrayBuffer;
 }
+
 interface ArrayBuffer {
   /**
    * Read-only. The length of the ArrayBuffer (in bytes).


### PR DESCRIPTION
### What does this PR do?

Fixes the `ArrayBufferConstructor` type signature to accept two arguments.

```ts
interface ArrayBufferConstructor {
  new (byteLength: number, options: { maxByteLength?: number }): ArrayBuffer;
}
```

Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer#parameters

Closes #5551 