### PR TITLE
Do not use removefileat()

### DIFF
--- a/src/darwin_c.zig
+++ b/src/darwin_c.zig
@@ -728,29 +728,6 @@ const IO_CTL_RELATED = struct {
 
 pub usingnamespace IO_CTL_RELATED;
 
-pub const RemoveFileFlags = struct {
-    /// If path is a directory, recurse (depth first traversal)
-    pub const recursive: u32 = (1 << 0);
-    /// Remove contents but not directory itself
-    pub const keep_parent: u32 = (1 << 1);
-    /// 7 pass DoD algorithm
-    pub const secure_7_pass: u32 = (1 << 2);
-    /// 35-pass Gutmann algorithm (overrides REMOVEFILE_SECURE_7_PASS)
-    pub const secure_35_pass: u32 = (1 << 3);
-    /// 1 pass single overwrite),
-    pub const secure_1_pass: u32 = (1 << 4);
-    /// 3 pass overwrite
-    pub const secure_3_pass: u32 = (1 << 5);
-    /// Single-pass overwrite, with 0 instead of random data
-    pub const secure_1_pass_zero: u32 = (1 << 6);
-    /// Cross mountpoints when deleting recursively. << 6),
-    pub const cross_mount: u32 = (1 << 7);
-    /// Paths may be longer than PATH_MAX - requires temporarily changing cwd
-    pub const allow_long_paths: u32 = (1 << 8);
-};
-pub const removefile_state_t = opaque {};
-pub extern fn removefileat(fd: c_int, path: [*c]const u8, state: ?*removefile_state_t, flags: u32) c_int;
-
 // As of Zig v0.11.0-dev.1393+38eebf3c4, ifaddrs.h is not included in the headers
 pub const ifaddrs = extern struct {
     ifa_next: ?*ifaddrs,


### PR DESCRIPTION
### What does this PR do?

`removefileat` errors on write-protected files. We do not want that.

Fixes #5954 

Also fixes some test failures in bun-install caused

### How did you verify your code works?

Existing tests