### PR TITLE
Fix toBeNaN's misleading JSDoc comment

### DIFF
--- a/packages/bun-types/bun-test.d.ts
+++ b/packages/bun-types/bun-test.d.ts
@@ -767,14 +767,14 @@ declare module "bun:test" {
      */
     toBeNull(): void;
     /**
-     * Asserts that a value can be coerced to `NaN`.
+     * Asserts that a value is `NaN`.
      *
      * Same as using `Number.isNaN()`.
      *
      * @example
      * expect(NaN).toBeNaN();
-     * expect(Infinity).toBeNaN();
-     * expect("notanumber").toBeNaN();
+     * expect(Infinity).toBeNaN(); // fail
+     * expect("notanumber").toBeNaN(); // fail
      */
     toBeNaN(): void;
     /**


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->
This fixes `toBeNaN`'s JSDoc comment, which currently says that it accepts any value coerced to `NaN` and that this is the same as `Number.isNaN`. This is misleading because `Number.isNaN` doesn't coerce the value. Only `isNaN` coerces.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN#description

The [zig source code](https://github.com/oven-sh/bun/blob/046d1975192316cb78886269c70c1c292a04a733/src/bun.js/test/expect.zig#L734) shows that the function acts like `Number.isNaN` and only accepts `NaN`, since pass is only true when the value is a number and doesn't equal itself.

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

I ran this test file with Bun and Jest to check.

```js
import { expect, test } from 'bun:test';

test('toBeNaN', () => {
  const NaNs = [NaN, Number.NaN, 0 / 0];
  for (const n of NaNs) {
    expect(n).toBeNaN();
    expect(Number.isNaN(n)).toBe(true);
  }

  const coercedNaNs = ['NaN', undefined, {}, 'blabla', 'notanumber'];
  for (const n of coercedNaNs) {
    expect(n).not.toBeNaN();
    expect(Number.isNaN(n)).toBe(false);
    expect(isNaN(n)).toBe(true);
  }

  const notNaNs = [37, true, null, '37', '37.37', '', ' ', Infinity];
  for (const n of notNaNs) {
    expect(n).not.toBeNaN();
    expect(Number.isNaN(n)).toBe(false);
    expect(isNaN(n)).toBe(false);
  }
});
```

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
