### PR TITLE
Enhancement: Exposing additional column details for SQLite.

### DIFF
--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -250,6 +250,10 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
         bool anyHoles = false;
         for (int i = 0; i < count; i++) {
             const char* name = sqlite3_column_name(stmt, i);
+            const char* column = sqlite3_column_origin_name(stmt, i);
+            const char* table = sqlite3_column_table_name(stmt, i);
+            const char* database = sqlite3_column_database_name(stmt, i);
+            const char* type = sqlite3_column_decltype(stmt, i);
 
             if (name == nullptr) {
                 anyHoles = true;
@@ -263,6 +267,10 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
             }
 
             columnNames->add(Identifier::fromString(vm, WTF::String::fromUTF8(name, len)));
+            columnNames->add(Identifier::fromString(vm, WTF::String::fromUTF8(column)));
+            columnNames->add(Identifier::fromString(vm, WTF::String::fromUTF8(table)));
+            columnNames->add(Identifier::fromString(vm, WTF::String::fromUTF8(database)));
+            columnNames->add(Identifier::fromString(vm, WTF::String::fromUTF8(type)));
         }
 
         if (LIKELY(!anyHoles)) {
@@ -296,6 +304,10 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
 
     for (int i = 0; i < count; i++) {
         const char* name = sqlite3_column_name(stmt, i);
+        const char* column = sqlite3_column_origin_name(stmt, i);
+        const char* table = sqlite3_column_table_name(stmt, i);
+        const char* database = sqlite3_column_database_name(stmt, i);
+        const char* type = sqlite3_column_decltype(stmt, i);
 
         if (name == nullptr)
             break;
@@ -327,6 +339,17 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
 
         object->putDirect(vm, key, primitive, 0);
         castedThis->columnNames->add(key);
+
+        // Add additional details
+        auto columnKey = Identifier::fromString(vm, WTF::String::fromUTF8(column));
+        auto tableKey = Identifier::fromString(vm, WTF::String::fromUTF8(table));
+        auto databaseKey = Identifier::fromString(vm, WTF::String::fromUTF8(database));
+        auto typeKey = Identifier::fromString(vm, WTF::String::fromUTF8(type));
+
+        object->putDirect(vm, columnKey, JSValue(jsString(vm, WTF::String::fromUTF8(column))), 0);
+        object->putDirect(vm, tableKey, JSValue(jsString(vm, WTF::String::fromUTF8(table))), 0);
+        object->putDirect(vm, databaseKey, JSValue(jsString(vm, WTF::String::fromUTF8(database))), 0);
+        object->putDirect(vm, typeKey, JSValue(jsString(vm, WTF::String::fromUTF8(type))), 0);
     }
     castedThis->_prototype.set(vm, castedThis, object);
 }


### PR DESCRIPTION
### What does this PR do?

- This commit improves the SQLite integration by adding support for retrieving additional column details such as column name, origin name, table name, database name, and type.

- **Issue**: #7134 

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
