### PR TITLE
Add fs.statfs{Sync} to missing fs apis

### DIFF
--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -54,7 +54,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:fs`](https://nodejs.org/api/fs.html)
 
-🟡 Missing `fs.fdatasync{Sync}` `fs.opendir{Sync}`. `fs.promises.open` incorrectly returns a file descriptor instead of a `FileHandle`.
+🟡 Missing `fs.fdatasync{Sync}` `fs.opendir{Sync}`, `fs.statfs{Sync}`. `fs.promises.open` incorrectly returns a file descriptor instead of a `FileHandle`.
 
 ### [`node:http`](https://nodejs.org/api/http.html)
 


### PR DESCRIPTION
### What does this PR do?
In title

Tested via script
```js
import * as fs from 'fs'

// Object.keys(fs) in node
const targetProperties = [
  "appendFile",
  "appendFileSync",
  "access",
  "accessSync",
  "chown",
  "chownSync",
  "chmod",
  "chmodSync",
  "close",
  "closeSync",
  "copyFile",
  "copyFileSync",
  "cp",
  "cpSync",
  "createReadStream",
  "createWriteStream",
  "exists",
  "existsSync",
  "fchown",
  "fchownSync",
  "fchmod",
  "fchmodSync",
  "fdatasync",
  "fdatasyncSync",
  "fstat",
  "fstatSync",
  "fsync",
  "fsyncSync",
  "ftruncate",
  "ftruncateSync",
  "futimes",
  "futimesSync",
  "lchown",
  "lchownSync",
  "lchmod",
  "lchmodSync",
  "link",
  "linkSync",
  "lstat",
  "lstatSync",
  "lutimes",
  "lutimesSync",
  "mkdir",
  "mkdirSync",
  "mkdtemp",
  "mkdtempSync",
  "open",
  "openSync",
  "openAsBlob",
  "readdir",
  "readdirSync",
  "read",
  "readSync",
  "readv",
  "readvSync",
  "readFile",
  "readFileSync",
  "readlink",
  "readlinkSync",
  "realpath",
  "realpathSync",
  "rename",
  "renameSync",
  "rm",
  "rmSync",
  "rmdir",
  "rmdirSync",
  "stat",
  "statfs",
  "statSync",
  "statfsSync",
  "symlink",
  "symlinkSync",
  "truncate",
  "truncateSync",
  "unwatchFile",
  "unlink",
  "unlinkSync",
  "utimes",
  "utimesSync",
  "watch",
  "watchFile",
  "writeFile",
  "writeFileSync",
  "write",
  "writeSync",
  "writev",
  "writevSync",
  "Dirent",
  "Stats",
  "ReadStream",
  "WriteStream",
  "FileReadStream",
  "FileWriteStream",
  "_toUnixTimestamp",
  "Dir",
  "opendir",
  "opendirSync",
  "F_OK",
  "R_OK",
  "W_OK",
  "X_OK",
  "constants",
  "promises",
  "default"
]


for (const property of targetProperties) {
  if (!Object.hasOwn(fs, property)) {
    console.log(`Property not found in bun:fs`, property)
  }
}
```
```
Property not found in bun:fs fdatasync
Property not found in bun:fs fdatasyncSync
Property not found in bun:fs openAsBlob
Property not found in bun:fs statfs
Property not found in bun:fs statfsSync
Property not found in bun:fs FileReadStream
Property not found in bun:fs FileWriteStream
Property not found in bun:fs Dir
Property not found in bun:fs opendir
Property not found in bun:fs opendirSync
Property not found in bun:fs F_OK
Property not found in bun:fs R_OK
Property not found in bun:fs W_OK
Property not found in bun:fs X_OK
```


This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
