### PR TITLE
fix: Docker - Include `bunx` symlink in distroless variant

### DIFF
--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -52,16 +52,16 @@ RUN apt-get update -qq \
     && mv "bun-linux-$build/bun" /usr/local/bin/bun \
     && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \
     && chmod +x /usr/local/bin/bun \
+    && ln -s /usr/local/bin/bun /usr/local/bin/bunx \
     && which bun \
+    && which bunx \
     && bun --version
 
 FROM gcr.io/distroless/base-nossl-debian11
 
-COPY --from=build /usr/local/bin/bun /usr/local/bin/
-
-# Known issue: `bunx` is not available in distroless.
-#
-# If `ln` is used in the build image, the size of the final
-# image will be double, because of: https://github.com/oven-sh/bun/issues/5269
+# List of sources to destination (final path):
+COPY --from=build \
+  /usr/local/bin/bun /usr/local/bin/bunx \
+  /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/bun"]


### PR DESCRIPTION
### What does this PR do?

Seems [my suggestion](https://github.com/oven-sh/bun/issues/5269#issuecomment-1724856820) was missed. Keeps consistent with other images by including `bunx` symlink.

I saw the merged PR and [commented about making this change](https://github.com/oven-sh/bun/pull/5771/files#r1337887524). I figured I might as well raise a PR for it while I'm at it 😅 

### How did you verify your code works?

Comparision:

```console
# Resolved with single COPY, symlink works:
$ docker save local-bun-build | gzip -c | wc -c | numfmt --to iec
40M

# The duplicate issue that previously existed:
$ docker save oven/bun | gzip -c | wc -c | numfmt --to iec
97M

# Resolved vs original image size:
$ docker images
REPOSITORY                  TAG                IMAGE ID       CREATED          SIZE
local-bun-build             latest             020acf83835e   7 minutes ago    110MB
oven/bun                    latest             647ebb4444b7   3 days ago       271MB
```

Full information: https://github.com/oven-sh/bun/issues/5269#issuecomment-1724856820