### PR TITLE
fix(node:process): fix return value of `process.kill`

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -681,7 +681,7 @@ interface Process {
    */
   setSourceMapsEnabled(enabled: boolean): void;
 
-  kill(pid: number, signal?: string | number): void;
+  kill(pid: number, signal?: string | number): true;
 
   on(event: "beforeExit", listener: BeforeExitListener): this;
   // on(event: "disconnect", listener: DisconnectListener): this;

--- a/src/bun.js/bindings/Process.cpp
+++ b/src/bun.js/bindings/Process.cpp
@@ -1835,7 +1835,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionKill,
         return JSValue::encode(jsUndefined());
     }
 
-    return JSValue::encode(jsUndefined());
+    return JSValue::encode(jsBoolean(true));
 }
 
 extern "C" void Process__emitMessageEvent(Zig::GlobalObject* global, EncodedJSValue value)

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -407,7 +407,8 @@ describe("signal", () => {
       stdout: "pipe",
     });
     const prom = child.exited;
-    process.kill(child.pid, "SIGTERM");
+    const ret = process.kill(child.pid, "SIGTERM");
+    expect(ret).toBe(true);
     await prom;
     expect(child.signalCode).toBe("SIGTERM");
   });
@@ -418,7 +419,8 @@ describe("signal", () => {
       stdout: "pipe",
     });
     const prom = child.exited;
-    process.kill(child.pid, 9);
+    const ret = process.kill(child.pid, 9);
+    expect(ret).toBe(true);
     await prom;
     expect(child.signalCode).toBe("SIGKILL");
   });


### PR DESCRIPTION
### What does this PR do?

`process.kill` should return `true` on success, not `undefined`. It affected some code used to test for the existence of a process. e.g.
 
```JavaScript
function processExist(pid) {
  try {
    return kill(pid, 0);
  } catch {
    return false;
  }
}

console.log(processExist(process.pid));
console.log(processExist(234234));
```

Ref: https://github.com/nodejs/node/blob/092fb9f541ce8cc07289b5a69eb93892445739f5/lib/internal/process/per_thread.js#L211-L237



- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
