### PR TITLE
fix(async_hooks) fix disable and disable test

### DIFF
--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -209,6 +209,7 @@ class AsyncLocalStorage {
     $debug("disable " + (this as any).__id__);
     // In this case, we actually do want to mutate the context state
     if (this.#disabled) return;
+    this.#disabled = true;
     var context = get() as any[];
     if (context) {
       var { length } = context;

--- a/test/js/node/async_hooks/async_hooks.node.test.ts
+++ b/test/js/node/async_hooks/async_hooks.node.test.ts
@@ -32,7 +32,7 @@ test("node async_hooks.AsyncLocalStorage enable disable", async done => {
   });
 });
 
-test("node async_hooks.AsyncLocalStorage enable disable multiple times", done => {
+test("node async_hooks.AsyncLocalStorage enable disable multiple times", async () => {
   const asyncLocalStorage = new AsyncLocalStorage();
 
   asyncLocalStorage.enterWith("first value");
@@ -45,17 +45,29 @@ test("node async_hooks.AsyncLocalStorage enable disable multiple times", done =>
   asyncLocalStorage.disable();
   expect(asyncLocalStorage.getStore()).toBe(undefined);
 
+  const { promise, resolve, reject } = Promise.withResolvers();
   asyncLocalStorage.run("first run value", () => {
-    expect(asyncLocalStorage.getStore()).toBe("first run value");
-    asyncLocalStorage.disable();
-    expect(asyncLocalStorage.getStore()).toBe(undefined);
-    asyncLocalStorage.run("second run value", () => {
-      expect(asyncLocalStorage.getStore()).toBe("second run value");
+    try {
+      expect(asyncLocalStorage.getStore()).toBe("first run value");
       asyncLocalStorage.disable();
       expect(asyncLocalStorage.getStore()).toBe(undefined);
-      done();
+    } catch (e) {
+      reject(e);
+    }
+    asyncLocalStorage.run("second run value", () => {
+      try {
+        expect(asyncLocalStorage.getStore()).toBe("second run value");
+        asyncLocalStorage.disable();
+        expect(asyncLocalStorage.getStore()).toBe(undefined);
+
+        resolve(undefined);
+      } catch (e) {
+        reject(e);
+      }
     });
   });
+
+  await promise;
 });
 
 test("AsyncResource.prototype.bind", () => {

--- a/test/js/node/async_hooks/async_hooks.node.test.ts
+++ b/test/js/node/async_hooks/async_hooks.node.test.ts
@@ -49,7 +49,6 @@ test("node async_hooks.AsyncLocalStorage enable disable multiple times", done =>
     expect(asyncLocalStorage.getStore()).toBe("first run value");
     asyncLocalStorage.disable();
     expect(asyncLocalStorage.getStore()).toBe(undefined);
-
     asyncLocalStorage.run("second run value", () => {
       expect(asyncLocalStorage.getStore()).toBe("second run value");
       asyncLocalStorage.disable();

--- a/test/js/node/async_hooks/async_hooks.node.test.ts
+++ b/test/js/node/async_hooks/async_hooks.node.test.ts
@@ -51,20 +51,20 @@ test("node async_hooks.AsyncLocalStorage enable disable multiple times", async (
       expect(asyncLocalStorage.getStore()).toBe("first run value");
       asyncLocalStorage.disable();
       expect(asyncLocalStorage.getStore()).toBe(undefined);
+      asyncLocalStorage.run("second run value", () => {
+        try {
+          expect(asyncLocalStorage.getStore()).toBe("second run value");
+          asyncLocalStorage.disable();
+          expect(asyncLocalStorage.getStore()).toBe(undefined);
+
+          resolve(undefined);
+        } catch (e) {
+          reject(e);
+        }
+      });
     } catch (e) {
       reject(e);
     }
-    asyncLocalStorage.run("second run value", () => {
-      try {
-        expect(asyncLocalStorage.getStore()).toBe("second run value");
-        asyncLocalStorage.disable();
-        expect(asyncLocalStorage.getStore()).toBe(undefined);
-
-        resolve(undefined);
-      } catch (e) {
-        reject(e);
-      }
-    });
   });
 
   await promise;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
Existing tests
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
