### PR TITLE
Remove `bunx --bun` from Vite guide

### DIFF
--- a/docs/guides/ecosystem/vite.md
+++ b/docs/guides/ecosystem/vite.md
@@ -28,42 +28,10 @@ bun install
 
 ---
 
-Start the development server with the `vite` CLI using `bunx`.
-
-The `--bun` flag tells Bun to run Vite's CLI using `bun` instead of `node`; by default Bun respects Vite's `#!/usr/bin/env node` [shebang line](<https://en.wikipedia.org/wiki/Shebang_(Unix)>). After Bun 1.0 this flag will no longer be necessary.
-
-```bash
-bunx --bun vite
-```
-
----
-
-To simplify this command, update the `"dev"` script in `package.json` to the following.
-
-```json-diff#package.json
-  "scripts": {
--   "dev": "vite",
-+   "dev": "bunx --bun vite",
-    "build": "vite build",
-    "serve": "vite preview"
-  },
-  // ...
-```
-
----
-
 Now you can start the development server with `bun run dev`.
 
 ```bash
 bun run dev
-```
-
----
-
-The following command will build your app for production.
-
-```sh
-$ bunx --bun vite build
 ```
 
 ---


### PR DESCRIPTION
The Vite guide references running Vite commands using `bunx --bun vite`. This should no longer be required since Bun 1.0 (according to documentation on the same page), so we can fall back to `bun run` instead.

### What does this PR do?

This replaces the instructions for running Vite with `bunx  --bun` with 'regular' `bun run` commands.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

