### PR TITLE
fix #6416

### DIFF
--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -808,6 +808,14 @@ pub const PackageManifest = struct {
             return this.findByVersion(left.version);
         }
 
+        if (!group.flags.isSet(Semver.Query.Group.Flags.pre)) {
+            if (this.findByDistTag("latest")) |latest| {
+                if (group.satisfies(latest.version)) {
+                    return latest;
+                }
+            }
+        }
+
         {
             const releases = this.pkg.releases.keys.get(this.versions);
             var i = releases.len;
@@ -832,10 +840,6 @@ pub const PackageManifest = struct {
                 if (group.satisfies(version)) {
                     return .{ .version = version, .package = &packages[i - 1] };
                 }
-            }
-        } else if (this.findByDistTag("latest")) |result| {
-            if (group.satisfies(result.version)) {
-                return result;
             }
         }
 

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -808,10 +808,15 @@ pub const PackageManifest = struct {
             return this.findByVersion(left.version);
         }
 
-        if (!group.flags.isSet(Semver.Query.Group.Flags.pre)) {
-            if (this.findByDistTag("latest")) |latest| {
-                if (group.satisfies(latest.version)) {
-                    return latest;
+        if (this.findByDistTag("latest")) |result| {
+            if (group.satisfies(result.version)) {
+                if (group.flags.isSet(Semver.Query.Group.Flags.pre)) {
+                    if (left.version.order(result.version, this.string_buf, this.string_buf) == .eq) {
+                        // if prerelease, use latest if semver+tag match range exactly
+                        return result;
+                    }
+                } else {
+                    return result;
                 }
             }
         }

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -808,12 +808,6 @@ pub const PackageManifest = struct {
             return this.findByVersion(left.version);
         }
 
-        if (this.findByDistTag("latest")) |result| {
-            if (group.satisfies(result.version)) {
-                return result;
-            }
-        }
-
         {
             const releases = this.pkg.releases.keys.get(this.versions);
             var i = releases.len;
@@ -838,6 +832,10 @@ pub const PackageManifest = struct {
                 if (group.satisfies(version)) {
                     return .{ .version = version, .package = &packages[i - 1] };
                 }
+            }
+        } else if (this.findByDistTag("latest")) |result| {
+            if (group.satisfies(result.version)) {
+                return result;
             }
         }
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1966,6 +1966,34 @@ it("should install latest with prereleases", async () => {
   out = await new Response(stdout).text();
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\n/)).toEqual([" + baz@1.0.0-8", "", " 1 package installed"]);
   expect(await exited).toBe(0);
+
+  await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+  await rm(join(package_dir, "bun.lockb"), { recursive: true, force: true });
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        baz: "^1.0.0-0",
+      },
+    }),
+  );
+  ({ stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: package_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  }));
+  expect(stderr).toBeDefined();
+  err = await new Response(stderr).text();
+  expect(err).toContain("Saved lockfile");
+  expect(stdout).toBeDefined();
+  out = await new Response(stdout).text();
+  expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\n/)).toEqual([" + baz@1.0.0-0", "", " 1 package installed"]);
+  expect(await exited).toBe(0);
   await access(join(package_dir, "bun.lockb"));
 });
 


### PR DESCRIPTION
### What does this PR do?
fixes #6416 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
added tests and tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
