### PR TITLE
fix jsx key parse and visit order

### DIFF
--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -1669,6 +1669,9 @@ pub const E = struct {
         /// key is the key prop like <ListItem key="foo">
         key: ?ExprNodeIndex = null,
 
+        /// index of key used to keep parsing and visiting in the same order
+        key_index: i32 = -1,
+
         flags: Flags.JSXElement.Bitset = Flags.JSXElement.Bitset{},
 
         close_tag_loc: logger.Loc = logger.Loc.Empty,

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -1666,11 +1666,8 @@ pub const E = struct {
         /// JSX element children <div>{this_is_a_child_element}</div>
         children: ExprNodeList = ExprNodeList{},
 
-        /// key is the key prop like <ListItem key="foo">
-        key: ?ExprNodeIndex = null,
-
-        /// index of key used to keep parsing and visiting in the same order
-        key_index: i32 = -1,
+        // needed to make sure parse and visit happen in the same order
+        original_key_prop_i: i32 = -1,
 
         flags: Flags.JSXElement.Bitset = Flags.JSXElement.Bitset{},
 

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -14919,12 +14919,19 @@ fn NewParser_(
                                 }
                             };
 
-                            const jsx_props = e_.properties.slice();
-                            const last = jsx_props.len - 1;
+                            const jsx_props = brk: {
+                                const slice = e_.properties.slice();
+                                if (e_.original_key_prop_i != -1) break :brk slice[0 .. slice.len - 1];
+                                break :brk slice;
+                            };
                             for (jsx_props, 0..) |property, i| {
                                 // make sure key is visited in the same order it was parsed
                                 if (i == e_.original_key_prop_i) {
+                                    const last = e_.properties.len - 1;
                                     e_.properties.ptr[last].key = p.visitExpr(e_.properties.ptr[last].key.?);
+                                    if (e_.properties.ptr[last].value != null) {
+                                        e_.properties.ptr[last].value = p.visitExpr(e_.properties.ptr[last].value.?);
+                                    }
                                 }
 
                                 if (property.kind != .spread) {

--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -1192,6 +1192,44 @@ export default <>hi</>
     expect(fragment.includes("var JSXFrag = foo.frag,")).toBe(true);
   });
 
+  it("JSX keys", () => {
+    var bun = new Bun.Transpiler({
+      loader: "jsx",
+      define: {
+        "process.env.NODE_ENV": JSON.stringify("development"),
+      },
+    });
+
+    expect(bun.transformSync("console.log(<div key={() => {}} points={() => {}}></div>);")).toBe(
+      `console.log(jsxDEV("div", {
+  points: () => {
+  }
+}, () => {
+}, false, undefined, this));
+`,
+    );
+
+    expect(bun.transformSync("console.log(<div points={() => {}} key={() => {}}></div>);")).toBe(
+      `console.log(jsxDEV("div", {
+  points: () => {
+  }
+}, () => {
+}, false, undefined, this));
+`,
+    );
+
+    expect(bun.transformSync("console.log(<div key={() => {}}></div>);")).toBe(
+      `console.log(jsxDEV("div", {}, () => {
+}, false, undefined, this));
+`,
+    );
+
+    expect(bun.transformSync("console.log(<div></div>);")).toBe(
+      `console.log(jsxDEV("div", {}, undefined, false, undefined, this));
+`,
+    );
+  });
+
   it.todo("JSX", () => {
     var bun = new Bun.Transpiler({
       loader: "jsx",


### PR DESCRIPTION
### What does this PR do?
fixes #2694 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
added tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
