### PR TITLE
fix(console.log): change default depth from 8 to 2

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -1042,7 +1042,7 @@ pub const ZigConsoleClient = struct {
         flush: bool,
         ordered_properties: bool = false,
         quote_strings: bool = false,
-        max_depth: u16 = 8,
+        max_depth: u16 = 2,
     };
 
     pub fn format(

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -50,3 +50,10 @@ String 123 should be 2nd word, 456 == 456 and percent s %s == What okay
 [
   {}, {}, {}, {}
 ]
+{
+  level1: {
+    level2: {
+      level3: [Object ...]
+    }
+  }
+}

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -58,3 +58,17 @@ infinteLoop.bar = infinteLoop;
 console.log(infinteLoop, "am");
 
 console.log(new Array(4).fill({}));
+const nestedObject = {
+  level1: {
+    level2: {
+      level3: {
+        level4: {
+          level5: {
+            name: "Deeply nested object",
+          },
+        },
+      },
+    },
+  },
+};
+console.log(nestedObject);


### PR DESCRIPTION

### What does this PR do?

Changes the default depth to match Node. [Source in Node](https://github.com/nodejs/node/blob/480ab8c3a40451d5ea459dd35b4039679b26e195/doc/api/console.md?plain=1#L285)

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I or my editor ran `zig fmt` on the changed files
- [X] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
