### PR TITLE
[types] allow onLoad plugin callbacks to return undefined

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3214,7 +3214,7 @@ declare module "bun" {
     loader: Loader;
   }
 
-  type OnLoadResult = OnLoadResultSourceCode | OnLoadResultObject;
+  type OnLoadResult = OnLoadResultSourceCode | OnLoadResultObject | undefined;
   type OnLoadCallback = (
     args: OnLoadArgs,
   ) => OnLoadResult | Promise<OnLoadResult>;


### PR DESCRIPTION
Returning `undefined` simply falls through to the next plugin, or to the default loader.
This behaviour is defined by esbuild, and supported by Bun, but the types don't reflect it properly. This PR fixes that.