### PR TITLE
fix: force close Bun.serve in node http listener

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5449,7 +5449,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
 
         pub fn deinitIfWeCan(this: *ThisServer) void {
             httplog("deinitIfWeCan", .{});
-            if (this.pending_requests == 0 and this.listener == null and this.flags.has_js_deinited and !this.hasActiveWebSockets()) {
+            if (this.pending_requests == 0 and this.listener == null and !this.hasActiveWebSockets()) {
                 if (this.config.websocket) |*ws| {
                     ws.handler.app = null;
                 }

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -443,7 +443,7 @@ class Server extends EventEmitter {
     }
     this.#server = undefined;
     if (typeof optionalCallback === "function") this.once("close", optionalCallback);
-    server.stop(true);
+    server.stop();
     this.emit("close");
   }
 

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -443,7 +443,7 @@ class Server extends EventEmitter {
     }
     this.#server = undefined;
     if (typeof optionalCallback === "function") this.once("close", optionalCallback);
-    server.stop();
+    server.stop(true);
     this.emit("close");
   }
 

--- a/test/js/third_party/body-parser/express-body-parser-test.test.ts
+++ b/test/js/third_party/body-parser/express-body-parser-test.test.ts
@@ -23,7 +23,7 @@ test("iconv works", () => {
 
 // https://github.com/oven-sh/bun/issues/7031
 test("doesn't reuse listeners", async () => {
-  const PORT = 9999;
+  let PORT = 0;
   const newServer = async () => {
     const app = express();
     const x = Math.random();
@@ -38,12 +38,14 @@ test("doesn't reuse listeners", async () => {
     });
   };
   const listener = await newServer();
-  let r = await fetch("http://localhost:9999");
+  const addr = listener.address();
+  PORT = addr.port;
+  let r = await fetch(`http://localhost:${PORT}`);
   const text1 = await r.text();
   await listener.close();
 
   const listener2 = await newServer();
-  r = await fetch("http://localhost:9999");
+  r = await fetch(`http://localhost:${PORT}`);
   const text2 = await r.text();
   await listener2.close();
 


### PR DESCRIPTION
This forces the app close within the Bun.serve listener for node http, if we don't do this, the issue appears where if you instantly recreate a listener on the same port, its hitting the old server causing weird issues.

Fixes: https://github.com/oven-sh/bun/issues/7031
Related: https://github.com/oven-sh/bun/issues/6632

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
- [x] I included a test for the new code, or an existing test covers it
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
