### PR TITLE
fix: add check to sqlite extension loading logic

### DIFF
--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -695,6 +695,11 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementLoadExtensionFunction, (JSC::JSGlobalObje
         return JSValue::encode(JSC::jsUndefined());
     }
 
+    if(sqlite3_compileoption_used("SQLITE_OMIT_LOAD_EXTENSION")) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "This build of sqlite3 does not support dynamic extension loading"_s));
+        return JSValue::encode(JSC::jsUndefined());
+    }
+
     auto entryPointStr = callFrame->argumentCount() > 2 && callFrame->argument(2).isString() ? callFrame->argument(2).toWTFString(lexicalGlobalObject) : String();
     const char* entryPoint = entryPointStr.length() == 0 ? NULL : entryPointStr.utf8().data();
     char* error;

--- a/src/bun.js/bindings/sqlite/lazy_sqlite3.h
+++ b/src/bun.js/bindings/sqlite/lazy_sqlite3.h
@@ -71,6 +71,7 @@ typedef int (*lazy_sqlite3_deserialize_type)(
 );
 
 typedef int (*lazy_sqlite3_stmt_readonly_type)(sqlite3_stmt* pStmt);
+typedef int (*lazy_sqlite3_compileoption_used_type)(const char *zOptName);
 
 static lazy_sqlite3_bind_blob_type lazy_sqlite3_bind_blob;
 static lazy_sqlite3_bind_double_type lazy_sqlite3_bind_double;
@@ -112,6 +113,7 @@ static lazy_sqlite3_malloc64_type lazy_sqlite3_malloc64;
 static lazy_sqlite3_serialize_type lazy_sqlite3_serialize;
 static lazy_sqlite3_deserialize_type lazy_sqlite3_deserialize;
 static lazy_sqlite3_stmt_readonly_type lazy_sqlite3_stmt_readonly;
+static lazy_sqlite3_compileoption_used_type lazy_sqlite3_compileoption_used;
 
 #define sqlite3_bind_blob lazy_sqlite3_bind_blob
 #define sqlite3_bind_double lazy_sqlite3_bind_double
@@ -152,6 +154,7 @@ static lazy_sqlite3_stmt_readonly_type lazy_sqlite3_stmt_readonly;
 #define sqlite3_deserialize lazy_sqlite3_deserialize
 #define sqlite3_stmt_readonly lazy_sqlite3_stmt_readonly
 #define sqlite3_column_int64 lazy_sqlite3_column_int64
+#define sqlite3_compileoption_used lazy_sqlite3_compileoption_used;
 
 static void* sqlite3_handle = nullptr;
 static const char* sqlite3_lib_path = "libsqlite3.dylib";
@@ -204,6 +207,7 @@ static int lazyLoadSQLite()
     lazy_sqlite3_deserialize = (lazy_sqlite3_deserialize_type)dlsym(sqlite3_handle, "sqlite3_deserialize");
     lazy_sqlite3_malloc64 = (lazy_sqlite3_malloc64_type)dlsym(sqlite3_handle, "sqlite3_malloc64");
     lazy_sqlite3_stmt_readonly = (lazy_sqlite3_stmt_readonly_type)dlsym(sqlite3_handle, "sqlite3_stmt_readonly");
+    lazy_sqlite3_compileoption_used = (lazy_sqlite3_compileoption_used_type)dlsym(sqlite3_handle, "sqlite3_compileoption_used");
 
     return 0;
 }


### PR DESCRIPTION
### What does this PR do?
The sqlite3 logic to dynamically load extensions can be disabled to save space, which macos does by default.
sqlite3 provides a api to check for these compile time settings at runtime, we can use that to throw a js error rather then crashing. It is worth noting though that the api to check for these settings at runtime itself can be disabled through SQLITE_OMIT_COMPILEOPTION_DIAGS but this seams to be a edge case.

Fixes https://github.com/oven-sh/bun/issues/5756
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Its not completely straight forward to add automated testing for this as it requires a custom build of sqlite3, assuming macOS version of sqlite3 will always disable extension loading is a bad approach.

Furthermore i work on arch even though i have a mac(i might test this later this week), i used this to test for the presence of flags outside of `SQLITE_OMIT_LOAD_EXTENSION` which worked as expected. So testing was done.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
