### PR TITLE
fix(install): dont replace git urls when already present

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5221,6 +5221,18 @@ pub const PackageManager = struct {
                                         }
                                     }
                                     break;
+                                } else {
+                                    if (request.version.tag == .github or request.version.tag == .git) {
+                                        for (query.expr.data.e_object.properties.slice()) |item| {
+                                            if (item.value) |v| {
+                                                const url = request.version.literal.slice(request.version_buf);
+                                                if (v.data == .e_string and v.data.e_string.eql(string, url)) {
+                                                    remaining -= 1;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5227,6 +5227,7 @@ pub const PackageManager = struct {
                                             if (item.value) |v| {
                                                 const url = request.version.literal.slice(request.version_buf);
                                                 if (v.data == .e_string and v.data.e_string.eql(string, url)) {
+                                                    request.e_string = v.data.e_string;
                                                     remaining -= 1;
                                                     break;
                                                 }

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1114,6 +1114,49 @@ it("should handle Git URL in dependencies (SCP-style)", async () => {
   expect(requested).toBe(0);
 }, 20000);
 
+it("should not save git urls twice", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+    }),
+  );
+  const { exited: exited1 } = spawn({
+    cmd: [bunExe(), "add", "https://github.com/liz3/bun-ui.git"],
+    cwd: package_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  expect(await exited1).toBe(0);
+
+  const package_json_content = await file(join(package_dir, "package.json")).json();
+  expect(package_json_content.dependencies).toEqual({
+    "bun-ui": "https://github.com/liz3/bun-ui.git",
+  });
+
+  const { exited: exited2 } = spawn({
+    cmd: [bunExe(), "add", "https://github.com/liz3/bun-ui.git"],
+    cwd: package_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  expect(await exited2).toBe(0);
+
+  const package_json_content2 = await file(join(package_dir, "package.json")).json();
+  expect(package_json_content2.dependencies).toEqual({
+    "bun-ui": "https://github.com/liz3/bun-ui.git",
+  });
+}, 20000);
+
 it("should prefer optionalDependencies over dependencies of the same name", async () => {
   const urls: string[] = [];
   setHandler(


### PR DESCRIPTION
### What does this PR do?
When adding a git url as package which was already added, it would replace the existing with a faulty entry using a key with the url, this is because there was a step where both the entries would be present before resolving so the new entry did not have the actual name yet leading to preemtively adding it.
When the name then got resolved the logic matched but the key wasnt updated so it replaced the correct one.

This prevents the addititon to begin with by checking if the version matches any values.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->
- [x] I included a test for the new code, or an existing test covers it
<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files

- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
