### PR TITLE
Update hot.md: use correct URL for Vite

### DIFF
--- a/docs/runtime/hot.md
+++ b/docs/runtime/hot.md
@@ -67,7 +67,7 @@ $ bun --watch test
 
 Use `bun --hot` to enable hot reloading when executing code with Bun. This is distinct from `--watch` mode in that Bun does not hard-restart the entire process. Instead, it detects code changes and updates its internal module cache with the new code.
 
-**Note** — This is not the same as hot reloading in the browser! Many frameworks provide a "hot reloading" experience, where you can edit & save your frontend code (say, a React component) and see the changes reflected in the browser without refreshing the page. Bun's `--hot` is the server-side equivalent of this experience. To get hot reloading in the browser, use a framework like [Vite](https://vite.dev).
+**Note** — This is not the same as hot reloading in the browser! Many frameworks provide a "hot reloading" experience, where you can edit & save your frontend code (say, a React component) and see the changes reflected in the browser without refreshing the page. Bun's `--hot` is the server-side equivalent of this experience. To get hot reloading in the browser, use a framework like [Vite](https://vitejs.dev).
 
 ```bash
 $ bun --hot server.ts


### PR DESCRIPTION
### What does this PR do?

The original URL for Vite was pointing at the incorrect website. This PR fixes the link.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

I opened the new link from the corrected markdown document, and it opens the correct website.