### PR TITLE
fix lockfile struct padding

### DIFF
--- a/src/install/integrity.zig
+++ b/src/install/integrity.zig
@@ -3,8 +3,7 @@ const strings = @import("../string_immutable.zig");
 const Crypto = @import("../sha.zig").Hashers;
 
 pub const Integrity = extern struct {
-    // this is zeroed like this to work around a comptime issue.
-    const empty_digest_buf: [Integrity.digest_buf_len]u8 = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    const empty_digest_buf: [Integrity.digest_buf_len]u8 = [_]u8{0} ** Integrity.digest_buf_len;
 
     tag: Tag = Tag.unknown,
     /// Possibly a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) value initially

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -4120,8 +4120,7 @@ pub const Package = extern struct {
 
         man_dir: String = String{},
         integrity: Integrity = Integrity{},
-        _padding_integrity1: u8 = 0,
-        _padding_integrity2: u16 = 0,
+        _padding_integrity: [3]u8 = .{0} ** 3,
 
         /// Does the `cpu` arch and `os` match the requirements listed in the package?
         /// This is completely unrelated to "devDependencies", "peerDependencies", "optionalDependencies" etc

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -4120,6 +4120,8 @@ pub const Package = extern struct {
 
         man_dir: String = String{},
         integrity: Integrity = Integrity{},
+        _padding_integrity1: u8 = 0,
+        _padding_integrity2: u16 = 0,
 
         /// Does the `cpu` arch and `os` match the requirements listed in the package?
         /// This is completely unrelated to "devDependencies", "peerDependencies", "optionalDependencies" etc

--- a/src/install/padding_checker.zig
+++ b/src/install/padding_checker.zig
@@ -55,7 +55,6 @@ pub fn assertNoUninitializedPadding(comptime T: type) void {
     // if (info.layout != .Extern) {
     //     @compileError("assertNoUninitializedPadding(" ++ @typeName(T) ++ ") expects an extern struct type, got a struct of layout '" ++ @tagName(info.layout) ++ "'");
     // }
-    var i = 0;
     for (info.fields) |field| {
         const fieldInfo = @typeInfo(field.type);
         switch (fieldInfo) {
@@ -69,9 +68,12 @@ pub fn assertNoUninitializedPadding(comptime T: type) void {
             else => {},
         }
     }
+
     if (info_ == .Union) {
         return;
     }
+
+    var i = 0;
     for (info.fields, 0..) |field, j| {
         const offset = @offsetOf(T, field.name);
         if (offset != i) {
@@ -89,5 +91,18 @@ pub fn assertNoUninitializedPadding(comptime T: type) void {
             ));
         }
         i = offset + @sizeOf(field.type);
+    }
+
+    if (i != @sizeOf(T)) {
+        @compileError(std.fmt.comptimePrint(
+            \\Expected no possibly uninitialized bytes of memory in '{s}', but found a {d} byte gap at the end of the struct. This can be fixed by adding a padding field to the struct like `padding: [{d}]u8 = .{{0}} ** {d},` between these fields. For more information, look at `padding_checker.zig`
+        ,
+            .{
+                @typeName(T),
+                @sizeOf(T) - i,
+                @sizeOf(T) - i,
+                @sizeOf(T) - i,
+            },
+        ));
     }
 }


### PR DESCRIPTION
### What does this PR do?
fixes a test in `bun-update.test.ts`
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
