### PR TITLE
docs(contributing) add ruby dependency

### DIFF
--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -92,7 +92,7 @@ $ brew install automake ccache cmake coreutils gnu-sed go libiconv libtool ninja
 ```
 
 ```bash#Ubuntu/Debian
-$ sudo apt install cargo ccache cmake git golang libtool ninja-build pkg-config rustc
+$ sudo apt install cargo ccache cmake git golang libtool ninja-build pkg-config rustc ruby-full
 ```
 
 ```bash#Arch


### PR DESCRIPTION
Don't know why ruby is required to build bun, but without it `bun setup` fails.

### What does this PR do?

Improves contributing doc.

### How did you verify your code works?
N / A