### PR TITLE
fix(node:buffer): fix `Buffer.write` stuck

### DIFF
--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -2079,12 +2079,16 @@ pub fn copyLatin1IntoUTF8StopOnNonASCII(buf_: []u8, comptime Type: type, latin1_
             }
         }
 
-        if (latin1.len > 0 and buf.len >= 2) {
-            if (comptime stop) return .{ .written = std.math.maxInt(u32), .read = std.math.maxInt(u32) };
+        if (latin1.len > 0) {
+            if (buf.len >= 2) {
+                if (comptime stop) return .{ .written = std.math.maxInt(u32), .read = std.math.maxInt(u32) };
 
-            buf[0..2].* = latin1ToCodepointBytesAssumeNotASCII(latin1[0]);
-            latin1 = latin1[1..];
-            buf = buf[2..];
+                buf[0..2].* = latin1ToCodepointBytesAssumeNotASCII(latin1[0]);
+                latin1 = latin1[1..];
+                buf = buf[2..];
+            } else {
+                break;
+            }
         }
     }
 

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -211,11 +211,29 @@ it("only top level parent propagates from a non-pooled instance", () => {
 });
 
 it("UTF-8 write() & slice()", () => {
-  const testValue = "\u00F6\u65E5\u672C\u8A9E"; // ö日本語
-  const buffer = Buffer.allocUnsafe(32);
-  const size = buffer.write(testValue, 0, "utf8");
-  const slice = buffer.toString("utf8", 0, size);
-  expect(slice).toBe(testValue);
+  {
+    const testValue = "\u00F6\u65E5\u672C\u8A9E"; // ö日本語
+    const buffer = Buffer.allocUnsafe(32);
+    const size = buffer.write(testValue, 0, "utf8");
+    const slice = buffer.toString("utf8", 0, size);
+    expect(slice).toBe(testValue);
+  }
+  {
+    const buffer = Buffer.allocUnsafe(1);
+    buffer.write("\x61");
+    buffer.write("\xFF");
+    expect(buffer).toStrictEqual(Buffer.from([0x61]));
+  }
+  {
+    const buffer = Buffer.alloc(5);
+    buffer.write("\x61\xFF\x62\xFF\x63", "utf8");
+    expect(buffer).toStrictEqual(Buffer.from([0x61, 0xc3, 0xbf, 0x62, 0x00]));
+  }
+  {
+    const buffer = Buffer.alloc(5);
+    buffer.write("\xFF\x61\xFF\x62\xFF", "utf8");
+    expect(buffer).toStrictEqual(Buffer.from([0xc3, 0xbf, 0x61, 0xc3, 0xbf]));
+  }
 });
 
 it("triple slice", () => {


### PR DESCRIPTION
### What does this PR do?
Run following code, bun will not exit.
```JavaScript
const buffer = Buffer.alloc(5);
buffer.write("\xF0\x9F\x98\xAD\xFF");
console.log(buffer);

// node.js output
// <Buffer c3 b0 c2 9f 00>
```

The `while` loop at line 2071 copies ASCII slice to buffer, and next byte is greater than `0x7f`. UTF-8 encoding requires two bytes for characters between 0x80 and 0xff. Line 2082 only checks `buf.len >= 2`. If `buf.len == 1` it will cause a dead loop.


https://github.com/oven-sh/bun/blob/4cdaabd4336866adb7aae9ab4cbb41ad4b4a8f2a/src/string_immutable.zig#L2071-L2089

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests
