### PR TITLE
Fix the TypeError of `isValidTLSArray` for http

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -96,11 +96,13 @@ function isValidTLSArray(obj) {
   if (typeof obj === "string" || isTypedArray(obj) || obj instanceof ArrayBuffer || obj instanceof Blob) return true;
   if (Array.isArray(obj)) {
     for (var i = 0; i < obj.length; i++) {
-      if (typeof obj !== "string" && !isTypedArray(obj) && !(obj instanceof ArrayBuffer) && !(obj instanceof Blob))
+      const item = obj[i];
+      if (typeof item !== "string" && !isTypedArray(item) && !(item instanceof ArrayBuffer) && !(item instanceof Blob))
         return false;
     }
     return true;
   }
+  return false;
 }
 
 class ERR_INVALID_ARG_TYPE extends TypeError {


### PR DESCRIPTION
fix: https://github.com/oven-sh/bun/issues/7153


### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Code changes

### How did you verify your code works?

Code from: https://github.com/oven-sh/bun/blob/85c997513d2b05acab21e758512954273e3a589a/src/js/node/tls.js#L35

It should be consistent with the one in: https://github.com/oven-sh/bun/blob/85c997513d2b05acab21e758512954273e3a589a/src/js/node/http.ts#L95

`index.ts`

```ts
console.log("Hello via Bun!");

import { Server } from "http";
import { isTypedArray } from "util/types";

function isValidTLSArray1(obj) {
    if (typeof obj === "string" || isTypedArray(obj) || obj instanceof ArrayBuffer || obj instanceof Blob) return true;
    if (Array.isArray(obj)) {
        for (var i = 0; i < obj.length; i++) {
            if (typeof obj !== "string" && !isTypedArray(obj) && !(obj instanceof ArrayBuffer) && !(obj instanceof Blob))
                return false;
        }
        return true;
    }
}

function isValidTLSArray2(obj) {
    if (typeof obj === "string" || isTypedArray(obj) || obj instanceof ArrayBuffer || obj instanceof Blob) return true;
    if (Array.isArray(obj)) {
        for (var i = 0; i < obj.length; i++) {
            const item = obj[i];
            if (typeof item !== "string" && !isTypedArray(item) && !(item instanceof ArrayBuffer) && !(item instanceof Blob))
                return false;
        }
        return true;
    }
    return false;
}
console.log(`----------------------`);
console.log(`isValidTLSArray1("")`, isValidTLSArray1(""));
console.log(`isValidTLSArray1([])`, isValidTLSArray1([]));
console.log(`isValidTLSArray1([""])`, isValidTLSArray1([""]));
console.log(`isValidTLSArray2("")`, isValidTLSArray2(""));
console.log(`isValidTLSArray2([])`, isValidTLSArray2([]));
console.log(`isValidTLSArray2([""])`, isValidTLSArray2([""]));
console.log(`----------------------`);
console.log(`const server1 = new Server({ key: "123" });`);
const server1 = new Server({ key: "123" });
console.log(`----------------------`);
console.log(`const server2 = new Server({ key: ["123"] });`);
const server2 = new Server({ key: ["123"] });
```

```log
Hello via Bun!
----------------------
isValidTLSArray1("") true
isValidTLSArray1([]) true
isValidTLSArray1([""]) false
isValidTLSArray2("") true
isValidTLSArray2([]) true
isValidTLSArray2([""]) true
----------------------
const server1 = new Server({ key: "123" });
----------------------
const server2 = new Server({ key: ["123"] });
281 |   #tls;
282 |   #is_tls = !1;
283 |   listening = !1;
284 |   serverName;
285 | 
286 |   constructor(options, callback) {
                             ^
TypeError: key argument must be an string, Buffer, TypedArray, BunFile or an array containing string, Buffer, TypedArray or BunFile
      at new Server (node:http:286:26)
      at index.ts:41:16
```

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
