### PR TITLE
Fix running `Bun.spawn` on Vercel and GCP

### DIFF
--- a/src/bun.js/api/bun/spawn.zig
+++ b/src/bun.js/api/bun/spawn.zig
@@ -30,13 +30,13 @@ const errno = std.os.errno;
 const mode_t = std.os.mode_t;
 const unexpectedErrno = std.os.unexpectedErrno;
 
-pub const WaitPidResult = struct {
-    pid: pid_t,
-    status: u32,
-};
-
 // mostly taken from zig's posix_spawn.zig
 pub const PosixSpawn = struct {
+    pub const WaitPidResult = struct {
+        pid: pid_t,
+        status: u32,
+    };
+
     pub const Attr = struct {
         attr: system.posix_spawnattr_t,
 

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1808,11 +1808,11 @@ pub const Subprocess = struct {
                         switch (this.watch()) {
                             .result => {},
                             .err => |err| {
-                                if (err.getErrno() == .SRCH) {
-                                    waitpid_result = PosixSpawn.waitpid(pid, if (sync) 0 else std.os.W.NOHANG);
-                                    continue;
-                                } else {
-                                    // @panic("This shouldn't happen");
+                                if (!WaiterThread.shouldUseWaiterThread()) {
+                                    if (err.getErrno() == .SRCH) {
+                                        waitpid_result = PosixSpawn.waitpid(pid, if (sync) 0 else std.os.W.NOHANG);
+                                        continue;
+                                    }
                                 }
                             },
                         }

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1808,7 +1808,7 @@ pub const Subprocess = struct {
                         switch (this.watch()) {
                             .result => {},
                             .err => |err| {
-                                if (comptime !Environment.isLinux) {
+                                if (comptime Environment.isMac) {
                                     if (err.getErrno() == .SRCH) {
                                         waitpid_result = PosixSpawn.waitpid(pid, if (sync) 0 else std.os.W.NOHANG);
                                         continue;

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -415,7 +415,7 @@ pub const Subprocess = struct {
                         const errno = std.os.linux.getErrno(rc);
 
                         // if the process was already killed don't throw
-                        if (errno != .SRCH and errno != .ENOSYS)
+                        if (errno != .SRCH and errno != .NOSYS)
                             return .{ .err = bun.sys.Error.fromCode(errno, .kill) };
                     } else {
                         break :send_signal;

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1808,7 +1808,7 @@ pub const Subprocess = struct {
                         switch (this.watch()) {
                             .result => {},
                             .err => |err| {
-                                if (!WaiterThread.shouldUseWaiterThread()) {
+                                if (comptime !Environment.isLinux) {
                                     if (err.getErrno() == .SRCH) {
                                         waitpid_result = PosixSpawn.waitpid(pid, if (sync) 0 else std.os.W.NOHANG);
                                         continue;

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -1834,7 +1834,7 @@ pub const FilePoll = struct {
                 log("onUpdate " ++ kqueue_or_epoll ++ " (fd: {d}) Subprocess", .{poll.fd});
                 var loader = ptr.as(JSC.Subprocess);
 
-                loader.onExitNotification();
+                loader.onExitNotificationTask();
             },
             @field(Owner.Tag, "FileSink") => {
                 log("onUpdate " ++ kqueue_or_epoll ++ " (fd: {d}) FileSink", .{poll.fd});

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -924,6 +924,10 @@ pub const EventLoop = struct {
                     var any: *Unlink = task.get(Unlink).?;
                     any.runFromJSThread();
                 },
+                @field(Task.Tag, typeBaseName(@typeName(WaitPidResultTask))) => {
+                    var any: *WaitPidResultTask = task.get(WaitPidResultTask).?;
+                    any.runFromJSThread();
+                },
                 else => if (Environment.allow_assert) {
                     bun.Output.prettyln("\nUnexpected tag: {s}\n", .{@tagName(task.tag())});
                 } else {

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -344,7 +344,7 @@ const Futimes = JSC.Node.Async.futimes;
 const Lchmod = JSC.Node.Async.lchmod;
 const Lchown = JSC.Node.Async.lchown;
 const Unlink = JSC.Node.Async.unlink;
-
+const WaitPidResultTask = JSC.Subprocess.WaiterThread.WaitPidResultTask;
 // Task.get(ReadFileTask) -> ?ReadFileTask
 pub const Task = TaggedPointerUnion(.{
     FetchTasklet,
@@ -403,6 +403,7 @@ pub const Task = TaggedPointerUnion(.{
     Lchmod,
     Lchown,
     Unlink,
+    WaitPidResultTask,
 });
 const UnboundedQueue = @import("./unbounded_queue.zig").UnboundedQueue;
 pub const ConcurrentTask = struct {
@@ -1131,6 +1132,7 @@ pub const EventLoop = struct {
 
         var global = ctx.global;
         var global_vm = ctx.jsc;
+
         while (true) {
             while (this.tickWithCount() > 0) : (this.global.handleRejectedPromises()) {
                 this.tickConcurrent();

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -739,6 +739,13 @@ pub const VirtualMachine = struct {
         }
 
         if (map.get("BUN_GARBAGE_COLLECTOR_LEVEL")) |gc_level| {
+            // Reuse this flag for other things to avoid unnecessary hashtable
+            // lookups on start for obscure flags which we do not want others to
+            // depend on.
+            if (map.get("BUN_FEATURE_FLAG_FORCE_WAITER_THREAD") != null) {
+                JSC.Subprocess.WaiterThread.setShouldUseWaiterThread();
+            }
+
             if (strings.eqlComptime(gc_level, "1")) {
                 this.aggressive_garbage_collection = .mild;
             } else if (strings.eqlComptime(gc_level, "2")) {

--- a/src/output.zig
+++ b/src/output.zig
@@ -476,11 +476,23 @@ pub fn scoped(comptime tag: @Type(.EnumLiteral), comptime disabled: bool) _log_f
             defer lock.unlock();
 
             if (Output.enable_ansi_colors_stderr) {
-                out.print(comptime prettyFmt("<r><d>[" ++ @tagName(tag) ++ "]<r> " ++ fmt, true), args) catch unreachable;
-                buffered_writer.flush() catch unreachable;
+                out.print(comptime prettyFmt("<r><d>[" ++ @tagName(tag) ++ "]<r> " ++ fmt, true), args) catch {
+                    really_disable = true;
+                    return;
+                };
+                buffered_writer.flush() catch {
+                    really_disable = true;
+                    return;
+                };
             } else {
-                out.print(comptime prettyFmt("<r><d>[" ++ @tagName(tag) ++ "]<r> " ++ fmt, false), args) catch unreachable;
-                buffered_writer.flush() catch unreachable;
+                out.print(comptime prettyFmt("<r><d>[" ++ @tagName(tag) ++ "]<r> " ++ fmt, false), args) catch {
+                    really_disable = true;
+                    return;
+                };
+                buffered_writer.flush() catch {
+                    really_disable = true;
+                    return;
+                };
             }
         }
     }.log;

--- a/src/standalone_bun.zig
+++ b/src/standalone_bun.zig
@@ -568,11 +568,23 @@ pub const StandaloneModuleGraph = struct {
                 if (bun.strings.eqlComptimeIgnoreLen(bun.argv()[0][0..argv0_len], "bun")) {
                     return null;
                 }
+
+                if (comptime Environment.isDebug) {
+                    if (bun.strings.eqlComptimeIgnoreLen(bun.argv()[0][0..argv0_len], "bun-debug")) {
+                        return null;
+                    }
+                }
             }
 
             if (argv0_len == 4) {
                 if (bun.strings.eqlComptimeIgnoreLen(bun.argv()[0][0..argv0_len], "bunx")) {
                     return null;
+                }
+
+                if (comptime Environment.isDebug) {
+                    if (bun.strings.eqlComptimeIgnoreLen(bun.argv()[0][0..argv0_len], "bun-debugx")) {
+                        return null;
+                    }
                 }
             }
         }

--- a/test/js/bun/spawn/spawn-streaming-stdout.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdout.test.ts
@@ -5,14 +5,11 @@ import { closeSync, openSync } from "fs";
 
 test("spawn can read from stdout multiple chunks", async () => {
   gcTick(true);
-  const maxFD = openSync("/dev/null", "w");
-  closeSync(maxFD);
-
-  for (let i = 0; i < 10; i++)
+  var maxFD: number = -1;
+  for (let i = 0; i < 100; i++) {
     await (async function () {
-      var exited;
       const proc = spawn({
-        cmd: [bunExe(), import.meta.dir + "/spawn-streaming-stdout-repro.js"],
+        cmd: ["bun", import.meta.dir + "/spawn-streaming-stdout-repro.js"],
         stdin: "ignore",
         stdout: "pipe",
         stderr: "ignore",
@@ -35,7 +32,11 @@ test("spawn can read from stdout multiple chunks", async () => {
       proc.kill();
       expect(Buffer.concat(chunks).toString()).toBe("Wrote to stdout\n".repeat(4));
     })();
-
+    if (maxFD === -1) {
+      maxFD = openSync("/dev/null", "w");
+      closeSync(maxFD);
+    }
+  }
   const newMaxFD = openSync("/dev/null", "w");
   closeSync(newMaxFD);
   expect(newMaxFD).toBe(maxFD);

--- a/test/js/bun/spawn/spawn-streaming-stdout.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdout.test.ts
@@ -31,6 +31,7 @@ test("spawn can read from stdout multiple chunks", async () => {
       // TODO: fix bug with returning SIGHUP instead of exit code 1
       proc.kill();
       expect(Buffer.concat(chunks).toString()).toBe("Wrote to stdout\n".repeat(4));
+      await proc.exited;
     })();
     if (maxFD === -1) {
       maxFD = openSync("/dev/null", "w");
@@ -40,4 +41,4 @@ test("spawn can read from stdout multiple chunks", async () => {
   const newMaxFD = openSync("/dev/null", "w");
   closeSync(newMaxFD);
   expect(newMaxFD).toBe(maxFD);
-});
+}, 60_000);

--- a/test/js/bun/spawn/spawn-streaming-stdout.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdout.test.ts
@@ -9,7 +9,7 @@ test("spawn can read from stdout multiple chunks", async () => {
   for (let i = 0; i < 100; i++) {
     await (async function () {
       const proc = spawn({
-        cmd: ["bun", import.meta.dir + "/spawn-streaming-stdout-repro.js"],
+        cmd: [bunExe(), import.meta.dir + "/spawn-streaming-stdout-repro.js"],
         stdin: "ignore",
         stdout: "pipe",
         stderr: "ignore",

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -161,7 +161,7 @@ for (let [gcTick, label] of [
           expect(exitCode1).toBe(0);
           expect(exitCode2).toBe(1);
         }
-      }, 20_000);
+      }, 60_000_0);
 
       // FIXME: fix the assertion failure
       it.skip("Uint8Array works as stdout", () => {

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1,6 +1,6 @@
 import { ArrayBufferSink, readableStreamToText, spawn, spawnSync, write } from "bun";
 import { describe, expect, it } from "bun:test";
-import { gcTick as _gcTick, bunExe } from "harness";
+import { gcTick as _gcTick, bunExe, bunEnv } from "harness";
 import { rmSync, writeFileSync } from "node:fs";
 import path from "path";
 
@@ -475,4 +475,23 @@ for (let [gcTick, label] of [
       });
     });
   });
+}
+
+if (!process.env.BUN_FEATURE_FLAG_FORCE_WAITER_THREAD) {
+  it("with BUN_FEATURE_FLAG_FORCE_WAITER_THREAD", async () => {
+    const result = spawnSync({
+      cmd: [bunExe(), "test", import.meta.path],
+      env: {
+        ...bunEnv,
+        // Both flags are necessary to force this condition
+        "BUN_FEATURE_FLAG_FORCE_WAITER_THREAD": "1",
+        "BUN_GARBAGE_COLLECTOR_LEVEL": "1",
+      },
+    });
+    if (result.exitCode !== 0) {
+      console.error(result.stderr.toString());
+      console.log(result.stdout.toString());
+    }
+    expect(result.exitCode).toBe(0);
+  }, 60_000);
 }


### PR DESCRIPTION
### What does this PR do?

`pidfd_open` is not implemented by gVisor and by older Linux kernels. This implements a workaround where we spawn a thread, enqueue concurrent tasks and call `waitpid` on each `Subprocess`'s `pid`.  This workaround is very loosely based on libuv's default behavior. 

Fixes https://github.com/oven-sh/bun/issues/5803

Need to manually test that it does indeed fix the issue, but it should

### How did you verify your code works?

I tested manually + added a hidden environment variable to let us manually enable this for testing purposes