### PR TITLE
Update `preload` documentation to make applicability to plugins more obvious

### DIFF
--- a/docs/runtime/bunfig.md
+++ b/docs/runtime/bunfig.md
@@ -19,11 +19,11 @@ Bun's runtime behavior is configured using top-level fields in the `bunfig.toml`
 
 ### `preload`
 
-An array of scripts to execute before running a file or script. This is useful for registering plugins.
+An array of scripts/plugins to execute before running a file or script.
 
 ```toml
-# scripts to run before `bun run`ning a file or script
-# useful for registering plugins
+# scripts to run before `bun run`-ing a file or script
+# register plugins by adding them to this list
 preload = ["./preload.ts"]
 ```
 


### PR DESCRIPTION
### What does this PR do?

This updates the bunfig documentation to make it obvious that this is where plugins should be passed. It might seem obvious with the current documentation. I promise you, it's not.

- [X] Documentation or TypeScript types
- [ ] Code changes

Fixes https://github.com/oven-sh/bun/issues/6297