### PR TITLE
feat(runtime): implement `console._stdout`

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3451,7 +3451,7 @@ JSC_DEFINE_CUSTOM_GETTER(getConsoleStdout, (JSGlobalObject * globalObject, Encod
     if (!stdout)
         return JSValue::encode({});
 
-    console->putDirect(vm, property, stdout, 0);
+    console->putDirect(vm, property, stdout, PropertyAttribute::DontEnum | 0);
     return JSValue::encode(stdout);
 }
 
@@ -3467,7 +3467,7 @@ JSC_DEFINE_CUSTOM_GETTER(getConsoleStderr, (JSGlobalObject * globalObject, Encod
     if (!stdout)
         return JSValue::encode({});
 
-    console->putDirect(vm, property, stdout, 0);
+    console->putDirect(vm, property, stdout, PropertyAttribute::DontEnum | 0);
     return JSValue::encode(stdout);
 }
 

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -68,9 +68,23 @@ describe("console.Console", () => {
 test("console._stdout", () => {
   // @ts-ignore
   expect(console._stdout).toBe(process.stdout);
+
+  expect(Object.getOwnPropertyDescriptor(console, "_stdout")).toEqual({
+    value: process.stdout,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
 });
 
 test("console._stderr", () => {
   // @ts-ignore
   expect(console._stderr).toBe(process.stderr);
+
+  expect(Object.getOwnPropertyDescriptor(console, "_stderr")).toEqual({
+    value: process.stderr,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
 });

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -64,3 +64,13 @@ describe("console.Console", () => {
     expect(await errValue()).toBe("uh oh!\n");
   });
 });
+
+test("console._stdout", () => {
+  // @ts-ignore
+  expect(console._stdout).toBe(process.stdout);
+});
+
+test("console._stderr", () => {
+  // @ts-ignore
+  expect(console._stderr).toBe(process.stderr);
+});


### PR DESCRIPTION
### What does this PR do?

nonenumerable secret api that older verisons of consola depends on; which breaks some libraries. does not close but related to #3771 and nuxt 2.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
