### PR TITLE
Adds macOS Keychain certs to default CA store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,8 @@ ifeq ($(OS_NAME), darwin)
 SYMBOLS=-exported_symbols_list $(realpath src/symbols.txt)
 PLATFORM_LINKER_FLAGS += -DDU_DISABLE_RENAMING=1 \
 		-lstdc++ \
-		-fno-keep-static-consts -lresolv
+		-fno-keep-static-consts -lresolv \
+		-framework Security -framework CoreFoundation
 endif
 
 ifeq ($(OS_NAME),linux)

--- a/Makefile
+++ b/Makefile
@@ -424,8 +424,7 @@ ifeq ($(OS_NAME), darwin)
 SYMBOLS=-exported_symbols_list $(realpath src/symbols.txt)
 PLATFORM_LINKER_FLAGS += -DDU_DISABLE_RENAMING=1 \
 		-lstdc++ \
-		-fno-keep-static-consts -lresolv \
-		-framework Security -framework CoreFoundation
+		-fno-keep-static-consts -lresolv
 endif
 
 ifeq ($(OS_NAME),linux)


### PR DESCRIPTION
### What does this PR do?

Adds support to `bun-usockets` to load trusted certificates from the native platform certificate store into the default CA store. This PR implements this for the macOS Keychain. Windows Certificate Stores could be added in the future.

Partially relevant: #271 

Note: All added code is usockets internal. Also change does not update `rootCertificates` in `internals/tls`.

Implementation based on [rustls-native-certs](https://github.com/rustls/rustls-native-certs/blob/main/src/macos.rs).

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [x] Tested locally
- [ ] I included a test for the new code, or an existing test covers it
	- Not sure how to since it's platform specific

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
