### PR TITLE
feat: switch disableTelemetry to bunfig

### DIFF
--- a/docs/runtime/bunfig.md
+++ b/docs/runtime/bunfig.md
@@ -100,12 +100,12 @@ Bun supports the following loaders:
 - `dataurl`
 - `text`
 
-### `disableTelemetry`
+### `telemetry`
 
-The `disableTelemetry` field permit to enable/disable the analytics records. Bun records bundle timings (so we can answer with data, "is Bun getting faster?") and feature usage (e.g., "are people actually using macros?"). The request body size is about 60 bytes, so it's not a lot of data.
+The `telemetry` field permit to enable/disable the analytics records. Bun records bundle timings (so we can answer with data, "is Bun getting faster?") and feature usage (e.g., "are people actually using macros?"). The request body size is about 60 bytes, so it's not a lot of data. By default the telemetry is enabled. Equivalent of `DO_NOT_TRACK` env variable.
 
 ```toml
-disableTelemetry = true
+telemetry = false
 ```
 
 ## Test runner

--- a/docs/runtime/bunfig.md
+++ b/docs/runtime/bunfig.md
@@ -100,6 +100,14 @@ Bun supports the following loaders:
 - `dataurl`
 - `text`
 
+### `disableTelemetry`
+
+The `disableTelemetry` field permit to enable/disable the analytics records. Bun records bundle timings (so we can answer with data, "is Bun getting faster?") and feature usage (e.g., "are people actually using macros?"). The request body size is about 60 bytes, so it's not a lot of data.
+
+```toml
+disableTelemetry = true
+```
+
 ## Test runner
 
 The test runner is configured under the `[test]` section of your bunfig.toml.

--- a/docs/runtime/env.md
+++ b/docs/runtime/env.md
@@ -75,3 +75,10 @@ These environment variables are read by Bun and configure aspects of its behavio
 
 - `FORCE_COLOR`
 - If `FORCE_COLOR=1`, then ANSI color output is force enabled, even if `NO_COLOR` is set.
+
+---
+
+- `DO_NOT_TRACK`
+- If `DO_NOT_TRACK=1`, then analytics are [disabled](https://do-not-track.dev/). Bun records bundle timings (so we can answer with data, "is Bun getting faster?") and feature usage (e.g., "are people actually using macros?"). The request body size is about 60 bytes, so it's not a lot of data. Equivalent of `telemetry=false` in bunfig.
+
+{% /table %}

--- a/docs/runtime/env.md
+++ b/docs/runtime/env.md
@@ -75,10 +75,3 @@ These environment variables are read by Bun and configure aspects of its behavio
 
 - `FORCE_COLOR`
 - If `FORCE_COLOR=1`, then ANSI color output is force enabled, even if `NO_COLOR` is set.
-
----
-
-- `DO_NOT_TRACK`
-- If `DO_NOT_TRACK=1`, then analytics are [disabled](https://do-not-track.dev/). Bun records bundle timings (so we can answer with data, "is Bun getting faster?") and feature usage (e.g., "are people actually using macros?"). The request body size is about 60 bytes, so it's not a lot of data.
-
-{% /table %}

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -488,6 +488,13 @@ pub const Bundler = struct {
             else => {},
         }
 
+        if (this.env.map.get("DO_NOT_TRACK")) |dnt| {
+            // https://do-not-track.dev/
+            if (strings.eqlComptime(dnt, "1")) {
+                Analytics.disabled = true;
+            }
+        }
+
         Analytics.is_ci = Analytics.is_ci or this.env.isCI();
 
         if (strings.eqlComptime(this.env.map.get("BUN_DISABLE_TRANSPILER") orelse "0", "1")) {

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -488,13 +488,6 @@ pub const Bundler = struct {
             else => {},
         }
 
-        if (this.env.map.get("DO_NOT_TRACK")) |dnt| {
-            // https://do-not-track.dev/
-            if (strings.eqlComptime(dnt, "1")) {
-                Analytics.disabled = true;
-            }
-        }
-
         Analytics.is_ci = Analytics.is_ci or this.env.isCI();
 
         if (strings.eqlComptime(this.env.map.get("BUN_DISABLE_TRANSPILER") orelse "0", "1")) {

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -207,6 +207,11 @@ pub const Bunfig = struct {
                 if (json.get("preload")) |expr| {
                     try this.loadPreload(allocator, expr);
                 }
+
+                if(json.get("disableTelemetry")) |expr| {
+                    try this.expect(expr, .e_boolean);
+                    Analytics.disabled = expr.data.e_boolean.value;
+                }
             }
 
             if (comptime cmd == .RunCommand or cmd == .AutoCommand) {

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -208,9 +208,9 @@ pub const Bunfig = struct {
                     try this.loadPreload(allocator, expr);
                 }
 
-                if (json.get("disableTelemetry")) |expr| {
+                if (json.get("telemetry")) |expr| {
                     try this.expect(expr, .e_boolean);
-                    Analytics.disabled = expr.data.e_boolean.value;
+                    Analytics.disabled = !expr.data.e_boolean.value;
                 }
             }
 

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -208,7 +208,7 @@ pub const Bunfig = struct {
                     try this.loadPreload(allocator, expr);
                 }
 
-                if(json.get("disableTelemetry")) |expr| {
+                if (json.get("disableTelemetry")) |expr| {
                     try this.expect(expr, .e_boolean);
                     Analytics.disabled = expr.data.e_boolean.value;
                 }


### PR DESCRIPTION
### What does this PR do?
Closes: https://github.com/oven-sh/bun/issues/5683
<!-- **Please explain what your changes do**, example: -->
This PR switch ```disableTelemetry```to bunfig instead of .env.
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Manual tests

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files


<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
