### PR TITLE
fix(jest): fix toStrictEqual on same URLs

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -669,6 +669,7 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     case JSDOMWrapperType: {
         if (c2Type == JSDOMWrapperType) {
             // https://github.com/oven-sh/bun/issues/4089
+            // https://github.com/oven-sh/bun/issues/6492
             auto* url2 = jsDynamicCast<JSDOMURL*>(v2);
             auto* url1 = jsDynamicCast<JSDOMURL*>(v1);
 
@@ -677,19 +678,15 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                 if ((url2 == nullptr) != (url1 == nullptr)) {
                     return false;
                 }
-
-                if (url2 && url1) {
-                    return url1->wrapped().href() != url2->wrapped().href();
-                }
-            } else {
-                if (url2 && url1) {
-                    // toEqual should return false when the URLs' href is not equal
-                    // But you could have added additional properties onto the
-                    // url object itself, so we must check those as well
-                    // But it's definitely not equal if the href() is not the same
-                    if (url1->wrapped().href() != url2->wrapped().href()) {
-                        return false;
-                    }
+            } 
+            
+            if (url2 && url1) {
+                // toEqual or toStrictEqual should return false when the URLs' href is not equal
+                // But you could have added additional properties onto the
+                // url object itself, so we must check those as well
+                // But it's definitely not equal if the href() is not the same
+                if (url1->wrapped().href() != url2->wrapped().href()) {
+                    return false;
                 }
             }
         }

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -977,11 +977,17 @@ describe("expect()", () => {
     for (let [first, second] of equals) {
       expect(first).toEqual(second);
       expect(second).toEqual(first);
+
+      expect(first).toStrictEqual(second);
+      expect(second).toStrictEqual(first);
     }
 
     for (let [first, second] of not) {
       expect(first).not.toEqual(second);
       expect(second).not.toEqual(first);
+
+      expect(first).not.toStrictEqual(second);
+      expect(second).not.toStrictEqual(first);
     }
 
     expect(Object.fromEntries(Object.entries(new URL("https://example.com")))).not.toStrictEqual(


### PR DESCRIPTION
### What does this PR do?

This fix toStrictEqual on compare two same URLs.

This line on **Bun__deepEquals**, always return false if the URLs are equal on strict.
`return url1->wrapped().href() != url2->wrapped().href();`

On toStrictEqual should continue checking additional properties like toEqual.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

Fixes: #6492 
Correlated issue: https://github.com/oven-sh/bun/issues/4089
Correlated fix: https://github.com/oven-sh/bun/pull/4105

