### PR TITLE
add cache and main

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -235,7 +235,10 @@ declare namespace NodeJS {
   interface Require {
     (id: string): any;
     resolve: RequireResolve;
+    cache: Record<string, NodeModule>;
+    main: NodeModule | undefined;
   }
+
   interface ProcessEnv {}
   type Signals =
     | "SIGABRT"


### PR DESCRIPTION
### What does this PR do?

Added remaining types to Require's interface, cache and main. 

Previously, in my own project, I could not do:
`delete require.cache[filePath];`

to clear my import cache, because cache was not a recognized type on require.


- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
