### PR TITLE
fix: support custom file type in Bun.file

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1316,7 +1316,7 @@ pub const Blob = struct {
 
         var blob = Blob.findOrCreateFileFromPath(path, globalObject);
 
-        if (arguments.len == 2) {
+        if (arguments.len >= 2) {
             const opts = arguments[1];
 
             if (opts.isObject()) {
@@ -1326,19 +1326,18 @@ pub const Blob = struct {
                             var allocator = bun.default_allocator;
                             var str = file_type.toSlice(globalObject, bun.default_allocator);
                             defer str.deinit();
-                            var slice = str.slice();
+                            const slice = str.slice();
                             if (!strings.isAllASCII(slice)) {
                                 break :inner;
                             }
+                            blob.content_type_was_set = true;
                             if (vm.mimeType(str.slice())) |entry| {
-                                if (blob.store) |store| {
-                                    store.mime_type = entry;
-                                }
-                                blob.content_type_was_set = true;
-                                var content_type_buf = allocator.alloc(u8, slice.len) catch unreachable;
-                                blob.content_type = strings.copyLowercase(slice, content_type_buf);
-                                blob.content_type_allocated = true;
+                                blob.content_type = entry.value;
+                                break :inner;
                             }
+                            var content_type_buf = allocator.alloc(u8, slice.len) catch unreachable;
+                            blob.content_type = strings.copyLowercase(slice, content_type_buf);
+                            blob.content_type_allocated = true;
                         }
                     }
                 }

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1314,7 +1314,39 @@ pub const Blob = struct {
             return .undefined;
         };
 
-        const blob = Blob.findOrCreateFileFromPath(path, globalObject);
+        var blob = Blob.findOrCreateFileFromPath(path, globalObject);
+
+        if (arguments.len == 2) {
+            const opts = arguments[1];
+
+            if (opts.isObject()) {
+                if (opts.getTruthy(globalObject, "type")) |file_type| {
+                    inner: {
+                        if (file_type.isString()) {
+                            var allocator = bun.default_allocator;
+                            var str = file_type.toSlice(globalObject, bun.default_allocator);
+                            defer str.deinit();
+                            var slice = str.slice();
+                            if (!strings.isAllASCII(slice)) {
+                                break :inner;
+                            }
+                            if (vm.mimeType(str.slice())) |entry| {
+                                if (blob.store) |store| {
+                                    store.mime_type = entry;
+                                }
+                                blob.content_type_was_set = true;
+                                var content_type_buf = allocator.alloc(u8, slice.len) catch unreachable;
+                                blob.content_type = strings.copyLowercase(slice, content_type_buf);
+                                blob.content_type_allocated = true;
+                            }
+                        }
+                    }
+                }
+                if (opts.getTruthy(globalObject, "lastModified")) |last_modified| {
+                    blob.last_modified = last_modified.coerce(f64, globalObject);
+                }
+            }
+        }
 
         var ptr = bun.default_allocator.create(Blob) catch unreachable;
         ptr.* = blob;

--- a/test/js/bun/util/file-type.test.ts
+++ b/test/js/bun/util/file-type.test.ts
@@ -1,9 +1,14 @@
 import { test, expect, describe } from "bun:test";
 describe("util file tests", () => {
-  test("custom type respected (#6507)", () => {
+  test("custom set mime-type respected (#6507)", () => {
     const file = Bun.file("test", {
       type: "text/markdown",
     });
     expect(file.type).toBe("text/markdown");
+
+    const custom_type = Bun.file("test", {
+      type: "custom/mimetype",
+    });
+    expect(custom_type.type).toBe("custom/mimetype");
   });
 });

--- a/test/js/bun/util/file-type.test.ts
+++ b/test/js/bun/util/file-type.test.ts
@@ -1,0 +1,9 @@
+import { test, expect, describe } from "bun:test";
+describe("util file tests", () => {
+  test("custom type respected (#6507)", () => {
+    const file = Bun.file("test", {
+      type: "text/markdown",
+    });
+    expect(file.type).toBe("text/markdown");
+  });
+});


### PR DESCRIPTION
In the docs it seamed to suggest this is something supported, it seamed to be only supported in JSDOMFiles or blob. 

This Adds the 2 properties `type` and `lastModified` to be supported on `Bun.file`

Fixes: https://github.com/oven-sh/bun/issues/6507

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be

- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
