### PR TITLE
fix(asyncLocalStorage) store can be disabled  multiple times

### DIFF
--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -72,7 +72,7 @@ function set(contextValue: ReadonlyArray<any> | undefined) {
 }
 
 class AsyncLocalStorage {
-  #disableCalled = false;
+  #disabled = false;
 
   constructor() {
     setAsyncHooksEnabled(true);
@@ -109,6 +109,8 @@ class AsyncLocalStorage {
 
   enterWith(store) {
     cleanupLater();
+    // we must renable it when asyncLocalStorage.enterWith() is called https://nodejs.org/api/async_context.html#asynclocalstoragedisable
+    this.#disabled = false;
     var context = get();
     if (!context) {
       set([this, store]);
@@ -143,6 +145,9 @@ class AsyncLocalStorage {
     var previous_value;
     var i = 0;
     var contextWasAlreadyInit = !context;
+    // we must renable it when asyncLocalStorage.run() is called https://nodejs.org/api/async_context.html#asynclocalstoragedisable
+    const wasDisabled = this.#disabled;
+    this.#disabled = false;
     if (contextWasAlreadyInit) {
       set((context = [this, store_value]));
     } else {
@@ -171,7 +176,7 @@ class AsyncLocalStorage {
     } finally {
       // Note: early `return` will prevent `throw` above from working. I think...
       // Set AsyncContextFrame to undefined if we are out of context values
-      if (!this.#disableCalled) {
+      if (!wasDisabled) {
         var context2 = get()! as any[]; // we make sure to .slice() before mutating
         if (context2 === context && contextWasAlreadyInit) {
           $assert(context2.length === 2, "context was mutated without copy");
@@ -203,24 +208,24 @@ class AsyncLocalStorage {
   disable() {
     $debug("disable " + (this as any).__id__);
     // In this case, we actually do want to mutate the context state
-    if (!this.#disableCalled) {
-      var context = get() as any[];
-      if (context) {
-        var { length } = context;
-        for (var i = 0; i < length; i += 2) {
-          if (context[i] === this) {
-            context.splice(i, 2);
-            set(context.length ? context : undefined);
-            break;
-          }
+    if (this.#disabled) return;
+    var context = get() as any[];
+    if (context) {
+      var { length } = context;
+      for (var i = 0; i < length; i += 2) {
+        if (context[i] === this) {
+          context.splice(i, 2);
+          set(context.length ? context : undefined);
+          break;
         }
       }
-      this.#disableCalled = true;
     }
   }
 
   getStore() {
     $debug("getStore " + (this as any).__id__);
+    // disabled AsyncLocalStorage always returns undefined https://nodejs.org/api/async_context.html#asynclocalstoragedisable
+    if (this.#disabled) return;
     var context = get();
     if (!context) return;
     var { length } = context;

--- a/test/js/node/async_hooks/async_hooks.node.test.ts
+++ b/test/js/node/async_hooks/async_hooks.node.test.ts
@@ -25,10 +25,36 @@ test("node async_hooks.AsyncLocalStorage enable disable", async done => {
         assert.strictEqual(asyncLocalStorage.getStore(), undefined);
         asyncLocalStorage.run(new Map().set("bar", "foo"), () => {
           assert.strictEqual(asyncLocalStorage.getStore()!.get("bar"), "foo");
-
           done();
         });
       });
+    });
+  });
+});
+
+test("node async_hooks.AsyncLocalStorage enable disable multiple times", done => {
+  const asyncLocalStorage = new AsyncLocalStorage();
+
+  asyncLocalStorage.enterWith("first value");
+  expect(asyncLocalStorage.getStore()).toBe("first value");
+  asyncLocalStorage.disable();
+  expect(asyncLocalStorage.getStore()).toBe(undefined);
+
+  asyncLocalStorage.enterWith("second value");
+  expect(asyncLocalStorage.getStore()).toBe("second value");
+  asyncLocalStorage.disable();
+  expect(asyncLocalStorage.getStore()).toBe(undefined);
+
+  asyncLocalStorage.run("first run value", () => {
+    expect(asyncLocalStorage.getStore()).toBe("first run value");
+    asyncLocalStorage.disable();
+    expect(asyncLocalStorage.getStore()).toBe(undefined);
+
+    asyncLocalStorage.run("second run value", () => {
+      expect(asyncLocalStorage.getStore()).toBe("second run value");
+      asyncLocalStorage.disable();
+      expect(asyncLocalStorage.getStore()).toBe(undefined);
+      done();
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/6972

<!-- **Please explain what your changes do**, example: -->
<!--
This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
