### PR TITLE
[Docs] Add Fedora build instructions to development.md

### DIFF
--- a/docs/project/development.md
+++ b/docs/project/development.md
@@ -49,6 +49,12 @@ $ wget https://apt.llvm.org/llvm.sh -O - | sudo bash -s -- 16 all
 $ sudo pacman -S llvm clang lld
 ```
 
+```bash#Fedora
+$ sudo dnf install 'dnf-command(copr)'
+$ sudo dnf copr enable -y @fedora-llvm-team/llvm-snapshots
+$ sudo dnf install llvm clang lld
+```
+
 {% /codetabs %}
 
 If none of the above solutions apply, you will have to install it [manually](https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.6).
@@ -96,6 +102,10 @@ $ sudo apt install cargo ccache cmake git golang libtool ninja-build pkg-config 
 
 ```bash#Arch
 $ sudo pacman -S base-devel ccache cmake esbuild git go libiconv libtool make ninja pkg-config python rust sed unzip
+```
+
+```bash#Fedora
+$ sudo dnf install cargo ccache cmake git golang libtool ninja-build pkg-config rustc golang-github-evanw-esbuild libatomic-static libstdc++-static sed unzip
 ```
 
 {% /codetabs %}


### PR DESCRIPTION
### What does this PR do?

Adds build commands for Fedora to the codetabs in development.md


- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?









