### PR TITLE
(console.log) Print className for an object if present

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2862,6 +2862,12 @@ pub const ZigConsoleClient = struct {
                         .parent = value,
                     };
 
+                    var class_name = ZigString.Empty;
+                    value.getClassName(this.globalThis, &class_name);
+                    if (class_name.len > 0 and !strings.eqlComptime(class_name.slice(), "Object")) {
+                        writer.print("{} ", .{class_name});
+                    }
+
                     if (this.depth > this.max_depth) {
                         if (this.always_newline_scope or this.goodTimeForANewLine()) {
                             writer.writeAll("\n");

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -36,7 +36,7 @@ Promise { <pending> }
 [Function]
 [class Foo]
 [class (anonymous)]
-{}
+Foo {}
 [Function: foooo]
 /FooRegex/
 Is it a bug or a feature that formatting numbers like 123 is colored
@@ -64,7 +64,7 @@ Set(1) {
   "foo",
 }
 ArrayBuffer(8) [ 0, 0, 0, 0, 0, 0, 0, 0 ]
-{
+FooWithFunc {
   a: 1,
   b: 2,
   test: [Function: test]

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -57,3 +57,15 @@ String 123 should be 2nd word, 456 == 456 and percent s %s == What okay
     }
   }
 }
+Map(1) {
+  "foo": "bar",
+}
+Set(1) {
+  "foo",
+}
+ArrayBuffer(8) [ 0, 0, 0, 0, 0, 0, 0, 0 ]
+{
+  a: 1,
+  b: 2,
+  test: [Function: test]
+}

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -72,3 +72,24 @@ const nestedObject = {
   },
 };
 console.log(nestedObject);
+
+const m = new Map();
+m.set("foo", "bar");
+console.log(m);
+
+const s = new Set();
+s.add("foo");
+console.log(s);
+
+const ab = new ArrayBuffer(8);
+console.log(ab);
+
+class FooWithFunc {
+  a = 1;
+  b = 2;
+  test() {
+    return 3;
+  }
+}
+
+console.log(new FooWithFunc());


### PR DESCRIPTION
### What does this PR do?

This adds the functionality to print Object's class name if it exists matching Node's functionality. 

As well as adding adding tests for printing Maps, Sets and ArrayBuffers.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

- [X] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [X] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I or my editor ran `zig fmt` on the changed files
- [X] I included a test for the new code, or an existing test covers it