### PR TITLE
fix(node:fs): use the right `copyFile` constants

### DIFF
--- a/src/bun.js/node/node_fs_constant.zig
+++ b/src/bun.js/node/node_fs_constant.zig
@@ -42,16 +42,15 @@ pub const Constants = struct {
     };
 
     /// Constant for fs.copyFile. Flag indicating the destination file should not be overwritten if it already exists.
-    pub const COPYFILE_EXCL: i32 = 1 << Copyfile.exclusive;
-
+    pub const COPYFILE_EXCL: i32 = Copyfile.exclusive;
     ///
     /// Constant for fs.copyFile. copy operation will attempt to create a copy-on-write reflink.
     /// If the underlying platform does not support copy-on-write, then a fallback copy mechanism is used.
-    pub const COPYFILE_FICLONE: i32 = 1 << Copyfile.clone;
+    pub const COPYFILE_FICLONE: i32 = Copyfile.clone;
     ///
     /// Constant for fs.copyFile. Copy operation will attempt to create a copy-on-write reflink.
     /// If the underlying platform does not support copy-on-write, then the operation will fail with an error.
-    pub const COPYFILE_FICLONE_FORCE: i32 = 1 << Copyfile.force;
+    pub const COPYFILE_FICLONE_FORCE: i32 = Copyfile.force;
     // File Open Constants
     /// Constant for fs.open(). Flag indicating to open a file for read-only access.
     pub const O_RDONLY = std.os.O.RDONLY;

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -136,6 +136,35 @@ describe("copyFileSync", () => {
     expect(Bun.hash(readFileSync(tempdir + "/copyFileSync.dest.blob"))).toBe(Bun.hash(buffer.buffer));
   });
 
+  it("constants are right", () => {
+    expect(fs.constants.COPYFILE_EXCL).toBe(1);
+    expect(fs.constants.COPYFILE_FICLONE).toBe(2);
+    expect(fs.constants.COPYFILE_FICLONE_FORCE).toBe(4);
+  });
+
+  it("FICLONE option does not error ever", () => {
+    const tempdir = `${tmpdir()}/fs.test.js/${Date.now()}.FICLONE/1234/hi`;
+    expect(existsSync(tempdir)).toBe(false);
+    expect(tempdir.includes(mkdirSync(tempdir, { recursive: true })!)).toBe(true);
+
+    // that don't exist
+    copyFileSync(import.meta.path, tempdir + "/copyFileSync.js", fs.constants.COPYFILE_FICLONE);
+    copyFileSync(import.meta.path, tempdir + "/copyFileSync.js", fs.constants.COPYFILE_FICLONE);
+    copyFileSync(import.meta.path, tempdir + "/copyFileSync.js", fs.constants.COPYFILE_FICLONE);
+  });
+
+  it("COPYFILE_EXCL works", () => {
+    const tempdir = `${tmpdir()}/fs.test.js/${Date.now()}.COPYFILE_EXCL/1234/hi`;
+    expect(existsSync(tempdir)).toBe(false);
+    expect(tempdir.includes(mkdirSync(tempdir, { recursive: true })!)).toBe(true);
+
+    // that don't exist
+    copyFileSync(import.meta.path, tempdir + "/copyFileSync.js", fs.constants.COPYFILE_EXCL);
+    expect(() => {
+      copyFileSync(import.meta.path, tempdir + "/copyFileSync.js", fs.constants.COPYFILE_EXCL);
+    }).toThrow();
+  });
+
   if (process.platform === "linux") {
     describe("should work when copyFileRange is not available", () => {
       it("on large files", () => {
@@ -212,7 +241,7 @@ describe("copyFileSync", () => {
 
 describe("mkdirSync", () => {
   it("should create a directory", () => {
-    const tempdir = `${tmpdir()}/fs.test.js/${Date.now()}/1234/hi`;
+    const tempdir = `${tmpdir()}/fs.test.js/${Date.now()}.mkdirSync/1234/hi`;
     expect(existsSync(tempdir)).toBe(false);
     expect(tempdir.includes(mkdirSync(tempdir, { recursive: true })!)).toBe(true);
     expect(existsSync(tempdir)).toBe(true);


### PR DESCRIPTION
### What does this PR do?

fixes passing the options to copyFile
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
