### PR TITLE
Store workspace package versions

### DIFF
--- a/src/identity_context.zig
+++ b/src/identity_context.zig
@@ -20,4 +20,14 @@ pub const ArrayIdentityContext = struct {
     pub fn eql(_: @This(), a: u32, b: u32, _: usize) bool {
         return a == b;
     }
+
+    pub const U64 = struct {
+        pub fn hash(_: @This(), key: u64) u32 {
+            return @truncate(key);
+        }
+
+        pub fn eql(_: @This(), a: u64, b: u64, _: usize) bool {
+            return a == b;
+        }
+    };
 };

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2949,6 +2949,8 @@ pub const PackageManager = struct {
         );
     }
 
+    const debug = Output.scoped(.PackageManager, true);
+
     /// Q: "What do we do with a dependency in a package.json?"
     /// A: "We enqueue it!"
     fn enqueueDependencyWithMainAndSuccessFn(
@@ -3075,11 +3077,35 @@ pub const PackageManager = struct {
                                     this.enqueueNetworkTask(network_task);
                                 }
                             }
+
+                            if (comptime Environment.allow_assert)
+                                debug(
+                                    "enqueueDependency({d}, {s}, {s}, {s}) = {d}",
+                                    .{
+                                        id,
+                                        @tagName(dependency.version.tag),
+                                        this.lockfile.str(&name),
+                                        this.lockfile.str(&version.literal),
+                                        result.package.meta.id,
+                                    },
+                                );
                         } else if (dependency.version.tag.isNPM()) {
                             const name_str = this.lockfile.str(&name);
                             const task_id = Task.Id.forManifest(name_str);
 
                             if (comptime Environment.allow_assert) std.debug.assert(task_id != 0);
+
+                            if (comptime Environment.allow_assert)
+                                debug(
+                                    "enqueueDependency({d}, {s}, {s}, {s}) = task {d}",
+                                    .{
+                                        id,
+                                        @tagName(dependency.version.tag),
+                                        this.lockfile.str(&name),
+                                        this.lockfile.str(&version.literal),
+                                        task_id,
+                                    },
+                                );
 
                             if (!dependency.behavior.isPeer()) {
                                 var network_entry = try this.network_dedupe_map.getOrPutContext(this.allocator, task_id, .{});
@@ -3181,6 +3207,18 @@ pub const PackageManager = struct {
                     id,
                 );
 
+                if (comptime Environment.allow_assert)
+                    debug(
+                        "enqueueDependency({d}, {s}, {s}, {s}) = {s}",
+                        .{
+                            id,
+                            @tagName(dependency.version.tag),
+                            this.lockfile.str(&name),
+                            this.lockfile.str(&version.literal),
+                            url,
+                        },
+                    );
+
                 if (this.git_repositories.get(clone_id)) |repo_fd| {
                     const resolved = try Repository.findCommit(
                         this.allocator,
@@ -3246,6 +3284,18 @@ pub const PackageManager = struct {
                 if (!entry.found_existing) {
                     entry.value_ptr.* = TaskCallbackList{};
                 }
+
+                if (comptime Environment.allow_assert)
+                    debug(
+                        "enqueueDependency({d}, {s}, {s}, {s}) = {s}",
+                        .{
+                            id,
+                            @tagName(dependency.version.tag),
+                            this.lockfile.str(&name),
+                            this.lockfile.str(&version.literal),
+                            url,
+                        },
+                    );
 
                 const callback_tag = comptime if (successFn == assignRootResolution) "root_dependency" else "dependency";
                 try entry.value_ptr.append(this.allocator, @unionInit(TaskCallbackContext, callback_tag, id));
@@ -3314,6 +3364,18 @@ pub const PackageManager = struct {
 
                     // should not trigger a network call
                     if (comptime Environment.allow_assert) std.debug.assert(result.network_task == null);
+
+                    if (comptime Environment.allow_assert)
+                        debug(
+                            "enqueueDependency({d}, {s}, {s}, {s}) = {d}",
+                            .{
+                                id,
+                                @tagName(dependency.version.tag),
+                                this.lockfile.str(&name),
+                                this.lockfile.str(&version.literal),
+                                result.package.meta.id,
+                            },
+                        );
                 } else if (dependency.behavior.isRequired()) {
                     if (comptime dependency_tag == .workspace) {
                         this.log.addErrorFmt(
@@ -3393,6 +3455,18 @@ pub const PackageManager = struct {
                 if (!entry.found_existing) {
                     entry.value_ptr.* = TaskCallbackList{};
                 }
+
+                if (comptime Environment.allow_assert)
+                    debug(
+                        "enqueueDependency({d}, {s}, {s}, {s}) = {s}",
+                        .{
+                            id,
+                            @tagName(dependency.version.tag),
+                            this.lockfile.str(&name),
+                            this.lockfile.str(&version.literal),
+                            url,
+                        },
+                    );
 
                 const callback_tag = comptime if (successFn == assignRootResolution) "root_dependency" else "dependency";
                 try entry.value_ptr.append(this.allocator, @unionInit(TaskCallbackContext, callback_tag, id));

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1659,7 +1659,7 @@ pub const PackageManager = struct {
     package_json_updates: []UpdateRequest = &[_]UpdateRequest{},
 
     // absolute path to package json expr
-    package_json_cache: std.StringArrayHashMap(js_parser.Expr),
+    package_json_cache: std.ArrayHashMap(u64, js_parser.Expr, ArrayIdentityContext.U64, false),
 
     // used for looking up workspaces that aren't loaded into Lockfile.workspace_paths
     workspaces: std.StringArrayHashMap(?Semver.Version),
@@ -5468,7 +5468,7 @@ pub const PackageManager = struct {
             .lockfile = undefined,
             .root_package_json_file = package_json_file,
             .waiter = try Waker.init(ctx.allocator),
-            .package_json_cache = std.StringArrayHashMap(js_parser.Expr).init(ctx.allocator),
+            .package_json_cache = std.ArrayHashMap(u64, js_parser.Expr, ArrayIdentityContext.U64, false).init(ctx.allocator),
             .workspaces = workspaces,
             // .progress
         };
@@ -5548,7 +5548,7 @@ pub const PackageManager = struct {
             .lockfile = undefined,
             .root_package_json_file = undefined,
             .waiter = try Waker.init(allocator),
-            .package_json_cache = std.StringArrayHashMap(js_parser.Expr).init(allocator),
+            .package_json_cache = std.ArrayHashMap(u64, js_parser.Expr, ArrayIdentityContext.U64, false).init(allocator),
             .workspaces = std.StringArrayHashMap(?Semver.Version).init(allocator),
         };
         manager.lockfile = try allocator.create(Lockfile);

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1658,9 +1658,6 @@ pub const PackageManager = struct {
     cpu_count: u32 = 0,
     package_json_updates: []UpdateRequest = &[_]UpdateRequest{},
 
-    // absolute path to package json expr
-    package_json_cache: std.ArrayHashMap(u64, js_parser.Expr, ArrayIdentityContext.U64, false),
-
     // used for looking up workspaces that aren't loaded into Lockfile.workspace_paths
     workspaces: std.StringArrayHashMap(?Semver.Version),
 
@@ -5468,7 +5465,6 @@ pub const PackageManager = struct {
             .lockfile = undefined,
             .root_package_json_file = package_json_file,
             .waiter = try Waker.init(ctx.allocator),
-            .package_json_cache = std.ArrayHashMap(u64, js_parser.Expr, ArrayIdentityContext.U64, false).init(ctx.allocator),
             .workspaces = workspaces,
             // .progress
         };
@@ -5548,7 +5544,6 @@ pub const PackageManager = struct {
             .lockfile = undefined,
             .root_package_json_file = undefined,
             .waiter = try Waker.init(allocator),
-            .package_json_cache = std.ArrayHashMap(u64, js_parser.Expr, ArrayIdentityContext.U64, false).init(allocator),
             .workspaces = std.StringArrayHashMap(?Semver.Version).init(allocator),
         };
         manager.lockfile = try allocator.create(Lockfile);

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2538,11 +2538,7 @@ pub const Package = extern struct {
                         const version = to_deps[to_i].version;
                         if (switch (version.tag) {
                             .workspace => if (to_lockfile.workspace_paths.getPtr(from_dep.name_hash)) |path_ptr| brk: {
-                                const workspace_path = to_lockfile.str(path_ptr);
-                                var path = try allocator.alloc(u8, workspace_path.len + "/package.json".len);
-                                @memcpy(path[0..workspace_path.len], workspace_path);
-                                @memcpy(path[workspace_path.len..], "/package.json");
-
+                                const path = to_lockfile.str(path_ptr);
                                 var file = std.fs.cwd().openFile(Path.join(
                                     &[_]string{
                                         path,
@@ -2552,7 +2548,6 @@ pub const Package = extern struct {
                                 defer file.close();
                                 const bytes = try file.readToEndAlloc(allocator, std.math.maxInt(usize));
                                 defer allocator.free(bytes);
-
                                 const source = logger.Source.initPathString(path, bytes);
 
                                 var workspace = Package{};

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2540,9 +2540,7 @@ pub const Package = extern struct {
                             .workspace => if (to_lockfile.workspace_paths.getPtr(from_dep.name_hash)) |path_ptr| brk: {
                                 const path = to_lockfile.str(path_ptr);
                                 var file = std.fs.cwd().openFile(Path.join(
-                                    &[_]string{
-                                        path,
-                                    },
+                                    &[_]string{ path, "package.json" },
                                     .auto,
                                 ), .{ .mode = .read_only }) catch break :brk false;
                                 defer file.close();

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2626,7 +2626,7 @@ pub const Package = extern struct {
     ) !void {
         const json = brk: {
             const key = strings.withoutTrailingSlash(source.path.name.dir);
-            var gop = try PackageManager.instance.package_json_cache.getOrPut(key);
+            var gop = try PackageManager.instance.package_json_cache.getOrPut(String.Builder.stringHash(key));
             if (gop.found_existing) {
                 break :brk gop.value_ptr.*;
             }

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2494,20 +2494,16 @@ pub const Package = extern struct {
                 found: {
                     const prev_i = to_i;
 
-                    // std.debug.print("searching for: {s}, {d}\n", .{ from_lockfile.str(&from_dep.name), from_dep.name_hash });
-
                     // common case, dependency is present in both versions:
                     // - in the same position
                     // - shifted by a constant offset
                     while (to_i < to_deps.len) : (to_i += 1) {
-                        // std.debug.print("comparing: {s}, {d}\n", .{ to_lockfile.str(&to_deps[to_i].name), to_deps[to_i].name_hash });
                         if (from_dep.name_hash == to_deps[to_i].name_hash) break :found;
                     }
 
                     // less common, o(n^2) case
                     to_i = 0;
                     while (to_i < prev_i) : (to_i += 1) {
-                        // std.debug.print("comparing: {s}, {d}\n", .{ to_lockfile.str(&to_deps[to_i].name), to_deps[to_i].name_hash });
                         if (from_dep.name_hash == to_deps[to_i].name_hash) break :found;
                     }
 
@@ -2515,8 +2511,6 @@ pub const Package = extern struct {
                         skipped_workspaces += 1;
                         continue;
                     }
-
-                    // std.debug.print("removed {s}\n", .{from_lockfile.str(&from_dep.name)});
 
                     // We found a removed dependency!
                     // We don't need to remove it

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -5550,7 +5550,7 @@ it("should handle installing packages from inside a workspace with `*`", async (
   await access(join(package_dir, "bun.lockb"));
 });
 
-it("should handle installing packages from inside a workspace with without prefix", async () => {
+it("should handle installing packages from inside a workspace without prefix", async () => {
   await writeFile(
     join(package_dir, "package.json"),
     JSON.stringify({


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
