### PR TITLE
Stop swallowing errors from create_hash_table during the build

### DIFF
--- a/src/codegen/create-hash-table.ts
+++ b/src/codegen/create-hash-table.ts
@@ -12,7 +12,11 @@ const { stdout, exited } = spawn({
   stdout: "pipe",
   stderr: "inherit",
 });
-await exited;
+const procResult = await exited;
+if (procResult.exitCode !== 0) {
+  console.log("Failed to generate " + output + ", create_hash_table exited with " + procResult);
+  process.exit(1);
+}
 let str = await new Response(stdout).text();
 str = str.replaceAll(/^\/\/.*$/gm, "");
 str = str.replaceAll(/^#include.*$/gm, "");


### PR DESCRIPTION
### What does this PR do?

If src/codegen/create_hash_table can't be run due to some reason (e.g. due to missing Math::BigInt Perl module) the build continues but fails later, during bindings compilation, because the generated files are empty.

Fix it by handling the failure to run create_hash_table properly.

Closes #7074

### How did you verify your code works?

Ran the build with and without Math::BigInt Perl module installed, verified that without this module build fails early.