### PR TITLE
docs: `file.stream()` is not a promise

### DIFF
--- a/docs/guides/read-file/stream.md
+++ b/docs/guides/read-file/stream.md
@@ -8,7 +8,7 @@ The `Bun.file()` function accepts a path and returns a `BunFile` instance. The `
 const path = "/path/to/package.json";
 const file = Bun.file(path);
 
-const stream = await file.stream();
+const stream = file.stream();
 ```
 
 ---


### PR DESCRIPTION
### What does this PR do?

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
