### PR TITLE
fix(lockfile): ensure all bytes of union are initialized before serialization.

### DIFF
--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -67,7 +67,9 @@ pub const Bin = extern struct {
     }
 
     pub fn clone(this: *const Bin, buf: []const u8, prev_external_strings: []const ExternalString, all_extern_strings: []ExternalString, extern_strings_slice: []ExternalString, comptime StringBuilder: type, builder: StringBuilder) Bin {
-        var cloned = std.mem.zeroes(Bin);
+        var cloned: Bin = Bin{};
+        @memset(std.mem.asBytes(&cloned), 0);
+
         switch (this.tag) {
             .none => {
                 cloned.tag = .none;

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -1,7 +1,7 @@
 import { file, listen, Socket, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
 import { bunExe, bunEnv as env } from "harness";
-import { access, mkdir, readlink, realpath, rm, writeFile } from "fs/promises";
+import { readFile, access, mkdir, readlink, realpath, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import {
   dummyAfterAll,
@@ -256,4 +256,67 @@ it("should update to latest versions of dependencies", async () => {
     },
   });
   await access(join(package_dir, "bun.lockb"));
+});
+
+it("lockfile should not be modified when there are no version changes, issue#5888", async () => {
+  // Install packages
+  const urls: string[] = [];
+  const registry = {
+    "0.0.3": {
+      bin: {
+        "baz-run": "index.js",
+      },
+    },
+    latest: "0.0.3",
+  };
+  setHandler(dummyRegistry(urls, registry));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      dependencies: {
+        baz: "0.0.3",
+      },
+    }),
+  );
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: package_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(await exited).toBe(0);
+  const err1 = await new Response(stderr).text();
+  expect(err1).not.toContain("error:");
+  expect(err1).toContain("Saved lockfile");
+  expect(stdout).toBeDefined();
+  const out1 = await new Response(stdout).text();
+  expect(out1.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+    " + baz@0.0.3",
+    "",
+    " 1 packages installed",
+  ]);
+
+  // Test if the lockb has been modified by `bun update`.
+  const getLockbContent = async () => {
+    const { exited } = spawn({
+      cmd: [bunExe(), "update"],
+      cwd: package_dir, // package.json is not changed
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await exited).toBe(0);
+    return await readFile(join(package_dir, "bun.lockb"));
+  };
+
+  let prev = await getLockbContent();
+  for (let i = 0; i < 5; i++) {
+    const content = await getLockbContent();
+    expect(prev).toStrictEqual(content);
+    prev = content;
+  }
 });


### PR DESCRIPTION
### What does this PR do?


Close: #5888

When serializing to `bun.lockb`, we directly use `std.mem.sliceAsBytes` to write the memory of the struct.

https://github.com/oven-sh/bun/blob/ec0e931e9f7934f4f1f7617eac2a880d13794d0c/src/install/lockfile.zig#L3757-L3762

In the `Bin` struct, the `value` field is `union` type, and its size depends on the largest member. If we initialize it with `.{.none = {}}`, there will be some uninitialized memory. This can lead to the `bun.lockb` file being different with each `bun update`(no packages updated).

https://github.com/oven-sh/bun/blob/ec0e931e9f7934f4f1f7617eac2a880d13794d0c/src/install/bin.zig#L19-L23


https://github.com/oven-sh/bun/blob/ec0e931e9f7934f4f1f7617eac2a880d13794d0c/src/install/bin.zig#L102-L135



- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->



- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
