### PR TITLE
Fix minify-whitespace `case undefined`

### DIFF
--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -981,6 +981,7 @@ fn NewPrinter(
                     p.print("void 0");
                 }
             } else {
+                p.printSpaceBeforeIdentifier();
                 p.addSourceMapping(loc);
                 p.print("undefined");
             }

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -307,4 +307,24 @@ describe("bundler", () => {
       stdout: "PASS",
     },
   });
+  // https://github.com/oven-sh/bun/issues/6750
+  itBundled("minify/SwitchUndefined", {
+    files: {
+      "/entry.js": /* js */ `
+        switch (1) {
+          case undefined: {
+          }
+        }
+        console.log("PASS");
+      `,
+    },
+    minifyWhitespace: true,
+    minifySyntax: false,
+    minifyIdentifiers: false,
+    target: "bun",
+    backend: "cli",
+    run: {
+      stdout: "PASS",
+    },
+  });
 });


### PR DESCRIPTION
Print a space before `undefined` in `printUndefined`.

fix https://github.com/oven-sh/bun/issues/6750

### What does this PR do?

Fix minify-whitespace formatting error.

### How did you verify your code works?

I wrote automated tests

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I or my editor ran `zig fmt` on the changed files
- [X] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
