### PR TITLE
WebCryptoAPI: remove JWK "EdDSA" alg checks

### DIFF
--- a/src/bun.js/bindings/webcrypto/CryptoKeyOKP.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoKeyOKP.cpp
@@ -137,8 +137,6 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifie
             return nullptr;
         if (keyData.crv != "Ed25519"_s)
             return nullptr;
-        if (!keyData.alg.isEmpty() && keyData.alg != "EdDSA"_s)
-            return nullptr;
         if (usages && !keyData.use.isEmpty() && keyData.use != "sig"_s)
             return nullptr;
         if (keyData.key_ops && ((keyData.usages & usages) != usages))


### PR DESCRIPTION
### What does this PR do?

This removes the check in SubtleCrypto importKey() for JWK Ed25519 "alg" member values. These have been removed in https://github.com/WICG/webcrypto-secure-curves/pull/24

The other portion (JWK Ed25519 "alg" member export) was not even implemented as far as i can see.