### PR TITLE
fix(node:zlib): extend zlib.brotli* stubs

### DIFF
--- a/packages/bun-types/util.d.ts
+++ b/packages/bun-types/util.d.ts
@@ -126,7 +126,11 @@ declare module "util" {
    * // when printed to a terminal.
    * ```
    */
-  export function formatWithOptions(inspectOptions: InspectOptions, format?: any, ...param: any[]): string;
+  export function formatWithOptions(
+    inspectOptions: InspectOptions,
+    format?: any,
+    ...param: any[]
+  ): string;
   /**
    * Returns the string name for a numeric error code that comes from a Node.js API.
    * The mapping between error codes and error names is platform-dependent.

--- a/src/js/node/zlib.js
+++ b/src/js/node/zlib.js
@@ -4066,10 +4066,23 @@ var require_lib = __commonJS({
     exports.inflateRawSync = function (buffer, opts) {
       return zlibBufferSync(new InflateRaw(opts), buffer);
     };
-    // not implemented, stub
-    exports.brotliCompress = function (buffer, opts, callback) {
-      throw new Error("zlib.brotliCompress is not implemented");
-    };
+
+    // not implemented, stubs
+    for (const method of [
+      "BrotliCompress",
+      "BrotliDecompress",
+      "brotliCompress",
+      "brotliCompressSync",
+      "brotliDecompress",
+      "brotliDecompressSync",
+      "createBrotliCompress",
+      "createBrotliDecompress",
+    ]) {
+      exports[method] = function (buffer, opts, callback) {
+        throw new Error(`zlib.${method} is not implemented`);
+      };
+    }
+
     function zlibBuffer(engine, buffer, callback) {
       var buffers = [];
       var nread = 0;

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -37,3 +37,20 @@ describe("zlib.gunzip", () => {
     });
   });
 });
+
+describe("zlib.brotli*", () => {
+  it("returns stub", () => {
+    for (const method of [
+      "BrotliCompress",
+      "BrotliDecompress",
+      "brotliCompress",
+      "brotliCompressSync",
+      "brotliDecompress",
+      "brotliDecompressSync",
+      "createBrotliCompress",
+      "createBrotliDecompress",
+    ]) {
+      expect(() => zlib[method]()).toThrow(new Error(`zlib.${method} is not implemented`));
+    }
+  });
+});


### PR DESCRIPTION
### What does this PR do?

This PR extends zlib.brotli* stubs to avoid crashes on `util.promisify` calls

### How did you verify your code works?

I wrote automated tests