### PR TITLE
fix(napi): incorrect refCount with napi_wrap()

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -666,8 +666,8 @@ extern "C" napi_status napi_wrap(napi_env env,
 
     auto clientData = WebCore::clientData(vm);
 
-    auto* ref = new NapiRef(globalObject, 1);
-    ref->strongRef.set(globalObject->vm(), value.getObject());
+    auto* ref = new NapiRef(globalObject, 0);
+    ref->weakValueRef.setObject(value.getObject(), weakValueHandleOwner(), ref);
 
     if (finalize_cb) {
         ref->finalizer.finalize_cb = finalize_cb;


### PR DESCRIPTION
## TLDR
updates `napi_wrap()` so that it it's refCount starts with 0 instead of 1 to match the behavior of node.js

## Details
while trying to get [`node-usb`](https://github.com/node-usb/node-usb) running with bun, it always failed because close() is only allowed when there are no open references.

https://github.com/node-usb/node-usb/blob/7e0182df8cfc684f6ec0cc59691c79731bdb459f/src/node_usb.h#L39-L41
```c++
    inline void ref(){ refs_ = Ref();}
    inline void unref(){ refs_ = Unref();}
    inline bool canClose(){return refs_ == 0;}
```

`Ref()` and `Unref()` are both called once, with node.js resulting in `refs_ == 0` (which is expected), but with bun `refs_ == 1`.

I've made this small script to reproduce the bug:
https://github.com/alangecker/bun-ref-bug/blob/main/binding.cc
```
run with bun 1.0.6:
 - refcount: 2 (expected: 1)
run with node 20.8.1:
 - refcount: 1 (expected: 1)
```

during a long debugging journey I found out, that buns `NapiRef::ref()` is also just called once (as expected), but within `napi_wrap()` the `NapiRef` gets initialized already with the refCount set to 1

https://github.com/oven-sh/bun/blob/378385ba60900be7bd797923c219ec489101f2f5/src/bun.js/bindings/napi.cpp#L669
After changing it to `new NapiRef(globalObject, 0)` it got the expected behavior / same as with node.js and node-usb works. as far as I understand it, a `NapiRef` with refCount=0 should then be weak instead of strong, which is why I have changed this too.

### What does this PR do?

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
- I've ran the `make test-all` which fails with the same set of tests as without the change^^
- I've manually tested some modules using the napi API

## unclear to me
1. should the Reference really be changed to be weak?
2. does this change have any other implications / breaking something?
