### PR TITLE
fix(error): correct the `path` field in syscall error message.

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1040,7 +1040,10 @@ pub const Blob = struct {
                     break :brk result;
                 },
                 .err => |err| {
-                    return JSC.JSPromise.rejectedPromiseValue(globalThis, err.toJSC(globalThis));
+                    return JSC.JSPromise.rejectedPromiseValue(
+                        globalThis,
+                        err.withPath(pathlike.path.slice()).toJSC(globalThis),
+                    );
                 },
             }
             unreachable;
@@ -1081,7 +1084,10 @@ pub const Blob = struct {
                             return .zero;
                         }
 
-                        return JSC.JSPromise.rejectedPromiseValue(globalThis, err.toJSC(globalThis));
+                        return JSC.JSPromise.rejectedPromiseValue(
+                            globalThis,
+                            err.withPath(pathlike.path.slice()).toJSC(globalThis),
+                        );
                     },
                 }
             }
@@ -1110,7 +1116,10 @@ pub const Blob = struct {
                     break :brk result;
                 },
                 .err => |err| {
-                    return JSC.JSPromise.rejectedPromiseValue(globalThis, err.toJSC(globalThis));
+                    return JSC.JSPromise.rejectedPromiseValue(
+                        globalThis,
+                        err.withPath(pathlike.path.slice()).toJSC(globalThis),
+                    );
                 },
             }
             unreachable;
@@ -1145,7 +1154,10 @@ pub const Blob = struct {
                         needs_async.* = true;
                         return .zero;
                     }
-                    return JSC.JSPromise.rejectedPromiseValue(globalThis, err.toJSC(globalThis));
+                    return JSC.JSPromise.rejectedPromiseValue(
+                        globalThis,
+                        err.withPath(pathlike.path.slice()).toJSC(globalThis),
+                    );
                 },
             }
         }
@@ -2289,7 +2301,7 @@ pub const Blob = struct {
                                 this.source_fd = 0;
                             }
 
-                            this.system_error = errno.toSystemError();
+                            this.system_error = errno.withPath(this.destination_file_store.pathlike.path.slice()).toSystemError();
                             return AsyncIO.asError(errno.errno);
                         },
                     };

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1083,7 +1083,9 @@ pub const Blob = struct {
                             needs_async.* = true;
                             return .zero;
                         }
-
+                        if (comptime !needs_open) {
+                            return JSC.JSPromise.rejectedPromiseValue(globalThis, err.toJSC(globalThis));
+                        }
                         return JSC.JSPromise.rejectedPromiseValue(
                             globalThis,
                             err.withPath(pathlike.path.slice()).toJSC(globalThis),
@@ -1153,6 +1155,9 @@ pub const Blob = struct {
                     if (err.getErrno() == .AGAIN) {
                         needs_async.* = true;
                         return .zero;
+                    }
+                    if (comptime !needs_open) {
+                        return JSC.JSPromise.rejectedPromiseValue(globalThis, err.toJSC(globalThis));
                     }
                     return JSC.JSPromise.rejectedPromiseValue(
                         globalThis,


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `path` field in error messages within `Bun.write`. Close: #6336

#### 1
```JavaScript
// 1. `./baz.txt` exists.
// 2. `foo/` doesn't exist.
await Bun.write('./foo/bar.txt', Bun.file('./baz.txt'));

// Output:
// ENOENT: No such file or directory
//    path: "./baz.txt"
//  syscall: "open"
//    errno: -2

```

https://github.com/oven-sh/bun/blob/35109160ca5d439116bedeb3302ec3745e2895d5/src/bun.js/webcore/blob.zig#L2292


https://github.com/oven-sh/bun/blob/35109160ca5d439116bedeb3302ec3745e2895d5/src/bun.js/webcore/blob.zig#L2197-L2200

The `path` field in the error message will use the value from the second parameter. This happens because in the `doOpenFile` function, we do not assign the `path` field to the error, the error context is incomplete. And when rejecting, it defaults to the source's path.

----

#### 2
```JavaScript
await Bun.write("./foo/bar.txt", "");

// Output
// 1 | await Bun.write("./foo/bar.txt", "");
//          ^
// ENOENT: No such file or directory
//  syscall: "open"
//    errno: -2

```

In the `writeStringToFileFast` function, the `path` field is not assigned.

https://github.com/oven-sh/bun/blob/35109160ca5d439116bedeb3302ec3745e2895d5/src/bun.js/webcore/blob.zig#L1043C1-L1043C1

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->



- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
