### PR TITLE
fix: correctly call abort handler when request is aborted

### DIFF
--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -250,6 +250,8 @@ pub const Request = struct {
             //Lazy create default signal
             const js_signal = AbortSignal.create(globalThis);
             js_signal.ensureStillAlive();
+            js_signal.protect();
+            this.signal_js_ref = js_signal;
             if (AbortSignal.fromJS(js_signal)) |signal| {
                 this.signal = signal.ref();
             }


### PR DESCRIPTION
We where not protecting the signal js object on the request when it was requested, leading to the garbage collection of it, preventing handlers like `on("abort")` and `signal.onabort = ...` from being executed on the JS side.
This fixes that by storing the js value and unprotecting it when required.

Fixes: https://github.com/oven-sh/bun/issues/4517

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
- [x] I included a test for the new code, or an existing test covers it
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)


-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
