### PR TITLE
chore: simplify url parsing code in debugger

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -270,17 +270,17 @@ function parseUrl(url: string): URL {
       return new URL(randomId(), `ws://${defaultHostname}:${defaultPort}/`);
     } else if (url.startsWith("/")) {
       return new URL(url, `ws://${defaultHostname}:${defaultPort}/`);
-    } else if (/^[a-z+]+:\/\//i.test(url)) {
-      return new URL(url);
     } else if (/^\d+$/.test(url)) {
       return new URL(randomId(), `ws://${defaultHostname}:${url}/`);
-    } else if (!url.includes("/") && url.includes(":")) {
-      return new URL(randomId(), `ws://${url}/`);
-    } else if (!url.includes(":")) {
-      const [hostname, pathname] = url.split("/", 2);
-      return new URL(`ws://${hostname}:${defaultPort}/${pathname}`);
     } else {
-      return new URL(randomId(), `ws://${url}`);
+      const base = new URL(`ws://${url}`);
+      if (base.port === "") {
+        base.port = defaultPort.toString();
+      }
+      if (base.pathname !== "/") {
+        return base;
+      }
+      return new URL(randomId(), base);
     }
   } catch {
     throw new TypeError(`Invalid hostname or URL: '${url}'`);

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -264,7 +264,7 @@ function bufferedWriter(writer: Writer): Writer {
 const defaultHostname = "localhost";
 const defaultPort = 6499;
 
-function parseUrl(url: string): URL {
+export function parseUrl(url: string): URL {
   try {
     if (!url) {
       return new URL(randomId(), `ws://${defaultHostname}:${defaultPort}/`);
@@ -287,7 +287,7 @@ function parseUrl(url: string): URL {
   }
 }
 
-function randomId() {
+export function randomId() {
   return Math.random().toString(36).slice(2);
 }
 

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -264,7 +264,7 @@ function bufferedWriter(writer: Writer): Writer {
 const defaultHostname = "localhost";
 const defaultPort = 6499;
 
-export function parseUrl(url: string): URL {
+function parseUrl(url: string): URL {
   try {
     if (!url) {
       return new URL(randomId(), `ws://${defaultHostname}:${defaultPort}/`);
@@ -287,7 +287,7 @@ export function parseUrl(url: string): URL {
   }
 }
 
-export function randomId() {
+function randomId() {
   return Math.random().toString(36).slice(2);
 }
 

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -25,7 +25,7 @@ export default function (
     if (protocol.includes("ws")) {
       Bun.write(Bun.stderr, `Inspect in browser:\n  ${link(`https://debug.bun.sh/#${host}${pathname}`)}\n`);
     }
-    Bun.write(Bun.stderr, dim("--------------------- Bun Inspector ---------------------")+ reset() + "\n");
+    Bun.write(Bun.stderr, dim("--------------------- Bun Inspector ---------------------") + reset() + "\n");
   }
 
   const unix = process.env["BUN_INSPECT_NOTIFY"];
@@ -273,7 +273,7 @@ function parseUrl(url: string): URL {
     } else if (/^\d+$/.test(url)) {
       return new URL(randomId(), `ws://${defaultHostname}:${url}/`);
     } else {
-      const base = new URL(`ws://${url}`);
+      const base = !url.startsWith("ws://") ? new URL(`ws://${url}`) : new URL(url);
       if (base.port === "") {
         base.port = defaultPort.toString();
       }

--- a/test/cli/debug/debugger.test.ts
+++ b/test/cli/debug/debugger.test.ts
@@ -1,31 +1,61 @@
-import * as path from "node:path";
-import { expect, it, mock } from "bun:test";
+import * as os from "os";
+import { join } from "path";
+import { mkdir, writeFile, rm } from "fs/promises";
+import { bunEnv, bunExe } from "harness";
+import { tmpdir } from "os";
+import { expect, it } from "bun:test";
 
-it("test parseUrl", () => {
-  const modulePath = path.join(import.meta.path, "../../../../src/js/internal/debugger.ts");
-  const debuggerModule = require(modulePath);
-  mock.module(modulePath, () => ({
-    ...debuggerModule,
-    randomId: () => "random",
-  }));
-  const parseUrl = debuggerModule.parseUrl;
+it.each([
+  ["", "ws://localhost:6499/random"],
+  ["9898", "ws://localhost:9898/random"],
+  ["/prefix", "ws://localhost:6499/prefix"],
+  ["localhost", "ws://localhost:6499/random"],
+  ["localhost:9898", "ws://localhost:9898/random"],
+  ["localhost:9898/prefix", "ws://localhost:9898/prefix"],
+  ["localhost:9898/", "ws://localhost:9898/random"],
+  ["0.0.0.0", "ws://0.0.0.0:6499/random"],
+  ["127.0.0.1:9898", "ws://127.0.0.1:9898/random"],
+  ["127.0.0.1:9898/prefix", "ws://127.0.0.1:9898/prefix"],
+  ["127.0.0.1:9898/", "ws://127.0.0.1:9898/random"],
+  ["[::1]", "ws://[::1]:6499/random"],
+  ["[::1]:9898", "ws://[::1]:9898/random"],
+  ["[::1]:9898/prefix", "ws://[::1]:9898/prefix"],
+  ["[::1]:9898/", "ws://[::1]:9898/random"],
+])("test inspect=%s", async (url, expected) => {
+  const testDir = join(tmpdir(), "bun-debugger-test-" + Math.random().toString(36).slice(2));
+  await mkdir(testDir);
+  await writeFile(join(testDir, "index.ts"), "setTimeout(() => {}, 200)");
 
-  expect(parseUrl("")).toStrictEqual(new URL("ws://localhost:6499/random"));
-  expect(parseUrl("9898")).toStrictEqual(new URL("ws://localhost:9898/random"));
-  expect(parseUrl("/prefix")).toStrictEqual(new URL("ws://localhost:6499/prefix"));
+  const { stdout, stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "run", `--inspect=${url}`, "index.ts"],
+    cwd: testDir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  try {
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeDefined();
+    expect(stdout).toBeDefined();
+    expect(stderr.toString("utf-8")).toBe("");
 
-  expect(parseUrl("localhost")).toStrictEqual(new URL("ws://localhost:6499/random"));
-  expect(parseUrl("localhost:9898")).toStrictEqual(new URL("ws://localhost:9898/random"));
-  expect(parseUrl("localhost:9898/prefix")).toStrictEqual(new URL("ws://localhost:9898/prefix"));
-  expect(parseUrl("localhost:9898/")).toStrictEqual(new URL("ws://localhost:9898/random"));
-
-  expect(parseUrl("0.0.0.0")).toStrictEqual(new URL("ws://0.0.0.0:6499/random"));
-  expect(parseUrl("127.0.0.1:9898")).toStrictEqual(new URL("ws://127.0.0.1:9898/random"));
-  expect(parseUrl("127.0.0.1:9898/prefix")).toStrictEqual(new URL("ws://127.0.0.1:9898/prefix"));
-  expect(parseUrl("127.0.0.1:9898/")).toStrictEqual(new URL("ws://127.0.0.1:9898/random"));
-
-  expect(parseUrl("[::1]")).toStrictEqual(new URL("ws://[::1]:6499/random"));
-  expect(parseUrl("[::1]:9898")).toStrictEqual(new URL("ws://[::1]:9898/random"));
-  expect(parseUrl("[::1]:9898/prefix")).toStrictEqual(new URL("ws://[::1]:9898/prefix"));
-  expect(parseUrl("[::1]:9898/")).toStrictEqual(new URL("ws://[::1]:9898/random"));
+    const line = stdout
+      .toString("utf-8")
+      .split(os.EOL)
+      .map(line => line.trim())
+      .find(line => line.startsWith("ws://"));
+    expect(line).toBeDefined();
+    if (expected.endsWith("random")) {
+      const realURL = new URL(line!);
+      const expectedURL = new URL(expected);
+      expect(realURL.hostname).toStrictEqual(expectedURL.hostname);
+      expect(realURL.port).toStrictEqual(expectedURL.port);
+      expect(realURL.pathname.length).not.toBe(0);
+    } else {
+      expect(line).toStrictEqual(expected);
+    }
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
+  }
 });

--- a/test/cli/debug/debugger.test.ts
+++ b/test/cli/debug/debugger.test.ts
@@ -1,0 +1,31 @@
+import * as path from "node:path";
+import { expect, it, mock } from "bun:test";
+
+it("test parseUrl", () => {
+  const modulePath = path.join(import.meta.path, "../../../../src/js/internal/debugger.ts");
+  const debuggerModule = require(modulePath);
+  mock.module(modulePath, () => ({
+    ...debuggerModule,
+    randomId: () => "random",
+  }));
+  const parseUrl = debuggerModule.parseUrl;
+
+  expect(parseUrl("")).toStrictEqual(new URL("ws://localhost:6499/random"));
+  expect(parseUrl("9898")).toStrictEqual(new URL("ws://localhost:9898/random"));
+  expect(parseUrl("/prefix")).toStrictEqual(new URL("ws://localhost:6499/prefix"));
+
+  expect(parseUrl("localhost")).toStrictEqual(new URL("ws://localhost:6499/random"));
+  expect(parseUrl("localhost:9898")).toStrictEqual(new URL("ws://localhost:9898/random"));
+  expect(parseUrl("localhost:9898/prefix")).toStrictEqual(new URL("ws://localhost:9898/prefix"));
+  expect(parseUrl("localhost:9898/")).toStrictEqual(new URL("ws://localhost:9898/random"));
+
+  expect(parseUrl("0.0.0.0")).toStrictEqual(new URL("ws://0.0.0.0:6499/random"));
+  expect(parseUrl("127.0.0.1:9898")).toStrictEqual(new URL("ws://127.0.0.1:9898/random"));
+  expect(parseUrl("127.0.0.1:9898/prefix")).toStrictEqual(new URL("ws://127.0.0.1:9898/prefix"));
+  expect(parseUrl("127.0.0.1:9898/")).toStrictEqual(new URL("ws://127.0.0.1:9898/random"));
+
+  expect(parseUrl("[::1]")).toStrictEqual(new URL("ws://[::1]:6499/random"));
+  expect(parseUrl("[::1]:9898")).toStrictEqual(new URL("ws://[::1]:9898/random"));
+  expect(parseUrl("[::1]:9898/prefix")).toStrictEqual(new URL("ws://[::1]:9898/prefix"));
+  expect(parseUrl("[::1]:9898/")).toStrictEqual(new URL("ws://[::1]:9898/random"));
+});

--- a/test/cli/debug/debugger.test.ts
+++ b/test/cli/debug/debugger.test.ts
@@ -13,10 +13,12 @@ it.each([
   ["localhost:9898", "ws://localhost:9898/random"],
   ["localhost:9898/prefix", "ws://localhost:9898/prefix"],
   ["localhost:9898/", "ws://localhost:9898/random"],
+  ["ws://localhost:9898/", "ws://localhost:9898/random"],
   ["0.0.0.0", "ws://0.0.0.0:6499/random"],
   ["127.0.0.1:9898", "ws://127.0.0.1:9898/random"],
   ["127.0.0.1:9898/prefix", "ws://127.0.0.1:9898/prefix"],
   ["127.0.0.1:9898/", "ws://127.0.0.1:9898/random"],
+  ["ws://127.0.0.1:9898/", "ws://127.0.0.1:9898/random"],
   ["[::1]", "ws://[::1]:6499/random"],
   ["[::1]:9898", "ws://[::1]:9898/random"],
   ["[::1]:9898/prefix", "ws://[::1]:9898/prefix"],
@@ -38,9 +40,8 @@ it.each([
     expect(exitCode).toBe(0);
     expect(stderr).toBeDefined();
     expect(stdout).toBeDefined();
-    expect(stderr.toString("utf-8")).toBe("");
 
-    const line = stdout
+    const line = stderr
       .toString("utf-8")
       .split(os.EOL)
       .map(line => line.trim())


### PR DESCRIPTION
### What does this PR do?

Related to https://github.com/oven-sh/bun/issues/7225

Small fix for running `bun --inspect=0.0.0.0` and get `https://debug.bun.sh/#0.0.0.0:6499/undefined`


**Before**
```
>>​ bun --inspect=127.0.0.1:9898/prefix index.ts
Inspect in browser:
  https://debug.bun.sh/#127.0.0.1:9898/hnqrskhiqnj

>>​ bun --inspect=127.0.0.1 index.ts
Inspect in browser:
  https://debug.bun.sh/#127.0.0.1:6499/undefined

>>​ bun --inspect=127.0.0.1/prefix  index.ts
Inspect in browser:
  https://debug.bun.sh/#127.0.0.1:6499/prefix

```

**Now**

```
>>​  bun --inspect=127.0.0.1:9898/prefix index.ts
Inspect in browser:
  https://debug.bun.sh/#127.0.0.1:9898/prefix


>>​ bun --inspect=127.0.0.1 index.ts
Inspect in browser:
  https://debug.bun.sh/#127.0.0.1:6499/tlv5z50m13c

>>​ bun --inspect=127.0.0.1/prefix  index.ts
Inspect in browser:
  https://debug.bun.sh/#127.0.0.1:6499/prefix

```


- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes


### How did you verify your code works?
```TypeScript
import { expect, it } from "bun:test";

const defaultHostname = "localhost";
const defaultPort = 6499;

function parseUrl(url: string): URL {
  try {
    if (!url) {
      return new URL(randomId(), `ws://${defaultHostname}:${defaultPort}/`);
    } else if (url.startsWith("/")) {
      return new URL(url, `ws://${defaultHostname}:${defaultPort}/`);
    } else if (/^\d+$/.test(url)) {
      return new URL(randomId(), `ws://${defaultHostname}:${url}/`);
    } else {
      const base = new URL(`ws://${url}`);
      if (base.port === "") {
        base.port = defaultPort.toString();
      }
      if (base.pathname !== "/") {
        return base;
      }
      return new URL(randomId(), base);
    }
  } catch {
    throw new TypeError(`Invalid hostname or URL: '${url}'`);
  }
}

function randomId() {
  return "random";
}

it("simple test", () => {
  expect(parseUrl("")).toStrictEqual(new URL("ws://localhost:6499/random"));
  expect(parseUrl("9898")).toStrictEqual(new URL("ws://localhost:9898/random"));
  expect(parseUrl("/prefix")).toStrictEqual(new URL("ws://localhost:6499/prefix"));

  expect(parseUrl("localhost")).toStrictEqual(new URL("ws://localhost:6499/random"));
  expect(parseUrl("localhost:9898")).toStrictEqual(new URL("ws://localhost:9898/random"));
  expect(parseUrl("localhost:9898/prefix")).toStrictEqual(new URL("ws://localhost:9898/prefix"));
  expect(parseUrl("localhost:9898/")).toStrictEqual(new URL("ws://localhost:9898/random"));

  expect(parseUrl("0.0.0.0")).toStrictEqual(new URL("ws://0.0.0.0:6499/random"));
  expect(parseUrl("127.0.0.1:9898")).toStrictEqual(new URL("ws://127.0.0.1:9898/random"));
  expect(parseUrl("127.0.0.1:9898/prefix")).toStrictEqual(new URL("ws://127.0.0.1:9898/prefix"));
  expect(parseUrl("127.0.0.1:9898/")).toStrictEqual(new URL("ws://127.0.0.1:9898/random"));

  expect(parseUrl("[::1]")).toStrictEqual(new URL("ws://[::1]:6499/random"));
  expect(parseUrl("[::1]:9898")).toStrictEqual(new URL("ws://[::1]:9898/random"));
  expect(parseUrl("[::1]:9898/prefix")).toStrictEqual(new URL("ws://[::1]:9898/prefix"));
  expect(parseUrl("[::1]:9898/")).toStrictEqual(new URL("ws://[::1]:9898/random"));
});



```
