### PR TITLE
Hide env elapsed time when loglevel=info

### DIFF
--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -398,8 +398,8 @@ pub const Bundler = struct {
             DotEnv.instance = env_loader;
         }
 
-        // only print elapsed time when loglevel is verbose or debug
-        env_loader.quiet = !log.level.atLeast(.debug);
+        // hide elapsed time when loglevel is warn or error
+        env_loader.quiet = !log.level.atLeast(.info);
 
         // var pool = try allocator.create(ThreadPool);
         // try pool.init(ThreadPool.InitConfig{

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -399,7 +399,7 @@ pub const Bundler = struct {
         }
 
         // only print elapsed time when loglevel is verbose or debug
-        env_loader.quiet = !log.level.atLeast(.info);
+        env_loader.quiet = !log.level.atLeast(.debug);
 
         // var pool = try allocator.create(ThreadPool);
         // try pool.init(ThreadPool.InitConfig{

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -398,7 +398,8 @@ pub const Bundler = struct {
             DotEnv.instance = env_loader;
         }
 
-        env_loader.quiet = !log.level.atLeast(.warn);
+        // only print elapsed time when loglevel is verbose or debug
+        env_loader.quiet = !log.level.atLeast(.info);
 
         // var pool = try allocator.create(ThreadPool);
         // try pool.init(ThreadPool.InitConfig{

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -662,11 +662,11 @@ pub const Log = struct {
     }
 
     pub const Level = enum(i8) {
-        verbose,
-        debug,
-        info,
-        warn,
-        err,
+        verbose, // 0
+        debug, // 1
+        info, // 2
+        warn, //  3
+        err, // 4
 
         pub fn atLeast(this: Level, other: Level) bool {
             return @intFromEnum(this) <= @intFromEnum(other);

--- a/test/cli/run/log-test.test.ts
+++ b/test/cli/run/log-test.test.ts
@@ -32,7 +32,7 @@ it("should log .env by default", async () => {
     env: bunEnv,
   });
 
-  expect(stderr?.toString().includes(".env")).toBe(true);
+  expect(stderr?.toString().includes(".env")).toBe(false);
 });
 
 function writeDirectoryTree(base: string, paths: Record<string, any>) {


### PR DESCRIPTION
Disables `[0.05ms] ".env"` messages when logLevel is info