### PR TITLE
node:util core-js compat. fix

### DIFF
--- a/packages/bun-types/util.d.ts
+++ b/packages/bun-types/util.d.ts
@@ -126,7 +126,11 @@ declare module "util" {
    * // when printed to a terminal.
    * ```
    */
-  export function formatWithOptions(inspectOptions: InspectOptions, format?: any, ...param: any[]): string;
+  export function formatWithOptions(
+    inspectOptions: InspectOptions,
+    format?: any,
+    ...param: any[]
+  ): string;
   /**
    * Returns the string name for a numeric error code that comes from a Node.js API.
    * The mapping between error codes and error names is platform-dependent.

--- a/src/js/internal/primordials.js
+++ b/src/js/internal/primordials.js
@@ -49,17 +49,16 @@ const makeSafe = (unsafe, safe) => {
     ArrayPrototypeForEach(Reflect.ownKeys(unsafe.prototype), key => {
       if (!Reflect.getOwnPropertyDescriptor(safe.prototype, key)) {
         const desc = Reflect.getOwnPropertyDescriptor(unsafe.prototype, key);
-        if (
-          typeof desc.value === "function" &&
-          desc.value.length === 0 &&
-          Symbol.iterator in (desc.value.$call(dummy) || {})
-        ) {
-          const createIterator = uncurryThis(desc.value);
-          next ??= uncurryThis(createIterator(dummy).next);
-          const SafeIterator = createSafeIterator(createIterator, next);
-          desc.value = function () {
-            return new SafeIterator(this);
-          };
+        if (typeof desc.value === "function" && desc.value.length === 0) {
+          const called = desc.value.$call(dummy) || {};
+          if (Symbol.iterator in (typeof called === "object" ? called : {})) {
+            const createIterator = uncurryThis(desc.value);
+            next ??= uncurryThis(createIterator(dummy).next);
+            const SafeIterator = createSafeIterator(createIterator, next);
+            desc.value = function () {
+              return new SafeIterator(this);
+            };
+          }
         }
         Reflect.defineProperty(safe.prototype, key, desc);
       }


### PR DESCRIPTION
### What does this PR do?

Quick fix for a compatibility issue between node:util's internals and some core-js polyfills (https://github.com/oven-sh/bun/pull/4493#issuecomment-1806825114)

Previously this code would error on methods that returned a non-falsy non-object value, such as `true` or `1`.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes
