### PR TITLE
Make error message when importing a node: module in a browser bundle clearer

### DIFF
--- a/src/logger.zig
+++ b/src/logger.zig
@@ -1108,6 +1108,31 @@ pub const Log = struct {
         });
     }
 
+    pub fn addRangeErrorFmtWithNote(
+        log: *Log,
+        source: ?*const Source,
+        r: Range,
+        allocator: std.mem.Allocator,
+        comptime fmt: string,
+        args: anytype,
+        comptime note_fmt: string,
+        note_args: anytype,
+        note_range: Range,
+    ) !void {
+        @setCold(true);
+        if (!Kind.shouldPrint(.err, log.level)) return;
+        log.errors += 1;
+
+        var notes = try allocator.alloc(Data, 1);
+        notes[0] = rangeData(source, note_range, allocPrint(allocator, note_fmt, note_args) catch unreachable);
+
+        try log.addMsg(.{
+            .kind = .err,
+            .data = rangeData(source, r, allocPrint(allocator, fmt, args) catch unreachable),
+            .notes = notes,
+        });
+    }
+
     pub fn addWarning(log: *Log, source: ?*const Source, l: Loc, text: string) !void {
         @setCold(true);
         if (!Kind.shouldPrint(.warn, log.level)) return;

--- a/src/options.zig
+++ b/src/options.zig
@@ -87,7 +87,7 @@ pub const ExternalModules = struct {
     };
 
     pub fn isNodeBuiltin(str: string) bool {
-        return NodeBuiltinsMap.has(str);
+        return bun.JSC.HardcodedModule.Aliases.has(str, .node);
     }
 
     const default_wildcard_patterns = &[_]WildcardPattern{


### PR DESCRIPTION
### What does this PR do?

People are confused why importing a Node.js builtin module fails in `bun build`. They need to add `--target=bun` or `--target=node`. The error message isn't clear enough

### How did you verify your code works?

I didn't, lets see what tests expect the previous error message and tweak accordingly.