### PR TITLE
fix: `ninja` invocation error in `scripts/setup.sh`

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,4 +8,4 @@ bun i
 
 mkdir build
 cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -G Ninja
-ninja
+ninja -C build


### PR DESCRIPTION
### What does this PR do?

Running the script ended with this error:

```sh
$ bash ./scripts/setup.sh
...
ninja: error: loading 'build.ninja': No such file or directory
```

It happens because the `build.ninja` file is inside the `build` directory, not the current directory, so `ninja` is not able to detect the presence of that file and run the builds.

The error started happening in https://github.com/oven-sh/bun/pull/4410, where this script was introduced.