### PR TITLE
fix typo in help menu

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1906,7 +1906,7 @@ pub const Command = struct {
                 Command.Tag.BuildCommand => {
                     const intro_text =
                         \\<b>Usage<r>:
-                        \\  Transpile and bundle one more more files.
+                        \\  Transpile and bundle one or more files.
                         \\  <b><green>bun build<r> <cyan>[...flags]<r> [...entrypoints]
                     ;
 


### PR DESCRIPTION
### What does this PR do?

Fix typo in help menu `more more` -> `or more`

### How did you verify your code works?

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I or my editor ran `zig fmt` on the changed files
