### PR TITLE
Implement `expect.unreachable(msg?: string | Error)`

### DIFF
--- a/packages/bun-types/bun-test.d.ts
+++ b/packages/bun-types/bun-test.d.ts
@@ -522,6 +522,30 @@ declare module "bun:test" {
     anything: () => Expect;
     stringContaining: (str: string) => Expect<string>;
     stringMatching: <T extends RegExp | string>(regex: T) => Expect<T>;
+
+    /**
+     * Throw an error if this function is called.
+     *
+     * @param msg Optional message to display if the test fails
+     * @returns never
+     *
+     * @example
+     * ## Example
+     *
+     * ```ts
+     * import { expect, test } from "bun:test";
+     *
+     * test("!!abc!! is not a module", () => {
+     *  try {
+     *     require("!!abc!!");
+     *     expect.unreachable();
+     *  } catch(e) {
+     *     expect(e.name).not.toBe("UnreachableError");
+     *  }
+     * });
+     * ```
+     */
+    unreachable(msg?: string | Error): never;
   };
   /**
    * Asserts that a value matches some criteria.

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4774,3 +4774,9 @@ CPP_DECL void JSC__VM__setControlFlowProfiler(JSC__VM* vm, bool isEnabled)
         vm->disableControlFlowProfiler();
     }
 }
+
+extern "C" EncodedJSValue JSC__createError(JSC::JSGlobalObject* globalObject, BunString* str)
+{
+    return JSValue::encode(
+        JSC::createError(globalObject, str->toWTFString()));
+}

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -3563,6 +3563,27 @@ pub const Expect = struct {
         var vm = globalObject.bunVM();
         vm.autoGarbageCollect();
     }
+
+    pub fn doUnreachable(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) JSC.JSValue {
+        const arg = callframe.arguments(1).ptr[0];
+
+        if (arg.isEmptyOrUndefinedOrNull()) {
+            const error_value = bun.String.init("reached unreachable code").toErrorInstance(globalObject);
+            error_value.put(globalObject, ZigString.static("name"), bun.String.init("UnreachableError").toJSConst(globalObject));
+            globalObject.throwValue(error_value);
+            return .zero;
+        }
+
+        if (arg.isString()) {
+            const error_value = arg.toBunString(globalObject).toErrorInstance(globalObject);
+            error_value.put(globalObject, ZigString.static("name"), bun.String.init("UnreachableError").toJSConst(globalObject));
+            globalObject.throwValue(error_value);
+            return .zero;
+        }
+
+        globalObject.throwValue(arg);
+        return .zero;
+    }
 };
 
 pub const ExpectAnything = struct {

--- a/src/bun.js/test/jest.classes.ts
+++ b/src/bun.js/test/jest.classes.ts
@@ -118,6 +118,10 @@ export default [
       rejects: {
         getter: "getStaticRejects",
       },
+      unreachable: {
+        fn: "doUnreachable",
+        length: 1,
+      },
     },
     proto: {
       pass: {

--- a/src/string.zig
+++ b/src/string.zig
@@ -435,8 +435,9 @@ pub const String = extern struct {
         }
     }
 
-    pub fn toErrorInstance(this: String, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
-        return this.toZigString().toErrorInstance(globalObject);
+    pub fn toErrorInstance(this_: String, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
+        var this = this_;
+        return JSC__createError(globalObject, &this);
     }
 
     pub fn static(input: []const u8) String {
@@ -860,6 +861,8 @@ pub const String = extern struct {
     pub fn eql(this: String, other: String) bool {
         return this.toZigString().eql(other.toZigString());
     }
+
+    extern fn JSC__createError(*JSC.JSGlobalObject, str: *String) JSC.JSValue;
 };
 
 pub const SliceWithUnderlyingString = struct {

--- a/test/js/bun/test/expect-unreaachable.test.ts
+++ b/test/js/bun/test/expect-unreaachable.test.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "bun:test";
+
+test("expect.unreachable()", () => {
+  expect(expect.unreachable).toBeTypeOf("function");
+  expect(() => expect.unreachable("message here")).toThrow("message here");
+  const error = new Error("message here");
+  expect(() => expect.unreachable(error)).toThrow(error);
+  expect(() => expect.unreachable()).toThrow("reached unreachable code");
+});

--- a/test/js/node/assert/assert.test.ts
+++ b/test/js/node/assert/assert.test.ts
@@ -6,6 +6,6 @@ test("assert as a function does not throw", () => assert(true));
 test("assert as a function does throw", () => {
   try {
     assert(false);
-    expect(false).toBe(true);
+    expect.unreachable();
   } catch (e) {}
 });

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1691,7 +1691,7 @@ it("Buffer.swap16", () => {
   const buf = Buffer.from("123", "utf-8");
   try {
     buf.swap16();
-    expect(false).toBe(true);
+    expect.unreachable();
   } catch (exception) {
     expect(exception.message).toBe("Buffer size must be a multiple of 16-bits");
   }
@@ -1717,7 +1717,7 @@ it("Buffer.swap32", () => {
   const buf = Buffer.from("12345", "utf-8");
   try {
     buf.swap32();
-    expect(false).toBe(true);
+    expect.unreachable();
   } catch (exception) {
     expect(exception.message).toBe("Buffer size must be a multiple of 32-bits");
   }
@@ -1743,7 +1743,7 @@ it("Buffer.swap64", () => {
   const buf = Buffer.from("123456789", "utf-8");
   try {
     buf.swap64();
-    expect(false).toBe(true);
+    expect.unreachable();
   } catch (exception) {
     expect(exception.message).toBe("Buffer size must be a multiple of 64-bits");
   }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -329,7 +329,7 @@ it("promises.readFile", async () => {
   for (let i = 0; i < 20; i++) {
     try {
       await fs.promises.readFile("/i-dont-exist", "utf-8");
-      expect(false).toBeTrue();
+      expect.unreachable();
     } catch (e: any) {
       expect(e).toBeInstanceOf(Error);
       expect(e.message).toBe("No such file or directory");

--- a/test/js/node/tls/fetch-tls-cert.test.ts
+++ b/test/js/node/tls/fetch-tls-cert.test.ts
@@ -100,7 +100,7 @@ it.todo("Request cert from TLS1.2 client that doesn't have one.", async () => {
         requestCert: true,
       },
     });
-    expect(true).toBe("unreachable");
+    expect.unreachable();
   } catch (err: any) {
     expect(err.code).toBe("ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE");
   }
@@ -178,7 +178,7 @@ it("Fail to complete server's chain", async () => {
         cert: server.single,
       },
     });
-    expect(true).toBe("unreachable");
+    expect.unreachable();
   } catch (err: any) {
     expect(err.code).toBe("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
   }
@@ -200,7 +200,7 @@ it.todo("Fail to complete client's chain.", async () => {
         requestCert: true,
       },
     });
-    expect(true).toBe("unreachable");
+    expect.unreachable();
   } catch (err: any) {
     expect(err.code).toBe("UNABLE_TO_GET_ISSUER_CERT");
   }
@@ -217,7 +217,7 @@ it("Fail to find CA for server.", async () => {
         cert: server.cert,
       },
     });
-    expect(true).toBe("unreachable");
+    expect.unreachable();
   } catch (err: any) {
     expect(err.code).toBe("UNABLE_TO_GET_ISSUER_CERT_LOCALLY");
   }
@@ -234,7 +234,7 @@ it("Server sent their CA, but CA cannot be trusted if it is not locally known.",
         cert: server.cert + "\n" + server.ca,
       },
     });
-    expect(true).toBe("unreachable");
+    expect.unreachable();
   } catch (err: any) {
     expect(err.code).toBe("SELF_SIGNED_CERT_IN_CHAIN");
   }

--- a/test/js/node/tls/node-tls-cert.test.ts
+++ b/test/js/node/tls/node-tls-cert.test.ts
@@ -155,7 +155,7 @@ it.todo("Request cert from TLS1.2 client that doesn't have one.", async () => {
         requestCert: true,
       },
     });
-    expect(true).toBe("unreachable");
+    expect.unreachable();
   } catch (err: any) {
     expect(err.code).toBe("ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE");
   }
@@ -224,7 +224,7 @@ it("Fail to complete server's chain", async () => {
         cert: server.single,
       },
     });
-    expect(true).toBe("unreachable");
+    expect.unreachable();
   } catch (err: any) {
     expect(err.code).toBe("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
   }
@@ -246,7 +246,7 @@ it("Fail to complete client's chain.", async () => {
         requestCert: true,
       },
     });
-    expect(true).toBe("unreachable");
+    expect.unreachable();
   } catch (err: any) {
     expect(err.code).toBe("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
   }
@@ -263,7 +263,7 @@ it("Fail to find CA for server.", async () => {
         cert: server.cert,
       },
     });
-    expect(true).toBe("unreachable");
+    expect.unreachable();
   } catch (err: any) {
     expect(err.code).toBe("UNABLE_TO_GET_ISSUER_CERT_LOCALLY");
   }
@@ -280,7 +280,7 @@ it("Server sent their CA, but CA cannot be trusted if it is not locally known.",
         cert: server.cert + "\n" + server.ca,
       },
     });
-    expect(true).toBe("unreachable");
+    expect.unreachable();
   } catch (err: any) {
     expect(err.code).toBe("SELF_SIGNED_CERT_IN_CHAIN");
   }

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -61,7 +61,7 @@ describe("fetch() with streaming", () => {
           const { done } = await reader?.read();
           if (done) break;
         }
-        expect(true).toBe("unreachable");
+        expect.unreachable();
       } catch (err: any) {
         if (err.name !== "TimeoutError") throw err;
         expect(err.message).toBe("The operation timed out.");
@@ -107,7 +107,7 @@ describe("fetch() with streaming", () => {
         const promise = res.text(); // start buffering
         res.body?.getReader(); // get a reader
         const result = await promise; // should throw the right error
-        expect(result).toBe("unreachable");
+        expect.unreachable();
       } catch (err: any) {
         if (err.name !== "TypeError") throw err;
         expect(err.message).toBe("ReadableStream is locked");
@@ -154,7 +154,7 @@ describe("fetch() with streaming", () => {
         const promise = res.text(); // start buffering
         body.getReader(); // get a reader
         const result = await promise; // should throw the right error
-        expect(result).toBe("unreachable");
+        expect.unreachable();
       } catch (err: any) {
         if (err.name !== "TypeError") throw err;
         expect(err.message).toBe("ReadableStream is locked");

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -1087,7 +1087,7 @@ describe("Response", () => {
     });
     try {
       await body.json();
-      expect(false).toBe(true);
+      expect.unreachable();
     } catch (exception) {
       expect(exception instanceof SyntaxError).toBe(true);
     }

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -45,7 +45,7 @@ it("can handle multiple requests with non native checkServerIdentity", async () 
       }).then((res: Response) => res.text());
       expect(result?.length).toBeGreaterThan(0);
     } catch (e: any) {
-      expect(e).toBe("unreachable");
+      expect.unreachable();
     }
   }
   const promises = [];
@@ -150,7 +150,7 @@ it("fetch with self-sign certificate tls + rejectUnauthorized: false should not 
         const result = await fetch(url, { tls: { rejectUnauthorized: false } }).then((res: Response) => res.text());
         expect(result).toBe("Hello World");
       } catch (e: any) {
-        expect(e).toBe("unreachable");
+        expect.unreachable();
       }
     }
   });
@@ -164,7 +164,7 @@ it("fetch with invalid tls + rejectUnauthorized: false should not throw", async 
         const result = await fetch(url, { tls: { rejectUnauthorized: false } }).then((res: Response) => res.text());
         expect(result).toBe("Hello World");
       } catch (e: any) {
-        expect(e).toBe("unreachable");
+        expect.unreachable();
       }
     }
   });

--- a/test/js/web/timers/setImmediate.test.js
+++ b/test/js/web/timers/setImmediate.test.js
@@ -35,7 +35,7 @@ it("clearImmediate", async () => {
   var called = false;
   const id = setImmediate(() => {
     called = true;
-    expect(false).toBe(true);
+    expect.unreachable();
   });
   clearImmediate(id);
 

--- a/test/js/web/timers/setInterval.test.js
+++ b/test/js/web/timers/setInterval.test.js
@@ -33,7 +33,7 @@ it("clearInterval", async () => {
   var called = false;
   const id = setInterval(() => {
     called = true;
-    expect(false).toBe(true);
+    expect.unreachable();
   }, 1);
   clearInterval(id);
   await new Promise((resolve, reject) => {

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -41,7 +41,7 @@ it("clearTimeout", async () => {
   {
     const id = setTimeout(() => {
       called = true;
-      expect(false).toBe(true);
+      expect.unreachable();
     }, 0);
     clearTimeout(id);
 
@@ -53,7 +53,7 @@ it("clearTimeout", async () => {
   {
     const id = setTimeout(() => {
       called = true;
-      expect(false).toBe(true);
+      expect.unreachable();
     }, 0);
     clearTimeout(+id);
 

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -147,19 +147,19 @@ it("crypto.timingSafeEqual", () => {
   expect(crypto.timingSafeEqual(uuid, uuid.slice())).toBe(true);
   try {
     crypto.timingSafeEqual(uuid, uuid.slice(1));
-    expect(false).toBe(true);
+    expect.unreachable();
   } catch (e) {}
 
   try {
     crypto.timingSafeEqual(uuid, uuid.slice(0, uuid.length - 2));
-    expect(false).toBe(true);
+    expect.unreachable();
   } catch (e) {
     expect(e.message).toBe("Input buffers must have the same length");
   }
 
   try {
     expect(crypto.timingSafeEqual(uuid, crypto.randomUUID())).toBe(false);
-    expect(false).toBe(true);
+    expect.unreachable();
   } catch (e) {
     expect(e.name).toBe("TypeError");
   }


### PR DESCRIPTION
### What does this PR do?

This implements [`expect.unreachable`](https://vitest.dev/api/expect#expect-unreachable).

```ts
import {test, expect} from 'bun:test';
import {connect} from 'bun';

const server = data(); // ...

test("Fail to find CA for server", async () => {
  try {
    await connect({
      client: {
        checkServerIdentity,
      },
      server: {
        key: server.key,
        cert: server.cert,
      },
    });
    expect.unreachable();
  } catch (err: any) {
    expect(err.code).toBe("UNABLE_TO_GET_ISSUER_CERT_LOCALLY");
  }
});
```

See also https://github.com/Khan/career-competencies/pull/38

### How did you verify your code works?

There is a test