### PR TITLE
Call `Error.prepareStackTrace` on `new Error().stack`

### DIFF
--- a/src/bun.js/bindings/ErrorStackTrace.h
+++ b/src/bun.js/bindings/ErrorStackTrace.h
@@ -61,9 +61,9 @@ private:
     JSC::BytecodeIndex m_bytecodeIndex;
 
     // Lazy-initialized
-    JSC::JSString* m_sourceURL;
-    JSC::JSString* m_functionName;
-    JSC::JSString* m_typeName;
+    WTF::String m_sourceURL;
+    WTF::String m_functionName;
+    WTF::String m_typeName;
 
     // m_wasmFunctionIndexOrName has meaning only when m_isWasmFrame is set
     JSC::Wasm::IndexOrName m_wasmFunctionIndexOrName;
@@ -105,7 +105,7 @@ public:
     bool isConstructor() const { return m_codeBlock && (JSC::CodeForConstruct == m_codeBlock->specializationKind()); }
 
 private:
-    ALWAYS_INLINE JSC::JSString* retrieveSourceURL();
+    ALWAYS_INLINE String retrieveSourceURL();
 
     /* Regarding real functions (not eval\module\global code), both v8 and JSC seem to follow
      * the same logic, which is to first try the function's "display name", and if it's not defined,
@@ -119,9 +119,9 @@ private:
      * and just try to use the "name" property when needed, so our lookup will be:
      * "display name" property -> "name" property -> JSFunction\InternalFunction "name" methods.
      */
-    ALWAYS_INLINE JSC::JSString* retrieveFunctionName();
+    ALWAYS_INLINE String retrieveFunctionName();
 
-    ALWAYS_INLINE JSC::JSString* retrieveTypeName();
+    ALWAYS_INLINE String retrieveTypeName();
 
     bool calculateSourcePositions();
 };

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -153,7 +153,7 @@ public:
     void clearDOMGuardedObjects();
 
     static void createCallSitesFromFrames(JSC::JSGlobalObject* lexicalGlobalObject, JSCStackTrace& stackTrace, JSC::JSArray* callSites);
-    JSC::JSValue formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites);
+    void formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites);
 
     static void reportUncaughtExceptionAtEventLoop(JSGlobalObject*, JSC::Exception*);
     static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject* globalObject);
@@ -350,6 +350,8 @@ public:
 
     // mutable WriteBarrier<Unknown> m_JSBunDebuggerValue;
     mutable WriteBarrier<JSFunction> m_thenables[promiseFunctionsSize + 1];
+
+    mutable WriteBarrier<JSC::Unknown> m_errorConstructorPrepareStackTraceValue;
 
     Structure* memoryFootprintStructure()
     {

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -152,8 +152,8 @@ public:
 
     void clearDOMGuardedObjects();
 
-    static void createCallSitesFromFrames(JSC::JSGlobalObject* lexicalGlobalObject, JSCStackTrace& stackTrace, JSC::JSArray* callSites);
-    void formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites);
+    static void createCallSitesFromFrames(Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, JSCStackTrace& stackTrace, JSC::JSArray* callSites);
+    void formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites, JSValue prepareStack = JSC::jsUndefined());
 
     static void reportUncaughtExceptionAtEventLoop(JSGlobalObject*, JSC::Exception*);
     static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject* globalObject);

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -505,7 +505,6 @@ test("Error.prepareStackTrace inside a node:vm works", () => {
   Error.prepareStackTrace = null;
   const result = runInNewContext(
     `
-    const {prepareStackTrace} = Error;
     Error.prepareStackTrace = (err, stack) => {
       if (typeof err.stack !== "string") {
         throw new Error("err.stack is not a string");

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -460,14 +460,29 @@ test("CallFrame.p.toString", () => {
   expect(e.stack[0].toString().includes("<anonymous>")).toBe(true);
 });
 
-test.todo("err.stack should invoke prepareStackTrace", () => {
-  // This is V8's behavior.
-  let prevPrepareStackTrace = Error.prepareStackTrace;
-  let wasCalled = false;
-  Error.prepareStackTrace = (e, s) => {
-    wasCalled = true;
-  };
-  const e = new Error();
-  e.stack;
-  expect(wasCalled).toBe(true);
+test("err.stack should invoke prepareStackTrace", () => {
+  var lineNumber = -1;
+  var functionName = "";
+  var parentLineNumber = -1;
+  function functionWithAName() {
+    // This is V8's behavior.
+    let prevPrepareStackTrace = Error.prepareStackTrace;
+
+    Error.prepareStackTrace = (e, s) => {
+      lineNumber = s[0].getLineNumber();
+      functionName = s[0].getFunctionName();
+      parentLineNumber = s[1].getLineNumber();
+      expect(s[0].getFileName().includes("capture-stack-trace.test.js")).toBe(true);
+      expect(s[1].getFileName().includes("capture-stack-trace.test.js")).toBe(true);
+    };
+    const e = new Error();
+    e.stack;
+    Error.prepareStackTrace = prevPrepareStackTrace;
+  }
+
+  functionWithAName();
+
+  expect(functionName).toBe("functionWithAName");
+  expect(lineNumber).toBe(479);
+  expect(parentLineNumber).toBe(487);
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -101,7 +101,7 @@ function testRunInContext(
     expect(typeof result).toBe("function");
     expect(result()).toBe("bar");
   });
-  test.skip("can throw a syntax error", () => {
+  test("can throw a syntax error", () => {
     const context = createContext({});
     const result = () => fn("!?", context);
     expect(result).toThrow({


### PR DESCRIPTION
### What does this PR do?

Previously, Bun was only calling `Error.prepareStackTrace` when `Error.captureStackTrace` was called. This broke a lot of packages. 

This makes Bun call `Error.prepareStackTrace` whenever it's defined, and also makes it very slightly faster to check for the existence of `Error.prepareStackTrace.

### How did you verify your code works?

There are tests.