### PR TITLE
Fix hang introduced in #6991

### DIFF
--- a/src/http_client_async.zig
+++ b/src/http_client_async.zig
@@ -3344,24 +3344,31 @@ pub fn handleResponseMetadata(
         response.status_code = 304;
     }
 
-    // according to RFC 7230 section 6.3:
-    //   In order to remain persistent, all messages on a connection need to
-    //   have a self-defined message length (i.e., one not defined by closure
-    //   of the connection)
-    // therefore, if response has no content-length header and is not chunked, implicitly disable
-    // the keep-alive behavior (keep-alive being the default behavior for HTTP/1.1 and not for HTTP/1.0)
-    if (this.state.content_length == null and this.state.transfer_encoding != .chunked) {
-        this.state.allow_keepalive = false;
-    }
+    // Don't do this for proxies because those connections will be open for awhile.
+    if (!this.proxy_tunneling) {
 
-    // according to RFC 7230 section 3.3.3:
-    //   1. Any response to a HEAD request and any response with a 1xx (Informational),
-    //      204 (No Content), or 304 (Not Modified) status code
-    //      [...] cannot contain a message body or trailer section.
-    // therefore in these cases set content-length to 0, so the response body is always ignored
-    // and is not waited for (which could cause a timeout)
-    if ((response.status_code >= 100 and response.status_code < 200) or response.status_code == 204 or response.status_code == 304) {
-        this.state.content_length = 0;
+        // according to RFC 7230 section 3.3.3:
+        //   1. Any response to a HEAD request and any response with a 1xx (Informational),
+        //      204 (No Content), or 304 (Not Modified) status code
+        //      [...] cannot contain a message body or trailer section.
+        // therefore in these cases set content-length to 0, so the response body is always ignored
+        // and is not waited for (which could cause a timeout)
+        if ((response.status_code >= 100 and response.status_code < 200) or response.status_code == 204 or response.status_code == 304) {
+            this.state.content_length = 0;
+        }
+
+        //
+        // according to RFC 7230 section 6.3:
+        //   In order to remain persistent, all messages on a connection need to
+        //   have a self-defined message length (i.e., one not defined by closure
+        //   of the connection)
+        // therefore, if response has no content-length header and is not chunked, implicitly disable
+        // the keep-alive behavior (keep-alive being the default behavior for HTTP/1.1 and not for HTTP/1.0)
+        //
+        // but, we must only do this IF the status code allows it to contain a body.
+        else if (this.state.content_length == null and this.state.transfer_encoding != .chunked) {
+            this.state.allow_keepalive = false;
+        }
     }
 
     if (this.proxy_tunneling and this.proxy_tunnel == null) {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5925,7 +5925,17 @@ pub const PackageManager = struct {
             subcommand,
         );
 
-        manager.timestamp_for_manifest_cache_control = @as(u32, @truncate(@as(u64, @intCast(@max(std.time.timestamp(), 0)))));
+        manager.timestamp_for_manifest_cache_control = brk: {
+            if (comptime bun.Environment.allow_assert) {
+                if (env.map.get("BUN_CONFIG_MANIFEST_CACHE_CONTROL_TIMESTAMP")) |cache_control| {
+                    if (std.fmt.parseInt(u32, cache_control, 10)) |int| {
+                        break :brk int;
+                    } else |_| {}
+                }
+            }
+
+            break :brk @as(u32, @truncate(@as(u64, @intCast(@max(std.time.timestamp(), 0)))));
+        };
         return manager;
     }
 


### PR DESCRIPTION

### What does this PR do?

#6991 causes keep-alive to be disabled for HTTP status codes that do not support bodies, leading to bun install to hang in cached manifest requests 


### How did you verify your code works?

Manually, but also the `bun init` test was hanging