### PR TITLE
Handle whitespace in no_proxy environment variable

### DIFF
--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -140,6 +140,7 @@ pub const Loader = struct {
         }
 
         // NO_PROXY filter
+        // See the syntax at https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/
         if (http_proxy != null) {
             if (this.map.get("no_proxy") orelse this.map.get("NO_PROXY")) |no_proxy_text| {
                 if (no_proxy_text.len == 0 or strings.eqlComptime(no_proxy_text, "\"\"") or strings.eqlComptime(no_proxy_text, "''")) {
@@ -149,7 +150,7 @@ pub const Loader = struct {
                 var no_proxy_list = std.mem.split(u8, no_proxy_text, ",");
                 var next = no_proxy_list.next();
                 while (next != null) {
-                    var host = next.?;
+                    var host = strings.trim(next.?, &strings.whitespace_chars);
                     if (strings.eql(host, "*")) {
                         return null;
                     }

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -4367,10 +4367,14 @@ pub fn trim(slice: anytype, comptime values_to_strip: []const u8) @TypeOf(slice)
     return slice[begin..end];
 }
 
+pub const whitespace_chars = [_]u8{ ' ', '\t', '\n', '\r', std.ascii.control_code.vt, std.ascii.control_code.ff };
+
 pub fn lengthOfLeadingWhitespaceASCII(slice: string) usize {
     for (slice) |*c| {
         switch (c.*) {
-            ' ', '\t', '\n', '\r', std.ascii.control_code.vt, std.ascii.control_code.ff => {},
+            whitespace: {
+                inline for (whitespace_chars) |wc| break :whitespace wc;
+            } => {},
             else => {
                 return @intFromPtr(c) - @intFromPtr(slice.ptr);
             },


### PR DESCRIPTION
### What does this PR do?

De facto standard format of no_proxy enivronment variable allows whitespace around the host names. Make it work.

Closes #6339

### How did you verify your code works?

Zig unit tests are completely bitrotted (I have tried to make them work, but after an hour or so chasing `@import`s that do not work and disabling tests that do not compile anymore I gave up) , so I had to test it manually.

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
