### PR TITLE
check for empty in `JSValue.jsType`

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -1698,9 +1698,8 @@ unsigned char JSC__JSValue__jsType(JSC__JSValue JSValue0)
     // if the value is NOT a cell
     // asCell will return an invalid pointer rather than a nullptr
     //
-    // The empty check is needed because the value could be empty
-    // and return true from isCell if it's an array hole from a
-    // sparse array.
+    // The empty check is needed because isCell returns true for
+    // empty values, and asCell on an empty value returns nullptr
     if (jsValue.isCell() and !jsValue.isEmpty())
         return jsValue.asCell()->type();
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -1697,10 +1697,7 @@ unsigned char JSC__JSValue__jsType(JSC__JSValue JSValue0)
     JSC::JSValue jsValue = JSC::JSValue::decode(JSValue0);
     // if the value is NOT a cell
     // asCell will return an invalid pointer rather than a nullptr
-    //
-    // The empty check is needed because isCell returns true for
-    // empty values, and asCell on an empty value returns nullptr
-    if (jsValue.isCell() and !jsValue.isEmpty())
+    if (jsValue.isCell())
         return jsValue.asCell()->type();
 
     return 0;

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -1697,7 +1697,11 @@ unsigned char JSC__JSValue__jsType(JSC__JSValue JSValue0)
     JSC::JSValue jsValue = JSC::JSValue::decode(JSValue0);
     // if the value is NOT a cell
     // asCell will return an invalid pointer rather than a nullptr
-    if (jsValue.isCell())
+    //
+    // The empty check is needed because the value could be empty
+    // and return true from isCell if it's an array hole from a
+    // sparse array.
+    if (jsValue.isCell() and !jsValue.isEmpty())
         return jsValue.asCell()->type();
 
     return 0;

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -3516,9 +3516,13 @@ pub const JSValue = enum(JSValueReprInt) {
         );
     }
 
+    /// The value cannot be empty. Check `!this.isEmpty()` before calling this function
     pub fn jsType(
         this: JSValue,
     ) JSType {
+        if (comptime bun.Environment.allow_assert) {
+            std.debug.assert(!this.isEmpty());
+        }
         return cppFn("jsType", .{this});
     }
 

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1944,7 +1944,7 @@ fn eachBind(
         var test_idx: usize = 0;
         while (iter.next()) |item| {
             const func_params_length = function.getLength(globalThis);
-            const item_is_array = !item.isEmptyOrUndefinedOrNull() and !item.isEmpty() and item.jsType().isArray();
+            const item_is_array = !item.isEmptyOrUndefinedOrNull() and item.jsType().isArray();
             var arg_size: usize = 1;
 
             if (item_is_array) {

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1826,7 +1826,7 @@ fn formatLabel(globalThis: *JSC.JSGlobalObject, label: string, function_args: []
 
             switch (label[idx + 1]) {
                 's' => {
-                    try consumeArg(globalThis, current_arg.jsType().isString(), &idx, &args_idx, &list, &current_arg, "%s");
+                    try consumeArg(globalThis, !current_arg.isEmpty() and current_arg.jsType().isString(), &idx, &args_idx, &list, &current_arg, "%s");
                 },
                 'i' => {
                     try consumeArg(globalThis, current_arg.isAnyInt(), &idx, &args_idx, &list, &current_arg, "%i");
@@ -1944,7 +1944,7 @@ fn eachBind(
         var test_idx: usize = 0;
         while (iter.next()) |item| {
             const func_params_length = function.getLength(globalThis);
-            const item_is_array = !item.isEmptyOrUndefinedOrNull() and item.jsType().isArray();
+            const item_is_array = !item.isEmptyOrUndefinedOrNull() and !item.isEmpty() and item.jsType().isArray();
             var arg_size: usize = 1;
 
             if (item_is_array) {
@@ -2036,7 +2036,7 @@ inline fn createEach(
     }
 
     var array = args[0];
-    if (!array.jsType().isArray()) {
+    if (array.isEmpty() or !array.jsType().isArray()) {
         globalThis.throwPretty("{s} expects an array", .{signature});
         return .zero;
     }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
