### PR TITLE
fix(fs.writeFile): correctly decode when encoding is base64

### DIFF
--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -832,6 +832,14 @@ describe("writeFileSync", () => {
       expect(buffer[i]).toBe(out[i]);
     }
   });
+  it("correctly decodes base64(#7165)", () => {
+    const path = `${tmpdir()}/${Date.now()}.base64.writeFileSync.txt`;
+    const data = Buffer.from("this is a test message which should be written as plain text through base64");
+    const b64 = data.toString("base64");
+    writeFileSync(path, b64, "base64");
+    const out = readFileSync(path);
+    expect(out).toEqual(data);
+  });
   it("returning ArrayBuffer works", () => {
     const buffer = new Buffer([
       70, 105, 108, 101, 32, 119, 114, 105, 116, 116, 101, 110, 32, 115, 117, 99, 99, 101, 115, 115, 102, 117, 108, 108,


### PR DESCRIPTION
We where not decoding base64 into the binary form when the passed encoding was base64 leading to a incorrect file content.

Fixes: https://github.com/oven-sh/bun/issues/7165

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
- [x] I included a test for the new code, or an existing test covers it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it


-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be

- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
