### PR TITLE
Fix: script passthough args not split if contains space

### DIFF
--- a/test/cli/run/run-passthough.test.ts
+++ b/test/cli/run/run-passthough.test.ts
@@ -2,15 +2,15 @@ import { expect, it } from "bun:test";
 import { bunExe, tempDirWithFiles } from "harness";
 
 it("should wrap passthrough arguments with doublequote", () => {
-    const package_json = JSON.stringify({
-      scripts: {
-        test: `${bunExe()} test.js $1`,
-      },
-    });
-    const dir = tempDirWithFiles("run-warp-arguments", { "package.json": package_json, "test.js": "console.log(process.argv[2])"});
-    const { stdout } = Bun.spawnSync({
-        cmd: [bunExe(), "run", "test", "Hello World"],
-        cwd: dir,
-      });
-    expect(stdout.toString("utf8").trim()).toBe("Hello World");
+  const package_json = JSON.stringify({
+    scripts: {
+      test: `${bunExe()} test.js $1`,
+    },
   });
+  const dir = tempDirWithFiles("run-warp-arguments", { "package.json": package_json, "test.js": "console.log(process.argv[2])"});
+  const { stdout } = Bun.spawnSync({
+    cmd: [bunExe(), "run", "test", "Hello World"],
+    cwd: dir,
+  });
+  expect(stdout.toString("utf8").trim()).toBe("Hello World");
+});

--- a/test/cli/run/run-passthough.test.ts
+++ b/test/cli/run/run-passthough.test.ts
@@ -1,0 +1,16 @@
+import { expect, it } from "bun:test";
+import { bunExe, tempDirWithFiles } from "harness";
+
+it("should wrap passthrough arguments with doublequote", () => {
+    const package_json = JSON.stringify({
+      scripts: {
+        test: `${bunExe()} test.js $1`,
+      },
+    });
+    const dir = tempDirWithFiles("run-warp-arguments", { "package.json": package_json, "test.js": "console.log(process.argv[2])"});
+    const { stdout } = Bun.spawnSync({
+        cmd: [bunExe(), "run", "test", "Hello World"],
+        cwd: dir,
+      });
+    expect(stdout.toString("utf8").trim()).toBe("Hello World");
+  });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix #6780 where console arguments that contain space will be splited when running script as a result of double quotes missing.
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated test.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

If Zig files changed:

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be.
(only change buffer content, not touch any allocation.)
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
