### PR TITLE
Update docs of TCP sockets to use IP address in hostname

### DIFF
--- a/docs/api/tcp.md
+++ b/docs/api/tcp.md
@@ -6,7 +6,7 @@ To start a TCP server with `Bun.listen`:
 
 ```ts
 Bun.listen({
-  hostname: "localhost",
+  hostname: "127.0.0.1",
   port: 8080,
   socket: {
     data(socket, data) {}, // message received from client
@@ -24,7 +24,7 @@ In Bun, a set of handlers are declared once per server instead of assigning call
 
 ```ts
 Bun.listen({
-  hostname: "localhost",
+  hostname: "127.0.0.1",
   port: 8080,
   socket: {
     open(socket) {},
@@ -46,7 +46,7 @@ Contextual data can be attached to a socket in the `open` handler.
 type SocketData = { sessionId: string };
 
 Bun.listen<SocketData>({
-  hostname: "localhost",
+  hostname: "127.0.0.1",
   port: 8080,
   socket: {
     data(socket, data) {
@@ -63,7 +63,7 @@ To enable TLS, pass a `tls` object containing `key` and `cert` fields.
 
 ```ts
 Bun.listen({
-  hostname: "localhost",
+  hostname: "127.0.0.1",
   port: 8080,
   socket: {
     data(socket, data) {},


### PR DESCRIPTION
### What does this PR do?

Updating the TCP sockets docs with hostname to IP address

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
