### PR TITLE
Fix RedirectURLTooLong errors

### DIFF
--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -33,7 +33,7 @@ const BoringSSL = bun.BoringSSL;
 const X509 = @import("./bun.js/api/bun/x509.zig");
 const c_ares = @import("./deps/c_ares.zig");
 
-const URLBufferPool = ObjectPool([4096]u8, null, false, 10);
+const URLBufferPool = ObjectPool([8192]u8, null, false, 10);
 const uws = bun.uws;
 pub const MimeType = @import("./http/mime_type.zig");
 pub const URLPath = @import("./http/url_path.zig");


### PR DESCRIPTION
The URL to download the manifest for Artifact Registry in Google is larger than 4092 bytes.

cf. #4748

### What does this PR do?

Increase the URLBufferPool size to 8192 bytes to support larger manifest URLs

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

I built and ran `bun-debug install` on a repo having dependencies from Artifact Registry. It failed with the `RedirectURLTooLong` error :x: 

I then made the fix, built and ran `bun-debug install` again on the same repo. This time it succeeded :white_check_mark: 

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->
