### PR TITLE
Make error message for `new URL(invalid)` better

### DIFF
--- a/src/bun.js/bindings/DOMURL.cpp
+++ b/src/bun.js/bindings/DOMURL.cpp
@@ -58,15 +58,15 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const URL& base)
     ASSERT(base.isValid() || base.isNull());
     URL completeURL { base, url };
     if (!completeURL.isValid())
-        return Exception { TypeError };
+        return Exception { TypeError, makeString("\"", url, "\" cannot be parsed as a URL.") };
     return adoptRef(*new DOMURL(WTFMove(completeURL), base));
 }
 
 ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const String& base)
 {
-    URL baseURL { URL {}, base };
+    URL baseURL { base };
     if (!base.isNull() && !baseURL.isValid())
-        return Exception { TypeError };
+        return Exception { TypeError, makeString("\"", url, "\" cannot be parsed as a URL against \"", base, "\".") };
     return create(url, baseURL);
 }
 
@@ -79,7 +79,7 @@ ExceptionOr<void> DOMURL::setHref(const String& url)
 {
     URL completeURL { URL {}, url };
     if (!completeURL.isValid())
-        return Exception { TypeError };
+        return Exception { TypeError, makeString("\"", url, "\" cannot be parsed as a URL.") };
     m_url = WTFMove(completeURL);
     if (m_searchParams)
         m_searchParams->updateFromAssociatedURL();

--- a/src/bun.js/bindings/DOMURL.cpp
+++ b/src/bun.js/bindings/DOMURL.cpp
@@ -36,6 +36,14 @@
 
 namespace WebCore {
 
+static inline String redact(const String& input)
+{
+    if (input.contains("@"_s))
+        return "<redacted>"_s;
+
+    return makeString('"', input, '"');
+}
+
 inline DOMURL::DOMURL(URL&& completeURL, const URL& baseURL)
     : m_baseURL(baseURL)
     , m_url(WTFMove(completeURL))
@@ -58,7 +66,7 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const URL& base)
     ASSERT(base.isValid() || base.isNull());
     URL completeURL { base, url };
     if (!completeURL.isValid())
-        return Exception { TypeError, makeString("\"", url, "\" cannot be parsed as a URL.") };
+        return Exception { TypeError, makeString(redact(url), " cannot be parsed as a URL.") };
     return adoptRef(*new DOMURL(WTFMove(completeURL), base));
 }
 
@@ -66,7 +74,7 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const String& base)
 {
     URL baseURL { base };
     if (!base.isNull() && !baseURL.isValid())
-        return Exception { TypeError, makeString("\"", url, "\" cannot be parsed as a URL against \"", base, "\".") };
+        return Exception { TypeError, makeString(redact(url), " cannot be parsed as a URL against "_s, redact(base)) };
     return create(url, baseURL);
 }
 
@@ -78,8 +86,10 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const DOMURL& base)
 ExceptionOr<void> DOMURL::setHref(const String& url)
 {
     URL completeURL { URL {}, url };
-    if (!completeURL.isValid())
-        return Exception { TypeError, makeString("\"", url, "\" cannot be parsed as a URL.") };
+    if (!completeURL.isValid()) {
+
+        return Exception { TypeError, makeString(redact(url), " cannot be parsed as a URL.") };
+    }
     m_url = WTFMove(completeURL);
     if (m_searchParams)
         m_searchParams->updateFromAssociatedURL();

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -7,6 +7,11 @@ describe("url", () => {
     expect(() => new URL("boop", "http!/example.com")).toThrow(
       '"boop" cannot be parsed as a URL against "http!/example.com"',
     );
+
+    // redact
+    expect(() => new URL("boop", "https!!username:password@example.com")).toThrow(
+      '"boop" cannot be parsed as a URL against <redacted>',
+    );
   });
 
   it("should have correct origin and protocol", () => {

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from "bun:test";
 
 describe("url", () => {
+  it("URL throws", () => {
+    expect(() => new URL("")).toThrow('"" cannot be parsed as a URL');
+    expect(() => new URL(" ")).toThrow('" " cannot be parsed as a URL');
+    expect(() => new URL("boop", "http!/example.com")).toThrow(
+      '"boop" cannot be parsed as a URL against "http!/example.com"',
+    );
+  });
+
   it("should have correct origin and protocol", () => {
     var url = new URL("https://example.com");
     expect(url.protocol).toBe("https:");


### PR DESCRIPTION
Thanks to @karlcow https://github.com/WebKit/WebKit/pull/13802

### What does this PR do?

Improve error message for `new URL(invalid)`

### How did you verify your code works?

Test