### PR TITLE
Fix memory leak in fetch()

### DIFF
--- a/src/zlib.zig
+++ b/src/zlib.zig
@@ -575,8 +575,6 @@ pub const ZlibReaderArrayList = struct {
 
             switch (rc) {
                 ReturnCode.StreamEnd => {
-                    this.state = State.End;
-
                     this.end();
                     return;
                 },


### PR DESCRIPTION
### What does this PR do?

We were not calling inflateEnd, which caused fetch() requests with gzip/deflate to leak memory

![hmasd](https://github.com/oven-sh/bun/assets/709451/e54002dd-e980-44b7-a194-3374cd017c82)



### How did you verify your code works?

Memory usage is more stable now