### PR TITLE
Fix fetch response skipping body if no content-length (#6932)

### DIFF
--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -3344,6 +3344,16 @@ pub fn handleResponseMetadata(
         response.status_code = 304;
     }
 
+    // according to RFC 7230 section 6.3:
+    //   In order to remain persistent, all messages on a connection need to
+    //   have a self-defined message length (i.e., one not defined by closure
+    //   of the connection)
+    // therefore, if response has no content-length header and is not chunked, implicitly disable
+    // the keep-alive behavior (keep-alive being the default behavior for HTTP/1.1 and not for HTTP/1.0)
+    if (this.state.content_length == null and this.state.transfer_encoding != .chunked) {
+        this.state.allow_keepalive = false;
+    }
+
     // according to RFC 7230 section 3.3.3:
     //   1. Any response to a HEAD request and any response with a 1xx (Informational),
     //      204 (No Content), or 304 (Not Modified) status code

--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -3094,7 +3094,7 @@ fn handleResponseBodyFromMultiplePackets(this: *HTTPClient, incoming_data: []con
 
     // done or streaming
     const is_done = content_length != null and this.state.total_body_received >= content_length.?;
-    if (is_done or this.signals.get(.body_streaming)) {
+    if (is_done or this.signals.get(.body_streaming) or content_length == null) {
         const processed = try this.state.processBodyBuffer(buffer.*);
 
         if (this.progress_node) |progress| {
@@ -3541,7 +3541,7 @@ pub fn handleResponseMetadata(
         log("handleResponseMetadata: content_length is null and transfer_encoding {}", .{this.state.transfer_encoding});
     }
 
-    if (this.method.hasBody() and ((content_length != null and content_length.? > 0) or !this.state.allow_keepalive or this.state.transfer_encoding == .chunked or is_server_sent_events)) {
+    if (this.method.hasBody() and (content_length == null or content_length.? > 0 or !this.state.allow_keepalive or this.state.transfer_encoding == .chunked or is_server_sent_events)) {
         return ShouldContinue.continue_streaming;
     } else {
         return ShouldContinue.finished;

--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -3344,6 +3344,16 @@ pub fn handleResponseMetadata(
         response.status_code = 304;
     }
 
+    // according to RFC 7230 section 3.3.3:
+    //   1. Any response to a HEAD request and any response with a 1xx (Informational),
+    //      204 (No Content), or 304 (Not Modified) status code
+    //      [...] cannot contain a message body or trailer section.
+    // therefore in these cases set content-length to 0, so the response body is always ignored
+    // and is not waited for (which could cause a timeout)
+    if ((response.status_code >= 100 and response.status_code < 200) or response.status_code == 204 or response.status_code == 304) {
+        this.state.content_length = 0;
+    }
+
     if (this.proxy_tunneling and this.proxy_tunnel == null) {
         if (response.status_code == 200) {
             // signal to continue the proxing

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -40,7 +40,7 @@ afterAll(() => {
   }
 });
 
-[101, 418, 599, 200, 200n, 101n, 599n].forEach(statusCode => {
+[200, 200n, 303, 418, 599, 599n].forEach(statusCode => {
   it(`should response with HTTP status code (${statusCode})`, async () => {
     await runTest(
       {

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -1816,3 +1816,84 @@ it("304 not modified with 0 content-length does not cause a request timeout", as
   expect(await response.arrayBuffer()).toHaveLength(0);
   server.stop(true);
 });
+
+describe("http/1.1 response body length", () => {
+  // issue #6932 (support response without Content-Length and Transfer-Encoding) + some regression tests
+
+  let server: net.Server | undefined;
+  beforeAll(async () => {
+    server = net.createServer(socket => {
+      socket.on("data", data => {
+        const lines = data.toString().split("\r\n");
+        for (const line of lines) {
+          const [method, path] = line.split(" ");
+          if (method === "GET" || method === "HEAD") {
+            if (path === "/text") {
+              socket.end("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nHello, World!");
+            } else if (path === "/json") {
+              socket.end('HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{"hello":"World"}');
+            } else if (path === "/chunked") {
+              socket.end(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\nd\r\nHello, World!\r\n0\r\n\r\n",
+              );
+            } else if (path === "/empty") {
+              socket.end("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+            } else {
+              const status = +path.slice(1) || 200;
+              socket.end(
+                `HTTP/1.1 ${status} STATUS MESSAGE\r\nContent-Type: text/plain\r\nContent-Length: 13\r\n\r\nHello, World!`,
+              );
+            }
+          }
+        }
+      });
+    });
+
+    const { promise: start, resolve } = Promise.withResolvers();
+    server.listen(8080, resolve);
+    await start;
+  });
+  afterAll(() => {
+    server?.close?.();
+  });
+
+  const getHost = () => `127.0.0.1:${(server!.address() as net.AddressInfo).port}`;
+
+  describe("without content-length", () => {
+    it("should read text until socket closed", async () => {
+      const response = await fetch(`http://${getHost()}/text`);
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("Hello, World!");
+    });
+
+    it("should read json until socket closed", async () => {
+      const response = await fetch(`http://${getHost()}/json`);
+      expect(response.status).toBe(200);
+      expect(await response.json<unknown>()).toEqual({ "hello": "World" });
+    });
+  });
+
+  it("should support transfer-encoding: chunked", async () => {
+    const response = await fetch(`http://${getHost()}/chunked`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("Hello, World!");
+  });
+
+  it("should support non-zero content-length", async () => {
+    const response = await fetch(`http://${getHost()}/non-empty`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("Hello, World!");
+  });
+
+  it("should support content-length: 0", async () => {
+    const response = await fetch(`http://${getHost()}/empty`);
+    expect(response.status).toBe(200);
+    expect(await response.arrayBuffer()).toHaveLength(0);
+  });
+
+  it("should ignore body on HEAD", async () => {
+    const response = await fetch(`http://${getHost()}/text`, { method: "HEAD" });
+    expect(response.status).toBe(200);
+    expect(await response.arrayBuffer()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fixes the case when `fetch()` Response has no `Content-Length` header (and is not chunked) returning an empty body, instead of returning all bytes until the TCP socket is closed by the server, which is the expected behavior for HTTP/1.1 according to [RFC 7230 section 3.3.3](https://www.rfc-editor.org/rfc/rfc7230#section-3.3.3) bullet point 7.

Fixes #6932 and adds tests for the fix, and also for any potential regression on edge cases.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

Also ran these tests (sligthly tweaked so they work) on NodeJS, to ensure the behavior is consistent, and all passed on NodeJS v21.1.0.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:
-->

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
