### PR TITLE
docs: Removing versions from arch dependencies

### DIFF
--- a/docs/project/development.md
+++ b/docs/project/development.md
@@ -46,7 +46,7 @@ $ wget https://apt.llvm.org/llvm.sh -O - | sudo bash -s -- 16 all
 ```
 
 ```bash#Arch
-$ sudo pacman -S llvm16 clang16 lld
+$ sudo pacman -S llvm clang lld
 
 ```
 


### PR DESCRIPTION
### What does this PR do?

Removes versions from arch dependencies as they are not needed. Below are the two packages in Arch x86_64 repository which are named without the versions:

Clang: https://archlinux.org/packages/?name=clang
LLVM: https://archlinux.org/packages/?name=llvm

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

Verified the install command on my arch machine.
