### PR TITLE
Fix build on arch and fix `bun x` to execute local binaries from root package.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ endif()
 
 set(DEFAULT_USE_STATIC_LIBATOMIC ON)
 if(UNIX AND NOT APPLE)
-    execute_process(COMMAND cat /etc/os-release COMMAND head -n1 OUTPUT_VARIABLE LINUX_DISTRO)
+    execute_process(COMMAND cat /usr/lib/os-release COMMAND head -n1 OUTPUT_VARIABLE LINUX_DISTRO)
     if(${LINUX_DISTRO} STREQUAL "NAME=\"Arch Linux\"\n")
         set(DEFAULT_USE_STATIC_LIBATOMIC OFF)
     endif()


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

This allows `bun x` command to search first for local binaries mentioned in the root package.json and execute them if found similar to npx, which wasn't possible earlier.

For example we have a package.json in our root dir
```json
{
  "name": "cli",
  "module": "index.ts",
  "type": "module",
  "bin": "./index.ts",
  "devDependencies": {
    "bun-types": "latest"
  },
  "peerDependencies": {
    "typescript": "^5.0.0"
  }
}
```
Previously `bun x cli` would not execute this binary but `npx cli` worked. This PR allows `bun x cli` to work as expected and to execute local binaries from root package.json.

Also fixes build not working on arch distros having different names.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Manual tests.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
