### PR TITLE
change circles for color-blinds

### DIFF
--- a/docs/test/writing.md
+++ b/docs/test/writing.md
@@ -174,252 +174,252 @@ Bun implements the following matchers. Full Jest compatibility is on the roadmap
 
 ---
 
-- 🟢
+- ✔️
 - [`.not`](https://jestjs.io/docs/expect#not)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBe()`](https://jestjs.io/docs/expect#tobevalue)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toEqual()`](https://jestjs.io/docs/expect#toequalvalue)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeNull()`](https://jestjs.io/docs/expect#tobenull)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeUndefined()`](https://jestjs.io/docs/expect#tobeundefined)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeNaN()`](https://jestjs.io/docs/expect#tobenan)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeDefined()`](https://jestjs.io/docs/expect#tobedefined)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeFalsy()`](https://jestjs.io/docs/expect#tobefalsy)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeTruthy()`](https://jestjs.io/docs/expect#tobetruthy)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toContain()`](https://jestjs.io/docs/expect#tocontainitem)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toStrictEqual()`](https://jestjs.io/docs/expect#tostrictequalvalue)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toThrow()`](https://jestjs.io/docs/expect#tothrowerror)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toHaveLength()`](https://jestjs.io/docs/expect#tohavelengthnumber)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toHaveProperty()`](https://jestjs.io/docs/expect#tohavepropertykeypath-value)
 
 ---
 
-- 🔴
+- ✖️
 - [`.extend`](https://jestjs.io/docs/expect#expectextendmatchers)
 
 ---
 
-- 🟢
+- ✔️
 - [`.anything()`](https://jestjs.io/docs/expect#expectanything)
 
 ---
 
-- 🟢
+- ✔️
 - [`.any()`](https://jestjs.io/docs/expect#expectanyconstructor)
 
 ---
 
-- 🔴
+- ✖️
 - [`.arrayContaining()`](https://jestjs.io/docs/expect#expectarraycontainingarray)
 
 ---
 
-- 🔴
+- ✖️
 - [`.assertions()`](https://jestjs.io/docs/expect#expectassertionsnumber)
 
 ---
 
-- 🔴
+- ✖️
 - [`.closeTo()`](https://jestjs.io/docs/expect#expectclosetonumber-numdigits)
 
 ---
 
-- 🔴
+- ✖️
 - [`.hasAssertions()`](https://jestjs.io/docs/expect#expecthasassertions)
 
 ---
 
-- 🔴
+- ✖️
 - [`.objectContaining()`](https://jestjs.io/docs/expect#expectobjectcontainingobject)
 
 ---
 
-- 🟢
+- ✔️
 - [`.stringContaining()`](https://jestjs.io/docs/expect#expectstringcontainingstring)
 
 ---
 
-- 🟢
+- ✔️
 - [`.stringMatching()`](https://jestjs.io/docs/expect#expectstringmatchingstring--regexp)
 
 ---
 
-- 🔴
+- ✖️
 - [`.addSnapshotSerializer()`](https://jestjs.io/docs/expect#expectaddsnapshotserializerserializer)
 
 ---
 
-- 🟢
+- ✔️
 - [`.resolves()`](https://jestjs.io/docs/expect#resolves)
 
 ---
 
-- 🟢
+- ✔️
 - [`.rejects()`](https://jestjs.io/docs/expect#rejects)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toHaveBeenCalled()`](https://jestjs.io/docs/expect#tohavebeencalled)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toHaveBeenCalledTimes()`](https://jestjs.io/docs/expect#tohavebeencalledtimesnumber)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toHaveBeenCalledWith()`](https://jestjs.io/docs/expect#tohavebeencalledwitharg1-arg2-)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toHaveBeenLastCalledWith()`](https://jestjs.io/docs/expect#tohavebeenlastcalledwitharg1-arg2-)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toHaveBeenNthCalledWith()`](https://jestjs.io/docs/expect#tohavebeennthcalledwithnthcall-arg1-arg2-)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toHaveReturned()`](https://jestjs.io/docs/expect#tohavereturned)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toHaveReturnedTimes()`](https://jestjs.io/docs/expect#tohavereturnedtimesnumber)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toHaveReturnedWith()`](https://jestjs.io/docs/expect#tohavereturnedwithvalue)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toHaveLastReturnedWith()`](https://jestjs.io/docs/expect#tohavelastreturnedwithvalue)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toHaveNthReturnedWith()`](https://jestjs.io/docs/expect#tohaventhreturnedwithnthcall-value)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeCloseTo()`](https://jestjs.io/docs/expect#tobeclosetonumber-numdigits)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeGreaterThan()`](https://jestjs.io/docs/expect#tobegreaterthannumber--bigint)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeGreaterThanOrEqual()`](https://jestjs.io/docs/expect#tobegreaterthanorequalnumber--bigint)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeLessThan()`](https://jestjs.io/docs/expect#tobelessthannumber--bigint)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeLessThanOrEqual()`](https://jestjs.io/docs/expect#tobelessthanorequalnumber--bigint)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toBeInstanceOf()`](https://jestjs.io/docs/expect#tobeinstanceofclass)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toContainEqual()`](https://jestjs.io/docs/expect#tocontainequalitem)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toMatch()`](https://jestjs.io/docs/expect#tomatchregexp--string)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toMatchObject()`](https://jestjs.io/docs/expect#tomatchobjectobject)
 
 ---
 
-- 🟢
+- ✔️
 - [`.toMatchSnapshot()`](https://jestjs.io/docs/expect#tomatchsnapshotpropertymatchers-hint)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toMatchInlineSnapshot()`](https://jestjs.io/docs/expect#tomatchinlinesnapshotpropertymatchers-inlinesnapshot)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toThrowErrorMatchingSnapshot()`](https://jestjs.io/docs/expect#tothrowerrormatchingsnapshothint)
 
 ---
 
-- 🔴
+- ✖️
 - [`.toThrowErrorMatchingInlineSnapshot()`](https://jestjs.io/docs/expect#tothrowerrormatchinginlinesnapshotinlinesnapshot)
 
 {% /table %}


### PR DESCRIPTION
### What does this PR do?

It's just a tiny replacement of red and green circles with a checkmark and times icon to be more recognizable for colorblinds like me.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
