### PR TITLE
fix: support console.dir options object correctly

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -987,9 +987,9 @@ pub const ZigConsoleClient = struct {
 
         var print_length = len;
         var print_options: FormatOptions = .{
-                    .enable_colors = enable_colors,
-                    .add_newline = true,
-                    .flush = true,
+            .enable_colors = enable_colors,
+            .add_newline = true,
+            .flush = true,
         };
 
         if (message_type == .Dir and len >= 2) {
@@ -999,7 +999,7 @@ pub const ZigConsoleClient = struct {
                 var depth_prop = opts.get(global, "depth") orelse JSValue.zero;
                 if (depth_prop.isNumber())
                     print_options.max_depth = depth_prop.toU16();
-                if(depth_prop.isNull())
+                if (depth_prop.isNull())
                     print_options.max_depth = std.math.maxInt(u16);
                 var colors_option = opts.get(global, "colors") orelse JSValue.zero;
                 if (colors_option.isBoolean())

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -996,14 +996,16 @@ pub const ZigConsoleClient = struct {
             print_length = 1;
             var opts = vals[1];
             if (opts.isObject()) {
-                var depth_prop = opts.get(global, "depth") orelse JSValue.zero;
-                if (depth_prop.isNumber())
-                    print_options.max_depth = depth_prop.toU16();
-                if (depth_prop.isNull())
-                    print_options.max_depth = std.math.maxInt(u16);
-                var colors_option = opts.get(global, "colors") orelse JSValue.zero;
-                if (colors_option.isBoolean())
-                    print_options.enable_colors = colors_option.toBoolean();
+                if (opts.get(global, "depth")) |depth_prop| {
+                    if (depth_prop.isNumber())
+                        print_options.max_depth = depth_prop.toU16();
+                    if (depth_prop.isNull() or depth_prop.toInt64() == std.math.maxInt(i64))
+                        print_options.max_depth = std.math.maxInt(u16);
+                }
+                if (opts.get(global, "colors")) |colors_prop| {
+                    if (colors_prop.isBoolean())
+                        print_options.enable_colors = colors_prop.toBoolean();
+                }
             }
         }
 

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -57,3 +57,6 @@ String 123 should be 2nd word, 456 == 456 and percent s %s == What okay
     }
   }
 }
+{
+  "1": [Object ...]
+}

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -60,3 +60,18 @@ String 123 should be 2nd word, 456 == 456 and percent s %s == What okay
 {
   "1": [Object ...]
 }
+{
+  "1": [Object ...]
+}
+{
+  "1": {
+    "2": [Object ...]
+  }
+}
+{
+  "1": {
+    "2": {
+      "3": 3
+    }
+  }
+}

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -73,3 +73,6 @@ const nestedObject = {
 };
 console.log(nestedObject);
 console.dir({ 1: { 2: { 3: 3 } } }, { depth: 0, colors: false }, "Some ignored arg");
+console.dir({ 1: { 2: { 3: 3 } } }, { depth: -1, colors: false }, "Some ignored arg");
+console.dir({ 1: { 2: { 3: 3 } } }, { depth: 1.2, colors: false }, "Some ignored arg");
+console.dir({ 1: { 2: { 3: 3 } } }, { depth: Infinity, colors: false }, "Some ignored arg");

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -72,3 +72,4 @@ const nestedObject = {
   },
 };
 console.log(nestedObject);
+console.dir({ 1: { 2: { 3: 3 } } }, { depth: 0, colors: false }, "Some ignored arg");


### PR DESCRIPTION
`console.dir` can be passed a second argument which is a object of options. This implements that logic with the currently supported properties: `depth` and `colors`.
I used node as a reference for implementation details.

Fixes: https://github.com/oven-sh/bun/issues/6039

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be

- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
