### PR TITLE
Fix missing function names in console.log and Bun.inspect

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3913,6 +3913,8 @@ extern "C" void JSC__JSValue__getName(JSC__JSValue JSValue0, JSC__JSGlobalObject
     auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
     JSObject* object = value.getObject();
     auto displayName = JSC::getCalculatedDisplayName(vm, object);
+
+    // JSC doesn't include @@toStringTag in calculated display name
     if (displayName.isEmpty()) {
         if (auto toStringTagValue = object->getIfPropertyExists(globalObject, vm.propertyNames->toStringTagSymbol)) {
             if (toStringTagValue.isString()) {

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -676,8 +676,8 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                 if ((url2 == nullptr) != (url1 == nullptr)) {
                     return false;
                 }
-            } 
-            
+            }
+
             if (url2 && url1) {
                 // toEqual or toStrictEqual should return false when the URLs' href is not equal
                 // But you could have added additional properties onto the
@@ -3900,6 +3900,16 @@ void JSC__JSValue__getNameProperty(JSC__JSValue JSValue0, JSC__JSGlobalObject* a
     }
 
     arg2->len = 0;
+}
+
+extern "C" void JSC__JSValue__getName(JSC__JSValue JSValue0, JSC__JSGlobalObject* arg1, BunString* arg2)
+{
+    JSC::JSValue value = JSC::JSValue::decode(JSValue0);
+    if (!value.isObject()) {
+        *arg2 = BunStringEmpty;
+        return;
+    }
+    *arg2 = Bun::toStringRef(JSC::getCalculatedDisplayName(arg1->vm(), value.getObject()));
 }
 
 JSC__JSValue JSC__JSValue__toError_(JSC__JSValue JSValue0)

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -4096,9 +4096,10 @@ pub const JSValue = enum(JSValueReprInt) {
         cppFn("getNameProperty", .{ this, global, ret });
     }
 
-    pub fn getName(this: JSValue, global: *JSGlobalObject) ZigString {
-        var ret = ZigString.init("");
-        getNameProperty(this, global, &ret);
+    extern fn JSC__JSValue__getName(JSC.JSValue, *JSC.JSGlobalObject, *bun.String) void;
+    pub fn getName(this: JSValue, global: *JSGlobalObject) bun.String {
+        var ret = bun.String.empty;
+        JSC__JSValue__getName(this, global, &ret);
         return ret;
     }
 

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -1818,14 +1818,16 @@ pub const ZigConsoleClient = struct {
                             .ctx = this.writer,
                             .failed = false,
                         };
-                        var name_str = ZigString.init("");
 
-                        value.getNameProperty(globalThis, &name_str);
-                        if (name_str.len > 0 and !strings.eqlComptime(name_str.slice(), "Object")) {
+                        var name_str = value.getName(globalThis);
+                        defer name_str.deref();
+                        if (!name_str.isEmpty() and !name_str.eqlComptime("Object")) {
                             writer.print("{} ", .{name_str});
                         } else {
-                            value.getPrototype(globalThis).getNameProperty(globalThis, &name_str);
-                            if (name_str.len > 0 and !strings.eqlComptime(name_str.slice(), "Object")) {
+                            name_str.deref();
+                            name_str = value.getPrototype(globalThis).getName(globalThis);
+
+                            if (!name_str.isEmpty() and !name_str.eqlComptime("Object")) {
                                 writer.print("{} ", .{name_str});
                             }
                         }
@@ -2184,10 +2186,10 @@ pub const ZigConsoleClient = struct {
                     }
                 },
                 .Function => {
-                    var printable = ZigString.init(&name_buf);
-                    value.getNameProperty(this.globalThis, &printable);
+                    var printable = value.getName(this.globalThis);
+                    defer printable.deref();
 
-                    if (printable.len == 0) {
+                    if (printable.isEmpty()) {
                         writer.print(comptime Output.prettyFmt("<cyan>[Function]<r>", enable_ansi_colors), .{});
                     } else {
                         writer.print(comptime Output.prettyFmt("<cyan>[Function: {}]<r>", enable_ansi_colors), .{printable});
@@ -2890,8 +2892,8 @@ pub const ZigConsoleClient = struct {
                         }
 
                         var display_name = value.getName(this.globalThis);
-                        if (display_name.len == 0) {
-                            display_name = ZigString.init("Object");
+                        if (display_name.isEmpty()) {
+                            display_name = String.static("Object");
                         }
                         writer.print(comptime Output.prettyFmt("<r><cyan>[{} ...]<r>", enable_ansi_colors), .{
                             display_name,

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -752,14 +752,16 @@ pub const JestPrettyFormat = struct {
                             .ctx = this.writer,
                             .failed = false,
                         };
-                        var name_str = ZigString.init("");
 
-                        value.getNameProperty(globalThis, &name_str);
-                        if (name_str.len > 0 and !strings.eqlComptime(name_str.slice(), "Object")) {
+                        var name_str = value.getName(globalThis);
+                        defer name_str.deref();
+                        if (!name_str.isEmpty() and !name_str.eqlComptime("Object")) {
                             writer.print("{} ", .{name_str});
                         } else {
-                            value.getPrototype(globalThis).getNameProperty(globalThis, &name_str);
-                            if (name_str.len > 0 and !strings.eqlComptime(name_str.slice(), "Object")) {
+                            name_str.deref();
+                            name_str = value.getPrototype(globalThis).getName(globalThis);
+
+                            if (!name_str.isEmpty() and !name_str.eqlComptime("Object")) {
                                 writer.print("{} ", .{name_str});
                             }
                         }
@@ -771,7 +773,7 @@ pub const JestPrettyFormat = struct {
                     if (this.formatter.indent == 0) this.writer.writeAll("\n") catch {};
                     var classname = ZigString.Empty;
                     value.getClassName(globalThis, &classname);
-                    if (!strings.eqlComptime(classname.slice(), "Object")) {
+                    if (!classname.eqlComptime("Object")) {
                         this.writer.print("{} ", .{classname}) catch {};
                     }
 
@@ -1129,10 +1131,10 @@ pub const JestPrettyFormat = struct {
                     }
                 },
                 .Function => {
-                    var printable = ZigString.init(&name_buf);
-                    value.getNameProperty(this.globalThis, &printable);
+                    var printable = value.getName(this.globalThis);
+                    defer printable.deref();
 
-                    if (printable.len == 0) {
+                    if (printable.isEmpty()) {
                         writer.print(comptime Output.prettyFmt("<cyan>[Function]<r>", enable_ansi_colors), .{});
                     } else {
                         writer.print(comptime Output.prettyFmt("<cyan>[Function: {}]<r>", enable_ansi_colors), .{printable});

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -752,16 +752,14 @@ pub const JestPrettyFormat = struct {
                             .ctx = this.writer,
                             .failed = false,
                         };
+                        var name_str = ZigString.init("");
 
-                        var name_str = value.getName(globalThis);
-                        defer name_str.deref();
-                        if (!name_str.isEmpty() and !name_str.eqlComptime("Object")) {
+                        value.getNameProperty(globalThis, &name_str);
+                        if (name_str.len > 0 and !strings.eqlComptime(name_str.slice(), "Object")) {
                             writer.print("{} ", .{name_str});
                         } else {
-                            name_str.deref();
-                            name_str = value.getPrototype(globalThis).getName(globalThis);
-
-                            if (!name_str.isEmpty() and !name_str.eqlComptime("Object")) {
+                            value.getPrototype(globalThis).getNameProperty(globalThis, &name_str);
+                            if (name_str.len > 0 and !strings.eqlComptime(name_str.slice(), "Object")) {
                                 writer.print("{} ", .{name_str});
                             }
                         }
@@ -773,7 +771,7 @@ pub const JestPrettyFormat = struct {
                     if (this.formatter.indent == 0) this.writer.writeAll("\n") catch {};
                     var classname = ZigString.Empty;
                     value.getClassName(globalThis, &classname);
-                    if (!classname.eqlComptime("Object")) {
+                    if (!strings.eqlComptime(classname.slice(), "Object")) {
                         this.writer.print("{} ", .{classname}) catch {};
                     }
 
@@ -1131,10 +1129,10 @@ pub const JestPrettyFormat = struct {
                     }
                 },
                 .Function => {
-                    var printable = value.getName(this.globalThis);
-                    defer printable.deref();
+                    var printable = ZigString.init(&name_buf);
+                    value.getNameProperty(this.globalThis, &printable);
 
-                    if (printable.isEmpty()) {
+                    if (printable.len == 0) {
                         writer.print(comptime Output.prettyFmt("<cyan>[Function]<r>", enable_ansi_colors), .{});
                     } else {
                         writer.print(comptime Output.prettyFmt("<cyan>[Function: {}]<r>", enable_ansi_colors), .{printable});

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -1245,7 +1245,7 @@ describe("bundler", () => {
     },
     target: "browser",
     run: {
-      stdout: "[Function]",
+      stdout: "[Function: fs]",
     },
   });
   itBundled("default/RequireFSNode", {

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -1245,7 +1245,7 @@ describe("bundler", () => {
     },
     target: "browser",
     run: {
-      stdout: "[Function: fs]",
+      stdout: "[Function]",
     },
   });
   itBundled("default/RequireFSNode", {
@@ -1280,7 +1280,7 @@ describe("bundler", () => {
       `,
     },
     run: {
-      stdout: "[Function] undefined undefined",
+      stdout: "[Function: fs] undefined undefined",
     },
     target: "browser",
   });

--- a/test/bundler/esbuild/splitting.test.ts
+++ b/test/bundler/esbuild/splitting.test.ts
@@ -359,6 +359,7 @@ describe("bundler", () => {
     },
     entryPoints: ["/a.js", "/b.js", "/c.js"],
     splitting: true,
+    target: "bun",
     runtimeFiles: {
       "/test.js": /* js */ `
         import './out/c.js';
@@ -372,9 +373,9 @@ describe("bundler", () => {
       `,
     },
     run: [
-      { file: "/out/a.js", stdout: "side effects! [Function]\nsetValue 123" },
-      { file: "/out/b.js", stdout: "side effects! [Function]\nb" },
-      { file: "/test.js", stdout: "side effects! [Function]\nsetValue 123\nobserver 123\nb" },
+      { file: "/out/a.js", stdout: "side effects! [Function: getValue]\nsetValue 123" },
+      { file: "/out/b.js", stdout: "side effects! [Function: getValue]\nb" },
+      { file: "/test.js", stdout: "side effects! [Function: getValue]\nsetValue 123\nobserver 123\nb" },
     ],
   });
   itBundled("splitting/CrossChunkAssignmentDependenciesRecursive", {
@@ -513,8 +514,8 @@ describe("bundler", () => {
     splitting: true,
     minifyIdentifiers: true,
     run: [
-      { file: "/out/a.js", stdout: "[Function]" },
-      { file: "/out/b.js", stdout: "[Function]" },
+      { file: "/out/a.js", stdout: "[Function: f]" },
+      { file: "/out/b.js", stdout: "[Function: f]" },
     ],
   });
   itBundled("splitting/HybridESMAndCJSESBuildIssue617", {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -362,3 +362,46 @@ it("new Date(..)", () => {
 it("Bun.inspect.custom exists", () => {
   expect(Bun.inspect.custom).toBe(util.inspect.custom);
 });
+
+describe("Functions with names", () => {
+  const closures = [
+    () => function f() {},
+    () => {
+      var f = function () {};
+      return f;
+    },
+    () => {
+      const f = function () {};
+      // workaround transpiler inlining losing the display name
+      // TODO: preserve the name on functions being inlined
+      f.length;
+      return f;
+    },
+    () => {
+      let f = function () {};
+      // workaround transpiler inlining losing the display name
+      // TODO: preserve the name on functions being inlined
+      f.length;
+      return f;
+    },
+    () => {
+      var f = function f() {};
+      return f;
+    },
+    () => {
+      var foo = function f() {};
+      return foo;
+    },
+    () => {
+      function f() {}
+      var foo = f;
+      return foo;
+    },
+  ];
+
+  for (let closure of closures) {
+    it(JSON.stringify(closure.toString()), () => {
+      expect(Bun.inspect(closure())).toBe("[Function: f]");
+    });
+  }
+});


### PR DESCRIPTION
### What does this PR do?

Uses `JSC::getCalculatedDisplayName` for getting function names instead of  

```zig
❯ bun /tmp/a.js
[Function]

❯ bun-debug /tmp/a.js
[Function: f]

❯ cat /tmp/a.js
       │ File: /tmp/a.js
   1   │ var f = (x) => x;
   2   │ f.length;
   3   │ console.log(f);
```

Note that we do need to address a transpiler issue where inlining causes names of functions to be lost. This impacts `const` and `let`. We should assign these to their declared names instead. This is not possible to do for arrow functions, but is possible to do for regular functions.

### How did you verify your code works?

Tests