### PR TITLE
Fix util.formatWithOptions typing.

### DIFF
--- a/packages/bun-types/util.d.ts
+++ b/packages/bun-types/util.d.ts
@@ -126,8 +126,7 @@ declare module "util" {
    * // when printed to a terminal.
    * ```
    */
-  // FIXME: util.formatWithOptions is typed, but is not defined in the polyfill
-  // export function formatWithOptions(inspectOptions: InspectOptions, format?: any, ...param: any[]): string;
+  export function formatWithOptions(inspectOptions: InspectOptions, format?: any, ...param: any[]): string;
   /**
    * Returns the string name for a numeric error code that comes from a Node.js API.
    * The mapping between error codes and error names is platform-dependent.


### PR DESCRIPTION
### What does this PR do?

Uncomments the Typescript type for util.formatWithOptions. When formatWithOptions was [first implemented](https://github.com/oven-sh/bun/pull/4090), its types were not uncommented. 

Referenced in this issue: https://github.com/oven-sh/bun/issues/6996

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
