### PR TITLE
Add license information to package.json

### DIFF
--- a/packages/bun-types/package.json
+++ b/packages/bun-types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bun-types",
   "repository": "https://github.com/oven-sh/bun",
+  "license": "MIT",
   "devDependencies": {
     "conditional-type-checks": "^1.0.6",
     "prettier": "^2.4.1",


### PR DESCRIPTION
### What does this PR do?

Add MIT as license information in the package.json of `bun-types`

### How did you verify your code works?

No code changed

### Assumtions

`bun-types` is distributed under MIT just like the rest of the Bun project as indicated here: https://bun.sh/docs/project/licensing


### Background

I use bun for bundling and testing, so I depend on bun-types. But without the license information in the package.json I get this FOSSA warning

![image](https://github.com/oven-sh/bun/assets/1063454/e5ee6382-65bd-45c5-8240-3dcaa8c9e5c9)


