### PR TITLE
feat(console): add printer for mapiterator

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -1749,13 +1749,13 @@ pub const ZigConsoleClient = struct {
             this.estimated_line_length += 1;
         }
 
-        pub fn MapIterator(comptime Writer: type, comptime enable_ansi_colors: bool, comptime isIterator: bool) type {
+        pub fn MapIterator(comptime Writer: type, comptime enable_ansi_colors: bool, comptime is_iterator: bool) type {
             return struct {
                 formatter: *ZigConsoleClient.Formatter,
                 writer: Writer,
                 pub fn forEach(_: [*c]JSC.VM, globalObject: [*c]JSGlobalObject, ctx: ?*anyopaque, nextValue: JSValue) callconv(.C) void {
                     var this: *@This() = bun.cast(*@This(), ctx orelse return);
-                    if (!isIterator) {
+                    if (!is_iterator) {
                         const key = JSC.JSObject.getIndex(nextValue, globalObject, 0);
                         const value = JSC.JSObject.getIndex(nextValue, globalObject, 1);
                         this.formatter.writeIndent(Writer, this.writer) catch unreachable;

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -75,3 +75,37 @@ String 123 should be 2nd word, 456 == 456 and percent s %s == What okay
     }
   }
 }
+SetIterator { 
+  1,
+  "123",
+  {
+    a: [],
+    str: "123123132",
+    nr: 3453
+  },
+}
+SetIterator { 
+  1,
+  "123",
+  {
+    a: [],
+    str: "123123132",
+    nr: 3453
+  },
+}
+SetIterator { } SetIterator { }
+MapIterator { 
+  "key",
+  "key_2",
+}
+MapIterator { 
+  {
+    a: [],
+    str: "123123132",
+    nr: 3453
+  },
+  {
+    b: "test"
+  },
+}
+MapIterator { } MapIterator { }

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -76,3 +76,14 @@ console.dir({ 1: { 2: { 3: 3 } } }, { depth: 0, colors: false }, "Some ignored a
 console.dir({ 1: { 2: { 3: 3 } } }, { depth: -1, colors: false }, "Some ignored arg");
 console.dir({ 1: { 2: { 3: 3 } } }, { depth: 1.2, colors: false }, "Some ignored arg");
 console.dir({ 1: { 2: { 3: 3 } } }, { depth: Infinity, colors: false }, "Some ignored arg");
+const set = new Set([1, "123", { a: [], str: "123123132", nr: 3453 }]);
+console.log(set.keys());
+console.log(set.values());
+console.log(new Set().keys(), new Set().values());
+const m = new Map([
+  ["key", { a: [], str: "123123132", nr: 3453 }],
+  ["key_2", { b: "test" }],
+]);
+console.log(m.keys());
+console.log(m.values());
+console.log(new Map().keys(), new Map().values());


### PR DESCRIPTION
MapIterator was not supported in printing, libraries like discordjs make big use of maps and so i think supporting them would be a good idea.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
- Manual test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
