### PR TITLE
Fix `bun install` reading Github API from wrong environment variable

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2146,7 +2146,7 @@ pub const PackageManager = struct {
             this.allocator,
             "{s}/repos/{s}/{s}{s}tarball/{s}",
             .{
-                github_api_url,
+                strings.withoutTrailingSlash(github_api_url),
                 owner,
                 repo,
                 // repo might be empty if dep is https://github.com/... style

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2131,10 +2131,10 @@ pub const PackageManager = struct {
     }
 
     fn allocGitHubURL(this: *const PackageManager, repository: *const Repository) string {
-        var github_api_domain: string = "api.github.com";
-        if (this.env.map.get("GITHUB_API_DOMAIN")) |api_domain| {
-            if (api_domain.len > 0) {
-                github_api_domain = api_domain;
+        var github_api_url: string = "https://api.github.com";
+        if (this.env.map.get("GITHUB_API_URL")) |url| {
+            if (url.len > 0) {
+                github_api_url = url;
             }
         }
 
@@ -2144,9 +2144,9 @@ pub const PackageManager = struct {
 
         return std.fmt.allocPrint(
             this.allocator,
-            "https://{s}/repos/{s}/{s}{s}tarball/{s}",
+            "{s}/repos/{s}/{s}{s}tarball/{s}",
             .{
-                github_api_domain,
+                github_api_url,
                 owner,
                 repo,
                 // repo might be empty if dep is https://github.com/... style

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2906,6 +2906,65 @@ it("should handle GitHub tarball URL in dependencies (https://github.com/user/re
   await access(join(package_dir, "bun.lockb"));
 });
 
+it("should handle GitHub tarball URL in dependencies (https://github.com/user/repo/tarball/ref) with custom GITHUB_API_URL", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "Foo",
+      version: "0.0.1",
+      dependencies: {
+        when: "https://github.com/cujojs/when/tarball/1.0.2",
+      },
+    }),
+  );
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: package_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      GITHUB_API_URL: "https://example.com/github/api",
+    },
+  });
+  expect(stderr).toBeDefined();
+  const err = await new Response(stderr).text();
+  expect(err).toContain("Saved lockfile");
+  expect(stdout).toBeDefined();
+  let out = await new Response(stdout).text();
+  out = out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "");
+  out = out.replace(/(github:[^#]+)#[a-f0-9]+/, "$1");
+  expect(out.split(/\r?\n/)).toEqual([
+    " + when@https://github.com/cujojs/when/tarball/1.0.2",
+    "",
+    " 1 packages installed",
+  ]);
+  expect(await exited).toBe(0);
+  expect(urls.sort()).toBeEmpty();
+  expect(requested).toBe(0);
+  expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".cache", "when"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", "when"))).toEqual([
+    ".gitignore",
+    ".gitmodules",
+    "LICENSE.txt",
+    "README.md",
+    "apply.js",
+    "cancelable.js",
+    "delay.js",
+    "package.json",
+    "test",
+    "timed.js",
+    "timeout.js",
+    "when.js",
+  ]);
+  const package_json = await file(join(package_dir, "node_modules", "when", "package.json")).json();
+  expect(package_json.name).toBe("when");
+  await access(join(package_dir, "bun.lockb"));
+});
+
 it("should handle GitHub URL with existing lockfile", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));


### PR DESCRIPTION
### What does this PR do?

`bun install` would previously read `GITHUB_API_DOMAIN` to check for Github's API. This environment variable does not exist in Github Actions, it is instead `GITHUB_API_URL`.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
