### PR TITLE
Add Drizzle guide

### DIFF
--- a/docs/guides/ecosystem/drizzle.md
+++ b/docs/guides/ecosystem/drizzle.md
@@ -34,7 +34,9 @@ To see the database in action, add these lines to `index.ts`.
 ```ts#index.ts
 import { db } from "./db";
 import { sql } from "drizzle-orm";
-console.log(await db.get<string>(sql`select "hello world" as text;`));
+
+const query = sql`select "hello world" as text;`
+console.log(await db.get<string>(query));
 ```
 
 ---

--- a/docs/guides/ecosystem/drizzle.md
+++ b/docs/guides/ecosystem/drizzle.md
@@ -1,5 +1,5 @@
 ---
-name: Use Drizzle with Bun
+name: Use Drizzle ORM with Bun
 ---
 
 Drizzle is an ORM that supports both a SQL-like "query builder" API and an ORM-like [Queries API](https://orm.drizzle.team/docs/rqb). It supports the `bun:sqlite` built-in module.

--- a/docs/guides/ecosystem/drizzle.md
+++ b/docs/guides/ecosystem/drizzle.md
@@ -1,0 +1,183 @@
+---
+name: Use Drizzle with Bun
+---
+
+Drizzle is an ORM that supports both a SQL-like "query builder" API and an ORM-like [Queries API](https://orm.drizzle.team/docs/rqb). It supports the `bun:sqlite` built-in module.
+
+---
+
+Let's get started by creating a fresh project with `bun init` and installing Drizzle.
+
+```sh
+$ bun init -y
+$ bun add drizzle
+$ bun add -D drizzle-kit
+```
+
+---
+
+Then we'll connect to a SQLite database using the `bun:sqlite` module and create the Drizzle database instance.
+
+```ts#db.ts
+import { drizzle, BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
+import { sql } from "drizzle-orm";
+import { Database } from "bun:sqlite";
+
+const sqlite = new Database("sqlite.db");
+export const db: BunSQLiteDatabase = drizzle(sqlite);
+```
+
+---
+
+To see the database in action, add these lines to `index.ts`.
+
+```ts#index.ts
+import { db } from "./db";
+import { sql } from "drizzle-orm";
+console.log(await db.get<string>(sql`select "hello world" as text;`));
+```
+
+---
+
+Then run `index.ts` with Bun. Bun wil automatically create `sqlite.db` and execute the query.
+
+```sh
+$ bun run index.ts
+{
+  text: "hello world"
+}
+```
+
+---
+
+Lets give our database a proper schema. Create a `schema.ts` file and define a `movies` table.
+
+```ts#schema.ts
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const movies = sqliteTable("movies", {
+  id: integer("id").primaryKey(),
+  title: text("name"),
+  releaseYear: integer("release_year"),
+});
+```
+
+---
+
+We can use the `drizzle-kit` CLI to generate an initial SQL migration.
+
+```sh
+$ bunx drizzle-kit migrate:sqlite --schema ./schema.ts
+```
+
+---
+
+This creates a new `drizzle` directory containing a `.sql` migration file and `meta` directory.
+
+```txt
+drizzle
+├── 0000_ordinary_beyonder.sql
+└── meta
+    ├── 0000_snapshot.json
+    └── _journal.json
+```
+
+---
+
+We can execute these migrations with a simple `migrate.ts` script.
+
+This script creates a new connection to a SQLite database that writes to `sqlite.db`, then executes all unexecuted migrations in the `drizzle` directory.
+
+```ts#migrate.ts
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+
+import { drizzle, BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
+import { Database } from "bun:sqlite";
+
+const sqlite = new Database("sqlite.db");
+const db: BunSQLiteDatabase = drizzle(sqlite);
+await migrate(db, { migrationsFolder: "./drizzle" });
+```
+
+---
+
+We can run this script with `bun` to execute the migration.
+
+```sh
+$ bun run migrate.ts
+```
+
+---
+
+Now that we have a database, let's add some data to it. Create a `seed.ts` file with the following contents.
+
+```ts#seed.ts
+import { db } from "./db";
+import * as schema from "./schema";
+
+await db.insert(schema.movies).values([
+  {
+    title: "The Matrix",
+    releaseYear: 1999,
+  },
+  {
+    title: "The Matrix Reloaded",
+    releaseYear: 2003,
+  },
+  {
+    title: "The Matrix Revolutions",
+    releaseYear: 2003,
+  },
+]);
+
+console.log(`Seeding complete.`);
+```
+
+---
+
+Then run this file.
+
+```sh
+$ bun run seed.ts
+Seeding complete.
+```
+
+---
+
+We finally have a database with a schema and some sample data. Let's use Drizzle to query it. Replace the contents of `index.ts` with the following.
+
+```ts#index.ts
+import * as schema from "./schema";
+import { db } from "./db";
+
+const result = await db.select().from(schema.movies);
+console.log(result);
+```
+
+---
+
+Then run the file. You should see the three movies we inserted.
+
+```sh
+$ bun run index.ts
+bun run index.ts
+[
+  {
+    id: 1,
+    title: "The Matrix",
+    releaseYear: 1999
+  }, {
+    id: 2,
+    title: "The Matrix Reloaded",
+    releaseYear: 2003
+  }, {
+    id: 3,
+    title: "The Matrix Revolutions",
+    releaseYear: 2003
+  }
+]
+```
+
+---
+
+Refer to the [Drizzle website](https://orm.drizzle.team/docs/overview) for complete documentation.


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
