### PR TITLE
fix(bun install): Handle vercel and github tarball path dependencies

### DIFF
--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -233,7 +233,7 @@ pub inline fn isGitHubTarballPath(dependency: string) bool {
 
     while (parts.next()) |part| {
         n_parts += 1;
-        if (n_parts == 3 and !part.eql("tarball")) {
+        if (n_parts == 3 and !strings.eql(part, "tarball")) {
             return false;
         } else if (n_parts > 4) {
             return false;

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -223,11 +223,11 @@ pub inline fn isGitHubRepoPath(dependency: string) bool {
 
 // Github allows for the following format of URL:
 // https://github.com/<org>/<repo>/tarball/<ref>
-// This is a legacy (but still supported) method of retrieiving a tarball of an
+// This is a legacy (but still supported) method of retrieving a tarball of an
 // entire source tree at some git reference. (branch, tag, etc)
 // The function expects "https://github.com/" is already stripped from the string
 pub inline fn isGitHubTarballPath(dependency: string) bool {
-    var parts = dependency.split("/");
+    var parts = strings.split(dependency, "/");
 
     var n_parts: usize = 0;
 


### PR DESCRIPTION
package.json dependency entries like:

```
"when": "https://github.com/cujojs/when/tarball/1.0.2"
```

and

```
"@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-230922.2"
```

are both links to tarballs. In the github case, this is a URL pattern, and in the vercel case, this seems to be everything served from their server.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
