### PR TITLE
fix typescript metadata for import identifiers

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -19597,12 +19597,21 @@ fn NewParser_(
                         i -= 1;
                     }
 
-                    current_expr.* = p.newExpr(
-                        E.Identifier{
-                            .ref = refs.items[0],
-                        },
-                        logger.Loc.Empty,
-                    );
+                    if (p.is_import_item.contains(refs.items[0])) {
+                        current_expr.* = p.newExpr(
+                            E.ImportIdentifier{
+                                .ref = refs.items[0],
+                            },
+                            logger.Loc.Empty,
+                        );
+                    } else {
+                        current_expr.* = p.newExpr(
+                            E.Identifier{
+                                .ref = refs.items[0],
+                            },
+                            logger.Loc.Empty,
+                        );
+                    }
 
                     const dot_identifier = current_expr.*;
                     var current_dot = dots;

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -19556,6 +19556,15 @@ fn NewParser_(
 
                 .m_identifier => |ref| {
                     p.recordUsage(ref);
+                    if (p.is_import_item.contains(ref)) {
+                        return p.maybeDefinedHelper(p.newExpr(
+                            E.ImportIdentifier{
+                                .ref = ref,
+                            },
+                            logger.Loc.Empty,
+                        ));
+                    }
+
                     return p.maybeDefinedHelper(p.newExpr(
                         E.Identifier{ .ref = ref },
                         logger.Loc.Empty,

--- a/test/bundler/bundler_decorator_metadata.test.ts
+++ b/test/bundler/bundler_decorator_metadata.test.ts
@@ -503,3 +503,37 @@ itBundled("decorator_metadata/TypeSerialization", {
     stdout: "true\n".repeat(212),
   },
 });
+
+itBundled("decorator_metadata/ImportIdentifiers", {
+  files: {
+    "/entry.ts": /* ts */ `
+        import "reflect-metadata";
+        import { Foo } from "./foo.js";
+
+        function d1() {}
+
+        @d1
+        class Bar {
+            constructor(foo: Foo) {}
+        }
+
+        console.log(Reflect.getMetadata("design:paramtypes", Bar)[0] === Foo);
+    `,
+    "/foo.js": /* js */ `
+        const f = () => "Foo";
+        module.exports[f()] = class Foo {};
+    `,
+    "/tsconfig.json": /* json */ `
+        {
+            "compilerOptions": {
+                "experimentalDecorators": true,
+                "emitDecoratorMetadata": true,
+            }
+        }
+    `,
+  },
+  install: ["reflect-metadata"],
+  run: {
+    stdout: "true\n",
+  },
+});


### PR DESCRIPTION
### What does this PR do?
fixes #6088
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
added test and tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
