### PR TITLE
Windows install with wsl

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,6 +48,15 @@ The test runner, package manager, and bundler are still under development. The f
 - `bun link/unlink`
 - `bun build`
 
+For now, you can use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) to run your bun.
+
+First, create a folder, open a PowerShell inside this directory and run these comands:
+```powershell
+Write-Output "wsl bash -ic `"bun %*`"" | out-file "bun.bat" -Encoding ASCII
+$env:Path += ";$pwd"
+wsl bash -ic "curl -fsSL https://bun.sh/install | bash"
+```
+
 ## Upgrading
 
 Once installed, the binary can upgrade itself.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -53,9 +53,8 @@ For now, you can use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install
 ```powershell
 $BunInstallFolder = "$env:ProgramData/bun" # An installation folder. You can change it
 mkdir $BunInstallFolder
-cd $BunInstallFolder
-Write-Output "@ECHO OFF`nwsl bash -ic `"bun %*`"" | out-file "bun.bat" -Encoding ASCII
-$env:Path += ";$pwd"
+Write-Output "@ECHO OFF`nwsl bash -ic `"bun %*`"" | out-file "$BunInstallFolder/bun.bat" -Encoding ASCII
+[Environment]::SetEnvironmentVariable("Path", $env:Path + ";$BunInstallFolder", "Machine")
 wsl bash -ic "curl -fsSL https://bun.sh/install | bash"
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,11 +48,13 @@ The test runner, package manager, and bundler are still under development. The f
 - `bun link/unlink`
 - `bun build`
 
-For now, you can use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) to run your bun.
+For now, you can use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) to run your bun, using a batch file to call bun inside wsl, as the example above.
 
-First, create a folder, open a PowerShell inside this directory and run these comands:
 ```powershell
-Write-Output "wsl bash -ic `"bun %*`"" | out-file "bun.bat" -Encoding ASCII
+$BunInstallFolder = "$env:ProgramData/bun" # An installation folder. You can change it
+mkdir $BunInstallFolder
+cd $BunInstallFolder
+Write-Output "@ECHO OFF`nwsl bash -ic `"bun %*`"" | out-file "bun.bat" -Encoding ASCII
 $env:Path += ";$pwd"
 wsl bash -ic "curl -fsSL https://bun.sh/install | bash"
 ```


### PR DESCRIPTION
With a simple bat file, you can configure the command bun use directly wsl to run your env

### What does this PR do?

In docummentation, I put  an example of how you can set your bun to run on Windows with wsl, creating a bat file, adding the current folder to path and installing bun inside wsl.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

Installed on my personal computer
