### PR TITLE
chore: add quotes for task names containing spaces

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1035,8 +1035,13 @@ pub const RunCommand = struct {
                             Output.prettyln("<r><blue><b>{s}<r> scripts:<r>\n", .{display_name});
                             while (iterator.next()) |entry| {
                                 Output.prettyln("\n", .{});
-                                Output.prettyln(" bun run <blue>{s}<r>\n", .{entry.key_ptr.*});
-                                Output.prettyln(" <d>  {s}<r>\n", .{entry.value_ptr.*});
+                                if (std.mem.indexOfScalar(u8, entry.key_ptr.*}, ' ') != null) {
+                                    Output.prettyln(" bun run <blue>\"{s}\"<r>\n", .{entry.key_ptr.*});
+                                    Output.prettyln(" <d>  \"{s}\"<r>\n", .{entry.value_ptr.*});
+                                } else {
+                                    Output.prettyln(" bun run <blue>{s}<r>\n", .{entry.key_ptr.*});
+                                    Output.prettyln(" <d>  {s}<r>\n", .{entry.value_ptr.*});
+                                }
                             }
 
                             Output.prettyln("\n<d>{d} scripts<r>", .{scripts.count()});

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1042,7 +1042,6 @@ pub const RunCommand = struct {
                                 }
                                 Output.prettyln(" <d>  {s}<r>\n", .{entry.value_ptr.*});
                             }
-
                             Output.prettyln("\n<d>{d} scripts<r>", .{scripts.count()});
 
                             Output.flush();

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1037,11 +1037,11 @@ pub const RunCommand = struct {
                                 Output.prettyln("\n", .{});
                                 if (std.mem.indexOfScalar(u8, entry.key_ptr.*}, ' ') != null) {
                                     Output.prettyln(" bun run <blue>\"{s}\"<r>\n", .{entry.key_ptr.*});
-                                    Output.prettyln(" <d>  \"{s}\"<r>\n", .{entry.value_ptr.*});
                                 } else {
                                     Output.prettyln(" bun run <blue>{s}<r>\n", .{entry.key_ptr.*});
-                                    Output.prettyln(" <d>  {s}<r>\n", .{entry.value_ptr.*});
                                 }
+                                Output.prettyln(" <d>  {s}<r>\n", .{entry.value_ptr.*});
+
                             }
 
                             Output.prettyln("\n<d>{d} scripts<r>", .{scripts.count()});

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1041,7 +1041,6 @@ pub const RunCommand = struct {
                                     Output.prettyln(" bun run <blue>{s}<r>\n", .{entry.key_ptr.*});
                                 }
                                 Output.prettyln(" <d>  {s}<r>\n", .{entry.value_ptr.*});
-
                             }
 
                             Output.prettyln("\n<d>{d} scripts<r>", .{scripts.count()});


### PR DESCRIPTION
### What does this PR do?

Enhances `bun run` command output to include double quotes for task names that include spaces

### How did you verify your code works?

I extracted the pertinent lines to a test script:

```zig
const std = @import("std");

const Entry = struct {
    key_ptr: []const u8,
    value_ptr: []const u8,
};

pub fn main() !void {
    const Output = std.io.getStdOut().writer();
    
    const testData = [_]Entry{
        Entry{ .key_ptr = "dev https", .value_ptr = "value1" },
        Entry{ .key_ptr = "dev", .value_ptr = "value2" },
    };
    
    for (testData) |entry| {
        if (std.mem.indexOfScalar(u8, entry.key_ptr, ' ') != null) {
            try Output.print(" bun run <blue>\"{s}\"<r>\n", .{entry.key_ptr});
            try Output.print(" <d>  \"{s}\"<r>\n", .{entry.value_ptr});
        } else {
            try Output.print(" bun run <blue>{s}<r>\n", .{entry.key_ptr});
            try Output.print(" <d>  {s}<r>\n", .{entry.value_ptr});
        }
    }
}
```

Output:
```
 bun run "dev https"
   "value1"
 bun run dev
   value2
```

(value for `<d>` doesn't exist in the test)