### PR TITLE
Cleanup how build errors are displayed slightly

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -150,13 +150,12 @@ pub const SavedSourceMap = struct {
                             Output.errorWriter(),
                             logger.Kind.warn,
                             true,
-                            false,
                         );
                     } else {
                         try fail.toData(path).writeFormat(
                             Output.errorWriter(),
                             logger.Kind.warn,
-                            false,
+
                             false,
                         );
                     }
@@ -2022,6 +2021,10 @@ pub const VirtualMachine = struct {
         if (!result.isEmptyOrUndefinedOrNull())
             this.last_reported_error_for_dedupe = result;
 
+        var prev_had_errors = this.had_errors;
+        this.had_errors = false;
+        defer this.had_errors = prev_had_errors;
+
         if (result.isException(this.global.vm())) {
             var exception = @as(*Exception, @ptrCast(result.asVoid()));
 
@@ -2429,9 +2432,12 @@ pub const VirtualMachine = struct {
             if (value.as(JSC.BuildMessage)) |build_error| {
                 defer Output.flush();
                 if (!build_error.logged) {
+                    if (this.had_errors) {
+                        writer.writeAll("\n") catch {};
+                    }
                     build_error.msg.writeFormat(writer, allow_ansi_color) catch {};
-                    writer.writeAll("\n") catch {};
                     build_error.logged = true;
+                    writer.writeAll("\n") catch {};
                 }
                 this.had_errors = this.had_errors or build_error.msg.kind == .err;
                 if (exception_list != null) {
@@ -2443,8 +2449,12 @@ pub const VirtualMachine = struct {
             } else if (value.as(JSC.ResolveMessage)) |resolve_error| {
                 defer Output.flush();
                 if (!resolve_error.logged) {
+                    if (this.had_errors) {
+                        writer.writeAll("\n") catch {};
+                    }
                     resolve_error.msg.writeFormat(writer, allow_ansi_color) catch {};
                     resolve_error.logged = true;
+                    writer.writeAll("\n") catch {};
                 }
 
                 this.had_errors = this.had_errors or resolve_error.msg.kind == .err;
@@ -2683,12 +2693,14 @@ pub const VirtualMachine = struct {
         }
     }
 
-    pub fn printErrorInstance(this: *VirtualMachine, error_instance: JSValue, exception_list: ?*ExceptionList, comptime Writer: type, writer: Writer, comptime allow_ansi_color: bool, comptime allow_side_effects: bool) !void {
+    pub fn printErrorInstance(this: *VirtualMachine, error_instance: JSValue, exception_list: ?*ExceptionList, comptime Writer: type, writer: Writer, comptime allow_ansi_color: bool, comptime allow_side_effects: bool) anyerror!void {
         var exception_holder = ZigException.Holder.init();
         var exception = exception_holder.zigException();
         defer exception_holder.deinit();
         this.remapZigException(exception, error_instance, exception_list);
+        var prev_had_errors = this.had_errors;
         this.had_errors = true;
+        defer this.had_errors = prev_had_errors;
 
         if (allow_side_effects) {
             defer if (this.on_exception) |cb| {
@@ -2807,27 +2819,41 @@ pub const VirtualMachine = struct {
             "info",
             "pkg",
             "errors",
+            "cause",
         };
+
+        // This is usually unsafe to do, but we are protecting them each time first
+        var errors_to_append = std.ArrayList(JSC.JSValue).init(this.allocator);
+        defer {
+            for (errors_to_append.items) |err| {
+                err.unprotect();
+            }
+            errors_to_append.deinit();
+        }
 
         if (error_instance != .zero and error_instance.isCell() and error_instance.jsType().canGet()) {
             inline for (extra_fields) |field| {
-                if (error_instance.get(this.global, field)) |value| {
-                    if (!value.isEmptyOrUndefinedOrNull()) {
-                        const kind = value.jsType();
-                        if (kind.isStringLike()) {
-                            if (value.toStringOrNull(this.global)) |str| {
-                                var zig_str = str.toSlice(this.global, bun.default_allocator);
-                                defer zig_str.deinit();
-                                try writer.print(comptime Output.prettyFmt(" {s}<d>: <r>\"{s}\"<r>\n", allow_ansi_color), .{ field, zig_str.slice() });
-                                add_extra_line = true;
-                            }
-                        } else if (kind.isObject() or kind.isArray()) {
-                            var bun_str = bun.String.empty;
-                            defer bun_str.deref();
-                            value.jsonStringify(this.global, 2, &bun_str); //2
-                            try writer.print(comptime Output.prettyFmt(" {s}<d>: <r>{any}<r>\n", allow_ansi_color), .{ field, bun_str });
+                if (error_instance.getTruthy(this.global, field)) |value| {
+                    const kind = value.jsType();
+                    if (kind.isStringLike()) {
+                        if (value.toStringOrNull(this.global)) |str| {
+                            var zig_str = str.toSlice(this.global, bun.default_allocator);
+                            defer zig_str.deinit();
+                            try writer.print(comptime Output.prettyFmt(" {s}<d>: <r>\"{s}\"<r>\n", allow_ansi_color), .{ field, zig_str.slice() });
                             add_extra_line = true;
                         }
+                    } else if (kind == .ErrorInstance and
+                        // avoid infinite recursion
+                        !prev_had_errors)
+                    {
+                        value.protect();
+                        try errors_to_append.append(value);
+                    } else if (kind.isObject() or kind.isArray()) {
+                        var bun_str = bun.String.empty;
+                        defer bun_str.deref();
+                        value.jsonStringify(this.global, 2, &bun_str); //2
+                        try writer.print(comptime Output.prettyFmt(" {s}<d>: <r>{any}<r>\n", allow_ansi_color), .{ field, bun_str });
+                        add_extra_line = true;
                     }
                 }
             }
@@ -2878,6 +2904,11 @@ pub const VirtualMachine = struct {
         if (add_extra_line) try writer.writeAll("\n");
 
         try printStackTrace(@TypeOf(writer), writer, exception.stack, allow_ansi_color);
+
+        for (errors_to_append.items) |err| {
+            try writer.writeAll("\n");
+            try this.printErrorInstance(err, exception_list, Writer, writer, allow_ansi_color, allow_side_effects);
+        }
     }
 
     fn printErrorNameAndMessage(_: *VirtualMachine, name: String, message: String, comptime Writer: type, writer: Writer, comptime allow_ansi_color: bool) !void {

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -7265,7 +7265,7 @@ pub const Macro = struct {
                     this.source,
                     this.caller.loc,
                     this.allocator,
-                    "cannot coerce {s} to Bun's AST. Please return a valid macro using the JSX syntax",
+                    "cannot coerce {s} to Bun's AST. Please return a simpler type",
                     .{@tagName(value.jsType())},
                 ) catch unreachable;
                 return error.MacroFailed;

--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -3126,7 +3126,6 @@ pub fn rangeOfIdentifier(source: *const Source, loc: logger.Loc) logger.Range {
     }
 
     if (isIdentifierStart(cursor.c) or cursor.c == '\\') {
-        defer r.len = @as(i32, @intCast(cursor.i));
         while (iter.next(&cursor)) {
             if (cursor.c == '\\') {
 
@@ -3144,9 +3143,12 @@ pub fn rangeOfIdentifier(source: *const Source, loc: logger.Loc) logger.Range {
                     }
                 }
             } else if (!isIdentifierContinue(cursor.c)) {
+                r.len = @as(i32, @intCast(cursor.i));
                 return r;
             }
         }
+
+        r.len = @as(i32, @intCast(cursor.i));
     }
 
     // const offset = @intCast(usize, loc.start);

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -192,8 +192,8 @@ pub const Location = struct {
                 .namespace = source.path.namespace,
                 .line = usize2Loc(data.line_count).start,
                 .column = usize2Loc(data.column_count).start,
-                .length = full_line.len,
-                .line_text = full_line,
+                .length = if (r.len > -1) @as(u32, @intCast(r.len)) else 1,
+                .line_text = std.mem.trimLeft(u8, full_line, "\n\r"),
                 .offset = @as(usize, @intCast(@max(r.loc.start, 0))),
             };
         } else {
@@ -273,7 +273,7 @@ pub const Data = struct {
             else => comptime Output.color_map.get("d").?,
         };
 
-        try to.writeAll("\n\n");
+        try to.writeAll("\n");
 
         if (comptime enable_ansi_colors) {
             try to.writeAll(color_name);
@@ -287,65 +287,88 @@ pub const Data = struct {
             try to.writeAll(message_color);
         }
 
-        try std.fmt.format(to, comptime Output.prettyFmt("{s}<r>\n", enable_ansi_colors), .{this.text});
+        try std.fmt.format(to, comptime Output.prettyFmt("{s}<r>", enable_ansi_colors), .{this.text});
 
         if (this.location) |location| {
             if (location.line_text) |line_text_| {
-                const line_text = std.mem.trimRight(u8, line_text_, "\r\n\t");
+                try to.writeAll("\n");
+                const location_in_line_text_original = @as(usize, @intCast(@max(location.column, 1) - 1));
 
-                const location_in_line_text = @as(u32, @intCast(@max(location.column, 1) - 1));
+                const line_text_right_trimmed = std.mem.trimRight(u8, line_text_, " \r\n\t");
+                const line_text = std.mem.trimLeft(u8, line_text_right_trimmed, "\n\r");
+                const line_text_left_trimmed_offset = line_text_right_trimmed.len -| line_text.len;
+                const location_in_line_text: usize = line_text_left_trimmed_offset + (location_in_line_text_original -| @as(usize, @intCast(line_text_.len -| line_text.len)));
+
                 const has_position = location.column > -1 and line_text.len > 0 and location_in_line_text < line_text.len;
+
+                var line_offset_for_second_line: usize = location_in_line_text;
 
                 if (has_position) {
                     if (comptime enable_ansi_colors) {
                         const is_colored = message_color.len > 0;
 
-                        const before_segment = line_text[0..location_in_line_text];
-
-                        try to.writeAll(before_segment);
-                        if (is_colored) {
-                            try to.writeAll(color_name);
+                        var before_segment = line_text[0..location_in_line_text];
+                        if (before_segment.len > 40) {
+                            before_segment = before_segment[before_segment.len - 40 ..];
                         }
 
+                        try to.writeAll(before_segment);
+
                         const rest_of_line = line_text[location_in_line_text..];
+                        line_offset_for_second_line = before_segment.len;
 
-                        if (rest_of_line.len > 0) {
-                            var end_of_segment: usize = 1;
+                        const end_of_segment: usize = brk: {
+                            if (rest_of_line.len == 0) break :brk 0;
+                            if (location.length > 0 and location.length < rest_of_line.len) {
+                                break :brk location.length;
+                            }
+
                             var iter = strings.CodepointIterator.initOffset(rest_of_line, 1);
-                            // extremely naive: we should really use IsIdentifierContinue || isIdentifierStart here
-
-                            // highlight until we reach the next matching
                             switch (line_text[location_in_line_text]) {
                                 '\'' => {
-                                    end_of_segment = iter.scanUntilQuotedValueOrEOF('\'');
+                                    break :brk iter.scanUntilQuotedValueOrEOF('\'');
                                 },
                                 '"' => {
-                                    end_of_segment = iter.scanUntilQuotedValueOrEOF('"');
+                                    break :brk iter.scanUntilQuotedValueOrEOF('"');
                                 },
                                 '<' => {
-                                    end_of_segment = iter.scanUntilQuotedValueOrEOF('>');
+                                    break :brk iter.scanUntilQuotedValueOrEOF('>');
                                 },
                                 '`' => {
-                                    end_of_segment = iter.scanUntilQuotedValueOrEOF('`');
+                                    break :brk iter.scanUntilQuotedValueOrEOF('`');
                                 },
                                 else => {},
                             }
-                            try to.writeAll(rest_of_line[0..end_of_segment]);
+
+                            break :brk 1;
+                        };
+
+                        var middle_segment: []const u8 = rest_of_line[0..end_of_segment];
+
+                        if (middle_segment.len > 0) {
+                            try to.writeAll(Output.color_map.get("b").?);
+                            try to.writeAll(middle_segment);
+
                             if (is_colored) {
                                 try to.writeAll("\x1b[0m");
                             }
 
-                            try to.writeAll(rest_of_line[end_of_segment..]);
+                            var after = rest_of_line[middle_segment.len..];
+                            if (after.len > 40) {
+                                after = after[0..40];
+                            }
+                            try to.writeAll(after);
                         } else if (is_colored) {
                             try to.writeAll("\x1b[0m");
                         }
                     } else {
+                        line_offset_for_second_line = location_in_line_text;
                         try to.writeAll(line_text);
                     }
 
                     try to.writeAll("\n");
 
-                    try to.writeByteNTimes(' ', location_in_line_text);
+                    try to.writeByteNTimes(' ', line_offset_for_second_line);
                     if (comptime enable_ansi_colors) {
                         const is_colored = message_color.len > 0;
                         if (is_colored) {
@@ -545,6 +568,9 @@ pub const Msg = struct {
         try msg.data.writeFormat(to, msg.kind, enable_ansi_colors, false);
 
         if (msg.notes) |notes| {
+            if (notes.len > 0)
+                try to.writeAll("\n");
+
             for (notes) |note| {
                 try note.writeFormat(to, .note, enable_ansi_colors, true);
             }
@@ -1245,7 +1271,7 @@ pub const Log = struct {
     }
 
     pub fn printForLogLevelWithEnableAnsiColors(self: *Log, to: anytype, comptime enable_ansi_colors: bool) !void {
-        var printed = false;
+        var needs_newline = false;
 
         if (self.warnings > 0 and self.errors > 0) {
             // Print warnings at the top
@@ -1253,12 +1279,12 @@ pub const Log = struct {
             // This is so if you're reading from a terminal
             // and there are a bunch of warnings
             // You can more easily see where the errors are
-
             for (self.msgs.items) |msg| {
                 if (msg.kind != .err) {
                     if (msg.kind.shouldPrint(self.level)) {
+                        if (needs_newline) _ = try to.write("\n");
                         try msg.writeFormat(to, enable_ansi_colors);
-                        printed = true;
+                        needs_newline = true;
                     }
                 }
             }
@@ -1266,21 +1292,23 @@ pub const Log = struct {
             for (self.msgs.items) |msg| {
                 if (msg.kind == .err) {
                     if (msg.kind.shouldPrint(self.level)) {
+                        if (needs_newline) _ = try to.write("\n");
                         try msg.writeFormat(to, enable_ansi_colors);
-                        printed = true;
+                        needs_newline = true;
                     }
                 }
             }
         } else {
             for (self.msgs.items) |msg| {
                 if (msg.kind.shouldPrint(self.level)) {
+                    if (needs_newline) _ = try to.write("\n");
                     try msg.writeFormat(to, enable_ansi_colors);
-                    printed = true;
+                    needs_newline = true;
                 }
             }
         }
 
-        if (printed) _ = try to.write("\n");
+        if (needs_newline) _ = try to.write("\n");
     }
 
     pub fn toZigException(this: *const Log, allocator: std.mem.Allocator) *js.ZigException.Holder {

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -28,11 +28,17 @@ function errorOrWarnParser(isError = true) {
       i = errorLineI + 1;
       const fileLineI = text.indexOf(" at ", errorLineI + message.length);
 
-      if (fileLineI === -1) return list;
-      const fileLineEnd = text.indexOf("\n", fileLineI + 1);
-      const fileLine = text.slice(fileLineI + "\n    at ".length, fileLineEnd);
-      i = fileLineEnd;
+      let fileLine = "";
+      if (fileLineI !== -1) {
+        const fileLineEnd = text.indexOf("\n", fileLineI + 1);
+        fileLine = text.slice(fileLineI + "\n    at ".length, fileLineEnd);
+        i = fileLineEnd;
+      }
       list.push([message, fileLine]);
+
+      if (i === -1) {
+        break;
+      }
     }
     return list;
   };

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -14,6 +14,33 @@ import * as esbuild from "esbuild";
 
 let currentFile: string | undefined;
 
+function errorOrWarnParser(isError = true) {
+  const prefix = isError ? "error: " : "warn: ";
+  return function (text: string) {
+    var i = 0;
+    var list = [];
+    while (i < text.length) {
+      let errorLineI = text.indexOf(prefix, i);
+      if (errorLineI === -1) {
+        return list;
+      }
+      const message = text.slice(errorLineI + prefix.length, text.indexOf("\n", errorLineI + 1));
+      i = errorLineI + 1;
+      const fileLineI = text.indexOf(" at ", errorLineI + message.length);
+
+      if (fileLineI === -1) return list;
+      const fileLineEnd = text.indexOf("\n", fileLineI + 1);
+      const fileLine = text.slice(fileLineI + "\n    at ".length, fileLineEnd);
+      i = fileLineEnd;
+      list.push([message, fileLine]);
+    }
+    return list;
+  };
+}
+
+const errorParser = errorOrWarnParser(true);
+const warnParser = errorOrWarnParser(false);
+
 type BunTestExports = typeof import("bun:test");
 export function testForFile(file: string): BunTestExports {
   if (file.startsWith("file://")) {
@@ -653,15 +680,16 @@ function expectBundled(
       if (!success) {
         if (!ESBUILD) {
           const errorText = stderr.toString("utf-8");
-          const errorRegex = /^error: (.*?)\n(?:.*?\n\s*\^\s*\n(.*?)\n)?/gms;
+
           var skip = false;
           if (errorText.includes("----- bun meta -----")) {
             skip = true;
           }
+
           const allErrors = skip
             ? []
-            : ([...errorText.matchAll(errorRegex)]
-                .map(([_str1, error, source]) => {
+            : (errorParser(errorText)
+                .map(([error, source]) => {
                   if (!source) {
                     if (error === "FileNotFound") {
                       return null;
@@ -674,7 +702,6 @@ function expectBundled(
                   return { error, file, line, col };
                 })
                 .filter(Boolean) as any[]);
-
           if (allErrors.length === 0) {
             console.log(errorText);
           }
@@ -746,8 +773,8 @@ function expectBundled(
 
       // Check for warnings
       if (!ESBUILD) {
-        const warningRegex = /^warn: (.*?)\n.*?\n\s*\^\s*\n(.*?)\n/gms;
-        const allWarnings = [...stderr!.toString("utf-8").matchAll(warningRegex)].map(([_str1, error, source]) => {
+        const warningText = stderr!.toString("utf-8");
+        const allWarnings = warnParser(warningText).map(([error, source]) => {
           const [_str2, fullFilename, line, col] = source.match(/bun-build-tests\/(.*):(\d+):(\d+)/)!;
           const file = fullFilename.slice(id.length + path.basename(outBase).length + 1);
           return { error, file, line, col };

--- a/test/cli/install/__snapshots__/bun-install.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-install.test.ts.snap
@@ -1,0 +1,56 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should report error on invalid format for package.json 1`] = `
+"bun install
+foo
+^
+error: Unexpected foo
+    at [dir]/package.json:1:1 0
+ParserError parsing package.json in "[dir]/"
+"
+`;
+
+exports[`should report error on invalid format for dependencies 1`] = `
+"bun install
+{"name":"foo","version":"0.0.1","dependencies":[]}
+                                ^
+error: dependencies expects a map of specifiers, e.g.
+"dependencies": {
+  "bun": "latest"
+}
+    at [dir]/package.json:1:33 32
+"
+`;
+
+exports[`should report error on invalid format for optionalDependencies 1`] = `
+"bun install
+{"name":"foo","version":"0.0.1","optionalDependencies":"bar"}
+                                ^
+error: optionalDependencies expects a map of specifiers, e.g.
+"optionalDependencies": {
+  "bun": "latest"
+}
+    at [dir]/package.json:1:33 32
+"
+`;
+
+exports[`should report error on invalid format for workspaces 1`] = `
+"bun install
+{"name":"foo","version":"0.0.1","workspaces":{"packages":{"bar":true}}}
+                                ^
+error: Workspaces expects an array of strings, e.g.
+"workspaces": [
+  "path/to/package"
+]
+    at [dir]/package.json:1:33 32
+"
+`;
+
+exports[`should report error on duplicated workspace packages 1`] = `
+"bun install
+{"name":"foo","version":"0.0.1","workspaces":["bar","baz"]}
+^
+error: Workspace name "moo" already exists
+    at [dir]/package.json:1:1 0
+"
+`;

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -4180,17 +4180,7 @@ it("should report error on invalid format for package.json", async () => {
   });
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err.replace(/^bun install v.+\n/, "bun install\n").split(/\r?\n/)).toEqual([
-    "bun install",
-    "",
-    "",
-    "error: Unexpected foo",
-    "foo",
-    "^",
-    `${package_dir}/package.json:1:1 0`,
-    `ParserError parsing package.json in "${package_dir}/"`,
-    "",
-  ]);
+  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir, "[dir]")).toMatchSnapshot();
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out).toEqual("");
@@ -4216,19 +4206,7 @@ it("should report error on invalid format for dependencies", async () => {
   });
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err.replace(/^bun install v.+\n/, "bun install\n").split(/\r?\n/)).toEqual([
-    "bun install",
-    "",
-    "",
-    "error: dependencies expects a map of specifiers, e.g.",
-    '"dependencies": {',
-    '  "bun": "latest"',
-    "}",
-    '{"name":"foo","version":"0.0.1","dependencies":[]}',
-    "                                ^",
-    `${package_dir}/package.json:1:33 32`,
-    "",
-  ]);
+  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir, "[dir]")).toMatchSnapshot();
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out).toEqual("");
@@ -4254,19 +4232,7 @@ it("should report error on invalid format for optionalDependencies", async () =>
   });
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err.replace(/^bun install v.+\n/, "bun install\n").split(/\r?\n/)).toEqual([
-    "bun install",
-    "",
-    "",
-    "error: optionalDependencies expects a map of specifiers, e.g.",
-    '"optionalDependencies": {',
-    '  "bun": "latest"',
-    "}",
-    '{"name":"foo","version":"0.0.1","optionalDependencies":"bar"}',
-    "                                ^",
-    `${package_dir}/package.json:1:33 32`,
-    "",
-  ]);
+  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir, "[dir]")).toMatchSnapshot();
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out).toEqual("");
@@ -4294,19 +4260,7 @@ it("should report error on invalid format for workspaces", async () => {
   });
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err.replace(/^bun install v.+\n/, "bun install\n").split(/\r?\n/)).toEqual([
-    "bun install",
-    "",
-    "",
-    "error: Workspaces expects an array of strings, e.g.",
-    '"workspaces": [',
-    '  "path/to/package"',
-    "]",
-    '{"name":"foo","version":"0.0.1","workspaces":{"packages":{"bar":true}}}',
-    "                                ^",
-    `${package_dir}/package.json:1:33 32`,
-    "",
-  ]);
+  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir, "[dir]")).toMatchSnapshot();
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out).toEqual("");
@@ -4348,17 +4302,7 @@ it("should report error on duplicated workspace packages", async () => {
   });
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err.replace(/^bun install v.+\n/, "bun install\n").split(/\r?\n/)).toEqual([
-    "bun install",
-    "",
-    "",
-    'error: Workspace name "moo" already exists',
-    '{"name":"foo","version":"0.0.1","workspaces":["bar","baz"]}',
-    // we don't have a name location anymore
-    "^",
-    `${package_dir}/package.json:1:1 0`,
-    "",
-  ]);
+  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir, "[dir]")).toMatchSnapshot();
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out).toEqual("");

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,6 +1,6 @@
 import { file, listen, Socket, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it, describe, test } from "bun:test";
-import { bunExe, bunEnv as env, withoutMimalloc } from "harness";
+import { bunExe, bunEnv as env, ignoreMimallocWarning, withoutMimalloc } from "harness";
 import { access, mkdir, readlink, realpath, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import {
@@ -21,19 +21,7 @@ afterAll(dummyAfterAll);
 beforeEach(dummyBeforeEach);
 afterEach(dummyAfterEach);
 
-// TODO: fix the underlying cause of this
-const origResponseText = Response.prototype.text;
-beforeAll(() => {
-  // @ts-expect-error
-  Response.prototype.text = async function () {
-    return withoutMimalloc(await origResponseText.call(this));
-  };
-});
-
-afterAll(() => {
-  // @ts-expect-error
-  Response.prototype.text = origResponseText;
-});
+ignoreMimallocWarning({ beforeAll, afterAll });
 
 describe("chooses", () => {
   async function runTest(latest: string, range: string, chosen = "0.0.5") {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -15,7 +15,7 @@ export function bunExe() {
 }
 
 export function withoutMimalloc(input: string) {
-  return input.replaceAll(/^mimalloc warning: .*$/gm, "");
+  return input.replaceAll(/^mimalloc warning:.*$/gm, "");
 }
 
 export function nodeExe(): string | null {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -14,6 +14,10 @@ export function bunExe() {
   return process.execPath;
 }
 
+export function withoutMimalloc(input: string) {
+  return input.replaceAll(/^mimalloc: .*$/gm, "");
+}
+
 export function nodeExe(): string | null {
   return which("node") || null;
 }

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -15,7 +15,7 @@ export function bunExe() {
 }
 
 export function withoutMimalloc(input: string) {
-  return input.replaceAll(/^mimalloc: .*$/gm, "");
+  return input.replaceAll(/^mimalloc warning: .*$/gm, "");
 }
 
 export function nodeExe(): string | null {
@@ -158,4 +158,25 @@ export function bunRunAsScript(dir: string, script: string, env?: Record<string,
     stdout: result.stdout.toString("utf8").trim(),
     stderr: result.stderr.toString("utf8").trim(),
   };
+}
+
+/**
+ * Ignore mimalloc warnings in development
+ */
+export function ignoreMimallocWarning({
+  beforeAll,
+  afterAll,
+}: Pick<typeof import("bun:test"), "beforeAll"> & Pick<typeof import("bun:test"), "afterAll">) {
+  const origResponseText = Response.prototype.text;
+  beforeAll(() => {
+    // @ts-expect-error
+    Response.prototype.text = async function () {
+      return withoutMimalloc(await origResponseText.call(this));
+    };
+  });
+
+  afterAll(() => {
+    // @ts-expect-error
+    Response.prototype.text = origResponseText;
+  });
 }

--- a/test/js/bun/util/__snapshots__/inspect-error.test.js.snap
+++ b/test/js/bun/util/__snapshots__/inspect-error.test.js.snap
@@ -1,0 +1,46 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`error.cause 1`] = `
+"1 | import { test, expect } from "bun:test";
+2 | 
+3 | test("error.cause", () => {
+4 |   const err = new Error("error 1");
+5 |   const err2 = new Error("error 2", { cause: err });
+                   ^
+error: error 2
+      at [dir]/inspect-error.test.js:5:15
+
+1 | import { test, expect } from "bun:test";
+2 | 
+3 | test("error.cause", () => {
+4 |   const err = new Error("error 1");
+                  ^
+error: error 1
+      at [dir]/inspect-error.test.js:4:14
+"
+`;
+
+exports[`Error 1`] = `
+" 5 |   const err2 = new Error("error 2", { cause: err });
+ 6 |   expect(Bun.inspect(err2).replaceAll(import.meta.dir, "[dir]")).toMatchSnapshot();
+ 7 | });
+ 8 | 
+ 9 | test("Error", () => {
+10 |   const err = new Error("my message");
+                  ^
+error: my message
+      at [dir]/inspect-error.test.js:10:14
+"
+`;
+
+exports[`BuildMessage 1`] = `
+"const duplicateConstDecl = 456;
+      ^
+error: "duplicateConstDecl" has already been declared
+    at [dir]/inspect-error-fixture-bad.js:2:7 38
+
+const duplicateConstDecl = 123;
+      ^
+note: "duplicateConstDecl" was originally declared here
+   at [dir]/inspect-error-fixture-bad.js:1:7 6"
+`;

--- a/test/js/bun/util/inspect-error-fixture-bad.js
+++ b/test/js/bun/util/inspect-error-fixture-bad.js
@@ -1,0 +1,2 @@
+const duplicateConstDecl = 123;
+const duplicateConstDecl = 456;

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test";
+
+test("error.cause", () => {
+  const err = new Error("error 1");
+  const err2 = new Error("error 2", { cause: err });
+  expect(Bun.inspect(err2).replaceAll(import.meta.dir, "[dir]")).toMatchSnapshot();
+});
+
+test("Error", () => {
+  const err = new Error("my message");
+  expect(Bun.inspect(err).replaceAll(import.meta.dir, "[dir]")).toMatchSnapshot();
+});
+
+test("BuildMessage", async () => {
+  try {
+    await import("./inspect-error-fixture-bad.js");
+    expect.unreachable();
+  } catch (e) {
+    expect(Bun.inspect(e).replaceAll(import.meta.dir, "[dir]")).toMatchSnapshot();
+  }
+});

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -291,5 +291,5 @@ test("cp with missing callback throws", () => {
   expect(() => {
     // @ts-expect-error
     fs.cp("a", "b" as any);
-  }).toThrow(/callback/);
+  }).toThrow(/Callback/);
 });

--- a/test/regression/issue/03830.test.ts
+++ b/test/regression/issue/03830.test.ts
@@ -2,7 +2,7 @@
 
 import { it, expect } from "bun:test";
 import { bunEnv, bunExe } from "harness";
-import { mkdirSync, rmSync, writeFileSync, readFileSync, mkdtempSync } from "fs";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, mkdtempSync, realpathSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -10,7 +10,7 @@ it("macros should not lead to seg faults under any given input", async () => {
   // this test code follows the same structure as and
   // is based on the code for testing issue 4893
 
-  const testDir = mkdtempSync(join(tmpdir(), "issue3830-"));
+  let testDir = mkdtempSync(join(tmpdir(), "issue3830-"));
 
   // Clean up from prior runs if necessary
   rmSync(testDir, { recursive: true, force: true });
@@ -19,6 +19,7 @@ it("macros should not lead to seg faults under any given input", async () => {
   mkdirSync(testDir, { recursive: true });
   writeFileSync(join(testDir, "macro.ts"), "export function fn(str) { return str; }");
   writeFileSync(join(testDir, "index.ts"), "import { fn } from './macro' assert { type: 'macro' };\nfn(`©${''}`);");
+  testDir = realpathSync(testDir);
 
   const { stderr, exitCode } = Bun.spawnSync({
     cmd: [bunExe(), "build", "--minify", join(testDir, "index.ts")],
@@ -26,7 +27,6 @@ it("macros should not lead to seg faults under any given input", async () => {
     stderr: "pipe",
   });
 
-  expect(stderr.toString().trim()).toStartWith('error: "Cannot convert argument type to JS');
-  expect(exitCode).not.toBe(0);
+  expect(stderr.toString().trim().replaceAll(testDir, "[dir]")).toMatchSnapshot();
   expect(exitCode).toBe(1);
 });


### PR DESCRIPTION
### What does this PR do?

Two things:


#### Formatting tweaks

- Removes extra newlines
- Fixes `logger.rangeOfIdentifier` to include the complete length of the identifier (usage of `defer` broke that)
- Making the selected portion colored is too intense IMO for longer lines

#####  Before:
<img width="587" alt="image" src="https://github.com/oven-sh/bun/assets/709451/f1a39ea6-3abf-44b9-8803-9a42038ccac3">


#####  After:
<img width="600" alt="image" src="https://github.com/oven-sh/bun/assets/709451/1fdca927-afcb-4d3c-8693-1369ff47a5b6">


#### Build-time error for unsupported ESM<>CommonJS features 

You can use `require` and `import` in the same file in Bun, but you cannot use `import` and `module.exports` in the same file. You also cannot use `exports`, `module`, `with` or top-level return.

Currently, we rely on JavaScriptCore's errors for these things, but they're really hard to read and don't give us an easy way to show a stack trace pointing to which line exactly caused it. 

This moves those errors to build-time.

#####  Input:
```js
import "abc";

with (Bun) {
  write("/tmp/file.txt", escapeHTML(file("/tmp/file.html").text()));
  console.log({
    contents: file("/tmp/file.txt").text(),
  });
}
```

#####  Before (note how it says "import call"):

<img width="607" alt="image" src="https://github.com/oven-sh/bun/assets/709451/a1228119-2360-4bef-b1e9-ca37ac0c6a6d">


#####  After:
<img width="477" alt="image" src="https://github.com/oven-sh/bun/assets/709451/579a6330-2c62-4745-aa01-b7e9675ac532">

##### Input:
```js
import _ from "lodash";
module.exports = _.constant(42);
```

##### Before:
<img width="596" alt="image" src="https://github.com/oven-sh/bun/assets/709451/fdb26e11-58bc-427e-8f9a-0a86de36831e">

##### After:
<img width="456" alt="image" src="https://github.com/oven-sh/bun/assets/709451/edafc3d8-457c-44a2-9c68-186c7952ac71">






### How did you verify your code works?

I wrote a few tests