### PR TITLE
Don't allocate new `"require"` and `"resolve"` strings in CJS modules

### DIFF
--- a/src/bun.js/bindings/BunCommonStrings.cpp
+++ b/src/bun.js/bindings/BunCommonStrings.cpp
@@ -1,0 +1,39 @@
+#include "root.h"
+#include "BunBuiltinNames.h"
+#include "BunCommonStrings.h"
+#include <JavaScriptCore/JSString.h>
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/LazyProperty.h>
+#include <JavaScriptCore/LazyPropertyInlines.h>
+#include "ZigGlobalObject.h"
+#include <JavaScriptCore/SlotVisitorInlines.h>
+#include <JavaScriptCore/VMTrapsInlines.h>
+
+namespace Bun {
+using namespace JSC;
+
+#define BUN_COMMON_STRINGS_LAZY_PROPERTY_DEFINITION(jsName)                        \
+    this->m_commonString_##jsName.initLater(                                       \
+        [](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) { \
+            auto& names = WebCore::builtinNames(init.vm);                          \
+            auto name = names.jsName##PublicName();                                \
+            init.set(jsOwnedString(init.vm, name.string()));                       \
+        });
+
+#define BUN_COMMON_STRINGS_LAZY_PROPERTY_VISITOR(name) this->m_commonString_##name.visit(visitor);
+
+void CommonStrings::initialize()
+{
+    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_LAZY_PROPERTY_DEFINITION)
+}
+
+template<typename Visitor>
+void CommonStrings::visit(Visitor& visitor)
+{
+    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_LAZY_PROPERTY_VISITOR)
+}
+
+template void CommonStrings::visit(JSC::AbstractSlotVisitor&);
+template void CommonStrings::visit(JSC::SlotVisitor&);
+
+} // namespace Bun

--- a/src/bun.js/bindings/BunCommonStrings.h
+++ b/src/bun.js/bindings/BunCommonStrings.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// clang-format off
+#define BUN_COMMON_STRINGS_EACH_NAME(macro) \
+    macro(require)                          \
+    macro(resolve)
+// clang-format on
+
+#define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)                           \
+    JSC::JSString* name##String(JSC::JSGlobalObject* globalObject)             \
+    {                                                                          \
+        return m_commonString_##name.getInitializedOnMainThread(globalObject); \
+    }
+
+#define BUN_COMMON_STRINGS_LAZY_PROPERTY_DECLARATION(name) \
+    JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString> m_commonString_##name;
+
+namespace Bun {
+
+class CommonStrings {
+public:
+    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION)
+
+    void initialize();
+
+    template<typename Visitor>
+    void visit(Visitor& visitor);
+
+private:
+    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_LAZY_PROPERTY_DECLARATION)
+};
+
+} // namespace Bun
+
+#undef BUN_COMMON_STRINGS_ACCESSOR_DEFINITION
+#undef BUN_COMMON_STRINGS_LAZY_PROPERTY_DECLARATION

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -223,7 +223,7 @@ static JSValue constructDNSObject(VM& vm, JSObject* bunObject)
     JSC::JSObject* dnsObject = JSC::constructEmptyObject(globalObject);
     dnsObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "lookup"_s), 2, Bun__DNSResolver__lookup, ImplementationVisibility::Public, NoIntrinsic,
         JSC::PropertyAttribute::DontDelete | 0);
-    dnsObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "resolve"_s), 2, Bun__DNSResolver__resolve, ImplementationVisibility::Public, NoIntrinsic,
+    dnsObject->putDirectNativeFunction(vm, globalObject, builtinNames(vm).resolvePublicName(), 2, Bun__DNSResolver__resolve, ImplementationVisibility::Public, NoIntrinsic,
         JSC::PropertyAttribute::DontDelete | 0);
     dnsObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "resolveSrv"_s), 2, Bun__DNSResolver__resolveSrv, ImplementationVisibility::Public, NoIntrinsic,
         JSC::PropertyAttribute::DontDelete | 0);

--- a/src/bun.js/bindings/CommonJSModuleRecord.cpp
+++ b/src/bun.js/bindings/CommonJSModuleRecord.cpp
@@ -238,7 +238,7 @@ RequireFunctionPrototype* RequireFunctionPrototype::create(
     RequireFunctionPrototype* prototype = new (NotNull, JSC::allocateCell<RequireFunctionPrototype>(vm)) RequireFunctionPrototype(vm, structure);
     prototype->finishCreation(vm);
 
-    prototype->putDirect(vm, JSC::Identifier::fromString(vm, "resolve"_s), jsCast<Zig::GlobalObject*>(globalObject)->requireResolveFunctionUnbound(), 0);
+    prototype->putDirect(vm, builtinNames(vm).resolvePublicName(), jsCast<Zig::GlobalObject*>(globalObject)->requireResolveFunctionUnbound(), 0);
 
     return prototype;
 }

--- a/src/bun.js/bindings/CommonJSModuleRecord.cpp
+++ b/src/bun.js/bindings/CommonJSModuleRecord.cpp
@@ -108,12 +108,12 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
         globalObject,
         globalObject->requireResolveFunctionUnbound(),
         moduleObject->id(),
-        ArgList(), 1, jsString(vm, String("resolve"_s)));
+        ArgList(), 1, globalObject->commonStrings().resolveString(globalObject));
     JSFunction* requireFunction = JSC::JSBoundFunction::create(vm,
         globalObject,
         globalObject->requireFunctionUnbound(),
         moduleObject,
-        ArgList(), 1, jsString(vm, String("require"_s)));
+        ArgList(), 1, globalObject->commonStrings().requireString(globalObject));
     requireFunction->putDirect(vm, vm.propertyNames->resolve, resolveFunction, 0);
     moduleObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().requirePublicName(), requireFunction, 0);
 
@@ -1059,13 +1059,13 @@ JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* l
         globalObject,
         globalObject->requireFunctionUnbound(),
         moduleObject,
-        ArgList(), 1, jsString(vm, String("require"_s)));
+        ArgList(), 1, globalObject->commonStrings().requireString(globalObject));
 
     JSFunction* resolveFunction = JSC::JSBoundFunction::create(vm,
         globalObject,
         globalObject->requireResolveFunctionUnbound(),
         moduleObject,
-        ArgList(), 1, jsString(vm, String("resolve"_s)));
+        ArgList(), 1, globalObject->commonStrings().resolveString(globalObject));
 
     requireFunction->putDirect(vm, vm.propertyNames->resolve, resolveFunction, 0);
 

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -43,6 +43,7 @@ class InternalModuleRegistry;
 #include "ProcessBindingConstants.h"
 #include "WebCoreJSBuiltins.h"
 #include "headers-handwritten.h"
+#include "BunCommonStrings.h"
 
 namespace WebCore {
 class GlobalScope;
@@ -424,6 +425,7 @@ public:
 
     JSObject* cryptoObject() { return m_cryptoObject.getInitializedOnMainThread(this); }
     JSObject* JSDOMFileConstructor() { return m_JSDOMFileConstructor.getInitializedOnMainThread(this); }
+    Bun::CommonStrings& commonStrings() { return m_commonStrings; }
 
 #include "ZigGeneratedClasses+lazyStructureHeader.h"
 
@@ -441,6 +443,7 @@ private:
     Lock m_gcLock;
     WebCore::ScriptExecutionContext* m_scriptExecutionContext;
     Ref<WebCore::DOMWrapperWorld> m_world;
+    Bun::CommonStrings m_commonStrings;
 
     // JSC's hashtable code-generator tries to access these properties, so we make them public.
     // However, we'd like it better if they could be protected.

--- a/src/bun.js/modules/NodeModuleModule.h
+++ b/src/bun.js/modules/NodeModuleModule.h
@@ -2,10 +2,10 @@
 
 #include "CommonJSModuleRecord.h"
 #include "ImportMetaObject.h"
-#include <JavaScriptCore/JSBoundFunction.h>
-#include <JavaScriptCore/ObjectConstructor.h>
 #include "_NativeModule.h"
 #include "isBuiltinModule.h"
+#include <JavaScriptCore/JSBoundFunction.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 
 using namespace Zig;
 using namespace JSC;
@@ -189,7 +189,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeModuleCreateRequire,
                  vm, globalObject, val)));
 }
 extern "C" JSC::EncodedJSValue Resolver__nodeModulePathsForJS(JSGlobalObject *,
-                                                         CallFrame *);
+                                                              CallFrame *);
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionFindSourceMap,
                          (JSGlobalObject * globalObject,


### PR DESCRIPTION

### What does this PR do?

There is a crash when materializing the error info that can occur due to the garbage collector allocating memory for a bound function name while an error is materializing

This GC activity is mostly due to creating new `"require"` and `"resolve"` `JSString*` in every CommonJS module we load for the `require` and `resolve` bound function names.

This adds `Bun::CommonStrings` where we can stick frequently-used strings to be loaded once and visited by the GC. These strings are never freed.  

### How did you verify your code works?

It compiled 