### PR TITLE
Update to example for creating a nextjs app with Bun

### DIFF
--- a/docs/guides/ecosystem/nextjs.md
+++ b/docs/guides/ecosystem/nextjs.md
@@ -11,7 +11,7 @@ The Next.js [App Router](https://nextjs.org/docs/app) currently relies on Node.j
 Initialize a Next.js app with `create-next-app`. This automatically installs dependencies using `npm`.
 
 ```sh
-$ bun create next-app
+$ bunx create-next-app
 ✔ What is your project named? … my-app
 ✔ Would you like to use TypeScript with this project? … No / Yes
 ✔ Would you like to use ESLint with this project? … No / Yes


### PR DESCRIPTION


### What does this PR do?
Updates the NextJS app creation example to use "bunx create-next-app" as the existing "bun create next-app" does not work.

