### PR TITLE
Support import.meta.env on build time

### DIFF
--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -1313,6 +1313,7 @@ pub fn scanImports(
         &this.scan_pass_result,
         opts,
         bundler.options.define,
+        bundler.env.map,
         &log,
         &source,
     ) catch |err| {

--- a/src/bun.js/test/snapshot.zig
+++ b/src/bun.js/test/snapshot.zig
@@ -127,6 +127,7 @@ pub const Snapshots = struct {
             &temp_log,
             &source,
             vm.bundler.options.define,
+            vm.bundler.env.map,
             this.allocator,
         );
 

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -1366,6 +1366,7 @@ pub const Bundler = struct {
                     allocator,
                     opts,
                     bundler.options.define,
+                    bundler.env.map,
                     bundler.log,
                     &source,
                 ) catch null) orelse return null) {

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2386,7 +2386,7 @@ pub const ParseTask = struct {
 
     fn getEmptyAST(log: *Logger.Log, bundler: *Bundler, opts: js_parser.Parser.Options, allocator: std.mem.Allocator, source: Logger.Source, comptime RootType: type) !JSAst {
         const root = Expr.init(RootType, RootType{}, Logger.Loc.Empty);
-        return JSAst.init((try js_parser.newLazyExportAST(allocator, bundler.options.define, opts, log, root, &source, "")).?);
+        return JSAst.init((try js_parser.newLazyExportAST(allocator, bundler.options.define, bundler.env.map, opts, log, root, &source, "")).?);
     }
 
     fn getAST(
@@ -2408,6 +2408,7 @@ pub const ParseTask = struct {
                     bundler.allocator,
                     opts,
                     bundler.options.define,
+                    bundler.env.map,
                     log,
                     &source,
                 )) |res|
@@ -2427,20 +2428,20 @@ pub const ParseTask = struct {
                 const trace = tracer(@src(), "ParseJSON");
                 defer trace.end();
                 const root = (try resolver.caches.json.parseJSON(log, source, allocator)) orelse Expr.init(E.Object, E.Object{}, Logger.Loc.Empty);
-                return JSAst.init((try js_parser.newLazyExportAST(allocator, bundler.options.define, opts, log, root, &source, "")).?);
+                return JSAst.init((try js_parser.newLazyExportAST(allocator, bundler.options.define, bundler.env.map, opts, log, root, &source, "")).?);
             },
             .toml => {
                 const trace = tracer(@src(), "ParseTOML");
                 defer trace.end();
                 const root = try TOML.parse(&source, log, allocator);
-                return JSAst.init((try js_parser.newLazyExportAST(allocator, bundler.options.define, opts, log, root, &source, "")).?);
+                return JSAst.init((try js_parser.newLazyExportAST(allocator, bundler.options.define, bundler.env.map, opts, log, root, &source, "")).?);
             },
             .text => {
                 const root = Expr.init(E.String, E.String{
                     .data = source.contents,
                     .prefer_template = true,
                 }, Logger.Loc{ .start = 0 });
-                return JSAst.init((try js_parser.newLazyExportAST(allocator, bundler.options.define, opts, log, root, &source, "")).?);
+                return JSAst.init((try js_parser.newLazyExportAST(allocator, bundler.options.define, bundler.env.map, opts, log, root, &source, "")).?);
             },
             // TODO: css
             else => {
@@ -2449,7 +2450,7 @@ pub const ParseTask = struct {
                     .data = unique_key,
                 }, Logger.Loc{ .start = 0 });
                 unique_key_for_additional_file.* = unique_key;
-                return JSAst.init((try js_parser.newLazyExportAST(allocator, bundler.options.define, opts, log, root, &source, "")).?);
+                return JSAst.init((try js_parser.newLazyExportAST(allocator, bundler.options.define, bundler.env.map, opts, log, root, &source, "")).?);
             },
         }
     }

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -17,6 +17,7 @@ const js_parser = bun.js_parser;
 const json_parser = bun.JSON;
 const options = @import("./options.zig");
 const Define = @import("./defines.zig").Define;
+const EnvMap = @import("./env_loader.zig").Map;
 const std = @import("std");
 const fs = @import("./fs.zig");
 const sync = @import("sync.zig");
@@ -244,11 +245,12 @@ pub const JavaScript = struct {
         allocator: std.mem.Allocator,
         opts: js_parser.Parser.Options,
         defines: *Define,
+        env: *EnvMap,
         log: *logger.Log,
         source: *const logger.Source,
     ) anyerror!?js_ast.Result {
         var temp_log = logger.Log.init(allocator);
-        var parser = js_parser.Parser.init(opts, &temp_log, source, defines, allocator) catch {
+        var parser = js_parser.Parser.init(opts, &temp_log, source, defines, env, allocator) catch {
             temp_log.appendToMaybeRecycled(log, source) catch {};
             return null;
         };
@@ -272,6 +274,7 @@ pub const JavaScript = struct {
         scan_pass_result: *js_parser.ScanPassResult,
         opts: js_parser.Parser.Options,
         defines: *Define,
+        env: *EnvMap,
         log: *logger.Log,
         source: *const logger.Source,
     ) anyerror!void {
@@ -282,7 +285,7 @@ pub const JavaScript = struct {
         var temp_log = logger.Log.init(allocator);
         defer temp_log.appendToMaybeRecycled(log, source) catch {};
 
-        var parser = js_parser.Parser.init(opts, &temp_log, source, defines, allocator) catch return;
+        var parser = js_parser.Parser.init(opts, &temp_log, source, defines, env, allocator) catch return;
 
         return try parser.scanImports(scan_pass_result);
     }

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -2786,6 +2786,37 @@ describe("bundler", () => {
       bunArgs: ["--define", 'import.meta.url="url_here"', "--define", 'import.meta.path="path_here"'],
     },
   });
+  itBundled("default/ImportMetaEnv", {
+    files: {
+      "/entry.js":
+        "console.log([" +
+        "import.meta.env.BUN_A," + // basic access
+        "import.meta['env'].BUN_A," + // access the env object with ['']
+        "import.meta['env']['BUN_A']," + // access both with ['']
+        "import.meta.env['BUN_A']," + // access env with ['']
+        'import.meta.env["BUN_A"],' + // access env with [""]
+        "import.meta.env[`BUN_A`]," + // access env with [``]
+        "import.meta.env.BUN_A.length," + // access a subproperty
+        "import.meta.env['BUN_A'].length," +
+        "import.meta.env.BUN_A['length']," +
+        "import.meta.env['BUN_A']['length']," +
+        "import.meta.env.BUN_B," +
+        "import.meta.env.BUN_C," + // access undefined env, should return undefined
+        "import.meta.env.BUN_C?.length," + // access undefined env subproperty
+        "import.meta.env.SECRET," + // access an env which should be hidden and act as if didn't exist
+        "import.meta.env.BUN_DEFINED," + // access an env that has also exists as a define
+        "import.meta.env[0]," + // indexing the env object with a non-string value, should leave it as is
+        "].map(x => '' + x).join(','))",
+    },
+    env: { "BUN_A": "A", "BUN_B": "B", "SECRET": "S", "BUN_DEFINED": "0" },
+    bundling: false,
+    run: {
+      stdout: "A,A,A,A,A,A,1,1,1,1,B,undefined,undefined,undefined,D,undefined",
+    },
+    define: {
+      "import.meta.env.BUN_DEFINED": "'D'",
+    },
+  });
   itBundled("default/LegalCommentsNone", {
     files: {
       "/entry.js": /* js */ `

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import vm from "node:vm";
 import { bunRun, bunRunAsScript, bunTest, tempDirWithFiles, bunExe, bunEnv } from "harness";
 import path from "path";
 
@@ -473,6 +474,8 @@ describe("access from different apis", () => {
       "index3.ts": "console.log(import.meta.env.FOO);",
       "index4.ts": "console.log(import.meta.env.FOO + Bun.env.FOO);",
       "index5.ts": "console.log(Bun.env.FOO + import.meta.env.FOO);",
+      "overwrite.ts":
+        "import.meta.env.FOO = '2'; import.meta.env.BAR = '2'; console.log(import.meta.env.FOO + import.meta.env.BAR + Bun.env.BAR);",
     });
   });
 
@@ -481,6 +484,17 @@ describe("access from different apis", () => {
   test("only import.meta.env", () => expect(bunRun(`${dir}/index3.ts`).stdout).toBe("1"));
   test("import.meta.env as 1st access", () => expect(bunRun(`${dir}/index4.ts`).stdout).toBe("11"));
   test("import.meta.env as 2nd access", () => expect(bunRun(`${dir}/index5.ts`).stdout).toBe("11"));
+
+  test("values in import.meta.env can be modified", () => {
+    expect(bunRun(`${dir}/overwrite.ts`).stdout).toBe("222");
+  });
+
+  //test("import.meta.env works inside node:vm", () => {
+  //  const context = { out: '0' };
+  //  vm.createContext(context);
+  //  vm.runInContext("out = import.meta.env.FOO", context);
+  //  expect(context.out).toBe(undefined);
+  //});
 });
 
 describe("--env-file", () => {


### PR DESCRIPTION
### What does this PR do?

Implements support for build-time replacement of accesses to `import.meta.env` (see issue #4667, note that #7094 did only implement support for runtime).

Currently only exposes the env variables that either start with `BUN_` or  `VITE_`, and all others appear as if they were not defined, following [vite's rationale](https://vitejs.dev/guide/env-and-mode.html#env-files):
> To prevent accidentally leaking env variables to the client, only variables prefixed with VITE_ are exposed to your Vite-processed code.

---

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:
-->
- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
