### PR TITLE
fix: set user agent header

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -216,6 +216,7 @@ const NetworkTask = struct {
     // https://github.com/oven-sh/bun/issues/341
     // https://www.jfrog.com/jira/browse/RTFACT-18398
     const accept_header_value = "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
+    const user_agent_value = "npm/?";
 
     const default_headers_buf: string = "Accept" ++ accept_header_value;
 
@@ -336,6 +337,8 @@ const NetworkTask = struct {
             header_builder.header_count = 1;
             header_builder.content = GlobalStringBuilder{ .ptr = @as([*]u8, @ptrFromInt(@intFromPtr(bun.span(default_headers_buf).ptr))), .len = default_headers_buf.len, .cap = default_headers_buf.len };
         }
+
+        header_builder.append("User-Agent", user_agent_value);
 
         this.response_buffer = try MutableString.init(allocator, 0);
         this.allocator = allocator;


### PR DESCRIPTION
### What does this PR do?

This add the agent header that some repos expect to be there

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

I tried to build bun locally however I couldnt get it to build (I read the getting started)

Is this something that you guys want? (if so I can look further into adding tests ect)
