### PR TITLE
Add a note about `bun add --exact` alias to docs

### DIFF
--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -35,6 +35,10 @@ $ bun add --optional lodash
 
 ## `--exact`
 
+{% callout %}
+**Alias** — `-E`
+{% /callout %}
+
 To add a package and pin to the resolved version, use `--exact`. This will resolve the version of the package and add it to your `package.json` with an exact version number instead of a version range.
 
 ```bash


### PR DESCRIPTION
To match with other commands on the page, `--dev` and `--global`.

### What does this PR do?

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

👀 
