### PR TITLE
fix workspace dependency install

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2682,7 +2682,11 @@ pub const PackageManager = struct {
             },
             .workspace => {
                 // relative to cwd
-                const workspace_path: *const String = this.lockfile.workspace_paths.getPtr(@truncate(String.Builder.stringHash(this.lockfile.str(&version.value.workspace)))) orelse &version.value.workspace;
+                // if the workspace name is '*', use the name of the dependency itself
+                const workspace_name = this.lockfile.str(&version.value.workspace);
+                const workspace_hash = if (strings.eqlComptime(workspace_name, "*")) name_hash else String.Builder.stringHash(workspace_name);
+
+                const workspace_path: *const String = this.lockfile.workspace_paths.getPtr(@truncate(workspace_hash)) orelse &version.value.workspace;
 
                 const res = FolderResolution.getOrPut(.{ .relative = .workspace }, version, this.lockfile.str(workspace_path), this);
 
@@ -2956,7 +2960,7 @@ pub const PackageManager = struct {
         const name = dependency.realname();
 
         const name_hash = switch (dependency.version.tag) {
-            .dist_tag, .git, .github, .npm, .tarball => String.Builder.stringHash(this.lockfile.str(&name)),
+            .dist_tag, .git, .github, .npm, .tarball, .workspace => String.Builder.stringHash(this.lockfile.str(&name)),
             else => dependency.name_hash,
         };
         const version = dependency.version;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2681,12 +2681,8 @@ pub const PackageManager = struct {
                 }
             },
             .workspace => {
-                // relative to cwd
-                // if the workspace name is '*', use the name of the dependency itself
-                const workspace_name = this.lockfile.str(&version.value.workspace);
-                const workspace_hash = if (strings.eqlComptime(workspace_name, "*")) name_hash else String.Builder.stringHash(workspace_name);
-
-                const workspace_path: *const String = this.lockfile.workspace_paths.getPtr(@truncate(workspace_hash)) orelse &version.value.workspace;
+                // package name hash should be used to find workspace path from map
+                const workspace_path: *const String = this.lockfile.workspace_paths.getPtr(@truncate(name_hash)) orelse &version.value.workspace;
 
                 const res = FolderResolution.getOrPut(.{ .relative = .workspace }, version, this.lockfile.str(workspace_path), this);
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -5496,6 +5496,7 @@ it("should handle installing packages inside workspaces with difference versions
     });
     await writeFile(join(package_dir, "packages", "package5", "package.json"), package5);
   }
+
   const {
     stdout: stdout1,
     stderr: stderr1,
@@ -5525,6 +5526,32 @@ it("should handle installing packages inside workspaces with difference versions
   expect(requested).toBe(0);
   await access(join(package_dir, "bun.lockb"));
 
+  var urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+
+  const {
+    stdout: stdout1_2,
+    stderr: stderr1_2,
+    exited: exited1_2,
+  } = spawn({
+    cmd: [bunExe(), "install", "bar"],
+    cwd: join(package_dir, "packages", "package2"),
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr1_2).toBeDefined();
+  expect(stderr1_2).toBeDefined();
+  const err1_2 = await new Response(stderr1_2).text();
+  expect(err1_2).toContain("Saved lockfile");
+  expect(stdout1_2).toBeDefined();
+  const out1_2 = await new Response(stdout1_2).text();
+  expect(out1_2).toContain("installed bar");
+  expect(await exited1_2).toBe(0);
+  expect(urls.sort()).toEqual([`${root_url}/bar`, `${root_url}/bar-0.0.2.tgz`]);
+  await access(join(package_dir, "bun.lockb"));
+
   await rm(join(package_dir, "node_modules"), { force: true, recursive: true });
   await rm(join(package_dir, "bun.lockb"), { force: true, recursive: true });
 
@@ -5552,9 +5579,30 @@ it("should handle installing packages inside workspaces with difference versions
     " + package4@workspace:packages/package4",
     " + package5@workspace:packages/package5",
     "",
-    " 5 packages installed",
+    " 6 packages installed",
   ]);
   expect(await exited2).toBe(0);
+
+  const {
+    stdout: stdout2_2,
+    stderr: stderr2_2,
+    exited: exited2_2,
+  } = spawn({
+    cmd: [bunExe(), "install", "bar"],
+    cwd: join(package_dir, "packages", "package3"),
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr2_2).toBeDefined();
+  expect(stderr2_2).toBeDefined();
+  const err2_2 = await new Response(stderr2_2).text();
+  expect(err2_2).toContain("Saved lockfile");
+  expect(stdout2_2).toBeDefined();
+  const out2_2 = await new Response(stdout2_2).text();
+  expect(out2_2).toContain("installed bar");
+  expect(await exited2_2).toBe(0);
   await access(join(package_dir, "bun.lockb"));
 
   await rm(join(package_dir, "node_modules"), { force: true, recursive: true });
@@ -5584,9 +5632,30 @@ it("should handle installing packages inside workspaces with difference versions
     " + package4@workspace:packages/package4",
     " + package5@workspace:packages/package5",
     "",
-    " 5 packages installed",
+    " 6 packages installed",
   ]);
   expect(await exited3).toBe(0);
+
+  const {
+    stdout: stdout3_2,
+    stderr: stderr3_2,
+    exited: exited3_2,
+  } = spawn({
+    cmd: [bunExe(), "install", "bar"],
+    cwd: join(package_dir, "packages", "package4"),
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr3_2).toBeDefined();
+  expect(stderr3_2).toBeDefined();
+  const err3_2 = await new Response(stderr3_2).text();
+  expect(err3_2).toContain("Saved lockfile");
+  expect(stdout3_2).toBeDefined();
+  const out3_2 = await new Response(stdout3_2).text();
+  expect(out3_2).toContain("installed bar");
+  expect(await exited3_2).toBe(0);
   await access(join(package_dir, "bun.lockb"));
 
   await rm(join(package_dir, "node_modules"), { force: true, recursive: true });
@@ -5616,9 +5685,30 @@ it("should handle installing packages inside workspaces with difference versions
     " + package4@workspace:packages/package4",
     " + package5@workspace:packages/package5",
     "",
-    " 5 packages installed",
+    " 6 packages installed",
   ]);
   expect(await exited4).toBe(0);
+
+  const {
+    stdout: stdout4_2,
+    stderr: stderr4_2,
+    exited: exited4_2,
+  } = spawn({
+    cmd: [bunExe(), "install", "bar"],
+    cwd: join(package_dir, "packages", "package5"),
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr4_2).toBeDefined();
+  expect(stderr4_2).toBeDefined();
+  const err4_2 = await new Response(stderr4_2).text();
+  expect(err4_2).toContain("Saved lockfile");
+  expect(stdout4_2).toBeDefined();
+  const out4_2 = await new Response(stdout4_2).text();
+  expect(out4_2).toContain("installed bar");
+  expect(await exited4_2).toBe(0);
   await access(join(package_dir, "bun.lockb"));
 
   // from the root
@@ -5649,9 +5739,30 @@ it("should handle installing packages inside workspaces with difference versions
     " + package4@workspace:packages/package4",
     " + package5@workspace:packages/package5",
     "",
-    " 5 packages installed",
+    " 6 packages installed",
   ]);
   expect(await exited5).toBe(0);
+
+  const {
+    stdout: stdout5_2,
+    stderr: stderr5_2,
+    exited: exited5_2,
+  } = spawn({
+    cmd: [bunExe(), "install", "bar"],
+    cwd: join(package_dir),
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr5_2).toBeDefined();
+  expect(stderr5_2).toBeDefined();
+  const err5_2 = await new Response(stderr5_2).text();
+  expect(err5_2).toContain("Saved lockfile");
+  expect(stdout5_2).toBeDefined();
+  const out5_2 = await new Response(stdout5_2).text();
+  expect(out5_2).toContain("installed bar");
+  expect(await exited5_2).toBe(0);
   await access(join(package_dir, "bun.lockb"));
 });
 


### PR DESCRIPTION
### What does this PR do?
fixes #5926 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
added a test and tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
