### PR TITLE
Fixes output path for build command

### DIFF
--- a/packages/bun-lambda/README.md
+++ b/packages/bun-lambda/README.md
@@ -58,7 +58,7 @@ export default {
 
 The final step is to upload your Bun handler. You can technically write the handler directly in the console if you wish, but if you want a full development environment, use the Bun toolkit. There are several ways you can choose to build and manage your artifacts, but follow these steps for a simple approach:
 
-1. Run `bun build <handler-entry>.[ts|js] --outfile /dist/handler.js`
+1. Run `bun build <handler-entry>.[ts|js] --outfile ./dist/handler.js`
 2. Zip the `/dist` folder
 
 ### Step 3: Create the Lambda function on AWS


### PR DESCRIPTION
### What does this PR do?

Fixes the output path for build command as the current one tries to write at the filesystem's root.

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes