### PR TITLE
Fix failing bun add test

### DIFF
--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1125,7 +1125,7 @@ it("should not save git urls twice", async () => {
     }),
   );
   const { exited: exited1 } = spawn({
-    cmd: [bunExe(), "add", "https://github.com/liz3/bun-ui.git"],
+    cmd: [bunExe(), "add", "https://github.com/liz3/empty-bun-repo"],
     cwd: package_dir,
     stdout: null,
     stdin: "pipe",
@@ -1137,11 +1137,11 @@ it("should not save git urls twice", async () => {
 
   const package_json_content = await file(join(package_dir, "package.json")).json();
   expect(package_json_content.dependencies).toEqual({
-    "bun-ui": "https://github.com/liz3/bun-ui.git",
+    "test-repo": "https://github.com/liz3/empty-bun-repo",
   });
 
   const { exited: exited2 } = spawn({
-    cmd: [bunExe(), "add", "https://github.com/liz3/bun-ui.git"],
+    cmd: [bunExe(), "add", "https://github.com/liz3/empty-bun-repo"],
     cwd: package_dir,
     stdout: null,
     stdin: "pipe",
@@ -1153,7 +1153,7 @@ it("should not save git urls twice", async () => {
 
   const package_json_content2 = await file(join(package_dir, "package.json")).json();
   expect(package_json_content2.dependencies).toEqual({
-    "bun-ui": "https://github.com/liz3/bun-ui.git",
+    "test-repo": "https://github.com/liz3/empty-bun-repo",
   });
 }, 20000);
 


### PR DESCRIPTION
### What does this PR do?
This replaces the repo used for the `bun add` test concerning saving gits url as a key in the package.json with a empty repository.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
