### PR TITLE
Added .DS_Store to gitignore-for-init

### DIFF
--- a/src/cli/gitignore-for-init
+++ b/src/cli/gitignore-for-init
@@ -170,3 +170,7 @@ dist
 
 # IntelliJ based IDEs
 .idea
+
+# Finder (MacOS) folder config
+.DS_Store
+


### PR DESCRIPTION
### What does this PR do?

This PR adds .DS_Store files, which are automatically generated by macOS's Finder application, to the default .gitignore generated by the bun init command to prevent them from being inadvertently committed.

- [x] Code changes

### How did you verify your code works?

This is a simple update to the gitignore-for-init file to comply with OSS best-practices.