### PR TITLE
MINOR : Update gitignore-for-init removing duplicate .cache pattern

### DIFF
--- a/src/cli/gitignore-for-init
+++ b/src/cli/gitignore-for-init
@@ -10,6 +10,10 @@ yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
 
+# Caches 
+
+.cache
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 
 report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
@@ -104,7 +108,6 @@ web_modules/
 
 # parcel-bundler cache (https://parceljs.org/)
 
-.cache
 .parcel-cache
 
 # Next.js build output
@@ -119,8 +122,6 @@ dist
 
 # Gatsby files
 
-.cache/
-
 # Comment in the public line in if your project uses Gatsby and not Next.js
 
 # https://nextjs.org/blog/next-9-1#public-directory-support
@@ -134,7 +135,6 @@ dist
 # vuepress v2.x temp and cache directory
 
 .temp
-.cache
 
 # Docusaurus cache and generated files
 


### PR DESCRIPTION
'.cache' pattern is defined more than once

### What does this PR do?

`Warning:(137, 1) '.cache' pattern is defined more than once`

removing this error. 


