### PR TITLE
Fix bug causing "Connection Refused" errors

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -691,7 +691,7 @@ static int bsd_do_connect(struct addrinfo *rp, int *fd)
         }
 
         int resultFd = bsd_create_socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-        if (resultFd == LIBUS_SOCKET_ERROR) {
+        if (resultFd < 0) {
             return -1;
         }
         *fd = resultFd;

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -737,7 +737,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(const char *host, int port, co
             return LIBUS_SOCKET_ERROR;
         }
     } else {
-        if (bsd_do_connect(result, &fd) != 0 && errno != EINPROGRESS) {
+        if (bsd_do_connect(result, &fd) != 0) {
             freeaddrinfo(result);
             return LIBUS_SOCKET_ERROR;
         }

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -731,7 +731,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(const char *host, int port, co
             }
         }
 
-        if (bsd_do_connect_raw(result, fd) != 0 && errno != EINPROGRESS) {
+        if (bsd_do_connect_raw(result, fd) != 0) {
             bsd_close_socket(fd);
             freeaddrinfo(result);
             return LIBUS_SOCKET_ERROR;

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -687,12 +687,12 @@ static int bsd_do_connect(struct addrinfo *rp, int *fd)
         bsd_close_socket(*fd);
 
         if (rp == NULL) {
-            return -1;
+            return LIBUS_SOCKET_ERROR;
         }
 
         int resultFd = bsd_create_socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
         if (resultFd < 0) {
-            return -1;
+            return LIBUS_SOCKET_ERROR;
         }
         *fd = resultFd;
     }

--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -1343,7 +1343,7 @@ pub const InternalState = struct {
         return this.transfer_encoding == Encoding.chunked;
     }
 
-    pub fn reset(this: *InternalState, buffering: bool, allocator: std.mem.Allocator) void {
+    pub fn reset(this: *InternalState, allocator: std.mem.Allocator) void {
         this.compressed_body.deinit();
         this.response_message_buffer.deinit();
 
@@ -1352,12 +1352,6 @@ pub const InternalState = struct {
         if (this.zlib_reader) |reader| {
             this.zlib_reader = null;
             reader.deinit();
-        }
-
-        if (!buffering) {
-            // if we are holding a cloned_metadata we need to deinit it
-            // this should never happen because we should always return the metadata to the user
-            std.debug.assert(this.cloned_metadata == null);
         }
 
         // just in case we check and free to avoid leaks
@@ -2186,7 +2180,7 @@ pub fn doRedirect(this: *HTTPClient) void {
         this.fail(error.TooManyRedirects);
         return;
     }
-    this.state.reset(this.signals.isEmpty(), this.allocator);
+    this.state.reset(this.allocator);
     // also reset proxy to redirect
     this.proxy_tunneling = false;
     if (this.proxy_tunnel != null) {
@@ -2907,7 +2901,7 @@ fn fail(this: *HTTPClient, err: anyerror) void {
         _ = socket_async_http_abort_tracker.swapRemove(this.async_http_id);
     }
 
-    this.state.reset(this.signals.isEmpty(), this.allocator);
+    this.state.reset(this.allocator);
     this.proxy_tunneling = false;
 
     this.state.request_stage = .fail;
@@ -2993,7 +2987,7 @@ pub fn progressUpdate(this: *HTTPClient, comptime is_ssl: bool, ctx: *NewHTTPCon
                 socket.close(0, null);
             }
 
-            this.state.reset(this.signals.isEmpty(), this.allocator);
+            this.state.reset(this.allocator);
             this.state.response_stage = .done;
             this.state.request_stage = .done;
             this.state.stage = .done;


### PR DESCRIPTION
### What does this PR do?

"Connection refused" and connection timeouts can be caused by the first initial socket address returned in `getaddrinfo` being unable to connect. So we must loop through the linked list of socket addresses returned to find one which does successfully connect. This PR does that. Previously, we were not doing that.

This is likely to fix the following, but these are all difficult to reproduce so it's pretty hard to know for sure.

Fixes #4066
Fixes #6204
Fixes #5548
Fixes #6101
Fixes #4832



### How did you verify your code works?

Existing tests