### PR TITLE
 Fix IncomingMessage class to properly handle pending chunks

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -696,7 +696,6 @@ var typeSymbol = Symbol("type");
 var reqSymbol = Symbol("req");
 var pendingChunksSymbol = Symbol("pendingChunks");
 var bodyReaderSymbol = Symbol("bodyReader");
-var bodyStreamSymbol = Symbol("bodyStream");
 var noBodySymbol = Symbol("noBody");
 var abortedSymbol = Symbol("aborted");
 function IncomingMessage(req, defaultIncomingOpts) {
@@ -735,7 +734,6 @@ function IncomingMessage(req, defaultIncomingOpts) {
 
   this[pendingChunksSymbol] = [];
   this[bodyReaderSymbol] = undefined;
-  this[bodyStreamSymbol] = this[noBodySymbol] ? undefined : this[reqSymbol].body!;
   this.complete = !!this[noBodySymbol];
 }
 
@@ -859,11 +857,10 @@ function handleDone(self) {
 function abort(self) {
   if (self[abortedSymbol]) return;
   self[abortedSymbol] = true;
-  var bodyStream = self[bodyStreamSymbol];
-  if (!bodyStream) return;
-  bodyStream.cancel();
+  var bodyReader = self[bodyReaderSymbol];
+  if (!bodyReader) return;
+  bodyReader.cancel();
   self.complete = true;
-  self[bodyStreamSymbol] = undefined;
   self[bodyReaderSymbol] = undefined;
   self.push(null);
 }

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -171,6 +171,14 @@ describe("node:http", () => {
   });
 
   describe("request", () => {
+    class Collector extends Writable {
+      public bufferedBytes: Uint8Array[] = [];
+
+      _write(chunk: Uint8Array, encoding: string, callback: () => void) {
+        this.bufferedBytes.push(chunk);
+        callback();
+      }
+    }
     function runTest(done: Function, callback: (server: Server, port: number, done: (err?: Error) => void) => void) {
       var timer;
       var server = createServer((req, res) => {
@@ -759,6 +767,119 @@ describe("node:http", () => {
           done(err);
         });
         req.end();
+      });
+    });
+    it(`should allow piping multiple chunks to collector stream`, done => {
+      const chunkSize = 1024 * 16; // 16 kb
+      const testData = Buffer.from(Array(chunkSize * 5).fill("a"));
+
+      const createStream = () =>
+        new Response(
+          new ReadableStream({
+            async start(controller) {
+              const chunksNum = Math.ceil(testData.length / chunkSize);
+
+              for (let i = 0; i < chunksNum; i++) {
+                const start = i * chunkSize;
+                controller.enqueue(testData.subarray(start, start + chunkSize));
+              }
+
+              controller.close();
+            },
+          }),
+          {
+            headers: {
+              "content-length": testData.length.toString(),
+            },
+          },
+        );
+
+      const collector = new Collector();
+      const response = new IncomingMessage(createStream(), { type: "response" });
+      response.pipe(collector);
+      response.on("error", err => {
+        collector.end();
+        done(err);
+      });
+      collector.on("error", done);
+      collector.on("finish", () => {
+        const result = Buffer.concat(collector.bufferedBytes).toString("utf8");
+
+        expect(result).toBeDefined();
+        expect(result.length).toEqual(chunkSize * 5);
+        done();
+      });
+    });
+    it(`should allow piping single chunk to collector stream`, done => {
+      const chunkSize = 1000 * 16; // 16 kb
+      const testData = Buffer.from(Array(chunkSize * 1).fill("a"));
+
+      const createStream = () =>
+        new Response(
+          new ReadableStream({
+            async start(controller) {
+              const chunksNum = Math.ceil(testData.length / chunkSize);
+
+              for (let i = 0; i < chunksNum; i++) {
+                const start = i * chunkSize;
+                controller.enqueue(testData.subarray(start, start + chunkSize));
+              }
+
+              controller.close();
+            },
+          }),
+          {
+            headers: {
+              "content-length": testData.length.toString(),
+            },
+          },
+        );
+
+      const collector = new Collector();
+      const response = new IncomingMessage(createStream(), { type: "response" });
+      response.pipe(collector);
+      response.on("error", err => {
+        collector.end();
+        done(err);
+      });
+      collector.on("error", done);
+      collector.on("finish", () => {
+        const result = Buffer.concat(collector.bufferedBytes).toString("utf8");
+
+        expect(result).toBeDefined();
+        expect(result.length).toEqual(chunkSize * 1);
+        done();
+      });
+    });
+    it(`should allow piping no chunks to collector stream`, done => {
+      const createStream = () =>
+        new Response(
+          new ReadableStream({
+            async start(controller) {
+              controller.close();
+            },
+          }),
+          {
+            headers: {
+              "content-length": "0",
+            },
+          },
+        );
+
+      const collector = new Collector();
+      const response = new IncomingMessage(createStream(), { type: "response" });
+      response.pipe(collector);
+      response.on("error", err => {
+        collector.end();
+        done(err);
+      });
+      collector.on("error", done);
+      collector.on("finish", () => {
+        const result = Buffer.concat(collector.bufferedBytes).toString("utf8");
+
+        expect(result).toBeDefined();
+        expect(result.length).toEqual(0);
+        done();
       });
     });
   });
@@ -1619,61 +1740,6 @@ it("IncomingMessage with a RequestLike object", () => {
     "header-63",
     "value-63",
   ]);
-});
-
-describe("IncomingMessage", () => {
-  class Collector extends Writable {
-    public bufferedBytes: Uint8Array[] = [];
-
-    _write(chunk: Uint8Array, encoding: string, callback: () => void) {
-      this.bufferedBytes.push(chunk);
-      callback();
-    }
-  }
-
-  const chunkSize = 1024 * 16; // 16 kb
-  const bigData = Buffer.from(Array(chunkSize * 5).fill("a"));
-
-  const createStream = () =>
-    new Response(
-      new ReadableStream({
-        async start(controller) {
-          const chunksNum = Math.ceil(bigData.length / chunkSize);
-
-          for (let i = 0; i < chunksNum; i++) {
-            const start = i * chunkSize;
-            controller.enqueue(bigData.subarray(start, start + chunkSize));
-          }
-
-          controller.close();
-        },
-      }),
-      {
-        headers: {
-          "content-length": bigData.length.toString(),
-        },
-      },
-    );
-
-  it(`.pipe()`, async () => {
-    const data = await new Promise<string>((resolve, reject) => {
-      const collector = new Collector();
-      const response = new IncomingMessage(createStream());
-      response.pipe(collector);
-      response.on("error", err => {
-        collector.end();
-        reject(err);
-      });
-      collector.on("error", reject);
-      collector.on("finish", () => {
-        const result = Buffer.concat(collector.bufferedBytes).toString("utf8");
-        resolve(result);
-      });
-    });
-
-    expect(data).toBeDefined();
-    expect(data.length).toEqual(chunkSize * 5);
-  });
 });
 
 it("#6892", () => {


### PR DESCRIPTION
### What does this PR do?

There is an issue with IncomingMessage class, where if you `.pipe()` its result to other stream, it hangs indefinitely when number of chunks is > 3.
I have added a test ("should allow piping multiple chunks to collector stream") in `node-http.test.ts` which demonstrates this issue. Other tests have been added for safety, just to make sure other behaviour still works.

This pattern is used in AWS SDK v3, or in other words, it fixes a bug where AWS SDK v3 requests occasionally hang indefinitely, where response is chunked a certain way. In my tests it affects less than 0.1% of all requests, buuut nonetheless, its extremely annoying bug.

Closed previous PR by accident, sorry for spam

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [x] I included a test for the new code, or an existing test covers it