### PR TITLE
add reejs in guides

### DIFF
--- a/docs/guides/ecosystem/reejs.md
+++ b/docs/guides/ecosystem/reejs.md
@@ -1,0 +1,63 @@
+---
+name: Build an app with Reejs and Bun
+---
+
+{% callout %}
+Currently Reejs depends on `node:repl` to provide a custom repl service for `reejs repl` command. Therefore `repl` command is disabled for Bun (and Deno). Other things should work fine as expected.
+{% /callout %}
+
+---
+
+Install Reejs globally, as this improves your developer experience.
+
+```sh
+$ bun i reejs -g
+```
+
+Initialize a Reejs app with `create-reejs`.
+
+```sh
+$ reejs x https://esm.sh/create-reejs
+✓ https://esm.sh/create-reejs@0.14.0 in 0.12s
+
+╭────────────────────────────────╮
+│                                │
+│   Welcome to Reejs Framework   │
+│                                │
+╰────────────────────────────────╯
+
+┌  Let's create a new project!
+│
+◇  What would we create your next project?
+│  ./reejs-project
+│
+◇  Choose the features you want to include in your project
+│  React, Twind CSS, API Server, Serve Static Files
+│
+◇  Which package manager do you want to use (alongside URL Imports)?
+│  bun
+│
+◇  Should we install dependencies for you?
+│  No
+│
+◇   ────────────────────────────────────────────────╮
+│                                                   │
+│  cd into ./reejs-project and run `reejs install`  │
+│                                                   │
+├───────────────────────────────────────────────────╯
+│
+└  Let's get started!
+
+```
+
+> Note: Feel free to choose any features you want. Incompatible features will be mentioned before-hand.
+
+Verify that the dependencies are installed. You can do that by looking whether `.reejs` folder is filled with lot of files inside `.reejs/cache` folder and `node_modules` folder seems to be filled too. If not, run `reejs i` to install the dependencies and link them.
+
+To run the dev server, run `reejs packit bun -d`. Please note that `-d` runs Packit (the underlying code generator & transpiler) to run in dev mode - continuously looking for file changes and not minifying files. To run reejs in production, run `reejs packit bun`. It will generate a `packit.build.js` file, use `bun ./packit.build.js` to run it.
+
+Open [http://localhost:3000](http://localhost:3000) to see the app.
+
+Read the [Reejs docs](https://ree.js.org/) for more information on how to build apps with Reejs.
+
+If Reejs ever fails on Bun (but runs on Nodejs), **please** consider making an issue on their [github](https://github.com/rovelstars/reejs/issues).

--- a/docs/guides/ecosystem/reejs.md
+++ b/docs/guides/ecosystem/reejs.md
@@ -14,7 +14,11 @@ Install Reejs globally, as this improves your developer experience.
 $ bun i reejs -g
 ```
 
+---
+
 Initialize a Reejs app with `create-reejs`.
+
+Choose any features you want. Incompatible features will be mentioned before-hand.
 
 ```sh
 $ reejs x https://esm.sh/create-reejs
@@ -29,7 +33,7 @@ $ reejs x https://esm.sh/create-reejs
 ┌  Let's create a new project!
 │
 ◇  What would we create your next project?
-│  ./reejs-project
+│  ./my-reejs-app
 │
 ◇  Choose the features you want to include in your project
 │  React, Twind CSS, API Server, Serve Static Files
@@ -38,11 +42,11 @@ $ reejs x https://esm.sh/create-reejs
 │  bun
 │
 ◇  Should we install dependencies for you?
-│  No
+│  Yes
 │
 ◇   ────────────────────────────────────────────────╮
 │                                                   │
-│  cd into ./reejs-project and run `reejs install`  │
+│  cd into ./my-reejs-app and run `reejs install`  │
 │                                                   │
 ├───────────────────────────────────────────────────╯
 │
@@ -50,14 +54,44 @@ $ reejs x https://esm.sh/create-reejs
 
 ```
 
-> Note: Feel free to choose any features you want. Incompatible features will be mentioned before-hand.
+---
 
-Verify that the dependencies are installed. You can do that by looking whether `.reejs` folder is filled with lot of files inside `.reejs/cache` folder and `node_modules` folder seems to be filled too. If not, run `reejs i` to install the dependencies and link them.
+Check for the existence of the `.reejs` to verify that the dependencies are installed.
 
-To run the dev server, run `reejs packit bun -d`. Please note that `-d` runs Packit (the underlying code generator & transpiler) to run in dev mode - continuously looking for file changes and not minifying files. To run reejs in production, run `reejs packit bun`. It will generate a `packit.build.js` file, use `bun ./packit.build.js` to run it.
+If not, run `reejs i` to install and link dependencies.
+
+```sh
+$ ls .reejs
+cache       copy.cache  deps        files.cache serve       serve.cache
+```
+
+---
+
+Then start the dev server.
+
+Note that `-d` runs Packit (the underlying code generator & transpiler) in dev mode, which watches for file changes and disables minification.
+
+```sh
+$ reejs packit bun -d
+```
+
+---
 
 Open [http://localhost:3000](http://localhost:3000) to see the app.
 
+---
+
+To build and run a production app with Reejs, don't use the `-d` flag. This will generate a `*.build.js` file that can be executed directly with `bun`.
+
+```sh
+$ reejs packit bun
+$ bun ./packit.build.js
+```
+
+---
+
 Read the [Reejs docs](https://ree.js.org/) for more information on how to build apps with Reejs.
 
-If Reejs ever fails on Bun (but runs on Nodejs), **please** consider making an issue on their [github](https://github.com/rovelstars/reejs/issues).
+```
+
+```


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
This PR adds Reejs to Bun guides.


- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
