### PR TITLE
fix(node:buffer): fix the behavior of `totalLength` in `Buffer.concat`

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -742,23 +742,16 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JS
         byteLength += typedArray->length();
     }
 
-    if (callFrame->argumentCount() > 1) {
-        auto totalLengthValue = callFrame->uncheckedArgument(1);
-        if (!totalLengthValue.isUndefined()) {
-            if (UNLIKELY(!totalLengthValue.isNumber())) {
-                throwTypeError(lexicalGlobalObject, throwScope, "totalLength must be a valid number"_s);
-                return JSValue::encode(jsUndefined());
-            }
-
-            auto totalLength = totalLengthValue.toInt32(lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(throwScope, {});
-
-            if (UNLIKELY(totalLength < 0)) {
-                throwRangeError(lexicalGlobalObject, throwScope, "The value of totalLength is out of range"_s);
-                return JSValue::encode(jsUndefined());
-            }
-            byteLength = totalLength;
+    JSValue totalLengthValue = callFrame->argument(1);
+    if (!totalLengthValue.isUndefined()) {
+        if (UNLIKELY(!totalLengthValue.isNumber())) {
+            throwTypeError(lexicalGlobalObject, throwScope, "totalLength must be a valid number"_s);
+            return JSValue::encode(jsUndefined());
         }
+
+        auto totalLength = totalLengthValue.toTypedArrayIndex(lexicalGlobalObject, "totalLength must be a valid number"_s);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        byteLength = totalLength;
     }
 
     if (byteLength == 0) {

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1327,6 +1327,14 @@ it("Buffer.concat", () => {
   expect(Buffer.concat([array1, array2, array3], 222).length).toBe(222);
   expect(Buffer.concat([array1, array2, array3], 222).subarray(0, 128).join("")).toBe("100".repeat(128));
   expect(Buffer.concat([array1, array2, array3], 222).subarray(129, 222).join("")).toBe("200".repeat(222 - 129));
+  // issue#6570
+  expect(Buffer.concat([array1, array2, array3], undefined).join("")).toBe(
+    array1.join("") + array2.join("") + array3.join(""),
+  );
+  // issue#3639
+  expect(Buffer.concat([array1, array2, array3], 128 * 4).join("")).toBe(
+    array1.join("") + array2.join("") + array3.join("") + Buffer.alloc(128).join(""),
+  );
 });
 
 it("read", () => {

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1327,6 +1327,12 @@ it("Buffer.concat", () => {
   expect(Buffer.concat([array1, array2, array3], 222).length).toBe(222);
   expect(Buffer.concat([array1, array2, array3], 222).subarray(0, 128).join("")).toBe("100".repeat(128));
   expect(Buffer.concat([array1, array2, array3], 222).subarray(129, 222).join("")).toBe("200".repeat(222 - 129));
+  expect(() => {
+    Buffer.concat([array1], -1);
+  }).toThrow(RangeError);
+  expect(() => {
+    Buffer.concat([array1], "1");
+  }).toThrow(TypeError);
   // issue#6570
   expect(Buffer.concat([array1, array2, array3], undefined).join("")).toBe(
     array1.join("") + array2.join("") + array3.join(""),


### PR DESCRIPTION
### What does this PR do?

Close: #6570
Close: #3639


- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
