### PR TITLE
fix(blob): Add the current offset to the new blob slice

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -3003,12 +3003,13 @@ pub const Blob = struct {
             }
         }
 
+        const offset = this.offset +| @as(SizeType, @intCast(relativeStart));
         const len = @as(SizeType, @intCast(@max(relativeEnd -| relativeStart, 0)));
 
         // This copies over the is_all_ascii flag
         // which is okay because this will only be a <= slice
         var blob = this.dupe();
-        blob.offset = @as(SizeType, @intCast(relativeStart));
+        blob.offset = offset;
         blob.size = len;
 
         // infer the content type if it was not specified

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "bun:test";
 
-test("Blob.slice", () => {
+test("Blob.slice", async () => {
   const blob = new Blob(["Bun", "Foo"]);
   const b1 = blob.slice(0, 3, "Text/HTML");
   expect(b1 instanceof Blob).toBeTruthy();
@@ -26,6 +26,33 @@ test("Blob.slice", () => {
   expect(blob.slice(null, "-123").size).toBe(6);
   expect(blob.slice(0, 10).size).toBe(blob.size);
   expect(blob.slice("text/plain;charset=utf-8").type).toBe("text/plain;charset=utf-8");
+
+  // test Blob.slice().slice(), issue#6252
+  expect(await blob.slice(0, 4).slice(0, 3).text()).toBe("Bun");
+  expect(await blob.slice(0, 4).slice(1, 3).text()).toBe("un");
+  expect(await blob.slice(1, 4).slice(0, 3).text()).toBe("unF");
+  expect(await blob.slice(1, 4).slice(1, 3).text()).toBe("nF");
+  expect(await blob.slice(1, 4).slice(2, 3).text()).toBe("F");
+  expect(await blob.slice(1, 4).slice(3, 3).text()).toBe("");
+  expect(await blob.slice(1, 4).slice(4, 3).text()).toBe("");
+  // test negative start
+  expect(await blob.slice(1, 4).slice(-1, 3).text()).toBe("F");
+  expect(await blob.slice(1, 4).slice(-2, 3).text()).toBe("nF");
+  expect(await blob.slice(1, 4).slice(-3, 3).text()).toBe("unF");
+  expect(await blob.slice(1, 4).slice(-4, 3).text()).toBe("unF");
+  expect(await blob.slice(1, 4).slice(-5, 3).text()).toBe("unF");
+  expect(await blob.slice(-1, 4).slice(-1, 3).text()).toBe("");
+  expect(await blob.slice(-2, 4).slice(-1, 3).text()).toBe("");
+  expect(await blob.slice(-3, 4).slice(-1, 3).text()).toBe("F");
+  expect(await blob.slice(-4, 4).slice(-1, 3).text()).toBe("F");
+  expect(await blob.slice(-5, 4).slice(-1, 3).text()).toBe("F");
+  expect(await blob.slice(-5, 4).slice(-2, 3).text()).toBe("nF");
+  expect(await blob.slice(-5, 4).slice(-3, 3).text()).toBe("unF");
+  expect(await blob.slice(-5, 4).slice(-4, 3).text()).toBe("unF");
+  expect(await blob.slice(-4, 4).slice(-3, 3).text()).toBe("nF");
+  expect(await blob.slice(-5, 4).slice(-4, 3).text()).toBe("unF");
+  expect(await blob.slice(-3, 4).slice(-2, 3).text()).toBe("F");
+  expect(await blob.slice(-blob.size, 4).slice(-blob.size, 3).text()).toBe("Bun");
 });
 
 test("new Blob", () => {


### PR DESCRIPTION
### What does this PR do?

Close: #6252

```JavaScript
const blob = new Blob(["0123456789"]);
console.log(await blob.slice(2, 8).slice(0, 3).text());
// Output:
// node: 234
// bun: 012
```

`offset` is overwritten by `relativeStart`, causing `blob.slice().slice()` to always use the parameters from the last `slice` call. This Add the current `offset` to the new blob slice.

https://github.com/oven-sh/bun/blob/47651f321ae5eb82686da5d759e9b1b5b12340ad/src/bun.js/webcore/blob.zig#L3010-L3012




- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

