### PR TITLE
fix findBestMatch so it finds the best match and not the first match

### DIFF
--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -823,26 +823,25 @@ pub const PackageManifest = struct {
 
         {
             const releases = this.pkg.releases.keys.get(this.versions);
-            var i = releases.len;
 
             var best_match_version: ?Semver.Version = null;
-            var best_match_package: ?PackageVersion = null;
+            var best_match_package_index: usize = 0;
+            var i = releases.len;
             // For now, this is the dumb way
             while (i > 0) : (i -= 1) {
                 const version = releases[i - 1];
 
                 // If we find one that matches, save it, but keep looping because we might find a newer match.
                 // The versions from the registry are not in any particular order.
-                if (group.satisfies(version) and (best_match_version == null or
-                    (Semver.Version.order(version, best_match_version.?, "", "") == .gt)))
-                {
+                if (group.satisfies(version) and (best_match_version == null or Semver.Version.order(version, best_match_version.?, "", "") == .gt)) {
                     best_match_version = version;
-                    best_match_package = this.pkg.releases.values.get(this.package_versions)[i - 1];
+                    best_match_package_index = i - 1;
                 }
             }
 
-            if (best_match_version != null and best_match_package != null) {
-                return .{ .version = best_match_version.?, .package = &best_match_package.? };
+            if (best_match_version != null) {
+                const packages = this.pkg.releases.values.get(this.package_versions);
+                return .{ .version = best_match_version.?, .package = &packages[best_match_package_index] };
             }
         }
 

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -825,22 +825,24 @@ pub const PackageManifest = struct {
             const releases = this.pkg.releases.keys.get(this.versions);
             var i = releases.len;
 
-            var bestMatchVersion: ?Semver.Version = null;
-            var bestMatchPackage: ?PackageVersion = null;
+            var best_match_version: ?Semver.Version = null;
+            var best_match_package: ?PackageVersion = null;
             // For now, this is the dumb way
             while (i > 0) : (i -= 1) {
                 const version = releases[i - 1];
 
                 // If we find one that matches, save it, but keep looping because we might find a newer match.
                 // The versions from the registry are not in any particular order.
-                if (group.satisfies(version) and (bestMatchVersion == null or Semver.Version.gt(version, bestMatchVersion.?))) {
-                    bestMatchVersion = version;
-                    bestMatchPackage = this.pkg.releases.values.get(this.package_versions)[i - 1];
+                if (group.satisfies(version) and (best_match_version == null or
+                    (Semver.Version.order(version, best_match_version.?, "", "") == .gt)))
+                {
+                    best_match_version = version;
+                    best_match_package = this.pkg.releases.values.get(this.package_versions)[i - 1];
                 }
             }
 
-            if (bestMatchVersion != null and bestMatchPackage != null) {
-                return .{ .version = bestMatchVersion.?, .package = &bestMatchPackage.? };
+            if (best_match_version != null and best_match_package != null) {
+                return .{ .version = best_match_version.?, .package = &best_match_package.? };
             }
         }
 

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -824,14 +824,23 @@ pub const PackageManifest = struct {
         {
             const releases = this.pkg.releases.keys.get(this.versions);
             var i = releases.len;
+
+            var bestMatchVersion: ?Semver.Version = null;
+            var bestMatchPackage: ?PackageVersion = null;
             // For now, this is the dumb way
             while (i > 0) : (i -= 1) {
                 const version = releases[i - 1];
-                const packages = this.pkg.releases.values.get(this.package_versions);
 
-                if (group.satisfies(version)) {
-                    return .{ .version = version, .package = &packages[i - 1] };
+                // If we find one that matches, save it, but keep looping because we might find a newer match.
+                // The versions from the registry are not in any particular order.
+                if (group.satisfies(version) and (bestMatchVersion == null or Semver.Version.gt(version, bestMatchVersion.?))) {
+                    bestMatchVersion = version;
+                    bestMatchPackage = this.pkg.releases.values.get(this.package_versions)[i - 1];
                 }
+            }
+
+            if (bestMatchVersion != null and bestMatchPackage != null) {
+                return .{ .version = bestMatchVersion.?, .package = &bestMatchPackage.? };
             }
         }
 

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -721,6 +721,13 @@ pub const Version = extern struct {
         return lhs.major == rhs.major and lhs.minor == rhs.minor and lhs.patch == rhs.patch and rhs.tag.eql(lhs.tag);
     }
 
+    pub fn gt(lhs: Version, rhs: Version) bool {
+        if (lhs.major < rhs.major) return false;
+        if (lhs.minor < rhs.minor) return false;
+        if (lhs.patch < rhs.patch) return false;
+        return true;
+    }
+
     pub const HashContext = struct {
         pub fn hash(_: @This(), lhs: Version) u32 {
             return @as(u32, @truncate(lhs.hash()));

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -721,13 +721,6 @@ pub const Version = extern struct {
         return lhs.major == rhs.major and lhs.minor == rhs.minor and lhs.patch == rhs.patch and rhs.tag.eql(lhs.tag);
     }
 
-    pub fn gt(lhs: Version, rhs: Version) bool {
-        if (lhs.major < rhs.major) return false;
-        if (lhs.minor < rhs.minor) return false;
-        if (lhs.patch < rhs.patch) return false;
-        return true;
-    }
-
     pub const HashContext = struct {
         pub fn hash(_: @This(), lhs: Version) u32 {
             return @as(u32, @truncate(lhs.hash()));

--- a/test/cli/install/migration/complex-workspace.test.ts
+++ b/test/cli/install/migration/complex-workspace.test.ts
@@ -119,3 +119,6 @@ mustNotExist("packages/second/node_modules/body-parser/node_modules/body-parser/
 mustNotExist("packages/second/node_modules/body-parser/node_modules/iconv-lite");
 mustNotExist("packages/second/node_modules/iconv-lite");
 mustNotExist("node_modules/iconv-lite");
+
+// Should pick 1.2.4, not 1.2.0.
+validate("node_modules/lines-and-columns", "1.2.4");

--- a/test/cli/install/migration/complex-workspace/package.json
+++ b/test/cli/install/migration/complex-workspace/package.json
@@ -7,6 +7,7 @@
     "hello": "file:hello-0.3.2.tgz",
     "install-test": "bitbucket:dylan-conway/public-install-test",
     "install-test1": "git+ssh://git@github.com/dylan-conway/install-test.git#596234dab30564f37adae1e5c4d7123bcffce537",
+    "lines-and-columns": "^1.1.6",
     "public-install-test": "gitlab:dylan-conway/public-install-test",
     "svelte": "4.1.2"
   },


### PR DESCRIPTION
### What does this PR do?

Fixes `findBestMatch`.

### Bug Explained

`findBestMatch` was picking the *first* version that satisfies semver range, but registries don't return versions in any particular order. 

This was easily repeatable with `lines-and-columns@^1.1.6`, it would always pick the first version `1.2.0`, which happens to be deprecated and broken, instead of the _best_ match, which is `1.2.4`.

This PR should help with a bunch of install-related bugs:
* fixes #5914
* fixes #5506
* fixes #5504
* fixes #3873
* fixes #6489
* And probably others...

- [X] Code changes

### How did you verify your code works?

- This includes a test that was failing before this PR was added: #6489

### This modifies zig code

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I or my editor ran `zig fmt` on the changed files
- [X] I included a test for the new code, or an existing test covers it

### First time Zig user

I've contributed to Bun before, but this is my first time contributing to the zig code. I installed Zig and its dependencies this morning. I'm happy to accept input to improve this PR!