### PR TITLE
Add a new argument to the bash installer to be able to skip editing the users rc files (#6901)

### DIFF
--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -150,14 +150,6 @@ tildify() {
 
 success "bun was installed successfully to $Bold_Green$(tildify "$exe")"
 
-if command -v bun >/dev/null; then
-    # Install completions, but we don't care if it fails
-    IS_BUN_AUTO_UPDATE=true $exe completions &>/dev/null || :
-
-    echo "Run 'bun --help' to get started"
-    exit
-fi
-
 refresh_command=''
 
 tilde_bin_dir=$(tildify "$bin_dir")
@@ -169,129 +161,141 @@ fi
 
 echo
 
-case $(basename "$SHELL") in
-fish)
-    # Install completions, but we don't care if it fails
-    IS_BUN_AUTO_UPDATE=true SHELL=fish $exe completions &>/dev/null || :
-
-    commands=(
-        "set --export $install_env $quoted_install_dir"
-        "set --export PATH $bin_env \$PATH"
-    )
-
-    fish_config=$HOME/.config/fish/config.fish
-    tilde_fish_config=$(tildify "$fish_config")
-
-    if [[ -w $fish_config ]]; then
-        {
-            echo -e '\n# bun'
-
-            for command in "${commands[@]}"; do
-                echo "$command"
-            done
-        } >>"$fish_config"
-
-        info "Added \"$tilde_bin_dir\" to \$PATH in \"$tilde_fish_config\""
-
-        refresh_command="source $tilde_fish_config"
-    else
-        echo "Manually add the directory to $tilde_fish_config (or similar):"
-
-        for command in "${commands[@]}"; do
-            info_bold "  $command"
-        done
+install_completions() {
+    if command -v bun >/dev/null; then
+        # Install completions, but we don't care if it fails
+        IS_BUN_AUTO_UPDATE=true $exe completions &>/dev/null || :
+        return
     fi
-    ;;
-zsh)
-    # Install completions, but we don't care if it fails
-    IS_BUN_AUTO_UPDATE=true SHELL=zsh $exe completions &>/dev/null || :
 
-    commands=(
-        "export $install_env=$quoted_install_dir"
-        "export PATH=\"$bin_env:\$PATH\""
-    )
+    case $(basename "$SHELL") in
+    fish)
+        # Install completions, but we don't care if it fails
+        IS_BUN_AUTO_UPDATE=true SHELL=fish $exe completions &>/dev/null || :
 
-    zsh_config=$HOME/.zshrc
-    tilde_zsh_config=$(tildify "$zsh_config")
-
-    if [[ -w $zsh_config ]]; then
-        {
-            echo -e '\n# bun'
-
-            for command in "${commands[@]}"; do
-                echo "$command"
-            done
-        } >>"$zsh_config"
-
-        info "Added \"$tilde_bin_dir\" to \$PATH in \"$tilde_zsh_config\""
-
-        refresh_command="exec $SHELL"
-    else
-        echo "Manually add the directory to $tilde_zsh_config (or similar):"
-
-        for command in "${commands[@]}"; do
-            info_bold "  $command"
-        done
-    fi
-    ;;
-bash)
-    # Install completions, but we don't care if it fails
-    IS_BUN_AUTO_UPDATE=true SHELL=bash $exe completions &>/dev/null || :
-
-    commands=(
-        "export $install_env=$quoted_install_dir"
-        "export PATH=$bin_env:\$PATH"
-    )
-
-    bash_configs=(
-        "$HOME/.bashrc"
-        "$HOME/.bash_profile"
-    )
-
-    if [[ ${XDG_CONFIG_HOME:-} ]]; then
-        bash_configs+=(
-            "$XDG_CONFIG_HOME/.bash_profile"
-            "$XDG_CONFIG_HOME/.bashrc"
-            "$XDG_CONFIG_HOME/bash_profile"
-            "$XDG_CONFIG_HOME/bashrc"
+        commands=(
+            "set --export $install_env $quoted_install_dir"
+            "set --export PATH $bin_env \$PATH"
         )
-    fi
 
-    set_manually=true
-    for bash_config in "${bash_configs[@]}"; do
-        tilde_bash_config=$(tildify "$bash_config")
+        fish_config=$HOME/.config/fish/config.fish
+        tilde_fish_config=$(tildify "$fish_config")
 
-        if [[ -w $bash_config ]]; then
+        if [[ -w $fish_config ]]; then
             {
                 echo -e '\n# bun'
 
                 for command in "${commands[@]}"; do
                     echo "$command"
                 done
-            } >>"$bash_config"
+            } >>"$fish_config"
 
-            info "Added \"$tilde_bin_dir\" to \$PATH in \"$tilde_bash_config\""
+            info "Added \"$tilde_bin_dir\" to \$PATH in \"$tilde_fish_config\""
 
-            refresh_command="source $bash_config"
-            set_manually=false
-            break
+            refresh_command="source $tilde_fish_config"
+        else
+            echo "Manually add the directory to $tilde_fish_config (or similar):"
+
+            for command in "${commands[@]}"; do
+                info_bold "  $command"
+            done
         fi
-    done
+        ;;
+    zsh)
+        # Install completions, but we don't care if it fails
+        IS_BUN_AUTO_UPDATE=true SHELL=zsh $exe completions &>/dev/null || :
 
-    if [[ $set_manually = true ]]; then
-        echo "Manually add the directory to $tilde_bash_config (or similar):"
+        commands=(
+            "export $install_env=$quoted_install_dir"
+            "export PATH=\"$bin_env:\$PATH\""
+        )
 
-        for command in "${commands[@]}"; do
-            info_bold "  $command"
+        zsh_config=$HOME/.zshrc
+        tilde_zsh_config=$(tildify "$zsh_config")
+
+        if [[ -w $zsh_config ]]; then
+            {
+                echo -e '\n# bun'
+
+                for command in "${commands[@]}"; do
+                    echo "$command"
+                done
+            } >>"$zsh_config"
+
+            info "Added \"$tilde_bin_dir\" to \$PATH in \"$tilde_zsh_config\""
+
+            refresh_command="exec $SHELL"
+        else
+            echo "Manually add the directory to $tilde_zsh_config (or similar):"
+
+            for command in "${commands[@]}"; do
+                info_bold "  $command"
+            done
+        fi
+        ;;
+    bash)
+        # Install completions, but we don't care if it fails
+        IS_BUN_AUTO_UPDATE=true SHELL=bash $exe completions &>/dev/null || :
+
+        commands=(
+            "export $install_env=$quoted_install_dir"
+            "export PATH=$bin_env:\$PATH"
+        )
+
+        bash_configs=(
+            "$HOME/.bashrc"
+            "$HOME/.bash_profile"
+        )
+
+        if [[ ${XDG_CONFIG_HOME:-} ]]; then
+            bash_configs+=(
+                "$XDG_CONFIG_HOME/.bash_profile"
+                "$XDG_CONFIG_HOME/.bashrc"
+                "$XDG_CONFIG_HOME/bash_profile"
+                "$XDG_CONFIG_HOME/bashrc"
+            )
+        fi
+
+        set_manually=true
+        for bash_config in "${bash_configs[@]}"; do
+            tilde_bash_config=$(tildify "$bash_config")
+
+            if [[ -w $bash_config ]]; then
+                {
+                    echo -e '\n# bun'
+
+                    for command in "${commands[@]}"; do
+                        echo "$command"
+                    done
+                } >>"$bash_config"
+
+                info "Added \"$tilde_bin_dir\" to \$PATH in \"$tilde_bash_config\""
+
+                refresh_command="source $bash_config"
+                set_manually=false
+                break
+            fi
         done
-    fi
-    ;;
-*)
-    echo 'Manually add the directory to ~/.bashrc (or similar):'
-    info_bold "  export $install_env=$quoted_install_dir"
-    info_bold "  export PATH=\"$bin_env:\$PATH\""
-    ;;
-esac
+
+        if [[ $set_manually = true ]]; then
+            echo "Manually add the directory to $tilde_bash_config (or similar):"
+
+            for command in "${commands[@]}"; do
+                info_bold "  $command"
+            done
+        fi
+        ;;
+    *)
+        echo 'Manually add the directory to ~/.bashrc (or similar):'
+        info_bold "  export $install_env=$quoted_install_dir"
+        info_bold "  export PATH=\"$bin_env:\$PATH\""
+        ;;
+    esac
+}
+
+if [ -z ${!install_env} ]; then
+    install_completions
+fi
 
 echo
 info "To get started, run:"


### PR DESCRIPTION
### What does this PR do?

Skips installing completions if BUN_INSTALL is already defined, assuming that it's already done

~~The current [install script](https://github.com/oven-sh/bun/blob/main/src/cli/install.sh) always edits my `~/.zshrc` file, which I don't want it to do as I prefer to set completions/environment variables/etc myself.~~

~~This PR adds a new cli option to `install.sh` (curl -fsSL https://bun.sh/install | bash)
`--skip-rc`. It just skips the section at the end where it would install completions/edit rc files.~~

~~The existing check that disallowed adding more than 2 options was moved to the argument interpreter, and only limits positional arguments, not flags. Examples of this behavior:~~

```sh
src/cli/install.sh foo bar # okay
src/cli/install.sh foo bar zed # same error as before
src/cli/install.sh --skip-rc foo bar # okay
src/cli/install.sh -vq --skip-rc --another-thing foo bar # okay
src/cli/install.sh -vq foo bar zed # still an error
```

> ~~Note that the argument parser errors for unknown parameters so the bottom two examples would error out on that note first. But this would be the behavior if they would be defined.~~

### Prior art

~~This is used in other similar install scripts for example in [jabba](https://github.com/shyiko/jabba/blob/master/install.sh) a Java version manager.~~

~~The argument parser was taken from [a shell script I wrote](https://github.com/AlexAegis/pont/blob/master/pont.sh#L683) where the aim was compatibility across Linux/BSD/macOS so using getopt(s) was a no-go. Not to mentions both getopt and getopts has their own problems that prompted me to write a parser myself.~~

### How did you verify your code works?

~~I tried it out. I didn't find any pre-existing test for this install script.
I used a similar format in which this script will be used in (piped it into bash too, besides just running the script)~~

```sh
cat src/cli/install.sh | bash -s -- --skip-rc
```
