### PR TITLE
Create `AbortSignal` without JS

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5641,17 +5641,14 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             var body = JSC.WebCore.InitRequestBodyValue(.{ .Null = {} }) catch unreachable;
 
             ctx.request_body = body;
-            const js_signal = JSC.WebCore.AbortSignal.create(this.globalThis);
-            js_signal.ensureStillAlive();
-            if (JSC.WebCore.AbortSignal.fromJS(js_signal)) |signal| {
-                ctx.signal = signal.ref().ref(); // +2 refs 1 for the request and 1 for the request context
-            }
+            var signal = JSC.WebCore.AbortSignal.new(this.globalThis);
+            ctx.signal = signal;
 
             request_object.* = .{
                 .method = ctx.method,
                 .request_context = AnyRequestContext.init(ctx),
                 .https = ssl_enabled,
-                .signal = ctx.signal,
+                .signal = signal.ref(),
                 .body = body.ref(),
             };
 
@@ -5762,18 +5759,15 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             var body = JSC.WebCore.InitRequestBodyValue(.{ .Null = {} }) catch unreachable;
 
             ctx.request_body = body;
-            const js_signal = JSC.WebCore.AbortSignal.create(this.globalThis);
-            js_signal.ensureStillAlive();
-            if (JSC.WebCore.AbortSignal.fromJS(js_signal)) |signal| {
-                ctx.signal = signal.ref().ref(); // +2 refs 1 for the request and 1 for the request context
-            }
+            var signal = JSC.WebCore.AbortSignal.new(this.globalThis);
+            ctx.signal = signal;
 
             request_object.* = .{
                 .method = ctx.method,
                 .request_context = AnyRequestContext.init(ctx),
                 .upgrader = ctx,
                 .https = ssl_enabled,
-                .signal = ctx.signal,
+                .signal = signal.ref(),
                 .body = body.ref(),
             };
             ctx.upgrade_context = upgrade_ctx;

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4539,7 +4539,6 @@ extern "C" WebCore::AbortSignal* WebCore__AbortSignal__new(JSC__JSGlobalObject* 
     Zig::GlobalObject* thisObject = JSC::jsCast<Zig::GlobalObject*>(globalObject);
     auto* context = thisObject->scriptExecutionContext();
     RefPtr<WebCore::AbortSignal> abortSignal = WebCore::AbortSignal::create(context);
-    abortSignal->ref();
     return abortSignal.leakRef();
 }
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4534,6 +4534,15 @@ extern "C" void JSC__JSGlobalObject__queueMicrotaskJob(JSC__JSGlobalObject* arg0
         JSC::JSValue::decode(JSValue4));
 }
 
+extern "C" WebCore::AbortSignal* WebCore__AbortSignal__new(JSC__JSGlobalObject* globalObject)
+{
+    Zig::GlobalObject* thisObject = JSC::jsCast<Zig::GlobalObject*>(globalObject);
+    auto* context = thisObject->scriptExecutionContext();
+    RefPtr<WebCore::AbortSignal> abortSignal = WebCore::AbortSignal::create(context);
+    abortSignal->ref();
+    return abortSignal.leakRef();
+}
+
 extern "C" JSC__JSValue WebCore__AbortSignal__create(JSC__JSGlobalObject* globalObject)
 {
     Zig::GlobalObject* thisObject = JSC::jsCast<Zig::GlobalObject*>(globalObject);

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -1969,6 +1969,12 @@ pub const AbortSignal = extern opaque {
         return cppFn("create", .{global});
     }
 
+    extern fn WebCore__AbortSignal__new(*JSGlobalObject) *AbortSignal;
+    pub fn new(global: *JSGlobalObject) *AbortSignal {
+        JSC.markBinding(@src());
+        return WebCore__AbortSignal__new(global);
+    }
+
     pub fn createAbortError(message: *const ZigString, code: *const ZigString, global: *JSGlobalObject) JSValue {
         return cppFn("createAbortError", .{ message, code, global });
     }

--- a/src/bun.js/bindings/webcore/AbortSignal.h
+++ b/src/bun.js/bindings/webcore/AbortSignal.h
@@ -45,6 +45,7 @@ class AbortSignal final : public RefCounted<AbortSignal>, public EventTargetWith
 public:
     static Ref<AbortSignal> create(ScriptExecutionContext*);
     WEBCORE_EXPORT ~AbortSignal();
+    using NativeCallbackTuple = std::tuple<void*, void (*)(void*, JSC::EncodedJSValue)>;
 
     static Ref<AbortSignal> abort(JSDOMGlobalObject&, ScriptExecutionContext&, JSC::JSValue reason);
     static Ref<AbortSignal> timeout(ScriptExecutionContext&, uint64_t milliseconds);
@@ -66,7 +67,7 @@ public:
     using Algorithm = Function<void(JSValue)>;
     void addAlgorithm(Algorithm&& algorithm) { m_algorithms.append(WTFMove(algorithm)); }
     void cleanNativeBindings(void* ref);
-    void addNativeCallback(std::tuple<void*, void (*)(void*, JSC::EncodedJSValue)> callback) { m_native_callbacks.append(callback); }
+    void addNativeCallback(NativeCallbackTuple callback) { m_native_callbacks.append(callback); }
 
     bool isFollowingSignal() const { return !!m_followingSignal; }
 
@@ -87,8 +88,8 @@ private:
     void eventListenersDidChange() final;
 
     bool m_aborted { false };
-    Vector<Algorithm> m_algorithms;
-    Vector<std::tuple<void*, void (*)(void*, JSC::EncodedJSValue)>> m_native_callbacks;
+    Vector<Algorithm, 2> m_algorithms;
+    Vector<NativeCallbackTuple, 2> m_native_callbacks;
     WeakPtr<AbortSignal> m_followingSignal;
     JSC::Strong<JSC::Unknown> m_reason;
     bool m_hasActiveTimeoutTimer { false };


### PR DESCRIPTION
### What does this PR do?

Micro-optimize AbortSignal a little

- Slightly reduce memory usage of `AbortSignal` by setting the inline capacity of the `Vector`  used within to 2 instead of the default of 6
- Instead of creating a JS object for AbortSignal, we can create the C++ one and lazily create the GC'd version

### How did you verify your code works?

Existing tests