### PR TITLE
Update Drizzle docs

### DIFF
--- a/docs/guides/ecosystem/drizzle.md
+++ b/docs/guides/ecosystem/drizzle.md
@@ -19,11 +19,11 @@ $ bun add -D drizzle-kit
 Then we'll connect to a SQLite database using the `bun:sqlite` module and create the Drizzle database instance.
 
 ```ts#db.ts
-import { drizzle, BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
 import { Database } from "bun:sqlite";
 
 const sqlite = new Database("sqlite.db");
-export const db: BunSQLiteDatabase = drizzle(sqlite);
+export const db = drizzle(sqlite);
 ```
 
 ---
@@ -34,8 +34,8 @@ To see the database in action, add these lines to `index.ts`.
 import { db } from "./db";
 import { sql } from "drizzle-orm";
 
-const query = sql`select "hello world" as text;`
-console.log(await db.get<string>(query));
+const query = sql`select "hello world" as text`;
+console.log(db.get<{ text: string }>(query));
 ```
 
 ---
@@ -97,7 +97,7 @@ import { Database } from "bun:sqlite";
 
 const sqlite = new Database("sqlite.db");
 const db: BunSQLiteDatabase = drizzle(sqlite);
-await migrate(db, { migrationsFolder: "./drizzle" });
+migrate(db, { migrationsFolder: "./drizzle" });
 ```
 
 ---

--- a/docs/guides/ecosystem/drizzle.md
+++ b/docs/guides/ecosystem/drizzle.md
@@ -92,11 +92,11 @@ This script creates a new connection to a SQLite database that writes to `sqlite
 ```ts#migrate.ts
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 
-import { drizzle, BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
 import { Database } from "bun:sqlite";
 
 const sqlite = new Database("sqlite.db");
-const db: BunSQLiteDatabase = drizzle(sqlite);
+const db = drizzle(sqlite);
 migrate(db, { migrationsFolder: "./drizzle" });
 ```
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Update code examples in Drizzle guide

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->


1. You shouldn't specify the `BunSQLiteDatabase` type directly on the db, it'll prevent the relational queries from working if they are configured. The type should be inferred from the `drizzle()` call.
2. `db.get/all/run/values` and `migrate` API is sync for `bun:sqlite`.
3. The query return type was specified incorrectly.