### PR TITLE
Update `install.dryRun` docs to be accurate.

### DIFF
--- a/docs/runtime/bunfig.md
+++ b/docs/runtime/bunfig.md
@@ -313,7 +313,7 @@ frozenLockfile = false
 
 ### `install.dryRun`
 
-Whether to install optional dependencies. Default `false`. When true, it's equivalent to setting `--dry-run` on all `bun install` commands.
+Whether `bun install` will actually install dependencies. Default `false`. When true, it's equivalent to setting `--dry-run` on all `bun install` commands.
 
 ```toml
 [install]


### PR DESCRIPTION
### What does this PR do?

This updates the description of `install.dryRun` in the docs to describe what it actually does; previously it looked to be copy-pasted from `install.optional`.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes