### PR TITLE
Fix create command with template prefixed with @ char #6007

### DIFF
--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -23,7 +23,8 @@ pub const BunxCommand = struct {
 
         var new_str = try allocator.allocSentinel(u8, input.len + prefixLength, 0);
         if (input[0] == '@') {
-            if (strings.indexAnyComptime(input, "/")) |index| {
+            if (strings.indexAnyComptime(input, "/")) |slashIndex| {
+                const index = slashIndex + 1;
                 @memcpy(new_str[0..index], input[0..index]);
                 @memcpy(new_str[index .. index + prefixLength], "create-");
                 @memcpy(new_str[index + prefixLength ..], input[index..]);

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -1,0 +1,30 @@
+import { spawn } from "bun";
+import { afterEach, beforeEach, expect, it } from "bun:test";
+import { bunExe, bunEnv as env } from "harness";
+import { mkdtemp, realpath, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let x_dir: string;
+
+beforeEach(async () => {
+  x_dir = await realpath(await mkdtemp(join(tmpdir(), "bun-x.test")));
+});
+afterEach(async () => {
+  await rm(x_dir, { force: true, recursive: true });
+});
+
+it("should create selected template with @ prefix", async () => {
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "create", "@quick-start/some-template"],
+    cwd: x_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const err = await new Response(stderr).text();
+  expect(err.split(/\r?\n/)).toContain(`error: package "@quick-start/create-some-template" not found registry.npmjs.org/@quick-start%2fcreate-some-template 404`);
+});
+

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -25,6 +25,7 @@ it("should create selected template with @ prefix", async () => {
   });
 
   const err = await new Response(stderr).text();
-  expect(err.split(/\r?\n/)).toContain(`error: package "@quick-start/create-some-template" not found registry.npmjs.org/@quick-start%2fcreate-some-template 404`);
+  expect(err.split(/\r?\n/)).toContain(
+    `error: package "@quick-start/create-some-template" not found registry.npmjs.org/@quick-start%2fcreate-some-template 404`,
+  );
 });
-


### PR DESCRIPTION
### What does this PR do?

fix error when command `bun create <@some-template/template>` is executed, the command is appending a `create-` prefix wrongly.
For example:
`bun create @quick-start/electron`
tries to create with this template: `@quick-startcreate-/electron`

Fixes: https://github.com/oven-sh/bun/issues/6007
<!-- This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->
Typescript test of `create` command that check the error case with the correct template.
I couldn't add a test in `bunx_command.zig` because it fails when tries to find "root".bun file ([zig issue here](https://github.com/ziglang/zig/issues/17109)). 
- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
![image](https://github.com/oven-sh/bun/assets/87334103/abec8aeb-d192-47bb-9763-1c787a2bda9a)

