### PR TITLE
fix(sqlite): fix column offset for join result

### DIFF
--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -25,6 +25,8 @@
 #include "DOMJITIDLTypeFilter.h"
 #include "DOMJITHelpers.h"
 #include <JavaScriptCore/DFGAbstractHeap.h>
+#include <iostream>
+using namespace std;
 
 /* ******************************************************************************** */
 // Lazy Load SQLite on macOS
@@ -251,8 +253,9 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
         PropertyOffset offset;
         auto columnNames = castedThis->columnNames.get();
         bool anyHoles = false;
-        for (int i = 0; i < count; i++) {
+        for (int i = count - 1; i >= 0; i--) {
             const char* name = sqlite3_column_name(stmt, i);
+            std::cout << "column name is "<< name  << std::endl;
 
             if (name == nullptr) {
                 anyHoles = true;
@@ -306,7 +309,7 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
     // see https://github.com/oven-sh/bun/issues/987
     JSC::JSObject* object = JSC::constructEmptyObject(lexicalGlobalObject, lexicalGlobalObject->objectPrototype(), std::min(static_cast<unsigned>(count), JSFinalObject::maxInlineCapacity));
 
-    for (int i = 0; i < count; i++) {
+    for (int i = count - 1; i >= 0; i--) {
         const char* name = sqlite3_column_name(stmt, i);
 
         if (name == nullptr)
@@ -1110,13 +1113,14 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
     JSC::JSObject* result;
 
     auto* stmt = castedThis->stmt;
+    int total = sqlite3_column_count(stmt);
 
     if (auto* structure = castedThis->_structure.get()) {
         result = JSC::constructEmptyObject(vm, structure);
 
-        for (unsigned int i = 0, j = 0; j < count; i++, j++) {
-            if (j > 0 && (castedThis->columnOffsets & (1u << i)) == 0) {
-                j -= 1;
+        for (int i = total - 1, j = total - 1; j >= 0 && i >= 0; i--, j--) {
+            if ((castedThis->columnOffsets & (1u << i)) == 0) {
+                j += 1;
                 continue;
             }
             JSValue value;
@@ -1165,7 +1169,7 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
             }
             }
 
-            result->putDirectOffset(vm, j, value);
+            result->putDirectOffset(vm, total - 1 - j, value);
         }
 
     } else {
@@ -1175,9 +1179,9 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
             result = JSC::JSFinalObject::create(vm, JSC::JSFinalObject::createStructure(vm, lexicalGlobalObject, lexicalGlobalObject->objectPrototype(), JSFinalObject::maxInlineCapacity));
         }
 
-        for (int i = 0, j = 0; j < count; i++, j++) {
+        for (int i = total - 1, j = total - 1; j >= 0 && i > 0; i--, j--) {
             if (j > 0 && (castedThis->columnOffsets & (1u << i)) == 0) {
-                j -= 1;
+                j += 1;
                 continue;
             }
             auto name = columnNames[j];
@@ -1238,10 +1242,11 @@ static inline JSC::JSArray* constructResultRow(JSC::JSGlobalObject* lexicalGloba
 
     JSC::JSArray* result = JSArray::create(vm, lexicalGlobalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), count);
     auto* stmt = castedThis->stmt;
+    int total = sqlite3_column_count(stmt);
 
-    for (int i = 0, j = 0; j < count; i++, j++) {
-        if (j > 0 && (castedThis->columnOffsets & (1u << i)) == 0) {
-            j -= 1;
+    for (int i = total - 1, j = total - 1; j >= 0 && i >= 0; i--, j--) {
+        if ((castedThis->columnOffsets & (1u << i)) == 0) {
+            j += 1;
             continue;
         }
 

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -199,8 +199,6 @@ public:
     VersionSqlite3* version_db;
     uint64_t version;
     bool hasExecuted = false;
-    // default setting for SQLITE_MAX_COLUMN is 2000, Ref: https://sqlite.org/limits.html
-    uint16_t columnOffsets = 0;
     std::unique_ptr<PropertyNameArray> columnNames;
     mutable JSC::WriteBarrier<JSC::JSObject> _prototype;
     mutable JSC::WriteBarrier<JSC::Structure> _structure;
@@ -227,7 +225,6 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
             castedThis->columnNames->vm(),
             castedThis->columnNames->propertyNameMode(),
             castedThis->columnNames->privateSymbolMode()));
-        castedThis->columnOffsets = 0;
     }
     castedThis->update_version();
 
@@ -271,8 +268,10 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
             );
             int curCount = columnNames->size();
 
-            if (preCount != curCount) {
-                castedThis->columnOffsets |= (1u << i);
+            if (preCount == curCount) {
+                const char* tableName = sqlite3_column_table_name(stmt, i);
+                WTF::String fullName = WTF::String::fromUTF8(tableName, strlen(tableName)) + "_" + name;
+                columnNames->add(Identifier::fromString(vm, fullName));
             }
         }
 
@@ -294,7 +293,6 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
                 castedThis->columnNames->vm(),
                 castedThis->columnNames->propertyNameMode(),
                 castedThis->columnNames->privateSymbolMode()));
-            castedThis->columnOffsets = 0;
         }
     }
 
@@ -338,13 +336,7 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
         }
 
         object->putDirect(vm, key, primitive, 0);
-        int preCount = castedThis->columnNames->size();
         castedThis->columnNames->add(key);
-        int curCount = castedThis->columnNames->size();
-
-        if (preCount != curCount) {
-            castedThis->columnOffsets |= (1u << i);
-        }
     }
     castedThis->_prototype.set(vm, castedThis, object);
 }
@@ -1114,11 +1106,7 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
     if (auto* structure = castedThis->_structure.get()) {
         result = JSC::constructEmptyObject(vm, structure);
 
-        for (unsigned int i = 0, j = 0; j < count; i++, j++) {
-            if (j > 0 && (castedThis->columnOffsets & (1u << i)) == 0) {
-                j -= 1;
-                continue;
-            }
+        for (unsigned int i = 0; i < count; i++) {
             JSValue value;
 
             // Loop 1. Fill the rowBuffer with values from SQLite
@@ -1165,7 +1153,7 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
             }
             }
 
-            result->putDirectOffset(vm, j, value);
+            result->putDirectOffset(vm, i, value);
         }
 
     } else {
@@ -1175,12 +1163,8 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
             result = JSC::JSFinalObject::create(vm, JSC::JSFinalObject::createStructure(vm, lexicalGlobalObject, lexicalGlobalObject->objectPrototype(), JSFinalObject::maxInlineCapacity));
         }
 
-        for (int i = 0, j = 0; j < count; i++, j++) {
-            if (j > 0 && (castedThis->columnOffsets & (1u << i)) == 0) {
-                j -= 1;
-                continue;
-            }
-            auto name = columnNames[j];
+        for (int i = 0; i < count; i++) {
+            auto name = columnNames[i];
 
             switch (sqlite3_column_type(stmt, i)) {
             case SQLITE_INTEGER: {
@@ -1239,20 +1223,16 @@ static inline JSC::JSArray* constructResultRow(JSC::JSGlobalObject* lexicalGloba
     JSC::JSArray* result = JSArray::create(vm, lexicalGlobalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), count);
     auto* stmt = castedThis->stmt;
 
-    for (int i = 0, j = 0; j < count; i++, j++) {
-        if (j > 0 && (castedThis->columnOffsets & (1u << i)) == 0) {
-            j -= 1;
-            continue;
-        }
+    for (int i = 0; i < count; i++) {
 
         switch (sqlite3_column_type(stmt, i)) {
         case SQLITE_INTEGER: {
             // https://github.com/oven-sh/bun/issues/1536
-            result->putDirectIndex(lexicalGlobalObject, j, jsNumberFromSQLite(stmt, i));
+            result->putDirectIndex(lexicalGlobalObject, i, jsNumberFromSQLite(stmt, i));
             break;
         }
         case SQLITE_FLOAT: {
-            result->putDirectIndex(lexicalGlobalObject, j, jsDoubleNumber(sqlite3_column_double(stmt, i)));
+            result->putDirectIndex(lexicalGlobalObject, i, jsDoubleNumber(sqlite3_column_double(stmt, i)));
             break;
         }
         // > Note that the SQLITE_TEXT constant was also used in SQLite version
@@ -1263,10 +1243,10 @@ static inline JSC::JSArray* constructResultRow(JSC::JSGlobalObject* lexicalGloba
             size_t len = sqlite3_column_bytes(stmt, i);
             const unsigned char* text = len > 0 ? sqlite3_column_text(stmt, i) : nullptr;
             if (UNLIKELY(text == nullptr || len == 0)) {
-                result->putDirectIndex(lexicalGlobalObject, j, jsEmptyString(vm));
+                result->putDirectIndex(lexicalGlobalObject, i, jsEmptyString(vm));
                 continue;
             }
-            result->putDirectIndex(lexicalGlobalObject, j, len < 64 ? jsString(vm, WTF::String::fromUTF8(text, len)) : JSC::JSValue::decode(Bun__encoding__toStringUTF8(text, len, lexicalGlobalObject)));
+            result->putDirectIndex(lexicalGlobalObject, i, len < 64 ? jsString(vm, WTF::String::fromUTF8(text, len)) : JSC::JSValue::decode(Bun__encoding__toStringUTF8(text, len, lexicalGlobalObject)));
             break;
         }
         case SQLITE_BLOB: {
@@ -1274,11 +1254,11 @@ static inline JSC::JSArray* constructResultRow(JSC::JSGlobalObject* lexicalGloba
             const void* blob = len > 0 ? sqlite3_column_blob(stmt, i) : nullptr;
             JSC::JSUint8Array* array = JSC::JSUint8Array::createUninitialized(lexicalGlobalObject, lexicalGlobalObject->m_typedArrayUint8.get(lexicalGlobalObject), len);
             memcpy(array->vector(), blob, len);
-            result->putDirectIndex(lexicalGlobalObject, j, array);
+            result->putDirectIndex(lexicalGlobalObject, i, array);
             break;
         }
         default: {
-            result->putDirectIndex(lexicalGlobalObject, j, jsNull());
+            result->putDirectIndex(lexicalGlobalObject, i, jsNull());
             break;
         }
         }

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -199,6 +199,8 @@ public:
     VersionSqlite3* version_db;
     uint64_t version;
     bool hasExecuted = false;
+    // default setting for SQLITE_MAX_COLUMN is 2000, Ref: https://sqlite.org/limits.html
+    uint16_t columnOffsets = 0;
     std::unique_ptr<PropertyNameArray> columnNames;
     mutable JSC::WriteBarrier<JSC::JSObject> _prototype;
     mutable JSC::WriteBarrier<JSC::Structure> _structure;
@@ -225,6 +227,7 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
             castedThis->columnNames->vm(),
             castedThis->columnNames->propertyNameMode(),
             castedThis->columnNames->privateSymbolMode()));
+        castedThis->columnOffsets = 0;
     }
     castedThis->update_version();
 
@@ -268,10 +271,8 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
             );
             int curCount = columnNames->size();
 
-            if (preCount == curCount) {
-                const char* tableName = sqlite3_column_table_name(stmt, i);
-                WTF::String fullName = WTF::String::fromUTF8(tableName, strlen(tableName)) + "_" + name;
-                columnNames->add(Identifier::fromString(vm, fullName));
+            if (preCount != curCount) {
+                castedThis->columnOffsets |= (1u << i);
             }
         }
 
@@ -293,6 +294,7 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
                 castedThis->columnNames->vm(),
                 castedThis->columnNames->propertyNameMode(),
                 castedThis->columnNames->privateSymbolMode()));
+            castedThis->columnOffsets = 0;
         }
     }
 
@@ -336,7 +338,13 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
         }
 
         object->putDirect(vm, key, primitive, 0);
+        int preCount = castedThis->columnNames->size();
         castedThis->columnNames->add(key);
+        int curCount = castedThis->columnNames->size();
+
+        if (preCount != curCount) {
+            castedThis->columnOffsets |= (1u << i);
+        }
     }
     castedThis->_prototype.set(vm, castedThis, object);
 }
@@ -1106,7 +1114,11 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
     if (auto* structure = castedThis->_structure.get()) {
         result = JSC::constructEmptyObject(vm, structure);
 
-        for (unsigned int i = 0; i < count; i++) {
+        for (unsigned int i = 0, j = 0; j < count; i++, j++) {
+            if (j > 0 && (castedThis->columnOffsets & (1u << i)) == 0) {
+                j -= 1;
+                continue;
+            }
             JSValue value;
 
             // Loop 1. Fill the rowBuffer with values from SQLite
@@ -1153,7 +1165,7 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
             }
             }
 
-            result->putDirectOffset(vm, i, value);
+            result->putDirectOffset(vm, j, value);
         }
 
     } else {
@@ -1163,8 +1175,12 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
             result = JSC::JSFinalObject::create(vm, JSC::JSFinalObject::createStructure(vm, lexicalGlobalObject, lexicalGlobalObject->objectPrototype(), JSFinalObject::maxInlineCapacity));
         }
 
-        for (int i = 0; i < count; i++) {
-            auto name = columnNames[i];
+        for (int i = 0, j = 0; j < count; i++, j++) {
+            if (j > 0 && (castedThis->columnOffsets & (1u << i)) == 0) {
+                j -= 1;
+                continue;
+            }
+            auto name = columnNames[j];
 
             switch (sqlite3_column_type(stmt, i)) {
             case SQLITE_INTEGER: {
@@ -1223,16 +1239,20 @@ static inline JSC::JSArray* constructResultRow(JSC::JSGlobalObject* lexicalGloba
     JSC::JSArray* result = JSArray::create(vm, lexicalGlobalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), count);
     auto* stmt = castedThis->stmt;
 
-    for (int i = 0; i < count; i++) {
+    for (int i = 0, j = 0; j < count; i++, j++) {
+        if (j > 0 && (castedThis->columnOffsets & (1u << i)) == 0) {
+            j -= 1;
+            continue;
+        }
 
         switch (sqlite3_column_type(stmt, i)) {
         case SQLITE_INTEGER: {
             // https://github.com/oven-sh/bun/issues/1536
-            result->putDirectIndex(lexicalGlobalObject, i, jsNumberFromSQLite(stmt, i));
+            result->putDirectIndex(lexicalGlobalObject, j, jsNumberFromSQLite(stmt, i));
             break;
         }
         case SQLITE_FLOAT: {
-            result->putDirectIndex(lexicalGlobalObject, i, jsDoubleNumber(sqlite3_column_double(stmt, i)));
+            result->putDirectIndex(lexicalGlobalObject, j, jsDoubleNumber(sqlite3_column_double(stmt, i)));
             break;
         }
         // > Note that the SQLITE_TEXT constant was also used in SQLite version
@@ -1243,10 +1263,10 @@ static inline JSC::JSArray* constructResultRow(JSC::JSGlobalObject* lexicalGloba
             size_t len = sqlite3_column_bytes(stmt, i);
             const unsigned char* text = len > 0 ? sqlite3_column_text(stmt, i) : nullptr;
             if (UNLIKELY(text == nullptr || len == 0)) {
-                result->putDirectIndex(lexicalGlobalObject, i, jsEmptyString(vm));
+                result->putDirectIndex(lexicalGlobalObject, j, jsEmptyString(vm));
                 continue;
             }
-            result->putDirectIndex(lexicalGlobalObject, i, len < 64 ? jsString(vm, WTF::String::fromUTF8(text, len)) : JSC::JSValue::decode(Bun__encoding__toStringUTF8(text, len, lexicalGlobalObject)));
+            result->putDirectIndex(lexicalGlobalObject, j, len < 64 ? jsString(vm, WTF::String::fromUTF8(text, len)) : JSC::JSValue::decode(Bun__encoding__toStringUTF8(text, len, lexicalGlobalObject)));
             break;
         }
         case SQLITE_BLOB: {
@@ -1254,11 +1274,11 @@ static inline JSC::JSArray* constructResultRow(JSC::JSGlobalObject* lexicalGloba
             const void* blob = len > 0 ? sqlite3_column_blob(stmt, i) : nullptr;
             JSC::JSUint8Array* array = JSC::JSUint8Array::createUninitialized(lexicalGlobalObject, lexicalGlobalObject->m_typedArrayUint8.get(lexicalGlobalObject), len);
             memcpy(array->vector(), blob, len);
-            result->putDirectIndex(lexicalGlobalObject, i, array);
+            result->putDirectIndex(lexicalGlobalObject, j, array);
             break;
         }
         default: {
-            result->putDirectIndex(lexicalGlobalObject, i, jsNull());
+            result->putDirectIndex(lexicalGlobalObject, j, jsNull());
             break;
         }
         }

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -610,20 +610,15 @@ it("#5872", () => {
 
 it("issue#6597", () => {
   const db = new Database(":memory:");
-  db.run("CREATE TABLE Users (Id INTEGER PRIMARY KEY, Name VARCHAR(255), CreatedAt TIMESTAMP)");
-  db.run(
-    "CREATE TABLE Cars (Id INTEGER PRIMARY KEY, Driver INTEGER, CreatedAt TIMESTAMP, FOREIGN KEY (Driver) REFERENCES Users(Id))",
-  );
-  db.run('INSERT INTO Users (Id, Name, CreatedAt) VALUES (1, "Alice", "2022-01-01");');
-  db.run('INSERT INTO Cars (Id, Driver, CreatedAt) VALUES (1, 1, "2023-01-01");');
+  db.run("CREATE TABLE Users (Id INTEGER PRIMARY KEY, Name VARCHAR(255));");
+  db.run("CREATE TABLE Cars (Id INTEGER PRIMARY KEY, Driver INTEGER, FOREIGN KEY (Driver) REFERENCES Users(Id))");
+  db.run('INSERT INTO Users (Id, Name) VALUES (1, "Alice");');
+  db.run("INSERT INTO Cars (Id, Driver) VALUES (1,1);");
   const result = db.query("SELECT * FROM Cars JOIN Users ON Driver=Users.Id").get();
   expect(result).toEqual({
     Id: 1,
     Driver: 1,
     Name: "Alice",
-    CreatedAt: "2023-01-01",
-    Users_CreatedAt: "2022-01-01",
-    Users_Id: 1,
   });
   db.close();
 });

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -428,46 +428,46 @@ it("inlineCapacity #987", async () => {
 
   const db = new Database(path);
 
-  const query = `SELECT 
-  media.mid, 
-  UPPER(media.name) as name, 
-  media.url, 
-  media.duration, 
-  time(media.duration, 'unixepoch') AS durationStr, 
-  sum(totalDurations) AS totalDurations, 
-  sum(logs.views) AS views, 
-  total.venues, 
-  total.devices, 
+  const query = `SELECT
+  media.mid,
+  UPPER(media.name) as name,
+  media.url,
+  media.duration,
+  time(media.duration, 'unixepoch') AS durationStr,
+  sum(totalDurations) AS totalDurations,
+  sum(logs.views) AS views,
+  total.venues,
+  total.devices,
   SUM(CASE WHEN day = '01' THEN logs.views ELSE 0 END) as 'vi01', SUM(CASE WHEN day = '02' THEN logs.views ELSE 0 END) as 'vi02', SUM(CASE WHEN day = '03' THEN logs.views ELSE 0 END) as 'vi03', SUM(CASE WHEN day = '04' THEN logs.views ELSE 0 END) as 'vi04', SUM(CASE WHEN day = '05' THEN logs.views ELSE 0 END) as 'vi05', SUM(CASE WHEN day = '06' THEN logs.views ELSE 0 END) as 'vi06', SUM(CASE WHEN day = '07' THEN logs.views ELSE 0 END) as 'vi07', SUM(CASE WHEN day = '08' THEN logs.views ELSE 0 END) as 'vi08', SUM(CASE WHEN day = '09' THEN logs.views ELSE 0 END) as 'vi09', SUM(CASE WHEN day = '10' THEN logs.views ELSE 0 END) as 'vi10', SUM(CASE WHEN day = '11' THEN logs.views ELSE 0 END) as 'vi11', SUM(CASE WHEN day = '12' THEN logs.views ELSE 0 END) as 'vi12', SUM(CASE WHEN day = '13' THEN logs.views ELSE 0 END) as 'vi13', SUM(CASE WHEN day = '14' THEN logs.views ELSE 0 END) as 'vi14', SUM(CASE WHEN day = '15' THEN logs.views ELSE 0 END) as 'vi15', SUM(CASE WHEN day = '16' THEN logs.views ELSE 0 END) as 'vi16', SUM(CASE WHEN day = '17' THEN logs.views ELSE 0 END) as 'vi17', SUM(CASE WHEN day = '18' THEN logs.views ELSE 0 END) as 'vi18', SUM(CASE WHEN day = '19' THEN logs.views ELSE 0 END) as 'vi19', SUM(CASE WHEN day = '20' THEN logs.views ELSE 0 END) as 'vi20', SUM(CASE WHEN day = '21' THEN logs.views ELSE 0 END) as 'vi21', SUM(CASE WHEN day = '22' THEN logs.views ELSE 0 END) as 'vi22', SUM(CASE WHEN day = '23' THEN logs.views ELSE 0 END) as 'vi23', SUM(CASE WHEN day = '24' THEN logs.views ELSE 0 END) as 'vi24', SUM(CASE WHEN day = '25' THEN logs.views ELSE 0 END) as 'vi25', SUM(CASE WHEN day = '26' THEN logs.views ELSE 0 END) as 'vi26', SUM(CASE WHEN day = '27' THEN logs.views ELSE 0 END) as 'vi27', SUM(CASE WHEN day = '28' THEN logs.views ELSE 0 END) as 'vi28', SUM(CASE WHEN day = '29' THEN logs.views ELSE 0 END) as 'vi29', SUM(CASE WHEN day = '30' THEN logs.views ELSE 0 END) as 'vi30', MAX(CASE WHEN day = '01' THEN logs.venues ELSE 0 END) as 've01', MAX(CASE WHEN day = '02' THEN logs.venues ELSE 0 END) as 've02', MAX(CASE WHEN day = '03' THEN logs.venues ELSE 0 END) as 've03', MAX(CASE WHEN day = '04' THEN logs.venues ELSE 0 END) as 've04', MAX(CASE WHEN day = '05' THEN logs.venues ELSE 0 END) as 've05', MAX(CASE WHEN day = '06' THEN logs.venues ELSE 0 END) as 've06', MAX(CASE WHEN day = '07' THEN logs.venues ELSE 0 END) as 've07', MAX(CASE WHEN day = '08' THEN logs.venues ELSE 0 END) as 've08', MAX(CASE WHEN day = '09' THEN logs.venues ELSE 0 END) as 've09', MAX(CASE WHEN day = '10' THEN logs.venues ELSE 0 END) as 've10', MAX(CASE WHEN day = '11' THEN logs.venues ELSE 0 END) as 've11', MAX(CASE WHEN day = '12' THEN logs.venues ELSE 0 END) as 've12', MAX(CASE WHEN day = '13' THEN logs.venues ELSE 0 END) as 've13', MAX(CASE WHEN day = '14' THEN logs.venues ELSE 0 END) as 've14', MAX(CASE WHEN day = '15' THEN logs.venues ELSE 0 END) as 've15', MAX(CASE WHEN day = '16' THEN logs.venues ELSE 0 END) as 've16', MAX(CASE WHEN day = '17' THEN logs.venues ELSE 0 END) as 've17', MAX(CASE WHEN day = '18' THEN logs.venues ELSE 0 END) as 've18', MAX(CASE WHEN day = '19' THEN logs.venues ELSE 0 END) as 've19', MAX(CASE WHEN day = '20' THEN logs.venues ELSE 0 END) as 've20', MAX(CASE WHEN day = '21' THEN logs.venues ELSE 0 END) as 've21', MAX(CASE WHEN day = '22' THEN logs.venues ELSE 0 END) as 've22', MAX(CASE WHEN day = '23' THEN logs.venues ELSE 0 END) as 've23', MAX(CASE WHEN day = '24' THEN logs.venues ELSE 0 END) as 've24', MAX(CASE WHEN day = '25' THEN logs.venues ELSE 0 END) as 've25', MAX(CASE WHEN day = '26' THEN logs.venues ELSE 0 END) as 've26', MAX(CASE WHEN day = '27' THEN logs.venues ELSE 0 END) as 've27', MAX(CASE WHEN day = '28' THEN logs.venues ELSE 0 END) as 've28', MAX(CASE WHEN day = '29' THEN logs.venues ELSE 0 END) as 've29', MAX(CASE WHEN day = '30' THEN logs.venues ELSE 0 END) as 've30', MAX(CASE WHEN day = '01' THEN logs.devices ELSE 0 END) as 'de01', MAX(CASE WHEN day = '02' THEN logs.devices ELSE 0 END) as 'de02', MAX(CASE WHEN day = '03' THEN logs.devices ELSE 0 END) as 'de03', MAX(CASE WHEN day = '04' THEN logs.devices ELSE 0 END) as 'de04', MAX(CASE WHEN day = '05' THEN logs.devices ELSE 0 END) as 'de05', MAX(CASE WHEN day = '06' THEN logs.devices ELSE 0 END) as 'de06', MAX(CASE WHEN day = '07' THEN logs.devices ELSE 0 END) as 'de07', MAX(CASE WHEN day = '08' THEN logs.devices ELSE 0 END) as 'de08', MAX(CASE WHEN day = '09' THEN logs.devices ELSE 0 END) as 'de09', MAX(CASE WHEN day = '10' THEN logs.devices ELSE 0 END) as 'de10', MAX(CASE WHEN day = '11' THEN logs.devices ELSE 0 END) as 'de11', MAX(CASE WHEN day = '12' THEN logs.devices ELSE 0 END) as 'de12', MAX(CASE WHEN day = '13' THEN logs.devices ELSE 0 END) as 'de13', MAX(CASE WHEN day = '14' THEN logs.devices ELSE 0 END) as 'de14', MAX(CASE WHEN day = '15' THEN logs.devices ELSE 0 END) as 'de15', MAX(CASE WHEN day = '16' THEN logs.devices ELSE 0 END) as 'de16', MAX(CASE WHEN day = '17' THEN logs.devices ELSE 0 END) as 'de17', MAX(CASE WHEN day = '18' THEN logs.devices ELSE 0 END) as 'de18', MAX(CASE WHEN day = '19' THEN logs.devices ELSE 0 END) as 'de19', MAX(CASE WHEN day = '20' THEN logs.devices ELSE 0 END) as 'de20', MAX(CASE WHEN day = '21' THEN logs.devices ELSE 0 END) as 'de21', MAX(CASE WHEN day = '22' THEN logs.devices ELSE 0 END) as 'de22', MAX(CASE WHEN day = '23' THEN logs.devices ELSE 0 END) as 'de23', MAX(CASE WHEN day = '24' THEN logs.devices ELSE 0 END) as 'de24', MAX(CASE WHEN day = '25' THEN logs.devices ELSE 0 END) as 'de25', MAX(CASE WHEN day = '26' THEN logs.devices ELSE 0 END) as 'de26', MAX(CASE WHEN day = '27' THEN logs.devices ELSE 0 END) as 'de27', MAX(CASE WHEN day = '28' THEN logs.devices ELSE 0 END) as 'de28', MAX(CASE WHEN day = '29' THEN logs.devices ELSE 0 END) as 'de29', MAX(CASE WHEN day = '30' THEN logs.devices ELSE 0 END) as 'de30'
-  FROM 
+  FROM
   (
-    SELECT 
-      logs.mid, 
-      sum(logs.duration) AS totalDurations, 
-      strftime ('%d', START, 'unixepoch', 'localtime') AS day, 
-      count(*) AS views, 
-      count(DISTINCT did) AS devices, 
-      count(DISTINCT vid) AS venues 
-    FROM 
-      logs 
+    SELECT
+      logs.mid,
+      sum(logs.duration) AS totalDurations,
+      strftime ('%d', START, 'unixepoch', 'localtime') AS day,
+      count(*) AS views,
+      count(DISTINCT did) AS devices,
+      count(DISTINCT vid) AS venues
+    FROM
+      logs
     WHERE strftime('%m-%Y', start, 'unixepoch', 'localtime')='06-2022'
-    GROUP BY 
-      day, 
+    GROUP BY
+      day,
       logs.mid
-  ) logs 
-  INNER JOIN media ON media.id = logs.mid 
+  ) logs
+  INNER JOIN media ON media.id = logs.mid
   INNER JOIN (
-    SELECT 
-      mid, 
-      count(DISTINCT vid) as venues, 
-      count(DISTINCT did) as devices 
-    FROM 
-      logs 
+    SELECT
+      mid,
+      count(DISTINCT vid) as venues,
+      count(DISTINCT did) as devices
+    FROM
+      logs
     WHERE strftime('%m-%Y', start, 'unixepoch', 'localtime')='06-2022'
-    GROUP by 
+    GROUP by
       mid
-  ) total ON logs.mid = total.mid 
-  ORDER BY 
+  ) total ON logs.mid = total.mid
+  ORDER BY
   name`;
 
   expect(Object.keys(db.query(query).all()[0]).length).toBe(99);
@@ -609,16 +609,52 @@ it("#5872", () => {
 });
 
 it("issue#6597", () => {
-  const db = new Database(":memory:");
-  db.run("CREATE TABLE Users (Id INTEGER PRIMARY KEY, Name VARCHAR(255));");
-  db.run("CREATE TABLE Cars (Id INTEGER PRIMARY KEY, Driver INTEGER, FOREIGN KEY (Driver) REFERENCES Users(Id))");
-  db.run('INSERT INTO Users (Id, Name) VALUES (1, "Alice");');
-  db.run("INSERT INTO Cars (Id, Driver) VALUES (1,1);");
-  const result = db.query("SELECT * FROM Cars JOIN Users ON Driver=Users.Id").get();
-  expect(result).toEqual({
+  // better-sqlite3 returns the last value of duplicate fields
+  let db = new Database(":memory:");
+  db.run("CREATE TABLE Users (Id INTEGER PRIMARY KEY, Name VARCHAR(255), CreatedAt TIMESTAMP)");
+  db.run(
+    "CREATE TABLE Cars (Id INTEGER PRIMARY KEY, Driver INTEGER, CreatedAt TIMESTAMP, FOREIGN KEY (Driver) REFERENCES Users(Id))",
+  );
+  db.run('INSERT INTO Users (Id, Name, CreatedAt) VALUES (1, "Alice", "2022-01-01");');
+  db.run('INSERT INTO Cars (Id, Driver, CreatedAt) VALUES (2, 1, "2023-01-01");');
+  let result = db.prepare("SELECT * FROM Cars JOIN Users ON Driver=Users.Id").get();
+  expect(result).toStrictEqual({
     Id: 1,
     Driver: 1,
+    CreatedAt: "2022-01-01",
     Name: "Alice",
   });
+  db.close();
+});
+
+it("issue#7147", () => {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE foos (foo_id INTEGER NOT NULL PRIMARY KEY, foo_a TEXT, foo_b TEXT)");
+  db.exec(
+    "CREATE TABLE bars (bar_id INTEGER NOT NULL PRIMARY KEY, foo_id INTEGER NOT NULL, bar_a INTEGER, bar_b INTEGER, FOREIGN KEY (foo_id) REFERENCES foos (foo_id))",
+  );
+  db.exec("INSERT INTO foos VALUES (1, 'foo_1', 'foo_2')");
+  db.exec("INSERT INTO bars VALUES (1, 1, 'bar_1', 'bar_2')");
+  db.exec("INSERT INTO bars VALUES (2, 1, 'baz_3', 'baz_4')");
+  const query = db.query("SELECT f.*, b.* FROM foos f JOIN bars b ON b.foo_id = f.foo_id");
+  const result = query.all();
+  expect(result).toStrictEqual([
+    {
+      foo_id: 1,
+      foo_a: "foo_1",
+      foo_b: "foo_2",
+      bar_id: 1,
+      bar_a: "bar_1",
+      bar_b: "bar_2",
+    },
+    {
+      foo_id: 1,
+      foo_a: "foo_1",
+      foo_b: "foo_2",
+      bar_id: 2,
+      bar_a: "baz_3",
+      bar_b: "baz_4",
+    },
+  ]);
   db.close();
 });

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -607,3 +607,18 @@ it("#5872", () => {
   const result = query.all({ $greeting: "sup" });
   expect(result).toEqual([]);
 });
+
+it("issue#6597", () => {
+  const db = new Database(":memory:");
+  db.run("CREATE TABLE Users (Id INTEGER PRIMARY KEY, Name VARCHAR(255));");
+  db.run("CREATE TABLE Cars (Id INTEGER PRIMARY KEY, Driver INTEGER, FOREIGN KEY (Driver) REFERENCES Users(Id))");
+  db.run('INSERT INTO Users (Id, Name) VALUES (1, "Alice");');
+  db.run("INSERT INTO Cars (Id, Driver) VALUES (1,1);");
+  const result = db.query("SELECT * FROM Cars JOIN Users ON Driver=Users.Id").get();
+  expect(result).toEqual({
+    Id: 1,
+    Driver: 1,
+    Name: "Alice",
+  });
+  db.close();
+});

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -610,15 +610,20 @@ it("#5872", () => {
 
 it("issue#6597", () => {
   const db = new Database(":memory:");
-  db.run("CREATE TABLE Users (Id INTEGER PRIMARY KEY, Name VARCHAR(255));");
-  db.run("CREATE TABLE Cars (Id INTEGER PRIMARY KEY, Driver INTEGER, FOREIGN KEY (Driver) REFERENCES Users(Id))");
-  db.run('INSERT INTO Users (Id, Name) VALUES (1, "Alice");');
-  db.run("INSERT INTO Cars (Id, Driver) VALUES (1,1);");
+  db.run("CREATE TABLE Users (Id INTEGER PRIMARY KEY, Name VARCHAR(255), CreatedAt TIMESTAMP)");
+  db.run(
+    "CREATE TABLE Cars (Id INTEGER PRIMARY KEY, Driver INTEGER, CreatedAt TIMESTAMP, FOREIGN KEY (Driver) REFERENCES Users(Id))",
+  );
+  db.run('INSERT INTO Users (Id, Name, CreatedAt) VALUES (1, "Alice", "2022-01-01");');
+  db.run('INSERT INTO Cars (Id, Driver, CreatedAt) VALUES (1, 1, "2023-01-01");');
   const result = db.query("SELECT * FROM Cars JOIN Users ON Driver=Users.Id").get();
   expect(result).toEqual({
     Id: 1,
     Driver: 1,
     Name: "Alice",
+    CreatedAt: "2023-01-01",
+    Users_CreatedAt: "2022-01-01",
+    Users_Id: 1,
   });
   db.close();
 });


### PR DESCRIPTION
### What does this PR do?

Close: #6597
Close: https://github.com/oven-sh/bun/issues/7147

When iterating the columns from `sqlite3_column_name`, we will get 

```
Id
Driver
Id
Name
```

It will contain duplicated column names But `PropertyNameArray` will not store them. The offset is mismatched.


|  `PropertyNameArray` | value from `sqlite3_column_value`  |
|---|---|
| Id  | 1 |
| Driver  | 1 |
| Name  | 1 |
|   | `Alice` |


This PR includes two kinds of fixes, I'm not sure which one to use.

- https://github.com/oven-sh/bun/commit/d56ed431b7c136c4e0ac2c3e48b8c8c1eda6389b  adds a bitmap `columnOffsets` to track the offsets corresponding to the names stored in `PropertyNameArray`. It will skip duplicated column name. If there are many columns, hashset might be more efficient. 

```
    Id: 1,
    Driver: 1,
    Name: "Alice",
```

- https://github.com/oven-sh/bun/commit/b77e6acea40dceeb5d236a94be5ac8ff56016591 just concat the table name and column name.

```
    Id: 1,
    Driver: 1,
    Users_Id: 1,
    Name: "Alice",
```



- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests.