### PR TITLE
fix #4766

### DIFF
--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1843,17 +1843,17 @@ pub const Example = struct {
 
         if (env_loader.map.get("GITHUB_ACCESS_TOKEN")) |access_token| {
             if (access_token.len > 0) {
-                headers_buf = try std.fmt.allocPrint(ctx.allocator, "Access-TokenBearer {s}", .{access_token});
+                headers_buf = try std.fmt.allocPrint(ctx.allocator, "AuthorizationBearer {s}", .{access_token});
                 try header_entries.append(
                     ctx.allocator,
                     Headers.Kv{
                         .name = Api.StringPointer{
                             .offset = 0,
-                            .length = @as(u32, @intCast("Access-Token".len)),
+                            .length = @as(u32, @intCast("Authorization".len)),
                         },
                         .value = Api.StringPointer{
-                            .offset = @as(u32, @intCast("Access-Token".len)),
-                            .length = @as(u32, @intCast(headers_buf.len - "Access-Token".len)),
+                            .offset = @as(u32, @intCast("Authorization".len)),
+                            .length = @as(u32, @intCast(headers_buf.len - "Authorization".len)),
                         },
                     },
                 );


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/4766

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

If Zig files changed:

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it

-   Hard to test without using a valid GH token. I am open to suggestions though.  However, the command has been validated locally

- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
