### PR TITLE
fix(ffi): fix ffi with large `uint32_t` values

### DIFF
--- a/src/bun.js/api/FFI.h
+++ b/src/bun.js/api/FFI.h
@@ -197,7 +197,7 @@ static EncodedJSValue INT32_TO_JSVALUE(int32_t val) {
 
 static EncodedJSValue UINT32_TO_JSVALUE(uint32_t val) {
   EncodedJSValue res;
-  if(val < MAX_INT32) {
+  if(val <= MAX_INT32) {
     res.asInt64 = NumberTag | val;
     return res;
   } else {

--- a/src/bun.js/api/FFI.h
+++ b/src/bun.js/api/FFI.h
@@ -195,8 +195,18 @@ static EncodedJSValue INT32_TO_JSVALUE(int32_t val) {
    return res;
 }
 
-
-
+static EncodedJSValue UINT32_TO_JSVALUE(uint32_t val) {
+  EncodedJSValue res;
+  if(val < MAX_INT32) {
+    res.asInt64 = NumberTag | val;
+    return res;
+  } else {
+    EncodedJSValue res;
+    res.asDouble = val;
+    res.asInt64 += DoubleEncodeOffset;
+    return res;
+  }
+}
 
 static EncodedJSValue FLOAT_TO_JSVALUE(float val) {
   return DOUBLE_TO_JSVALUE((double)val);

--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -157,8 +157,24 @@ ffiWrappers[FFIType.uint8_t] = "val<0?0:val>=255?255:val|0";
 ffiWrappers[FFIType.int16_t] = "val<=-32768?-32768:val>=32768?32768:val|0";
 ffiWrappers[FFIType.uint16_t] = "val<=0?0:val>=65536?65536:val|0";
 ffiWrappers[FFIType.int32_t] = "val|0";
-// we never want to return NaN
-ffiWrappers[FFIType.uint32_t] = "val<=0?0:val>=0xffffffff?0xffffffff:+val||0";
+// https://github.com/oven-sh/bun/issues/7007
+// This cast with `|0` looks incorrect as it converts 0xffffffff into -1, but this misinterpretation
+// of the integer is taken advantage of by a second misinterpretation of the bytes in the C binding
+// The bitwise operator | forces a conversion to int32_t, but it will wrap to negative numbers
+// when going above >0x7fffffff.
+//
+// What this |0 operatation also *seems to do* (citation needed) is convert the internal representation
+// of JSC::JSValue to ALWAYS use Int32Tag, which is important as `JSValue::asInt32()` can only handle
+// this encoding to properly deserialize this as an int32.
+//
+// tldr jsc internals: JSValue represents int32 as a tag value, then the int32 bytes.
+//                     and all other integers are as tagged 64-bit floats.
+//
+// The trick to fixing the bug: after using |0 to misinterpret and force the integer into Int32Tag,
+// when passing the value to the C ffi code, misinterpret it again, resulting in the correct uint32_t.
+//
+// To do this in native code, there is a spot in zig where uint32_t just prints int32_t.
+ffiWrappers[FFIType.uint32_t] = "val<0?0:val>0xFFFFFFFF?-1:(val|0)";
 ffiWrappers[FFIType.i64_fast] = `{
   if (typeof val === "bigint") {
     if (val <= BigInt(Number.MAX_SAFE_INTEGER) && val >= BigInt(-Number.MAX_SAFE_INTEGER)) {

--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -174,7 +174,7 @@ ffiWrappers[FFIType.int32_t] = "val|0";
 // when passing the value to the C ffi code, misinterpret it again, resulting in the correct uint32_t.
 //
 // To do this in native code, there is a spot in zig where uint32_t just prints int32_t.
-ffiWrappers[FFIType.uint32_t] = "val<0?0:val>0xFFFFFFFF?-1:(val|0)";
+ffiWrappers[FFIType.uint32_t] = "val<0?0:val>0xFFFFFFFF?-1:val|0";
 ffiWrappers[FFIType.i64_fast] = `{
   if (typeof val === "bigint") {
     if (val <= BigInt(Number.MAX_SAFE_INTEGER) && val >= BigInt(-Number.MAX_SAFE_INTEGER)) {

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -575,6 +575,36 @@ function ffiRunner(fast) {
       }
     });
 
+    describe("integer identities work for all possible values", () => {
+      const cases = [
+        { type: "int8_t", min: -128, max: 127, fn: identity_int8_t },
+        { type: "int16_t", min: -32768, max: 32767, fn: identity_int16_t },
+        { type: "int32_t", min: -2147483648, max: 2147483647, fn: identity_int32_t },
+        { type: "int64_t", min: -9223372036854775808n, max: 9223372036854775807n, fn: identity_int64_t },
+        { type: "uint8_t", min: 0, max: 255, fn: identity_uint8_t },
+        { type: "uint16_t", min: 0, max: 65535, fn: identity_uint16_t },
+        { type: "uint32_t", min: 0, max: 4294967295, fn: identity_uint32_t },
+        { type: "uint64_t", min: 0n, max: 18446744073709551615n, fn: identity_uint64_t },
+      ];
+
+      for (const { type, min, max, fn } of cases) {
+        const bigint = typeof min === "bigint";
+        const inc = bigint
+          ? //
+            (max - min) / 32768n
+          : Math.ceil((max - min) / 32768);
+        it(type, () => {
+          expect(bigint ? BigInt(fn(min)) : fn(min)).toBe(min);
+          expect(bigint ? BigInt(fn(max)) : fn(max)).toBe(max);
+          expect(bigint ? BigInt(fn(0n)) : fn(0)).toBe(bigint ? 0n : 0);
+
+          for (let i = min; i <= max; i += inc) {
+            expect(bigint ? BigInt(fn(i)) : fn(i)).toBe(i);
+          }
+        });
+      }
+    });
+
     afterAll(() => {
       close();
     });


### PR DESCRIPTION
### What does this PR do?

Fixes #7007 

This fixes the following C code
```c
unsigned int return_u32(unsigned int x) {
  printf("%x\n", x);
  return x;
}
```

And the given JS code
```js
import { dlopen } from "bun:ffi";

const dl = dlopen("wtf.dylib", {
  return_u32: {
    args: ["uint32_t"],
    returns: "uint32_t",
  },
});

console.log(dl.symbols.return_u32(0x7fffffff).toFixed(16));
console.log(dl.symbols.return_u32(0x80000000).toFixed(16));
console.log(dl.symbols.return_u32(0x80000001).toFixed(16));
console.log(dl.symbols.return_u32(0x80000002).toFixed(16));
```

bun is before, bd is after
<img width="620" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/588d98bf-c36e-4103-bc1a-fa46b32b4e3b">

To get this fix, I am abusing JSValue's int32 tag and the js bitwise or operator to efficiently pass uint32 through to C. Here is the comment left in the source code:

> This cast with `|0` looks incorrect as it converts 0xffffffff into -1, but this misinterpretation of the integer is taken advantage of by a second misinterpretation of the bytes in the C binding The bitwise operator | forces a conversion to int32_t, but it will wrap to negative numbers when going above >0x7fffffff.
>
> What this `|0` operatation also *seems to do* (citation needed) is convert the internal representation of `JSC::JSValue` to ALWAYS use Int32Tag, which is important as `JSValue::asInt32()` can only handle
> this encoding to properly deserialize this as an int32.
>
> *tldr jsc internals*: JSValue represents int32 as a tag value, then the int32 bytes. and all other integers are as tagged 64-bit floats.
>
> The trick to fixing the bug: after using |0 to misinterpret and force the integer into Int32Tag,
> when passing the value to the C ffi code, misinterpret it again, resulting in the correct uint32_t.
>
> To do this in native code, there is a spot in zig where `uint32_t` just prints `int32_t`.

A separate issue existed for going back from C to JS, which is handled by implementing a dedicated uint32_t -> JSValue, as this must encode values above MAX_U32 as a double

### How did you verify your code works?

Manually tested FFI and added tests to `ffi.test.ts`. I spotted existing crashes from this test when you enable FFI.
