### PR TITLE
feat(console.log): Print anonymous when class name is unknown

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2158,7 +2158,7 @@ pub const ZigConsoleClient = struct {
                     this.addForNewLine(printable.len);
 
                     if (printable.len == 0) {
-                        writer.print(comptime Output.prettyFmt("<cyan>[class]<r>", enable_ansi_colors), .{});
+                        writer.print(comptime Output.prettyFmt("<cyan>[class (anonymous)]<r>", enable_ansi_colors), .{});
                     } else {
                         writer.print(comptime Output.prettyFmt("<cyan>[class {}]<r>", enable_ansi_colors), .{printable});
                     }

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -35,7 +35,7 @@ Promise { <pending> }
 [Function]
 [Function]
 [class Foo]
-[class]
+[class (anonymous)]
 {}
 [Function: foooo]
 /FooRegex/


### PR DESCRIPTION

### What does this PR do?

This matches the functionality in Node. when printing a class that doesn't have a name.

Previously this code:
```js

console.log(class { });

``` 

Would print:
```
[class]
```

Updated to print matching with Node:
```
[class (anonymous)]
```

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

- [X] I included a test for the new code, or an existing test covers it