### PR TITLE
packages/bun-error: Fix when an error is thrown in development mode, …

### DIFF
--- a/packages/bun-error/bun-error.css
+++ b/packages/bun-error/bun-error.css
@@ -121,6 +121,7 @@
   color: var(--bun-error-color);
   font-size: 16pt;
   font-weight: bold;
+  padding: 8px 0;
 }
 
 .BunError-list {

--- a/packages/bun-error/index.tsx
+++ b/packages/bun-error/index.tsx
@@ -414,7 +414,7 @@ const AsyncSourceLines = ({
         controller.current = null;
       }
     };
-  }, [controller, setLoadState, setSourceLines, url, highlight]);
+  }, [controller, setLoadState, url, highlight]);
 
   switch (loadState) {
     case LoadState.pending: {
@@ -710,6 +710,7 @@ const NativeStackFrame = ({
 };
 
 const NativeStackFrames = ({ frames, urlBuilder }) => {
+  frames = frames.filter(({ scope }: StackFrame) => scope !== undefined);
   const items = new Array(frames.length);
   var maxLength = 0;
 
@@ -760,10 +761,11 @@ const NativeStackTrace = ({
     (line, column) => urlBuilder(file, line, column),
     [file, urlBuilder],
   );
+  const isEditorOpen = filename.length > 0 && position.line !== -1 && position.column_start !== -1;
 
   return (
     <div ref={ref} className={`BunError-NativeStackTrace`}>
-      <a
+      {isEditorOpen && <a
         href={urlBuilder(filename, position.line, position.column_start)}
         data-line={position.line}
         data-column={position.column_start}
@@ -773,7 +775,7 @@ const NativeStackTrace = ({
         className="BunError-NativeStackTrace-filename"
       >
         {filename}:{position.line}:{position.column_start}
-      </a>
+      </a>}
       {sourceLines.length > 0 && (
         <SourceLines
           highlight={position.line}


### PR DESCRIPTION
…there are empty stacks, the absence of a link to the editor, and continuous fetch requests in the browser console. This occurs, for instance, when an error is thrown in the form of 'throw "test"'.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

There were no tests in the location where I made changes.
I tested it under 'packages/bun-error' by running the 'bun build' command.
Additionally, I tested it by running the `make release-bindings` and `make release` commands.

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
