### PR TITLE
fix: form data content type

### DIFF
--- a/src/url.zig
+++ b/src/url.zig
@@ -1098,8 +1098,10 @@ pub const FormData = struct {
                         }
                         if (filename_str.len > 0) {
                             const extension = std.fs.path.extension(filename_str);
-                            if (bun.HTTP.MimeType.byExtensionNoDefault(extension[1..extension.len])) |mime| {
-                                break :brk mime.value;
+                            if (extension.len > 0) {
+                                if (bun.HTTP.MimeType.byExtensionNoDefault(extension[1..extension.len])) |mime| {
+                                    break :brk mime.value;
+                                }
                             }
                         }
 

--- a/src/url.zig
+++ b/src/url.zig
@@ -1097,7 +1097,8 @@ pub const FormData = struct {
                             break :brk field.content_type.slice(buf);
                         }
                         if (filename_str.len > 0) {
-                            if (bun.HTTP.MimeType.byExtensionNoDefault(std.fs.path.extension(filename_str))) |mime| {
+                            const extension = std.fs.path.extension(filename_str);
+                            if (bun.HTTP.MimeType.byExtensionNoDefault(extension[1..extension.len])) |mime| {
                                 break :brk mime.value;
                             }
                         }


### PR DESCRIPTION
fix for #6012 

```
std.fs.path.extension(filename_str); 
// return extension name with a dot(.) the ex: somefile.pdf -> .pdf
```

```
bun.HTTP.MimeType.byExtensionNoDefault()
// expects extension name without any dot(.)  
```


verified the code runs on my local build

![image](https://github.com/oven-sh/bun/assets/20675891/d21b856d-8055-4ae8-9315-d86841e9ff88)
