### PR TITLE
Change `Bun.serve({ fetch })` types to allow `void` when using websockets

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1915,7 +1915,7 @@ declare module "bun" {
       this: Server,
       request: Request,
       server: Server,
-    ): any | Promise<any>;
+    ): Response | Promise<Response>;
   }
 
   export interface UnixServeOptions extends GenericServeOptions {
@@ -1933,7 +1933,7 @@ declare module "bun" {
       this: Server,
       request: Request,
       server: Server,
-    ): any | Promise<any>;
+    ): Response | Promise<Response>;
   }
 
   export interface WebSocketServeOptions<WebSocketDataType = undefined>
@@ -2014,7 +2014,7 @@ declare module "bun" {
       this: Server,
       request: Request,
       server: Server,
-    ): any | Promise<any>;
+    ): Response | undefined | void | Promise<Response | undefined | void>;
   }
 
   export interface UnixWebSocketServeOptions<WebSocketDataType = undefined>
@@ -2075,7 +2075,7 @@ declare module "bun" {
       this: Server,
       request: Request,
       server: Server,
-    ): any | Promise<any>;
+    ): Response | undefined | void | Promise<Response | undefined | void>;
   }
 
   export interface TLSWebSocketServeOptions<WebSocketDataType = undefined>
@@ -2290,7 +2290,7 @@ declare module "bun" {
      * consistently in all cases and it doesn't yet call the `error` handler
      * consistently. This needs to be fixed
      */
-    fetch(request: Request | string): any | Promise<any>;
+    fetch(request: Request | string): Response | Promise<Response>;
 
     /**
      * Upgrade a {@link Request} to a {@link ServerWebSocket}

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1915,7 +1915,7 @@ declare module "bun" {
       this: Server,
       request: Request,
       server: Server,
-    ): Response | Promise<Response>;
+    ): any | Promise<any>;
   }
 
   export interface UnixServeOptions extends GenericServeOptions {
@@ -1933,7 +1933,7 @@ declare module "bun" {
       this: Server,
       request: Request,
       server: Server,
-    ): Response | Promise<Response>;
+    ): any | Promise<any>;
   }
 
   export interface WebSocketServeOptions<WebSocketDataType = undefined>
@@ -2014,7 +2014,7 @@ declare module "bun" {
       this: Server,
       request: Request,
       server: Server,
-    ): Response | undefined | Promise<Response | undefined>;
+    ): any | Promise<any>;
   }
 
   export interface UnixWebSocketServeOptions<WebSocketDataType = undefined>
@@ -2075,7 +2075,7 @@ declare module "bun" {
       this: Server,
       request: Request,
       server: Server,
-    ): Response | undefined | Promise<Response | undefined>;
+    ): any | Promise<any>;
   }
 
   export interface TLSWebSocketServeOptions<WebSocketDataType = undefined>
@@ -2290,7 +2290,7 @@ declare module "bun" {
      * consistently in all cases and it doesn't yet call the `error` handler
      * consistently. This needs to be fixed
      */
-    fetch(request: Request | string): Response | Promise<Response>;
+    fetch(request: Request | string): any | Promise<any>;
 
     /**
      * Upgrade a {@link Request} to a {@link ServerWebSocket}

--- a/packages/bun-types/tests/serve.test-d.ts
+++ b/packages/bun-types/tests/serve.test-d.ts
@@ -80,6 +80,25 @@ Bun.serve<User>({
 });
 
 Bun.serve({
+  fetch(req, server) {
+    server.upgrade(req)
+  },
+
+  websocket: {
+    open(ws) {
+      console.log("WebSocket opened");
+      ws.subscribe("test-channel");
+    },
+
+    message(ws, message) {
+      ws.publish("test-channel", `${message}`);
+    },
+
+    perMessageDeflate: true,
+  },
+});
+
+Bun.serve({
   fetch(req) {
     throw new Error("woops!");
   },

--- a/packages/bun-types/tests/serve.test-d.ts
+++ b/packages/bun-types/tests/serve.test-d.ts
@@ -81,7 +81,7 @@ Bun.serve<User>({
 
 Bun.serve({
   fetch(req, server) {
-    server.upgrade(req)
+    server.upgrade(req);
   },
 
   websocket: {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Since #7159 recieved the `typescript` tag i assumed that this was not intentional so i changed the fetch types so you can return whatever you want/not return.
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
