### PR TITLE
In `bun:sqlite`, make sure we set the number tag correctly when creating the JSValue

### DIFF
--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -1430,7 +1430,7 @@ static const JSC::DOMJIT::Signature DOMJITSignatureForjsSQLStatementExecuteState
     jsSQLStatementExecuteStatementFunctionGetWithoutTypeChecking,
     JSSQLStatement::info(),
     JSC::DOMJIT::Effect::forReadWriteKinds(readKinds, writeKinds),
-    JSC::SpecHeapTop);
+    JSC::SpecOther);
 
 JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -347,6 +347,13 @@ it("db.query()", () => {
     ),
   ).toBe(JSON.stringify([{ id: 1, name: "Hello" }]));
 
+  const domjit = db.query("SELECT * FROM test");
+  (function (domjit) {
+    for (let i = 0; i < 100000; i++) {
+      domjit.get().name;
+    }
+  })(domjit);
+
   db.close();
 
   // Check that a closed database doesn't crash


### PR DESCRIPTION
### What does this PR do?

I have not observed this PR to produce any different output. Just out of an abundance of caution, we should use jsDoubleNumber instead of jsNumber when the number potentially exceeds the maximum/minimum signed 32-bit integer


### How did you verify your code works?

Existing tests + an added DOMJIT test