### PR TITLE
fix: online docs moved

### DIFF
--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -286,7 +286,7 @@ pub const PackageManagerCommand = struct {
             \\  bun pm <b>cache rm<r>     clear the cache
             \\  bun pm <b>migrate<r>      migrate another package manager's lockfile without installing anything
             \\
-            \\Learn more about these at <magenta>https://bun.sh/docs/install/utilities<r>
+            \\Learn more about these at <magenta>https://bun.sh/docs/cli/pm<r>
             \\
         , .{});
 


### PR DESCRIPTION
### What does this PR do?

Fixes a broken link.

https://bun.sh/docs/install/utilities was going to a 404 (a default Vercel styled 404), I've changed this to https://bun.sh/docs/cli/pm (note that the Help Docs are not complete - there's actually more commands like `bun pm migrate` which are in the Docs).

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)

### How did you verify your code works?

No, but it's a very simple change (see commit diff).