### PR TITLE
don't pass script flags to pre- or post- scripts

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1067,7 +1067,7 @@ pub const RunCommand = struct {
                                     temp_script_buffer[1..],
                                     this_bundler.fs.top_level_dir,
                                     this_bundler.env,
-                                    passthrough,
+                                    &.{},
                                     ctx.debug.silent,
                                 )) {
                                     return false;
@@ -1093,7 +1093,7 @@ pub const RunCommand = struct {
                                     temp_script_buffer,
                                     this_bundler.fs.top_level_dir,
                                     this_bundler.env,
-                                    passthrough,
+                                    &.{},
                                     ctx.debug.silent,
                                 )) {
                                     return false;

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -176,6 +176,28 @@ logLevel = "debug"
         expect(stdout.toString()).toBe("Hello, world!\n");
         expect(exitCode).toBe(0);
       });
+
+      it("should not passthrough script arguments to pre- or post- scripts", async () => {
+        await writeFile(
+          join(run_dir, "package.json"),
+          JSON.stringify({
+            scripts: {
+              premyscript: "echo pre",
+              myscript: "echo main",
+              postmyscript: "echo post",
+            },
+          }),
+        );
+        const { stdout, stderr, exitCode } = spawnSync({
+          cmd: [bunExe(), "run", "--silent", "myscript", "-a", "-b", "-c"].filter(Boolean),
+          cwd: run_dir,
+          env: bunEnv,
+        });
+
+        expect(stderr.toString()).toBe("");
+        expect(stdout.toString()).toBe("pre\n" + "main -a -b -c\n" + "post\n");
+        expect(exitCode).toBe(0);
+      });
     });
   });
 }


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/6595

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [x] I included a test for the new code, or an existing test covers it
- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I added TypeScript types for the new methods, getters, or setters
- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
- [ ] I ran `make headers` to regenerate the C header file
- [ ] I ran `make codegen` to regenerate the C++ and Zig code
- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
