### PR TITLE
chore(git): ignore .envrc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ packages/*/*.wasm
 profile.json
 
 node_modules
+.envrc
 .swcrc
 yarn.lock
 dist


### PR DESCRIPTION
### What does this PR do?

Using `.envrc` files allows [automatically loading](https://direnv.net/) custom env vars during development.
This file might contain tokens, keys or any other developer-workflow-specific config that we don't want to push to the repo.

This PR adds .envrc to .gitignore