### PR TITLE
fix: remove stray semicolon that causes SQLite's loadExtension to always throw an error on Mac

### DIFF
--- a/src/bun.js/bindings/sqlite/lazy_sqlite3.h
+++ b/src/bun.js/bindings/sqlite/lazy_sqlite3.h
@@ -162,7 +162,7 @@ static lazy_sqlite3_compileoption_used_type lazy_sqlite3_compileoption_used;
 #define sqlite3_deserialize lazy_sqlite3_deserialize
 #define sqlite3_stmt_readonly lazy_sqlite3_stmt_readonly
 #define sqlite3_column_int64 lazy_sqlite3_column_int64
-#define sqlite3_compileoption_used lazy_sqlite3_compileoption_used;
+#define sqlite3_compileoption_used lazy_sqlite3_compileoption_used
 
 #if !OS(WINDOWS)
 #define HMODULE void*


### PR DESCRIPTION
### What does this PR do?

This PR removes a semicolon from a `#define` that was causing false positive errors in the SQLite module's `loadExtension` function.

Specifically, this line was always resolving to true: https://github.com/oven-sh/bun/blob/8130d9f3e1e578f09ba2d2e5aff0a66cde704708/src/bun.js/bindings/sqlite/JSSQLStatement.cpp#L693

It looks like this was introduced by https://github.com/oven-sh/bun/pull/5773/files#diff-e269c85734e55134d1309f98479c12ea50568e482c851b63e5f5451723757d5dR157

- [x] Code changes

### How did you verify your code works?

I built and ran this branch on my Mac (Sonoma) and verified that the code is now correctly detecting the `SQLITE_OMIT_LOAD_EXTENSION` compile option and only throwing an error when it was used.

I also compared the modified line to the lines above it, none of which have terminating semicolons.
