### PR TITLE
docs: fix typo and add a direct troubleshooting for `installation.md`

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -89,7 +89,7 @@ f you've installed Bun but are seeing a `command not found` error, you may have 
 
 ```sh
 $ echo $SHELL
-/bin/zsh # or /bin/bash or /bin/fish
+/bin/bash # or /bin/zsh or /bin/fish
 ```
 
 Then add these lines to the appropriate file, save it, and open a new shell.
@@ -103,7 +103,7 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 ```
 
 ```bash#zsh
-# ~/.bashrc
+# ~/.zshrc
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,6 +116,23 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 
 {% /codetabs %}
 
+You can also execute the following commands to add the installation directory to your `PATH` with automatic detection of the shell you're using:
+
+```sh
+$ SHELL_NAME=$(basename "$SHELL")
+$ CONFIG_FILE=""
+$ 
+$ case "$SHELL_NAME" in
+$     bash) CONFIG_FILE=~/.bashrc ;;
+$     zsh) CONFIG_FILE=~/.zshrc ;;
+$     fish) CONFIG_FILE=~/.config/fish/config.fish ;;
+$ esac
+$ 
+$ echo 'export BUN_INSTALL="$HOME/.bun"' >> "$CONFIG_FILE"
+$ echo 'export PATH="$BUN_INSTALL/bin:$PATH"' >> "$CONFIG_FILE"
+$ source "$CONFIG_FILE"
+```
+
 ## Upgrading
 
 Once installed, the binary can upgrade itself.


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

1. Fix typo in the zsh code tab
2. arrange the order to align with the code tabs
3. add a direct troubleshooting to add the installation path based on the shell name.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

N/A
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->


cc: @colinhacks 
