### PR TITLE
Refresh dependencies in contribution guide

### DIFF
--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -2,6 +2,30 @@ Configuring a development environment for Bun can take 10-30 minutes depending o
 
 If you are using Windows, you must use a WSL environment as Bun does not yet compile on Windows natively.
 
+## Install Dependencies
+
+Using your system's package manager, install the Bun's dependencies:
+
+{% codetabs %}
+
+```bash#macOS (Homebrew)
+$ brew install automake ccache cmake coreutils gnu-sed go libiconv libtool ninja pkg-config rust
+```
+
+```bash#Ubuntu/Debian
+$ sudo apt install cargo ccache cmake git golang libtool ninja-build pkg-config rustc ruby-full xz-utils
+```
+
+```bash#Arch
+$ sudo pacman -S base-devel ccache cmake git go libiconv libtool make ninja pkg-config python rust sed unzip ruby
+```
+
+```bash#Fedora
+$ sudo dnf install cargo ccache cmake git golang libtool ninja-build pkg-config rustc libatomic-static libstdc++-static sed unzip which libicu-devel
+```
+
+{% /codetabs %}
+
 Before starting, you will need to already have a release build of Bun installed, as we use our bundler to transpile and minify our code, as well as for code generation scripts.
 
 {% codetabs %}
@@ -77,30 +101,6 @@ $ export PATH="$PATH:$(brew --prefix llvm@16)/bin"
 ```bash#Arch
 # use fish_add_path if you're using fish
 $ export PATH="$PATH:/usr/lib/llvm16/bin"
-```
-
-{% /codetabs %}
-
-## Install Dependencies
-
-Using your system's package manager, install the rest of Bun's dependencies:
-
-{% codetabs %}
-
-```bash#macOS (Homebrew)
-$ brew install automake ccache cmake coreutils gnu-sed go libiconv libtool ninja pkg-config rust
-```
-
-```bash#Ubuntu/Debian
-$ sudo apt install cargo ccache cmake git golang libtool ninja-build pkg-config rustc ruby-full
-```
-
-```bash#Arch
-$ sudo pacman -S base-devel ccache cmake git go libiconv libtool make ninja pkg-config python rust sed unzip ruby
-```
-
-```bash#Fedora
-$ sudo dnf install cargo ccache cmake git golang libtool ninja-build pkg-config rustc libatomic-static libstdc++-static sed unzip
 ```
 
 {% /codetabs %}


### PR DESCRIPTION
### What does this PR do?

Build dependencies in contribution guide got outdated a bit, refresh them:

- move dependencies installation to the front, as the next steps depend on them
- add missing xz-utils, which, libicu-devel

### How did you verify your code works?

- Created the fresh Debian, Fedora chroots
- installed dependencies from the old list
- tested that the builds fail
- added new dependencies
- Run the builds again and saw them succeeding

Closes #7076
Closes #7077
