### PR TITLE
Adds systemd guide to run a bun application as a daemon

### DIFF
--- a/docs/guides/ecosystem/systemd.md
+++ b/docs/guides/ecosystem/systemd.md
@@ -19,7 +19,7 @@ $ touch my-app.service
 
 ---
 
-Here is a typical service file that runs an application on system start. You can use this as a template for your own service.
+Here is a typical service file that runs an application on system start. You can use this as a template for your own service. Refer to the [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.service.html) for more information on each setting.
 
 ```ini
 [Unit]
@@ -83,7 +83,7 @@ $ sudo systemctl status my-app
 
 ---
 
-To update the service, edit the contents of the service file then reload the daemon.
+To update the service, edit the contents of the service file, then reload the daemon.
 
 ```bash
 sudo systemctl daemon-reload
@@ -91,13 +91,13 @@ sudo systemctl daemon-reload
 
 ---
 
-Fore a complete guide on the service unit configuration, you can check [this page](https://www.freedesktop.org/software/systemd/man/systemd.service.html). Or refer to this cheatsheet of common commands:
+For a complete guide on the service unit configuration, you can check [this page](https://www.freedesktop.org/software/systemd/man/systemd.service.html). Or refer to this cheatsheet of common commands:
 
 ```bash
-sudo systemctl daemon-reload # Tells the systemd that some files got changed
-sudo systemctl enable my-app # Enables the app to auto start
-sudo systemctl disable my-app # Disable the app from auto starting
-sudo systemctl start my-app # It starts the app if is stopped (This doesn't affect enable/disable)
-sudo systemctl stop my-app # It stops the app (This doesn't affect enable/disable)
-sudo systemctl restart my-app # It restarts the app
+sudo systemctl daemon-reload # tell systemd that some files got changed
+sudo systemctl enable my-app # enable the app (to allow auto-start)
+sudo systemctl disable my-app # disable the app (turns off auto-start)
+sudo systemctl start my-app # start the app if is stopped
+sudo systemctl stop my-app # stop the app
+sudo systemctl restart my-app # restart the app
 ```

--- a/docs/guides/ecosystem/systemd.md
+++ b/docs/guides/ecosystem/systemd.md
@@ -10,7 +10,7 @@ Other parts include a logging daemon, utilities to control basic system configur
 
 ---
 
-### The service file
+### The service unit configuration
 
 ---
 
@@ -26,7 +26,7 @@ The service file contains:
   - **Type** -> In most cases you will use the `simple` type, but if you need a special case, you can find the rest of the types [here](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=)
   - **User** ->
 
-    - Which user to use when starting the application, if you are using the ports 80 or 443, a normal user might not have permission to use those ports
+    - Which user to use when starting the application, if you are using the ports **80** or **443**, a normal user might not have permission to use those ports
     - Use the `root` user at your own risk, as it might expose a security risk
     - In order to use those ports with your non-root user, you need to run this as sudo, With this you can grant permanent access to a specific binary to bind to low-numbered ports
 
@@ -113,5 +113,7 @@ sudo systemctl restart my-app # It restarts the app
 ```
 
 ---
+
+Fore a complete guide on the service unit configuration, you can check [this page](https://www.freedesktop.org/software/systemd/man/systemd.service.html)
 
 #### Now your application is now running as a daemon with systemd using Bun as the interpreter 🥳

--- a/docs/guides/ecosystem/systemd.md
+++ b/docs/guides/ecosystem/systemd.md
@@ -55,7 +55,7 @@ WantedBy=multi-user.target
 If your application starts a webserver, note that non-`root` users are not able to listen on ports 80 or 443 by default. To permanently allow Bun to listen on these ports when executed by a non-`root` user, use the following command. This step isn't necessary when running as `root`.
 
 ```bash
-sudo setcap CAP_NET_BIND_SERVICE=+eip ~/.bun/bin/bun
+$ sudo setcap CAP_NET_BIND_SERVICE=+eip ~/.bun/bin/bun
 ```
 
 ---
@@ -63,7 +63,7 @@ sudo setcap CAP_NET_BIND_SERVICE=+eip ~/.bun/bin/bun
 With the service file configured, you can now _enable_ the service. Once enabled, it will start automatically on reboot. This requires `sudo` permissions.
 
 ```bash
-sudo systemctl enable my-app
+$ sudo systemctl enable my-app
 ```
 
 ---
@@ -96,7 +96,7 @@ $ sudo systemctl status my-app
 To update the service, edit the contents of the service file, then reload the daemon.
 
 ```bash
-sudo systemctl daemon-reload
+$ sudo systemctl daemon-reload
 ```
 
 ---
@@ -104,10 +104,10 @@ sudo systemctl daemon-reload
 For a complete guide on the service unit configuration, you can check [this page](https://www.freedesktop.org/software/systemd/man/systemd.service.html). Or refer to this cheatsheet of common commands:
 
 ```bash
-sudo systemctl daemon-reload # tell systemd that some files got changed
-sudo systemctl enable my-app # enable the app (to allow auto-start)
-sudo systemctl disable my-app # disable the app (turns off auto-start)
-sudo systemctl start my-app # start the app if is stopped
-sudo systemctl stop my-app # stop the app
-sudo systemctl restart my-app # restart the app
+$ sudo systemctl daemon-reload # tell systemd that some files got changed
+$ sudo systemctl enable my-app # enable the app (to allow auto-start)
+$ sudo systemctl disable my-app # disable the app (turns off auto-start)
+$ sudo systemctl start my-app # start the app if is stopped
+$ sudo systemctl stop my-app # stop the app
+$ sudo systemctl restart my-app # restart the app
 ```

--- a/docs/guides/ecosystem/systemd.md
+++ b/docs/guides/ecosystem/systemd.md
@@ -19,9 +19,11 @@ $ touch my-app.service
 
 ---
 
-Here is a typical service file that runs an application on system start. You can use this as a template for your own service. Refer to the [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.service.html) for more information on each setting.
+Here is a typical service file that runs an application on system start. You can use this as a template for your own service. Replace `YOUR_USER` with the name of the user you want to run the application as. To run as `root`, replace `YOUR_USER` with `root`, though this is generally not recommended for security reasons.
 
-```ini
+Refer to the [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.service.html) for more information on each setting.
+
+```ini#my-app.service
 [Unit]
 # describe the app
 Description=My App
@@ -46,6 +48,14 @@ Restart=always
 [Install]
 # start the app automatically
 WantedBy=multi-user.target
+```
+
+---
+
+If your application starts a webserver, note that non-`root` users are not able to listen on ports 80 or 443 by default. To permanently allow Bun to listen on these ports when executed by a non-`root` user, use the following command. This step isn't necessary when running as `root`.
+
+```bash
+sudo setcap CAP_NET_BIND_SERVICE=+eip ~/.bun/bin/bun
 ```
 
 ---
@@ -78,7 +88,7 @@ $ sudo systemctl status my-app
      Memory: 40.9M
         CPU: 1.093s
      CGroup: /system.slice/my-app.service
-             └─309641 /home/YOUR_USER/.bun/bin/bun run /home/YOUR_USER/application/dist/index.js
+             └─309641 /home/YOUR_USER/.bun/bin/bun run /home/YOUR_USER/application/index.ts
 ```
 
 ---

--- a/docs/guides/ecosystem/systemd.md
+++ b/docs/guides/ecosystem/systemd.md
@@ -1,0 +1,106 @@
+---
+name: Run Bun as a daemon with systemd
+---
+
+[systemd](https://systemd.io) is a suite of basic building blocks for a Linux system. It provides a system and service manager that runs as PID 1 and starts the rest of the system.
+
+systemd provides aggressive parallelization capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, keeps track of processes using Linux control groups, maintains mount and auto mount points, and implements an elaborate transactional dependency-based service control logic. systemd supports SysV and LSB init scripts and works as a replacement for sysvinit.
+
+Other parts include a logging daemon, utilities to control basic system configuration like the hostname, date, locale, maintain a list of logged-in users and running containers and virtual machines, system accounts, runtime directories and settings, and daemons to manage simple network configuration, network time synchronization, log forwarding, and name resolution.
+
+---
+
+### The service file
+
+---
+
+To run the **bun** application using **systemd** you need to create the following file in `/lib/systemd/system/` and the file name must end in `.service`, e.g. `my-app.service` and the full path for this file will be `/lib/systemd/system/my-app.service`.
+
+The service file contains:
+
+- [Unit]
+  - **Description** -> A description about your application
+  - **After** -> by setting the value `network.target` the system will know to start your application after the network is available
+- [Service]
+  - **Type** -> In most cases you will use the `simple` type, but if you need a special case, you can find the rest of the types [here](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=)
+  - **User** -> Which user to use when starting the application, if you are using the ports 80 or 443, a normal user might not have permission to use those ports
+  - **WorkingDirectory** -> This needs to be set to the root directory of your application
+  - **ExecStart** -> Here you need to specify the executable and the file to start, in the case of bun, you need to point to the path `/home/YOUR_USER/.bun/bin/bun` because systemd will not know about bun.
+  - **Restart** -> If set to **always** than the service will restart every time when the process is closed even on a clean exit, available options for this are: `no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, always`
+- [Install]
+  - **WantedBy** -> multi-user.target normally defines a system state where all network services are started up and the system will accept logins. If you omit this part, the service will not start automatically unless another service has `Requires` or `Wants` that points to your service
+
+```ini
+[Unit]
+Description=My App
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/home/YOUR_USER/application
+ExecStart=/home/YOUR_USER/.bun/bin/bun run /home/YOUR_USER/application/dist/index.js
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+---
+
+### Commands to start/stop/enable/restart your service
+
+---
+
+Now that you have your service file, you can start the file using the following command, **note** that this command requires **sudo** permissions. The name of the service is the name of the file
+
+```bash
+sudo systemctl start my-app
+```
+
+To check the status of your application use `status` instead of `start`
+
+```bash
+sudo systemctl status my-app
+```
+
+If the application started successfully you should see something like this:
+
+```bash
+● my-app.service - My App
+     Loaded: loaded (/lib/systemd/system/my-app.service; enabled; preset: enabled)
+     Active: active (running) since Thu 2023-10-12 11:34:08 UTC; 1h 8min ago
+   Main PID: 309641 (bun)
+      Tasks: 3 (limit: 503)
+     Memory: 40.9M
+        CPU: 1.093s
+     CGroup: /system.slice/my-app.service
+             └─309641 /home/YOUR_USER/.bun/bin/bun run /home/YOUR_USER/application/dist/index.js
+```
+
+Now you only started the app, but is not enough to automatically start the app on boot, you need to enable the service using this command:
+
+```bash
+sudo systemctl enable my-app
+```
+
+Once enabled, the app will start on boot, but if you want to change the contents of the service file, you need to run the following command after the edit in order to tell the system that the file changed:
+
+```bash
+sudo systemctl daemon-reload
+```
+
+And that is it!! Now you might want to know the following commands and recap the used ones:
+
+```bash
+sudo systemctl daemon-reload # Tells the systemd that some files got changed
+sudo systemctl enable my-app # Enables the app to auto start
+sudo systemctl disable my-app # Disable the app from auto starting
+sudo systemctl start my-app # It starts the app if is stopped (This doesn't affect enable/disable)
+sudo systemctl stop my-app # It stops the app (This doesn't affect enable/disable)
+sudo systemctl restart my-app # It restarts the app
+```
+
+---
+
+#### Now your application is now running as a daemon with systemd using Bun as the interpreter 🥳

--- a/docs/guides/ecosystem/systemd.md
+++ b/docs/guides/ecosystem/systemd.md
@@ -22,11 +22,22 @@ The service file contains:
   - **Description** -> A description about your application
   - **After** -> by setting the value `network.target` the system will know to start your application after the network is available
 - [Service]
+
   - **Type** -> In most cases you will use the `simple` type, but if you need a special case, you can find the rest of the types [here](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=)
-  - **User** -> Which user to use when starting the application, if you are using the ports 80 or 443, a normal user might not have permission to use those ports
+  - **User** ->
+
+    - Which user to use when starting the application, if you are using the ports 80 or 443, a normal user might not have permission to use those ports
+    - Use the `root` user at your own risk, as it might expose a security risk
+    - In order to use those ports with your non-root user, you need to run this as sudo, With this you can grant permanent access to a specific binary to bind to low-numbered ports
+
+      ```bash
+      sudo setcap CAP_NET_BIND_SERVICE=+eip ~/.bun/bin/bun
+      ```
+
   - **WorkingDirectory** -> This needs to be set to the root directory of your application
   - **ExecStart** -> Here you need to specify the executable and the file to start, in the case of bun, you need to point to the path `/home/YOUR_USER/.bun/bin/bun` because systemd will not know about bun.
   - **Restart** -> If set to **always** than the service will restart every time when the process is closed even on a clean exit, available options for this are: `no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, always`
+
 - [Install]
   - **WantedBy** -> multi-user.target normally defines a system state where all network services are started up and the system will accept logins. If you omit this part, the service will not start automatically unless another service has `Requires` or `Wants` that points to your service
 
@@ -37,7 +48,7 @@ After=network.target
 
 [Service]
 Type=simple
-User=root
+User=YOUR_USER
 WorkingDirectory=/home/YOUR_USER/application
 ExecStart=/home/YOUR_USER/.bun/bin/bun run /home/YOUR_USER/application/dist/index.js
 Restart=always


### PR DESCRIPTION
### What does this PR do?

Adds a guide for using `systemd` to run a bun application as a daemon

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)