### PR TITLE
docs: fixing a couple typos

### DIFF
--- a/docs/cli/bun-install.md
+++ b/docs/cli/bun-install.md
@@ -21,7 +21,7 @@ Configuring with `bunfig.toml` is optional. Bun tries to be zero configuration i
 
 # Scope name      The value can be a URL string or an object
 "@mybigcompany" = { token = "123456", url = "https://registry.mybigcompany.com" }
-# URL is optional and fallsback to the default registry
+# URL is optional and falls back to the default registry
 
 # The "@" in the scope is optional
 mybigcompany2 = { token = "123456" }

--- a/docs/dev/css.md
+++ b/docs/dev/css.md
@@ -49,7 +49,7 @@ This is useful for preventing flash of unstyled content.
 
 ## With `bun bun`
 
-Bun bundles `.css` files imported via `@import` into a single file. It doesn’t autoprefix or minify CSS today. Multiple `.css` files imported in one JavaScript file will _not_ be bundled into one file. You’ll have to import those from a `.css` file.
+Bun bundles `.css` files imported via `@import` into a single file. It doesn’t auto-prefix or minify CSS today. Multiple `.css` files imported in one JavaScript file will _not_ be bundled into one file. You’ll have to import those from a `.css` file.
 
 This input:
 


### PR DESCRIPTION
### What does this PR do?

Fixing a couple typos I found looking at the docs.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes