### PR TITLE
Properly handle errors from `posix_spawn`

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1517,7 +1517,10 @@ pub const Subprocess = struct {
             }
 
             break :brk switch (PosixSpawn.spawnZ(argv.items[0].?, actions, attr, @as([*:null]?[*:0]const u8, @ptrCast(argv.items[0..].ptr)), env)) {
-                .err => |err| return err.toJSC(globalThis),
+                .err => |err| {
+                    globalThis.throwValue(err.toJSC(globalThis));
+                    return .zero;
+                },
                 .result => |pid_| pid_,
             };
         };

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -46,6 +46,15 @@ for (let [gcTick, label] of [
         expect(exitCode2).toBe(1);
         gcTick();
       });
+
+      it("throws errors for invalid arguments", async () => {
+        expect(() => {
+          spawnSync({
+            cmd: ["echo", "hi"],
+            cwd: "./this-should-not-exist",
+          });
+        }).toThrow("No such file or directory");
+      });
     });
 
     describe("spawn", () => {
@@ -472,6 +481,15 @@ for (let [gcTick, label] of [
           childProc.send(parentMessage);
           gcTick();
         });
+      });
+
+      it("throws errors for invalid arguments", async () => {
+        expect(() => {
+          spawnSync({
+            cmd: ["echo", "hi"],
+            cwd: "./this-should-not-exist",
+          });
+        }).toThrow("No such file or directory");
       });
     });
   });


### PR DESCRIPTION
### What does this PR do?

`posix_spawn` returns 0 on success, and errno on failure. We were not handling this case properly, also fixed a dormant bug where `Bun.spawn()` would _return_ an error, instead of _throw_ it.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests