### PR TITLE
fix(install): Return NotSupported when errno == XDEV

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1070,6 +1070,7 @@ const PackageInstall = struct {
                             )) {
                                 0 => {},
                                 else => |errno| switch (std.os.errno(errno)) {
+                                    .XDEV => return error.NotSupported, // not same file system
                                     .OPNOTSUPP => return error.NotSupported,
                                     .NOENT => return error.FileNotFound,
                                     // sometimes the downlowded npm package has already node_modules with it, so just ignore exist error here
@@ -1128,6 +1129,7 @@ const PackageInstall = struct {
         )) {
             0 => .{ .success = {} },
             else => |errno| switch (std.os.errno(errno)) {
+                .XDEV => error.NotSupported, // not same file system
                 .OPNOTSUPP => error.NotSupported,
                 .NOENT => error.FileNotFound,
                 // We first try to delete the directory


### PR DESCRIPTION
### What does this PR do?

When crossing the file system, the errno of `clonefile()` function is `.XDEV`.

This PR fixes it by returning `.XDEV` as `.NotSupported`.

Fixed #362

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I test it manually. Looking for a way to test it automatically:

```
  ~/dev/Tmp/tt 5m 48s
base ❯ /Users/pan93412/dev-local/bun/packages/debug-bun-darwin-aarch64/bun-debug install
[SYS] read(3, 4096) = 4096 (0.354ms)
[SYS] close(3)
bun install v1.0.3_debug (0404d09c)
 + bun-types@1.0.2

 1 packages installed [27.00ms]
````

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

- [x] ~~I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be~~
- [x] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [x] ~~JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed~~

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
