### PR TITLE
Documentation for the IPC of Bun.spawn

### DIFF
--- a/docs/api/spawn.md
+++ b/docs/api/spawn.md
@@ -185,7 +185,13 @@ proc.unref();
 
 ## IPC - Inter-Process Communication
 
-`Bun.spawn()` supports IPC between other bun sub processes
+When the ipc is specified, Bun will open an IPC channel to the subprocess. The passed callback is called for incoming messages, and `subprocess.send` can send messages to the subprocess. Messages are serialized using the JSC serialize API, which allows for the same types that `postMessage`/`structuredClone` supports.
+
+
+The subprocess can send and recieve messages by using `process.send` and `process.on("message")`, respectively. This is the same API as what Node.js exposes when `child_process.fork()` is used.
+
+
+Currently, this is only compatible with processes that are other `bun` instances.
 
 ```ts
 // parent.ts
@@ -204,14 +210,9 @@ The child process and send messages to the parent using the `process.send` metho
 
 ```ts
 // child.ts
-interface ChildProcess extends Process {
-  send: (message: any) => void;
-}
-
-const send = (process as ChildProcess).send;
-
-send("Hello from child as string");
-send({ message: "Hello from child as object" });
+// process.send will be undefined if the ipc channel is not open
+process.send("Hello from child as string");
+process.send({ message: "Hello from child as object" });
 
 process.on("message", (message) => {
     /**

--- a/docs/api/spawn.md
+++ b/docs/api/spawn.md
@@ -183,6 +183,43 @@ const proc = Bun.spawn(["echo", "hello"]);
 proc.unref();
 ```
 
+## IPC - Inter-Process Communication
+
+`Bun.spawn()` supports IPC between other bun sub processes
+
+```ts
+// parent.ts
+const child = Bun.spawn(["bun", "child.ts"], {
+  ipc(message) {
+    /**
+     * The message received from the sub process
+     **/
+  },
+});
+
+child.send("Hello from parent"); // The parent can send messages to the child as well
+```
+
+The child process and send messages to the parent using the `process.send` method
+
+```ts
+// child.ts
+interface ChildProcess extends Process {
+  send: (message: any) => void;
+}
+
+const send = (process as ChildProcess).send;
+
+send("Hello from child as string");
+send({ message: "Hello from child as object" });
+
+process.on("message", (message) => {
+    /**
+     * The message received from the parent
+     **/
+});
+```
+
 ## Blocking API (`Bun.spawnSync()`)
 
 Bun provides a synchronous equivalent of `Bun.spawn` called `Bun.spawnSync`. This is a blocking API that supports the same inputs and parameters as `Bun.spawn`. It returns a `SyncSubprocess` object, which differs from `Subprocess` in a few ways.

--- a/docs/guides/process/ipc.md
+++ b/docs/guides/process/ipc.md
@@ -1,0 +1,62 @@
+---
+name: Spawn a child process and communicate using IPC
+---
+
+Use [`Bun.spawn()`](/docs/api/spawn) to spawn a child process and in the second object specify the ipc
+
+```ts
+// index.ts
+const child = Bun.spawn(["bun", "child.ts"], {
+  ipc(message) {
+    console.log("[Parent] Received %o", message);
+  },
+});
+
+child.send("Hello from parent");
+```
+
+---
+
+The child.ts would look like this
+
+```ts
+// child.ts
+interface ChildProcess extends Process {
+  send: (message: any) => void;
+}
+
+const send = (process as ChildProcess).send;
+
+send("Hello from child");
+
+process.on("message", (message) => {
+  send(`echo: ${message}`);
+});
+
+/**
+ * Output from index.ts
+ * [Parent] Received Hello from child
+ * [Parent] Received echo: Hello from parent
+*/
+```
+
+---
+
+The payload in the send command can even be an object
+
+```ts
+// child.ts
+send({ message: "Hello from child" });
+
+/**
+ * Output
+ * [Parent] Received {
+ *  message: "Hello from child"
+ * }
+ * [Parent] Received echo: Hello from parent
+*/
+```
+
+---
+
+See [Docs > API > Child processes](/docs/api/spawn) for complete documentation.

--- a/docs/guides/process/ipc.md
+++ b/docs/guides/process/ipc.md
@@ -2,63 +2,63 @@
 name: Spawn a child process and communicate using IPC
 ---
 
-Use [`Bun.spawn()`](/docs/api/spawn) to spawn a child process and in the second object specify the ipc.
+Use [`Bun.spawn()`](/docs/api/spawn) to spawn a child process. When spawning a second `bun` process, you can open a direct inter-process communication (IPC) channel between the two processes.
 
-When the ipc is specified, Bun will open an IPC channel to the subprocess. The passed callback is called for incoming messages, and `subprocess.send` can send messages to the subprocess. Messages are serialized using the JSC serialize API, which allows for the same types that `postMessage`/`structuredClone` supports.
+{%callout%}
+**Note** — This API is only compatible with other `bun` processes. Use `process.execPath` to get a path to the currently running `bun` executable.
+{%/callout%}
 
-
-The subprocess can send and recieve messages by using `process.send` and `process.on("message")`, respectively. This is the same API as what Node.js exposes when `child_process.fork()` is used.
-
-
-Currently, this is only compatible with processes that are other `bun` instances.
-
-```ts
-// index.ts
+```ts#parent.ts
 const child = Bun.spawn(["bun", "child.ts"], {
   ipc(message) {
-    console.log("[Parent] Received %o", message);
+    /**
+     * The message received from the sub process
+     **/
+  },
+});
+```
+
+---
+
+The parent process can send messages to the subprocess using the `.send()` method on the returned `Subprocess` instance. A reference to the sending subprocess is also available as the second argument in the `ipc` handler.
+
+```ts#parent.ts
+const childProc = Bun.spawn(["bun", "child.ts"], {
+  ipc(message, childProc) {
+    /**
+     * The message received from the sub process
+     **/
+    childProc.send("Respond to child")
   },
 });
 
-child.send("Hello from parent");
+childProc.send("I am your father"); // The parent can send messages to the child as well
 ```
 
 ---
 
-The child.ts would look like this
+Meanwhile the child process can send messages to its parent using with `process.send()` and receive messages with `process.on("message")`. This is the same API used for `child_process.fork()` in Node.js.
 
-```ts
-// child.ts
-
-// process.send will be undefined if the ipc channel is not open
-process.send("Hello from child");
+```ts#child.ts
+process.send("Hello from child as string");
+process.send({ message: "Hello from child as object" });
 
 process.on("message", (message) => {
-  process.send(`echo: ${message}`);
+  // print message from parent
+  console.log(message);
 });
-
-/**
- * Output from index.ts
- * [Parent] Received Hello from child
- * [Parent] Received echo: Hello from parent
-*/
 ```
 
 ---
 
-The payload in the send command can even be an object
+All messages are serialized using the JSC `serialize` API, which allows for the same set of [transferrable types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) supported by `postMessage` and `structuredClone`, including strings, typed arrays, streams, and objects.
 
-```ts
-// child.ts
-process.send({ message: "Hello from child" });
+```ts#child.ts
+// send a string
+process.send("Hello from child as string");
 
-/**
- * Output
- * [Parent] Received {
- *  message: "Hello from child"
- * }
- * [Parent] Received echo: Hello from parent
-*/
+// send an object
+process.send({ message: "Hello from child as object" });
 ```
 
 ---

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -733,6 +733,8 @@ interface Process {
    * On other operating systems, this returns `undefined`.
    */
   constrainedMemory(): number | undefined;
+
+  send(data: any): void;
 }
 
 interface MemoryUsageObject {


### PR DESCRIPTION
### What does this PR do?

Adding the missing documentation for the IPC feature on Bun.spawn

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes