### PR TITLE
fix: Docker - Apply workaround with `RUN` to symlink `bunx`

### DIFF
--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -52,16 +52,18 @@ RUN apt-get update -qq \
     && mv "bun-linux-$build/bun" /usr/local/bin/bun \
     && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \
     && chmod +x /usr/local/bin/bun \
-    && ln -s /usr/local/bin/bun /usr/local/bin/bunx \
     && which bun \
-    && which bunx \
     && bun --version
 
 FROM gcr.io/distroless/base-nossl-debian11
 
-# List of sources to destination (final path):
-COPY --from=build \
-  /usr/local/bin/bun /usr/local/bin/bunx \
-  /usr/local/bin/
+COPY --from=build /usr/local/bin/bun /usr/local/bin/
+
+# Temporarily use the `build`-stage image binaries to create a symlink:
+RUN --mount=type=bind,from=build,source=/usr/bin,target=/usr/bin \
+    --mount=type=bind,from=build,source=/bin,target=/bin <<EOF
+  ln -s /usr/local/bin/bun /usr/local/bin/bunx
+  which bunx
+EOF
 
 ENTRYPOINT ["/usr/local/bin/bun"]


### PR DESCRIPTION
### What does this PR do?

In the [previous attempt to resolve this](https://github.com/oven-sh/bun/pull/6090), I mistakenly missed a `/` for the destination and did not properly test `bunx` actually ran.

This was resolved, but [doubled the size again](https://github.com/oven-sh/bun/issues/5269#issuecomment-1736887598) as Docker is resolving the symlink when copying 😞 

I [remembered a technique I proposed for `testssl.sh`](https://github.com/drwetter/testssl.sh/pull/2344/commits/1392987f01b748021cda4e98cbaf8e151c2f9a32#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R69-R84) when revising their `Dockerfile`. Even though it was only required for building the images, the [maintainer decision was the features used were too new](https://github.com/drwetter/testssl.sh/issues/2299#issuecomment-1479094496):
- `RUN --mount` requires a [Docker Engine release from 2022H2 (with BuildKit)](https://github.com/drwetter/testssl.sh/issues/2299#issuecomment-1479136828).
- HereDoc (_[introduced support in 2021H2](https://github.com/drwetter/testssl.sh/issues/2299#issuecomment-1478863039)_).

---

Using [`RUN --mount`](https://docs.docker.com/engine/reference/builder/#run---mounttypebind), we can run the command with the build stage files overlayed for the `ln` and `which` commands.

**NOTE:** The mounted `/bin` is a symlink to `/usr/bin`, both seem required to work correctly.

### How did you verify your code works?

Runs with the [same output now as the `bun x` command](https://github.com/oven-sh/bun/issues/5269#issuecomment-1736916694):

```console
$ docker buildx build -t bun-small .

$ docker run --rm -it --entrypoint /usr/local/bin/bunx bun-small eslint --version
error: Failed to run "eslint" due to error FileNotFound
```

But is still smaller:
```console
$ docker images
REPOSITORY   TAG          IMAGE ID       CREATED         SIZE
bun-small    latest       387d3d1f0c9f   3 minutes ago   110MB
oven/bun     distroless   f649763a2ca5   5 hours ago     205MB

$ docker save bun-small | gzip -c | wc -c | numfmt --to iec
40M
```
