### PR TITLE
fix(Bun.serve): return EACCESS when we don't have perms

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5607,7 +5607,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                             if (comptime Environment.isLinux) {
                                 var rc: i32 = -1;
                                 const code = Sys.getErrno(rc);
-                                if (code == bun.C.E.ACCESS) {
+                                if (code == bun.C.E.ACCES) {
                                     error_instance = (JSC.SystemError{
                                         .message = bun.String.init(std.fmt.bufPrint(&output_buf, "permission denied {s}:{d}", .{ tcp.hostname orelse "0.0.0.0", tcp.port }) catch "Failed to start server"),
                                         .code = bun.String.static("EACCES"),

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5602,7 +5602,6 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             if (error_instance == .zero) {
                 switch (this.config.address) {
                     .tcp => |tcp| {
-                        // this value is hard set by the underlying system, but it might be wrong for windows?
                         error_set: {
                             if (comptime Environment.isLinux) {
                                 var rc: i32 = -1;

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1304,13 +1304,14 @@ it("should response with HTTP 413 when request body is larger than maxRequestBod
 
   server.stop(true);
 });
-it("should use correct error when using a root range port(#7187)", () => {
-  expect(() => {
-    const server = Bun.serve({
-      port: 1003,
-      fetch(req) {
-        return new Response("request answered");
-      },
-    });
-  }).toThrow("permission denied 0.0.0.0:1003");
-});
+if (process.platform === "linux")
+  it("should use correct error when using a root range port(#7187)", () => {
+    expect(() => {
+      const server = Bun.serve({
+        port: 1003,
+        fetch(req) {
+          return new Response("request answered");
+        },
+      });
+    }).toThrow("permission denied 0.0.0.0:1003");
+  });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1304,3 +1304,13 @@ it("should response with HTTP 413 when request body is larger than maxRequestBod
 
   server.stop(true);
 });
+it("should use correct error when using a root range port(#7187)", () => {
+  expect(() => {
+    const server = Bun.serve({
+      port: 1003,
+      fetch(req) {
+        return new Response("request answered");
+      },
+    });
+  }).toThrow("permission denied 0.0.0.0:1003");
+});


### PR DESCRIPTION
The error reported to js land when listening fails was always the same, this adds a second one for EACCESS when we are not the super user.

Fixes: https://github.com/oven-sh/bun/issues/7187

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:


-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
