### PR TITLE
Output verbose logs when running in Github Action with debug mode

### DIFF
--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -199,6 +199,8 @@ const CreateOptions = struct {
     };
 
     pub fn parse(ctx: Command.Context) !CreateOptions {
+        Output.is_verbose = Output.isVerbose();
+
         var diag = clap.Diagnostic{};
 
         var args = clap.parse(clap.Help, &params, .{ .diagnostic = &diag, .allocator = ctx.allocator }) catch |err| {
@@ -215,7 +217,7 @@ const CreateOptions = struct {
 
         opts.skip_package_json = args.flag("--no-package-json");
 
-        opts.verbose = args.flag("--verbose");
+        opts.verbose = args.flag("--verbose") or Output.is_verbose;
         opts.open = args.flag("--open");
         opts.skip_install = args.flag("--no-install");
         opts.skip_git = args.flag("--no-git");

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -6632,6 +6632,8 @@ pub const PackageManager = struct {
         }
 
         pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !CommandLineArguments {
+            Output.is_verbose = Output.isVerbose();
+
             comptime var params: []const ParamType = &switch (subcommand) {
                 .install => install_params,
                 .update => update_params,
@@ -6671,7 +6673,7 @@ pub const PackageManager = struct {
             // cli.no_dedupe = args.flag("--no-dedupe");
             cli.no_cache = args.flag("--no-cache");
             cli.silent = args.flag("--silent");
-            cli.verbose = args.flag("--verbose");
+            cli.verbose = args.flag("--verbose") or Output.is_verbose;
             cli.ignore_scripts = args.flag("--ignore-scripts");
             cli.no_summary = args.flag("--no-summary");
 

--- a/src/output.zig
+++ b/src/output.zig
@@ -179,6 +179,7 @@ pub var enable_ansi_colors = Environment.isNative;
 pub var enable_ansi_colors_stderr = Environment.isNative;
 pub var enable_ansi_colors_stdout = Environment.isNative;
 pub var enable_buffering = Environment.isNative;
+pub var is_verbose = false;
 pub var is_github_action = false;
 
 pub var stderr_descriptor_type = OutputStreamDescriptor.unknown;
@@ -191,6 +192,16 @@ pub inline fn isEmojiEnabled() bool {
 pub fn isGithubAction() bool {
     if (bun.getenvZ("GITHUB_ACTIONS")) |value| {
         return strings.eqlComptime(value, "true");
+    }
+    return false;
+}
+
+pub fn isVerbose() bool {
+    // Set by Github Actions when a workflow is run using debug mode.
+    if (bun.getenvZ("RUNNER_DEBUG")) |value| {
+        if (strings.eqlComptime(value, "1")) {
+            return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
### What does this PR do?

When `bun install` or `bun create` is run in a Github Action with debug mode, it will automatically show logs as if it was run using `--verbose`.

<img width="732" alt="Screenshot 2023-11-17 at 9 17 00 AM" src="https://github.com/oven-sh/bun/assets/3238291/b32b9349-141d-4aa1-8bb3-883c5d93eb0d">


- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Manually.
