### PR TITLE
fix(crypto) oneshot Sign and Verify

### DIFF
--- a/src/bun.js/bindings/KeyObject.cpp
+++ b/src/bun.js/bindings/KeyObject.cpp
@@ -1298,7 +1298,7 @@ static ExceptionOr<Vector<uint8_t>> KeyObject__GetBuffer(JSValue bufferArg)
 }
 JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
-   auto count = callFrame->argumentCount();
+    auto count = callFrame->argumentCount();
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -1316,7 +1316,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
     JSValue bufferArg = callFrame->uncheckedArgument(1);
 
     auto buffer = KeyObject__GetBuffer(bufferArg);
-    if(buffer.hasException()) {
+    if (buffer.hasException()) {
         JSC::throwTypeError(globalObject, scope, "expected Buffer or array-like object as second argument"_s);
         return JSC::JSValue::encode(JSC::JSValue {});
     }
@@ -1328,7 +1328,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
     auto hash = WebCore::CryptoAlgorithmIdentifier::SHA_256;
     auto algorithm = callFrame->argument(2);
     auto customHash = false;
-    if(!algorithm.isUndefinedOrNull() && !algorithm.isEmpty()) {  
+    if (!algorithm.isUndefinedOrNull() && !algorithm.isEmpty()) {
         customHash = true;
         if (!algorithm.isString()) {
             JSC::throwTypeError(globalObject, scope, "algorithm is expected to be a string"_s);
@@ -1340,175 +1340,177 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
             JSC::throwTypeError(globalObject, scope, "invalid algorithm"_s);
             return JSC::JSValue::encode(JSC::JSValue {});
         }
-            
-        switch (*identifier)
-        {
-            case WebCore::CryptoAlgorithmIdentifier::SHA_1:
-            case WebCore::CryptoAlgorithmIdentifier::SHA_224:
-            case WebCore::CryptoAlgorithmIdentifier::SHA_256:
-            case WebCore::CryptoAlgorithmIdentifier::SHA_384:
-            case WebCore::CryptoAlgorithmIdentifier::SHA_512:{
 
-                hash = *identifier;
-                break;
-            }
-            default: {
-                JSC::throwTypeError(globalObject, scope, "invalid hash algorithm"_s);
-                return JSC::JSValue::encode(JSC::JSValue {});       
-            }
+        switch (*identifier) {
+        case WebCore::CryptoAlgorithmIdentifier::SHA_1:
+        case WebCore::CryptoAlgorithmIdentifier::SHA_224:
+        case WebCore::CryptoAlgorithmIdentifier::SHA_256:
+        case WebCore::CryptoAlgorithmIdentifier::SHA_384:
+        case WebCore::CryptoAlgorithmIdentifier::SHA_512: {
+
+            hash = *identifier;
+            break;
+        }
+        default: {
+            JSC::throwTypeError(globalObject, scope, "invalid hash algorithm"_s);
+            return JSC::JSValue::encode(JSC::JSValue {});
+        }
         }
     }
 
     switch (id) {
-        case CryptoKeyClass::HMAC: {
-            const auto& hmac = downcast<WebCore::CryptoKeyHMAC>(wrapped);
-            auto result = (customHash) ? WebCore::CryptoAlgorithmHMAC::platformSignWithAlgorithm(hmac, hash, vectorData) : WebCore::CryptoAlgorithmHMAC::platformSign(hmac, vectorData);
-            if (result.hasException()) {
-                WebCore::propagateException(*globalObject, scope, result.releaseException());
-                return JSC::JSValue::encode(JSC::JSValue {});
-            }
-            auto resultData = result.releaseReturnValue();
-            auto size = resultData.size();
-            auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-            if (size > 0)
-                memcpy(buffer->vector(), resultData.data(), size);
-
-            return JSC::JSValue::encode(buffer);
+    case CryptoKeyClass::HMAC: {
+        const auto& hmac = downcast<WebCore::CryptoKeyHMAC>(wrapped);
+        auto result = (customHash) ? WebCore::CryptoAlgorithmHMAC::platformSignWithAlgorithm(hmac, hash, vectorData) : WebCore::CryptoAlgorithmHMAC::platformSign(hmac, vectorData);
+        if (result.hasException()) {
+            WebCore::propagateException(*globalObject, scope, result.releaseException());
+            return JSC::JSValue::encode(JSC::JSValue {});
         }
-        case CryptoKeyClass::OKP: {
-            const auto& okpKey = downcast<WebCore::CryptoKeyOKP>(wrapped);
-            auto result = WebCore::CryptoAlgorithmEd25519::platformSign(okpKey, vectorData);
-            if (result.hasException()) {
-                WebCore::propagateException(*globalObject, scope, result.releaseException());
-                return JSC::JSValue::encode(JSC::JSValue {});
-            }
-            auto resultData = result.releaseReturnValue();
-            auto size = resultData.size();
-            auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-            if (size > 0)
-                memcpy(buffer->vector(), resultData.data(), size);
+        auto resultData = result.releaseReturnValue();
+        auto size = resultData.size();
+        auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
+        if (size > 0)
+            memcpy(buffer->vector(), resultData.data(), size);
 
-            return JSC::JSValue::encode(buffer);
+        return JSC::JSValue::encode(buffer);
+    }
+    case CryptoKeyClass::OKP: {
+        const auto& okpKey = downcast<WebCore::CryptoKeyOKP>(wrapped);
+        auto result = WebCore::CryptoAlgorithmEd25519::platformSign(okpKey, vectorData);
+        if (result.hasException()) {
+            WebCore::propagateException(*globalObject, scope, result.releaseException());
+            return JSC::JSValue::encode(JSC::JSValue {});
         }
-        case CryptoKeyClass::EC: {
-            const auto& ec = downcast<WebCore::CryptoKeyEC>(wrapped);
-            CryptoAlgorithmEcdsaParams params;
-            params.identifier = CryptoAlgorithmIdentifier::ECDSA;
-            params.hashIdentifier = hash;
-            params.encoding = CryptoAlgorithmECDSAEncoding::DER;
-            params.encoding = CryptoAlgorithmECDSAEncoding::DER;
+        auto resultData = result.releaseReturnValue();
+        auto size = resultData.size();
+        auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
+        if (size > 0)
+            memcpy(buffer->vector(), resultData.data(), size);
 
-            if (count > 3) {
-                auto encoding = callFrame->argument(3);
-                if (!encoding.isUndefinedOrNull() && !encoding.isEmpty()) {
-                    if (!encoding.isString()) {
-                        JSC::throwTypeError(globalObject, scope, "dsaEncoding is expected to be a string"_s);
-                        return JSC::JSValue::encode(JSC::JSValue {});
-                    }
-                    auto encoding_str = encoding.toWTFString(globalObject);
-                    if (encoding_str == "ieee-p1363"_s) {
-                        params.encoding = CryptoAlgorithmECDSAEncoding::IeeeP1363;
-                    } else if (encoding_str == "der"_s) {
-                        params.encoding = CryptoAlgorithmECDSAEncoding::DER;
-                    } else {
-                        JSC::throwTypeError(globalObject, scope, "invalid dsaEncoding"_s);
-                        return JSC::JSValue::encode(JSC::JSValue {});
-                    }
-                }
-            }            
-            auto result = WebCore::CryptoAlgorithmECDSA::platformSign(params, ec, vectorData);
-            auto resultData = result.releaseReturnValue();
-            auto size = resultData.size();
-            auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-            if (size > 0)
-                memcpy(buffer->vector(), resultData.data(), size);
-            
-            return JSC::JSValue::encode(buffer);
-        }
-        case CryptoKeyClass::RSA: {
-            const auto& rsa = downcast<WebCore::CryptoKeyRSA>(wrapped);
-            switch(rsa.algorithmIdentifier()) {
-                case CryptoAlgorithmIdentifier::RSASSA_PKCS1_v1_5: {
-                    auto result = (customHash) ? WebCore::CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSignWithAlgorithm(rsa, hash, vectorData) : CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSign(rsa, vectorData);
-                    if (result.hasException()) {
-                        WebCore::propagateException(*globalObject, scope, result.releaseException());
-                        return JSC::JSValue::encode(JSC::JSValue {});
-                    }
-                    auto resultData = result.releaseReturnValue();
-                    auto size = resultData.size();
-                    auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-                    if (size > 0)
-                        memcpy(buffer->vector(), resultData.data(), size);
-                    
-                    return JSC::JSValue::encode(buffer);
-                }
-                case CryptoAlgorithmIdentifier::RSA_PSS: {
-                    CryptoAlgorithmRsaPssParams params;
-                    params.padding = RSA_PKCS1_PADDING;
-                    if (count > 4) {
-                        auto padding = callFrame->argument(4);
-                        if (!padding.isUndefinedOrNull() && !padding.isEmpty()) {
-                            if (!padding.isNumber()) {
-                                JSC::throwTypeError(globalObject, scope, "padding is expected to be a number"_s);
-                                return JSC::JSValue::encode(JSC::JSValue {});
-                            }
-                            params.padding = padding.toUInt32(globalObject);
-                          
-                        }
-                        // requires saltLength
-                        if(params.padding == RSA_PKCS1_PSS_PADDING) {
-                            if (count <= 5) {
-                                JSC::throwTypeError(globalObject, scope, "saltLength is expected to be a number"_s);
-                                return JSC::JSValue::encode(JSC::JSValue {});
-                            }
+        return JSC::JSValue::encode(buffer);
+    }
+    case CryptoKeyClass::EC: {
+        const auto& ec = downcast<WebCore::CryptoKeyEC>(wrapped);
+        CryptoAlgorithmEcdsaParams params;
+        params.identifier = CryptoAlgorithmIdentifier::ECDSA;
+        params.hashIdentifier = hash;
+        params.encoding = CryptoAlgorithmECDSAEncoding::DER;
+        params.encoding = CryptoAlgorithmECDSAEncoding::DER;
 
-                            auto saltLength = callFrame->argument(5);
-                            if (saltLength.isUndefinedOrNull() || saltLength.isEmpty() || saltLength.isNumber()) {
-                                JSC::throwTypeError(globalObject, scope, "saltLength is expected to be a number"_s);
-                                return JSC::JSValue::encode(JSC::JSValue {});
-                            
-                                params.saltLength = saltLength.toUInt32(globalObject);
-                            }
-                        }
-                    }
-                    params.identifier = CryptoAlgorithmIdentifier::RSA_PSS;
-                    auto result = (customHash) ? WebCore::CryptoAlgorithmRSA_PSS::platformSignWithAlgorithm(params, hash, rsa, vectorData) : CryptoAlgorithmRSA_PSS::platformSign(params, rsa, vectorData);
-                    if (result.hasException()) {
-                        WebCore::propagateException(*globalObject, scope, result.releaseException());
-                        return JSC::JSValue::encode(JSC::JSValue {});
-                    }
-                    auto resultData = result.releaseReturnValue();
-                    auto size = resultData.size();
-                    auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-                    if (size > 0)
-                        memcpy(buffer->vector(), resultData.data(), size);
-                    
-                    return JSC::JSValue::encode(buffer);
+        if (count > 3) {
+            auto encoding = callFrame->argument(3);
+            if (!encoding.isUndefinedOrNull() && !encoding.isEmpty()) {
+                if (!encoding.isString()) {
+                    JSC::throwTypeError(globalObject, scope, "dsaEncoding is expected to be a string"_s);
+                    return JSC::JSValue::encode(JSC::JSValue {});
                 }
-                default: {
-                     JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Sign not supported for this key type"_s);
+                auto encoding_str = encoding.toWTFString(globalObject);
+                if (encoding_str == "ieee-p1363"_s) {
+                    params.encoding = CryptoAlgorithmECDSAEncoding::IeeeP1363;
+                } else if (encoding_str == "der"_s) {
+                    params.encoding = CryptoAlgorithmECDSAEncoding::DER;
+                } else {
+                    JSC::throwTypeError(globalObject, scope, "invalid dsaEncoding"_s);
                     return JSC::JSValue::encode(JSC::JSValue {});
                 }
             }
         }
-        case CryptoKeyClass::AES: {
-            JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Sign not supported for AES key type"_s);
+        auto result = WebCore::CryptoAlgorithmECDSA::platformSign(params, ec, vectorData);
+        if (result.hasException()) {
+            WebCore::propagateException(*globalObject, scope, result.releaseException());
             return JSC::JSValue::encode(JSC::JSValue {});
         }
-        case CryptoKeyClass::Raw: {
-            JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Sign not supported for Raw key type"_s);
-            return JSC::JSValue::encode(JSC::JSValue {});
+        auto resultData = result.releaseReturnValue();
+        auto size = resultData.size();
+        auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
+        if (size > 0)
+            memcpy(buffer->vector(), resultData.data(), size);
+
+        return JSC::JSValue::encode(buffer);
+    }
+    case CryptoKeyClass::RSA: {
+        const auto& rsa = downcast<WebCore::CryptoKeyRSA>(wrapped);
+        switch (rsa.algorithmIdentifier()) {
+        case CryptoAlgorithmIdentifier::RSASSA_PKCS1_v1_5: {
+            auto result = (customHash) ? WebCore::CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSignWithAlgorithm(rsa, hash, vectorData) : CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSign(rsa, vectorData);
+            if (result.hasException()) {
+                WebCore::propagateException(*globalObject, scope, result.releaseException());
+                return JSC::JSValue::encode(JSC::JSValue {});
+            }
+            auto resultData = result.releaseReturnValue();
+            auto size = resultData.size();
+            auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
+            if (size > 0)
+                memcpy(buffer->vector(), resultData.data(), size);
+
+            return JSC::JSValue::encode(buffer);
+        }
+        case CryptoAlgorithmIdentifier::RSA_PSS: {
+            CryptoAlgorithmRsaPssParams params;
+            params.padding = RSA_PKCS1_PADDING;
+            if (count > 4) {
+                auto padding = callFrame->argument(4);
+                if (!padding.isUndefinedOrNull() && !padding.isEmpty()) {
+                    if (!padding.isNumber()) {
+                        JSC::throwTypeError(globalObject, scope, "padding is expected to be a number"_s);
+                        return JSC::JSValue::encode(JSC::JSValue {});
+                    }
+                    params.padding = padding.toUInt32(globalObject);
+                }
+                // requires saltLength
+                if (params.padding == RSA_PKCS1_PSS_PADDING) {
+                    if (count <= 5) {
+                        JSC::throwTypeError(globalObject, scope, "saltLength is expected to be a number"_s);
+                        return JSC::JSValue::encode(JSC::JSValue {});
+                    }
+
+                    auto saltLength = callFrame->argument(5);
+                    if (saltLength.isUndefinedOrNull() || saltLength.isEmpty() || saltLength.isNumber()) {
+                        JSC::throwTypeError(globalObject, scope, "saltLength is expected to be a number"_s);
+                        return JSC::JSValue::encode(JSC::JSValue {});
+
+                        params.saltLength = saltLength.toUInt32(globalObject);
+                    }
+                }
+            }
+            params.identifier = CryptoAlgorithmIdentifier::RSA_PSS;
+            auto result = (customHash) ? WebCore::CryptoAlgorithmRSA_PSS::platformSignWithAlgorithm(params, hash, rsa, vectorData) : CryptoAlgorithmRSA_PSS::platformSign(params, rsa, vectorData);
+            if (result.hasException()) {
+                WebCore::propagateException(*globalObject, scope, result.releaseException());
+                return JSC::JSValue::encode(JSC::JSValue {});
+            }
+            auto resultData = result.releaseReturnValue();
+            auto size = resultData.size();
+            auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
+            if (size > 0)
+                memcpy(buffer->vector(), resultData.data(), size);
+
+            return JSC::JSValue::encode(buffer);
         }
         default: {
             JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Sign not supported for this key type"_s);
             return JSC::JSValue::encode(JSC::JSValue {});
         }
+        }
+    }
+    case CryptoKeyClass::AES: {
+        JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Sign not supported for AES key type"_s);
+        return JSC::JSValue::encode(JSC::JSValue {});
+    }
+    case CryptoKeyClass::Raw: {
+        JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Sign not supported for Raw key type"_s);
+        return JSC::JSValue::encode(JSC::JSValue {});
+    }
+    default: {
+        JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Sign not supported for this key type"_s);
+        return JSC::JSValue::encode(JSC::JSValue {});
+    }
     }
 }
 
 JSC::EncodedJSValue KeyObject__Verify(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
-   auto count = callFrame->argumentCount();
+    auto count = callFrame->argumentCount();
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -1525,7 +1527,7 @@ JSC::EncodedJSValue KeyObject__Verify(JSC::JSGlobalObject* globalObject, JSC::Ca
     }
     JSValue bufferArg = callFrame->uncheckedArgument(1);
     auto buffer = KeyObject__GetBuffer(bufferArg);
-    if(buffer.hasException()) {
+    if (buffer.hasException()) {
         JSC::throwTypeError(globalObject, scope, "expected data to be Buffer or array-like object as second argument"_s);
         return JSC::JSValue::encode(JSC::JSValue {});
     }
@@ -1533,13 +1535,11 @@ JSC::EncodedJSValue KeyObject__Verify(JSC::JSGlobalObject* globalObject, JSC::Ca
 
     JSValue signatureBufferArg = callFrame->uncheckedArgument(2);
     auto signatureBuffer = KeyObject__GetBuffer(signatureBufferArg);
-    if(signatureBuffer.hasException()) {
+    if (signatureBuffer.hasException()) {
         JSC::throwTypeError(globalObject, scope, "expected signature to be Buffer or array-like object as second argument"_s);
         return JSC::JSValue::encode(JSC::JSValue {});
     }
-    auto signatureData = buffer.releaseReturnValue();
-
-    
+    auto signatureData = signatureBuffer.releaseReturnValue();
 
     auto& wrapped = key->wrapped();
     auto key_type = wrapped.type();
@@ -1547,9 +1547,9 @@ JSC::EncodedJSValue KeyObject__Verify(JSC::JSGlobalObject* globalObject, JSC::Ca
 
     auto hash = WebCore::CryptoAlgorithmIdentifier::SHA_256;
     auto customHash = false;
-    
+
     auto algorithm = callFrame->argument(3);
-    if(!algorithm.isUndefinedOrNull() && !algorithm.isEmpty()) {  
+    if (!algorithm.isUndefinedOrNull() && !algorithm.isEmpty()) {
         customHash = true;
         if (!algorithm.isString()) {
             JSC::throwTypeError(globalObject, scope, "algorithm is expected to be a string"_s);
@@ -1561,139 +1561,141 @@ JSC::EncodedJSValue KeyObject__Verify(JSC::JSGlobalObject* globalObject, JSC::Ca
             JSC::throwTypeError(globalObject, scope, "invalid algorithm"_s);
             return JSC::JSValue::encode(JSC::JSValue {});
         }
-            
-        switch (*identifier)
-        {
-            case WebCore::CryptoAlgorithmIdentifier::SHA_1:
-            case WebCore::CryptoAlgorithmIdentifier::SHA_224:
-            case WebCore::CryptoAlgorithmIdentifier::SHA_256:
-            case WebCore::CryptoAlgorithmIdentifier::SHA_384:
-            case WebCore::CryptoAlgorithmIdentifier::SHA_512:{
 
-                hash = *identifier;
-                break;
-            }
-            default: {
-                JSC::throwTypeError(globalObject, scope, "invalid hash algorithm"_s);
-                return JSC::JSValue::encode(JSC::JSValue {});       
-            }
+        switch (*identifier) {
+        case WebCore::CryptoAlgorithmIdentifier::SHA_1:
+        case WebCore::CryptoAlgorithmIdentifier::SHA_224:
+        case WebCore::CryptoAlgorithmIdentifier::SHA_256:
+        case WebCore::CryptoAlgorithmIdentifier::SHA_384:
+        case WebCore::CryptoAlgorithmIdentifier::SHA_512: {
+
+            hash = *identifier;
+            break;
+        }
+        default: {
+            JSC::throwTypeError(globalObject, scope, "invalid hash algorithm"_s);
+            return JSC::JSValue::encode(JSC::JSValue {});
+        }
         }
     }
 
     switch (id) {
-        case CryptoKeyClass::HMAC: {
-            const auto& hmac = downcast<WebCore::CryptoKeyHMAC>(wrapped);
-            auto result = (customHash) ? WebCore::CryptoAlgorithmHMAC::platformVerifyWithAlgorithm(hmac, hash, signatureData, vectorData) : WebCore::CryptoAlgorithmHMAC::platformVerify(hmac, signatureData, vectorData);
-            if (result.hasException()) {
-                WebCore::propagateException(*globalObject, scope, result.releaseException());
-                return JSC::JSValue::encode(JSC::JSValue {});
-            }
-            return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));
+    case CryptoKeyClass::HMAC: {
+        const auto& hmac = downcast<WebCore::CryptoKeyHMAC>(wrapped);
+        auto result = (customHash) ? WebCore::CryptoAlgorithmHMAC::platformVerifyWithAlgorithm(hmac, hash, signatureData, vectorData) : WebCore::CryptoAlgorithmHMAC::platformVerify(hmac, signatureData, vectorData);
+        if (result.hasException()) {
+            WebCore::propagateException(*globalObject, scope, result.releaseException());
+            return JSC::JSValue::encode(JSC::JSValue {});
         }
-        case CryptoKeyClass::OKP: {
-            const auto& okpKey = downcast<WebCore::CryptoKeyOKP>(wrapped);
-            auto result = WebCore::CryptoAlgorithmEd25519::platformVerify(okpKey, signatureData, vectorData);
-            if (result.hasException()) {
-                WebCore::propagateException(*globalObject, scope, result.releaseException());
-                return JSC::JSValue::encode(JSC::JSValue {});
-            }
-            return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));
+        return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));
+    }
+    case CryptoKeyClass::OKP: {
+        const auto& okpKey = downcast<WebCore::CryptoKeyOKP>(wrapped);
+        auto result = WebCore::CryptoAlgorithmEd25519::platformVerify(okpKey, signatureData, vectorData);
+        if (result.hasException()) {
+            WebCore::propagateException(*globalObject, scope, result.releaseException());
+            return JSC::JSValue::encode(JSC::JSValue {});
         }
-        case CryptoKeyClass::EC: {
-            const auto& ec = downcast<WebCore::CryptoKeyEC>(wrapped);
-            CryptoAlgorithmEcdsaParams params;
-            params.identifier = CryptoAlgorithmIdentifier::ECDSA;
-            params.hashIdentifier = hash;
-            params.encoding = CryptoAlgorithmECDSAEncoding::DER;
+        return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));
+    }
+    case CryptoKeyClass::EC: {
+        const auto& ec = downcast<WebCore::CryptoKeyEC>(wrapped);
+        CryptoAlgorithmEcdsaParams params;
+        params.identifier = CryptoAlgorithmIdentifier::ECDSA;
+        params.hashIdentifier = hash;
+        params.encoding = CryptoAlgorithmECDSAEncoding::DER;
 
-            if (count > 4) {
-                auto encoding = callFrame->argument(4);
-                if (!encoding.isUndefinedOrNull() && !encoding.isEmpty()) {
-                    if (!encoding.isString()) {
-                        JSC::throwTypeError(globalObject, scope, "dsaEncoding is expected to be a string"_s);
-                        return JSC::JSValue::encode(JSC::JSValue {});
-                    }
-                    auto encoding_str = encoding.toWTFString(globalObject);
-                    if (encoding_str == "ieee-p1363"_s) {
-                        params.encoding = CryptoAlgorithmECDSAEncoding::IeeeP1363;
-                    } else if (encoding_str == "der"_s) {
-                        params.encoding = CryptoAlgorithmECDSAEncoding::DER;
-                    } else {
-                        JSC::throwTypeError(globalObject, scope, "invalid dsaEncoding"_s);
-                        return JSC::JSValue::encode(JSC::JSValue {});
-                    }
+        if (count > 4) {
+            auto encoding = callFrame->argument(4);
+            if (!encoding.isUndefinedOrNull() && !encoding.isEmpty()) {
+                if (!encoding.isString()) {
+                    JSC::throwTypeError(globalObject, scope, "dsaEncoding is expected to be a string"_s);
+                    return JSC::JSValue::encode(JSC::JSValue {});
                 }
-            }
-            auto result = WebCore::CryptoAlgorithmECDSA::platformVerify(params, ec, signatureData, vectorData);
-            return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));
-        }
-        case CryptoKeyClass::RSA: {
-            const auto& rsa = downcast<WebCore::CryptoKeyRSA>(wrapped);
-            switch(rsa.algorithmIdentifier()) {
-                case CryptoAlgorithmIdentifier::RSASSA_PKCS1_v1_5: {
-                    auto result = (customHash) ? WebCore::CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerifyWithAlgorithm(rsa, hash, signatureData, vectorData) : CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerify(rsa, signatureData, vectorData);
-                    if (result.hasException()) {
-                        WebCore::propagateException(*globalObject, scope, result.releaseException());
-                        return JSC::JSValue::encode(JSC::JSValue {});
-                    }
-                    return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));
-                }
-                case CryptoAlgorithmIdentifier::RSA_PSS: {
-                    CryptoAlgorithmRsaPssParams params;
-                    params.padding = RSA_PKCS1_PADDING;
-                    if (count > 5) {
-
-                        auto padding = callFrame->argument(5);
-                        if (!padding.isUndefinedOrNull() && !padding.isEmpty()) {
-                            if (!padding.isNumber()) {
-                                JSC::throwTypeError(globalObject, scope, "padding is expected to be a number"_s);
-                                return JSC::JSValue::encode(JSC::JSValue {});
-                            }
-                            params.padding = padding.toUInt32(globalObject);
-                          
-                        }
-                        // requires saltLength
-                        if(params.padding == RSA_PKCS1_PSS_PADDING) {
-                            if (count <= 6) {
-                                JSC::throwTypeError(globalObject, scope, "saltLength is expected to be a number"_s);
-                                return JSC::JSValue::encode(JSC::JSValue {});
-                            }
-
-                            auto saltLength = callFrame->argument(6);
-                            if (saltLength.isUndefinedOrNull() || saltLength.isEmpty() || saltLength.isNumber()) {
-                                JSC::throwTypeError(globalObject, scope, "saltLength is expected to be a number"_s);
-                                return JSC::JSValue::encode(JSC::JSValue {});
-                            
-                                params.saltLength = saltLength.toUInt32(globalObject);
-                            }
-                        }
-                    }
-                    params.identifier = CryptoAlgorithmIdentifier::RSA_PSS;
-                    auto result = (customHash) ? WebCore::CryptoAlgorithmRSA_PSS::platformVerifyWithAlgorithm(params, hash, rsa, signatureData, vectorData) : CryptoAlgorithmRSA_PSS::platformVerify(params, rsa, signatureData, vectorData);
-                    if (result.hasException()) {
-                        WebCore::propagateException(*globalObject, scope, result.releaseException());
-                        return JSC::JSValue::encode(JSC::JSValue {});
-                    }
-                    return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));
-                }
-                default: {
-                     JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for RSA key type"_s);
+                auto encoding_str = encoding.toWTFString(globalObject);
+                if (encoding_str == "ieee-p1363"_s) {
+                    params.encoding = CryptoAlgorithmECDSAEncoding::IeeeP1363;
+                } else if (encoding_str == "der"_s) {
+                    params.encoding = CryptoAlgorithmECDSAEncoding::DER;
+                } else {
+                    JSC::throwTypeError(globalObject, scope, "invalid dsaEncoding"_s);
                     return JSC::JSValue::encode(JSC::JSValue {});
                 }
             }
         }
-        case CryptoKeyClass::AES: {
-            JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for AES key type"_s);
+        auto result = WebCore::CryptoAlgorithmECDSA::platformVerify(params, ec, signatureData, vectorData);
+        if (result.hasException()) {
+            WebCore::propagateException(*globalObject, scope, result.releaseException());
             return JSC::JSValue::encode(JSC::JSValue {});
         }
-        case CryptoKeyClass::Raw: {
-            JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for Raw key type"_s);
-            return JSC::JSValue::encode(JSC::JSValue {});
+        return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));
+    }
+    case CryptoKeyClass::RSA: {
+        const auto& rsa = downcast<WebCore::CryptoKeyRSA>(wrapped);
+        switch (rsa.algorithmIdentifier()) {
+        case CryptoAlgorithmIdentifier::RSASSA_PKCS1_v1_5: {
+            auto result = (customHash) ? WebCore::CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerifyWithAlgorithm(rsa, hash, signatureData, vectorData) : CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerify(rsa, signatureData, vectorData);
+            if (result.hasException()) {
+                WebCore::propagateException(*globalObject, scope, result.releaseException());
+                return JSC::JSValue::encode(JSC::JSValue {});
+            }
+            return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));
+        }
+        case CryptoAlgorithmIdentifier::RSA_PSS: {
+            CryptoAlgorithmRsaPssParams params;
+            params.padding = RSA_PKCS1_PADDING;
+            if (count > 5) {
+
+                auto padding = callFrame->argument(5);
+                if (!padding.isUndefinedOrNull() && !padding.isEmpty()) {
+                    if (!padding.isNumber()) {
+                        JSC::throwTypeError(globalObject, scope, "padding is expected to be a number"_s);
+                        return JSC::JSValue::encode(JSC::JSValue {});
+                    }
+                    params.padding = padding.toUInt32(globalObject);
+                }
+                // requires saltLength
+                if (params.padding == RSA_PKCS1_PSS_PADDING) {
+                    if (count <= 6) {
+                        JSC::throwTypeError(globalObject, scope, "saltLength is expected to be a number"_s);
+                        return JSC::JSValue::encode(JSC::JSValue {});
+                    }
+
+                    auto saltLength = callFrame->argument(6);
+                    if (saltLength.isUndefinedOrNull() || saltLength.isEmpty() || saltLength.isNumber()) {
+                        JSC::throwTypeError(globalObject, scope, "saltLength is expected to be a number"_s);
+                        return JSC::JSValue::encode(JSC::JSValue {});
+
+                        params.saltLength = saltLength.toUInt32(globalObject);
+                    }
+                }
+            }
+            params.identifier = CryptoAlgorithmIdentifier::RSA_PSS;
+            auto result = (customHash) ? WebCore::CryptoAlgorithmRSA_PSS::platformVerifyWithAlgorithm(params, hash, rsa, signatureData, vectorData) : CryptoAlgorithmRSA_PSS::platformVerify(params, rsa, signatureData, vectorData);
+            if (result.hasException()) {
+                WebCore::propagateException(*globalObject, scope, result.releaseException());
+                return JSC::JSValue::encode(JSC::JSValue {});
+            }
+            return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));
         }
         default: {
-            JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for this key type"_s);
+            JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for RSA key type"_s);
             return JSC::JSValue::encode(JSC::JSValue {});
         }
+        }
+    }
+    case CryptoKeyClass::AES: {
+        JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for AES key type"_s);
+        return JSC::JSValue::encode(JSC::JSValue {});
+    }
+    case CryptoKeyClass::Raw: {
+        JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for Raw key type"_s);
+        return JSC::JSValue::encode(JSC::JSValue {});
+    }
+    default: {
+        JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for this key type"_s);
+        return JSC::JSValue::encode(JSC::JSValue {});
+    }
     }
 }
 

--- a/src/bun.js/bindings/KeyObject.cpp
+++ b/src/bun.js/bindings/KeyObject.cpp
@@ -1352,8 +1352,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
     switch (id) {
         case CryptoKeyClass::HMAC: {
             const auto& hmac = downcast<WebCore::CryptoKeyHMAC>(wrapped);
-            // TODO: fix this hash should be the informed by the user
-            auto result = WebCore::CryptoAlgorithmHMAC::platformSign(hmac, vectorData);
+            auto result = (customHash) ? WebCore::CryptoAlgorithmHMAC::platformSignWithAlgorithm(hmac, hash, vectorData) : WebCore::CryptoAlgorithmHMAC::platformSign(hmac, vectorData);
             if (result.hasException()) {
                 WebCore::propagateException(*globalObject, scope, result.releaseException());
                 return JSC::JSValue::encode(JSC::JSValue {});
@@ -1368,10 +1367,6 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
         }
         case CryptoKeyClass::OKP: {
             const auto& okpKey = downcast<WebCore::CryptoKeyOKP>(wrapped);
-            if(okpKey.namedCurve() != CryptoKeyOKP::NamedCurve::Ed25519) {
-                JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Invalid key type curve X25519 not supported"_s);
-                return JSC::JSValue::encode(JSC::JSValue {});
-            }
             auto result = WebCore::CryptoAlgorithmEd25519::platformSign(okpKey, vectorData);
             if (result.hasException()) {
                 WebCore::propagateException(*globalObject, scope, result.releaseException());
@@ -1394,6 +1389,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
             CryptoAlgorithmEcdsaParams params;
             params.identifier = CryptoAlgorithmIdentifier::ECDSA;
             params.hashIdentifier = hash;
+            // TODO: use the right encoding
             auto result = WebCore::CryptoAlgorithmECDSA::platformSign(params, ec, vectorData);
             auto resultData = result.releaseReturnValue();
             auto size = resultData.size();
@@ -1407,8 +1403,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
             const auto& rsa = downcast<WebCore::CryptoKeyRSA>(wrapped);
             switch(rsa.algorithmIdentifier()) {
                 case CryptoAlgorithmIdentifier::RSASSA_PKCS1_v1_5: {
-                    // TODO: fix this hash should be the informed by the user
-                    auto result = WebCore::CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSign(rsa, vectorData);
+                    auto result = (customHash) ? WebCore::CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSignWithAlgorithm(rsa, hash, vectorData) : CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSign(rsa, vectorData);
                     if (result.hasException()) {
                         WebCore::propagateException(*globalObject, scope, result.releaseException());
                         return JSC::JSValue::encode(JSC::JSValue {});

--- a/src/bun.js/bindings/KeyObject.cpp
+++ b/src/bun.js/bindings/KeyObject.cpp
@@ -1394,6 +1394,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
             CryptoAlgorithmEcdsaParams params;
             params.identifier = CryptoAlgorithmIdentifier::ECDSA;
             params.hashIdentifier = hash;
+            params.encoding = CryptoAlgorithmECDSAEncoding::DER;
             // TODO: use the right encoding
             auto result = WebCore::CryptoAlgorithmECDSA::platformSign(params, ec, vectorData);
             auto resultData = result.releaseReturnValue();
@@ -1539,6 +1540,7 @@ JSC::EncodedJSValue KeyObject__Verify(JSC::JSGlobalObject* globalObject, JSC::Ca
             CryptoAlgorithmEcdsaParams params;
             params.identifier = CryptoAlgorithmIdentifier::ECDSA;
             params.hashIdentifier = hash;
+            params.encoding = CryptoAlgorithmECDSAEncoding::DER;
             // TODO: use the right encoding
             auto result = WebCore::CryptoAlgorithmECDSA::platformVerify(params, ec, signatureData, vectorData);
             return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));

--- a/src/bun.js/bindings/KeyObject.cpp
+++ b/src/bun.js/bindings/KeyObject.cpp
@@ -1327,7 +1327,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
     auto hash = WebCore::CryptoAlgorithmIdentifier::SHA_256;
     auto customHash = count > 2;
     if (customHash) {
-        auto algorithm = callFrame->argument(3);
+        auto algorithm = callFrame->argument(2);
         if (algorithm.isUndefinedOrNull() || algorithm.isEmpty() || !algorithm.isString()) {
             JSC::throwTypeError(globalObject, scope, "algorithm is expected to be a string"_s);
             return JSC::JSValue::encode(JSC::JSValue {});
@@ -1391,10 +1391,6 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
         }
         case CryptoKeyClass::EC: {
             const auto& ec = downcast<WebCore::CryptoKeyEC>(wrapped);
-            if(ec.algorithmIdentifier() != WebCore::CryptoAlgorithmIdentifier::ECDSA) {
-                JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Invalid key type for EC only ECDSA is supported"_s);
-                return JSC::JSValue::encode(JSC::JSValue {});
-            }
             CryptoAlgorithmEcdsaParams params;
             params.identifier = CryptoAlgorithmIdentifier::ECDSA;
             params.hashIdentifier = hash;
@@ -1431,6 +1427,14 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
                 }
             }
         }
+        case CryptoKeyClass::AES: {
+            JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Sign not supported for AES key type"_s);
+            return JSC::JSValue::encode(JSC::JSValue {});
+        }
+        case CryptoKeyClass::Raw: {
+            JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Sign not supported for Raw key type"_s);
+            return JSC::JSValue::encode(JSC::JSValue {});
+        }
         default: {
             JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Sign not supported for this key type"_s);
             return JSC::JSValue::encode(JSC::JSValue {});
@@ -1445,7 +1449,7 @@ JSC::EncodedJSValue KeyObject__Verify(JSC::JSGlobalObject* globalObject, JSC::Ca
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (count < 3) {
-        JSC::throwTypeError(globalObject, scope, "verify requires 2 arguments"_s);
+        JSC::throwTypeError(globalObject, scope, "verify requires 3 arguments"_s);
         return JSC::JSValue::encode(JSC::JSValue {});
     }
 
@@ -1478,7 +1482,7 @@ JSC::EncodedJSValue KeyObject__Verify(JSC::JSGlobalObject* globalObject, JSC::Ca
     auto id = wrapped.keyClass();
 
     auto hash = WebCore::CryptoAlgorithmIdentifier::SHA_256;
-    auto customHash = count > 2;
+    auto customHash = count > 3;
     if (customHash) {
         auto algorithm = callFrame->argument(3);
         if (algorithm.isUndefinedOrNull() || algorithm.isEmpty() || !algorithm.isString()) {
@@ -1532,10 +1536,6 @@ JSC::EncodedJSValue KeyObject__Verify(JSC::JSGlobalObject* globalObject, JSC::Ca
         }
         case CryptoKeyClass::EC: {
             const auto& ec = downcast<WebCore::CryptoKeyEC>(wrapped);
-            if(ec.algorithmIdentifier() != WebCore::CryptoAlgorithmIdentifier::ECDSA) {
-                JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Invalid key type for EC only ECDSA is supported"_s);
-                return JSC::JSValue::encode(JSC::JSValue {});
-            }
             CryptoAlgorithmEcdsaParams params;
             params.identifier = CryptoAlgorithmIdentifier::ECDSA;
             params.hashIdentifier = hash;
@@ -1555,10 +1555,18 @@ JSC::EncodedJSValue KeyObject__Verify(JSC::JSGlobalObject* globalObject, JSC::Ca
                     return JSC::JSValue::encode(jsBoolean(result.releaseReturnValue()));
                 }
                 default: {
-                     JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for this key type"_s);
+                     JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for RSA-PSS key type"_s);
                     return JSC::JSValue::encode(JSC::JSValue {});
                 }
             }
+        }
+        case CryptoKeyClass::AES: {
+            JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for AES key type"_s);
+            return JSC::JSValue::encode(JSC::JSValue {});
+        }
+        case CryptoKeyClass::Raw: {
+            JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for Raw key type"_s);
+            return JSC::JSValue::encode(JSC::JSValue {});
         }
         default: {
             JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Verify not supported for this key type"_s);

--- a/src/bun.js/bindings/KeyObject.h
+++ b/src/bun.js/bindings/KeyObject.h
@@ -16,4 +16,6 @@ JSC::EncodedJSValue KeyObject__createPrivateKey(JSC::JSGlobalObject* lexicalGlob
 JSC::EncodedJSValue KeyObject__generateKeySync(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC::EncodedJSValue KeyObject__generateKeyPairSync(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame);
+JSC::EncodedJSValue KeyObject__Verify(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame);
+
 }

--- a/src/bun.js/bindings/KeyObject.h
+++ b/src/bun.js/bindings/KeyObject.h
@@ -15,4 +15,5 @@ JSC::EncodedJSValue KeyObject__createPublicKey(JSC::JSGlobalObject* lexicalGloba
 JSC::EncodedJSValue KeyObject__createPrivateKey(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC::EncodedJSValue KeyObject__generateKeySync(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC::EncodedJSValue KeyObject__generateKeyPairSync(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
+JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame);
 }

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1755,6 +1755,7 @@ JSC_DEFINE_HOST_FUNCTION(functionLazyLoad,
             obj->putDirect(vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "generateKeyPairSync"_s)), JSC::JSFunction::create(vm, globalObject, 2, "generateKeyPairSync"_s, KeyObject__generateKeyPairSync, ImplementationVisibility::Public, NoIntrinsic), 0);
 
             obj->putDirect(vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "sign"_s)), JSC::JSFunction::create(vm, globalObject, 3, "sign"_s, KeyObject__Sign, ImplementationVisibility::Public, NoIntrinsic), 0);
+            obj->putDirect(vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "verify"_s)), JSC::JSFunction::create(vm, globalObject, 4, "verify"_s, KeyObject__Sign, ImplementationVisibility::Public, NoIntrinsic), 0);
 
             return JSValue::encode(obj);
         }

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1754,6 +1754,8 @@ JSC_DEFINE_HOST_FUNCTION(functionLazyLoad,
 
             obj->putDirect(vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "generateKeyPairSync"_s)), JSC::JSFunction::create(vm, globalObject, 2, "generateKeyPairSync"_s, KeyObject__generateKeyPairSync, ImplementationVisibility::Public, NoIntrinsic), 0);
 
+            obj->putDirect(vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "sign"_s)), JSC::JSFunction::create(vm, globalObject, 3, "sign"_s, KeyObject__Sign, ImplementationVisibility::Public, NoIntrinsic), 0);
+
             return JSValue::encode(obj);
         }
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1755,7 +1755,7 @@ JSC_DEFINE_HOST_FUNCTION(functionLazyLoad,
             obj->putDirect(vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "generateKeyPairSync"_s)), JSC::JSFunction::create(vm, globalObject, 2, "generateKeyPairSync"_s, KeyObject__generateKeyPairSync, ImplementationVisibility::Public, NoIntrinsic), 0);
 
             obj->putDirect(vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "sign"_s)), JSC::JSFunction::create(vm, globalObject, 3, "sign"_s, KeyObject__Sign, ImplementationVisibility::Public, NoIntrinsic), 0);
-            obj->putDirect(vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "verify"_s)), JSC::JSFunction::create(vm, globalObject, 4, "verify"_s, KeyObject__Sign, ImplementationVisibility::Public, NoIntrinsic), 0);
+            obj->putDirect(vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "verify"_s)), JSC::JSFunction::create(vm, globalObject, 4, "verify"_s, KeyObject__Verify, ImplementationVisibility::Public, NoIntrinsic), 0);
 
             return JSValue::encode(obj);
         }

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmECDSA.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmECDSA.h
@@ -40,6 +40,8 @@ public:
     static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::ECDSA;
     static Ref<CryptoAlgorithm> create();
 
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&);
+    static ExceptionOr<bool> platformVerify(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 private:
     CryptoAlgorithmECDSA() = default;
     CryptoAlgorithmIdentifier identifier() const final;
@@ -50,8 +52,6 @@ private:
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&);
-    static ExceptionOr<bool> platformVerify(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 };
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmEcdsaParams.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmEcdsaParams.h
@@ -34,11 +34,17 @@
 
 namespace WebCore {
 
+enum CryptoAlgorithmECDSAEncoding {
+    IeeeP1363,
+    DER,
+};
 class CryptoAlgorithmEcdsaParams final : public CryptoAlgorithmParameters {
 public:
     // FIXME: Consider merging hash and hashIdentifier.
     std::variant<JSC::Strong<JSC::JSObject>, String> hash;
     CryptoAlgorithmIdentifier hashIdentifier;
+    // WebCrypto default is IeeeP1363.
+    CryptoAlgorithmECDSAEncoding encoding { CryptoAlgorithmECDSAEncoding::IeeeP1363 };
 
     Class parametersClass() const final { return Class::EcdsaParams; }
 
@@ -47,7 +53,7 @@ public:
         CryptoAlgorithmEcdsaParams result;
         result.identifier = identifier;
         result.hashIdentifier = hashIdentifier;
-
+        result.encoding = encoding;
         return result;
     }
 };

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmEd25519.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmEd25519.h
@@ -37,6 +37,8 @@ public:
     static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::Ed25519;
     static Ref<CryptoAlgorithm> create();
 
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&);
+    static ExceptionOr<bool> platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 private:
     CryptoAlgorithmEd25519() = default;
     CryptoAlgorithmIdentifier identifier() const final;
@@ -46,9 +48,6 @@ private:
     void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-
-    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&);
-    static ExceptionOr<bool> platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 };
 
 inline CryptoAlgorithmIdentifier CryptoAlgorithmEd25519::identifier() const

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMAC.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMAC.h
@@ -41,6 +41,7 @@ public:
 
     // Operations can be performed directly.
     static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyHMAC&, const Vector<uint8_t>&);
+    static ExceptionOr<Vector<uint8_t>> platformSignWithAlgorithm(const CryptoKeyHMAC&, CryptoAlgorithmIdentifier algorithm, const Vector<uint8_t>&);
     static ExceptionOr<bool> platformVerify(const CryptoKeyHMAC&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 
 private:

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMAC.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMAC.h
@@ -41,8 +41,10 @@ public:
 
     // Operations can be performed directly.
     static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyHMAC&, const Vector<uint8_t>&);
-    static ExceptionOr<Vector<uint8_t>> platformSignWithAlgorithm(const CryptoKeyHMAC&, CryptoAlgorithmIdentifier algorithm, const Vector<uint8_t>&);
+    static ExceptionOr<Vector<uint8_t>> platformSignWithAlgorithm(const CryptoKeyHMAC&, CryptoAlgorithmIdentifier, const Vector<uint8_t>&);
     static ExceptionOr<bool> platformVerify(const CryptoKeyHMAC&, const Vector<uint8_t>&, const Vector<uint8_t>&);
+    static ExceptionOr<bool> platformVerifyWithAlgorithm(const CryptoKeyHMAC&, CryptoAlgorithmIdentifier, const Vector<uint8_t>&, const Vector<uint8_t>&);
+
 
 private:
     CryptoAlgorithmHMAC() = default;

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMACOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMACOpenSSL.cpp
@@ -59,6 +59,18 @@ static std::optional<Vector<uint8_t>> calculateSignature(const EVP_MD* algorithm
     return cipherText;
 }
 
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSignWithAlgorithm(const CryptoKeyHMAC& key,  CryptoAlgorithmIdentifier algorithmIdentifier, const Vector<uint8_t>& data) {
+    
+    auto algorithm = digestAlgorithm(algorithmIdentifier);
+    if (!algorithm)
+        return Exception { OperationError };
+
+    auto result = calculateSignature(algorithm, key.key(), data.data(), data.size());
+    if (!result)
+        return Exception { OperationError };
+    return WTFMove(*result);
+}
+
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
 {
     auto algorithm = digestAlgorithm(key.hashAlgorithmIdentifier());

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMACOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMACOpenSSL.cpp
@@ -83,6 +83,18 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHM
     return WTFMove(*result);
 }
 
+ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerifyWithAlgorithm(const CryptoKeyHMAC& key, CryptoAlgorithmIdentifier algorithmIdentifier, const Vector<uint8_t>& signature, const Vector<uint8_t>& data) {
+
+    auto algorithm = digestAlgorithm(algorithmIdentifier);
+    if (!algorithm)
+        return Exception { OperationError };
+
+    auto expectedSignature = calculateSignature(algorithm, key.key(), data.data(), data.size());
+    if (!expectedSignature)
+        return Exception { OperationError };
+    // Using a constant time comparison to prevent timing attacks.
+    return signature.size() == expectedSignature->size() && !constantTimeMemcmp(expectedSignature->data(), signature.data(), expectedSignature->size());
+}
 ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
     auto algorithm = digestAlgorithm(key.hashAlgorithmIdentifier());

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
@@ -40,9 +40,12 @@ public:
     static Ref<CryptoAlgorithm> create();
 
     static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyRSA&, const Vector<uint8_t>&);
-    static ExceptionOr<Vector<uint8_t>> platformSignWithAlgorithm(const CryptoKeyRSA&, CryptoAlgorithmIdentifier algorithm, const Vector<uint8_t>&);
+    static ExceptionOr<Vector<uint8_t>> platformSignWithAlgorithm(const CryptoKeyRSA&, CryptoAlgorithmIdentifier, const Vector<uint8_t>&);
 
     static ExceptionOr<bool> platformVerify(const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);
+    static ExceptionOr<bool> platformVerifyWithAlgorithm(const CryptoKeyRSA&, CryptoAlgorithmIdentifier, const Vector<uint8_t>&, const Vector<uint8_t>&);
+
+    
 private:
     CryptoAlgorithmRSASSA_PKCS1_v1_5() = default;
     CryptoAlgorithmIdentifier identifier() const final;

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
@@ -40,6 +40,8 @@ public:
     static Ref<CryptoAlgorithm> create();
 
     static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyRSA&, const Vector<uint8_t>&);
+    static ExceptionOr<Vector<uint8_t>> platformSignWithAlgorithm(const CryptoKeyRSA&, CryptoAlgorithmIdentifier algorithm, const Vector<uint8_t>&);
+
     static ExceptionOr<bool> platformVerify(const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 private:
     CryptoAlgorithmRSASSA_PKCS1_v1_5() = default;

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
@@ -39,6 +39,8 @@ public:
     static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::RSASSA_PKCS1_v1_5;
     static Ref<CryptoAlgorithm> create();
 
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyRSA&, const Vector<uint8_t>&);
+    static ExceptionOr<bool> platformVerify(const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 private:
     CryptoAlgorithmRSASSA_PKCS1_v1_5() = default;
     CryptoAlgorithmIdentifier identifier() const final;
@@ -48,9 +50,6 @@ private:
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-
-    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyRSA&, const Vector<uint8_t>&);
-    static ExceptionOr<bool> platformVerify(const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 };
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp
@@ -33,11 +33,8 @@
 
 namespace WebCore {
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSign(const CryptoKeyRSA& key, const Vector<uint8_t>& data)
-{
-    const EVP_MD* md = digestAlgorithm(key.hashAlgorithmIdentifier());
-    if (!md)
-        return Exception { NotSupportedError };
+
+static ExceptionOr<Vector<uint8_t>> signWithEVP_MD(const CryptoKeyRSA& key,  const EVP_MD* md, const Vector<uint8_t>& data) {
 
     std::optional<Vector<uint8_t>> digest = calculateDigest(md, data);
     if (!digest)
@@ -66,6 +63,23 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSign(cons
     signature.shrink(signatureLen);
 
     return signature;
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSignWithAlgorithm(const CryptoKeyRSA& key,CryptoAlgorithmIdentifier algorithm, const Vector<uint8_t>& data) {
+
+    const EVP_MD* md = digestAlgorithm(algorithm);
+    if (!md)
+        return Exception { NotSupportedError };
+
+    return signWithEVP_MD(key, md, data);
+}
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSign(const CryptoKeyRSA& key, const Vector<uint8_t>& data)
+{
+    const EVP_MD* md = digestAlgorithm(key.hashAlgorithmIdentifier());
+    if (!md)
+        return Exception { NotSupportedError };
+
+    return signWithEVP_MD(key, md, data);
 }
 
 ExceptionOr<bool> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerify(const CryptoKeyRSA& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp
@@ -65,7 +65,7 @@ static ExceptionOr<Vector<uint8_t>> signWithEVP_MD(const CryptoKeyRSA& key,  con
     return signature;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSignWithAlgorithm(const CryptoKeyRSA& key,CryptoAlgorithmIdentifier algorithm, const Vector<uint8_t>& data) {
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSignWithAlgorithm(const CryptoKeyRSA& key, CryptoAlgorithmIdentifier algorithm, const Vector<uint8_t>& data) {
 
     const EVP_MD* md = digestAlgorithm(algorithm);
     if (!md)
@@ -82,12 +82,8 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSign(cons
     return signWithEVP_MD(key, md, data);
 }
 
-ExceptionOr<bool> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerify(const CryptoKeyRSA& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
-{
-    const EVP_MD* md = digestAlgorithm(key.hashAlgorithmIdentifier());
-    if (!md)
-        return Exception { NotSupportedError };
 
+static ExceptionOr<bool> verifyWithEVP_MD(const CryptoKeyRSA& key,  const EVP_MD* md, const Vector<uint8_t>& signature, const Vector<uint8_t>& data) {
     std::optional<Vector<uint8_t>> digest = calculateDigest(md, data);
     if (!digest)
         return Exception { OperationError };
@@ -108,6 +104,24 @@ ExceptionOr<bool> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerify(const CryptoK
     int ret = EVP_PKEY_verify(ctx.get(), signature.data(), signature.size(), digest->data(), digest->size());
 
     return ret == 1;
+}
+
+ExceptionOr<bool> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerifyWithAlgorithm(const CryptoKeyRSA& key, CryptoAlgorithmIdentifier algorithm, const Vector<uint8_t>& signature, const Vector<uint8_t>& data) {
+    const EVP_MD* md = digestAlgorithm(algorithm);
+    if (!md)
+        return Exception { NotSupportedError };
+
+    return verifyWithEVP_MD(key, md, signature, data);
+}
+
+
+ExceptionOr<bool> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerify(const CryptoKeyRSA& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+{
+    const EVP_MD* md = digestAlgorithm(key.hashAlgorithmIdentifier());
+    if (!md)
+        return Exception { NotSupportedError };
+
+    return verifyWithEVP_MD(key, md, signature, data);
 }
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_PSS.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_PSS.h
@@ -40,6 +40,13 @@ public:
     static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::RSA_PSS;
     static Ref<CryptoAlgorithm> create();
 
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoAlgorithmRsaPssParams&, const CryptoKeyRSA&, const Vector<uint8_t>&);
+    static ExceptionOr<Vector<uint8_t>> platformSignWithAlgorithm(const CryptoAlgorithmRsaPssParams&, CryptoAlgorithmIdentifier, const CryptoKeyRSA&, const Vector<uint8_t>&);
+
+    static ExceptionOr<bool> platformVerify(const CryptoAlgorithmRsaPssParams&, const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);
+    static ExceptionOr<bool> platformVerifyWithAlgorithm(const CryptoAlgorithmRsaPssParams&, CryptoAlgorithmIdentifier, const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);
+
+
 private:
     CryptoAlgorithmRSA_PSS() = default;
     CryptoAlgorithmIdentifier identifier() const final;
@@ -50,8 +57,6 @@ private:
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoAlgorithmRsaPssParams&, const CryptoKeyRSA&, const Vector<uint8_t>&);
-    static ExceptionOr<bool> platformVerify(const CryptoAlgorithmRsaPssParams&, const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 };
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRegistry.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRegistry.cpp
@@ -90,7 +90,8 @@ void CryptoAlgorithmRegistry::registerAlgorithm(const String& name, CryptoAlgori
     Locker locker { m_lock };
 
     ASSERT(!m_identifiers.contains(name));
-    ASSERT(!m_constructors.contains(static_cast<unsigned>(identifier)));
+    // hashs can contains 2 names (SHA-256 and SHA256)
+    // ASSERT(!m_constructors.contains(static_cast<unsigned>(identifier)));
 
     m_identifiers.add(name, identifier);
     m_constructors.add(static_cast<unsigned>(identifier), std::make_pair(name, constructor));

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRegistry.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRegistry.h
@@ -60,6 +60,11 @@ private:
     {
         registerAlgorithm(AlgorithmClass::s_name, AlgorithmClass::s_identifier, AlgorithmClass::create);
     }
+    template<typename AlgorithmClass> void registerAlgorithmWithAlternativeName()
+    {
+        registerAlgorithm(AlgorithmClass::s_name, AlgorithmClass::s_identifier, AlgorithmClass::create);
+        registerAlgorithm(AlgorithmClass::s_alternative_name, AlgorithmClass::s_identifier, AlgorithmClass::create);
+    }
 
     void registerAlgorithm(const String& name, CryptoAlgorithmIdentifier, CryptoAlgorithmConstructor);
 

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRegistryOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRegistryOpenSSL.cpp
@@ -67,11 +67,11 @@ void CryptoAlgorithmRegistry::platformRegisterAlgorithms()
     registerAlgorithm<CryptoAlgorithmRSASSA_PKCS1_v1_5>();
     registerAlgorithm<CryptoAlgorithmRSA_OAEP>();
     registerAlgorithm<CryptoAlgorithmRSA_PSS>();
-    registerAlgorithm<CryptoAlgorithmSHA1>();
-    registerAlgorithm<CryptoAlgorithmSHA224>();
-    registerAlgorithm<CryptoAlgorithmSHA256>();
-    registerAlgorithm<CryptoAlgorithmSHA384>();
-    registerAlgorithm<CryptoAlgorithmSHA512>();
+    registerAlgorithmWithAlternativeName<CryptoAlgorithmSHA1>();
+    registerAlgorithmWithAlternativeName<CryptoAlgorithmSHA224>();
+    registerAlgorithmWithAlternativeName<CryptoAlgorithmSHA256>();
+    registerAlgorithmWithAlternativeName<CryptoAlgorithmSHA384>();
+    registerAlgorithmWithAlternativeName<CryptoAlgorithmSHA512>();
     registerAlgorithm<CryptoAlgorithmEd25519>();
 }
 

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRsaPssParams.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRsaPssParams.h
@@ -34,6 +34,7 @@ namespace WebCore {
 class CryptoAlgorithmRsaPssParams final : public CryptoAlgorithmParameters {
 public:
     size_t saltLength;
+    size_t padding = 0; // 0 = default
 
     Class parametersClass() const final { return Class::RsaPssParams; }
 
@@ -42,6 +43,7 @@ public:
         CryptoAlgorithmRsaPssParams result;
         result.identifier = identifier;
         result.saltLength = saltLength;
+        result.padding = padding;
 
         return result;
     }

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA1.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA1.h
@@ -34,6 +34,8 @@ namespace WebCore {
 class CryptoAlgorithmSHA1 final : public CryptoAlgorithm {
 public:
     static constexpr ASCIILiteral s_name = "SHA-1"_s;
+    static constexpr ASCIILiteral s_alternative_name = "SHA1"_s;
+
     static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::SHA_1;
     static Ref<CryptoAlgorithm> create();
 

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA224.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA224.h
@@ -34,6 +34,8 @@ namespace WebCore {
 class CryptoAlgorithmSHA224 final : public CryptoAlgorithm {
 public:
     static constexpr ASCIILiteral s_name = "SHA-224"_s;
+    static constexpr ASCIILiteral s_alternative_name = "SHA224"_s;
+
     static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::SHA_224;
     static Ref<CryptoAlgorithm> create();
 

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA256.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA256.h
@@ -34,6 +34,8 @@ namespace WebCore {
 class CryptoAlgorithmSHA256 final : public CryptoAlgorithm {
 public:
     static constexpr ASCIILiteral s_name = "SHA-256"_s;
+    static constexpr ASCIILiteral s_alternative_name = "SHA256"_s;
+
     static const CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::SHA_256;
     static Ref<CryptoAlgorithm> create();
 

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA384.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA384.h
@@ -34,6 +34,8 @@ namespace WebCore {
 class CryptoAlgorithmSHA384 final : public CryptoAlgorithm {
 public:
     static constexpr ASCIILiteral s_name = "SHA-384"_s;
+    static constexpr ASCIILiteral s_alternative_name = "SHA384"_s;
+
     static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::SHA_384;
     static Ref<CryptoAlgorithm> create();
 

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA512.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA512.h
@@ -34,6 +34,8 @@ namespace WebCore {
 class CryptoAlgorithmSHA512 final : public CryptoAlgorithm {
 public:
     static constexpr ASCIILiteral s_name = "SHA-512"_s;
+    static constexpr ASCIILiteral s_alternative_name = "SHA512"_s;
+
     static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::SHA_512;
     static Ref<CryptoAlgorithm> create();
 

--- a/src/bun.js/bindings/webcrypto/CryptoKeyRSA.h
+++ b/src/bun.js/bindings/webcrypto/CryptoKeyRSA.h
@@ -93,6 +93,7 @@ public:
     std::unique_ptr<CryptoKeyRSAComponents> exportData() const;
 
     CryptoAlgorithmIdentifier hashAlgorithmIdentifier() const { return m_hash; }
+    bool isRestrictedToHash() const { return m_restrictedToSpecificHash; }
 
 private:
     CryptoKeyRSA(CryptoAlgorithmIdentifier, CryptoAlgorithmIdentifier hash, bool hasHash, CryptoKeyType, PlatformRSAKeyContainer&&, bool extractable, CryptoKeyUsageBitmap);

--- a/src/bun.js/bindings/webcrypto/CryptoKeyRSA.h
+++ b/src/bun.js/bindings/webcrypto/CryptoKeyRSA.h
@@ -93,7 +93,6 @@ public:
     std::unique_ptr<CryptoKeyRSAComponents> exportData() const;
 
     CryptoAlgorithmIdentifier hashAlgorithmIdentifier() const { return m_hash; }
-    bool isRestrictedToHash() const { return m_restrictedToSpecificHash; }
 
 private:
     CryptoKeyRSA(CryptoAlgorithmIdentifier, CryptoAlgorithmIdentifier hash, bool hasHash, CryptoKeyType, PlatformRSAKeyContainer&&, bool extractable, CryptoKeyUsageBitmap);

--- a/src/js/node/crypto.js
+++ b/src/js/node/crypto.js
@@ -12300,6 +12300,7 @@ const _createSign = crypto_exports.createSign;
 function getHashAlgorithm(algorithm) {
   if (typeof algorithm !== "string") throw new TypeError("Algorithm must be a string");
   switch (algorithm.toLowerCase()) {
+    case "ecdsa-with-SHA1":
     case "sha-1":
     case "sha1":
       return "SHA-1";
@@ -12326,8 +12327,8 @@ crypto_exports.sign = function (algorithm, data, key, callback) {
   // key must be a KeyObject
   if (!(key instanceof KeyObject)) {
     if ($isObject(key) && key.key) {
-      // padding = key.padding;
-      // saltLength = key.saltLength;
+      padding = key.padding;
+      saltLength = key.saltLength;
       dsaEncoding = key.dsaEncoding;
     }
     key = _createPrivateKey(key);
@@ -12342,9 +12343,9 @@ crypto_exports.sign = function (algorithm, data, key, callback) {
           .sign(key);
       } else {
         if (algorithm) {
-          result = nativeSign(key[kCryptoKey], data, getHashAlgorithm(algorithm), dsaEncoding);
+          result = nativeSign(key[kCryptoKey], data, getHashAlgorithm(algorithm), dsaEncoding, padding, saltLength);
         }
-        result = nativeSign(key[kCryptoKey], data, undefined, dsaEncoding);
+        result = nativeSign(key[kCryptoKey], data, undefined, dsaEncoding, padding, saltLength);
       }
       callback(null, result);
     } catch (err) {
@@ -12357,9 +12358,9 @@ crypto_exports.sign = function (algorithm, data, key, callback) {
         .sign(key);
     } else {
       if (algorithm) {
-        return nativeSign(key[kCryptoKey], data, getHashAlgorithm(algorithm), dsaEncoding);
+        return nativeSign(key[kCryptoKey], data, getHashAlgorithm(algorithm), dsaEncoding, padding, saltLength);
       }
-      return nativeSign(key[kCryptoKey], data, undefined, dsaEncoding);
+      return nativeSign(key[kCryptoKey], data, undefined, dsaEncoding, padding, saltLength);
     }
   }
 };

--- a/src/js/node/crypto.js
+++ b/src/js/node/crypto.js
@@ -12331,7 +12331,11 @@ crypto_exports.sign = function (algorithm, data, key, callback) {
       saltLength = key.saltLength;
       dsaEncoding = key.dsaEncoding;
     }
-    key = _createPrivateKey(key);
+    if (key.key instanceof KeyObject) {
+      key = key.key;
+    } else {
+      key = _createPrivateKey(key);
+    }
   }
   if (typeof callback === "function") {
     try {
@@ -12372,11 +12376,15 @@ crypto_exports.verify = function (algorithm, data, key, signature, callback) {
   // key must be a KeyObject
   if (!(key instanceof KeyObject)) {
     if ($isObject(key) && key.key) {
-      // padding = key.padding;
-      // saltLength = key.saltLength;
+      padding = key.padding;
+      saltLength = key.saltLength;
       dsaEncoding = key.dsaEncoding;
     }
-    key = _createPublicKey(key);
+    if (key.key instanceof KeyObject && key.key.type === "public") {
+      key = key.key;
+    } else {
+      key = _createPublicKey(key);
+    }
   }
   if (typeof callback === "function") {
     try {
@@ -12388,9 +12396,17 @@ crypto_exports.verify = function (algorithm, data, key, signature, callback) {
           .verify(key, signature);
       } else {
         if (algorithm) {
-          result = nativeVerify(key[kCryptoKey], data, signature, getHashAlgorithm(algorithm), dsaEncoding);
+          result = nativeVerify(
+            key[kCryptoKey],
+            data,
+            signature,
+            getHashAlgorithm(algorithm),
+            dsaEncoding,
+            padding,
+            saltLength,
+          );
         }
-        result = nativeVerify(key[kCryptoKey], data, signature, undefined, dsaEncoding);
+        result = nativeVerify(key[kCryptoKey], data, signature, undefined, dsaEncoding, padding, saltLength);
       }
       callback(null, result);
     } catch (err) {
@@ -12403,9 +12419,17 @@ crypto_exports.verify = function (algorithm, data, key, signature, callback) {
         .verify(key, signature);
     } else {
       if (algorithm) {
-        return nativeVerify(key[kCryptoKey], data, signature, getHashAlgorithm(algorithm));
+        return nativeVerify(
+          key[kCryptoKey],
+          data,
+          signature,
+          getHashAlgorithm(algorithm),
+          dsaEncoding,
+          padding,
+          saltLength,
+        );
       }
-      return nativeVerify(key[kCryptoKey], data, signature, undefined, dsaEncoding);
+      return nativeVerify(key[kCryptoKey], data, signature, undefined, dsaEncoding, padding, saltLength);
     }
   }
 };

--- a/src/js/node/crypto.js
+++ b/src/js/node/crypto.js
@@ -12297,30 +12297,6 @@ var webcrypto = crypto;
 var _subtle = webcrypto.subtle;
 const _createSign = crypto_exports.createSign;
 
-function getHashAlgorithm(algorithm) {
-  if (typeof algorithm !== "string") throw new TypeError("Algorithm must be a string");
-  switch (algorithm.toLowerCase()) {
-    case "ecdsa-with-SHA1":
-    case "sha-1":
-    case "sha1":
-      return "SHA-1";
-    case "sha-224":
-    case "sha224":
-      return "SHA-224";
-    case "sha-256":
-    case "sha256":
-      return "SHA-256";
-    case "sha-384":
-    case "sha384":
-      return "SHA-384";
-    case "sha-512":
-    case "sha512":
-      return "SHA-512";
-    default:
-      throw new TypeError(`Invalid hash algorithm "${algorithm}"`);
-  }
-}
-
 crypto_exports.sign = function (algorithm, data, key, callback) {
   // TODO: move this to native
   var dsaEncoding, padding, saltLength;
@@ -12346,10 +12322,7 @@ crypto_exports.sign = function (algorithm, data, key, callback) {
           .update(data)
           .sign(key);
       } else {
-        if (algorithm) {
-          result = nativeSign(key[kCryptoKey], data, getHashAlgorithm(algorithm), dsaEncoding, padding, saltLength);
-        }
-        result = nativeSign(key[kCryptoKey], data, undefined, dsaEncoding, padding, saltLength);
+        result = nativeSign(key[kCryptoKey], data, algorithm, dsaEncoding, padding, saltLength);
       }
       callback(null, result);
     } catch (err) {
@@ -12361,10 +12334,7 @@ crypto_exports.sign = function (algorithm, data, key, callback) {
         .update(data)
         .sign(key);
     } else {
-      if (algorithm) {
-        return nativeSign(key[kCryptoKey], data, getHashAlgorithm(algorithm), dsaEncoding, padding, saltLength);
-      }
-      return nativeSign(key[kCryptoKey], data, undefined, dsaEncoding, padding, saltLength);
+      return nativeSign(key[kCryptoKey], data, algorithm, dsaEncoding, padding, saltLength);
     }
   }
 };
@@ -12395,18 +12365,7 @@ crypto_exports.verify = function (algorithm, data, key, signature, callback) {
           .update(data)
           .verify(key, signature);
       } else {
-        if (algorithm) {
-          result = nativeVerify(
-            key[kCryptoKey],
-            data,
-            signature,
-            getHashAlgorithm(algorithm),
-            dsaEncoding,
-            padding,
-            saltLength,
-          );
-        }
-        result = nativeVerify(key[kCryptoKey], data, signature, undefined, dsaEncoding, padding, saltLength);
+        result = nativeVerify(key[kCryptoKey], data, signature, algorithm, dsaEncoding, padding, saltLength);
       }
       callback(null, result);
     } catch (err) {
@@ -12418,18 +12377,7 @@ crypto_exports.verify = function (algorithm, data, key, signature, callback) {
         .update(data)
         .verify(key, signature);
     } else {
-      if (algorithm) {
-        return nativeVerify(
-          key[kCryptoKey],
-          data,
-          signature,
-          getHashAlgorithm(algorithm),
-          dsaEncoding,
-          padding,
-          saltLength,
-        );
-      }
-      return nativeVerify(key[kCryptoKey], data, signature, undefined, dsaEncoding, padding, saltLength);
+      return nativeVerify(key[kCryptoKey], data, signature, algorithm, dsaEncoding, padding, saltLength);
     }
   }
 };

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -92,1505 +92,1488 @@ function testSignVerify(publicKey: any, privateKey: any) {
   }
 }
 
-// describe("crypto.KeyObjects", () => {
-//   test("Attempting to create a key using other than CryptoKey should throw", async () => {
-//     expect(() => new KeyObject("secret", "")).toThrow();
-//     expect(() => new KeyObject("secret")).toThrow();
-//     expect(() => KeyObject.from("invalid_key")).toThrow();
-//   });
-//   test("basics of createSecretKey should work", async () => {
-//     const keybuf = randomBytes(32);
-//     const key = createSecretKey(keybuf);
-//     expect(key.type).toBe("secret");
-//     expect(key.toString()).toBe("[object KeyObject]");
-//     expect(key.symmetricKeySize).toBe(32);
-//     expect(key.asymmetricKeyType).toBe(undefined);
-//     expect(key.asymmetricKeyDetails).toBe(undefined);
-
-//     const exportedKey = key.export();
-//     expect(keybuf).toEqual(exportedKey);
-
-//     const plaintext = Buffer.from("Hello world", "utf8");
-
-//     const cipher = createCipheriv("aes-256-ecb", key, null);
-//     const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
-
-//     const decipher = createDecipheriv("aes-256-ecb", key, null);
-//     const deciphered = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
-
-//     expect(plaintext).toEqual(deciphered);
-//   });
-
-//   test("Passing an existing public key object to createPublicKey should throw", async () => {
-//     // Passing an existing public key object to createPublicKey should throw.
-//     const publicKey = createPublicKey(publicPem);
-//     expect(() => createPublicKey(publicKey)).toThrow();
-
-//     // Constructing a private key from a public key should be impossible, even
-//     // if the public key was derived from a private key.
-//     expect(() => createPrivateKey(createPublicKey(privatePem))).toThrow();
-
-//     // Similarly, passing an existing private key object to createPrivateKey
-//     // should throw.
-//     const privateKey = createPrivateKey(privatePem);
-//     expect(() => createPrivateKey(privateKey)).toThrow();
-//   });
-
-//   test("basics should work", async () => {
-//     const jwk = {
-//       e: "AQAB",
-//       n:
-//         "t9xYiIonscC3vz_A2ceR7KhZZlDu_5bye53nCVTcKnWd2seY6UAdKersX6njr83Dd5OVe" +
-//         "1BW_wJvp5EjWTAGYbFswlNmeD44edEGM939B6Lq-_8iBkrTi8mGN4YCytivE24YI0D4XZ" +
-//         "MPfkLSpab2y_Hy4DjQKBq1ThZ0UBnK-9IhX37Ju_ZoGYSlTIGIhzyaiYBh7wrZBoPczIE" +
-//         "u6et_kN2VnnbRUtkYTF97ggcv5h-hDpUQjQW0ZgOMcTc8n-RkGpIt0_iM_bTjI3Tz_gsF" +
-//         "di6hHcpZgbopPL630296iByyigQCPJVzdusFrQN5DeC-zT_nGypQkZanLb4ZspSx9Q",
-//       d:
-//         "ktnq2LvIMqBj4txP82IEOorIRQGVsw1khbm8A-cEpuEkgM71Yi_0WzupKktucUeevQ5i0" +
-//         "Yh8w9e1SJiTLDRAlJz66kdky9uejiWWl6zR4dyNZVMFYRM43ijLC-P8rPne9Fz16IqHFW" +
-//         "5VbJqA1xCBhKmuPMsD71RNxZ4Hrsa7Kt_xglQTYsLbdGIwDmcZihId9VGXRzvmCPsDRf2" +
-//         "fCkAj7HDeRxpUdEiEDpajADc-PWikra3r3b40tVHKWm8wxJLivOIN7GiYXKQIW6RhZgH-" +
-//         "Rk45JIRNKxNagxdeXUqqyhnwhbTo1Hite0iBDexN9tgoZk0XmdYWBn6ElXHRZ7VCDQ",
-//       p:
-//         "8UovlB4nrBm7xH-u7XXBMbqxADQm5vaEZxw9eluc-tP7cIAI4sglMIvL_FMpbd2pEeP_B" +
-//         "kR76NTDzzDuPAZvUGRavgEjy0O9j2NAs_WPK4tZF-vFdunhnSh4EHAF4Ij9kbsUi90NOp" +
-//         "bGfVqPdOaHqzgHKoR23Cuusk9wFQ2XTV8",
-//       q:
-//         "wxHdEYT9xrpfrHPqSBQPpO0dWGKJEkrWOb-76rSfuL8wGR4OBNmQdhLuU9zTIh22pog-X" +
-//         "PnLPAecC-4yu_wtJ2SPCKiKDbJBre0CKPyRfGqzvA3njXwMxXazU4kGs-2Fg-xu_iKbaI" +
-//         "jxXrclBLhkxhBtySrwAFhxxOk6fFcPLSs",
-//       dp:
-//         "qS_Mdr5CMRGGMH0bKhPUWEtAixUGZhJaunX5wY71Xoc_Gh4cnO-b7BNJ_-5L8WZog0vr" +
-//         "6PgiLhrqBaCYm2wjpyoG2o2wDHm-NAlzN_wp3G2EFhrSxdOux-S1c0kpRcyoiAO2n29rN" +
-//         "Da-jOzwBBcU8ACEPdLOCQl0IEFFJO33tl8",
-//       dq:
-//         "WAziKpxLKL7LnL4dzDcx8JIPIuwnTxh0plCDdCffyLaT8WJ9lXbXHFTjOvt8WfPrlDP_" +
-//         "Ylxmfkw5BbGZOP1VLGjZn2DkH9aMiwNmbDXFPdG0G3hzQovx_9fajiRV4DWghLHeT9wzJ" +
-//         "fZabRRiI0VQR472300AVEeX4vgbrDBn600",
-//       qi:
-//         "k7czBCT9rHn_PNwCa17hlTy88C4vXkwbz83Oa-aX5L4e5gw5lhcR2ZuZHLb2r6oMt9rl" +
-//         "D7EIDItSs-u21LOXWPTAlazdnpYUyw_CzogM_PN-qNwMRXn5uXFFhmlP2mVg2EdELTahX" +
-//         "ch8kWqHaCSX53yvqCtRKu_j76V31TfQZGM",
-//       kty: "RSA",
-//     };
-//     const publicJwk = { kty: jwk.kty, e: jwk.e, n: jwk.n };
-
-//     const publicKey = createPublicKey(publicPem);
-//     expect(publicKey.type).toBe("public");
-//     expect(publicKey.toString()).toBe("[object KeyObject]");
-//     expect(publicKey.asymmetricKeyType).toBe("rsa");
-//     expect(publicKey.symmetricKeySize).toBe(undefined);
-
-//     const privateKey = createPrivateKey(privatePem);
-//     expect(privateKey.type).toBe("private");
-//     expect(privateKey.toString()).toBe("[object KeyObject]");
-//     expect(privateKey.asymmetricKeyType).toBe("rsa");
-//     expect(privateKey.symmetricKeySize).toBe(undefined);
-
-//     // It should be possible to derive a public key from a private key.
-//     const derivedPublicKey = createPublicKey(privateKey);
-//     expect(derivedPublicKey.type).toBe("public");
-//     expect(derivedPublicKey.toString()).toBe("[object KeyObject]");
-//     expect(derivedPublicKey.asymmetricKeyType).toBe("rsa");
-//     expect(derivedPublicKey.symmetricKeySize).toBe(undefined);
-
-//     const publicKeyFromJwk = createPublicKey({ key: publicJwk, format: "jwk" });
-//     expect(publicKey.type).toBe("public");
-//     expect(publicKey.toString()).toBe("[object KeyObject]");
-//     expect(publicKey.asymmetricKeyType).toBe("rsa");
-//     expect(publicKey.symmetricKeySize).toBe(undefined);
-
-//     const privateKeyFromJwk = createPrivateKey({ key: jwk, format: "jwk" });
-//     expect(privateKey.type).toBe("private");
-//     expect(privateKey.toString()).toBe("[object KeyObject]");
-//     expect(privateKey.asymmetricKeyType).toBe("rsa");
-//     expect(privateKey.symmetricKeySize).toBe(undefined);
-
-//     // It should also be possible to import an encrypted private key as a public
-//     // key.
-//     const decryptedKey = createPublicKey({
-//       key: privateKey.export({
-//         type: "pkcs8",
-//         format: "pem",
-//         passphrase: Buffer.from("123"),
-//         cipher: "aes-128-cbc",
-//       }),
-//       format: "pem",
-//       passphrase: "123", // this is not documented, but it works
-//     });
-//     expect(decryptedKey.type).toBe("public");
-//     expect(decryptedKey.asymmetricKeyType).toBe("rsa");
-
-//     // Exporting the key using JWK should not work since this format does not
-//     // support key encryption
-//     expect(() => {
-//       privateKey.export({ format: "jwk", passphrase: "secret" });
-//     }).toThrow();
-
-//     // Test exporting with an invalid options object, this should throw.
-//     for (const opt of [undefined, null, "foo", 0, NaN]) {
-//       expect(() => publicKey.export(opt)).toThrow();
-//     }
-
-//     for (const keyObject of [publicKey, derivedPublicKey, publicKeyFromJwk]) {
-//       const exported = keyObject.export({ format: "jwk" });
-//       expect(exported).toBeDefined();
-//       const { kty, n, e } = exported as { kty: string; n: string; e: string };
-//       expect({ kty, n, e }).toEqual({ kty: "RSA", n: jwk.n, e: jwk.e });
-//     }
-
-//     for (const keyObject of [privateKey, privateKeyFromJwk]) {
-//       const exported = keyObject.export({ format: "jwk" });
-//       expect(exported).toEqual(jwk);
-//     }
-
-//     const publicDER = publicKey.export({
-//       format: "der",
-//       type: "pkcs1",
-//     });
-
-//     const privateDER = privateKey.export({
-//       format: "der",
-//       type: "pkcs1",
-//     });
-
-//     expect(Buffer.isBuffer(publicDER)).toBe(true);
-//     expect(Buffer.isBuffer(privateDER)).toBe(true);
-//     const plaintext = Buffer.from("Hello world", "utf8");
-
-//     const testDecryption = (fn, ciphertexts, decryptionKeys) => {
-//       for (const ciphertext of ciphertexts) {
-//         for (const key of decryptionKeys) {
-//           const deciphered = fn(key, ciphertext);
-//           expect(deciphered).toEqual(plaintext);
-//         }
-//       }
-//     };
-
-//     testDecryption(
-//       privateDecrypt,
-//       [
-//         // Encrypt using the public key.
-//         publicEncrypt(publicKey, plaintext),
-//         publicEncrypt({ key: publicKey }, plaintext),
-//         publicEncrypt({ key: publicJwk, format: "jwk" }, plaintext),
-
-//         // Encrypt using the private key.
-//         publicEncrypt(privateKey, plaintext),
-//         publicEncrypt({ key: privateKey }, plaintext),
-//         publicEncrypt({ key: jwk, format: "jwk" }, plaintext),
-
-//         // Encrypt using a public key derived from the private key.
-//         publicEncrypt(derivedPublicKey, plaintext),
-//         publicEncrypt({ key: derivedPublicKey }, plaintext),
-
-//         // Test distinguishing PKCS#1 public and private keys based on the
-//         // DER-encoded data only.
-//         publicEncrypt({ format: "der", type: "pkcs1", key: publicDER }, plaintext),
-//         publicEncrypt({ format: "der", type: "pkcs1", key: privateDER }, plaintext),
-//       ],
-//       [
-//         privateKey,
-//         { format: "pem", key: privatePem },
-//         { format: "der", type: "pkcs1", key: privateDER },
-//         { key: jwk, format: "jwk" },
-//       ],
-//     );
-
-//     testDecryption(
-//       publicDecrypt,
-//       [privateEncrypt(privateKey, plaintext)],
-//       [
-//         // Decrypt using the public key.
-//         publicKey,
-//         { format: "pem", key: publicPem },
-//         { format: "der", type: "pkcs1", key: publicDER },
-//         { key: publicJwk, format: "jwk" },
-
-//         // Decrypt using the private key.
-//         privateKey,
-//         { format: "pem", key: privatePem },
-//         { format: "der", type: "pkcs1", key: privateDER },
-//         { key: jwk, format: "jwk" },
-//       ],
-//     );
-//   });
-
-//   test("This should not cause a crash: https://github.com/nodejs/node/issues/25247", async () => {
-//     expect(() => createPrivateKey({ key: "" })).toThrow();
-//   });
-//   test("This should not abort either: https://github.com/nodejs/node/issues/29904", async () => {
-//     expect(() => createPrivateKey({ key: Buffer.alloc(0), format: "der", type: "spki" })).toThrow();
-//   });
-
-//   test("BoringSSL will not parse PKCS#1", async () => {
-//     // Unlike SPKI, PKCS#1 is a valid encoding for private keys (and public keys),
-//     // so it should be accepted by createPrivateKey, but OpenSSL won't parse it.
-//     expect(() => {
-//       const key = createPublicKey(publicPem).export({
-//         format: "der",
-//         type: "pkcs1",
-//       });
-//       createPrivateKey({ key, format: "der", type: "pkcs1" });
-//     }).toThrow("Invalid use of PKCS#1 as private key");
-//   });
-
-//   [
-//     {
-//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed25519_private.pem"), "ascii"),
-//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed25519_public.pem"), "ascii"),
-//       keyType: "ed25519",
-//       jwk: {
-//         crv: "Ed25519",
-//         x: "K1wIouqnuiA04b3WrMa-xKIKIpfHetNZRv3h9fBf768",
-//         d: "wVK6M3SMhQh3NK-7GRrSV-BVWQx1FO5pW8hhQeu_NdA",
-//         kty: "OKP",
-//       },
-//     },
-//     {
-//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed448_private.pem"), "ascii"),
-//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed448_public.pem"), "ascii"),
-//       keyType: "ed448",
-//       jwk: {
-//         crv: "Ed448",
-//         x: "oX_ee5-jlcU53-BbGRsGIzly0V-SZtJ_oGXY0udf84q2hTW2RdstLktvwpkVJOoNb7o" + "Dgc2V5ZUA",
-//         d: "060Ke71sN0GpIc01nnGgMDkp0sFNQ09woVo4AM1ffax1-mjnakK0-p-S7-Xf859QewX" + "jcR9mxppY",
-//         kty: "OKP",
-//       },
-//     },
-//     {
-//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x25519_private.pem"), "ascii"),
-//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x25519_public.pem"), "ascii"),
-//       keyType: "x25519",
-//       jwk: {
-//         crv: "X25519",
-//         x: "aSb8Q-RndwfNnPeOYGYPDUN3uhAPnMLzXyfi-mqfhig",
-//         d: "mL_IWm55RrALUGRfJYzw40gEYWMvtRkesP9mj8o8Omc",
-//         kty: "OKP",
-//       },
-//     },
-//     {
-//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x448_private.pem"), "ascii"),
-//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x448_public.pem"), "ascii"),
-//       keyType: "x448",
-//       jwk: {
-//         crv: "X448",
-//         x: "ioHSHVpTs6hMvghosEJDIR7ceFiE3-Xccxati64oOVJ7NWjfozE7ae31PXIUFq6cVYg" + "vSKsDFPA",
-//         d: "tMNtrO_q8dlY6Y4NDeSTxNQ5CACkHiPvmukidPnNIuX_EkcryLEXt_7i6j6YZMKsrWy" + "S0jlSYJk",
-//         kty: "OKP",
-//       },
-//     },
-//   ].forEach(info => {
-//     const keyType = info.keyType;
-//     // X25519 implementation is incomplete, Ed448 and X448 are not supported yet
-//     const test = keyType === "ed25519" ? it : it.skip;
-//     let privateKey: KeyObject;
-//     test(`${keyType} from Buffer should work`, async () => {
-//       const key = createPrivateKey(info.private);
-//       privateKey = key;
-//       expect(key.type).toBe("private");
-//       expect(key.asymmetricKeyType).toBe(keyType);
-//       expect(key.symmetricKeySize).toBe(undefined);
-//       expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
-//       const jwt = key.export({ format: "jwk" });
-//       expect(jwt).toEqual(info.jwk);
-//     });
-
-//     test(`${keyType} createPrivateKey from jwk should work`, async () => {
-//       const key = createPrivateKey({ key: info.jwk, format: "jwk" });
-//       expect(key.type).toBe("private");
-//       expect(key.asymmetricKeyType).toBe(keyType);
-//       expect(key.symmetricKeySize).toBe(undefined);
-//       expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
-//       const jwt = key.export({ format: "jwk" });
-//       expect(jwt).toEqual(info.jwk);
-//     });
-
-//     [
-//       ["public", info.public],
-//       ["private", info.private],
-//       ["jwk", { key: info.jwk, format: "jwk" }],
-//     ].forEach(([name, input]) => {
-//       test(`${keyType} createPublicKey using ${name} key should work`, async () => {
-//         const key = createPublicKey(input);
-//         expect(key.type).toBe("public");
-//         expect(key.asymmetricKeyType).toBe(keyType);
-//         expect(key.symmetricKeySize).toBe(undefined);
-//         if (name == "public") {
-//           expect(key.export({ type: "spki", format: "pem" })).toEqual(info.public);
-//         }
-//         if (name == "jwk") {
-//           const jwt = { ...info.jwk };
-//           delete jwt.d;
-//           const jwk_exported = key.export({ format: "jwk" });
-//           expect(jwk_exported).toEqual(jwt);
-//         }
-//       });
-//     });
-//   });
-
-//   [
-//     {
-//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p256_private.pem"), "ascii"),
-//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p256_public.pem"), "ascii"),
-//       keyType: "ec",
-//       namedCurve: "prime256v1",
-//       jwk: {
-//         crv: "P-256",
-//         d: "DxBsPQPIgMuMyQbxzbb9toew6Ev6e9O6ZhpxLNgmAEo",
-//         kty: "EC",
-//         x: "X0mMYR_uleZSIPjNztIkAS3_ud5LhNpbiIFp6fNf2Gs",
-//         y: "UbJuPy2Xi0lW7UYTBxPK3yGgDu9EAKYIecjkHX5s2lI",
-//       },
-//     },
-//     {
-//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_secp256k1_private.pem"), "ascii"),
-//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_secp256k1_public.pem"), "ascii"),
-//       keyType: "ec",
-//       namedCurve: "secp256k1",
-//       jwk: {
-//         crv: "secp256k1",
-//         d: "c34ocwTwpFa9NZZh3l88qXyrkoYSxvC0FEsU5v1v4IM",
-//         kty: "EC",
-//         x: "cOzhFSpWxhalCbWNdP2H_yUkdC81C9T2deDpfxK7owA",
-//         y: "-A3DAZTk9IPppN-f03JydgHaFvL1fAHaoXf4SX4NXyo",
-//       },
-//     },
-//     {
-//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p384_private.pem"), "ascii"),
-//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p384_public.pem"), "ascii"),
-//       keyType: "ec",
-//       namedCurve: "secp384r1",
-//       jwk: {
-//         crv: "P-384",
-//         d: "dwfuHuAtTlMRn7ZBCBm_0grpc1D_4hPeNAgevgelljuC0--k_LDFosDgBlLLmZsi",
-//         kty: "EC",
-//         x: "hON3nzGJgv-08fdHpQxgRJFZzlK-GZDGa5f3KnvM31cvvjJmsj4UeOgIdy3rDAjV",
-//         y: "fidHhtecNCGCfLqmrLjDena1NSzWzWH1u_oUdMKGo5XSabxzD7-8JZxjpc8sR9cl",
-//       },
-//     },
-//     {
-//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p521_private.pem"), "ascii"),
-//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p521_public.pem"), "ascii"),
-//       keyType: "ec",
-//       namedCurve: "secp521r1",
-//       jwk: {
-//         crv: "P-521",
-//         d: "Eghuafcab9jXW4gOQLeDaKOlHEiskQFjiL8klijk6i6DNOXcFfaJ9GW48kxpodw16ttAf9Z1WQstfzpKGUetHIk",
-//         kty: "EC",
-//         x: "AaLFgjwZtznM3N7qsfb86awVXe6c6djUYOob1FN-kllekv0KEXV0bwcDjPGQz5f6MxL" + "CbhMeHRavUS6P10rsTtBn",
-//         y: "Ad3flexBeAfXceNzRBH128kFbOWD6W41NjwKRqqIF26vmgW_8COldGKZjFkOSEASxPB" + "cvA2iFJRUyQ3whC00j0Np",
-//       },
-//     },
-//   ].forEach(info => {
-//     const { keyType, namedCurve } = info;
-//     const test = namedCurve === "secp256k1" ? it.skip : it;
-//     let privateKey: KeyObject;
-//     test(`${keyType} ${namedCurve} createPrivateKey from Buffer should work`, async () => {
-//       const key = createPrivateKey(info.private);
-//       privateKey = key;
-//       expect(key.type).toBe("private");
-//       expect(key.asymmetricKeyType).toBe(keyType);
-//       expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
-//       expect(key.symmetricKeySize).toBe(undefined);
-//       expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
-//       const jwt = key.export({ format: "jwk" });
-//       expect(jwt).toEqual(info.jwk);
-//     });
-
-//     test(`${keyType} ${namedCurve} createPrivateKey from jwk should work`, async () => {
-//       const key = createPrivateKey({ key: info.jwk, format: "jwk" });
-//       expect(key.type).toBe("private");
-//       expect(key.asymmetricKeyType).toBe(keyType);
-//       expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
-//       expect(key.symmetricKeySize).toBe(undefined);
-//       expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
-//       const jwt = key.export({ format: "jwk" });
-//       expect(jwt).toEqual(info.jwk);
-//     });
-
-//     [
-//       ["public", info.public],
-//       ["private", info.private],
-//       ["jwk", { key: info.jwk, format: "jwk" }],
-//     ].forEach(([name, input]) => {
-//       test(`${keyType} ${namedCurve} createPublicKey using ${name} should work`, async () => {
-//         const key = createPublicKey(input);
-//         expect(key.type).toBe("public");
-//         expect(key.asymmetricKeyType).toBe(keyType);
-//         expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
-//         expect(key.symmetricKeySize).toBe(undefined);
-//         if (name == "public") {
-//           expect(key.export({ type: "spki", format: "pem" })).toEqual(info.public);
-//         }
-//         if (name == "jwk") {
-//           const jwt = { ...info.jwk };
-//           delete jwt.d;
-//           const jwk_exported = key.export({ format: "jwk" });
-//           expect(jwk_exported).toEqual(jwt);
-//         }
-
-//         const pkey = privateKey || info.private;
-//         const signature = createSign("sha256").update("foo").sign({ key: pkey });
-//         const okay = createVerify("sha256").update("foo").verify({ key: key }, signature);
-//         expect(okay).toBeTrue();
-//       });
-//     });
-//   });
-
-//   test("private encrypted should work", async () => {
-//     // Reading an encrypted key without a passphrase should fail.
-//     expect(() => createPrivateKey(privateEncryptedPem)).toThrow();
-//     // Reading an encrypted key with a passphrase that exceeds OpenSSL's buffer
-//     // size limit should fail with an appropriate error code.
-//     expect(() =>
-//       createPrivateKey({
-//         key: privateEncryptedPem,
-//         format: "pem",
-//         passphrase: Buffer.alloc(1025, "a"),
-//       }),
-//     ).toThrow();
-//     // The buffer has a size of 1024 bytes, so this passphrase should be permitted
-//     // (but will fail decryption).
-//     expect(() =>
-//       createPrivateKey({
-//         key: privateEncryptedPem,
-//         format: "pem",
-//         passphrase: Buffer.alloc(1024, "a"),
-//       }),
-//     ).toThrow();
-//     const publicKey = createPublicKey({
-//       key: privateEncryptedPem,
-//       format: "pem",
-//       passphrase: "password", // this is not documented but should work
-//     });
-//     expect(publicKey.type).toBe("public");
-//     expect(publicKey.asymmetricKeyType).toBe("rsa");
-//     expect(publicKey.symmetricKeySize).toBe(undefined);
-
-//     const privateKey = createPrivateKey({
-//       key: privateEncryptedPem,
-//       format: "pem",
-//       passphrase: "password",
-//     });
-//     expect(privateKey.type).toBe("private");
-//     expect(privateKey.asymmetricKeyType).toBe("rsa");
-//     expect(privateKey.symmetricKeySize).toBe(undefined);
-//   });
-
-//   [2048, 4096].forEach(suffix => {
-//     test(`RSA-${suffix} should work`, async () => {
-//       {
-//         const publicPem = fs.readFileSync(path.join(import.meta.dir, "fixtures", `rsa_public_${suffix}.pem`), "ascii");
-//         const privatePem = fs.readFileSync(
-//           path.join(import.meta.dir, "fixtures", `rsa_private_${suffix}.pem`),
-//           "ascii",
-//         );
-//         const publicKey = createPublicKey(publicPem);
-//         const expectedKeyDetails = {
-//           modulusLength: suffix,
-//           publicExponent: 65537n,
-//         };
-//         expect(publicKey.type).toBe("public");
-//         expect(publicKey.asymmetricKeyType).toBe("rsa");
-//         expect(publicKey.asymmetricKeyDetails).toEqual(expectedKeyDetails);
-
-//         const privateKey = createPrivateKey(privatePem);
-//         expect(privateKey.type).toBe("private");
-//         expect(privateKey.asymmetricKeyType).toBe("rsa");
-//         expect(privateKey.asymmetricKeyDetails).toEqual(expectedKeyDetails);
-
-//         for (const key of [privatePem, privateKey]) {
-//           // Any algorithm should work.
-//           for (const algo of ["sha1", "sha256"]) {
-//             // Any salt length should work.
-//             for (const saltLength of [undefined, 8, 10, 12, 16, 18, 20]) {
-//               const signature = createSign(algo).update("foo").sign({ key, saltLength });
-//               for (const pkey of [key, publicKey, publicPem]) {
-//                 const okay = createVerify(algo).update("foo").verify({ key: pkey, saltLength }, signature);
-//                 expect(okay).toBeTrue();
-//               }
-//             }
-//           }
-//         }
-//       }
-//     });
-//   });
-
-//   test("Exporting an encrypted private key requires a cipher", async () => {
-//     // Exporting an encrypted private key requires a cipher
-//     const privateKey = createPrivateKey(privatePem);
-//     expect(() => {
-//       privateKey.export({
-//         format: "pem",
-//         type: "pkcs8",
-//         passphrase: "super-secret",
-//       });
-//     }).toThrow(/cipher is required when passphrase is specified/);
-//   });
-
-//   test("secret export buffer format (default)", async () => {
-//     const buffer = Buffer.from("Hello World");
-//     const keyObject = createSecretKey(buffer);
-//     expect(keyObject.export()).toEqual(buffer);
-//     expect(keyObject.export({})).toEqual(buffer);
-//     expect(keyObject.export({ format: "buffer" })).toEqual(buffer);
-//     expect(keyObject.export({ format: undefined })).toEqual(buffer);
-//   });
-
-//   test('exporting an "oct" JWK from a secret', async () => {
-//     const buffer = Buffer.from("Hello World");
-//     const keyObject = createSecretKey(buffer);
-//     const jwk = keyObject.export({ format: "jwk" });
-//     expect(jwk).toEqual({ kty: "oct", k: "SGVsbG8gV29ybGQ" });
-//   });
-
-//   test("secret equals", async () => {
-//     {
-//       const first = Buffer.from("Hello");
-//       const second = Buffer.from("World");
-//       const keyObject = createSecretKey(first);
-//       expect(createSecretKey(first).equals(createSecretKey(first))).toBeTrue();
-//       expect(createSecretKey(first).equals(createSecretKey(second))).toBeFalse();
-
-//       expect(() => keyObject.equals(0)).toThrow(/otherKey must be a KeyObject/);
-
-//       expect(keyObject.equals(keyObject)).toBeTrue();
-//       expect(keyObject.equals(createPublicKey(publicPem))).toBeFalse();
-//       expect(keyObject.equals(createPrivateKey(privatePem))).toBeFalse();
-//     }
-
-//     {
-//       const first = createSecretKey(Buffer.alloc(0));
-//       const second = createSecretKey(new ArrayBuffer(0));
-//       const third = createSecretKey(Buffer.alloc(1));
-//       expect(first.equals(first)).toBeTrue();
-//       expect(first.equals(second)).toBeTrue();
-//       expect(first.equals(third)).toBeFalse();
-//       expect(third.equals(first)).toBeFalse();
-//     }
-//   });
-
-//   ["ed25519", "x25519"].forEach(keyType => {
-//     const test = keyType === "ed25519" ? it : it.skip;
-//     test(`${keyType} equals should work`, async () => {
-//       const first = generateKeyPairSync(keyType);
-//       const second = generateKeyPairSync(keyType);
-
-//       const secret = generateKeySync("aes", { length: 128 });
-
-//       expect(first.publicKey.equals(first.publicKey)).toBeTrue();
-
-//       expect(first.publicKey.equals(createPublicKey(first.publicKey.export({ format: "pem", type: "spki" }))));
-
-//       expect(first.publicKey.equals(second.publicKey)).toBeFalse();
-//       expect(first.publicKey.equals(second.privateKey)).toBeFalse();
-//       expect(first.publicKey.equals(secret)).toBeFalse();
-
-//       expect(first.privateKey.equals(first.privateKey)).toBeTrue();
-//       expect(
-//         first.privateKey.equals(createPrivateKey(first.privateKey.export({ format: "pem", type: "pkcs8" }))),
-//       ).toBeTrue();
-//       expect(first.privateKey.equals(second.privateKey)).toBeFalse();
-//       expect(first.privateKey.equals(second.publicKey)).toBeFalse();
-//       expect(first.privateKey.equals(secret)).toBeFalse();
-//     });
-//   });
-
-//   test("This should not cause a crash: https://github.com/nodejs/node/issues/44471", async () => {
-//     for (const key of ["", "foo", null, undefined, true, Boolean]) {
-//       expect(() => {
-//         createPublicKey({ key, format: "jwk" });
-//       }).toThrow();
-//       expect(() => {
-//         createPrivateKey({ key, format: "jwk" });
-//       }).toThrow();
-//     }
-//   });
-
-//   ["hmac", "aes"].forEach(type => {
-//     [128, 256].forEach(length => {
-//       test(`generateKey ${type} ${length}`, async () => {
-//         {
-//           const key = generateKeySync(type, { length });
-//           expect(key).toBeDefined();
-//           const keybuf = key.export();
-//           expect(keybuf.byteLength).toBe(length / 8);
-//         }
-
-//         const { promise, resolve, reject } = Promise.withResolvers();
-//         generateKey(type, { length }, (err, key) => {
-//           if (err) {
-//             reject(err);
-//           } else {
-//             resolve(key);
-//           }
-//         });
-
-//         {
-//           const key = await promise;
-//           expect(key).toBeDefined();
-//           const keybuf = key.export();
-//           expect(keybuf.byteLength).toBe(length / 8);
-//         }
-//       });
-//     });
-//   });
-//   describe("Test async elliptic curve key generation with 'jwk' encoding and named curve", () => {
-//     ["P-384", "P-256", "P-521", "secp256k1"].forEach(curve => {
-//       const test = curve === "secp256k1" ? it.skip : it;
-//       test(`should work with ${curve}`, async () => {
-//         const { promise, resolve, reject } = Promise.withResolvers();
-//         generateKeyPair(
-//           "ec",
-//           {
-//             namedCurve: curve,
-//             publicKeyEncoding: {
-//               format: "jwk",
-//             },
-//             privateKeyEncoding: {
-//               format: "jwk",
-//             },
-//           },
-//           (err, publicKey, privateKey) => {
-//             if (err) {
-//               return reject(err);
-//             }
-//             resolve({ publicKey, privateKey });
-//           },
-//         );
-
-//         const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
-//         expect(typeof publicKey).toBe("object");
-//         expect(typeof privateKey).toBe("object");
-//         expect(publicKey.x).toBe(privateKey.x);
-//         expect(publicKey.y).toBe(publicKey.y);
-//         expect(publicKey.d).toBeUndefined();
-//         expect(privateKey.d).toBeDefined();
-//         expect(publicKey.kty).toEqual("EC");
-//         expect(publicKey.kty).toEqual(privateKey.kty);
-//         expect(publicKey.crv).toEqual(curve);
-//         expect(publicKey.crv).toEqual(privateKey.crv);
-//       });
-//     });
-//   });
-
-//   describe("Test async elliptic curve key generation with 'jwk' encoding and RSA.", () => {
-//     [256, 1024, 2048].forEach(modulusLength => {
-//       test(`should work with ${modulusLength}`, async () => {
-//         const { promise, resolve, reject } = Promise.withResolvers();
-//         generateKeyPair(
-//           "rsa",
-//           {
-//             modulusLength,
-//             publicKeyEncoding: {
-//               format: "jwk",
-//             },
-//             privateKeyEncoding: {
-//               format: "jwk",
-//             },
-//           },
-//           (err, publicKey, privateKey) => {
-//             if (err) {
-//               return reject(err);
-//             }
-//             resolve({ publicKey, privateKey });
-//           },
-//         );
-
-//         const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
-//         expect(typeof publicKey).toEqual("object");
-//         expect(typeof privateKey).toEqual("object");
-//         expect(publicKey.kty).toEqual("RSA");
-//         expect(publicKey.kty).toEqual(privateKey.kty);
-//         expect(typeof publicKey.n).toEqual("string");
-//         expect(publicKey.n).toEqual(privateKey.n);
-//         expect(typeof publicKey.e).toEqual("string");
-//         expect(publicKey.e).toEqual(privateKey.e);
-//         expect(typeof privateKey.d).toEqual("string");
-//         expect(typeof privateKey.p).toEqual("string");
-//         expect(typeof privateKey.q).toEqual("string");
-//         expect(typeof privateKey.dp).toEqual("string");
-//         expect(typeof privateKey.dq).toEqual("string");
-//         expect(typeof privateKey.qi).toEqual("string");
-//       });
-//     });
-//   });
-
-//   describe("Test async elliptic curve key generation with 'jwk' encoding", () => {
-//     ["ed25519", "ed448", "x25519", "x448"].forEach(type => {
-//       const test = type === "ed25519" ? it : it.skip;
-//       test(`should work with ${type}`, async () => {
-//         const { promise, resolve, reject } = Promise.withResolvers();
-//         generateKeyPair(
-//           type,
-//           {
-//             publicKeyEncoding: {
-//               format: "jwk",
-//             },
-//             privateKeyEncoding: {
-//               format: "jwk",
-//             },
-//           },
-//           (err, publicKey, privateKey) => {
-//             if (err) {
-//               return reject(err);
-//             }
-//             resolve({ publicKey, privateKey });
-//           },
-//         );
-
-//         const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
-//         expect(typeof publicKey).toEqual("object");
-//         expect(typeof privateKey).toEqual("object");
-//         expect(publicKey.x).toEqual(privateKey.x);
-//         expect(publicKey.d).toBeUndefined();
-//         expect(privateKey.d).toBeDefined();
-//         expect(publicKey.kty).toEqual("OKP");
-//         expect(publicKey.kty).toEqual(privateKey.kty);
-//         const expectedCrv = `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
-//         expect(publicKey.crv).toEqual(expectedCrv);
-//         expect(publicKey.crv).toEqual(privateKey.crv);
-//       });
-//     });
-//   });
-
-//   test(`Test async RSA key generation with an encrypted private key, but encoded as DER`, async () => {
-//     const { promise, resolve, reject } = Promise.withResolvers();
-//     generateKeyPair(
-//       "rsa",
-//       {
-//         publicExponent: 0x10001,
-//         modulusLength: 512,
-//         publicKeyEncoding: {
-//           type: "pkcs1",
-//           format: "der",
-//         },
-//         privateKeyEncoding: {
-//           type: "pkcs1",
-//           format: "pem",
-//           cipher: "aes-256-cbc",
-//           passphrase: "secret",
-//         },
-//       },
-//       (err, publicKey, privateKey) => {
-//         if (err) {
-//           return reject(err);
-//         }
-//         resolve({ publicKey, privateKey });
-//       },
-//     );
-
-//     const { publicKey: publicKeyDER, privateKey } = await (promise as Promise<{
-//       publicKey: Buffer;
-//       privateKey: string;
-//     }>);
-//     expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
-//     assertApproximateSize(publicKeyDER, 74);
-
-//     expect(typeof privateKey).toBe("string");
-//     expect(privateKey).toMatch(pkcs1EncExp("AES-256-CBC"));
-
-//     const publicKey = {
-//       key: publicKeyDER,
-//       type: "pkcs1",
-//       format: "der",
-//     };
-//     expect(() => {
-//       testEncryptDecrypt(publicKey, privateKey);
-//     }).toThrow();
-
-//     const key = { key: privateKey, passphrase: "secret" };
-//     testEncryptDecrypt(publicKey, key);
-//     testSignVerify(publicKey, key);
-//   });
-
-//   test(`Test async RSA key generation with an encrypted private key`, async () => {
-//     const { promise, resolve, reject } = Promise.withResolvers();
-//     generateKeyPair(
-//       "rsa",
-//       {
-//         publicExponent: 0x10001,
-//         modulusLength: 512,
-//         publicKeyEncoding: {
-//           type: "pkcs1",
-//           format: "der",
-//         },
-//         privateKeyEncoding: {
-//           type: "pkcs8",
-//           format: "der",
-//         },
-//       },
-//       (err, publicKey, privateKey) => {
-//         if (err) {
-//           return reject(err);
-//         }
-//         resolve({ publicKey, privateKey });
-//       },
-//     );
-
-//     const { publicKey: publicKeyDER, privateKey: privateKeyDER } = await (promise as Promise<{
-//       publicKey: Buffer;
-//       privateKey: Buffer;
-//     }>);
-//     expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
-//     assertApproximateSize(publicKeyDER, 74);
-
-//     expect(Buffer.isBuffer(privateKeyDER)).toBeTrue();
-
-//     const publicKey = {
-//       key: publicKeyDER,
-//       type: "pkcs1",
-//       format: "der",
-//     };
-//     const privateKey = {
-//       key: privateKeyDER,
-//       format: "der",
-//       type: "pkcs8",
-//       passphrase: "secret",
-//     };
-//     testEncryptDecrypt(publicKey, privateKey);
-//     testSignVerify(publicKey, privateKey);
-//   });
-
-//   test(`Test async elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
-//     const { promise, resolve, reject } = Promise.withResolvers();
-//     generateKeyPair(
-//       "ec",
-//       {
-//         namedCurve: "P-256",
-//         publicKeyEncoding: {
-//           type: "spki",
-//           format: "pem",
-//         },
-//         privateKeyEncoding: {
-//           type: "pkcs8",
-//           format: "pem",
-//           cipher: "aes-128-cbc",
-//           passphrase: "top secret",
-//         },
-//       },
-//       (err, publicKey, privateKey) => {
-//         if (err) {
-//           return reject(err);
-//         }
-//         resolve({ publicKey, privateKey });
-//       },
-//     );
-
-//     const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
-//     expect(typeof publicKey).toBe("string");
-//     expect(publicKey).toMatch(spkiExp);
-//     expect(typeof privateKey).toBe("string");
-//     expect(privateKey).toMatch(pkcs8EncExp);
-
-//     expect(() => {
-//       testSignVerify(publicKey, privateKey);
-//     }).toThrow();
-
-//     testSignVerify(publicKey, {
-//       key: privateKey,
-//       passphrase: "top secret",
-//     });
-//   });
-
-//   test(`Test async explicit elliptic curve key generation with an encrypted private key`, async () => {
-//     const { promise, resolve, reject } = Promise.withResolvers();
-//     generateKeyPair(
-//       "ec",
-//       {
-//         namedCurve: "prime256v1",
-//         publicKeyEncoding: {
-//           type: "spki",
-//           format: "pem",
-//         },
-//         privateKeyEncoding: {
-//           type: "sec1",
-//           format: "pem",
-//           cipher: "aes-128-cbc",
-//           passphrase: "secret",
-//         },
-//       },
-//       (err, publicKey, privateKey) => {
-//         if (err) {
-//           return reject(err);
-//         }
-//         resolve({ publicKey, privateKey });
-//       },
-//     );
-
-//     const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
-//     expect(typeof publicKey).toBe("string");
-//     expect(publicKey).toMatch(spkiExp);
-//     expect(typeof privateKey).toBe("string");
-//     expect(privateKey).toMatch(sec1EncExp("AES-128-CBC"));
-
-//     expect(() => {
-//       testSignVerify(publicKey, privateKey);
-//     }).toThrow();
-
-//     testSignVerify(publicKey, {
-//       key: privateKey,
-//       passphrase: "secret",
-//     });
-//   });
-
-//   test(`Test async explicit elliptic curve key generation, e.g. for ECDSA, with a SEC1 private key`, async () => {
-//     const { promise, resolve, reject } = Promise.withResolvers();
-//     generateKeyPair(
-//       "ec",
-//       {
-//         namedCurve: "prime256v1",
-//         publicKeyEncoding: {
-//           type: "spki",
-//           format: "pem",
-//         },
-//         privateKeyEncoding: {
-//           type: "sec1",
-//           format: "pem",
-//         },
-//       },
-//       (err, publicKey, privateKey) => {
-//         if (err) {
-//           return reject(err);
-//         }
-//         resolve({ publicKey, privateKey });
-//       },
-//     );
-
-//     const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
-//     expect(typeof publicKey).toBe("string");
-//     expect(publicKey).toMatch(spkiExp);
-//     expect(typeof privateKey).toBe("string");
-//     expect(privateKey).toMatch(sec1Exp);
-//     testSignVerify(publicKey, privateKey);
-//   });
-
-//   test(`Test async elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
-//     const { promise, resolve, reject } = Promise.withResolvers();
-//     generateKeyPair(
-//       "ec",
-//       {
-//         namedCurve: "prime256v1",
-//         publicKeyEncoding: {
-//           type: "spki",
-//           format: "pem",
-//         },
-//         privateKeyEncoding: {
-//           type: "pkcs8",
-//           format: "pem",
-//           cipher: "aes-128-cbc",
-//           passphrase: "top secret",
-//         },
-//       },
-//       (err, publicKey, privateKey) => {
-//         if (err) {
-//           return reject(err);
-//         }
-//         resolve({ publicKey, privateKey });
-//       },
-//     );
-
-//     const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
-//     expect(typeof publicKey).toBe("string");
-//     expect(publicKey).toMatch(spkiExp);
-//     expect(typeof privateKey).toBe("string");
-//     expect(privateKey).toMatch(pkcs8EncExp);
-
-//     expect(() => {
-//       testSignVerify(publicKey, privateKey);
-//     }).toThrow();
-
-//     testSignVerify(publicKey, {
-//       key: privateKey,
-//       passphrase: "top secret",
-//     });
-//   });
-
-//   describe("Test sync elliptic curve key generation with 'jwk' encoding and named curve", () => {
-//     ["P-384", "P-256", "P-521", "secp256k1"].forEach(curve => {
-//       const test = curve === "secp256k1" ? it.skip : it;
-//       test(`should work with ${curve}`, async () => {
-//         const { publicKey, privateKey } = generateKeyPairSync("ec", {
-//           namedCurve: curve,
-//           publicKeyEncoding: {
-//             format: "jwk",
-//           },
-//           privateKeyEncoding: {
-//             format: "jwk",
-//           },
-//         });
-//         expect(typeof publicKey).toBe("object");
-//         expect(typeof privateKey).toBe("object");
-//         expect(publicKey.x).toBe(privateKey.x);
-//         expect(publicKey.y).toBe(publicKey.y);
-//         expect(publicKey.d).toBeUndefined();
-//         expect(privateKey.d).toBeDefined();
-//         expect(publicKey.kty).toEqual("EC");
-//         expect(publicKey.kty).toEqual(privateKey.kty);
-//         expect(publicKey.crv).toEqual(curve);
-//         expect(publicKey.crv).toEqual(privateKey.crv);
-//       });
-//     });
-//   });
-
-//   describe("Test sync elliptic curve key generation with 'jwk' encoding and RSA.", () => {
-//     [256, 1024, 2048].forEach(modulusLength => {
-//       test(`should work with ${modulusLength}`, async () => {
-//         const { publicKey, privateKey } = generateKeyPairSync("rsa", {
-//           modulusLength,
-//           publicKeyEncoding: {
-//             format: "jwk",
-//           },
-//           privateKeyEncoding: {
-//             format: "jwk",
-//           },
-//         });
-//         expect(typeof publicKey).toEqual("object");
-//         expect(typeof privateKey).toEqual("object");
-//         expect(publicKey.kty).toEqual("RSA");
-//         expect(publicKey.kty).toEqual(privateKey.kty);
-//         expect(typeof publicKey.n).toEqual("string");
-//         expect(publicKey.n).toEqual(privateKey.n);
-//         expect(typeof publicKey.e).toEqual("string");
-//         expect(publicKey.e).toEqual(privateKey.e);
-//         expect(typeof privateKey.d).toEqual("string");
-//         expect(typeof privateKey.p).toEqual("string");
-//         expect(typeof privateKey.q).toEqual("string");
-//         expect(typeof privateKey.dp).toEqual("string");
-//         expect(typeof privateKey.dq).toEqual("string");
-//         expect(typeof privateKey.qi).toEqual("string");
-//       });
-//     });
-//   });
-
-//   describe("Test sync elliptic curve key generation with 'jwk' encoding", () => {
-//     ["ed25519", "ed448", "x25519", "x448"].forEach(type => {
-//       const test = type === "ed25519" ? it : it.skip;
-//       test(`should work with ${type}`, async () => {
-//         const { publicKey, privateKey } = generateKeyPairSync(type, {
-//           publicKeyEncoding: {
-//             format: "jwk",
-//           },
-//           privateKeyEncoding: {
-//             format: "jwk",
-//           },
-//         });
-
-//         expect(typeof publicKey).toEqual("object");
-//         expect(typeof privateKey).toEqual("object");
-//         expect(publicKey.x).toEqual(privateKey.x);
-//         expect(publicKey.d).toBeUndefined();
-//         expect(privateKey.d).toBeDefined();
-//         expect(publicKey.kty).toEqual("OKP");
-//         expect(publicKey.kty).toEqual(privateKey.kty);
-//         const expectedCrv = `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
-//         expect(publicKey.crv).toEqual(expectedCrv);
-//         expect(publicKey.crv).toEqual(privateKey.crv);
-//       });
-//     });
-//   });
-
-//   test(`Test sync RSA key generation with an encrypted private key, but encoded as DER`, async () => {
-//     const { publicKey: publicKeyDER, privateKey } = generateKeyPairSync("rsa", {
-//       publicExponent: 0x10001,
-//       modulusLength: 512,
-//       publicKeyEncoding: {
-//         type: "pkcs1",
-//         format: "der",
-//       },
-//       privateKeyEncoding: {
-//         type: "pkcs1",
-//         format: "pem",
-//         cipher: "aes-256-cbc",
-//         passphrase: "secret",
-//       },
-//     });
-
-//     expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
-//     assertApproximateSize(publicKeyDER, 74);
-
-//     expect(typeof privateKey).toBe("string");
-//     expect(privateKey).toMatch(pkcs1EncExp("AES-256-CBC"));
-
-//     const publicKey = {
-//       key: publicKeyDER,
-//       type: "pkcs1",
-//       format: "der",
-//     };
-//     expect(() => {
-//       testEncryptDecrypt(publicKey, privateKey);
-//     }).toThrow();
-
-//     const key = { key: privateKey, passphrase: "secret" };
-//     testEncryptDecrypt(publicKey, key);
-//     testSignVerify(publicKey, key);
-//   });
-
-//   test(`Test sync RSA key generation with an encrypted private key`, async () => {
-//     const { publicKey: publicKeyDER, privateKey: privateKeyDER } = generateKeyPairSync("rsa", {
-//       publicExponent: 0x10001,
-//       modulusLength: 512,
-//       publicKeyEncoding: {
-//         type: "pkcs1",
-//         format: "der",
-//       },
-//       privateKeyEncoding: {
-//         type: "pkcs8",
-//         format: "der",
-//       },
-//     });
-
-//     expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
-//     assertApproximateSize(publicKeyDER, 74);
-
-//     expect(Buffer.isBuffer(privateKeyDER)).toBeTrue();
-
-//     const publicKey = {
-//       key: publicKeyDER,
-//       type: "pkcs1",
-//       format: "der",
-//     };
-//     const privateKey = {
-//       key: privateKeyDER,
-//       format: "der",
-//       type: "pkcs8",
-//       passphrase: "secret",
-//     };
-//     testEncryptDecrypt(publicKey, privateKey);
-//     testSignVerify(publicKey, privateKey);
-//   });
-
-//   test(`Test sync elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
-//     const { publicKey, privateKey } = generateKeyPairSync("ec", {
-//       namedCurve: "P-256",
-//       publicKeyEncoding: {
-//         type: "spki",
-//         format: "pem",
-//       },
-//       privateKeyEncoding: {
-//         type: "pkcs8",
-//         format: "pem",
-//         cipher: "aes-128-cbc",
-//         passphrase: "top secret",
-//       },
-//     });
-
-//     expect(typeof publicKey).toBe("string");
-//     expect(publicKey).toMatch(spkiExp);
-//     expect(typeof privateKey).toBe("string");
-//     expect(privateKey).toMatch(pkcs8EncExp);
-
-//     expect(() => {
-//       testSignVerify(publicKey, privateKey);
-//     }).toThrow();
-
-//     testSignVerify(publicKey, {
-//       key: privateKey,
-//       passphrase: "top secret",
-//     });
-//   });
-
-//   test(`Test sync explicit elliptic curve key generation with an encrypted private key`, async () => {
-//     const { publicKey, privateKey } = generateKeyPairSync(
-//       "ec",
-//       {
-//         namedCurve: "prime256v1",
-//         publicKeyEncoding: {
-//           type: "spki",
-//           format: "pem",
-//         },
-//         privateKeyEncoding: {
-//           type: "sec1",
-//           format: "pem",
-//           cipher: "aes-128-cbc",
-//           passphrase: "secret",
-//         },
-//       },
-//       (err, publicKey, privateKey) => {
-//         if (err) {
-//           return reject(err);
-//         }
-//         resolve({ publicKey, privateKey });
-//       },
-//     );
-
-//     expect(typeof publicKey).toBe("string");
-//     expect(publicKey).toMatch(spkiExp);
-//     expect(typeof privateKey).toBe("string");
-//     expect(privateKey).toMatch(sec1EncExp("AES-128-CBC"));
-
-//     expect(() => {
-//       testSignVerify(publicKey, privateKey);
-//     }).toThrow();
-
-//     testSignVerify(publicKey, {
-//       key: privateKey,
-//       passphrase: "secret",
-//     });
-//   });
-
-//   test(`Test sync explicit elliptic curve key generation, e.g. for ECDSA, with a SEC1 private key`, async () => {
-//     const { publicKey, privateKey } = generateKeyPairSync("ec", {
-//       namedCurve: "prime256v1",
-//       publicKeyEncoding: {
-//         type: "spki",
-//         format: "pem",
-//       },
-//       privateKeyEncoding: {
-//         type: "sec1",
-//         format: "pem",
-//       },
-//     });
-
-//     expect(typeof publicKey).toBe("string");
-//     expect(publicKey).toMatch(spkiExp);
-//     expect(typeof privateKey).toBe("string");
-//     expect(privateKey).toMatch(sec1Exp);
-//     testSignVerify(publicKey, privateKey);
-//   });
-
-//   test(`Test sync elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
-//     const { publicKey, privateKey } = generateKeyPairSync("ec", {
-//       namedCurve: "prime256v1",
-//       publicKeyEncoding: {
-//         type: "spki",
-//         format: "pem",
-//       },
-//       privateKeyEncoding: {
-//         type: "pkcs8",
-//         format: "pem",
-//         cipher: "aes-128-cbc",
-//         passphrase: "top secret",
-//       },
-//     });
-
-//     expect(typeof publicKey).toBe("string");
-//     expect(publicKey).toMatch(spkiExp);
-//     expect(typeof privateKey).toBe("string");
-//     expect(privateKey).toMatch(pkcs8EncExp);
-
-//     expect(() => {
-//       testSignVerify(publicKey, privateKey);
-//     }).toThrow();
-
-//     testSignVerify(publicKey, {
-//       key: privateKey,
-//       passphrase: "top secret",
-//     });
-//   });
-//   // SKIPED because we round the key size to the nearest multiple of 8 like documented
-//   test.skip(`this tests check that generateKeyPair returns correct bit length in KeyObject's asymmetricKeyDetails.`, async () => {
-//     // This tests check that generateKeyPair returns correct bit length in
-//     // https://github.com/nodejs/node/issues/46102#issuecomment-1372153541
-//     const { promise, resolve, reject } = Promise.withResolvers();
-//     generateKeyPair(
-//       "rsa",
-//       {
-//         modulusLength: 513,
-//       },
-//       (err, publicKey, privateKey) => {
-//         if (err) {
-//           return reject(err);
-//         }
-//         resolve({ publicKey, privateKey });
-//       },
-//     );
-
-//     const { publicKey, privateKey } = await (promise as Promise<{ publicKey: KeyObject; privateKey: KeyObject }>);
-//     expect(publicKey.asymmetricKeyDetails?.modulusLength).toBe(513);
-//     expect(privateKey.asymmetricKeyDetails?.modulusLength).toBe(513);
-//   });
-
-//   function testRunInContext(fn: any) {
-//     test("can generate key", () => {
-//       const context = createContext({ generateKeySync });
-//       const result = fn(`generateKeySync("aes", { length: 128 })`, context);
-//       expect(result).toBeDefined();
-//       const keybuf = result.export();
-//       expect(keybuf.byteLength).toBe(128 / 8);
-//     });
-//     test("can be used on another context", () => {
-//       const context = createContext({ generateKeyPairSync, assertApproximateSize, testEncryptDecrypt, testSignVerify });
-//       const result = fn(
-//         `
-//         const { publicKey: publicKeyDER, privateKey: privateKeyDER } = generateKeyPairSync(
-//           "rsa",
-//           {
-//             publicExponent: 0x10001,
-//             modulusLength: 512,
-//             publicKeyEncoding: {
-//               type: "pkcs1",
-//               format: "der",
-//             },
-//             privateKeyEncoding: {
-//               type: "pkcs8",
-//               format: "der",
-//             },
-//           }
-//         );
-
-//         assertApproximateSize(publicKeyDER, 74);
-
-//         const publicKey = {
-//           key: publicKeyDER,
-//           type: "pkcs1",
-//           format: "der",
-//         };
-//         const privateKey = {
-//           key: privateKeyDER,
-//           format: "der",
-//           type: "pkcs8",
-//           passphrase: "secret",
-//         };
-//         testEncryptDecrypt(publicKey, privateKey);
-//         testSignVerify(publicKey, privateKey);
-//       `,
-//         context,
-//       );
-//     });
-//   }
-//   describe("Script", () => {
-//     describe("runInContext()", () => {
-//       testRunInContext((code, context, options) => {
-//         // @ts-expect-error
-//         const script = new Script(code, options);
-//         return script.runInContext(context);
-//       });
-//     });
-//     describe("runInNewContext()", () => {
-//       testRunInContext((code, context, options) => {
-//         // @ts-expect-error
-//         const script = new Script(code, options);
-//         return script.runInNewContext(context);
-//       });
-//     });
-//     describe("runInThisContext()", () => {
-//       testRunInContext((code, context, options) => {
-//         // @ts-expect-error
-//         const script = new Script(code, options);
-//         return script.runInThisContext(context);
-//       });
-//     });
-//   });
-// });
+describe("crypto.KeyObjects", () => {
+  test("Attempting to create a key using other than CryptoKey should throw", async () => {
+    expect(() => new KeyObject("secret", "")).toThrow();
+    expect(() => new KeyObject("secret")).toThrow();
+    expect(() => KeyObject.from("invalid_key")).toThrow();
+  });
+  test("basics of createSecretKey should work", async () => {
+    const keybuf = randomBytes(32);
+    const key = createSecretKey(keybuf);
+    expect(key.type).toBe("secret");
+    expect(key.toString()).toBe("[object KeyObject]");
+    expect(key.symmetricKeySize).toBe(32);
+    expect(key.asymmetricKeyType).toBe(undefined);
+    expect(key.asymmetricKeyDetails).toBe(undefined);
+
+    const exportedKey = key.export();
+    expect(keybuf).toEqual(exportedKey);
+
+    const plaintext = Buffer.from("Hello world", "utf8");
+
+    const cipher = createCipheriv("aes-256-ecb", key, null);
+    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+
+    const decipher = createDecipheriv("aes-256-ecb", key, null);
+    const deciphered = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+
+    expect(plaintext).toEqual(deciphered);
+  });
+
+  test("Passing an existing public key object to createPublicKey should throw", async () => {
+    // Passing an existing public key object to createPublicKey should throw.
+    const publicKey = createPublicKey(publicPem);
+    expect(() => createPublicKey(publicKey)).toThrow();
+
+    // Constructing a private key from a public key should be impossible, even
+    // if the public key was derived from a private key.
+    expect(() => createPrivateKey(createPublicKey(privatePem))).toThrow();
+
+    // Similarly, passing an existing private key object to createPrivateKey
+    // should throw.
+    const privateKey = createPrivateKey(privatePem);
+    expect(() => createPrivateKey(privateKey)).toThrow();
+  });
+
+  test("basics should work", async () => {
+    const jwk = {
+      e: "AQAB",
+      n:
+        "t9xYiIonscC3vz_A2ceR7KhZZlDu_5bye53nCVTcKnWd2seY6UAdKersX6njr83Dd5OVe" +
+        "1BW_wJvp5EjWTAGYbFswlNmeD44edEGM939B6Lq-_8iBkrTi8mGN4YCytivE24YI0D4XZ" +
+        "MPfkLSpab2y_Hy4DjQKBq1ThZ0UBnK-9IhX37Ju_ZoGYSlTIGIhzyaiYBh7wrZBoPczIE" +
+        "u6et_kN2VnnbRUtkYTF97ggcv5h-hDpUQjQW0ZgOMcTc8n-RkGpIt0_iM_bTjI3Tz_gsF" +
+        "di6hHcpZgbopPL630296iByyigQCPJVzdusFrQN5DeC-zT_nGypQkZanLb4ZspSx9Q",
+      d:
+        "ktnq2LvIMqBj4txP82IEOorIRQGVsw1khbm8A-cEpuEkgM71Yi_0WzupKktucUeevQ5i0" +
+        "Yh8w9e1SJiTLDRAlJz66kdky9uejiWWl6zR4dyNZVMFYRM43ijLC-P8rPne9Fz16IqHFW" +
+        "5VbJqA1xCBhKmuPMsD71RNxZ4Hrsa7Kt_xglQTYsLbdGIwDmcZihId9VGXRzvmCPsDRf2" +
+        "fCkAj7HDeRxpUdEiEDpajADc-PWikra3r3b40tVHKWm8wxJLivOIN7GiYXKQIW6RhZgH-" +
+        "Rk45JIRNKxNagxdeXUqqyhnwhbTo1Hite0iBDexN9tgoZk0XmdYWBn6ElXHRZ7VCDQ",
+      p:
+        "8UovlB4nrBm7xH-u7XXBMbqxADQm5vaEZxw9eluc-tP7cIAI4sglMIvL_FMpbd2pEeP_B" +
+        "kR76NTDzzDuPAZvUGRavgEjy0O9j2NAs_WPK4tZF-vFdunhnSh4EHAF4Ij9kbsUi90NOp" +
+        "bGfVqPdOaHqzgHKoR23Cuusk9wFQ2XTV8",
+      q:
+        "wxHdEYT9xrpfrHPqSBQPpO0dWGKJEkrWOb-76rSfuL8wGR4OBNmQdhLuU9zTIh22pog-X" +
+        "PnLPAecC-4yu_wtJ2SPCKiKDbJBre0CKPyRfGqzvA3njXwMxXazU4kGs-2Fg-xu_iKbaI" +
+        "jxXrclBLhkxhBtySrwAFhxxOk6fFcPLSs",
+      dp:
+        "qS_Mdr5CMRGGMH0bKhPUWEtAixUGZhJaunX5wY71Xoc_Gh4cnO-b7BNJ_-5L8WZog0vr" +
+        "6PgiLhrqBaCYm2wjpyoG2o2wDHm-NAlzN_wp3G2EFhrSxdOux-S1c0kpRcyoiAO2n29rN" +
+        "Da-jOzwBBcU8ACEPdLOCQl0IEFFJO33tl8",
+      dq:
+        "WAziKpxLKL7LnL4dzDcx8JIPIuwnTxh0plCDdCffyLaT8WJ9lXbXHFTjOvt8WfPrlDP_" +
+        "Ylxmfkw5BbGZOP1VLGjZn2DkH9aMiwNmbDXFPdG0G3hzQovx_9fajiRV4DWghLHeT9wzJ" +
+        "fZabRRiI0VQR472300AVEeX4vgbrDBn600",
+      qi:
+        "k7czBCT9rHn_PNwCa17hlTy88C4vXkwbz83Oa-aX5L4e5gw5lhcR2ZuZHLb2r6oMt9rl" +
+        "D7EIDItSs-u21LOXWPTAlazdnpYUyw_CzogM_PN-qNwMRXn5uXFFhmlP2mVg2EdELTahX" +
+        "ch8kWqHaCSX53yvqCtRKu_j76V31TfQZGM",
+      kty: "RSA",
+    };
+    const publicJwk = { kty: jwk.kty, e: jwk.e, n: jwk.n };
+
+    const publicKey = createPublicKey(publicPem);
+    expect(publicKey.type).toBe("public");
+    expect(publicKey.toString()).toBe("[object KeyObject]");
+    expect(publicKey.asymmetricKeyType).toBe("rsa");
+    expect(publicKey.symmetricKeySize).toBe(undefined);
+
+    const privateKey = createPrivateKey(privatePem);
+    expect(privateKey.type).toBe("private");
+    expect(privateKey.toString()).toBe("[object KeyObject]");
+    expect(privateKey.asymmetricKeyType).toBe("rsa");
+    expect(privateKey.symmetricKeySize).toBe(undefined);
+
+    // It should be possible to derive a public key from a private key.
+    const derivedPublicKey = createPublicKey(privateKey);
+    expect(derivedPublicKey.type).toBe("public");
+    expect(derivedPublicKey.toString()).toBe("[object KeyObject]");
+    expect(derivedPublicKey.asymmetricKeyType).toBe("rsa");
+    expect(derivedPublicKey.symmetricKeySize).toBe(undefined);
+
+    const publicKeyFromJwk = createPublicKey({ key: publicJwk, format: "jwk" });
+    expect(publicKey.type).toBe("public");
+    expect(publicKey.toString()).toBe("[object KeyObject]");
+    expect(publicKey.asymmetricKeyType).toBe("rsa");
+    expect(publicKey.symmetricKeySize).toBe(undefined);
+
+    const privateKeyFromJwk = createPrivateKey({ key: jwk, format: "jwk" });
+    expect(privateKey.type).toBe("private");
+    expect(privateKey.toString()).toBe("[object KeyObject]");
+    expect(privateKey.asymmetricKeyType).toBe("rsa");
+    expect(privateKey.symmetricKeySize).toBe(undefined);
+
+    // It should also be possible to import an encrypted private key as a public
+    // key.
+    const decryptedKey = createPublicKey({
+      key: privateKey.export({
+        type: "pkcs8",
+        format: "pem",
+        passphrase: Buffer.from("123"),
+        cipher: "aes-128-cbc",
+      }),
+      format: "pem",
+      passphrase: "123", // this is not documented, but it works
+    });
+    expect(decryptedKey.type).toBe("public");
+    expect(decryptedKey.asymmetricKeyType).toBe("rsa");
+
+    // Exporting the key using JWK should not work since this format does not
+    // support key encryption
+    expect(() => {
+      privateKey.export({ format: "jwk", passphrase: "secret" });
+    }).toThrow();
+
+    // Test exporting with an invalid options object, this should throw.
+    for (const opt of [undefined, null, "foo", 0, NaN]) {
+      expect(() => publicKey.export(opt)).toThrow();
+    }
+
+    for (const keyObject of [publicKey, derivedPublicKey, publicKeyFromJwk]) {
+      const exported = keyObject.export({ format: "jwk" });
+      expect(exported).toBeDefined();
+      const { kty, n, e } = exported as { kty: string; n: string; e: string };
+      expect({ kty, n, e }).toEqual({ kty: "RSA", n: jwk.n, e: jwk.e });
+    }
+
+    for (const keyObject of [privateKey, privateKeyFromJwk]) {
+      const exported = keyObject.export({ format: "jwk" });
+      expect(exported).toEqual(jwk);
+    }
+
+    const publicDER = publicKey.export({
+      format: "der",
+      type: "pkcs1",
+    });
+
+    const privateDER = privateKey.export({
+      format: "der",
+      type: "pkcs1",
+    });
+
+    expect(Buffer.isBuffer(publicDER)).toBe(true);
+    expect(Buffer.isBuffer(privateDER)).toBe(true);
+    const plaintext = Buffer.from("Hello world", "utf8");
+
+    const testDecryption = (fn, ciphertexts, decryptionKeys) => {
+      for (const ciphertext of ciphertexts) {
+        for (const key of decryptionKeys) {
+          const deciphered = fn(key, ciphertext);
+          expect(deciphered).toEqual(plaintext);
+        }
+      }
+    };
+
+    testDecryption(
+      privateDecrypt,
+      [
+        // Encrypt using the public key.
+        publicEncrypt(publicKey, plaintext),
+        publicEncrypt({ key: publicKey }, plaintext),
+        publicEncrypt({ key: publicJwk, format: "jwk" }, plaintext),
+
+        // Encrypt using the private key.
+        publicEncrypt(privateKey, plaintext),
+        publicEncrypt({ key: privateKey }, plaintext),
+        publicEncrypt({ key: jwk, format: "jwk" }, plaintext),
+
+        // Encrypt using a public key derived from the private key.
+        publicEncrypt(derivedPublicKey, plaintext),
+        publicEncrypt({ key: derivedPublicKey }, plaintext),
+
+        // Test distinguishing PKCS#1 public and private keys based on the
+        // DER-encoded data only.
+        publicEncrypt({ format: "der", type: "pkcs1", key: publicDER }, plaintext),
+        publicEncrypt({ format: "der", type: "pkcs1", key: privateDER }, plaintext),
+      ],
+      [
+        privateKey,
+        { format: "pem", key: privatePem },
+        { format: "der", type: "pkcs1", key: privateDER },
+        { key: jwk, format: "jwk" },
+      ],
+    );
+
+    testDecryption(
+      publicDecrypt,
+      [privateEncrypt(privateKey, plaintext)],
+      [
+        // Decrypt using the public key.
+        publicKey,
+        { format: "pem", key: publicPem },
+        { format: "der", type: "pkcs1", key: publicDER },
+        { key: publicJwk, format: "jwk" },
+
+        // Decrypt using the private key.
+        privateKey,
+        { format: "pem", key: privatePem },
+        { format: "der", type: "pkcs1", key: privateDER },
+        { key: jwk, format: "jwk" },
+      ],
+    );
+  });
+
+  test("This should not cause a crash: https://github.com/nodejs/node/issues/25247", async () => {
+    expect(() => createPrivateKey({ key: "" })).toThrow();
+  });
+  test("This should not abort either: https://github.com/nodejs/node/issues/29904", async () => {
+    expect(() => createPrivateKey({ key: Buffer.alloc(0), format: "der", type: "spki" })).toThrow();
+  });
+
+  test("BoringSSL will not parse PKCS#1", async () => {
+    // Unlike SPKI, PKCS#1 is a valid encoding for private keys (and public keys),
+    // so it should be accepted by createPrivateKey, but OpenSSL won't parse it.
+    expect(() => {
+      const key = createPublicKey(publicPem).export({
+        format: "der",
+        type: "pkcs1",
+      });
+      createPrivateKey({ key, format: "der", type: "pkcs1" });
+    }).toThrow("Invalid use of PKCS#1 as private key");
+  });
+
+  [
+    {
+      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed25519_private.pem"), "ascii"),
+      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed25519_public.pem"), "ascii"),
+      keyType: "ed25519",
+      jwk: {
+        crv: "Ed25519",
+        x: "K1wIouqnuiA04b3WrMa-xKIKIpfHetNZRv3h9fBf768",
+        d: "wVK6M3SMhQh3NK-7GRrSV-BVWQx1FO5pW8hhQeu_NdA",
+        kty: "OKP",
+      },
+    },
+    {
+      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed448_private.pem"), "ascii"),
+      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed448_public.pem"), "ascii"),
+      keyType: "ed448",
+      jwk: {
+        crv: "Ed448",
+        x: "oX_ee5-jlcU53-BbGRsGIzly0V-SZtJ_oGXY0udf84q2hTW2RdstLktvwpkVJOoNb7o" + "Dgc2V5ZUA",
+        d: "060Ke71sN0GpIc01nnGgMDkp0sFNQ09woVo4AM1ffax1-mjnakK0-p-S7-Xf859QewX" + "jcR9mxppY",
+        kty: "OKP",
+      },
+    },
+    {
+      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x25519_private.pem"), "ascii"),
+      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x25519_public.pem"), "ascii"),
+      keyType: "x25519",
+      jwk: {
+        crv: "X25519",
+        x: "aSb8Q-RndwfNnPeOYGYPDUN3uhAPnMLzXyfi-mqfhig",
+        d: "mL_IWm55RrALUGRfJYzw40gEYWMvtRkesP9mj8o8Omc",
+        kty: "OKP",
+      },
+    },
+    {
+      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x448_private.pem"), "ascii"),
+      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x448_public.pem"), "ascii"),
+      keyType: "x448",
+      jwk: {
+        crv: "X448",
+        x: "ioHSHVpTs6hMvghosEJDIR7ceFiE3-Xccxati64oOVJ7NWjfozE7ae31PXIUFq6cVYg" + "vSKsDFPA",
+        d: "tMNtrO_q8dlY6Y4NDeSTxNQ5CACkHiPvmukidPnNIuX_EkcryLEXt_7i6j6YZMKsrWy" + "S0jlSYJk",
+        kty: "OKP",
+      },
+    },
+  ].forEach(info => {
+    const keyType = info.keyType;
+    // X25519 implementation is incomplete, Ed448 and X448 are not supported yet
+    const test = keyType === "ed25519" ? it : it.skip;
+    let privateKey: KeyObject;
+    test(`${keyType} from Buffer should work`, async () => {
+      const key = createPrivateKey(info.private);
+      privateKey = key;
+      expect(key.type).toBe("private");
+      expect(key.asymmetricKeyType).toBe(keyType);
+      expect(key.symmetricKeySize).toBe(undefined);
+      expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
+      const jwt = key.export({ format: "jwk" });
+      expect(jwt).toEqual(info.jwk);
+    });
+
+    test(`${keyType} createPrivateKey from jwk should work`, async () => {
+      const key = createPrivateKey({ key: info.jwk, format: "jwk" });
+      expect(key.type).toBe("private");
+      expect(key.asymmetricKeyType).toBe(keyType);
+      expect(key.symmetricKeySize).toBe(undefined);
+      expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
+      const jwt = key.export({ format: "jwk" });
+      expect(jwt).toEqual(info.jwk);
+    });
+
+    [
+      ["public", info.public],
+      ["private", info.private],
+      ["jwk", { key: info.jwk, format: "jwk" }],
+    ].forEach(([name, input]) => {
+      test(`${keyType} createPublicKey using ${name} key should work`, async () => {
+        const key = createPublicKey(input);
+        expect(key.type).toBe("public");
+        expect(key.asymmetricKeyType).toBe(keyType);
+        expect(key.symmetricKeySize).toBe(undefined);
+        if (name == "public") {
+          expect(key.export({ type: "spki", format: "pem" })).toEqual(info.public);
+        }
+        if (name == "jwk") {
+          const jwt = { ...info.jwk };
+          delete jwt.d;
+          const jwk_exported = key.export({ format: "jwk" });
+          expect(jwk_exported).toEqual(jwt);
+        }
+      });
+    });
+  });
+
+  [
+    {
+      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p256_private.pem"), "ascii"),
+      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p256_public.pem"), "ascii"),
+      keyType: "ec",
+      namedCurve: "prime256v1",
+      jwk: {
+        crv: "P-256",
+        d: "DxBsPQPIgMuMyQbxzbb9toew6Ev6e9O6ZhpxLNgmAEo",
+        kty: "EC",
+        x: "X0mMYR_uleZSIPjNztIkAS3_ud5LhNpbiIFp6fNf2Gs",
+        y: "UbJuPy2Xi0lW7UYTBxPK3yGgDu9EAKYIecjkHX5s2lI",
+      },
+    },
+    {
+      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_secp256k1_private.pem"), "ascii"),
+      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_secp256k1_public.pem"), "ascii"),
+      keyType: "ec",
+      namedCurve: "secp256k1",
+      jwk: {
+        crv: "secp256k1",
+        d: "c34ocwTwpFa9NZZh3l88qXyrkoYSxvC0FEsU5v1v4IM",
+        kty: "EC",
+        x: "cOzhFSpWxhalCbWNdP2H_yUkdC81C9T2deDpfxK7owA",
+        y: "-A3DAZTk9IPppN-f03JydgHaFvL1fAHaoXf4SX4NXyo",
+      },
+    },
+    {
+      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p384_private.pem"), "ascii"),
+      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p384_public.pem"), "ascii"),
+      keyType: "ec",
+      namedCurve: "secp384r1",
+      jwk: {
+        crv: "P-384",
+        d: "dwfuHuAtTlMRn7ZBCBm_0grpc1D_4hPeNAgevgelljuC0--k_LDFosDgBlLLmZsi",
+        kty: "EC",
+        x: "hON3nzGJgv-08fdHpQxgRJFZzlK-GZDGa5f3KnvM31cvvjJmsj4UeOgIdy3rDAjV",
+        y: "fidHhtecNCGCfLqmrLjDena1NSzWzWH1u_oUdMKGo5XSabxzD7-8JZxjpc8sR9cl",
+      },
+    },
+    {
+      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p521_private.pem"), "ascii"),
+      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p521_public.pem"), "ascii"),
+      keyType: "ec",
+      namedCurve: "secp521r1",
+      jwk: {
+        crv: "P-521",
+        d: "Eghuafcab9jXW4gOQLeDaKOlHEiskQFjiL8klijk6i6DNOXcFfaJ9GW48kxpodw16ttAf9Z1WQstfzpKGUetHIk",
+        kty: "EC",
+        x: "AaLFgjwZtznM3N7qsfb86awVXe6c6djUYOob1FN-kllekv0KEXV0bwcDjPGQz5f6MxL" + "CbhMeHRavUS6P10rsTtBn",
+        y: "Ad3flexBeAfXceNzRBH128kFbOWD6W41NjwKRqqIF26vmgW_8COldGKZjFkOSEASxPB" + "cvA2iFJRUyQ3whC00j0Np",
+      },
+    },
+  ].forEach(info => {
+    const { keyType, namedCurve } = info;
+    const test = namedCurve === "secp256k1" ? it.skip : it;
+    let privateKey: KeyObject;
+    test(`${keyType} ${namedCurve} createPrivateKey from Buffer should work`, async () => {
+      const key = createPrivateKey(info.private);
+      privateKey = key;
+      expect(key.type).toBe("private");
+      expect(key.asymmetricKeyType).toBe(keyType);
+      expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
+      expect(key.symmetricKeySize).toBe(undefined);
+      expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
+      const jwt = key.export({ format: "jwk" });
+      expect(jwt).toEqual(info.jwk);
+    });
+
+    test(`${keyType} ${namedCurve} createPrivateKey from jwk should work`, async () => {
+      const key = createPrivateKey({ key: info.jwk, format: "jwk" });
+      expect(key.type).toBe("private");
+      expect(key.asymmetricKeyType).toBe(keyType);
+      expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
+      expect(key.symmetricKeySize).toBe(undefined);
+      expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
+      const jwt = key.export({ format: "jwk" });
+      expect(jwt).toEqual(info.jwk);
+    });
+
+    [
+      ["public", info.public],
+      ["private", info.private],
+      ["jwk", { key: info.jwk, format: "jwk" }],
+    ].forEach(([name, input]) => {
+      test(`${keyType} ${namedCurve} createPublicKey using ${name} should work`, async () => {
+        const key = createPublicKey(input);
+        expect(key.type).toBe("public");
+        expect(key.asymmetricKeyType).toBe(keyType);
+        expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
+        expect(key.symmetricKeySize).toBe(undefined);
+        if (name == "public") {
+          expect(key.export({ type: "spki", format: "pem" })).toEqual(info.public);
+        }
+        if (name == "jwk") {
+          const jwt = { ...info.jwk };
+          delete jwt.d;
+          const jwk_exported = key.export({ format: "jwk" });
+          expect(jwk_exported).toEqual(jwt);
+        }
+
+        const pkey = privateKey || info.private;
+        const signature = createSign("sha256").update("foo").sign({ key: pkey });
+        const okay = createVerify("sha256").update("foo").verify({ key: key }, signature);
+        expect(okay).toBeTrue();
+      });
+    });
+  });
+
+  test("private encrypted should work", async () => {
+    // Reading an encrypted key without a passphrase should fail.
+    expect(() => createPrivateKey(privateEncryptedPem)).toThrow();
+    // Reading an encrypted key with a passphrase that exceeds OpenSSL's buffer
+    // size limit should fail with an appropriate error code.
+    expect(() =>
+      createPrivateKey({
+        key: privateEncryptedPem,
+        format: "pem",
+        passphrase: Buffer.alloc(1025, "a"),
+      }),
+    ).toThrow();
+    // The buffer has a size of 1024 bytes, so this passphrase should be permitted
+    // (but will fail decryption).
+    expect(() =>
+      createPrivateKey({
+        key: privateEncryptedPem,
+        format: "pem",
+        passphrase: Buffer.alloc(1024, "a"),
+      }),
+    ).toThrow();
+    const publicKey = createPublicKey({
+      key: privateEncryptedPem,
+      format: "pem",
+      passphrase: "password", // this is not documented but should work
+    });
+    expect(publicKey.type).toBe("public");
+    expect(publicKey.asymmetricKeyType).toBe("rsa");
+    expect(publicKey.symmetricKeySize).toBe(undefined);
+
+    const privateKey = createPrivateKey({
+      key: privateEncryptedPem,
+      format: "pem",
+      passphrase: "password",
+    });
+    expect(privateKey.type).toBe("private");
+    expect(privateKey.asymmetricKeyType).toBe("rsa");
+    expect(privateKey.symmetricKeySize).toBe(undefined);
+  });
+
+  [2048, 4096].forEach(suffix => {
+    test(`RSA-${suffix} should work`, async () => {
+      {
+        const publicPem = fs.readFileSync(path.join(import.meta.dir, "fixtures", `rsa_public_${suffix}.pem`), "ascii");
+        const privatePem = fs.readFileSync(
+          path.join(import.meta.dir, "fixtures", `rsa_private_${suffix}.pem`),
+          "ascii",
+        );
+        const publicKey = createPublicKey(publicPem);
+        const expectedKeyDetails = {
+          modulusLength: suffix,
+          publicExponent: 65537n,
+        };
+        expect(publicKey.type).toBe("public");
+        expect(publicKey.asymmetricKeyType).toBe("rsa");
+        expect(publicKey.asymmetricKeyDetails).toEqual(expectedKeyDetails);
+
+        const privateKey = createPrivateKey(privatePem);
+        expect(privateKey.type).toBe("private");
+        expect(privateKey.asymmetricKeyType).toBe("rsa");
+        expect(privateKey.asymmetricKeyDetails).toEqual(expectedKeyDetails);
+
+        for (const key of [privatePem, privateKey]) {
+          // Any algorithm should work.
+          for (const algo of ["sha1", "sha256"]) {
+            // Any salt length should work.
+            for (const saltLength of [undefined, 8, 10, 12, 16, 18, 20]) {
+              const signature = createSign(algo).update("foo").sign({ key, saltLength });
+              for (const pkey of [key, publicKey, publicPem]) {
+                const okay = createVerify(algo).update("foo").verify({ key: pkey, saltLength }, signature);
+                expect(okay).toBeTrue();
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  test("Exporting an encrypted private key requires a cipher", async () => {
+    // Exporting an encrypted private key requires a cipher
+    const privateKey = createPrivateKey(privatePem);
+    expect(() => {
+      privateKey.export({
+        format: "pem",
+        type: "pkcs8",
+        passphrase: "super-secret",
+      });
+    }).toThrow(/cipher is required when passphrase is specified/);
+  });
+
+  test("secret export buffer format (default)", async () => {
+    const buffer = Buffer.from("Hello World");
+    const keyObject = createSecretKey(buffer);
+    expect(keyObject.export()).toEqual(buffer);
+    expect(keyObject.export({})).toEqual(buffer);
+    expect(keyObject.export({ format: "buffer" })).toEqual(buffer);
+    expect(keyObject.export({ format: undefined })).toEqual(buffer);
+  });
+
+  test('exporting an "oct" JWK from a secret', async () => {
+    const buffer = Buffer.from("Hello World");
+    const keyObject = createSecretKey(buffer);
+    const jwk = keyObject.export({ format: "jwk" });
+    expect(jwk).toEqual({ kty: "oct", k: "SGVsbG8gV29ybGQ" });
+  });
+
+  test("secret equals", async () => {
+    {
+      const first = Buffer.from("Hello");
+      const second = Buffer.from("World");
+      const keyObject = createSecretKey(first);
+      expect(createSecretKey(first).equals(createSecretKey(first))).toBeTrue();
+      expect(createSecretKey(first).equals(createSecretKey(second))).toBeFalse();
+
+      expect(() => keyObject.equals(0)).toThrow(/otherKey must be a KeyObject/);
+
+      expect(keyObject.equals(keyObject)).toBeTrue();
+      expect(keyObject.equals(createPublicKey(publicPem))).toBeFalse();
+      expect(keyObject.equals(createPrivateKey(privatePem))).toBeFalse();
+    }
+
+    {
+      const first = createSecretKey(Buffer.alloc(0));
+      const second = createSecretKey(new ArrayBuffer(0));
+      const third = createSecretKey(Buffer.alloc(1));
+      expect(first.equals(first)).toBeTrue();
+      expect(first.equals(second)).toBeTrue();
+      expect(first.equals(third)).toBeFalse();
+      expect(third.equals(first)).toBeFalse();
+    }
+  });
+
+  ["ed25519", "x25519"].forEach(keyType => {
+    const test = keyType === "ed25519" ? it : it.skip;
+    test(`${keyType} equals should work`, async () => {
+      const first = generateKeyPairSync(keyType);
+      const second = generateKeyPairSync(keyType);
+
+      const secret = generateKeySync("aes", { length: 128 });
+
+      expect(first.publicKey.equals(first.publicKey)).toBeTrue();
+
+      expect(first.publicKey.equals(createPublicKey(first.publicKey.export({ format: "pem", type: "spki" }))));
+
+      expect(first.publicKey.equals(second.publicKey)).toBeFalse();
+      expect(first.publicKey.equals(second.privateKey)).toBeFalse();
+      expect(first.publicKey.equals(secret)).toBeFalse();
+
+      expect(first.privateKey.equals(first.privateKey)).toBeTrue();
+      expect(
+        first.privateKey.equals(createPrivateKey(first.privateKey.export({ format: "pem", type: "pkcs8" }))),
+      ).toBeTrue();
+      expect(first.privateKey.equals(second.privateKey)).toBeFalse();
+      expect(first.privateKey.equals(second.publicKey)).toBeFalse();
+      expect(first.privateKey.equals(secret)).toBeFalse();
+    });
+  });
+
+  test("This should not cause a crash: https://github.com/nodejs/node/issues/44471", async () => {
+    for (const key of ["", "foo", null, undefined, true, Boolean]) {
+      expect(() => {
+        createPublicKey({ key, format: "jwk" });
+      }).toThrow();
+      expect(() => {
+        createPrivateKey({ key, format: "jwk" });
+      }).toThrow();
+    }
+  });
+
+  ["hmac", "aes"].forEach(type => {
+    [128, 256].forEach(length => {
+      test(`generateKey ${type} ${length}`, async () => {
+        {
+          const key = generateKeySync(type, { length });
+          expect(key).toBeDefined();
+          const keybuf = key.export();
+          expect(keybuf.byteLength).toBe(length / 8);
+        }
+
+        const { promise, resolve, reject } = Promise.withResolvers();
+        generateKey(type, { length }, (err, key) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(key);
+          }
+        });
+
+        {
+          const key = await promise;
+          expect(key).toBeDefined();
+          const keybuf = key.export();
+          expect(keybuf.byteLength).toBe(length / 8);
+        }
+      });
+    });
+  });
+  describe("Test async elliptic curve key generation with 'jwk' encoding and named curve", () => {
+    ["P-384", "P-256", "P-521", "secp256k1"].forEach(curve => {
+      const test = curve === "secp256k1" ? it.skip : it;
+      test(`should work with ${curve}`, async () => {
+        const { promise, resolve, reject } = Promise.withResolvers();
+        generateKeyPair(
+          "ec",
+          {
+            namedCurve: curve,
+            publicKeyEncoding: {
+              format: "jwk",
+            },
+            privateKeyEncoding: {
+              format: "jwk",
+            },
+          },
+          (err, publicKey, privateKey) => {
+            if (err) {
+              return reject(err);
+            }
+            resolve({ publicKey, privateKey });
+          },
+        );
+
+        const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
+        expect(typeof publicKey).toBe("object");
+        expect(typeof privateKey).toBe("object");
+        expect(publicKey.x).toBe(privateKey.x);
+        expect(publicKey.y).toBe(publicKey.y);
+        expect(publicKey.d).toBeUndefined();
+        expect(privateKey.d).toBeDefined();
+        expect(publicKey.kty).toEqual("EC");
+        expect(publicKey.kty).toEqual(privateKey.kty);
+        expect(publicKey.crv).toEqual(curve);
+        expect(publicKey.crv).toEqual(privateKey.crv);
+      });
+    });
+  });
+
+  describe("Test async elliptic curve key generation with 'jwk' encoding and RSA.", () => {
+    [256, 1024, 2048].forEach(modulusLength => {
+      test(`should work with ${modulusLength}`, async () => {
+        const { promise, resolve, reject } = Promise.withResolvers();
+        generateKeyPair(
+          "rsa",
+          {
+            modulusLength,
+            publicKeyEncoding: {
+              format: "jwk",
+            },
+            privateKeyEncoding: {
+              format: "jwk",
+            },
+          },
+          (err, publicKey, privateKey) => {
+            if (err) {
+              return reject(err);
+            }
+            resolve({ publicKey, privateKey });
+          },
+        );
+
+        const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
+        expect(typeof publicKey).toEqual("object");
+        expect(typeof privateKey).toEqual("object");
+        expect(publicKey.kty).toEqual("RSA");
+        expect(publicKey.kty).toEqual(privateKey.kty);
+        expect(typeof publicKey.n).toEqual("string");
+        expect(publicKey.n).toEqual(privateKey.n);
+        expect(typeof publicKey.e).toEqual("string");
+        expect(publicKey.e).toEqual(privateKey.e);
+        expect(typeof privateKey.d).toEqual("string");
+        expect(typeof privateKey.p).toEqual("string");
+        expect(typeof privateKey.q).toEqual("string");
+        expect(typeof privateKey.dp).toEqual("string");
+        expect(typeof privateKey.dq).toEqual("string");
+        expect(typeof privateKey.qi).toEqual("string");
+      });
+    });
+  });
+
+  describe("Test async elliptic curve key generation with 'jwk' encoding", () => {
+    ["ed25519", "ed448", "x25519", "x448"].forEach(type => {
+      const test = type === "ed25519" ? it : it.skip;
+      test(`should work with ${type}`, async () => {
+        const { promise, resolve, reject } = Promise.withResolvers();
+        generateKeyPair(
+          type,
+          {
+            publicKeyEncoding: {
+              format: "jwk",
+            },
+            privateKeyEncoding: {
+              format: "jwk",
+            },
+          },
+          (err, publicKey, privateKey) => {
+            if (err) {
+              return reject(err);
+            }
+            resolve({ publicKey, privateKey });
+          },
+        );
+
+        const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
+        expect(typeof publicKey).toEqual("object");
+        expect(typeof privateKey).toEqual("object");
+        expect(publicKey.x).toEqual(privateKey.x);
+        expect(publicKey.d).toBeUndefined();
+        expect(privateKey.d).toBeDefined();
+        expect(publicKey.kty).toEqual("OKP");
+        expect(publicKey.kty).toEqual(privateKey.kty);
+        const expectedCrv = `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
+        expect(publicKey.crv).toEqual(expectedCrv);
+        expect(publicKey.crv).toEqual(privateKey.crv);
+      });
+    });
+  });
+
+  test(`Test async RSA key generation with an encrypted private key, but encoded as DER`, async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    generateKeyPair(
+      "rsa",
+      {
+        publicExponent: 0x10001,
+        modulusLength: 512,
+        publicKeyEncoding: {
+          type: "pkcs1",
+          format: "der",
+        },
+        privateKeyEncoding: {
+          type: "pkcs1",
+          format: "pem",
+          cipher: "aes-256-cbc",
+          passphrase: "secret",
+        },
+      },
+      (err, publicKey, privateKey) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve({ publicKey, privateKey });
+      },
+    );
+
+    const { publicKey: publicKeyDER, privateKey } = await (promise as Promise<{
+      publicKey: Buffer;
+      privateKey: string;
+    }>);
+    expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
+    assertApproximateSize(publicKeyDER, 74);
+
+    expect(typeof privateKey).toBe("string");
+    expect(privateKey).toMatch(pkcs1EncExp("AES-256-CBC"));
+
+    const publicKey = {
+      key: publicKeyDER,
+      type: "pkcs1",
+      format: "der",
+    };
+    expect(() => {
+      testEncryptDecrypt(publicKey, privateKey);
+    }).toThrow();
+
+    const key = { key: privateKey, passphrase: "secret" };
+    testEncryptDecrypt(publicKey, key);
+    testSignVerify(publicKey, key);
+  });
+
+  test(`Test async RSA key generation with an encrypted private key`, async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    generateKeyPair(
+      "rsa",
+      {
+        publicExponent: 0x10001,
+        modulusLength: 512,
+        publicKeyEncoding: {
+          type: "pkcs1",
+          format: "der",
+        },
+        privateKeyEncoding: {
+          type: "pkcs8",
+          format: "der",
+        },
+      },
+      (err, publicKey, privateKey) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve({ publicKey, privateKey });
+      },
+    );
+
+    const { publicKey: publicKeyDER, privateKey: privateKeyDER } = await (promise as Promise<{
+      publicKey: Buffer;
+      privateKey: Buffer;
+    }>);
+    expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
+    assertApproximateSize(publicKeyDER, 74);
+
+    expect(Buffer.isBuffer(privateKeyDER)).toBeTrue();
+
+    const publicKey = {
+      key: publicKeyDER,
+      type: "pkcs1",
+      format: "der",
+    };
+    const privateKey = {
+      key: privateKeyDER,
+      format: "der",
+      type: "pkcs8",
+      passphrase: "secret",
+    };
+    testEncryptDecrypt(publicKey, privateKey);
+    testSignVerify(publicKey, privateKey);
+  });
+
+  test(`Test async elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    generateKeyPair(
+      "ec",
+      {
+        namedCurve: "P-256",
+        publicKeyEncoding: {
+          type: "spki",
+          format: "pem",
+        },
+        privateKeyEncoding: {
+          type: "pkcs8",
+          format: "pem",
+          cipher: "aes-128-cbc",
+          passphrase: "top secret",
+        },
+      },
+      (err, publicKey, privateKey) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve({ publicKey, privateKey });
+      },
+    );
+
+    const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
+    expect(typeof publicKey).toBe("string");
+    expect(publicKey).toMatch(spkiExp);
+    expect(typeof privateKey).toBe("string");
+    expect(privateKey).toMatch(pkcs8EncExp);
+
+    expect(() => {
+      testSignVerify(publicKey, privateKey);
+    }).toThrow();
+
+    testSignVerify(publicKey, {
+      key: privateKey,
+      passphrase: "top secret",
+    });
+  });
+
+  test(`Test async explicit elliptic curve key generation with an encrypted private key`, async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    generateKeyPair(
+      "ec",
+      {
+        namedCurve: "prime256v1",
+        publicKeyEncoding: {
+          type: "spki",
+          format: "pem",
+        },
+        privateKeyEncoding: {
+          type: "sec1",
+          format: "pem",
+          cipher: "aes-128-cbc",
+          passphrase: "secret",
+        },
+      },
+      (err, publicKey, privateKey) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve({ publicKey, privateKey });
+      },
+    );
+
+    const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
+    expect(typeof publicKey).toBe("string");
+    expect(publicKey).toMatch(spkiExp);
+    expect(typeof privateKey).toBe("string");
+    expect(privateKey).toMatch(sec1EncExp("AES-128-CBC"));
+
+    expect(() => {
+      testSignVerify(publicKey, privateKey);
+    }).toThrow();
+
+    testSignVerify(publicKey, {
+      key: privateKey,
+      passphrase: "secret",
+    });
+  });
+
+  test(`Test async explicit elliptic curve key generation, e.g. for ECDSA, with a SEC1 private key`, async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    generateKeyPair(
+      "ec",
+      {
+        namedCurve: "prime256v1",
+        publicKeyEncoding: {
+          type: "spki",
+          format: "pem",
+        },
+        privateKeyEncoding: {
+          type: "sec1",
+          format: "pem",
+        },
+      },
+      (err, publicKey, privateKey) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve({ publicKey, privateKey });
+      },
+    );
+
+    const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
+    expect(typeof publicKey).toBe("string");
+    expect(publicKey).toMatch(spkiExp);
+    expect(typeof privateKey).toBe("string");
+    expect(privateKey).toMatch(sec1Exp);
+    testSignVerify(publicKey, privateKey);
+  });
+
+  test(`Test async elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    generateKeyPair(
+      "ec",
+      {
+        namedCurve: "prime256v1",
+        publicKeyEncoding: {
+          type: "spki",
+          format: "pem",
+        },
+        privateKeyEncoding: {
+          type: "pkcs8",
+          format: "pem",
+          cipher: "aes-128-cbc",
+          passphrase: "top secret",
+        },
+      },
+      (err, publicKey, privateKey) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve({ publicKey, privateKey });
+      },
+    );
+
+    const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
+    expect(typeof publicKey).toBe("string");
+    expect(publicKey).toMatch(spkiExp);
+    expect(typeof privateKey).toBe("string");
+    expect(privateKey).toMatch(pkcs8EncExp);
+
+    expect(() => {
+      testSignVerify(publicKey, privateKey);
+    }).toThrow();
+
+    testSignVerify(publicKey, {
+      key: privateKey,
+      passphrase: "top secret",
+    });
+  });
+
+  describe("Test sync elliptic curve key generation with 'jwk' encoding and named curve", () => {
+    ["P-384", "P-256", "P-521", "secp256k1"].forEach(curve => {
+      const test = curve === "secp256k1" ? it.skip : it;
+      test(`should work with ${curve}`, async () => {
+        const { publicKey, privateKey } = generateKeyPairSync("ec", {
+          namedCurve: curve,
+          publicKeyEncoding: {
+            format: "jwk",
+          },
+          privateKeyEncoding: {
+            format: "jwk",
+          },
+        });
+        expect(typeof publicKey).toBe("object");
+        expect(typeof privateKey).toBe("object");
+        expect(publicKey.x).toBe(privateKey.x);
+        expect(publicKey.y).toBe(publicKey.y);
+        expect(publicKey.d).toBeUndefined();
+        expect(privateKey.d).toBeDefined();
+        expect(publicKey.kty).toEqual("EC");
+        expect(publicKey.kty).toEqual(privateKey.kty);
+        expect(publicKey.crv).toEqual(curve);
+        expect(publicKey.crv).toEqual(privateKey.crv);
+      });
+    });
+  });
+
+  describe("Test sync elliptic curve key generation with 'jwk' encoding and RSA.", () => {
+    [256, 1024, 2048].forEach(modulusLength => {
+      test(`should work with ${modulusLength}`, async () => {
+        const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+          modulusLength,
+          publicKeyEncoding: {
+            format: "jwk",
+          },
+          privateKeyEncoding: {
+            format: "jwk",
+          },
+        });
+        expect(typeof publicKey).toEqual("object");
+        expect(typeof privateKey).toEqual("object");
+        expect(publicKey.kty).toEqual("RSA");
+        expect(publicKey.kty).toEqual(privateKey.kty);
+        expect(typeof publicKey.n).toEqual("string");
+        expect(publicKey.n).toEqual(privateKey.n);
+        expect(typeof publicKey.e).toEqual("string");
+        expect(publicKey.e).toEqual(privateKey.e);
+        expect(typeof privateKey.d).toEqual("string");
+        expect(typeof privateKey.p).toEqual("string");
+        expect(typeof privateKey.q).toEqual("string");
+        expect(typeof privateKey.dp).toEqual("string");
+        expect(typeof privateKey.dq).toEqual("string");
+        expect(typeof privateKey.qi).toEqual("string");
+      });
+    });
+  });
+
+  describe("Test sync elliptic curve key generation with 'jwk' encoding", () => {
+    ["ed25519", "ed448", "x25519", "x448"].forEach(type => {
+      const test = type === "ed25519" ? it : it.skip;
+      test(`should work with ${type}`, async () => {
+        const { publicKey, privateKey } = generateKeyPairSync(type, {
+          publicKeyEncoding: {
+            format: "jwk",
+          },
+          privateKeyEncoding: {
+            format: "jwk",
+          },
+        });
+
+        expect(typeof publicKey).toEqual("object");
+        expect(typeof privateKey).toEqual("object");
+        expect(publicKey.x).toEqual(privateKey.x);
+        expect(publicKey.d).toBeUndefined();
+        expect(privateKey.d).toBeDefined();
+        expect(publicKey.kty).toEqual("OKP");
+        expect(publicKey.kty).toEqual(privateKey.kty);
+        const expectedCrv = `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
+        expect(publicKey.crv).toEqual(expectedCrv);
+        expect(publicKey.crv).toEqual(privateKey.crv);
+      });
+    });
+  });
+
+  test(`Test sync RSA key generation with an encrypted private key, but encoded as DER`, async () => {
+    const { publicKey: publicKeyDER, privateKey } = generateKeyPairSync("rsa", {
+      publicExponent: 0x10001,
+      modulusLength: 512,
+      publicKeyEncoding: {
+        type: "pkcs1",
+        format: "der",
+      },
+      privateKeyEncoding: {
+        type: "pkcs1",
+        format: "pem",
+        cipher: "aes-256-cbc",
+        passphrase: "secret",
+      },
+    });
+
+    expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
+    assertApproximateSize(publicKeyDER, 74);
+
+    expect(typeof privateKey).toBe("string");
+    expect(privateKey).toMatch(pkcs1EncExp("AES-256-CBC"));
+
+    const publicKey = {
+      key: publicKeyDER,
+      type: "pkcs1",
+      format: "der",
+    };
+    expect(() => {
+      testEncryptDecrypt(publicKey, privateKey);
+    }).toThrow();
+
+    const key = { key: privateKey, passphrase: "secret" };
+    testEncryptDecrypt(publicKey, key);
+    testSignVerify(publicKey, key);
+  });
+
+  test(`Test sync RSA key generation with an encrypted private key`, async () => {
+    const { publicKey: publicKeyDER, privateKey: privateKeyDER } = generateKeyPairSync("rsa", {
+      publicExponent: 0x10001,
+      modulusLength: 512,
+      publicKeyEncoding: {
+        type: "pkcs1",
+        format: "der",
+      },
+      privateKeyEncoding: {
+        type: "pkcs8",
+        format: "der",
+      },
+    });
+
+    expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
+    assertApproximateSize(publicKeyDER, 74);
+
+    expect(Buffer.isBuffer(privateKeyDER)).toBeTrue();
+
+    const publicKey = {
+      key: publicKeyDER,
+      type: "pkcs1",
+      format: "der",
+    };
+    const privateKey = {
+      key: privateKeyDER,
+      format: "der",
+      type: "pkcs8",
+      passphrase: "secret",
+    };
+    testEncryptDecrypt(publicKey, privateKey);
+    testSignVerify(publicKey, privateKey);
+  });
+
+  test(`Test sync elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ec", {
+      namedCurve: "P-256",
+      publicKeyEncoding: {
+        type: "spki",
+        format: "pem",
+      },
+      privateKeyEncoding: {
+        type: "pkcs8",
+        format: "pem",
+        cipher: "aes-128-cbc",
+        passphrase: "top secret",
+      },
+    });
+
+    expect(typeof publicKey).toBe("string");
+    expect(publicKey).toMatch(spkiExp);
+    expect(typeof privateKey).toBe("string");
+    expect(privateKey).toMatch(pkcs8EncExp);
+
+    expect(() => {
+      testSignVerify(publicKey, privateKey);
+    }).toThrow();
+
+    testSignVerify(publicKey, {
+      key: privateKey,
+      passphrase: "top secret",
+    });
+  });
+
+  test(`Test sync explicit elliptic curve key generation with an encrypted private key`, async () => {
+    const { publicKey, privateKey } = generateKeyPairSync(
+      "ec",
+      {
+        namedCurve: "prime256v1",
+        publicKeyEncoding: {
+          type: "spki",
+          format: "pem",
+        },
+        privateKeyEncoding: {
+          type: "sec1",
+          format: "pem",
+          cipher: "aes-128-cbc",
+          passphrase: "secret",
+        },
+      },
+      (err, publicKey, privateKey) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve({ publicKey, privateKey });
+      },
+    );
+
+    expect(typeof publicKey).toBe("string");
+    expect(publicKey).toMatch(spkiExp);
+    expect(typeof privateKey).toBe("string");
+    expect(privateKey).toMatch(sec1EncExp("AES-128-CBC"));
+
+    expect(() => {
+      testSignVerify(publicKey, privateKey);
+    }).toThrow();
+
+    testSignVerify(publicKey, {
+      key: privateKey,
+      passphrase: "secret",
+    });
+  });
+
+  test(`Test sync explicit elliptic curve key generation, e.g. for ECDSA, with a SEC1 private key`, async () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ec", {
+      namedCurve: "prime256v1",
+      publicKeyEncoding: {
+        type: "spki",
+        format: "pem",
+      },
+      privateKeyEncoding: {
+        type: "sec1",
+        format: "pem",
+      },
+    });
+
+    expect(typeof publicKey).toBe("string");
+    expect(publicKey).toMatch(spkiExp);
+    expect(typeof privateKey).toBe("string");
+    expect(privateKey).toMatch(sec1Exp);
+    testSignVerify(publicKey, privateKey);
+  });
+
+  test(`Test sync elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ec", {
+      namedCurve: "prime256v1",
+      publicKeyEncoding: {
+        type: "spki",
+        format: "pem",
+      },
+      privateKeyEncoding: {
+        type: "pkcs8",
+        format: "pem",
+        cipher: "aes-128-cbc",
+        passphrase: "top secret",
+      },
+    });
+
+    expect(typeof publicKey).toBe("string");
+    expect(publicKey).toMatch(spkiExp);
+    expect(typeof privateKey).toBe("string");
+    expect(privateKey).toMatch(pkcs8EncExp);
+
+    expect(() => {
+      testSignVerify(publicKey, privateKey);
+    }).toThrow();
+
+    testSignVerify(publicKey, {
+      key: privateKey,
+      passphrase: "top secret",
+    });
+  });
+  // SKIPED because we round the key size to the nearest multiple of 8 like documented
+  test.skip(`this tests check that generateKeyPair returns correct bit length in KeyObject's asymmetricKeyDetails.`, async () => {
+    // This tests check that generateKeyPair returns correct bit length in
+    // https://github.com/nodejs/node/issues/46102#issuecomment-1372153541
+    const { promise, resolve, reject } = Promise.withResolvers();
+    generateKeyPair(
+      "rsa",
+      {
+        modulusLength: 513,
+      },
+      (err, publicKey, privateKey) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve({ publicKey, privateKey });
+      },
+    );
+
+    const { publicKey, privateKey } = await (promise as Promise<{ publicKey: KeyObject; privateKey: KeyObject }>);
+    expect(publicKey.asymmetricKeyDetails?.modulusLength).toBe(513);
+    expect(privateKey.asymmetricKeyDetails?.modulusLength).toBe(513);
+  });
+
+  function testRunInContext(fn: any) {
+    test("can generate key", () => {
+      const context = createContext({ generateKeySync });
+      const result = fn(`generateKeySync("aes", { length: 128 })`, context);
+      expect(result).toBeDefined();
+      const keybuf = result.export();
+      expect(keybuf.byteLength).toBe(128 / 8);
+    });
+    test("can be used on another context", () => {
+      const context = createContext({ generateKeyPairSync, assertApproximateSize, testEncryptDecrypt, testSignVerify });
+      const result = fn(
+        `
+        const { publicKey: publicKeyDER, privateKey: privateKeyDER } = generateKeyPairSync(
+          "rsa",
+          {
+            publicExponent: 0x10001,
+            modulusLength: 512,
+            publicKeyEncoding: {
+              type: "pkcs1",
+              format: "der",
+            },
+            privateKeyEncoding: {
+              type: "pkcs8",
+              format: "der",
+            },
+          }
+        );
+
+        assertApproximateSize(publicKeyDER, 74);
+
+        const publicKey = {
+          key: publicKeyDER,
+          type: "pkcs1",
+          format: "der",
+        };
+        const privateKey = {
+          key: privateKeyDER,
+          format: "der",
+          type: "pkcs8",
+          passphrase: "secret",
+        };
+        testEncryptDecrypt(publicKey, privateKey);
+        testSignVerify(publicKey, privateKey);
+      `,
+        context,
+      );
+    });
+  }
+  describe("Script", () => {
+    describe("runInContext()", () => {
+      testRunInContext((code, context, options) => {
+        // @ts-expect-error
+        const script = new Script(code, options);
+        return script.runInContext(context);
+      });
+    });
+    describe("runInNewContext()", () => {
+      testRunInContext((code, context, options) => {
+        // @ts-expect-error
+        const script = new Script(code, options);
+        return script.runInNewContext(context);
+      });
+    });
+    describe("runInThisContext()", () => {
+      testRunInContext((code, context, options) => {
+        // @ts-expect-error
+        const script = new Script(code, options);
+        return script.runInThisContext(context);
+      });
+    });
+  });
+});
 
 test("RSA-PSS should work", async () => {
   // Test RSA-PSS.
+  const expectedKeyDetails = {
+    modulusLength: 2048,
+    publicExponent: 65537n,
+  };
   {
-    // This key pair does not restrict the message digest algorithm or salt
-    // length.
-    const publicPem = fs.readFileSync(path.join(import.meta.dir, "fixtures", "rsa_pss_public_2048.pem"), "ascii");
-    const privatePem = fs.readFileSync(path.join(import.meta.dir, "fixtures", "rsa_pss_private_2048.pem"), "ascii");
-    console.log(publicPem);
-    console.log(privatePem);
-    const publicKey = createPublicKey(publicPem);
-    const privateKey = createPrivateKey(privatePem);
-    // Because no RSASSA-PSS-params appears in the PEM, no defaults should be
-    // added for the PSS parameters. This is different from an empty
-    // RSASSA-PSS-params sequence (see test below).
-    const expectedKeyDetails = {
+    const { privateKey, publicKey } = generateKeyPairSync("rsa-pss", {
       modulusLength: 2048,
-      publicExponent: 65537n,
-    };
+      publicExponent: 65537,
+    });
     expect(publicKey.type).toBe("public");
     expect(publicKey.asymmetricKeyType).toBe("rsa-pss");
-    expect(publicKey.asymmetricKeyDetails).toBe(expectedKeyDetails);
+    expect(publicKey.asymmetricKeyDetails).toEqual(expectedKeyDetails);
     expect(privateKey.type).toBe("private");
     expect(privateKey.asymmetricKeyType).toBe("rsa-pss");
-    expect(privateKey.asymmetricKeyDetails).toBe(expectedKeyDetails);
-    // assert.throws(() => publicKey.export({ format: "jwk" }), { code: "ERR_CRYPTO_JWK_UNSUPPORTED_KEY_TYPE" });
-    // assert.throws(
-    //   () => privateKey.export({ format: 'jwk' }),
-    //   { code: 'ERR_CRYPTO_JWK_UNSUPPORTED_KEY_TYPE' });
-    // for (const key of [privatePem, privateKey]) {
-    //   // Any algorithm should work.
-    //   for (const algo of ['sha1', 'sha256']) {
-    //     // Any salt length should work.
-    //     for (const saltLength of [undefined, 8, 10, 12, 16, 18, 20]) {
-    //       const signature = createSign(algo)
-    //                         .update('foo')
-    //                         .sign({ key, saltLength });
-    //       for (const pkey of [key, publicKey, publicPem]) {
-    //         const okay = createVerify(algo)
-    //                      .update('foo')
-    //                      .verify({ key: pkey, saltLength }, signature);
-    //         assert.ok(okay);
-    //       }
-    //     }
-    //   }
-    // }
-    // // Exporting the key using PKCS#1 should not work since this would discard
-    // // any algorithm restrictions.
-    // assert.throws(() => {
-    //   publicKey.export({ format: 'pem', type: 'pkcs1' });
-    // }, {
-    //   code: 'ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS'
-    // });
-    //   {
-    //     // This key pair enforces sha1 as the message digest and the MGF1
-    //     // message digest and a salt length of 20 bytes.
-    //     const publicPem = fixtures.readKey('rsa_pss_public_2048_sha1_sha1_20.pem');
-    //     const privatePem =
-    //         fixtures.readKey('rsa_pss_private_2048_sha1_sha1_20.pem');
-    //     const publicKey = createPublicKey(publicPem);
-    //     const privateKey = createPrivateKey(privatePem);
-    //     // Unlike the previous key pair, this key pair contains an RSASSA-PSS-params
-    //     // sequence. However, because all values in the RSASSA-PSS-params are set to
-    //     // their defaults (see RFC 3447), the ASN.1 structure contains an empty
-    //     // sequence. Node.js should add the default values to the key details.
-    //     const expectedKeyDetails = {
-    //       modulusLength: 2048,
-    //       publicExponent: 65537n,
-    //       hashAlgorithm: 'sha1',
-    //       mgf1HashAlgorithm: 'sha1',
-    //       saltLength: 20
-    //     };
-    //     assert.strictEqual(publicKey.type, 'public');
-    //     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa-pss');
-    //     assert.deepStrictEqual(publicKey.asymmetricKeyDetails, expectedKeyDetails);
-    //     assert.strictEqual(privateKey.type, 'private');
-    //     assert.strictEqual(privateKey.asymmetricKeyType, 'rsa-pss');
-    //     assert.deepStrictEqual(privateKey.asymmetricKeyDetails, expectedKeyDetails);
-    //   }
-    //   {
-    //     // This key pair enforces sha256 as the message digest and the MGF1
-    //     // message digest and a salt length of at least 16 bytes.
-    //     const publicPem =
-    //       fixtures.readKey('rsa_pss_public_2048_sha256_sha256_16.pem');
-    //     const privatePem =
-    //       fixtures.readKey('rsa_pss_private_2048_sha256_sha256_16.pem');
-    //     const publicKey = createPublicKey(publicPem);
-    //     const privateKey = createPrivateKey(privatePem);
-    //     assert.strictEqual(publicKey.type, 'public');
-    //     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa-pss');
-    //     assert.strictEqual(privateKey.type, 'private');
-    //     assert.strictEqual(privateKey.asymmetricKeyType, 'rsa-pss');
-    //     for (const key of [privatePem, privateKey]) {
-    //       // Signing with anything other than sha256 should fail.
-    //       assert.throws(() => {
-    //         createSign('sha1').sign(key);
-    //       }, /digest not allowed/);
-    //       // Signing with salt lengths less than 16 bytes should fail.
-    //       for (const saltLength of [8, 10, 12]) {
-    //         assert.throws(() => {
-    //           createSign('sha1').sign({ key, saltLength });
-    //         }, /pss saltlen too small/);
-    //       }
-    //       // Signing with sha256 and appropriate salt lengths should work.
-    //       for (const saltLength of [undefined, 16, 18, 20]) {
-    //         const signature = createSign('sha256')
-    //                           .update('foo')
-    //                           .sign({ key, saltLength });
-    //         for (const pkey of [key, publicKey, publicPem]) {
-    //           const okay = createVerify('sha256')
-    //                        .update('foo')
-    //                        .verify({ key: pkey, saltLength }, signature);
-    //           assert.ok(okay);
-    //         }
-    //       }
-    //     }
-    //   }
+    expect(privateKey.asymmetricKeyDetails).toEqual(expectedKeyDetails);
+    expect(() => publicKey.export({ format: "jwk" })).toThrow(/ERR_CRYPTO_JWK_UNSUPPORTED_KEY_TYPE/);
+    expect(() => privateKey.export({ format: "jwk" })).toThrow(/ERR_CRYPTO_JWK_UNSUPPORTED_KEY_TYPE/);
+
+    for (const key of [privateKey]) {
+      // Any algorithm should work.
+      for (const algo of ["sha1", "sha256"]) {
+        // Any salt length should work.
+        for (const saltLength of [undefined, 8, 10, 12, 16, 18, 20]) {
+          const signature = sign(algo, Buffer.from("foo"), { key, saltLength });
+          for (const pkey of [key, publicKey]) {
+            const okay = verify(algo, Buffer.from("foo"), { key: pkey, saltLength }, signature);
+            expect(okay).toBeTrue();
+          }
+        }
+      }
+    }
+    // Exporting the key using PKCS#1 should not work since this would discard
+    // any algorithm restrictions.
+    expect(() => {
+      publicKey.export({ format: "pem", type: "pkcs1" });
+    }).toThrow(/ERR_CRYPTO_JWK_UNSUPPORTED_KEY_TYPE/);
+
+    {
+      // Unlike the previous key pair, this key pair contains an RSASSA-PSS-params
+      // sequence. However, because all values in the RSASSA-PSS-params are set to
+      // their defaults (see RFC 3447), the ASN.1 structure contains an empty
+      // sequence. Node.js should add the default values to the key details.
+      const { privateKey, publicKey } = generateKeyPairSync("rsa-pss", {
+        modulusLength: 2048,
+        publicExponent: 65537,
+        hashAlgorithm: "sha1",
+        mgf1HashAlgorithm: "sha1",
+        saltLength: 20,
+      });
+
+      expect(publicKey.type).toBe("public");
+      expect(publicKey.asymmetricKeyType).toBe("rsa-pss");
+      // RSA_get0_pss_params returns NULL. In OpenSSL, this function retries RSA-PSS
+      // parameters associated with |RSA| objects, but BoringSSL does not support
+      // the id-RSASSA-PSS key encoding.
+      // We expect only modulusLength and publicExponent to be present.
+      expect(publicKey.asymmetricKeyDetails).toEqual(expectedKeyDetails);
+      expect(privateKey.type).toBe("private");
+      expect(privateKey.asymmetricKeyType).toBe("rsa-pss");
+    }
+    {
+      // This key pair enforces sha256 as the message digest and the MGF1
+      // message digest and a salt length of at least 16 bytes.
+      const { privateKey, publicKey } = generateKeyPairSync("rsa-pss", {
+        modulusLength: 2048,
+        publicExponent: 65537,
+        hashAlgorithm: "sha256",
+        saltLength: 16,
+      });
+      expect(publicKey.type).toBe("public");
+      expect(publicKey.asymmetricKeyType).toBe("rsa-pss");
+      expect(privateKey.type).toBe("private");
+      expect(privateKey.asymmetricKeyType).toBe("rsa-pss");
+      for (const key of [privateKey]) {
+        // Signing with anything other than sha256 should fail.
+        expect(() => {
+          sign("sha1", Buffer.from("foo"), key);
+        }).toThrow(/digest not allowed/);
+        // Signing with salt lengths less than 16 bytes should fail.
+        // We don't enforce this yet because of BoringSSL's limitations. TODO: check this
+        // for (const saltLength of [8, 10, 12]) {
+        //   expect(() => {
+        //     createSign("sha1").sign({ key, saltLength });
+        //   }).toThrow(/pss saltlen too small/);
+        // }
+        // Signing with sha256 and appropriate salt lengths should work.
+        for (const saltLength of [undefined, 16, 18, 20]) {
+          const signature = sign("sha256", Buffer.from("foo"), { key, saltLength });
+          for (const pkey of [key, publicKey]) {
+            const okay = verify("sha256", Buffer.from("foo"), { key: pkey, saltLength }, signature);
+            expect(okay).toBeTrue();
+          }
+        }
+      }
+    }
+
+    // TODO: check how to use MGF1 and saltLength using BoringSSL
     //   {
     //     // This key enforces sha512 as the message digest and sha256 as the MGF1
     //     // message digest.
@@ -1639,4 +1622,73 @@ test("RSA-PSS should work", async () => {
     //   }
     // }
   }
+});
+
+test("Ed25519 should work", async () => {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+
+  expect(publicKey.type).toBe("public");
+  expect(publicKey.asymmetricKeyType).toBe("ed25519");
+  expect(publicKey.asymmetricKeyDetails).toEqual({ namedCurve: "Ed25519" });
+  expect(privateKey.type).toBe("private");
+  expect(privateKey.asymmetricKeyType).toBe("ed25519");
+  expect(privateKey.asymmetricKeyDetails).toEqual({ namedCurve: "Ed25519" });
+
+  {
+    const signature = sign(undefined, Buffer.from("foo"), privateKey);
+    const okay = verify(undefined, Buffer.from("foo"), publicKey, signature);
+    expect(okay).toBeTrue();
+  }
+});
+
+test("ECDSA should work", async () => {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+
+  expect(publicKey.type).toBe("public");
+  expect(publicKey.asymmetricKeyType).toBe("ec");
+  expect(publicKey.asymmetricKeyDetails).toEqual({ namedCurve: "prime256v1" });
+  expect(privateKey.type).toBe("private");
+  expect(privateKey.asymmetricKeyType).toBe("ec");
+  expect(privateKey.asymmetricKeyDetails).toEqual({ namedCurve: "prime256v1" });
+
+  // default format (DER)
+  {
+    const signature = sign(undefined, Buffer.from("foo"), privateKey);
+    expect(signature.byteLength).not.toBe(64);
+    const okay = verify(undefined, Buffer.from("foo"), publicKey, signature);
+    expect(okay).toBeTrue();
+  }
+  // IeeeP1363 format
+  {
+    const signature = sign(undefined, Buffer.from("foo"), { key: privateKey, dsaEncoding: "ieee-p1363" });
+    expect(signature.byteLength).toBe(64);
+
+    const okay = verify(undefined, Buffer.from("foo"), { key: publicKey, dsaEncoding: "ieee-p1363" }, signature);
+    expect(okay).toBeTrue();
+  }
+  // DER format
+  {
+    const signature = sign(undefined, Buffer.from("foo"), { key: privateKey, dsaEncoding: "der" });
+    expect(signature.byteLength).not.toBe(64);
+
+    const okay = verify(undefined, Buffer.from("foo"), { key: publicKey, dsaEncoding: "der" }, signature);
+    expect(okay).toBeTrue();
+  }
+
+  expect(() => {
+    //@ts-ignore
+    sign(undefined, Buffer.from("foo"), { key: privateKey, dsaEncoding: "kjshdakjshd" });
+  }).toThrow(/invalid dsaEncoding/);
+
+  expect(() => {
+    const signature = sign(undefined, Buffer.from("foo"), privateKey);
+    //@ts-ignore
+    verify(undefined, Buffer.from("foo"), { key: publicKey, dsaEncoding: "ieee-p136" }, signature);
+  }).toThrow(/invalid dsaEncoding/);
+
+  expect(() => {
+    //@ts-ignore
+    const signature = sign(undefined, Buffer.from("foo"), { key: privateKey, dsaEncoding: "ieee-p136" });
+    verify(undefined, Buffer.from("foo"), { key: publicKey, dsaEncoding: "der" }, signature);
+  }).toThrow(/invalid dsaEncoding/);
 });

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1653,42 +1653,42 @@ test("ECDSA should work", async () => {
 
   // default format (DER)
   {
-    const signature = sign(undefined, Buffer.from("foo"), privateKey);
+    const signature = sign("sha256", Buffer.from("foo"), privateKey);
     expect(signature.byteLength).not.toBe(64);
-    const okay = verify(undefined, Buffer.from("foo"), publicKey, signature);
+    const okay = verify("sha256", Buffer.from("foo"), publicKey, signature);
     expect(okay).toBeTrue();
   }
   // IeeeP1363 format
   {
-    const signature = sign(undefined, Buffer.from("foo"), { key: privateKey, dsaEncoding: "ieee-p1363" });
+    const signature = sign("sha256", Buffer.from("foo"), { key: privateKey, dsaEncoding: "ieee-p1363" });
     expect(signature.byteLength).toBe(64);
 
-    const okay = verify(undefined, Buffer.from("foo"), { key: publicKey, dsaEncoding: "ieee-p1363" }, signature);
+    const okay = verify("sha256", Buffer.from("foo"), { key: publicKey, dsaEncoding: "ieee-p1363" }, signature);
     expect(okay).toBeTrue();
   }
   // DER format
   {
-    const signature = sign(undefined, Buffer.from("foo"), { key: privateKey, dsaEncoding: "der" });
+    const signature = sign("sha256", Buffer.from("foo"), { key: privateKey, dsaEncoding: "der" });
     expect(signature.byteLength).not.toBe(64);
 
-    const okay = verify(undefined, Buffer.from("foo"), { key: publicKey, dsaEncoding: "der" }, signature);
+    const okay = verify("sha256", Buffer.from("foo"), { key: publicKey, dsaEncoding: "der" }, signature);
     expect(okay).toBeTrue();
   }
 
   expect(() => {
     //@ts-ignore
-    sign(undefined, Buffer.from("foo"), { key: privateKey, dsaEncoding: "kjshdakjshd" });
+    sign("sha256", Buffer.from("foo"), { key: privateKey, dsaEncoding: "kjshdakjshd" });
   }).toThrow(/invalid dsaEncoding/);
 
   expect(() => {
-    const signature = sign(undefined, Buffer.from("foo"), privateKey);
+    const signature = sign("sha256", Buffer.from("foo"), privateKey);
     //@ts-ignore
-    verify(undefined, Buffer.from("foo"), { key: publicKey, dsaEncoding: "ieee-p136" }, signature);
+    verify("sha256", Buffer.from("foo"), { key: publicKey, dsaEncoding: "ieee-p136" }, signature);
   }).toThrow(/invalid dsaEncoding/);
 
   expect(() => {
     //@ts-ignore
-    const signature = sign(undefined, Buffer.from("foo"), { key: privateKey, dsaEncoding: "ieee-p136" });
-    verify(undefined, Buffer.from("foo"), { key: publicKey, dsaEncoding: "der" }, signature);
+    const signature = sign("sha256", Buffer.from("foo"), { key: privateKey, dsaEncoding: "ieee-p136" });
+    verify("sha256", Buffer.from("foo"), { key: publicKey, dsaEncoding: "der" }, signature);
   }).toThrow(/invalid dsaEncoding/);
 });

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -92,1415 +92,1414 @@ function testSignVerify(publicKey: any, privateKey: any) {
   }
 }
 
-describe("crypto.KeyObjects", () => {
-  test("Attempting to create a key using other than CryptoKey should throw", async () => {
-    expect(() => new KeyObject("secret", "")).toThrow();
-    expect(() => new KeyObject("secret")).toThrow();
-    expect(() => KeyObject.from("invalid_key")).toThrow();
-  });
-  test("basics of createSecretKey should work", async () => {
-    const keybuf = randomBytes(32);
-    const key = createSecretKey(keybuf);
-    expect(key.type).toBe("secret");
-    expect(key.toString()).toBe("[object KeyObject]");
-    expect(key.symmetricKeySize).toBe(32);
-    expect(key.asymmetricKeyType).toBe(undefined);
-    expect(key.asymmetricKeyDetails).toBe(undefined);
-
-    const exportedKey = key.export();
-    expect(keybuf).toEqual(exportedKey);
-
-    const plaintext = Buffer.from("Hello world", "utf8");
-
-    const cipher = createCipheriv("aes-256-ecb", key, null);
-    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
-
-    const decipher = createDecipheriv("aes-256-ecb", key, null);
-    const deciphered = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
-
-    expect(plaintext).toEqual(deciphered);
-  });
-
-  test("Passing an existing public key object to createPublicKey should throw", async () => {
-    // Passing an existing public key object to createPublicKey should throw.
-    const publicKey = createPublicKey(publicPem);
-    expect(() => createPublicKey(publicKey)).toThrow();
-
-    // Constructing a private key from a public key should be impossible, even
-    // if the public key was derived from a private key.
-    expect(() => createPrivateKey(createPublicKey(privatePem))).toThrow();
-
-    // Similarly, passing an existing private key object to createPrivateKey
-    // should throw.
-    const privateKey = createPrivateKey(privatePem);
-    expect(() => createPrivateKey(privateKey)).toThrow();
-  });
-
-  test("basics should work", async () => {
-    const jwk = {
-      e: "AQAB",
-      n:
-        "t9xYiIonscC3vz_A2ceR7KhZZlDu_5bye53nCVTcKnWd2seY6UAdKersX6njr83Dd5OVe" +
-        "1BW_wJvp5EjWTAGYbFswlNmeD44edEGM939B6Lq-_8iBkrTi8mGN4YCytivE24YI0D4XZ" +
-        "MPfkLSpab2y_Hy4DjQKBq1ThZ0UBnK-9IhX37Ju_ZoGYSlTIGIhzyaiYBh7wrZBoPczIE" +
-        "u6et_kN2VnnbRUtkYTF97ggcv5h-hDpUQjQW0ZgOMcTc8n-RkGpIt0_iM_bTjI3Tz_gsF" +
-        "di6hHcpZgbopPL630296iByyigQCPJVzdusFrQN5DeC-zT_nGypQkZanLb4ZspSx9Q",
-      d:
-        "ktnq2LvIMqBj4txP82IEOorIRQGVsw1khbm8A-cEpuEkgM71Yi_0WzupKktucUeevQ5i0" +
-        "Yh8w9e1SJiTLDRAlJz66kdky9uejiWWl6zR4dyNZVMFYRM43ijLC-P8rPne9Fz16IqHFW" +
-        "5VbJqA1xCBhKmuPMsD71RNxZ4Hrsa7Kt_xglQTYsLbdGIwDmcZihId9VGXRzvmCPsDRf2" +
-        "fCkAj7HDeRxpUdEiEDpajADc-PWikra3r3b40tVHKWm8wxJLivOIN7GiYXKQIW6RhZgH-" +
-        "Rk45JIRNKxNagxdeXUqqyhnwhbTo1Hite0iBDexN9tgoZk0XmdYWBn6ElXHRZ7VCDQ",
-      p:
-        "8UovlB4nrBm7xH-u7XXBMbqxADQm5vaEZxw9eluc-tP7cIAI4sglMIvL_FMpbd2pEeP_B" +
-        "kR76NTDzzDuPAZvUGRavgEjy0O9j2NAs_WPK4tZF-vFdunhnSh4EHAF4Ij9kbsUi90NOp" +
-        "bGfVqPdOaHqzgHKoR23Cuusk9wFQ2XTV8",
-      q:
-        "wxHdEYT9xrpfrHPqSBQPpO0dWGKJEkrWOb-76rSfuL8wGR4OBNmQdhLuU9zTIh22pog-X" +
-        "PnLPAecC-4yu_wtJ2SPCKiKDbJBre0CKPyRfGqzvA3njXwMxXazU4kGs-2Fg-xu_iKbaI" +
-        "jxXrclBLhkxhBtySrwAFhxxOk6fFcPLSs",
-      dp:
-        "qS_Mdr5CMRGGMH0bKhPUWEtAixUGZhJaunX5wY71Xoc_Gh4cnO-b7BNJ_-5L8WZog0vr" +
-        "6PgiLhrqBaCYm2wjpyoG2o2wDHm-NAlzN_wp3G2EFhrSxdOux-S1c0kpRcyoiAO2n29rN" +
-        "Da-jOzwBBcU8ACEPdLOCQl0IEFFJO33tl8",
-      dq:
-        "WAziKpxLKL7LnL4dzDcx8JIPIuwnTxh0plCDdCffyLaT8WJ9lXbXHFTjOvt8WfPrlDP_" +
-        "Ylxmfkw5BbGZOP1VLGjZn2DkH9aMiwNmbDXFPdG0G3hzQovx_9fajiRV4DWghLHeT9wzJ" +
-        "fZabRRiI0VQR472300AVEeX4vgbrDBn600",
-      qi:
-        "k7czBCT9rHn_PNwCa17hlTy88C4vXkwbz83Oa-aX5L4e5gw5lhcR2ZuZHLb2r6oMt9rl" +
-        "D7EIDItSs-u21LOXWPTAlazdnpYUyw_CzogM_PN-qNwMRXn5uXFFhmlP2mVg2EdELTahX" +
-        "ch8kWqHaCSX53yvqCtRKu_j76V31TfQZGM",
-      kty: "RSA",
-    };
-    const publicJwk = { kty: jwk.kty, e: jwk.e, n: jwk.n };
-
-    const publicKey = createPublicKey(publicPem);
-    expect(publicKey.type).toBe("public");
-    expect(publicKey.toString()).toBe("[object KeyObject]");
-    expect(publicKey.asymmetricKeyType).toBe("rsa");
-    expect(publicKey.symmetricKeySize).toBe(undefined);
-
-    const privateKey = createPrivateKey(privatePem);
-    expect(privateKey.type).toBe("private");
-    expect(privateKey.toString()).toBe("[object KeyObject]");
-    expect(privateKey.asymmetricKeyType).toBe("rsa");
-    expect(privateKey.symmetricKeySize).toBe(undefined);
-
-    // It should be possible to derive a public key from a private key.
-    const derivedPublicKey = createPublicKey(privateKey);
-    expect(derivedPublicKey.type).toBe("public");
-    expect(derivedPublicKey.toString()).toBe("[object KeyObject]");
-    expect(derivedPublicKey.asymmetricKeyType).toBe("rsa");
-    expect(derivedPublicKey.symmetricKeySize).toBe(undefined);
-
-    const publicKeyFromJwk = createPublicKey({ key: publicJwk, format: "jwk" });
-    expect(publicKey.type).toBe("public");
-    expect(publicKey.toString()).toBe("[object KeyObject]");
-    expect(publicKey.asymmetricKeyType).toBe("rsa");
-    expect(publicKey.symmetricKeySize).toBe(undefined);
-
-    const privateKeyFromJwk = createPrivateKey({ key: jwk, format: "jwk" });
-    expect(privateKey.type).toBe("private");
-    expect(privateKey.toString()).toBe("[object KeyObject]");
-    expect(privateKey.asymmetricKeyType).toBe("rsa");
-    expect(privateKey.symmetricKeySize).toBe(undefined);
-
-    // It should also be possible to import an encrypted private key as a public
-    // key.
-    const decryptedKey = createPublicKey({
-      key: privateKey.export({
-        type: "pkcs8",
-        format: "pem",
-        passphrase: Buffer.from("123"),
-        cipher: "aes-128-cbc",
-      }),
-      format: "pem",
-      passphrase: "123", // this is not documented, but it works
-    });
-    expect(decryptedKey.type).toBe("public");
-    expect(decryptedKey.asymmetricKeyType).toBe("rsa");
-
-    // Exporting the key using JWK should not work since this format does not
-    // support key encryption
-    expect(() => {
-      privateKey.export({ format: "jwk", passphrase: "secret" });
-    }).toThrow();
-
-    // Test exporting with an invalid options object, this should throw.
-    for (const opt of [undefined, null, "foo", 0, NaN]) {
-      expect(() => publicKey.export(opt)).toThrow();
-    }
-
-    for (const keyObject of [publicKey, derivedPublicKey, publicKeyFromJwk]) {
-      const exported = keyObject.export({ format: "jwk" });
-      expect(exported).toBeDefined();
-      const { kty, n, e } = exported as { kty: string; n: string; e: string };
-      expect({ kty, n, e }).toEqual({ kty: "RSA", n: jwk.n, e: jwk.e });
-    }
-
-    for (const keyObject of [privateKey, privateKeyFromJwk]) {
-      const exported = keyObject.export({ format: "jwk" });
-      expect(exported).toEqual(jwk);
-    }
-
-    const publicDER = publicKey.export({
-      format: "der",
-      type: "pkcs1",
-    });
-
-    const privateDER = privateKey.export({
-      format: "der",
-      type: "pkcs1",
-    });
-
-    expect(Buffer.isBuffer(publicDER)).toBe(true);
-    expect(Buffer.isBuffer(privateDER)).toBe(true);
-    const plaintext = Buffer.from("Hello world", "utf8");
-
-    const testDecryption = (fn, ciphertexts, decryptionKeys) => {
-      for (const ciphertext of ciphertexts) {
-        for (const key of decryptionKeys) {
-          const deciphered = fn(key, ciphertext);
-          expect(deciphered).toEqual(plaintext);
-        }
-      }
-    };
-
-    testDecryption(
-      privateDecrypt,
-      [
-        // Encrypt using the public key.
-        publicEncrypt(publicKey, plaintext),
-        publicEncrypt({ key: publicKey }, plaintext),
-        publicEncrypt({ key: publicJwk, format: "jwk" }, plaintext),
-
-        // Encrypt using the private key.
-        publicEncrypt(privateKey, plaintext),
-        publicEncrypt({ key: privateKey }, plaintext),
-        publicEncrypt({ key: jwk, format: "jwk" }, plaintext),
-
-        // Encrypt using a public key derived from the private key.
-        publicEncrypt(derivedPublicKey, plaintext),
-        publicEncrypt({ key: derivedPublicKey }, plaintext),
-
-        // Test distinguishing PKCS#1 public and private keys based on the
-        // DER-encoded data only.
-        publicEncrypt({ format: "der", type: "pkcs1", key: publicDER }, plaintext),
-        publicEncrypt({ format: "der", type: "pkcs1", key: privateDER }, plaintext),
-      ],
-      [
-        privateKey,
-        { format: "pem", key: privatePem },
-        { format: "der", type: "pkcs1", key: privateDER },
-        { key: jwk, format: "jwk" },
-      ],
-    );
-
-    testDecryption(
-      publicDecrypt,
-      [privateEncrypt(privateKey, plaintext)],
-      [
-        // Decrypt using the public key.
-        publicKey,
-        { format: "pem", key: publicPem },
-        { format: "der", type: "pkcs1", key: publicDER },
-        { key: publicJwk, format: "jwk" },
-
-        // Decrypt using the private key.
-        privateKey,
-        { format: "pem", key: privatePem },
-        { format: "der", type: "pkcs1", key: privateDER },
-        { key: jwk, format: "jwk" },
-      ],
-    );
-  });
-
-  test("This should not cause a crash: https://github.com/nodejs/node/issues/25247", async () => {
-    expect(() => createPrivateKey({ key: "" })).toThrow();
-  });
-  test("This should not abort either: https://github.com/nodejs/node/issues/29904", async () => {
-    expect(() => createPrivateKey({ key: Buffer.alloc(0), format: "der", type: "spki" })).toThrow();
-  });
-
-  test("BoringSSL will not parse PKCS#1", async () => {
-    // Unlike SPKI, PKCS#1 is a valid encoding for private keys (and public keys),
-    // so it should be accepted by createPrivateKey, but OpenSSL won't parse it.
-    expect(() => {
-      const key = createPublicKey(publicPem).export({
-        format: "der",
-        type: "pkcs1",
-      });
-      createPrivateKey({ key, format: "der", type: "pkcs1" });
-    }).toThrow("Invalid use of PKCS#1 as private key");
-  });
-
-  [
-    {
-      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed25519_private.pem"), "ascii"),
-      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed25519_public.pem"), "ascii"),
-      keyType: "ed25519",
-      jwk: {
-        crv: "Ed25519",
-        x: "K1wIouqnuiA04b3WrMa-xKIKIpfHetNZRv3h9fBf768",
-        d: "wVK6M3SMhQh3NK-7GRrSV-BVWQx1FO5pW8hhQeu_NdA",
-        kty: "OKP",
-      },
-    },
-    {
-      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed448_private.pem"), "ascii"),
-      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed448_public.pem"), "ascii"),
-      keyType: "ed448",
-      jwk: {
-        crv: "Ed448",
-        x: "oX_ee5-jlcU53-BbGRsGIzly0V-SZtJ_oGXY0udf84q2hTW2RdstLktvwpkVJOoNb7o" + "Dgc2V5ZUA",
-        d: "060Ke71sN0GpIc01nnGgMDkp0sFNQ09woVo4AM1ffax1-mjnakK0-p-S7-Xf859QewX" + "jcR9mxppY",
-        kty: "OKP",
-      },
-    },
-    {
-      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x25519_private.pem"), "ascii"),
-      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x25519_public.pem"), "ascii"),
-      keyType: "x25519",
-      jwk: {
-        crv: "X25519",
-        x: "aSb8Q-RndwfNnPeOYGYPDUN3uhAPnMLzXyfi-mqfhig",
-        d: "mL_IWm55RrALUGRfJYzw40gEYWMvtRkesP9mj8o8Omc",
-        kty: "OKP",
-      },
-    },
-    {
-      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x448_private.pem"), "ascii"),
-      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x448_public.pem"), "ascii"),
-      keyType: "x448",
-      jwk: {
-        crv: "X448",
-        x: "ioHSHVpTs6hMvghosEJDIR7ceFiE3-Xccxati64oOVJ7NWjfozE7ae31PXIUFq6cVYg" + "vSKsDFPA",
-        d: "tMNtrO_q8dlY6Y4NDeSTxNQ5CACkHiPvmukidPnNIuX_EkcryLEXt_7i6j6YZMKsrWy" + "S0jlSYJk",
-        kty: "OKP",
-      },
-    },
-  ].forEach(info => {
-    const keyType = info.keyType;
-    // X25519 implementation is incomplete, Ed448 and X448 are not supported yet
-    const test = keyType === "ed25519" ? it : it.skip;
-    let privateKey: KeyObject;
-    test(`${keyType} from Buffer should work`, async () => {
-      const key = createPrivateKey(info.private);
-      privateKey = key;
-      expect(key.type).toBe("private");
-      expect(key.asymmetricKeyType).toBe(keyType);
-      expect(key.symmetricKeySize).toBe(undefined);
-      expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
-      const jwt = key.export({ format: "jwk" });
-      expect(jwt).toEqual(info.jwk);
-    });
-
-    test(`${keyType} createPrivateKey from jwk should work`, async () => {
-      const key = createPrivateKey({ key: info.jwk, format: "jwk" });
-      expect(key.type).toBe("private");
-      expect(key.asymmetricKeyType).toBe(keyType);
-      expect(key.symmetricKeySize).toBe(undefined);
-      expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
-      const jwt = key.export({ format: "jwk" });
-      expect(jwt).toEqual(info.jwk);
-    });
-
-    [
-      ["public", info.public],
-      ["private", info.private],
-      ["jwk", { key: info.jwk, format: "jwk" }],
-    ].forEach(([name, input]) => {
-      test(`${keyType} createPublicKey using ${name} key should work`, async () => {
-        const key = createPublicKey(input);
-        expect(key.type).toBe("public");
-        expect(key.asymmetricKeyType).toBe(keyType);
-        expect(key.symmetricKeySize).toBe(undefined);
-        if (name == "public") {
-          expect(key.export({ type: "spki", format: "pem" })).toEqual(info.public);
-        }
-        if (name == "jwk") {
-          const jwt = { ...info.jwk };
-          delete jwt.d;
-          const jwk_exported = key.export({ format: "jwk" });
-          expect(jwk_exported).toEqual(jwt);
-        }
-      });
-    });
-  });
-
-  [
-    {
-      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p256_private.pem"), "ascii"),
-      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p256_public.pem"), "ascii"),
-      keyType: "ec",
-      namedCurve: "prime256v1",
-      jwk: {
-        crv: "P-256",
-        d: "DxBsPQPIgMuMyQbxzbb9toew6Ev6e9O6ZhpxLNgmAEo",
-        kty: "EC",
-        x: "X0mMYR_uleZSIPjNztIkAS3_ud5LhNpbiIFp6fNf2Gs",
-        y: "UbJuPy2Xi0lW7UYTBxPK3yGgDu9EAKYIecjkHX5s2lI",
-      },
-    },
-    {
-      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_secp256k1_private.pem"), "ascii"),
-      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_secp256k1_public.pem"), "ascii"),
-      keyType: "ec",
-      namedCurve: "secp256k1",
-      jwk: {
-        crv: "secp256k1",
-        d: "c34ocwTwpFa9NZZh3l88qXyrkoYSxvC0FEsU5v1v4IM",
-        kty: "EC",
-        x: "cOzhFSpWxhalCbWNdP2H_yUkdC81C9T2deDpfxK7owA",
-        y: "-A3DAZTk9IPppN-f03JydgHaFvL1fAHaoXf4SX4NXyo",
-      },
-    },
-    {
-      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p384_private.pem"), "ascii"),
-      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p384_public.pem"), "ascii"),
-      keyType: "ec",
-      namedCurve: "secp384r1",
-      jwk: {
-        crv: "P-384",
-        d: "dwfuHuAtTlMRn7ZBCBm_0grpc1D_4hPeNAgevgelljuC0--k_LDFosDgBlLLmZsi",
-        kty: "EC",
-        x: "hON3nzGJgv-08fdHpQxgRJFZzlK-GZDGa5f3KnvM31cvvjJmsj4UeOgIdy3rDAjV",
-        y: "fidHhtecNCGCfLqmrLjDena1NSzWzWH1u_oUdMKGo5XSabxzD7-8JZxjpc8sR9cl",
-      },
-    },
-    {
-      private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p521_private.pem"), "ascii"),
-      public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p521_public.pem"), "ascii"),
-      keyType: "ec",
-      namedCurve: "secp521r1",
-      jwk: {
-        crv: "P-521",
-        d: "Eghuafcab9jXW4gOQLeDaKOlHEiskQFjiL8klijk6i6DNOXcFfaJ9GW48kxpodw16ttAf9Z1WQstfzpKGUetHIk",
-        kty: "EC",
-        x: "AaLFgjwZtznM3N7qsfb86awVXe6c6djUYOob1FN-kllekv0KEXV0bwcDjPGQz5f6MxL" + "CbhMeHRavUS6P10rsTtBn",
-        y: "Ad3flexBeAfXceNzRBH128kFbOWD6W41NjwKRqqIF26vmgW_8COldGKZjFkOSEASxPB" + "cvA2iFJRUyQ3whC00j0Np",
-      },
-    },
-  ].forEach(info => {
-    const { keyType, namedCurve } = info;
-    const test = namedCurve === "secp256k1" ? it.skip : it;
-    let privateKey: KeyObject;
-    test(`${keyType} ${namedCurve} createPrivateKey from Buffer should work`, async () => {
-      const key = createPrivateKey(info.private);
-      privateKey = key;
-      expect(key.type).toBe("private");
-      expect(key.asymmetricKeyType).toBe(keyType);
-      expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
-      expect(key.symmetricKeySize).toBe(undefined);
-      expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
-      const jwt = key.export({ format: "jwk" });
-      expect(jwt).toEqual(info.jwk);
-    });
-
-    test(`${keyType} ${namedCurve} createPrivateKey from jwk should work`, async () => {
-      const key = createPrivateKey({ key: info.jwk, format: "jwk" });
-      expect(key.type).toBe("private");
-      expect(key.asymmetricKeyType).toBe(keyType);
-      expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
-      expect(key.symmetricKeySize).toBe(undefined);
-      expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
-      const jwt = key.export({ format: "jwk" });
-      expect(jwt).toEqual(info.jwk);
-    });
-
-    [
-      ["public", info.public],
-      ["private", info.private],
-      ["jwk", { key: info.jwk, format: "jwk" }],
-    ].forEach(([name, input]) => {
-      test(`${keyType} ${namedCurve} createPublicKey using ${name} should work`, async () => {
-        const key = createPublicKey(input);
-        expect(key.type).toBe("public");
-        expect(key.asymmetricKeyType).toBe(keyType);
-        expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
-        expect(key.symmetricKeySize).toBe(undefined);
-        if (name == "public") {
-          expect(key.export({ type: "spki", format: "pem" })).toEqual(info.public);
-        }
-        if (name == "jwk") {
-          const jwt = { ...info.jwk };
-          delete jwt.d;
-          const jwk_exported = key.export({ format: "jwk" });
-          expect(jwk_exported).toEqual(jwt);
-        }
-
-        const pkey = privateKey || info.private;
-        const signature = createSign("sha256").update("foo").sign({ key: pkey });
-        const okay = createVerify("sha256").update("foo").verify({ key: key }, signature);
-        expect(okay).toBeTrue();
-      });
-    });
-  });
-
-  test("private encrypted should work", async () => {
-    // Reading an encrypted key without a passphrase should fail.
-    expect(() => createPrivateKey(privateEncryptedPem)).toThrow();
-    // Reading an encrypted key with a passphrase that exceeds OpenSSL's buffer
-    // size limit should fail with an appropriate error code.
-    expect(() =>
-      createPrivateKey({
-        key: privateEncryptedPem,
-        format: "pem",
-        passphrase: Buffer.alloc(1025, "a"),
-      }),
-    ).toThrow();
-    // The buffer has a size of 1024 bytes, so this passphrase should be permitted
-    // (but will fail decryption).
-    expect(() =>
-      createPrivateKey({
-        key: privateEncryptedPem,
-        format: "pem",
-        passphrase: Buffer.alloc(1024, "a"),
-      }),
-    ).toThrow();
-    const publicKey = createPublicKey({
-      key: privateEncryptedPem,
-      format: "pem",
-      passphrase: "password", // this is not documented but should work
-    });
-    expect(publicKey.type).toBe("public");
-    expect(publicKey.asymmetricKeyType).toBe("rsa");
-    expect(publicKey.symmetricKeySize).toBe(undefined);
-
-    const privateKey = createPrivateKey({
-      key: privateEncryptedPem,
-      format: "pem",
-      passphrase: "password",
-    });
-    expect(privateKey.type).toBe("private");
-    expect(privateKey.asymmetricKeyType).toBe("rsa");
-    expect(privateKey.symmetricKeySize).toBe(undefined);
-  });
-
-  [2048, 4096].forEach(suffix => {
-    test(`RSA-${suffix} should work`, async () => {
-      {
-        const publicPem = fs.readFileSync(path.join(import.meta.dir, "fixtures", `rsa_public_${suffix}.pem`), "ascii");
-        const privatePem = fs.readFileSync(
-          path.join(import.meta.dir, "fixtures", `rsa_private_${suffix}.pem`),
-          "ascii",
-        );
-        const publicKey = createPublicKey(publicPem);
-        const expectedKeyDetails = {
-          modulusLength: suffix,
-          publicExponent: 65537n,
-        };
-        expect(publicKey.type).toBe("public");
-        expect(publicKey.asymmetricKeyType).toBe("rsa");
-        expect(publicKey.asymmetricKeyDetails).toEqual(expectedKeyDetails);
-
-        const privateKey = createPrivateKey(privatePem);
-        expect(privateKey.type).toBe("private");
-        expect(privateKey.asymmetricKeyType).toBe("rsa");
-        expect(privateKey.asymmetricKeyDetails).toEqual(expectedKeyDetails);
-
-        for (const key of [privatePem, privateKey]) {
-          // Any algorithm should work.
-          for (const algo of ["sha1", "sha256"]) {
-            // Any salt length should work.
-            for (const saltLength of [undefined, 8, 10, 12, 16, 18, 20]) {
-              const signature = createSign(algo).update("foo").sign({ key, saltLength });
-              for (const pkey of [key, publicKey, publicPem]) {
-                const okay = createVerify(algo).update("foo").verify({ key: pkey, saltLength }, signature);
-                expect(okay).toBeTrue();
-              }
-            }
-          }
-        }
-      }
-    });
-  });
-
-  test("Exporting an encrypted private key requires a cipher", async () => {
-    // Exporting an encrypted private key requires a cipher
-    const privateKey = createPrivateKey(privatePem);
-    expect(() => {
-      privateKey.export({
-        format: "pem",
-        type: "pkcs8",
-        passphrase: "super-secret",
-      });
-    }).toThrow(/cipher is required when passphrase is specified/);
-  });
-
-  test("secret export buffer format (default)", async () => {
-    const buffer = Buffer.from("Hello World");
-    const keyObject = createSecretKey(buffer);
-    expect(keyObject.export()).toEqual(buffer);
-    expect(keyObject.export({})).toEqual(buffer);
-    expect(keyObject.export({ format: "buffer" })).toEqual(buffer);
-    expect(keyObject.export({ format: undefined })).toEqual(buffer);
-  });
-
-  test('exporting an "oct" JWK from a secret', async () => {
-    const buffer = Buffer.from("Hello World");
-    const keyObject = createSecretKey(buffer);
-    const jwk = keyObject.export({ format: "jwk" });
-    expect(jwk).toEqual({ kty: "oct", k: "SGVsbG8gV29ybGQ" });
-  });
-
-  test("secret equals", async () => {
-    {
-      const first = Buffer.from("Hello");
-      const second = Buffer.from("World");
-      const keyObject = createSecretKey(first);
-      expect(createSecretKey(first).equals(createSecretKey(first))).toBeTrue();
-      expect(createSecretKey(first).equals(createSecretKey(second))).toBeFalse();
-
-      expect(() => keyObject.equals(0)).toThrow(/otherKey must be a KeyObject/);
-
-      expect(keyObject.equals(keyObject)).toBeTrue();
-      expect(keyObject.equals(createPublicKey(publicPem))).toBeFalse();
-      expect(keyObject.equals(createPrivateKey(privatePem))).toBeFalse();
-    }
-
-    {
-      const first = createSecretKey(Buffer.alloc(0));
-      const second = createSecretKey(new ArrayBuffer(0));
-      const third = createSecretKey(Buffer.alloc(1));
-      expect(first.equals(first)).toBeTrue();
-      expect(first.equals(second)).toBeTrue();
-      expect(first.equals(third)).toBeFalse();
-      expect(third.equals(first)).toBeFalse();
-    }
-  });
-
-  ["ed25519", "x25519"].forEach(keyType => {
-    const test = keyType === "ed25519" ? it : it.skip;
-    test(`${keyType} equals should work`, async () => {
-      const first = generateKeyPairSync(keyType);
-      const second = generateKeyPairSync(keyType);
-
-      const secret = generateKeySync("aes", { length: 128 });
-
-      expect(first.publicKey.equals(first.publicKey)).toBeTrue();
-
-      expect(first.publicKey.equals(createPublicKey(first.publicKey.export({ format: "pem", type: "spki" }))));
-
-      expect(first.publicKey.equals(second.publicKey)).toBeFalse();
-      expect(first.publicKey.equals(second.privateKey)).toBeFalse();
-      expect(first.publicKey.equals(secret)).toBeFalse();
-
-      expect(first.privateKey.equals(first.privateKey)).toBeTrue();
-      expect(
-        first.privateKey.equals(createPrivateKey(first.privateKey.export({ format: "pem", type: "pkcs8" }))),
-      ).toBeTrue();
-      expect(first.privateKey.equals(second.privateKey)).toBeFalse();
-      expect(first.privateKey.equals(second.publicKey)).toBeFalse();
-      expect(first.privateKey.equals(secret)).toBeFalse();
-    });
-  });
-
-  test("This should not cause a crash: https://github.com/nodejs/node/issues/44471", async () => {
-    for (const key of ["", "foo", null, undefined, true, Boolean]) {
-      expect(() => {
-        createPublicKey({ key, format: "jwk" });
-      }).toThrow();
-      expect(() => {
-        createPrivateKey({ key, format: "jwk" });
-      }).toThrow();
-    }
-  });
-
-  ["hmac", "aes"].forEach(type => {
-    [128, 256].forEach(length => {
-      test(`generateKey ${type} ${length}`, async () => {
-        {
-          const key = generateKeySync(type, { length });
-          expect(key).toBeDefined();
-          const keybuf = key.export();
-          expect(keybuf.byteLength).toBe(length / 8);
-        }
-
-        const { promise, resolve, reject } = Promise.withResolvers();
-        generateKey(type, { length }, (err, key) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(key);
-          }
-        });
-
-        {
-          const key = await promise;
-          expect(key).toBeDefined();
-          const keybuf = key.export();
-          expect(keybuf.byteLength).toBe(length / 8);
-        }
-      });
-    });
-  });
-  describe("Test async elliptic curve key generation with 'jwk' encoding and named curve", () => {
-    ["P-384", "P-256", "P-521", "secp256k1"].forEach(curve => {
-      const test = curve === "secp256k1" ? it.skip : it;
-      test(`should work with ${curve}`, async () => {
-        const { promise, resolve, reject } = Promise.withResolvers();
-        generateKeyPair(
-          "ec",
-          {
-            namedCurve: curve,
-            publicKeyEncoding: {
-              format: "jwk",
-            },
-            privateKeyEncoding: {
-              format: "jwk",
-            },
-          },
-          (err, publicKey, privateKey) => {
-            if (err) {
-              return reject(err);
-            }
-            resolve({ publicKey, privateKey });
-          },
-        );
-
-        const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
-        expect(typeof publicKey).toBe("object");
-        expect(typeof privateKey).toBe("object");
-        expect(publicKey.x).toBe(privateKey.x);
-        expect(publicKey.y).toBe(publicKey.y);
-        expect(publicKey.d).toBeUndefined();
-        expect(privateKey.d).toBeDefined();
-        expect(publicKey.kty).toEqual("EC");
-        expect(publicKey.kty).toEqual(privateKey.kty);
-        expect(publicKey.crv).toEqual(curve);
-        expect(publicKey.crv).toEqual(privateKey.crv);
-      });
-    });
-  });
-
-  describe("Test async elliptic curve key generation with 'jwk' encoding and RSA.", () => {
-    [256, 1024, 2048].forEach(modulusLength => {
-      test(`should work with ${modulusLength}`, async () => {
-        const { promise, resolve, reject } = Promise.withResolvers();
-        generateKeyPair(
-          "rsa",
-          {
-            modulusLength,
-            publicKeyEncoding: {
-              format: "jwk",
-            },
-            privateKeyEncoding: {
-              format: "jwk",
-            },
-          },
-          (err, publicKey, privateKey) => {
-            if (err) {
-              return reject(err);
-            }
-            resolve({ publicKey, privateKey });
-          },
-        );
-
-        const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
-        expect(typeof publicKey).toEqual("object");
-        expect(typeof privateKey).toEqual("object");
-        expect(publicKey.kty).toEqual("RSA");
-        expect(publicKey.kty).toEqual(privateKey.kty);
-        expect(typeof publicKey.n).toEqual("string");
-        expect(publicKey.n).toEqual(privateKey.n);
-        expect(typeof publicKey.e).toEqual("string");
-        expect(publicKey.e).toEqual(privateKey.e);
-        expect(typeof privateKey.d).toEqual("string");
-        expect(typeof privateKey.p).toEqual("string");
-        expect(typeof privateKey.q).toEqual("string");
-        expect(typeof privateKey.dp).toEqual("string");
-        expect(typeof privateKey.dq).toEqual("string");
-        expect(typeof privateKey.qi).toEqual("string");
-      });
-    });
-  });
-
-  describe("Test async elliptic curve key generation with 'jwk' encoding", () => {
-    ["ed25519", "ed448", "x25519", "x448"].forEach(type => {
-      const test = type === "ed25519" ? it : it.skip;
-      test(`should work with ${type}`, async () => {
-        const { promise, resolve, reject } = Promise.withResolvers();
-        generateKeyPair(
-          type,
-          {
-            publicKeyEncoding: {
-              format: "jwk",
-            },
-            privateKeyEncoding: {
-              format: "jwk",
-            },
-          },
-          (err, publicKey, privateKey) => {
-            if (err) {
-              return reject(err);
-            }
-            resolve({ publicKey, privateKey });
-          },
-        );
-
-        const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
-        expect(typeof publicKey).toEqual("object");
-        expect(typeof privateKey).toEqual("object");
-        expect(publicKey.x).toEqual(privateKey.x);
-        expect(publicKey.d).toBeUndefined();
-        expect(privateKey.d).toBeDefined();
-        expect(publicKey.kty).toEqual("OKP");
-        expect(publicKey.kty).toEqual(privateKey.kty);
-        const expectedCrv = `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
-        expect(publicKey.crv).toEqual(expectedCrv);
-        expect(publicKey.crv).toEqual(privateKey.crv);
-      });
-    });
-  });
-
-  test(`Test async RSA key generation with an encrypted private key, but encoded as DER`, async () => {
-    const { promise, resolve, reject } = Promise.withResolvers();
-    generateKeyPair(
-      "rsa",
-      {
-        publicExponent: 0x10001,
-        modulusLength: 512,
-        publicKeyEncoding: {
-          type: "pkcs1",
-          format: "der",
-        },
-        privateKeyEncoding: {
-          type: "pkcs1",
-          format: "pem",
-          cipher: "aes-256-cbc",
-          passphrase: "secret",
-        },
-      },
-      (err, publicKey, privateKey) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve({ publicKey, privateKey });
-      },
-    );
-
-    const { publicKey: publicKeyDER, privateKey } = await (promise as Promise<{
-      publicKey: Buffer;
-      privateKey: string;
-    }>);
-    expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
-    assertApproximateSize(publicKeyDER, 74);
-
-    expect(typeof privateKey).toBe("string");
-    expect(privateKey).toMatch(pkcs1EncExp("AES-256-CBC"));
-
-    const publicKey = {
-      key: publicKeyDER,
-      type: "pkcs1",
-      format: "der",
-    };
-    expect(() => {
-      testEncryptDecrypt(publicKey, privateKey);
-    }).toThrow();
-
-    const key = { key: privateKey, passphrase: "secret" };
-    testEncryptDecrypt(publicKey, key);
-    testSignVerify(publicKey, key);
-  });
-
-  test(`Test async RSA key generation with an encrypted private key`, async () => {
-    const { promise, resolve, reject } = Promise.withResolvers();
-    generateKeyPair(
-      "rsa",
-      {
-        publicExponent: 0x10001,
-        modulusLength: 512,
-        publicKeyEncoding: {
-          type: "pkcs1",
-          format: "der",
-        },
-        privateKeyEncoding: {
-          type: "pkcs8",
-          format: "der",
-        },
-      },
-      (err, publicKey, privateKey) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve({ publicKey, privateKey });
-      },
-    );
-
-    const { publicKey: publicKeyDER, privateKey: privateKeyDER } = await (promise as Promise<{
-      publicKey: Buffer;
-      privateKey: Buffer;
-    }>);
-    expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
-    assertApproximateSize(publicKeyDER, 74);
-
-    expect(Buffer.isBuffer(privateKeyDER)).toBeTrue();
-
-    const publicKey = {
-      key: publicKeyDER,
-      type: "pkcs1",
-      format: "der",
-    };
-    const privateKey = {
-      key: privateKeyDER,
-      format: "der",
-      type: "pkcs8",
-      passphrase: "secret",
-    };
-    testEncryptDecrypt(publicKey, privateKey);
-    testSignVerify(publicKey, privateKey);
-  });
-
-  test(`Test async elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
-    const { promise, resolve, reject } = Promise.withResolvers();
-    generateKeyPair(
-      "ec",
-      {
-        namedCurve: "P-256",
-        publicKeyEncoding: {
-          type: "spki",
-          format: "pem",
-        },
-        privateKeyEncoding: {
-          type: "pkcs8",
-          format: "pem",
-          cipher: "aes-128-cbc",
-          passphrase: "top secret",
-        },
-      },
-      (err, publicKey, privateKey) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve({ publicKey, privateKey });
-      },
-    );
-
-    const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
-    expect(typeof publicKey).toBe("string");
-    expect(publicKey).toMatch(spkiExp);
-    expect(typeof privateKey).toBe("string");
-    expect(privateKey).toMatch(pkcs8EncExp);
-
-    expect(() => {
-      testSignVerify(publicKey, privateKey);
-    }).toThrow();
-
-    testSignVerify(publicKey, {
-      key: privateKey,
-      passphrase: "top secret",
-    });
-  });
-
-  test(`Test async explicit elliptic curve key generation with an encrypted private key`, async () => {
-    const { promise, resolve, reject } = Promise.withResolvers();
-    generateKeyPair(
-      "ec",
-      {
-        namedCurve: "prime256v1",
-        publicKeyEncoding: {
-          type: "spki",
-          format: "pem",
-        },
-        privateKeyEncoding: {
-          type: "sec1",
-          format: "pem",
-          cipher: "aes-128-cbc",
-          passphrase: "secret",
-        },
-      },
-      (err, publicKey, privateKey) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve({ publicKey, privateKey });
-      },
-    );
-
-    const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
-    expect(typeof publicKey).toBe("string");
-    expect(publicKey).toMatch(spkiExp);
-    expect(typeof privateKey).toBe("string");
-    expect(privateKey).toMatch(sec1EncExp("AES-128-CBC"));
-
-    expect(() => {
-      testSignVerify(publicKey, privateKey);
-    }).toThrow();
-
-    testSignVerify(publicKey, {
-      key: privateKey,
-      passphrase: "secret",
-    });
-  });
-
-  test(`Test async explicit elliptic curve key generation, e.g. for ECDSA, with a SEC1 private key`, async () => {
-    const { promise, resolve, reject } = Promise.withResolvers();
-    generateKeyPair(
-      "ec",
-      {
-        namedCurve: "prime256v1",
-        publicKeyEncoding: {
-          type: "spki",
-          format: "pem",
-        },
-        privateKeyEncoding: {
-          type: "sec1",
-          format: "pem",
-        },
-      },
-      (err, publicKey, privateKey) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve({ publicKey, privateKey });
-      },
-    );
-
-    const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
-    expect(typeof publicKey).toBe("string");
-    expect(publicKey).toMatch(spkiExp);
-    expect(typeof privateKey).toBe("string");
-    expect(privateKey).toMatch(sec1Exp);
-    testSignVerify(publicKey, privateKey);
-  });
-
-  test(`Test async elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
-    const { promise, resolve, reject } = Promise.withResolvers();
-    generateKeyPair(
-      "ec",
-      {
-        namedCurve: "prime256v1",
-        publicKeyEncoding: {
-          type: "spki",
-          format: "pem",
-        },
-        privateKeyEncoding: {
-          type: "pkcs8",
-          format: "pem",
-          cipher: "aes-128-cbc",
-          passphrase: "top secret",
-        },
-      },
-      (err, publicKey, privateKey) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve({ publicKey, privateKey });
-      },
-    );
-
-    const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
-    expect(typeof publicKey).toBe("string");
-    expect(publicKey).toMatch(spkiExp);
-    expect(typeof privateKey).toBe("string");
-    expect(privateKey).toMatch(pkcs8EncExp);
-
-    expect(() => {
-      testSignVerify(publicKey, privateKey);
-    }).toThrow();
-
-    testSignVerify(publicKey, {
-      key: privateKey,
-      passphrase: "top secret",
-    });
-  });
-
-  describe("Test sync elliptic curve key generation with 'jwk' encoding and named curve", () => {
-    ["P-384", "P-256", "P-521", "secp256k1"].forEach(curve => {
-      const test = curve === "secp256k1" ? it.skip : it;
-      test(`should work with ${curve}`, async () => {
-        const { publicKey, privateKey } = generateKeyPairSync("ec", {
-          namedCurve: curve,
-          publicKeyEncoding: {
-            format: "jwk",
-          },
-          privateKeyEncoding: {
-            format: "jwk",
-          },
-        });
-        expect(typeof publicKey).toBe("object");
-        expect(typeof privateKey).toBe("object");
-        expect(publicKey.x).toBe(privateKey.x);
-        expect(publicKey.y).toBe(publicKey.y);
-        expect(publicKey.d).toBeUndefined();
-        expect(privateKey.d).toBeDefined();
-        expect(publicKey.kty).toEqual("EC");
-        expect(publicKey.kty).toEqual(privateKey.kty);
-        expect(publicKey.crv).toEqual(curve);
-        expect(publicKey.crv).toEqual(privateKey.crv);
-      });
-    });
-  });
-
-  describe("Test sync elliptic curve key generation with 'jwk' encoding and RSA.", () => {
-    [256, 1024, 2048].forEach(modulusLength => {
-      test(`should work with ${modulusLength}`, async () => {
-        const { publicKey, privateKey } = generateKeyPairSync("rsa", {
-          modulusLength,
-          publicKeyEncoding: {
-            format: "jwk",
-          },
-          privateKeyEncoding: {
-            format: "jwk",
-          },
-        });
-        expect(typeof publicKey).toEqual("object");
-        expect(typeof privateKey).toEqual("object");
-        expect(publicKey.kty).toEqual("RSA");
-        expect(publicKey.kty).toEqual(privateKey.kty);
-        expect(typeof publicKey.n).toEqual("string");
-        expect(publicKey.n).toEqual(privateKey.n);
-        expect(typeof publicKey.e).toEqual("string");
-        expect(publicKey.e).toEqual(privateKey.e);
-        expect(typeof privateKey.d).toEqual("string");
-        expect(typeof privateKey.p).toEqual("string");
-        expect(typeof privateKey.q).toEqual("string");
-        expect(typeof privateKey.dp).toEqual("string");
-        expect(typeof privateKey.dq).toEqual("string");
-        expect(typeof privateKey.qi).toEqual("string");
-      });
-    });
-  });
-
-  describe("Test sync elliptic curve key generation with 'jwk' encoding", () => {
-    ["ed25519", "ed448", "x25519", "x448"].forEach(type => {
-      const test = type === "ed25519" ? it : it.skip;
-      test(`should work with ${type}`, async () => {
-        const { publicKey, privateKey } = generateKeyPairSync(type, {
-          publicKeyEncoding: {
-            format: "jwk",
-          },
-          privateKeyEncoding: {
-            format: "jwk",
-          },
-        });
-
-        expect(typeof publicKey).toEqual("object");
-        expect(typeof privateKey).toEqual("object");
-        expect(publicKey.x).toEqual(privateKey.x);
-        expect(publicKey.d).toBeUndefined();
-        expect(privateKey.d).toBeDefined();
-        expect(publicKey.kty).toEqual("OKP");
-        expect(publicKey.kty).toEqual(privateKey.kty);
-        const expectedCrv = `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
-        expect(publicKey.crv).toEqual(expectedCrv);
-        expect(publicKey.crv).toEqual(privateKey.crv);
-      });
-    });
-  });
-
-  test(`Test sync RSA key generation with an encrypted private key, but encoded as DER`, async () => {
-    const { publicKey: publicKeyDER, privateKey } = generateKeyPairSync("rsa", {
-      publicExponent: 0x10001,
-      modulusLength: 512,
-      publicKeyEncoding: {
-        type: "pkcs1",
-        format: "der",
-      },
-      privateKeyEncoding: {
-        type: "pkcs1",
-        format: "pem",
-        cipher: "aes-256-cbc",
-        passphrase: "secret",
-      },
-    });
-
-    expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
-    assertApproximateSize(publicKeyDER, 74);
-
-    expect(typeof privateKey).toBe("string");
-    expect(privateKey).toMatch(pkcs1EncExp("AES-256-CBC"));
-
-    const publicKey = {
-      key: publicKeyDER,
-      type: "pkcs1",
-      format: "der",
-    };
-    expect(() => {
-      testEncryptDecrypt(publicKey, privateKey);
-    }).toThrow();
-
-    const key = { key: privateKey, passphrase: "secret" };
-    testEncryptDecrypt(publicKey, key);
-    testSignVerify(publicKey, key);
-  });
-
-  test(`Test sync RSA key generation with an encrypted private key`, async () => {
-    const { publicKey: publicKeyDER, privateKey: privateKeyDER } = generateKeyPairSync("rsa", {
-      publicExponent: 0x10001,
-      modulusLength: 512,
-      publicKeyEncoding: {
-        type: "pkcs1",
-        format: "der",
-      },
-      privateKeyEncoding: {
-        type: "pkcs8",
-        format: "der",
-      },
-    });
-
-    expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
-    assertApproximateSize(publicKeyDER, 74);
-
-    expect(Buffer.isBuffer(privateKeyDER)).toBeTrue();
-
-    const publicKey = {
-      key: publicKeyDER,
-      type: "pkcs1",
-      format: "der",
-    };
-    const privateKey = {
-      key: privateKeyDER,
-      format: "der",
-      type: "pkcs8",
-      passphrase: "secret",
-    };
-    testEncryptDecrypt(publicKey, privateKey);
-    testSignVerify(publicKey, privateKey);
-  });
-
-  test(`Test sync elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
-    const { publicKey, privateKey } = generateKeyPairSync("ec", {
-      namedCurve: "P-256",
-      publicKeyEncoding: {
-        type: "spki",
-        format: "pem",
-      },
-      privateKeyEncoding: {
-        type: "pkcs8",
-        format: "pem",
-        cipher: "aes-128-cbc",
-        passphrase: "top secret",
-      },
-    });
-
-    expect(typeof publicKey).toBe("string");
-    expect(publicKey).toMatch(spkiExp);
-    expect(typeof privateKey).toBe("string");
-    expect(privateKey).toMatch(pkcs8EncExp);
-
-    expect(() => {
-      testSignVerify(publicKey, privateKey);
-    }).toThrow();
-
-    testSignVerify(publicKey, {
-      key: privateKey,
-      passphrase: "top secret",
-    });
-  });
-
-  test(`Test sync explicit elliptic curve key generation with an encrypted private key`, async () => {
-    const { publicKey, privateKey } = generateKeyPairSync(
-      "ec",
-      {
-        namedCurve: "prime256v1",
-        publicKeyEncoding: {
-          type: "spki",
-          format: "pem",
-        },
-        privateKeyEncoding: {
-          type: "sec1",
-          format: "pem",
-          cipher: "aes-128-cbc",
-          passphrase: "secret",
-        },
-      },
-      (err, publicKey, privateKey) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve({ publicKey, privateKey });
-      },
-    );
-
-    expect(typeof publicKey).toBe("string");
-    expect(publicKey).toMatch(spkiExp);
-    expect(typeof privateKey).toBe("string");
-    expect(privateKey).toMatch(sec1EncExp("AES-128-CBC"));
-
-    expect(() => {
-      testSignVerify(publicKey, privateKey);
-    }).toThrow();
-
-    testSignVerify(publicKey, {
-      key: privateKey,
-      passphrase: "secret",
-    });
-  });
-
-  test(`Test sync explicit elliptic curve key generation, e.g. for ECDSA, with a SEC1 private key`, async () => {
-    const { publicKey, privateKey } = generateKeyPairSync("ec", {
-      namedCurve: "prime256v1",
-      publicKeyEncoding: {
-        type: "spki",
-        format: "pem",
-      },
-      privateKeyEncoding: {
-        type: "sec1",
-        format: "pem",
-      },
-    });
-
-    expect(typeof publicKey).toBe("string");
-    expect(publicKey).toMatch(spkiExp);
-    expect(typeof privateKey).toBe("string");
-    expect(privateKey).toMatch(sec1Exp);
-    testSignVerify(publicKey, privateKey);
-  });
-
-  test(`Test sync elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
-    const { publicKey, privateKey } = generateKeyPairSync("ec", {
-      namedCurve: "prime256v1",
-      publicKeyEncoding: {
-        type: "spki",
-        format: "pem",
-      },
-      privateKeyEncoding: {
-        type: "pkcs8",
-        format: "pem",
-        cipher: "aes-128-cbc",
-        passphrase: "top secret",
-      },
-    });
-
-    expect(typeof publicKey).toBe("string");
-    expect(publicKey).toMatch(spkiExp);
-    expect(typeof privateKey).toBe("string");
-    expect(privateKey).toMatch(pkcs8EncExp);
-
-    expect(() => {
-      testSignVerify(publicKey, privateKey);
-    }).toThrow();
-
-    testSignVerify(publicKey, {
-      key: privateKey,
-      passphrase: "top secret",
-    });
-  });
-  // SKIPED because we round the key size to the nearest multiple of 8 like documented
-  test.skip(`this tests check that generateKeyPair returns correct bit length in KeyObject's asymmetricKeyDetails.`, async () => {
-    // This tests check that generateKeyPair returns correct bit length in
-    // https://github.com/nodejs/node/issues/46102#issuecomment-1372153541
-    const { promise, resolve, reject } = Promise.withResolvers();
-    generateKeyPair(
-      "rsa",
-      {
-        modulusLength: 513,
-      },
-      (err, publicKey, privateKey) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve({ publicKey, privateKey });
-      },
-    );
-
-    const { publicKey, privateKey } = await (promise as Promise<{ publicKey: KeyObject; privateKey: KeyObject }>);
-    expect(publicKey.asymmetricKeyDetails?.modulusLength).toBe(513);
-    expect(privateKey.asymmetricKeyDetails?.modulusLength).toBe(513);
-  });
-
-  function testRunInContext(fn: any) {
-    test("can generate key", () => {
-      const context = createContext({ generateKeySync });
-      const result = fn(`generateKeySync("aes", { length: 128 })`, context);
-      expect(result).toBeDefined();
-      const keybuf = result.export();
-      expect(keybuf.byteLength).toBe(128 / 8);
-    });
-    test("can be used on another context", () => {
-      const context = createContext({ generateKeyPairSync, assertApproximateSize, testEncryptDecrypt, testSignVerify });
-      const result = fn(
-        `
-        const { publicKey: publicKeyDER, privateKey: privateKeyDER } = generateKeyPairSync(
-          "rsa",
-          {
-            publicExponent: 0x10001,
-            modulusLength: 512,
-            publicKeyEncoding: {
-              type: "pkcs1",
-              format: "der",
-            },
-            privateKeyEncoding: {
-              type: "pkcs8",
-              format: "der",
-            },
-          }
-        );
-
-        
-        assertApproximateSize(publicKeyDER, 74);
-
-        const publicKey = {
-          key: publicKeyDER,
-          type: "pkcs1",
-          format: "der",
-        };
-        const privateKey = {
-          key: privateKeyDER,
-          format: "der",
-          type: "pkcs8",
-          passphrase: "secret",
-        };
-        testEncryptDecrypt(publicKey, privateKey);
-        testSignVerify(publicKey, privateKey);
-      `,
-        context,
-      );
-    });
-  }
-  describe("Script", () => {
-    describe("runInContext()", () => {
-      testRunInContext((code, context, options) => {
-        // @ts-expect-error
-        const script = new Script(code, options);
-        return script.runInContext(context);
-      });
-    });
-    describe("runInNewContext()", () => {
-      testRunInContext((code, context, options) => {
-        // @ts-expect-error
-        const script = new Script(code, options);
-        return script.runInNewContext(context);
-      });
-    });
-    describe("runInThisContext()", () => {
-      testRunInContext((code, context, options) => {
-        // @ts-expect-error
-        const script = new Script(code, options);
-        return script.runInThisContext(context);
-      });
-    });
-  });
-});
-
-test.todo("RSA-PSS should work", async () => {
+// describe("crypto.KeyObjects", () => {
+//   test("Attempting to create a key using other than CryptoKey should throw", async () => {
+//     expect(() => new KeyObject("secret", "")).toThrow();
+//     expect(() => new KeyObject("secret")).toThrow();
+//     expect(() => KeyObject.from("invalid_key")).toThrow();
+//   });
+//   test("basics of createSecretKey should work", async () => {
+//     const keybuf = randomBytes(32);
+//     const key = createSecretKey(keybuf);
+//     expect(key.type).toBe("secret");
+//     expect(key.toString()).toBe("[object KeyObject]");
+//     expect(key.symmetricKeySize).toBe(32);
+//     expect(key.asymmetricKeyType).toBe(undefined);
+//     expect(key.asymmetricKeyDetails).toBe(undefined);
+
+//     const exportedKey = key.export();
+//     expect(keybuf).toEqual(exportedKey);
+
+//     const plaintext = Buffer.from("Hello world", "utf8");
+
+//     const cipher = createCipheriv("aes-256-ecb", key, null);
+//     const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+
+//     const decipher = createDecipheriv("aes-256-ecb", key, null);
+//     const deciphered = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+
+//     expect(plaintext).toEqual(deciphered);
+//   });
+
+//   test("Passing an existing public key object to createPublicKey should throw", async () => {
+//     // Passing an existing public key object to createPublicKey should throw.
+//     const publicKey = createPublicKey(publicPem);
+//     expect(() => createPublicKey(publicKey)).toThrow();
+
+//     // Constructing a private key from a public key should be impossible, even
+//     // if the public key was derived from a private key.
+//     expect(() => createPrivateKey(createPublicKey(privatePem))).toThrow();
+
+//     // Similarly, passing an existing private key object to createPrivateKey
+//     // should throw.
+//     const privateKey = createPrivateKey(privatePem);
+//     expect(() => createPrivateKey(privateKey)).toThrow();
+//   });
+
+//   test("basics should work", async () => {
+//     const jwk = {
+//       e: "AQAB",
+//       n:
+//         "t9xYiIonscC3vz_A2ceR7KhZZlDu_5bye53nCVTcKnWd2seY6UAdKersX6njr83Dd5OVe" +
+//         "1BW_wJvp5EjWTAGYbFswlNmeD44edEGM939B6Lq-_8iBkrTi8mGN4YCytivE24YI0D4XZ" +
+//         "MPfkLSpab2y_Hy4DjQKBq1ThZ0UBnK-9IhX37Ju_ZoGYSlTIGIhzyaiYBh7wrZBoPczIE" +
+//         "u6et_kN2VnnbRUtkYTF97ggcv5h-hDpUQjQW0ZgOMcTc8n-RkGpIt0_iM_bTjI3Tz_gsF" +
+//         "di6hHcpZgbopPL630296iByyigQCPJVzdusFrQN5DeC-zT_nGypQkZanLb4ZspSx9Q",
+//       d:
+//         "ktnq2LvIMqBj4txP82IEOorIRQGVsw1khbm8A-cEpuEkgM71Yi_0WzupKktucUeevQ5i0" +
+//         "Yh8w9e1SJiTLDRAlJz66kdky9uejiWWl6zR4dyNZVMFYRM43ijLC-P8rPne9Fz16IqHFW" +
+//         "5VbJqA1xCBhKmuPMsD71RNxZ4Hrsa7Kt_xglQTYsLbdGIwDmcZihId9VGXRzvmCPsDRf2" +
+//         "fCkAj7HDeRxpUdEiEDpajADc-PWikra3r3b40tVHKWm8wxJLivOIN7GiYXKQIW6RhZgH-" +
+//         "Rk45JIRNKxNagxdeXUqqyhnwhbTo1Hite0iBDexN9tgoZk0XmdYWBn6ElXHRZ7VCDQ",
+//       p:
+//         "8UovlB4nrBm7xH-u7XXBMbqxADQm5vaEZxw9eluc-tP7cIAI4sglMIvL_FMpbd2pEeP_B" +
+//         "kR76NTDzzDuPAZvUGRavgEjy0O9j2NAs_WPK4tZF-vFdunhnSh4EHAF4Ij9kbsUi90NOp" +
+//         "bGfVqPdOaHqzgHKoR23Cuusk9wFQ2XTV8",
+//       q:
+//         "wxHdEYT9xrpfrHPqSBQPpO0dWGKJEkrWOb-76rSfuL8wGR4OBNmQdhLuU9zTIh22pog-X" +
+//         "PnLPAecC-4yu_wtJ2SPCKiKDbJBre0CKPyRfGqzvA3njXwMxXazU4kGs-2Fg-xu_iKbaI" +
+//         "jxXrclBLhkxhBtySrwAFhxxOk6fFcPLSs",
+//       dp:
+//         "qS_Mdr5CMRGGMH0bKhPUWEtAixUGZhJaunX5wY71Xoc_Gh4cnO-b7BNJ_-5L8WZog0vr" +
+//         "6PgiLhrqBaCYm2wjpyoG2o2wDHm-NAlzN_wp3G2EFhrSxdOux-S1c0kpRcyoiAO2n29rN" +
+//         "Da-jOzwBBcU8ACEPdLOCQl0IEFFJO33tl8",
+//       dq:
+//         "WAziKpxLKL7LnL4dzDcx8JIPIuwnTxh0plCDdCffyLaT8WJ9lXbXHFTjOvt8WfPrlDP_" +
+//         "Ylxmfkw5BbGZOP1VLGjZn2DkH9aMiwNmbDXFPdG0G3hzQovx_9fajiRV4DWghLHeT9wzJ" +
+//         "fZabRRiI0VQR472300AVEeX4vgbrDBn600",
+//       qi:
+//         "k7czBCT9rHn_PNwCa17hlTy88C4vXkwbz83Oa-aX5L4e5gw5lhcR2ZuZHLb2r6oMt9rl" +
+//         "D7EIDItSs-u21LOXWPTAlazdnpYUyw_CzogM_PN-qNwMRXn5uXFFhmlP2mVg2EdELTahX" +
+//         "ch8kWqHaCSX53yvqCtRKu_j76V31TfQZGM",
+//       kty: "RSA",
+//     };
+//     const publicJwk = { kty: jwk.kty, e: jwk.e, n: jwk.n };
+
+//     const publicKey = createPublicKey(publicPem);
+//     expect(publicKey.type).toBe("public");
+//     expect(publicKey.toString()).toBe("[object KeyObject]");
+//     expect(publicKey.asymmetricKeyType).toBe("rsa");
+//     expect(publicKey.symmetricKeySize).toBe(undefined);
+
+//     const privateKey = createPrivateKey(privatePem);
+//     expect(privateKey.type).toBe("private");
+//     expect(privateKey.toString()).toBe("[object KeyObject]");
+//     expect(privateKey.asymmetricKeyType).toBe("rsa");
+//     expect(privateKey.symmetricKeySize).toBe(undefined);
+
+//     // It should be possible to derive a public key from a private key.
+//     const derivedPublicKey = createPublicKey(privateKey);
+//     expect(derivedPublicKey.type).toBe("public");
+//     expect(derivedPublicKey.toString()).toBe("[object KeyObject]");
+//     expect(derivedPublicKey.asymmetricKeyType).toBe("rsa");
+//     expect(derivedPublicKey.symmetricKeySize).toBe(undefined);
+
+//     const publicKeyFromJwk = createPublicKey({ key: publicJwk, format: "jwk" });
+//     expect(publicKey.type).toBe("public");
+//     expect(publicKey.toString()).toBe("[object KeyObject]");
+//     expect(publicKey.asymmetricKeyType).toBe("rsa");
+//     expect(publicKey.symmetricKeySize).toBe(undefined);
+
+//     const privateKeyFromJwk = createPrivateKey({ key: jwk, format: "jwk" });
+//     expect(privateKey.type).toBe("private");
+//     expect(privateKey.toString()).toBe("[object KeyObject]");
+//     expect(privateKey.asymmetricKeyType).toBe("rsa");
+//     expect(privateKey.symmetricKeySize).toBe(undefined);
+
+//     // It should also be possible to import an encrypted private key as a public
+//     // key.
+//     const decryptedKey = createPublicKey({
+//       key: privateKey.export({
+//         type: "pkcs8",
+//         format: "pem",
+//         passphrase: Buffer.from("123"),
+//         cipher: "aes-128-cbc",
+//       }),
+//       format: "pem",
+//       passphrase: "123", // this is not documented, but it works
+//     });
+//     expect(decryptedKey.type).toBe("public");
+//     expect(decryptedKey.asymmetricKeyType).toBe("rsa");
+
+//     // Exporting the key using JWK should not work since this format does not
+//     // support key encryption
+//     expect(() => {
+//       privateKey.export({ format: "jwk", passphrase: "secret" });
+//     }).toThrow();
+
+//     // Test exporting with an invalid options object, this should throw.
+//     for (const opt of [undefined, null, "foo", 0, NaN]) {
+//       expect(() => publicKey.export(opt)).toThrow();
+//     }
+
+//     for (const keyObject of [publicKey, derivedPublicKey, publicKeyFromJwk]) {
+//       const exported = keyObject.export({ format: "jwk" });
+//       expect(exported).toBeDefined();
+//       const { kty, n, e } = exported as { kty: string; n: string; e: string };
+//       expect({ kty, n, e }).toEqual({ kty: "RSA", n: jwk.n, e: jwk.e });
+//     }
+
+//     for (const keyObject of [privateKey, privateKeyFromJwk]) {
+//       const exported = keyObject.export({ format: "jwk" });
+//       expect(exported).toEqual(jwk);
+//     }
+
+//     const publicDER = publicKey.export({
+//       format: "der",
+//       type: "pkcs1",
+//     });
+
+//     const privateDER = privateKey.export({
+//       format: "der",
+//       type: "pkcs1",
+//     });
+
+//     expect(Buffer.isBuffer(publicDER)).toBe(true);
+//     expect(Buffer.isBuffer(privateDER)).toBe(true);
+//     const plaintext = Buffer.from("Hello world", "utf8");
+
+//     const testDecryption = (fn, ciphertexts, decryptionKeys) => {
+//       for (const ciphertext of ciphertexts) {
+//         for (const key of decryptionKeys) {
+//           const deciphered = fn(key, ciphertext);
+//           expect(deciphered).toEqual(plaintext);
+//         }
+//       }
+//     };
+
+//     testDecryption(
+//       privateDecrypt,
+//       [
+//         // Encrypt using the public key.
+//         publicEncrypt(publicKey, plaintext),
+//         publicEncrypt({ key: publicKey }, plaintext),
+//         publicEncrypt({ key: publicJwk, format: "jwk" }, plaintext),
+
+//         // Encrypt using the private key.
+//         publicEncrypt(privateKey, plaintext),
+//         publicEncrypt({ key: privateKey }, plaintext),
+//         publicEncrypt({ key: jwk, format: "jwk" }, plaintext),
+
+//         // Encrypt using a public key derived from the private key.
+//         publicEncrypt(derivedPublicKey, plaintext),
+//         publicEncrypt({ key: derivedPublicKey }, plaintext),
+
+//         // Test distinguishing PKCS#1 public and private keys based on the
+//         // DER-encoded data only.
+//         publicEncrypt({ format: "der", type: "pkcs1", key: publicDER }, plaintext),
+//         publicEncrypt({ format: "der", type: "pkcs1", key: privateDER }, plaintext),
+//       ],
+//       [
+//         privateKey,
+//         { format: "pem", key: privatePem },
+//         { format: "der", type: "pkcs1", key: privateDER },
+//         { key: jwk, format: "jwk" },
+//       ],
+//     );
+
+//     testDecryption(
+//       publicDecrypt,
+//       [privateEncrypt(privateKey, plaintext)],
+//       [
+//         // Decrypt using the public key.
+//         publicKey,
+//         { format: "pem", key: publicPem },
+//         { format: "der", type: "pkcs1", key: publicDER },
+//         { key: publicJwk, format: "jwk" },
+
+//         // Decrypt using the private key.
+//         privateKey,
+//         { format: "pem", key: privatePem },
+//         { format: "der", type: "pkcs1", key: privateDER },
+//         { key: jwk, format: "jwk" },
+//       ],
+//     );
+//   });
+
+//   test("This should not cause a crash: https://github.com/nodejs/node/issues/25247", async () => {
+//     expect(() => createPrivateKey({ key: "" })).toThrow();
+//   });
+//   test("This should not abort either: https://github.com/nodejs/node/issues/29904", async () => {
+//     expect(() => createPrivateKey({ key: Buffer.alloc(0), format: "der", type: "spki" })).toThrow();
+//   });
+
+//   test("BoringSSL will not parse PKCS#1", async () => {
+//     // Unlike SPKI, PKCS#1 is a valid encoding for private keys (and public keys),
+//     // so it should be accepted by createPrivateKey, but OpenSSL won't parse it.
+//     expect(() => {
+//       const key = createPublicKey(publicPem).export({
+//         format: "der",
+//         type: "pkcs1",
+//       });
+//       createPrivateKey({ key, format: "der", type: "pkcs1" });
+//     }).toThrow("Invalid use of PKCS#1 as private key");
+//   });
+
+//   [
+//     {
+//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed25519_private.pem"), "ascii"),
+//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed25519_public.pem"), "ascii"),
+//       keyType: "ed25519",
+//       jwk: {
+//         crv: "Ed25519",
+//         x: "K1wIouqnuiA04b3WrMa-xKIKIpfHetNZRv3h9fBf768",
+//         d: "wVK6M3SMhQh3NK-7GRrSV-BVWQx1FO5pW8hhQeu_NdA",
+//         kty: "OKP",
+//       },
+//     },
+//     {
+//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed448_private.pem"), "ascii"),
+//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ed448_public.pem"), "ascii"),
+//       keyType: "ed448",
+//       jwk: {
+//         crv: "Ed448",
+//         x: "oX_ee5-jlcU53-BbGRsGIzly0V-SZtJ_oGXY0udf84q2hTW2RdstLktvwpkVJOoNb7o" + "Dgc2V5ZUA",
+//         d: "060Ke71sN0GpIc01nnGgMDkp0sFNQ09woVo4AM1ffax1-mjnakK0-p-S7-Xf859QewX" + "jcR9mxppY",
+//         kty: "OKP",
+//       },
+//     },
+//     {
+//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x25519_private.pem"), "ascii"),
+//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x25519_public.pem"), "ascii"),
+//       keyType: "x25519",
+//       jwk: {
+//         crv: "X25519",
+//         x: "aSb8Q-RndwfNnPeOYGYPDUN3uhAPnMLzXyfi-mqfhig",
+//         d: "mL_IWm55RrALUGRfJYzw40gEYWMvtRkesP9mj8o8Omc",
+//         kty: "OKP",
+//       },
+//     },
+//     {
+//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x448_private.pem"), "ascii"),
+//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "x448_public.pem"), "ascii"),
+//       keyType: "x448",
+//       jwk: {
+//         crv: "X448",
+//         x: "ioHSHVpTs6hMvghosEJDIR7ceFiE3-Xccxati64oOVJ7NWjfozE7ae31PXIUFq6cVYg" + "vSKsDFPA",
+//         d: "tMNtrO_q8dlY6Y4NDeSTxNQ5CACkHiPvmukidPnNIuX_EkcryLEXt_7i6j6YZMKsrWy" + "S0jlSYJk",
+//         kty: "OKP",
+//       },
+//     },
+//   ].forEach(info => {
+//     const keyType = info.keyType;
+//     // X25519 implementation is incomplete, Ed448 and X448 are not supported yet
+//     const test = keyType === "ed25519" ? it : it.skip;
+//     let privateKey: KeyObject;
+//     test(`${keyType} from Buffer should work`, async () => {
+//       const key = createPrivateKey(info.private);
+//       privateKey = key;
+//       expect(key.type).toBe("private");
+//       expect(key.asymmetricKeyType).toBe(keyType);
+//       expect(key.symmetricKeySize).toBe(undefined);
+//       expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
+//       const jwt = key.export({ format: "jwk" });
+//       expect(jwt).toEqual(info.jwk);
+//     });
+
+//     test(`${keyType} createPrivateKey from jwk should work`, async () => {
+//       const key = createPrivateKey({ key: info.jwk, format: "jwk" });
+//       expect(key.type).toBe("private");
+//       expect(key.asymmetricKeyType).toBe(keyType);
+//       expect(key.symmetricKeySize).toBe(undefined);
+//       expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
+//       const jwt = key.export({ format: "jwk" });
+//       expect(jwt).toEqual(info.jwk);
+//     });
+
+//     [
+//       ["public", info.public],
+//       ["private", info.private],
+//       ["jwk", { key: info.jwk, format: "jwk" }],
+//     ].forEach(([name, input]) => {
+//       test(`${keyType} createPublicKey using ${name} key should work`, async () => {
+//         const key = createPublicKey(input);
+//         expect(key.type).toBe("public");
+//         expect(key.asymmetricKeyType).toBe(keyType);
+//         expect(key.symmetricKeySize).toBe(undefined);
+//         if (name == "public") {
+//           expect(key.export({ type: "spki", format: "pem" })).toEqual(info.public);
+//         }
+//         if (name == "jwk") {
+//           const jwt = { ...info.jwk };
+//           delete jwt.d;
+//           const jwk_exported = key.export({ format: "jwk" });
+//           expect(jwk_exported).toEqual(jwt);
+//         }
+//       });
+//     });
+//   });
+
+//   [
+//     {
+//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p256_private.pem"), "ascii"),
+//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p256_public.pem"), "ascii"),
+//       keyType: "ec",
+//       namedCurve: "prime256v1",
+//       jwk: {
+//         crv: "P-256",
+//         d: "DxBsPQPIgMuMyQbxzbb9toew6Ev6e9O6ZhpxLNgmAEo",
+//         kty: "EC",
+//         x: "X0mMYR_uleZSIPjNztIkAS3_ud5LhNpbiIFp6fNf2Gs",
+//         y: "UbJuPy2Xi0lW7UYTBxPK3yGgDu9EAKYIecjkHX5s2lI",
+//       },
+//     },
+//     {
+//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_secp256k1_private.pem"), "ascii"),
+//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_secp256k1_public.pem"), "ascii"),
+//       keyType: "ec",
+//       namedCurve: "secp256k1",
+//       jwk: {
+//         crv: "secp256k1",
+//         d: "c34ocwTwpFa9NZZh3l88qXyrkoYSxvC0FEsU5v1v4IM",
+//         kty: "EC",
+//         x: "cOzhFSpWxhalCbWNdP2H_yUkdC81C9T2deDpfxK7owA",
+//         y: "-A3DAZTk9IPppN-f03JydgHaFvL1fAHaoXf4SX4NXyo",
+//       },
+//     },
+//     {
+//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p384_private.pem"), "ascii"),
+//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p384_public.pem"), "ascii"),
+//       keyType: "ec",
+//       namedCurve: "secp384r1",
+//       jwk: {
+//         crv: "P-384",
+//         d: "dwfuHuAtTlMRn7ZBCBm_0grpc1D_4hPeNAgevgelljuC0--k_LDFosDgBlLLmZsi",
+//         kty: "EC",
+//         x: "hON3nzGJgv-08fdHpQxgRJFZzlK-GZDGa5f3KnvM31cvvjJmsj4UeOgIdy3rDAjV",
+//         y: "fidHhtecNCGCfLqmrLjDena1NSzWzWH1u_oUdMKGo5XSabxzD7-8JZxjpc8sR9cl",
+//       },
+//     },
+//     {
+//       private: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p521_private.pem"), "ascii"),
+//       public: fs.readFileSync(path.join(import.meta.dir, "fixtures", "ec_p521_public.pem"), "ascii"),
+//       keyType: "ec",
+//       namedCurve: "secp521r1",
+//       jwk: {
+//         crv: "P-521",
+//         d: "Eghuafcab9jXW4gOQLeDaKOlHEiskQFjiL8klijk6i6DNOXcFfaJ9GW48kxpodw16ttAf9Z1WQstfzpKGUetHIk",
+//         kty: "EC",
+//         x: "AaLFgjwZtznM3N7qsfb86awVXe6c6djUYOob1FN-kllekv0KEXV0bwcDjPGQz5f6MxL" + "CbhMeHRavUS6P10rsTtBn",
+//         y: "Ad3flexBeAfXceNzRBH128kFbOWD6W41NjwKRqqIF26vmgW_8COldGKZjFkOSEASxPB" + "cvA2iFJRUyQ3whC00j0Np",
+//       },
+//     },
+//   ].forEach(info => {
+//     const { keyType, namedCurve } = info;
+//     const test = namedCurve === "secp256k1" ? it.skip : it;
+//     let privateKey: KeyObject;
+//     test(`${keyType} ${namedCurve} createPrivateKey from Buffer should work`, async () => {
+//       const key = createPrivateKey(info.private);
+//       privateKey = key;
+//       expect(key.type).toBe("private");
+//       expect(key.asymmetricKeyType).toBe(keyType);
+//       expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
+//       expect(key.symmetricKeySize).toBe(undefined);
+//       expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
+//       const jwt = key.export({ format: "jwk" });
+//       expect(jwt).toEqual(info.jwk);
+//     });
+
+//     test(`${keyType} ${namedCurve} createPrivateKey from jwk should work`, async () => {
+//       const key = createPrivateKey({ key: info.jwk, format: "jwk" });
+//       expect(key.type).toBe("private");
+//       expect(key.asymmetricKeyType).toBe(keyType);
+//       expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
+//       expect(key.symmetricKeySize).toBe(undefined);
+//       expect(key.export({ type: "pkcs8", format: "pem" })).toEqual(info.private);
+//       const jwt = key.export({ format: "jwk" });
+//       expect(jwt).toEqual(info.jwk);
+//     });
+
+//     [
+//       ["public", info.public],
+//       ["private", info.private],
+//       ["jwk", { key: info.jwk, format: "jwk" }],
+//     ].forEach(([name, input]) => {
+//       test(`${keyType} ${namedCurve} createPublicKey using ${name} should work`, async () => {
+//         const key = createPublicKey(input);
+//         expect(key.type).toBe("public");
+//         expect(key.asymmetricKeyType).toBe(keyType);
+//         expect(key.asymmetricKeyDetails?.namedCurve).toBe(namedCurve);
+//         expect(key.symmetricKeySize).toBe(undefined);
+//         if (name == "public") {
+//           expect(key.export({ type: "spki", format: "pem" })).toEqual(info.public);
+//         }
+//         if (name == "jwk") {
+//           const jwt = { ...info.jwk };
+//           delete jwt.d;
+//           const jwk_exported = key.export({ format: "jwk" });
+//           expect(jwk_exported).toEqual(jwt);
+//         }
+
+//         const pkey = privateKey || info.private;
+//         const signature = createSign("sha256").update("foo").sign({ key: pkey });
+//         const okay = createVerify("sha256").update("foo").verify({ key: key }, signature);
+//         expect(okay).toBeTrue();
+//       });
+//     });
+//   });
+
+//   test("private encrypted should work", async () => {
+//     // Reading an encrypted key without a passphrase should fail.
+//     expect(() => createPrivateKey(privateEncryptedPem)).toThrow();
+//     // Reading an encrypted key with a passphrase that exceeds OpenSSL's buffer
+//     // size limit should fail with an appropriate error code.
+//     expect(() =>
+//       createPrivateKey({
+//         key: privateEncryptedPem,
+//         format: "pem",
+//         passphrase: Buffer.alloc(1025, "a"),
+//       }),
+//     ).toThrow();
+//     // The buffer has a size of 1024 bytes, so this passphrase should be permitted
+//     // (but will fail decryption).
+//     expect(() =>
+//       createPrivateKey({
+//         key: privateEncryptedPem,
+//         format: "pem",
+//         passphrase: Buffer.alloc(1024, "a"),
+//       }),
+//     ).toThrow();
+//     const publicKey = createPublicKey({
+//       key: privateEncryptedPem,
+//       format: "pem",
+//       passphrase: "password", // this is not documented but should work
+//     });
+//     expect(publicKey.type).toBe("public");
+//     expect(publicKey.asymmetricKeyType).toBe("rsa");
+//     expect(publicKey.symmetricKeySize).toBe(undefined);
+
+//     const privateKey = createPrivateKey({
+//       key: privateEncryptedPem,
+//       format: "pem",
+//       passphrase: "password",
+//     });
+//     expect(privateKey.type).toBe("private");
+//     expect(privateKey.asymmetricKeyType).toBe("rsa");
+//     expect(privateKey.symmetricKeySize).toBe(undefined);
+//   });
+
+//   [2048, 4096].forEach(suffix => {
+//     test(`RSA-${suffix} should work`, async () => {
+//       {
+//         const publicPem = fs.readFileSync(path.join(import.meta.dir, "fixtures", `rsa_public_${suffix}.pem`), "ascii");
+//         const privatePem = fs.readFileSync(
+//           path.join(import.meta.dir, "fixtures", `rsa_private_${suffix}.pem`),
+//           "ascii",
+//         );
+//         const publicKey = createPublicKey(publicPem);
+//         const expectedKeyDetails = {
+//           modulusLength: suffix,
+//           publicExponent: 65537n,
+//         };
+//         expect(publicKey.type).toBe("public");
+//         expect(publicKey.asymmetricKeyType).toBe("rsa");
+//         expect(publicKey.asymmetricKeyDetails).toEqual(expectedKeyDetails);
+
+//         const privateKey = createPrivateKey(privatePem);
+//         expect(privateKey.type).toBe("private");
+//         expect(privateKey.asymmetricKeyType).toBe("rsa");
+//         expect(privateKey.asymmetricKeyDetails).toEqual(expectedKeyDetails);
+
+//         for (const key of [privatePem, privateKey]) {
+//           // Any algorithm should work.
+//           for (const algo of ["sha1", "sha256"]) {
+//             // Any salt length should work.
+//             for (const saltLength of [undefined, 8, 10, 12, 16, 18, 20]) {
+//               const signature = createSign(algo).update("foo").sign({ key, saltLength });
+//               for (const pkey of [key, publicKey, publicPem]) {
+//                 const okay = createVerify(algo).update("foo").verify({ key: pkey, saltLength }, signature);
+//                 expect(okay).toBeTrue();
+//               }
+//             }
+//           }
+//         }
+//       }
+//     });
+//   });
+
+//   test("Exporting an encrypted private key requires a cipher", async () => {
+//     // Exporting an encrypted private key requires a cipher
+//     const privateKey = createPrivateKey(privatePem);
+//     expect(() => {
+//       privateKey.export({
+//         format: "pem",
+//         type: "pkcs8",
+//         passphrase: "super-secret",
+//       });
+//     }).toThrow(/cipher is required when passphrase is specified/);
+//   });
+
+//   test("secret export buffer format (default)", async () => {
+//     const buffer = Buffer.from("Hello World");
+//     const keyObject = createSecretKey(buffer);
+//     expect(keyObject.export()).toEqual(buffer);
+//     expect(keyObject.export({})).toEqual(buffer);
+//     expect(keyObject.export({ format: "buffer" })).toEqual(buffer);
+//     expect(keyObject.export({ format: undefined })).toEqual(buffer);
+//   });
+
+//   test('exporting an "oct" JWK from a secret', async () => {
+//     const buffer = Buffer.from("Hello World");
+//     const keyObject = createSecretKey(buffer);
+//     const jwk = keyObject.export({ format: "jwk" });
+//     expect(jwk).toEqual({ kty: "oct", k: "SGVsbG8gV29ybGQ" });
+//   });
+
+//   test("secret equals", async () => {
+//     {
+//       const first = Buffer.from("Hello");
+//       const second = Buffer.from("World");
+//       const keyObject = createSecretKey(first);
+//       expect(createSecretKey(first).equals(createSecretKey(first))).toBeTrue();
+//       expect(createSecretKey(first).equals(createSecretKey(second))).toBeFalse();
+
+//       expect(() => keyObject.equals(0)).toThrow(/otherKey must be a KeyObject/);
+
+//       expect(keyObject.equals(keyObject)).toBeTrue();
+//       expect(keyObject.equals(createPublicKey(publicPem))).toBeFalse();
+//       expect(keyObject.equals(createPrivateKey(privatePem))).toBeFalse();
+//     }
+
+//     {
+//       const first = createSecretKey(Buffer.alloc(0));
+//       const second = createSecretKey(new ArrayBuffer(0));
+//       const third = createSecretKey(Buffer.alloc(1));
+//       expect(first.equals(first)).toBeTrue();
+//       expect(first.equals(second)).toBeTrue();
+//       expect(first.equals(third)).toBeFalse();
+//       expect(third.equals(first)).toBeFalse();
+//     }
+//   });
+
+//   ["ed25519", "x25519"].forEach(keyType => {
+//     const test = keyType === "ed25519" ? it : it.skip;
+//     test(`${keyType} equals should work`, async () => {
+//       const first = generateKeyPairSync(keyType);
+//       const second = generateKeyPairSync(keyType);
+
+//       const secret = generateKeySync("aes", { length: 128 });
+
+//       expect(first.publicKey.equals(first.publicKey)).toBeTrue();
+
+//       expect(first.publicKey.equals(createPublicKey(first.publicKey.export({ format: "pem", type: "spki" }))));
+
+//       expect(first.publicKey.equals(second.publicKey)).toBeFalse();
+//       expect(first.publicKey.equals(second.privateKey)).toBeFalse();
+//       expect(first.publicKey.equals(secret)).toBeFalse();
+
+//       expect(first.privateKey.equals(first.privateKey)).toBeTrue();
+//       expect(
+//         first.privateKey.equals(createPrivateKey(first.privateKey.export({ format: "pem", type: "pkcs8" }))),
+//       ).toBeTrue();
+//       expect(first.privateKey.equals(second.privateKey)).toBeFalse();
+//       expect(first.privateKey.equals(second.publicKey)).toBeFalse();
+//       expect(first.privateKey.equals(secret)).toBeFalse();
+//     });
+//   });
+
+//   test("This should not cause a crash: https://github.com/nodejs/node/issues/44471", async () => {
+//     for (const key of ["", "foo", null, undefined, true, Boolean]) {
+//       expect(() => {
+//         createPublicKey({ key, format: "jwk" });
+//       }).toThrow();
+//       expect(() => {
+//         createPrivateKey({ key, format: "jwk" });
+//       }).toThrow();
+//     }
+//   });
+
+//   ["hmac", "aes"].forEach(type => {
+//     [128, 256].forEach(length => {
+//       test(`generateKey ${type} ${length}`, async () => {
+//         {
+//           const key = generateKeySync(type, { length });
+//           expect(key).toBeDefined();
+//           const keybuf = key.export();
+//           expect(keybuf.byteLength).toBe(length / 8);
+//         }
+
+//         const { promise, resolve, reject } = Promise.withResolvers();
+//         generateKey(type, { length }, (err, key) => {
+//           if (err) {
+//             reject(err);
+//           } else {
+//             resolve(key);
+//           }
+//         });
+
+//         {
+//           const key = await promise;
+//           expect(key).toBeDefined();
+//           const keybuf = key.export();
+//           expect(keybuf.byteLength).toBe(length / 8);
+//         }
+//       });
+//     });
+//   });
+//   describe("Test async elliptic curve key generation with 'jwk' encoding and named curve", () => {
+//     ["P-384", "P-256", "P-521", "secp256k1"].forEach(curve => {
+//       const test = curve === "secp256k1" ? it.skip : it;
+//       test(`should work with ${curve}`, async () => {
+//         const { promise, resolve, reject } = Promise.withResolvers();
+//         generateKeyPair(
+//           "ec",
+//           {
+//             namedCurve: curve,
+//             publicKeyEncoding: {
+//               format: "jwk",
+//             },
+//             privateKeyEncoding: {
+//               format: "jwk",
+//             },
+//           },
+//           (err, publicKey, privateKey) => {
+//             if (err) {
+//               return reject(err);
+//             }
+//             resolve({ publicKey, privateKey });
+//           },
+//         );
+
+//         const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
+//         expect(typeof publicKey).toBe("object");
+//         expect(typeof privateKey).toBe("object");
+//         expect(publicKey.x).toBe(privateKey.x);
+//         expect(publicKey.y).toBe(publicKey.y);
+//         expect(publicKey.d).toBeUndefined();
+//         expect(privateKey.d).toBeDefined();
+//         expect(publicKey.kty).toEqual("EC");
+//         expect(publicKey.kty).toEqual(privateKey.kty);
+//         expect(publicKey.crv).toEqual(curve);
+//         expect(publicKey.crv).toEqual(privateKey.crv);
+//       });
+//     });
+//   });
+
+//   describe("Test async elliptic curve key generation with 'jwk' encoding and RSA.", () => {
+//     [256, 1024, 2048].forEach(modulusLength => {
+//       test(`should work with ${modulusLength}`, async () => {
+//         const { promise, resolve, reject } = Promise.withResolvers();
+//         generateKeyPair(
+//           "rsa",
+//           {
+//             modulusLength,
+//             publicKeyEncoding: {
+//               format: "jwk",
+//             },
+//             privateKeyEncoding: {
+//               format: "jwk",
+//             },
+//           },
+//           (err, publicKey, privateKey) => {
+//             if (err) {
+//               return reject(err);
+//             }
+//             resolve({ publicKey, privateKey });
+//           },
+//         );
+
+//         const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
+//         expect(typeof publicKey).toEqual("object");
+//         expect(typeof privateKey).toEqual("object");
+//         expect(publicKey.kty).toEqual("RSA");
+//         expect(publicKey.kty).toEqual(privateKey.kty);
+//         expect(typeof publicKey.n).toEqual("string");
+//         expect(publicKey.n).toEqual(privateKey.n);
+//         expect(typeof publicKey.e).toEqual("string");
+//         expect(publicKey.e).toEqual(privateKey.e);
+//         expect(typeof privateKey.d).toEqual("string");
+//         expect(typeof privateKey.p).toEqual("string");
+//         expect(typeof privateKey.q).toEqual("string");
+//         expect(typeof privateKey.dp).toEqual("string");
+//         expect(typeof privateKey.dq).toEqual("string");
+//         expect(typeof privateKey.qi).toEqual("string");
+//       });
+//     });
+//   });
+
+//   describe("Test async elliptic curve key generation with 'jwk' encoding", () => {
+//     ["ed25519", "ed448", "x25519", "x448"].forEach(type => {
+//       const test = type === "ed25519" ? it : it.skip;
+//       test(`should work with ${type}`, async () => {
+//         const { promise, resolve, reject } = Promise.withResolvers();
+//         generateKeyPair(
+//           type,
+//           {
+//             publicKeyEncoding: {
+//               format: "jwk",
+//             },
+//             privateKeyEncoding: {
+//               format: "jwk",
+//             },
+//           },
+//           (err, publicKey, privateKey) => {
+//             if (err) {
+//               return reject(err);
+//             }
+//             resolve({ publicKey, privateKey });
+//           },
+//         );
+
+//         const { publicKey, privateKey } = await (promise as Promise<{ publicKey: any; privateKey: any }>);
+//         expect(typeof publicKey).toEqual("object");
+//         expect(typeof privateKey).toEqual("object");
+//         expect(publicKey.x).toEqual(privateKey.x);
+//         expect(publicKey.d).toBeUndefined();
+//         expect(privateKey.d).toBeDefined();
+//         expect(publicKey.kty).toEqual("OKP");
+//         expect(publicKey.kty).toEqual(privateKey.kty);
+//         const expectedCrv = `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
+//         expect(publicKey.crv).toEqual(expectedCrv);
+//         expect(publicKey.crv).toEqual(privateKey.crv);
+//       });
+//     });
+//   });
+
+//   test(`Test async RSA key generation with an encrypted private key, but encoded as DER`, async () => {
+//     const { promise, resolve, reject } = Promise.withResolvers();
+//     generateKeyPair(
+//       "rsa",
+//       {
+//         publicExponent: 0x10001,
+//         modulusLength: 512,
+//         publicKeyEncoding: {
+//           type: "pkcs1",
+//           format: "der",
+//         },
+//         privateKeyEncoding: {
+//           type: "pkcs1",
+//           format: "pem",
+//           cipher: "aes-256-cbc",
+//           passphrase: "secret",
+//         },
+//       },
+//       (err, publicKey, privateKey) => {
+//         if (err) {
+//           return reject(err);
+//         }
+//         resolve({ publicKey, privateKey });
+//       },
+//     );
+
+//     const { publicKey: publicKeyDER, privateKey } = await (promise as Promise<{
+//       publicKey: Buffer;
+//       privateKey: string;
+//     }>);
+//     expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
+//     assertApproximateSize(publicKeyDER, 74);
+
+//     expect(typeof privateKey).toBe("string");
+//     expect(privateKey).toMatch(pkcs1EncExp("AES-256-CBC"));
+
+//     const publicKey = {
+//       key: publicKeyDER,
+//       type: "pkcs1",
+//       format: "der",
+//     };
+//     expect(() => {
+//       testEncryptDecrypt(publicKey, privateKey);
+//     }).toThrow();
+
+//     const key = { key: privateKey, passphrase: "secret" };
+//     testEncryptDecrypt(publicKey, key);
+//     testSignVerify(publicKey, key);
+//   });
+
+//   test(`Test async RSA key generation with an encrypted private key`, async () => {
+//     const { promise, resolve, reject } = Promise.withResolvers();
+//     generateKeyPair(
+//       "rsa",
+//       {
+//         publicExponent: 0x10001,
+//         modulusLength: 512,
+//         publicKeyEncoding: {
+//           type: "pkcs1",
+//           format: "der",
+//         },
+//         privateKeyEncoding: {
+//           type: "pkcs8",
+//           format: "der",
+//         },
+//       },
+//       (err, publicKey, privateKey) => {
+//         if (err) {
+//           return reject(err);
+//         }
+//         resolve({ publicKey, privateKey });
+//       },
+//     );
+
+//     const { publicKey: publicKeyDER, privateKey: privateKeyDER } = await (promise as Promise<{
+//       publicKey: Buffer;
+//       privateKey: Buffer;
+//     }>);
+//     expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
+//     assertApproximateSize(publicKeyDER, 74);
+
+//     expect(Buffer.isBuffer(privateKeyDER)).toBeTrue();
+
+//     const publicKey = {
+//       key: publicKeyDER,
+//       type: "pkcs1",
+//       format: "der",
+//     };
+//     const privateKey = {
+//       key: privateKeyDER,
+//       format: "der",
+//       type: "pkcs8",
+//       passphrase: "secret",
+//     };
+//     testEncryptDecrypt(publicKey, privateKey);
+//     testSignVerify(publicKey, privateKey);
+//   });
+
+//   test(`Test async elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
+//     const { promise, resolve, reject } = Promise.withResolvers();
+//     generateKeyPair(
+//       "ec",
+//       {
+//         namedCurve: "P-256",
+//         publicKeyEncoding: {
+//           type: "spki",
+//           format: "pem",
+//         },
+//         privateKeyEncoding: {
+//           type: "pkcs8",
+//           format: "pem",
+//           cipher: "aes-128-cbc",
+//           passphrase: "top secret",
+//         },
+//       },
+//       (err, publicKey, privateKey) => {
+//         if (err) {
+//           return reject(err);
+//         }
+//         resolve({ publicKey, privateKey });
+//       },
+//     );
+
+//     const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
+//     expect(typeof publicKey).toBe("string");
+//     expect(publicKey).toMatch(spkiExp);
+//     expect(typeof privateKey).toBe("string");
+//     expect(privateKey).toMatch(pkcs8EncExp);
+
+//     expect(() => {
+//       testSignVerify(publicKey, privateKey);
+//     }).toThrow();
+
+//     testSignVerify(publicKey, {
+//       key: privateKey,
+//       passphrase: "top secret",
+//     });
+//   });
+
+//   test(`Test async explicit elliptic curve key generation with an encrypted private key`, async () => {
+//     const { promise, resolve, reject } = Promise.withResolvers();
+//     generateKeyPair(
+//       "ec",
+//       {
+//         namedCurve: "prime256v1",
+//         publicKeyEncoding: {
+//           type: "spki",
+//           format: "pem",
+//         },
+//         privateKeyEncoding: {
+//           type: "sec1",
+//           format: "pem",
+//           cipher: "aes-128-cbc",
+//           passphrase: "secret",
+//         },
+//       },
+//       (err, publicKey, privateKey) => {
+//         if (err) {
+//           return reject(err);
+//         }
+//         resolve({ publicKey, privateKey });
+//       },
+//     );
+
+//     const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
+//     expect(typeof publicKey).toBe("string");
+//     expect(publicKey).toMatch(spkiExp);
+//     expect(typeof privateKey).toBe("string");
+//     expect(privateKey).toMatch(sec1EncExp("AES-128-CBC"));
+
+//     expect(() => {
+//       testSignVerify(publicKey, privateKey);
+//     }).toThrow();
+
+//     testSignVerify(publicKey, {
+//       key: privateKey,
+//       passphrase: "secret",
+//     });
+//   });
+
+//   test(`Test async explicit elliptic curve key generation, e.g. for ECDSA, with a SEC1 private key`, async () => {
+//     const { promise, resolve, reject } = Promise.withResolvers();
+//     generateKeyPair(
+//       "ec",
+//       {
+//         namedCurve: "prime256v1",
+//         publicKeyEncoding: {
+//           type: "spki",
+//           format: "pem",
+//         },
+//         privateKeyEncoding: {
+//           type: "sec1",
+//           format: "pem",
+//         },
+//       },
+//       (err, publicKey, privateKey) => {
+//         if (err) {
+//           return reject(err);
+//         }
+//         resolve({ publicKey, privateKey });
+//       },
+//     );
+
+//     const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
+//     expect(typeof publicKey).toBe("string");
+//     expect(publicKey).toMatch(spkiExp);
+//     expect(typeof privateKey).toBe("string");
+//     expect(privateKey).toMatch(sec1Exp);
+//     testSignVerify(publicKey, privateKey);
+//   });
+
+//   test(`Test async elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
+//     const { promise, resolve, reject } = Promise.withResolvers();
+//     generateKeyPair(
+//       "ec",
+//       {
+//         namedCurve: "prime256v1",
+//         publicKeyEncoding: {
+//           type: "spki",
+//           format: "pem",
+//         },
+//         privateKeyEncoding: {
+//           type: "pkcs8",
+//           format: "pem",
+//           cipher: "aes-128-cbc",
+//           passphrase: "top secret",
+//         },
+//       },
+//       (err, publicKey, privateKey) => {
+//         if (err) {
+//           return reject(err);
+//         }
+//         resolve({ publicKey, privateKey });
+//       },
+//     );
+
+//     const { publicKey, privateKey } = await (promise as Promise<{ publicKey: string; privateKey: string }>);
+//     expect(typeof publicKey).toBe("string");
+//     expect(publicKey).toMatch(spkiExp);
+//     expect(typeof privateKey).toBe("string");
+//     expect(privateKey).toMatch(pkcs8EncExp);
+
+//     expect(() => {
+//       testSignVerify(publicKey, privateKey);
+//     }).toThrow();
+
+//     testSignVerify(publicKey, {
+//       key: privateKey,
+//       passphrase: "top secret",
+//     });
+//   });
+
+//   describe("Test sync elliptic curve key generation with 'jwk' encoding and named curve", () => {
+//     ["P-384", "P-256", "P-521", "secp256k1"].forEach(curve => {
+//       const test = curve === "secp256k1" ? it.skip : it;
+//       test(`should work with ${curve}`, async () => {
+//         const { publicKey, privateKey } = generateKeyPairSync("ec", {
+//           namedCurve: curve,
+//           publicKeyEncoding: {
+//             format: "jwk",
+//           },
+//           privateKeyEncoding: {
+//             format: "jwk",
+//           },
+//         });
+//         expect(typeof publicKey).toBe("object");
+//         expect(typeof privateKey).toBe("object");
+//         expect(publicKey.x).toBe(privateKey.x);
+//         expect(publicKey.y).toBe(publicKey.y);
+//         expect(publicKey.d).toBeUndefined();
+//         expect(privateKey.d).toBeDefined();
+//         expect(publicKey.kty).toEqual("EC");
+//         expect(publicKey.kty).toEqual(privateKey.kty);
+//         expect(publicKey.crv).toEqual(curve);
+//         expect(publicKey.crv).toEqual(privateKey.crv);
+//       });
+//     });
+//   });
+
+//   describe("Test sync elliptic curve key generation with 'jwk' encoding and RSA.", () => {
+//     [256, 1024, 2048].forEach(modulusLength => {
+//       test(`should work with ${modulusLength}`, async () => {
+//         const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+//           modulusLength,
+//           publicKeyEncoding: {
+//             format: "jwk",
+//           },
+//           privateKeyEncoding: {
+//             format: "jwk",
+//           },
+//         });
+//         expect(typeof publicKey).toEqual("object");
+//         expect(typeof privateKey).toEqual("object");
+//         expect(publicKey.kty).toEqual("RSA");
+//         expect(publicKey.kty).toEqual(privateKey.kty);
+//         expect(typeof publicKey.n).toEqual("string");
+//         expect(publicKey.n).toEqual(privateKey.n);
+//         expect(typeof publicKey.e).toEqual("string");
+//         expect(publicKey.e).toEqual(privateKey.e);
+//         expect(typeof privateKey.d).toEqual("string");
+//         expect(typeof privateKey.p).toEqual("string");
+//         expect(typeof privateKey.q).toEqual("string");
+//         expect(typeof privateKey.dp).toEqual("string");
+//         expect(typeof privateKey.dq).toEqual("string");
+//         expect(typeof privateKey.qi).toEqual("string");
+//       });
+//     });
+//   });
+
+//   describe("Test sync elliptic curve key generation with 'jwk' encoding", () => {
+//     ["ed25519", "ed448", "x25519", "x448"].forEach(type => {
+//       const test = type === "ed25519" ? it : it.skip;
+//       test(`should work with ${type}`, async () => {
+//         const { publicKey, privateKey } = generateKeyPairSync(type, {
+//           publicKeyEncoding: {
+//             format: "jwk",
+//           },
+//           privateKeyEncoding: {
+//             format: "jwk",
+//           },
+//         });
+
+//         expect(typeof publicKey).toEqual("object");
+//         expect(typeof privateKey).toEqual("object");
+//         expect(publicKey.x).toEqual(privateKey.x);
+//         expect(publicKey.d).toBeUndefined();
+//         expect(privateKey.d).toBeDefined();
+//         expect(publicKey.kty).toEqual("OKP");
+//         expect(publicKey.kty).toEqual(privateKey.kty);
+//         const expectedCrv = `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
+//         expect(publicKey.crv).toEqual(expectedCrv);
+//         expect(publicKey.crv).toEqual(privateKey.crv);
+//       });
+//     });
+//   });
+
+//   test(`Test sync RSA key generation with an encrypted private key, but encoded as DER`, async () => {
+//     const { publicKey: publicKeyDER, privateKey } = generateKeyPairSync("rsa", {
+//       publicExponent: 0x10001,
+//       modulusLength: 512,
+//       publicKeyEncoding: {
+//         type: "pkcs1",
+//         format: "der",
+//       },
+//       privateKeyEncoding: {
+//         type: "pkcs1",
+//         format: "pem",
+//         cipher: "aes-256-cbc",
+//         passphrase: "secret",
+//       },
+//     });
+
+//     expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
+//     assertApproximateSize(publicKeyDER, 74);
+
+//     expect(typeof privateKey).toBe("string");
+//     expect(privateKey).toMatch(pkcs1EncExp("AES-256-CBC"));
+
+//     const publicKey = {
+//       key: publicKeyDER,
+//       type: "pkcs1",
+//       format: "der",
+//     };
+//     expect(() => {
+//       testEncryptDecrypt(publicKey, privateKey);
+//     }).toThrow();
+
+//     const key = { key: privateKey, passphrase: "secret" };
+//     testEncryptDecrypt(publicKey, key);
+//     testSignVerify(publicKey, key);
+//   });
+
+//   test(`Test sync RSA key generation with an encrypted private key`, async () => {
+//     const { publicKey: publicKeyDER, privateKey: privateKeyDER } = generateKeyPairSync("rsa", {
+//       publicExponent: 0x10001,
+//       modulusLength: 512,
+//       publicKeyEncoding: {
+//         type: "pkcs1",
+//         format: "der",
+//       },
+//       privateKeyEncoding: {
+//         type: "pkcs8",
+//         format: "der",
+//       },
+//     });
+
+//     expect(Buffer.isBuffer(publicKeyDER)).toBeTrue();
+//     assertApproximateSize(publicKeyDER, 74);
+
+//     expect(Buffer.isBuffer(privateKeyDER)).toBeTrue();
+
+//     const publicKey = {
+//       key: publicKeyDER,
+//       type: "pkcs1",
+//       format: "der",
+//     };
+//     const privateKey = {
+//       key: privateKeyDER,
+//       format: "der",
+//       type: "pkcs8",
+//       passphrase: "secret",
+//     };
+//     testEncryptDecrypt(publicKey, privateKey);
+//     testSignVerify(publicKey, privateKey);
+//   });
+
+//   test(`Test sync elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
+//     const { publicKey, privateKey } = generateKeyPairSync("ec", {
+//       namedCurve: "P-256",
+//       publicKeyEncoding: {
+//         type: "spki",
+//         format: "pem",
+//       },
+//       privateKeyEncoding: {
+//         type: "pkcs8",
+//         format: "pem",
+//         cipher: "aes-128-cbc",
+//         passphrase: "top secret",
+//       },
+//     });
+
+//     expect(typeof publicKey).toBe("string");
+//     expect(publicKey).toMatch(spkiExp);
+//     expect(typeof privateKey).toBe("string");
+//     expect(privateKey).toMatch(pkcs8EncExp);
+
+//     expect(() => {
+//       testSignVerify(publicKey, privateKey);
+//     }).toThrow();
+
+//     testSignVerify(publicKey, {
+//       key: privateKey,
+//       passphrase: "top secret",
+//     });
+//   });
+
+//   test(`Test sync explicit elliptic curve key generation with an encrypted private key`, async () => {
+//     const { publicKey, privateKey } = generateKeyPairSync(
+//       "ec",
+//       {
+//         namedCurve: "prime256v1",
+//         publicKeyEncoding: {
+//           type: "spki",
+//           format: "pem",
+//         },
+//         privateKeyEncoding: {
+//           type: "sec1",
+//           format: "pem",
+//           cipher: "aes-128-cbc",
+//           passphrase: "secret",
+//         },
+//       },
+//       (err, publicKey, privateKey) => {
+//         if (err) {
+//           return reject(err);
+//         }
+//         resolve({ publicKey, privateKey });
+//       },
+//     );
+
+//     expect(typeof publicKey).toBe("string");
+//     expect(publicKey).toMatch(spkiExp);
+//     expect(typeof privateKey).toBe("string");
+//     expect(privateKey).toMatch(sec1EncExp("AES-128-CBC"));
+
+//     expect(() => {
+//       testSignVerify(publicKey, privateKey);
+//     }).toThrow();
+
+//     testSignVerify(publicKey, {
+//       key: privateKey,
+//       passphrase: "secret",
+//     });
+//   });
+
+//   test(`Test sync explicit elliptic curve key generation, e.g. for ECDSA, with a SEC1 private key`, async () => {
+//     const { publicKey, privateKey } = generateKeyPairSync("ec", {
+//       namedCurve: "prime256v1",
+//       publicKeyEncoding: {
+//         type: "spki",
+//         format: "pem",
+//       },
+//       privateKeyEncoding: {
+//         type: "sec1",
+//         format: "pem",
+//       },
+//     });
+
+//     expect(typeof publicKey).toBe("string");
+//     expect(publicKey).toMatch(spkiExp);
+//     expect(typeof privateKey).toBe("string");
+//     expect(privateKey).toMatch(sec1Exp);
+//     testSignVerify(publicKey, privateKey);
+//   });
+
+//   test(`Test sync elliptic curve key generation, e.g. for ECDSA, with an encrypted private key`, async () => {
+//     const { publicKey, privateKey } = generateKeyPairSync("ec", {
+//       namedCurve: "prime256v1",
+//       publicKeyEncoding: {
+//         type: "spki",
+//         format: "pem",
+//       },
+//       privateKeyEncoding: {
+//         type: "pkcs8",
+//         format: "pem",
+//         cipher: "aes-128-cbc",
+//         passphrase: "top secret",
+//       },
+//     });
+
+//     expect(typeof publicKey).toBe("string");
+//     expect(publicKey).toMatch(spkiExp);
+//     expect(typeof privateKey).toBe("string");
+//     expect(privateKey).toMatch(pkcs8EncExp);
+
+//     expect(() => {
+//       testSignVerify(publicKey, privateKey);
+//     }).toThrow();
+
+//     testSignVerify(publicKey, {
+//       key: privateKey,
+//       passphrase: "top secret",
+//     });
+//   });
+//   // SKIPED because we round the key size to the nearest multiple of 8 like documented
+//   test.skip(`this tests check that generateKeyPair returns correct bit length in KeyObject's asymmetricKeyDetails.`, async () => {
+//     // This tests check that generateKeyPair returns correct bit length in
+//     // https://github.com/nodejs/node/issues/46102#issuecomment-1372153541
+//     const { promise, resolve, reject } = Promise.withResolvers();
+//     generateKeyPair(
+//       "rsa",
+//       {
+//         modulusLength: 513,
+//       },
+//       (err, publicKey, privateKey) => {
+//         if (err) {
+//           return reject(err);
+//         }
+//         resolve({ publicKey, privateKey });
+//       },
+//     );
+
+//     const { publicKey, privateKey } = await (promise as Promise<{ publicKey: KeyObject; privateKey: KeyObject }>);
+//     expect(publicKey.asymmetricKeyDetails?.modulusLength).toBe(513);
+//     expect(privateKey.asymmetricKeyDetails?.modulusLength).toBe(513);
+//   });
+
+//   function testRunInContext(fn: any) {
+//     test("can generate key", () => {
+//       const context = createContext({ generateKeySync });
+//       const result = fn(`generateKeySync("aes", { length: 128 })`, context);
+//       expect(result).toBeDefined();
+//       const keybuf = result.export();
+//       expect(keybuf.byteLength).toBe(128 / 8);
+//     });
+//     test("can be used on another context", () => {
+//       const context = createContext({ generateKeyPairSync, assertApproximateSize, testEncryptDecrypt, testSignVerify });
+//       const result = fn(
+//         `
+//         const { publicKey: publicKeyDER, privateKey: privateKeyDER } = generateKeyPairSync(
+//           "rsa",
+//           {
+//             publicExponent: 0x10001,
+//             modulusLength: 512,
+//             publicKeyEncoding: {
+//               type: "pkcs1",
+//               format: "der",
+//             },
+//             privateKeyEncoding: {
+//               type: "pkcs8",
+//               format: "der",
+//             },
+//           }
+//         );
+
+//         assertApproximateSize(publicKeyDER, 74);
+
+//         const publicKey = {
+//           key: publicKeyDER,
+//           type: "pkcs1",
+//           format: "der",
+//         };
+//         const privateKey = {
+//           key: privateKeyDER,
+//           format: "der",
+//           type: "pkcs8",
+//           passphrase: "secret",
+//         };
+//         testEncryptDecrypt(publicKey, privateKey);
+//         testSignVerify(publicKey, privateKey);
+//       `,
+//         context,
+//       );
+//     });
+//   }
+//   describe("Script", () => {
+//     describe("runInContext()", () => {
+//       testRunInContext((code, context, options) => {
+//         // @ts-expect-error
+//         const script = new Script(code, options);
+//         return script.runInContext(context);
+//       });
+//     });
+//     describe("runInNewContext()", () => {
+//       testRunInContext((code, context, options) => {
+//         // @ts-expect-error
+//         const script = new Script(code, options);
+//         return script.runInNewContext(context);
+//       });
+//     });
+//     describe("runInThisContext()", () => {
+//       testRunInContext((code, context, options) => {
+//         // @ts-expect-error
+//         const script = new Script(code, options);
+//         return script.runInThisContext(context);
+//       });
+//     });
+//   });
+// });
+
+test("RSA-PSS should work", async () => {
   // Test RSA-PSS.
   {
     // This key pair does not restrict the message digest algorithm or salt
     // length.
-    // const publicPem = fs.readFileSync(path.join(import.meta.dir, "fixtures", "rsa_pss_public_2048.pem"), "ascii");
-    // const privatePem = fs.readFileSync(path.join(import.meta.dir, "fixtures", "rsa_pss_private_2048.pem"), "ascii");
-    // const publicKey = createPublicKey(publicPem);
-    // const privateKey = createPrivateKey(privatePem);
-    // // Because no RSASSA-PSS-params appears in the PEM, no defaults should be
-    // // added for the PSS parameters. This is different from an empty
-    // // RSASSA-PSS-params sequence (see test below).
-    // const expectedKeyDetails = {
-    //   modulusLength: 2048,
-    //   publicExponent: 65537n,
-    // };
-    // expect(publicKey.type).toBe("public");
-    // expect(publicKey.asymmetricKeyType).toBe("rsa-pss");
-    // expect(publicKey.asymmetricKeyDetails).toBe(expectedKeyDetails);
-    // expect(privateKey.type).toBe("private");
-    // expect(privateKey.asymmetricKeyType).toBe("rsa-pss");
-    // expect(privateKey.asymmetricKeyDetails).toBe(expectedKeyDetails);
-    // assert.throws(
-    //   () => publicKey.export({ format: 'jwk' }),
-    //   { code: 'ERR_CRYPTO_JWK_UNSUPPORTED_KEY_TYPE' });
+    const publicPem = fs.readFileSync(path.join(import.meta.dir, "fixtures", "rsa_pss_public_2048.pem"), "ascii");
+    const privatePem = fs.readFileSync(path.join(import.meta.dir, "fixtures", "rsa_pss_private_2048.pem"), "ascii");
+    console.log(publicPem);
+    console.log(privatePem);
+    const publicKey = createPublicKey(publicPem);
+    const privateKey = createPrivateKey(privatePem);
+    // Because no RSASSA-PSS-params appears in the PEM, no defaults should be
+    // added for the PSS parameters. This is different from an empty
+    // RSASSA-PSS-params sequence (see test below).
+    const expectedKeyDetails = {
+      modulusLength: 2048,
+      publicExponent: 65537n,
+    };
+    expect(publicKey.type).toBe("public");
+    expect(publicKey.asymmetricKeyType).toBe("rsa-pss");
+    expect(publicKey.asymmetricKeyDetails).toBe(expectedKeyDetails);
+    expect(privateKey.type).toBe("private");
+    expect(privateKey.asymmetricKeyType).toBe("rsa-pss");
+    expect(privateKey.asymmetricKeyDetails).toBe(expectedKeyDetails);
+    // assert.throws(() => publicKey.export({ format: "jwk" }), { code: "ERR_CRYPTO_JWK_UNSUPPORTED_KEY_TYPE" });
     // assert.throws(
     //   () => privateKey.export({ format: 'jwk' }),
     //   { code: 'ERR_CRYPTO_JWK_UNSUPPORTED_KEY_TYPE' });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix: #6418
Add support to crypto.sign/crypto.verify using:
- [x] ECDSA
   - [x] dsaEncoding  
- [x] Ed25519
- [x] HMAC
- [x] RSA (non-native)
- [x] RSA-PSS (createVerify and createSign remains without RSA-PSS support)
  - [x] padding
  - [x] saltLength 
  
 Add improvements to generateKeyPairSync and generateKeyPair using RSA-PSS (partial implemented)
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing Tests + New Tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
