### PR TITLE
fix(Response): single `Content-Range` in http response

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3008,9 +3008,11 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             };
 
             var has_content_disposition = false;
+            var has_content_range = false;
             if (response.init.headers) |headers_| {
                 has_content_disposition = headers_.fastHas(.ContentDisposition);
-                needs_content_range = needs_content_range and headers_.fastHas(.ContentRange);
+                has_content_range = headers_.fastHas(.ContentRange);
+                needs_content_range = needs_content_range and has_content_range;
                 if (needs_content_range) {
                     status = 206;
                 }
@@ -3057,7 +3059,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 this.flags.needs_content_length = false;
             }
 
-            if (needs_content_range) {
+            if (needs_content_range and !has_content_range) {
                 var content_range_buf: [1024]u8 = undefined;
 
                 resp.writeHeader(

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -954,7 +954,7 @@ describe("should support Content-Range with Bun.file()", () => {
       const end = Number(searchParams.get("end"));
       const file = Bun.file(fixture);
       return new Response(file.slice(start, end), {
-        headers: { 'Content-Range': 'bytes ' + start + '-' + end + '/' + file.size }
+        headers: { "Content-Range": "bytes " + start + "-" + end + "/" + file.size },
       });
     },
   });
@@ -991,11 +991,11 @@ describe("should support Content-Range with Bun.file()", () => {
         const response = await fetch(`http://${server.hostname}:${server.port}/?start=${start}&end=${end}`, {
           verbose: true,
         });
-        expect(parseInt(response.headers.get('Content-Range')?.split("/")[1])).toEqual(full.byteLength)
+        expect(parseInt(response.headers.get("Content-Range")?.split("/")[1])).toEqual(full.byteLength);
         expect(await response.arrayBuffer()).toEqual(full.buffer.slice(start, end));
         expect(response.status).toBe(start > 0 || end < full.byteLength ? 206 : 200);
-      })
-    })
+      });
+    });
   }
 
   const emptyRanges = [


### PR DESCRIPTION
### What does this PR do?

Fix https://github.com/oven-sh/bun/issues/7051

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [x] Add test
