### PR TITLE
Add jsx-dev information

### DIFF
--- a/docs/runtime/jsx.md
+++ b/docs/runtime/jsx.md
@@ -57,6 +57,8 @@ How JSX constructs are transformed into vanilla JavaScript internally. The table
   jsx("Box", { width: 5 }, "Hello");
   ```
 
+This will work only when `NODE_ENV` is set to `production` otherwise this defaults to using the development version of React.
+
 ---
 
 - ```json


### PR DESCRIPTION
### What does this PR do?

Bun defaults to using development version of React even when jsx is set to `react-jsx`. the production version is loaded only when `NODE_ENV` is set to production. 

Ref: https://github.com/oven-sh/bun/blob/d4adcb3ccfb8623e2173d42f915a21952a98488e/src/resolver/tsconfig_json.zig#L171-L174

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
