### PR TITLE
Make bun install --verbose more verbose

### DIFF
--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -2289,10 +2289,6 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
                 };
             }
 
-            if (this.verbose) {
-                printRequest(request);
-            }
-
             const headers_len = list.items.len;
             std.debug.assert(list.items.len == writer.context.items.len);
             if (this.state.request_body.len > 0 and list.capacity - list.items.len > 0 and !this.proxy_tunneling) {
@@ -2326,6 +2322,10 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
 
             this.state.request_sent_len += @as(usize, @intCast(amount));
             const has_sent_headers = this.state.request_sent_len >= headers_len;
+
+            if (has_sent_headers and this.verbose) {
+                printRequest(request);
+            }
 
             if (has_sent_headers and this.state.request_body.len > 0) {
                 this.state.request_body = this.state.request_body[this.state.request_sent_len - headers_len ..];

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -358,6 +358,10 @@ const NetworkTask = struct {
         );
         this.http.client.reject_unauthorized = this.package_manager.tlsRejectUnauthorized();
 
+        if (PackageManager.verbose_install) {
+            this.http.client.verbose = true;
+        }
+
         this.callback = .{
             .package_manifest = .{
                 .name = try strings.StringOrTinyString.initAppendIfNeeded(name, *FileSystem.FilenameStore, &FileSystem.FilenameStore.instance),
@@ -437,6 +441,9 @@ const NetworkTask = struct {
             null,
         );
         this.http.client.reject_unauthorized = this.package_manager.tlsRejectUnauthorized();
+        if (PackageManager.verbose_install) {
+            this.http.client.verbose = true;
+        }
 
         this.callback = .{ .extract = tarball };
     }


### PR DESCRIPTION
### What does this PR do?

This dumps the HTTP request/response metadata when `bun install --verbose` is passed

Also prevents double-printing the request metadata

### How did you verify your code works?

manual