### PR TITLE
fix #6831

### DIFF
--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -436,7 +436,7 @@ const Scanner = struct {
 
         // In this particular case, we don't actually care about non-ascii latin1 characters.
         // so we skip the ascii check
-        const slice = if (test_name_str.is8Bit()) test_name_str.latin1() else brk: {
+        const slice = brk: {
             zig_slice = test_name_str.toUTF8(bun.default_allocator);
             break :brk zig_slice.slice();
         };

--- a/src/string.zig
+++ b/src/string.zig
@@ -563,6 +563,10 @@ pub const String = extern struct {
         if (self.tag == .Empty)
             return &[_]u8{};
 
+        if (self.tag == .ZigString) {
+            return self.value.ZigString.slice();
+        }
+
         std.debug.assert(self.tag == .WTFStringImpl);
         return self.value.WTFStringImpl.latin1Slice();
     }

--- a/src/string.zig
+++ b/src/string.zig
@@ -563,10 +563,6 @@ pub const String = extern struct {
         if (self.tag == .Empty)
             return &[_]u8{};
 
-        if (self.tag == .ZigString) {
-            return self.value.ZigString.slice();
-        }
-
         std.debug.assert(self.tag == .WTFStringImpl);
         return self.value.WTFStringImpl.latin1Slice();
     }


### PR DESCRIPTION
### What does this PR do?
fixes #6831 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
