### PR TITLE
add example to bun-types readme

### DIFF
--- a/packages/bun-types/README.md
+++ b/packages/bun-types/README.md
@@ -30,6 +30,17 @@ Add this to your `tsconfig.json` or `jsconfig.json`:
   }
 ```
 
+### Example
+
+```json
+{
+  "compilerOptions": {
+    "types": ["bun-types"],
+    "allowSyntheticDefaultImports": true
+  }
+}
+```
+
 # Contributing
 
 `bun-types` is generated via [./scripts/bundle.ts](./scripts/bundle.ts).


### PR DESCRIPTION
### What does this PR do?

Adds example tsconfig.json/jsconfig.json to ```packages/bun-types``` readme

### What is the purpose?

It allowed me to use code such as ```import fs from 'fs'``` without getting TS errors in VSCode

[✔] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
[----] Code changes