### PR TITLE
Add 'Bun Development Environement' devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
+
+ARG BUN_VERSION="1.0.11"
+ARG NODE_VERSION="20"
+ARG LLVM_VERSION="16"
+ARG ZIG_VERSION="0.12.0-dev.1297+a9e66ed73"
+ARG CMAKE_VERSION="3.27.7"
+ARG TARGETARCH
+
+ENV TARGETARCH=${TARGETARCH}
+ENV NODE_VERSION=${NODE_VERSION}
+ENV LLVM_VERSION=${LLVM_VERSION}
+ENV ZIG_VERSION=${ZIG_VERSION}
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+
+USER vscode
+
+ADD scripts/ /tmp/build-scripts
+
+RUN /tmp/build-scripts/setup-first.sh 
+RUN /tmp/build-scripts/setup-llvm.sh
+RUN /tmp/build-scripts/setup-nodejs.sh
+RUN /tmp/build-scripts/setup-cmake.sh
+RUN /tmp/build-scripts/setup-zig.sh
+
+RUN /tmp/build-scripts/setup-bun.sh
+RUN /tmp/build-scripts/setup-rust.sh

--- a/.devcontainer/build-devcontainer.sh
+++ b/.devcontainer/build-devcontainer.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+#TODO: Build with CI :shrug2:
+BUN_VERSION="1.0.11"
+
+docker build -t oven/bun-devcontainer:$BUN_VERSION .

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options
+{
+	"name": "Bun Development Environment",
+	"image": "oven/bun-devcontainer:1.0.11",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ziglang.vscode-zig",
+				"ms-vscode.cpptools",
+				"esbenp.prettier-vscode",
+				"vadimcn.vscode-lldb",
+				"ms-azuretools.vscode-docker"
+			]
+		}
+	},
+	"mounts": [
+		"source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
+		"source=${localWorkspaceFolderBasename}-build,target=${containerWorkspaceFolder}/build,type=volume"
+	],
+	"postCreateCommand": ".devcontainer/postCreate.sh",
+	"containerUser": "vscode"
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+sudo chown vscode node_modules
+sudo chown vscode build
+
+git config --global --add safe.directory /workspaces/bun
+echo export PATH=\$PATH:build >> ~/.bashrc
+
+echo "🎉 Bun Development Environment devcontainer setup complete! 🎉"
+echo "To build bun, run 'bun setup'"

--- a/.devcontainer/scripts/setup-bun.sh
+++ b/.devcontainer/scripts/setup-bun.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Intended for devcontainer image build ONLY
+# Assumes mcr.microsoft.com/vscode/devcontainers/base:bullseye base image for [aarch64|amd64]
+
+echo "Installing Bun"
+curl -fsSL https://bun.sh/install | bash -s "bun-v$BUN_VERSION"

--- a/.devcontainer/scripts/setup-cmake.sh
+++ b/.devcontainer/scripts/setup-cmake.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Intended for devcontainer image build ONLY
+# Assumes mcr.microsoft.com/vscode/devcontainers/base:bullseye base image for [aarch64|amd64]
+
+echo "Installing CMake"
+arch=$TARGETARCH && \
+    case ${arch} in \
+        "arm64")  export ARCH=aarch64 ;; \
+        "amd64")  export ARCH=x86_64 ;; \
+        *)        echo "error: unsupported architecture: $arch"; exit 1 ;; \
+    esac
+echo "TARGETARCH:$TARGETARCH"
+echo "ARCH:$ARCH"
+
+wget -P /tmp https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-$ARCH.sh
+chmod +x /tmp/cmake-$CMAKE_VERSION-linux-$ARCH.sh
+sudo mkdir -p /usr/bin/cmake
+sudo /tmp/cmake-$CMAKE_VERSION-linux-$ARCH.sh --skip-license --prefix=/usr/bin/cmake
+echo export PATH=\$PATH:/usr/bin/cmake/bin >> ~/.bashrc

--- a/.devcontainer/scripts/setup-first.sh
+++ b/.devcontainer/scripts/setup-first.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Intended for devcontainer image build ONLY
+# Assumes mcr.microsoft.com/vscode/devcontainers/base:bullseye base image for [aarch64|amd64]
+# Assumes running first before all other setup-*.sh scripts
+
+export CXX=clang++-16
+export CC=clang-16
+export AR=/usr/bin/llvm-ar-16
+export LD=lld-16
+
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+
+echo "Installing Deps"
+sudo apt-get install -y \
+    wget \
+    bash \
+    software-properties-common \
+    build-essential \
+    autoconf \
+    automake \
+    libtool \
+    pkg-config \
+    make \
+    ninja-build \
+    file \
+    libc-dev \
+    libxml2 \
+    libxml2-dev \
+    xz-utils \
+    git \
+    tar \
+    rsync \
+    gzip \
+    unzip \
+    perl \
+    python3 \
+    ruby \
+    golang \
+    ccache \
+    ruby-full

--- a/.devcontainer/scripts/setup-llvm.sh
+++ b/.devcontainer/scripts/setup-llvm.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Intended for devcontainer image build ONLY
+# Assumes mcr.microsoft.com/vscode/devcontainers/base:bullseye base image for [aarch64|amd64]
+
+echo "Installing LLVM"
+wget -P /tmp https://apt.llvm.org/llvm.sh
+chmod +x /tmp/llvm.sh
+sudo /tmp/llvm.sh $LLVM_VERSION
+sudo ln -s /usr/bin/clang-$LLVM_VERSION /usr/bin/clang
+sudo ln -s /usr/bin/clang++-$LLVM_VERSION /usr/bin/clang++
+sudo ln -s /usr/bin/lld-$LLVM_VERSION /usr/bin/lld
+sudo ln -s /usr/bin/lldb-$LLVM_VERSION /usr/bin/lldb
+sudo ln -s /usr/bin/clangd-$LLVM_VERSION /usr/bin/clangd
+sudo ln -s /usr/bin/llvm-ar-$LLVM_VERSION /usr/bin/llvm-ar

--- a/.devcontainer/scripts/setup-nodejs.sh
+++ b/.devcontainer/scripts/setup-nodejs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Intended for devcontainer image build ONLY
+# Assumes mcr.microsoft.com/vscode/devcontainers/base:bullseye base image for [aarch64|amd64]
+
+echo "Installing NodeJS"
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+sudo apt-get update
+sudo apt-get update && sudo apt-get install nodejs -y

--- a/.devcontainer/scripts/setup-rust.sh
+++ b/.devcontainer/scripts/setup-rust.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Intended for devcontainer image build ONLY
+# Assumes mcr.microsoft.com/vscode/devcontainers/base:bullseye base image for [aarch64|amd64]
+
+echo "Installing Rust"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/.devcontainer/scripts/setup-zig.sh
+++ b/.devcontainer/scripts/setup-zig.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Intended for devcontainer image build ONLY
+# Assumes mcr.microsoft.com/vscode/devcontainers/base:bullseye base image for [aarch64|amd64]
+
+echo "Installing Zig"
+arch=$TARGETARCH && \
+    case ${arch} in \
+        "arm64")  export ARCH=aarch64 ;; \
+        "amd64")  export ARCH=x86_64 ;; \
+        *)        echo "error: unsupported architecture: $arch"; exit 1 ;; \
+    esac
+echo "TARGETARCH:$TARGETARCH"
+echo "ARCH:$ARCH"
+
+ZIG_FOLDERNAME="zig-linux-$ARCH-$ZIG_VERSION"
+ZIG_FILENAME="$ZIG_FOLDERNAME.tar.xz"
+curl -sSL "https://ziglang.org/builds/$ZIG_FILENAME" -o /tmp/$ZIG_FILENAME
+tar xf /tmp/${ZIG_FILENAME} -C /tmp
+sudo mv /tmp/$ZIG_FOLDERNAME/lib /usr/lib/zig
+sudo mv /tmp/$ZIG_FOLDERNAME/zig /usr/bin/zig


### PR DESCRIPTION
### What does this PR do?

Added VSCode DevContainer to automate setup of Bun development environment.

TLDR;
- Added a `bun-devcontainer` image Dockerfile + dependency build setup scripts
- Added .devcontainer VSCode config
- Image based on known good VSCode base devcontainer image designed for devcontainers
- build and node_modules folders are mounted volumes which survive container rebuilds and build performance.
- Pre-built published image can save developers building their own development environment.
- Bun project can provide a default set of VSCode extensions which are automatically installed in the devcontainer.

First off, I'm a huge fan of the project! I initially wanted to help contribute by looking into fixing the devcontainer lockfile issue - https://github.com/oven-sh/bun/issues/4923
I started out seeing I could build the **bun** repo in a devcontainer cause I didn't want to contaminate my existing macbook development environment.  I use isolated devcontainers where I can.

It's my view that the value of being able to contribute to the bun project itself or developing with bun javascript projects in isolation with other dev environments on a dev's work or personal machine and not have to worry about setup of extensive deps that can interfere with other projects is a must.

Also devcontainers are great at allowing a project to capture infra as code for the development environment in source control and each contributor could rely on working with the same environment every time an issue is reported or giving confidence PRs are at least testing with a consistent dev env.  Hopefully I don't have to sell it much more :)

### How did you verify your code works?

#### Tested building docker image
Built and tested using Macbook M1

From **bun** repo folder
`cd ~/code/bun`

Build the image - Ideally this image would be built via CI or something and published most likely the same way the oven/bun image is.  This probably goes with out saying, but contributor developers wouldn't need to build the `bun-devcontainer` image.
`cd .devcontainer && ./build-devcontainer.sh`

#### Tested opening devcontainer + bun project in VSCode

`code .`

Open project in the devcontainer
`Command-Shift-P` - `>dev Containers: Reopen in Container`

You should see this message after devcontainer is ready for work.
<img width="643" alt="Screenshot 2023-11-12 at 8 06 27 PM" src="https://github.com/oven-sh/bun/assets/3587293/88c2ec7b-730a-49f7-a001-862e5f946097">

Now build **bun** as normal.   I found I had to run `scripts/clean-dependencies` to clean out all the other failed attempts to get the build environment right first.
`bun setup`

**And Bob's your uncle!**
<img width="396" alt="Screenshot 2023-11-12 at 2 54 25 PM" src="https://github.com/oven-sh/bun/assets/3587293/5357db14-cbc8-4eee-9db3-3a8ed5874afb">

#### Testing running bun-debug binary and debugging in VSCode with LLVM extension
<img width="1155" alt="Screenshot 2023-11-12 at 2 57 38 PM" src="https://github.com/oven-sh/bun/assets/3587293/2fe80def-282a-4571-9730-a543bd15beb2">

#### TODO: Building the multiple images for each supported target architectures.  I might need help with this I'm not familiar with this project and build pipeline.

Looking forward to any feedback or if this is something the project wants to incorporate.  This change is definitely not a triumph or anything but a nice to have even if it only lives on in my fork.  Thanks.