### PR TITLE
Support `bun run --if-present`

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -196,6 +196,7 @@ pub const Arguments = struct {
         clap.parseParam("--inspect <STR>?                  Activate Bun's Debugger") catch unreachable,
         clap.parseParam("--inspect-wait <STR>?             Activate Bun's Debugger, wait for a connection before executing") catch unreachable,
         clap.parseParam("--inspect-brk <STR>?              Activate Bun's Debugger, set breakpoint on first line of code and wait") catch unreachable,
+        clap.parseParam("--if-present                      Exit if the entrypoint does not exist") catch unreachable,
         clap.parseParam("<POS>...                          ") catch unreachable,
     };
 
@@ -538,6 +539,7 @@ pub const Arguments = struct {
                 ctx.preloads = preloads;
             }
 
+            ctx.runtime_options.if_present = args.flag("--if-present");
             ctx.runtime_options.smol = args.flag("--smol");
             if (args.option("--inspect")) |inspect_flag| {
                 ctx.runtime_options.debugger = if (inspect_flag.len == 0)
@@ -1022,6 +1024,7 @@ pub const Command = struct {
     pub const RuntimeOptions = struct {
         smol: bool = false,
         debugger: Debugger = .{ .unspecified = {} },
+        if_present: bool = false,
     };
 
     pub const Context = struct {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1669,6 +1669,10 @@ pub const Command = struct {
                     Global.exit(1);
                 }
 
+                if (ctx.runtime_options.if_present) {
+                    return;
+                }
+
                 if (was_js_like) {
                     Output.prettyErrorln("<r><red>error<r><d>:<r> module not found \"<b>{s}<r>\"", .{
                         ctx.positionals[0],

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1160,6 +1160,11 @@ pub const RunCommand = struct {
             }
         }
 
+        // If the script is not present and --if-present is passed, exit with 0
+        if (ctx.runtime_options.if_present) {
+            Global.exit(0);
+        }
+
         if (comptime log_errors) {
             Output.prettyError("<r><red>error<r><d>:<r> missing script \"<b>{s}<r>\"\n", .{script_name_to_search});
             Global.exit(1);

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1160,9 +1160,8 @@ pub const RunCommand = struct {
             }
         }
 
-        // If the script is not present and --if-present is passed, exit with 0
         if (ctx.runtime_options.if_present) {
-            Global.exit(0);
+            return true;
         }
 
         if (comptime log_errors) {

--- a/test/cli/run/if-present.test.ts
+++ b/test/cli/run/if-present.test.ts
@@ -1,26 +1,119 @@
-import { it, expect } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { describe, test, expect, beforeAll } from "bun:test";
+import { spawnSync } from "bun";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
-it("should not error using `bun --if-present`", () => {
-  const { stdout, stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), "--if-present", "doesnotexist"],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+let cwd: string;
+
+beforeAll(() => {
+  cwd = tempDirWithFiles("--if-present", {
+    "present.js": "console.log('Here!');",
+    "package.json": JSON.stringify({
+      "name": "present",
+      "scripts": {
+        "present": "echo 'Here!'",
+      },
+    }),
   });
-  expect(stdout.toString()).toBeEmpty();
-  expect(stderr.toString()).toBeEmpty();
-  expect(exitCode).toBe(0);
 });
 
-it("should not error using `bun --if-present`", () => {
-  const { stdout, stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), "run", "--if-present", "doesnotexist"],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+describe("bun", () => {
+  test("should error with missing script", () => {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd,
+      cmd: [bunExe(), "notpresent"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toBeEmpty();
+    expect(stderr.toString()).toMatch(/script not found/);
+    expect(exitCode).toBe(1);
   });
-  expect(stdout.toString()).toBeEmpty();
-  expect(stderr.toString()).toBeEmpty();
-  expect(exitCode).toBe(0);
+  test("should error with missing module", () => {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd,
+      cmd: [bunExe(), "./notpresent.js"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toBeEmpty();
+    expect(stderr.toString()).toMatch(/module not found/);
+    expect(exitCode).toBe(1);
+  });
+  test("should error with missing file", () => {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd,
+      cmd: [bunExe(), "/path/to/notpresent.txt"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toBeEmpty();
+    expect(stderr.toString()).toMatch(/file not found/);
+    expect(exitCode).toBe(1);
+  });
+});
+
+describe("bun --if-present", () => {
+  test("should not error with missing script", () => {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd,
+      cmd: [bunExe(), "--if-present", "notpresent"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toBeEmpty();
+    expect(stderr.toString()).toBeEmpty();
+    expect(exitCode).toBe(0);
+  });
+  test("should not error with missing module", () => {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd,
+      cmd: [bunExe(), "--if-present", "./notpresent.js"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toBeEmpty();
+    expect(stderr.toString()).toBeEmpty();
+    expect(exitCode).toBe(0);
+  });
+  test("should not error with missing file", () => {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd,
+      cmd: [bunExe(), "--if-present", "/path/to/notpresent.txt"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toBeEmpty();
+    expect(stderr.toString()).toBeEmpty();
+    expect(exitCode).toBe(0);
+  });
+  test("should run present script", () => {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd,
+      cmd: [bunExe(), "run", "present"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toMatch(/Here!/);
+    expect(stderr.toString()).not.toBeEmpty();
+    expect(exitCode).toBe(0);
+  });
+  test("should run present module", () => {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd,
+      cmd: [bunExe(), "run", "present.js"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toMatch(/Here!/);
+    expect(stderr.toString()).toBeEmpty();
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/cli/run/if-present.test.ts
+++ b/test/cli/run/if-present.test.ts
@@ -1,0 +1,26 @@
+import { it, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+it("should not error using `bun --if-present`", () => {
+  const { stdout, stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "--if-present", "doesnotexist"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(stdout.toString()).toBeEmpty();
+  expect(stderr.toString()).toBeEmpty();
+  expect(exitCode).toBe(0);
+});
+
+it("should not error using `bun --if-present`", () => {
+  const { stdout, stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "run", "--if-present", "doesnotexist"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(stdout.toString()).toBeEmpty();
+  expect(stderr.toString()).toBeEmpty();
+  expect(exitCode).toBe(0);
+});

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -84,7 +84,7 @@ export function hideFromStackTrace(block: CallableFunction) {
   });
 }
 
-export function tempDirWithFiles(basename: string, files: Record<string, string | Record<string, string>>) {
+export function tempDirWithFiles(basename: string, files: Record<string, string | Record<string, string>>): string {
   var fs = require("fs");
   var path = require("path");
   var { tmpdir } = require("os");


### PR DESCRIPTION
### What does this PR do?

```sh
bun run doesnotexist # => exits with 1
bun run --if-present doesnotexist # => exits with 0
```

Closes #5670

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
