### PR TITLE
Warn at start when using AVX build of Bun without AVX support

### DIFF
--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -83,7 +83,9 @@ pub const Version = struct {
     pub const triplet = platform_label ++ "-" ++ arch_label;
     const suffix = if (Environment.baseline) "-baseline" else "";
     pub const folder_name = "bun-" ++ triplet ++ suffix;
+    pub const baseline_folder_name = "bun-" ++ triplet ++ "-baseline";
     pub const zip_filename = folder_name ++ ".zip";
+    pub const baseline_zip_filename = baseline_folder_name ++ ".zip";
 
     pub const profile_folder_name = "bun-" ++ triplet ++ suffix ++ "-profile";
     pub const profile_zip_filename = profile_folder_name ++ ".zip";
@@ -93,6 +95,11 @@ pub const Version = struct {
     pub export const Bun__githubURL: [*:0]const u8 = std.fmt.comptimePrint("https://github.com/oven-sh/bun/release/bun-v{s}/{s}", .{
         Global.package_json_version,
         zip_filename,
+    });
+
+    pub const Bun__githubBaselineURL: [:0]const u8 = std.fmt.comptimePrint("https://github.com/oven-sh/bun/release/bun-v{s}/{s}", .{
+        Global.package_json_version,
+        baseline_zip_filename,
     });
 
     pub fn isCurrent(this: Version) bool {


### PR DESCRIPTION
### What does this PR do?

This PR adds a warning on start when the SIMD-enabled build of Bun is used on a CPU that lacks SIMD support


When using a SIMD-enabled build of Bun when the CPU doesn't support SIMD, Bun may crash with an "Illegal Instruction" error and no other explanation

We detect this in the install scripts, but it doesn't always seem to work and Zig doesn't support multi function versioning (https://github.com/ziglang/zig/issues/1018). 


### How did you verify your code works?

Manual