### PR TITLE
Add license information to package.json of bun-types

### DIFF
--- a/packages/bun-types/scripts/bundle.ts
+++ b/packages/bun-types/scripts/bundle.ts
@@ -47,6 +47,7 @@ await write(destination, text);
 const packageJSON = {
   name: process.env.PACKAGE_NAME || "bun-types",
   version: BUN_VERSION,
+  license: "MIT",
   description:
     "Type definitions for Bun, an incredibly fast JavaScript runtime",
   types: "types.d.ts",


### PR DESCRIPTION
### What does this PR do?

Add MIT as license information in the package.json of `bun-types`. 

### How did you verify your code works?

No code changed

### Assumtions

`bun-types` is distributed under MIT just like the rest of the Bun project as indicated here: https://bun.sh/docs/project/licensing


### Background

I use bun for bundling and testing, so I depend on bun-types. But without the license information in the package.json I get this FOSSA warning

![image](https://github.com/oven-sh/bun/assets/1063454/e5ee6382-65bd-45c5-8240-3dcaa8c9e5c9)

This is similar to the PR https://github.com/oven-sh/bun/pull/6255 that has already been merged.


