### PR TITLE
Fix TimeLike implementation to preserve milliseconds in fs.utimesSync.

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -890,7 +890,7 @@ pub const Arguments = struct {
                 return null;
             };
 
-            const atime = JSC.Node.timeLikeFromJS(ctx, arguments.next() orelse {
+            const atime = JSC.Node.TimeLike.fromJS(ctx, arguments.next() orelse {
                 if (exception.* == null) {
                     JSC.throwInvalidArguments(
                         "atime is required",
@@ -915,7 +915,7 @@ pub const Arguments = struct {
 
             arguments.eat();
 
-            const mtime = JSC.Node.timeLikeFromJS(ctx, arguments.next() orelse {
+            const mtime = JSC.Node.TimeLike.fromJS(ctx, arguments.next() orelse {
                 if (exception.* == null) {
                     JSC.throwInvalidArguments(
                         "mtime is required",
@@ -1856,7 +1856,7 @@ pub const Arguments = struct {
             arguments.eat();
             if (exception.* != null) return null;
 
-            const atime = JSC.Node.timeLikeFromJS(ctx, arguments.next() orelse {
+            const atime = JSC.Node.TimeLike.fromJS(ctx, arguments.next() orelse {
                 if (exception.* == null) {
                     JSC.throwInvalidArguments(
                         "atime is required",
@@ -1880,7 +1880,7 @@ pub const Arguments = struct {
 
             if (exception.* != null) return null;
 
-            const mtime = JSC.Node.timeLikeFromJS(ctx, arguments.next() orelse {
+            const mtime = JSC.Node.TimeLike.fromJS(ctx, arguments.next() orelse {
                 if (exception.* == null) {
                     JSC.throwInvalidArguments(
                         "mtime is required",
@@ -3714,12 +3714,12 @@ pub const NodeFS = struct {
 
         var times = [2]std.os.timespec{
             .{
-                .tv_sec = args.mtime,
-                .tv_nsec = 0,
+                .tv_sec = args.mtime.seconds,
+                .tv_nsec = args.mtime.nanos,
             },
             .{
-                .tv_sec = args.atime,
-                .tv_nsec = 0,
+                .tv_sec = args.atime.seconds,
+                .tv_nsec = args.atime.nanos,
             },
         };
 
@@ -4924,14 +4924,12 @@ pub const NodeFS = struct {
 
         var times = [2]std.c.timeval{
             .{
-                .tv_sec = args.mtime,
-                // TODO: is this correct?
-                .tv_usec = 0,
+                .tv_sec = args.mtime.seconds,
+                .tv_usec = args.mtime.nanos * 1000,
             },
             .{
-                .tv_sec = args.atime,
-                // TODO: is this correct?
-                .tv_usec = 0,
+                .tv_sec = args.mtime.seconds,
+                .tv_usec = args.mtime.nanos * 1000,
             },
         };
 
@@ -4948,14 +4946,12 @@ pub const NodeFS = struct {
 
         var times = [2]std.c.timeval{
             .{
-                .tv_sec = args.mtime,
-                // TODO: is this correct?
-                .tv_usec = 0,
+                .tv_sec = args.mtime.seconds,
+                .tv_usec = args.mtime.nanos,
             },
             .{
-                .tv_sec = args.atime,
-                // TODO: is this correct?
-                .tv_usec = 0,
+                .tv_sec = args.mtime.seconds,
+                .tv_usec = args.mtime.nanos,
             },
         };
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1930,6 +1930,22 @@ describe("utimesSync", () => {
     expect(finalStats.mtime).toEqual(prevModifiedTime);
     expect(finalStats.atime).toEqual(prevAccessTime);
   });
+
+  it("utimesSync keeps milliseconds correctly", () => {
+    const path = `${tmpdir()}/bun-fs-read-5-${Date.now()}.txt`;
+    fs.writeFileSync(path, "bun");
+
+    const atime = new Date();
+    const mtime = new Date();
+
+    atime.setMilliseconds(123);
+    mtime.setMilliseconds(123);
+
+    fs.utimesSync(path, atime, mtime);
+
+    expect(fs.statSync(path).atime.valueOf()).toBe(atime.getTime());
+    expect(fs.statSync(path).mtime.valueOf()).toBe(mtime.getTime());
+  });
 });
 
 it("createReadStream on a large file emits readable event correctly", () => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
fix https://github.com/oven-sh/bun/issues/6804

The millisecond portion of the data was lost in fs.utimesSync.

The TimeLike implementation only kept seconds. For example, Node.js [`process.hrtime.bigint()`](https://nodejs.org/dist/latest-v20.x/docs/api/process.html#processhrtimebigint) returns the current time in nanoseconds, so I modified it to keep the data in two parts, the seconds part and the nanoseconds part, for future implementation.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->


- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
  - maybe yes
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

I am new to Bun and zig so I am not sure if I am handling it properly. If I need free, I would be very grateful if you could tell me how to do it.

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
