### PR TITLE
fix sys.getErrno on linux/arm64

### DIFF
--- a/src/sys.zig
+++ b/src/sys.zig
@@ -253,7 +253,6 @@ pub fn getErrno(rc: anytype) bun.C.E {
         return bun.C.E.UNKNOWN;
     }
 
-    if (comptime use_libc) return std.os.errno(rc);
     const Type = @TypeOf(rc);
 
     return switch (Type) {


### PR DESCRIPTION
### What does this PR do?

On Linux/arm64 the function was doing an early return with `std.os.errno(rc)`, which will cause an integer cast crash when `rc` is unsigned. 

Here's the output of running a script which reproduces the problem:

```
$ ./packages/debug-bun-linux-aarch64/bun-debug run ~/bug.js                                                                                     
[SYS] read(3, 4096) = 4096 (0.194ms)                                                                                                                                      
[SYS] close(3)                                                                                                                                                            
[fs] openat(8, /home/ubuntu/bun/package.json) = 9                                                                                                                         
[SYS] close(9)                                                                                                                                                            
[fs] openat(8, /home/ubuntu/bun/tsconfig.json) = 9                                                                                                                        
[SYS] close(9)                                                                                                                                                            
[fs] openat(0, /home/ubuntu/bun/tsconfig.base.json) = 9                                                                                                                   
[SYS] close(9)                                                                                                                                                            
[SYS] close(5)                                                                                                                                                            
[SYS] close(6)                                                                                                                                                            
[SYS] close(7)                                                                                                                                                            
[SYS] close(8)                                                                                                                                                            
[fs] openat(0, /home/ubuntu/bug.js) = 13                                                                                                                                  
[SYS] close(13)                                                                                                                                                           
reading non-existent dir                                                                                                                                                  
[Loop] ref                                                                                                                                                                
[Loop] ref                                                                                                                                                                
[SYS] openat(-100, /invalid-directory) = 18446744073709551614                                                                                                             
                                                                                                                                                                          
uh-oh: integer cast truncated bits                                                                                                                                        
bun will crash now 😭😭😭                                                                                                                                                 
                                                                                                                                                                          
----- bun meta -----                                                                                                                                                      
Bun v1.0.7_debug (6a2768f2) Linux arm64 #52-Ubuntu SMP Mon Oct 16 09:55:50 UTC 2023                                                                                       
RunCommand: bunfig                                                                                                                                                        
Elapsed: 83ms | User: 60ms | Sys: 32ms                                                                                                                                    
RSS: 33.55MB | Peak: 61.31MB | Commit: 33.55MB | Faults: 0                                                                                                                
----- bun meta -----

```

To better understand the problem,  here is the `std.os.errno` implementation in zig stdlib:

```
pub fn getErrno(rc: anytype) c.E {                                                                                                                     
      if (rc == -1) {                                                                                                                                    
          return @as(c.E, @enumFromInt(c._errno().*));                                                                                                   
      } else {                                                                                                                                           
          return .SUCCESS;                                                                                                                               
      }                                                                                                                                                  
}  
```

As you can see, there's a comparison with a signed integer. The correct call to `std.os.linux.getErrno` (which expects an `usize` parameter) was being prevented by the short circuit.

I haven't added any tests, but as far as I can tell this affects every filesystem function that calls `sys.openat` (open a file or directory), so it is already tested implicitly.

### How did you verify your code works?

- [x] I built on an arm64 linux box and ran this script: https://github.com/oven-sh/bun/issues/5820#issuecomment-1736180312


close #4627
close #5820
