### PR TITLE
`deadCodeElimination` toggle for Bun.Transpiler

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -908,6 +908,14 @@ declare module "bun" {
      * Minify whitespace and comments from the output.
      */
     minifyWhitespace?: boolean;
+    /**
+     * **Experimental**
+     *
+     * Enabled by default, use this to disable dead code elimination.
+     * 
+     * Some other transpiler options may still do some specific dead code elimination.
+     */
+    deadCodeElimination?: boolean;
 
     /**
      * This does two things (and possibly more in the future):

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -912,7 +912,7 @@ declare module "bun" {
      * **Experimental**
      *
      * Enabled by default, use this to disable dead code elimination.
-     * 
+     *
      * Some other transpiler options may still do some specific dead code elimination.
      */
     deadCodeElimination?: boolean;

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -72,6 +72,7 @@ const TranspilerOptions = struct {
     trim_unused_imports: ?bool = null,
     inlining: bool = false,
 
+    dead_code_elimination: bool = true,
     minify_whitespace: bool = false,
     minify_identifiers: bool = false,
     minify_syntax: bool = false,
@@ -541,6 +542,10 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
         transpiler.minify_whitespace = flag.toBoolean();
     }
 
+    if (object.get(globalThis, "deadCodeElimination")) |flag| {
+        transpiler.dead_code_elimination = flag.toBoolean();
+    }
+
     if (object.getTruthy(globalThis, "minify")) |hot| {
         if (hot.isBoolean()) {
             transpiler.minify_whitespace = hot.coerce(bool, globalThis);
@@ -800,6 +805,7 @@ pub fn constructor(
         bundler.options.macro_remap = transpiler_options.macro_map;
     }
 
+    bundler.options.dead_code_elimination = transpiler_options.dead_code_elimination;
     bundler.options.minify_whitespace = transpiler_options.minify_whitespace;
 
     // Keep defaults for these

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -541,8 +541,9 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
     if (object.get(globalThis, "minifyWhitespace")) |flag| {
         transpiler.minify_whitespace = flag.toBoolean();
     }
-
-    if (object.get(globalThis, "deadCodeElimination")) |flag| {
+    // TODO: Currently only disables top level DCE, this is marked as experimental and undocumented to signal that.
+    // It should be made a full DCE toggle in the future and documented, but for now it satisfies the REPL's needs.
+    if (object.get(globalThis, "experimentalDeadCodeElimination")) |flag| {
         transpiler.dead_code_elimination = flag.toBoolean();
     }
 

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -541,9 +541,8 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
     if (object.get(globalThis, "minifyWhitespace")) |flag| {
         transpiler.minify_whitespace = flag.toBoolean();
     }
-    // TODO: Currently only disables top level DCE, this is marked as experimental and undocumented to signal that.
-    // It should be made a full DCE toggle in the future and documented, but for now it satisfies the REPL's needs.
-    if (object.get(globalThis, "experimentalDeadCodeElimination")) |flag| {
+
+    if (object.get(globalThis, "deadCodeElimination")) |flag| {
         transpiler.dead_code_elimination = flag.toBoolean();
     }
 

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -1333,6 +1333,7 @@ pub const Bundler = struct {
                 opts.features.inject_jest_globals = this_parse.inject_jest_globals;
                 opts.features.minify_syntax = bundler.options.minify_syntax;
                 opts.features.minify_identifiers = bundler.options.minify_identifiers;
+                opts.features.dead_code_elimination = bundler.options.dead_code_elimination;
 
                 if (bundler.macro_context == null) {
                     bundler.macro_context = js_ast.Macro.MacroContext.init(bundler);

--- a/src/options.zig
+++ b/src/options.zig
@@ -1442,6 +1442,7 @@ pub const BundleOptions = struct {
     minify_whitespace: bool = false,
     minify_syntax: bool = false,
     minify_identifiers: bool = false,
+    dead_code_elimination: bool = true,
 
     code_coverage: bool = false,
     debugger: bool = false,

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -289,6 +289,7 @@ pub const Runtime = struct {
 
         minify_syntax: bool = false,
         minify_identifiers: bool = false,
+        dead_code_elimination: bool = true,
 
         set_breakpoint_on_first_line: bool = false,
 

--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -1984,6 +1984,24 @@ console.log(resolve.length)
       // expectParseError("\u200Ca", 'Unexpected "\\u200c"');
       // expectParseError("\u200Da", 'Unexpected "\\u200d"');
     });
+
+    // TODO: Remember to update these when proper full DCE toggle is implemented
+    // Currently this only tests top level DCE which the REPL depends on
+    describe("dead code elimination", () => {
+      const transpilerNoDCE = new Bun.Transpiler({ experimentalDeadCodeElimination: false });
+      it("should DCE with experimentalDeadCodeElimination: true or by default", () => {
+        expect(parsed('123', true, false)).toBe('');
+        expect(parsed('[-1, 2n, null]', true, false)).toBe('');
+        expect(parsed('true', true, false)).toBe('');
+        expect(parsed('!0', true, false)).toBe('');
+      });
+      it("should not DCE with experimentalDeadCodeElimination: false", () => {
+        expect(parsed('123', true, false, transpilerNoDCE)).toBe('123');
+        expect(parsed('[1, 2n, null]', true, false, transpilerNoDCE)).toBe('[1, 2n, null]');
+        expect(parsed('true', true, false, transpilerNoDCE)).toBe('true');
+        expect(parsed('!0', true, false, transpilerNoDCE)).toBe('true');
+      });
+    });
   });
 
   it("private identifiers", () => {

--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -1988,22 +1988,24 @@ console.log(resolve.length)
     describe("dead code elimination", () => {
       const transpilerNoDCE = new Bun.Transpiler({ deadCodeElimination: false });
       it("should DCE with deadCodeElimination: true or by default", () => {
-        expect(parsed('123', true, false)).toBe('');
-        expect(parsed('[-1, 2n, null]', true, false)).toBe('');
-        expect(parsed('true', true, false)).toBe('');
-        expect(parsed('!0', true, false)).toBe('');
-        expect(parsed('if (!1) "dead";', true, false)).toBe('if (false)');
-        expect(parsed('if (!1) var x = 2;', true, false)).toBe('if (false)\n  var x');
-        expect(parsed('if (undefined) { let y = Math.random(); }', true, false)).toBe('if (undefined) {\n}');
+        expect(parsed("123", true, false)).toBe("");
+        expect(parsed("[-1, 2n, null]", true, false)).toBe("");
+        expect(parsed("true", true, false)).toBe("");
+        expect(parsed("!0", true, false)).toBe("");
+        expect(parsed('if (!1) "dead";', true, false)).toBe("if (false)");
+        expect(parsed("if (!1) var x = 2;", true, false)).toBe("if (false)\n  var x");
+        expect(parsed("if (undefined) { let y = Math.random(); }", true, false)).toBe("if (undefined) {\n}");
       });
       it("should not DCE with deadCodeElimination: false", () => {
-        expect(parsed('123', true, false, transpilerNoDCE)).toBe('123');
-        expect(parsed('[1, 2n, null]', true, false, transpilerNoDCE)).toBe('[1, 2n, null]');
-        expect(parsed('true', true, false, transpilerNoDCE)).toBe('true');
-        expect(parsed('!0', true, false, transpilerNoDCE)).toBe('!0');
+        expect(parsed("123", true, false, transpilerNoDCE)).toBe("123");
+        expect(parsed("[1, 2n, null]", true, false, transpilerNoDCE)).toBe("[1, 2n, null]");
+        expect(parsed("true", true, false, transpilerNoDCE)).toBe("true");
+        expect(parsed("!0", true, false, transpilerNoDCE)).toBe("!0");
         expect(parsed('if (!1) "dead";', true, false, transpilerNoDCE)).toBe('if (!1)\n  "dead"');
-        expect(parsed('if (!1) var x = 2;', true, false, transpilerNoDCE)).toBe('if (!1)\n  var x = 2');
-        expect(parsed('if (undefined) { let y = Math.random(); }', true, false, transpilerNoDCE)).toBe('if (undefined) {\n  let y = Math.random();\n}');
+        expect(parsed("if (!1) var x = 2;", true, false, transpilerNoDCE)).toBe("if (!1)\n  var x = 2");
+        expect(parsed("if (undefined) { let y = Math.random(); }", true, false, transpilerNoDCE)).toBe(
+          "if (undefined) {\n  let y = Math.random();\n}",
+        );
       });
     });
   });


### PR DESCRIPTION
### What does this PR do?

Adds a new option for `Bun.Transpiler`, called `deadCodeElimination`, which allows disabling of dead code elimination, which in turn enables proper use of Bun.Transpiler for transpilation of code meant to be top-level evaluated which would otherwise be voided by false-positive DCE due to lack of context to the transpiler. (examples: code passed to `eval()` or in a REPL)

The option is a boolean and is enabled by default for backwards compatibility given the transpiler has been doing DCE by default so far.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

- [x] I added TypeScript types for the new methods, getters, or setters

