### PR TITLE
When getting properties in native code, treat `undefined` the same as in JS

### DIFF
--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -4290,7 +4290,10 @@ pub const JSValue = enum(JSValueReprInt) {
     // intended to be more lightweight than ZigString
     pub fn fastGet(this: JSValue, global: *JSGlobalObject, builtin_name: BuiltinName) ?JSValue {
         const result = fastGet_(this, global, @intFromEnum(builtin_name));
-        if (result == .zero) {
+        if (result == .zero or
+            // JS APIs treat {}.a as mostly the same as though it was not defined
+            result == .undefined)
+        {
             return null;
         }
 

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -6,6 +6,16 @@ test("zero args returns an otherwise empty 200 response", () => {
   expect(response.statusText).toBe("");
 });
 
+test("undefined args don't throw", () => {
+  const response = new Response("", {
+    status: undefined,
+    statusText: undefined,
+    headers: undefined,
+  });
+  expect(response.status).toBe(200);
+  expect(response.statusText).toBe("");
+});
+
 test("1-arg form returns a 200 response", () => {
   const response = new Response("body text");
 

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -1,5 +1,17 @@
 import { test, expect } from "bun:test";
 
+test("undefined args don't throw", () => {
+  const request = new Request("https://example.com/", {
+    body: undefined,
+    "credentials": undefined,
+    "redirect": undefined,
+    "method": undefined,
+    "mode": undefined,
+  });
+
+  expect(request.method).toBe("GET");
+});
+
 test("request can receive undefined signal", async () => {
   const request = new Request("http://example.com/", {
     method: "POST",


### PR DESCRIPTION
### What does this PR do?

Currently, this throws:
```js
const response = new Response("", {
  status: undefined,
});
```

It should not throw.

We were distinguishing between `undefined` and whether or not the property was defined on the object. Property accesses in JS don't do that, and we shouldn't either.

### How did you verify your code works?

I wrote tests