### PR TITLE
fix(config): support for registry url without trailing slash

### DIFF
--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -70,7 +70,7 @@ pub const Bunfig = struct {
                         registry.password = url.password;
                         registry.url = try std.fmt.allocPrint(this.allocator, "{s}://{s}/{s}/", .{ url.displayProtocol(), url.displayHostname(), std.mem.trim(u8, url.pathname, "/") });
                     } else {
-                        if (std.mem.endsWith(u8, url.href, "/")) {
+                        if (strings.hasSuffixComptime(url.href, "/")) {
                             registry.url = url.href;
                         } else {
                             registry.url = try std.fmt.allocPrint(this.allocator, "{s}/", .{url.href});

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -80,7 +80,7 @@ pub const Bunfig = struct {
                 .e_object => |obj| {
                     if (obj.get("url")) |url| {
                         try this.expect(url, .e_string);
-                        if (std.mem.endsWith(u8, url.data.e_string.data, "/")) {
+                        if (strings.hasSuffixComptime(url.data.e_string.data, "/")) {
                             registry.url = url.data.e_string.data;
                         } else {
                             registry.url = try std.fmt.allocPrint(this.allocator, "{s}/", .{url.data.e_string.data});

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -64,19 +64,27 @@ pub const Bunfig = struct {
                     // Token
                     if (url.username.len == 0 and url.password.len > 0) {
                         registry.token = url.password;
-                        registry.url = try std.fmt.allocPrint(this.allocator, "{s}://{s}/{s}", .{ url.displayProtocol(), url.displayHostname(), std.mem.trimLeft(u8, url.pathname, "/") });
+                        registry.url = try std.fmt.allocPrint(this.allocator, "{s}://{s}/{s}/", .{ url.displayProtocol(), url.displayHostname(), std.mem.trim(u8, url.pathname, "/") });
                     } else if (url.username.len > 0 and url.password.len > 0) {
                         registry.username = url.username;
                         registry.password = url.password;
-                        registry.url = try std.fmt.allocPrint(this.allocator, "{s}://{s}/{s}", .{ url.displayProtocol(), url.displayHostname(), std.mem.trimLeft(u8, url.pathname, "/") });
+                        registry.url = try std.fmt.allocPrint(this.allocator, "{s}://{s}/{s}/", .{ url.displayProtocol(), url.displayHostname(), std.mem.trim(u8, url.pathname, "/") });
                     } else {
-                        registry.url = url.href;
+                        if (std.mem.endsWith(u8, url.href, "/")) {
+                            registry.url = url.href;
+                        } else {
+                            registry.url = try std.fmt.allocPrint(this.allocator, "{s}/", .{url.href});
+                        }
                     }
                 },
                 .e_object => |obj| {
                     if (obj.get("url")) |url| {
                         try this.expect(url, .e_string);
-                        registry.url = url.data.e_string.data;
+                        if (std.mem.endsWith(u8, url.data.e_string.data, "/")) {
+                            registry.url = url.data.e_string.data;
+                        } else {
+                            registry.url = try std.fmt.allocPrint(this.allocator, "{s}/", .{url.data.e_string.data});
+                        }
                     }
 
                     if (obj.get("username")) |username| {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6018,16 +6018,17 @@ describe("Registry URLs", () => {
     ["example", true],
     ["https://example.com:demo", true],
     ["http://[www.example.com]/", true],
-    ["c:", true],
     ["c:a", true],
     ["https://registry.npmjs.org/", false],
     ["https://artifactory.xxx.yyy/artifactory/api/npm/my-npm/", false], // https://github.com/oven-sh/bun/issues/3899
-    ["", false],
+    ["https://artifactory.xxx.yyy/artifactory/api/npm/my-npm", false], // https://github.com/oven-sh/bun/issues/5368
+    ["", true],
     ["https:example.org", false],
     ["https://////example.com///", false],
     ["https://example.com/https:example.org", false],
     ["https://example.com/[]?[]#[]", false],
     ["https://example/%?%#%", false],
+    ["c:", false],
     ["c:/", false],
     ["https://點看", false], // gets converted to punycode
     ["https://xn--c1yn36f/", false],
@@ -6066,7 +6067,8 @@ describe("Registry URLs", () => {
       const err = await new Response(stderr).text();
 
       if (fails) {
-        expect(err.includes(`Failed to join registry \"${regURL}\" and package \"notapackage\" URLs`)).toBeTrue();
+        const url = regURL.at(-1) === "/" ? regURL : regURL + "/";
+        expect(err.includes(`Failed to join registry \"${url}\" and package \"notapackage\" URLs`)).toBeTrue();
         expect(err.includes("error: InvalidURL")).toBeTrue();
       } else {
         expect(err.includes("error: notapackage@0.0.2 failed to resolve")).toBeTrue();
@@ -6106,7 +6108,7 @@ describe("Registry URLs", () => {
     expect(stderr).toBeDefined();
     const err = await new Response(stderr).text();
 
-    expect(err.includes(`Failed to join registry \"${regURL}\" and package \"notapackage\" URLs`)).toBeTrue();
+    expect(err.includes(`Failed to join registry \"${regURL}/\" and package \"notapackage\" URLs`)).toBeTrue();
     expect(err.includes("warn: InvalidURL")).toBeTrue();
 
     expect(await exited).toBe(0);


### PR DESCRIPTION


### What does this PR do?


Close: #4589, #5368


https://github.com/oven-sh/bun/blob/57e38e831222add628b25e72cbcaff84c71c4a4c/src/install/install.zig#L254-L259

If the registry url does not end with a `/`, it will result in the wrong url when joining. For example, joining `http://example.com/aaa` and `package` results in `http://example.com/package` instead of `http://example.com/aaa/package`

This PR fixes this by adding a trailing slash during the config parsing to ensure consistency.


- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?



I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
