### PR TITLE
Update vite.md : removal of incorrect information about --bun flag

### DIFF
--- a/docs/guides/ecosystem/vite.md
+++ b/docs/guides/ecosystem/vite.md
@@ -30,8 +30,7 @@ bun install
 
 Start the development server with the `vite` CLI using `bunx`.
 
-The `--bun` flag tells Bun to run Vite's CLI using `bun` instead of `node`; by default Bun respects Vite's `#!/usr/bin/env node` [shebang line](<https://en.wikipedia.org/wiki/Shebang_(Unix)>). After Bun 1.0 this flag will no longer be necessary.
-
+The `--bun` flag tells Bun to run Vite's CLI using `bun` instead of `node`; by default Bun respects Vite's `#!/usr/bin/env node` [shebang line](<https://en.wikipedia.org/wiki/Shebang_(Unix)>).
 ```bash
 bunx --bun vite
 ```


### PR DESCRIPTION
### What does this PR do?

removal of incorrect information about **bunx** `--bun` flag : "After Bun 1.0 this flag will no longer be necessary."

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
