### PR TITLE
docs: fixed typo in guides, install and runtime folder

### DIFF
--- a/docs/guides/test/mock-clock.md
+++ b/docs/guides/test/mock-clock.md
@@ -20,7 +20,7 @@ test("party like it's 1999", () => {
 
 ---
 
-The `setSystemTime` function is commonly used on conjunction with [Lifecycle Hooks](/docs/test/lifecycle) to configure a testing environment with a determinstic "fake clock".
+The `setSystemTime` function is commonly used on conjunction with [Lifecycle Hooks](/docs/test/lifecycle) to configure a testing environment with a deterministic "fake clock".
 
 ```ts
 import { test, expect, beforeAll, setSystemTime } from "bun:test";

--- a/docs/guides/util/import-meta-file.md
+++ b/docs/guides/util/import-meta-file.md
@@ -2,7 +2,7 @@
 name: Get the file name of the current file
 ---
 
-Bun provides a handful of module-specific utilities on the [`import.meta`](/docs/api/import-meta) object. Use `import.meta.file` to retreive the name of the current file.
+Bun provides a handful of module-specific utilities on the [`import.meta`](/docs/api/import-meta) object. Use `import.meta.file` to retrieve the name of the current file.
 
 ```ts#/a/b/c.ts
 import.meta.file; // => "c.ts"

--- a/docs/guides/util/import-meta-path.md
+++ b/docs/guides/util/import-meta-path.md
@@ -2,7 +2,7 @@
 name: Get the absolute path of the current file
 ---
 
-Bun provides a handful of module-specific utilities on the [`import.meta`](/docs/api/import-meta) object. Use `import.meta.path` to retreive the absolute path of the current file.
+Bun provides a handful of module-specific utilities on the [`import.meta`](/docs/api/import-meta) object. Use `import.meta.path` to retrieve the absolute path of the current file.
 
 ```ts#/a/b/c.ts
 import.meta.path; // => "/a/b/c.ts"

--- a/docs/install/overrides.md
+++ b/docs/install/overrides.md
@@ -32,7 +32,7 @@ node_modules
 └── bar@4.5.6
 ```
 
-But what if a security vulnerability was introduced in `bar@4.5.6`? We may want a way to pin `bar` to an older version that doesn't have the vulerability. This is where `"overrides"`/`"resolutions"` come in.
+But what if a security vulnerability was introduced in `bar@4.5.6`? We may want a way to pin `bar` to an older version that doesn't have the vulnerability. This is where `"overrides"`/`"resolutions"` come in.
 
 ## `"overrides"`
 

--- a/docs/runtime/plugins.md
+++ b/docs/runtime/plugins.md
@@ -221,7 +221,7 @@ console.log(mySvelteComponent.render());
 
 {% note %}
 
-This feature is currently only available at runtime with `Bun.plugin` and not yet supported in the bundler, but you can mimick the behavior using `onResolve` and `onLoad`.
+This feature is currently only available at runtime with `Bun.plugin` and not yet supported in the bundler, but you can mimic the behavior using `onResolve` and `onLoad`.
 
 {% /note %}
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

This PR fix the typos of files in guides, install and runtime folder inside docs folder.


```pseudo
determinstic > deterministic
retreive > retrieve
vulerability > vulnerability
mimick > mimic
```

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
