### PR TITLE
Update quickstart.md - removed the part for editing `compilerOptions`…

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,16 +48,6 @@ If you're using TypeScript, you may see a type error on the `Bun` global. To fix
 $ bun add -d bun-types
 ```
 
-Then add the following line to your `compilerOptions` in `tsconfig.json`.
-
-```json-diff#tsconfig.json
-{
-  "compilerOptions": {
-+   "types": ["bun-types"]
-  }
-}
-```
-
 Run the file from your shell.
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -42,11 +42,26 @@ const server = Bun.serve({
 console.log(`Listening on http://localhost:${server.port} ...`);
 ```
 
-If you're using TypeScript, you may see a type error on the `Bun` global. To fix this, install `bun-types`.
+{% details summary="Seeing TypeScript errors on `Bun`?" %}
+If you used `bun init`, Bun will have automatically installed Bun's TypeScript declarations and configured your `tsconfig.json`. If you're trying out Bun in an existing project, you may see a type error on the `Bun` global.
+
+To fix this, first install `bun-types` as a dev dependency.
 
 ```sh
 $ bun add -d bun-types
 ```
+
+Then add the following line to your `compilerOptions` in `tsconfig.json`.
+
+```json-diff#tsconfig.json
+{
+  "compilerOptions": {
++   "types": ["bun-types"]
+  }
+}
+```
+
+{% /details %}
 
 Run the file from your shell.
 


### PR DESCRIPTION
… in `tsconfig.json`

The line is already added to `compilerOptions` in `tsconfig.json` so there is no need to edit the file.

    "types": [
      "bun-types" // add Bun global
    ]

This was already added when the project initialized it seems.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
