### PR TITLE
bundler: default import_prefix to `./` if file_path does not start with a relative path signifier

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -11002,11 +11002,7 @@ pub const Chunk = struct {
                                     else => unreachable,
                                 };
 
-                                const pre_norm_file_path = if (from_chunk_dir.len == 0) file_path else bun.path.relative(from_chunk_dir, file_path);
-                                const cheap_normalizer = cheapPrefixNormalizer(if (import_prefix.len == 0 and !strings.hasPrefixComptime(pre_norm_file_path, "../"))
-                                    "./"
-                                else
-                                    import_prefix, pre_norm_file_path);
+                                const cheap_normalizer = cheapPrefixNormalizer(import_prefix, if (from_chunk_dir.len == 0) file_path else bun.path.relative(from_chunk_dir, file_path));
                                 count += cheap_normalizer[0].len + cheap_normalizer[1].len;
                             },
                             .none => {},
@@ -11041,11 +11037,7 @@ pub const Chunk = struct {
                                     else => unreachable,
                                 };
 
-                                const pre_norm_file_path = if (from_chunk_dir.len == 0) file_path else bun.path.relative(from_chunk_dir, file_path);
-                                const cheap_normalizer = cheapPrefixNormalizer(if (import_prefix.len == 0 and !strings.hasPrefixComptime(pre_norm_file_path, "../"))
-                                    "./"
-                                else
-                                    import_prefix, pre_norm_file_path);
+                                const cheap_normalizer = cheapPrefixNormalizer(import_prefix, if (from_chunk_dir.len == 0) file_path else bun.path.relative(from_chunk_dir, file_path));
 
                                 if (cheap_normalizer[0].len > 0) {
                                     @memcpy(remain[0..cheap_normalizer[0].len], cheap_normalizer[0]);
@@ -11286,8 +11278,13 @@ const ContentHasher = struct {
 // users can correctly put in a trailing slash if they want
 // this is just being nice
 fn cheapPrefixNormalizer(prefix: []const u8, suffix: []const u8) [2]string {
-    if (prefix.len == 0)
-        return .{ prefix, suffix };
+    // it no prefix is passed, we default it to "./" if the suffix does not start with a dot or slash
+    if (prefix.len == 0) {
+        if (strings.startsWithChar(suffix, '.') or strings.startsWithChar(suffix, '/')) {
+            return .{ prefix, suffix };
+        }
+        return .{ "./", suffix };
+    }
 
     // There are a few cases here we want to handle:
     // ["https://example.com/", "/out.js"]  => "https://example.com/out.js"

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -11003,13 +11003,10 @@ pub const Chunk = struct {
                                 };
 
                                 const pre_norm_file_path = if (from_chunk_dir.len == 0) file_path else bun.path.relative(from_chunk_dir, file_path);
-                                const cheap_normalizer = cheapPrefixNormalizer(
-                                    if (import_prefix.len == 0 and !strings.hasPrefixComptime(pre_norm_file_path, "../"))
-                                        "./"
-                                    else
-                                        import_prefix,
-                                    pre_norm_file_path
-                                );
+                                const cheap_normalizer = cheapPrefixNormalizer(if (import_prefix.len == 0 and !strings.hasPrefixComptime(pre_norm_file_path, "../"))
+                                    "./"
+                                else
+                                    import_prefix, pre_norm_file_path);
                                 count += cheap_normalizer[0].len + cheap_normalizer[1].len;
                             },
                             .none => {},
@@ -11045,13 +11042,10 @@ pub const Chunk = struct {
                                 };
 
                                 const pre_norm_file_path = if (from_chunk_dir.len == 0) file_path else bun.path.relative(from_chunk_dir, file_path);
-                                const cheap_normalizer = cheapPrefixNormalizer(
-                                    if (import_prefix.len == 0 and !strings.hasPrefixComptime(pre_norm_file_path, "../"))
-                                        "./"
-                                    else
-                                        import_prefix,
-                                    pre_norm_file_path
-                                );
+                                const cheap_normalizer = cheapPrefixNormalizer(if (import_prefix.len == 0 and !strings.hasPrefixComptime(pre_norm_file_path, "../"))
+                                    "./"
+                                else
+                                    import_prefix, pre_norm_file_path);
 
                                 if (cheap_normalizer[0].len > 0) {
                                     @memcpy(remain[0..cheap_normalizer[0].len], cheap_normalizer[0]);

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -11002,12 +11002,13 @@ pub const Chunk = struct {
                                     else => unreachable,
                                 };
 
+                                const pre_norm_file_path = if (from_chunk_dir.len == 0) file_path else bun.path.relative(from_chunk_dir, file_path);
                                 const cheap_normalizer = cheapPrefixNormalizer(
-                                    import_prefix,
-                                    if (from_chunk_dir.len == 0)
-                                        file_path
+                                    if (import_prefix.len == 0 and !strings.hasPrefixComptime(pre_norm_file_path, "../"))
+                                        "./"
                                     else
-                                        bun.path.relative(from_chunk_dir, file_path),
+                                        import_prefix,
+                                    pre_norm_file_path
                                 );
                                 count += cheap_normalizer[0].len + cheap_normalizer[1].len;
                             },
@@ -11042,12 +11043,14 @@ pub const Chunk = struct {
                                     .chunk => chunks[index].final_rel_path,
                                     else => unreachable,
                                 };
+
+                                const pre_norm_file_path = if (from_chunk_dir.len == 0) file_path else bun.path.relative(from_chunk_dir, file_path);
                                 const cheap_normalizer = cheapPrefixNormalizer(
-                                    import_prefix,
-                                    if (from_chunk_dir.len == 0)
-                                        file_path
+                                    if (import_prefix.len == 0 and !strings.hasPrefixComptime(pre_norm_file_path, "../"))
+                                        "./"
                                     else
-                                        bun.path.relative(from_chunk_dir, file_path),
+                                        import_prefix,
+                                    pre_norm_file_path
                                 );
 
                                 if (cheap_normalizer[0].len > 0) {

--- a/test/bundler/esbuild/splitting.test.ts
+++ b/test/bundler/esbuild/splitting.test.ts
@@ -609,4 +609,25 @@ describe("bundler", () => {
       stdout: "42 true 42",
     },
   });
+  itBundled("splitting/EntrypointRelativeImportOtherEntrypointOutsideRootIssue5700", {
+    files: {
+      "/src/a.js": /* js */ `
+        import greet from './greet/hello'
+        greet('world')
+      `,
+      "/src/greet/hello.js": /* js */ `
+        export default function greet(name) {
+          console.log("hello", name)
+        }
+      `,
+    },
+    entryPoints: ["/src/a.js", "/src/greet/hello.js"],
+    outputPaths: ["/out/a.js", "/out/greet/hello.js"],
+    outdir: "/out",
+    splitting: true,
+    run: {
+      file: '/out/a.js',
+      stdout: "hello world",
+    },
+  });
 });


### PR DESCRIPTION
### What does this PR do?

When generating import paths, the bundler now defaults `import_path` to `./` if no override is provided and if `bun.path.relative(from_chunk_dir, file_path)` does not result in a path with a relative path signifier (`../`). This fixes #5700.

### How did you verify your code works?

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be (*i am not sure how to do this properly*)
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code
