### PR TITLE
Fix dns.lookup returning wrong address for family

### DIFF
--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -102,11 +102,12 @@ const LibInfo = struct {
         ) catch unreachable;
         const promise_value = request.head.promise.value();
 
+        const hints = query.options.toLibC();
         const errno = getaddrinfo_async_start_(
             &request.backend.libinfo.machport,
             name_z.ptr,
             null,
-            null,
+            if (hints != null) &hints.? else null,
             GetAddrInfoRequest.getAddrInfoAsyncCallback,
             request,
         );
@@ -2475,7 +2476,7 @@ pub const DNSResolver = struct {
             return dns_lookup.promise.value();
         }
 
-        // var hints_buf = &[_]c_ares.AddrInfo_hints{query.toCAres()};
+        var hints_buf = &[_]c_ares.AddrInfo_hints{query.toCAres()};
         var request = GetAddrInfoRequest.init(
             cache,
             .{
@@ -2491,7 +2492,7 @@ pub const DNSResolver = struct {
         channel.getAddrInfo(
             query.name,
             query.port,
-            &.{},
+            hints_buf,
             GetAddrInfoRequest,
             request,
             GetAddrInfoRequest.onCaresComplete,

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -4,25 +4,13 @@ import { withoutAggressiveGC } from "harness";
 import { isIP, isIPv4, isIPv6 } from "node:net";
 
 const backends = ["system", "libc", "c-ares"];
-const validHostnames = [
-  "localhost",
-  "example.com",
-];
-const invalidHostnames = [
-  `this-should-not-exist-${Math.floor(Math.random() * 99999)}.com`,
-];
-const malformedHostnames = [
-  "",
-  " ",
-  ".",
-  " .",
-  "localhost:80",
-  "this is not a hostname",
-];
+const validHostnames = ["localhost", "example.com"];
+const invalidHostnames = [`this-should-not-exist-${Math.floor(Math.random() * 99999)}.com`];
+const malformedHostnames = ["", " ", ".", " .", "localhost:80", "this is not a hostname"];
 
 describe("dns", () => {
-  describe.each(backends)("lookup() [backend: %s]", (backend) => {
-    describe.each(validHostnames)("%s", (hostname) => {
+  describe.each(backends)("lookup() [backend: %s]", backend => {
+    describe.each(validHostnames)("%s", hostname => {
       test.each([
         {
           options: { backend },
@@ -55,7 +43,7 @@ describe("dns", () => {
         {
           options: { backend, family: "any" },
           address: isIP,
-        }
+        },
       ])("%j", async ({ options, address: expectedAddress, family: expectedFamily }) => {
         // @ts-expect-error
         const result = await dns.lookup(hostname, options);
@@ -74,11 +62,11 @@ describe("dns", () => {
         });
       });
     });
-    test.each(validHostnames)("%s [parallel x 10]", async (hostname) => {
+    test.each(validHostnames)("%s [parallel x 10]", async hostname => {
       const results = await Promise.all(
         // @ts-expect-error
-        Array.from({ length: 10 }, () => dns.lookup(hostname, { backend }))
-      )
+        Array.from({ length: 10 }, () => dns.lookup(hostname, { backend })),
+      );
       const answers = results.flat();
       expect(answers).toBeArray();
       expect(answers.length).toBeGreaterThan(10);
@@ -91,7 +79,7 @@ describe("dns", () => {
         }
       });
     });
-    test.each(invalidHostnames)("%s", (hostname) => {
+    test.each(invalidHostnames)("%s", hostname => {
       // @ts-expect-error
       expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
         code: "DNS_ENOTFOUND",

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -1,50 +1,108 @@
 import { dns } from "bun";
 import { describe, expect, it, test } from "bun:test";
 import { withoutAggressiveGC } from "harness";
+import { isIP, isIPv4, isIPv6 } from "node:net";
 
-describe("dns.lookup", () => {
-  const backends = [process.platform === "darwin" ? "system" : undefined, "libc", "c-ares"].filter(x => !!x) as (
-    | "system"
-    | "libc"
-    | "c-ares"
-  )[];
-  for (let backend of backends) {
-    it(backend + " parallell x 10", async () => {
-      const promises = [];
-      for (let i = 0; i < 10; i++) {
-        promises.push(dns.lookup("localhost", { backend }));
-      }
-      const results = (await Promise.all(promises)).flat();
-      withoutAggressiveGC(() => {
-        for (let { family, address } of results) {
-          if (family === 4) {
-            expect(address).toBe("127.0.0.1");
-          } else if (family === 6) {
-            expect(address).toBe("::1");
-          } else {
-            throw new Error("Unknown family");
+const backends = ["system", "libc", "c-ares"];
+const validHostnames = [
+  "localhost",
+  "example.com",
+];
+const invalidHostnames = [
+  `this-should-not-exist-${Math.floor(Math.random() * 99999)}.com`,
+];
+const malformedHostnames = [
+  "",
+  " ",
+  ".",
+  " .",
+  "localhost:80",
+  "this is not a hostname",
+];
+
+describe("dns", () => {
+  describe.each(backends)("lookup() [backend: %s]", (backend) => {
+    describe.each(validHostnames)("%s", (hostname) => {
+      test.each([
+        {
+          options: { backend },
+          address: isIP,
+        },
+        {
+          options: { backend, family: 4 },
+          address: isIPv4,
+          family: 4,
+        },
+        {
+          options: { backend, family: "IPv4" },
+          address: isIPv4,
+          family: 4,
+        },
+        {
+          options: { backend, family: 6 },
+          address: isIPv6,
+          family: 6,
+        },
+        {
+          options: { backend, family: "IPv6" },
+          address: isIPv6,
+          family: 6,
+        },
+        {
+          options: { backend, family: 0 },
+          address: isIP,
+        },
+        {
+          options: { backend, family: "any" },
+          address: isIP,
+        }
+      ])("%j", async ({ options, address: expectedAddress, family: expectedFamily }) => {
+        // @ts-expect-error
+        const result = await dns.lookup(hostname, options);
+        expect(result).toBeArray();
+        expect(result.length).toBeGreaterThan(0);
+        withoutAggressiveGC(() => {
+          for (const { family, address, ttl } of result) {
+            expect(address).toBeString();
+            expect(expectedAddress(address)).toBeTruthy();
+            expect(family).toBeInteger();
+            if (expectedFamily !== undefined) {
+              expect(family).toBe(expectedFamily);
+            }
+            expect(ttl).toBeInteger();
           }
+        });
+      });
+    });
+    test.each(validHostnames)("%s [parallel x 10]", async (hostname) => {
+      const results = await Promise.all(
+        // @ts-expect-error
+        Array.from({ length: 10 }, () => dns.lookup(hostname, { backend }))
+      )
+      const answers = results.flat();
+      expect(answers).toBeArray();
+      expect(answers.length).toBeGreaterThan(10);
+      withoutAggressiveGC(() => {
+        for (const { family, address, ttl } of answers) {
+          expect(address).toBeString();
+          expect(isIP(address)).toBeTruthy();
+          expect(family).toBeInteger();
+          expect(ttl).toBeInteger();
         }
       });
     });
-
-    it(backend + " remote", async () => {
-      const [first, second] = await dns.lookup("google.com", { backend });
-      console.log(first, second);
+    test.each(invalidHostnames)("%s", (hostname) => {
+      // @ts-expect-error
+      expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
+        code: "DNS_ENOTFOUND",
+      });
     });
-    it(backend + " local", async () => {
-      const [first, second] = await dns.lookup("localhost", { backend });
-      console.log(first, second);
-    });
-
-    it(backend + " failing domain throws an error without taking a very long time", async () => {
-      try {
-        await dns.lookup("yololololololo1234567.com", { backend });
-        throw 42;
-      } catch (e: any) {
-        expect(typeof e).not.toBe("number");
-        expect(e.code).toBe("DNS_ENOTFOUND");
-      }
-    });
-  }
+    // TODO: causes segfaults
+    // test.each(malformedHostnames)("%s", (hostname) => {
+    //   // @ts-expect-error
+    //   expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
+    //     code: "DNS_ENOTFOUND",
+    //   });
+    // });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes `Bun.dns` and `node:dns` from returning incorrect addresses when a `family` is specified. This was because we were not setting the proper hints.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

Closes #6452
