### PR TITLE
require `bun:test`

### DIFF
--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1724,13 +1724,32 @@ fn NewPrinter(
                 //      const foo = await Promise.resolve(globalThis.Bun)
                 //      const bar = globalThis.Bun
                 //
-                if (record.tag == .bun) {
-                    if (record.kind == .dynamic) {
-                        p.print("Promise.resolve(globalThis.Bun)");
-                    } else if (record.kind == .require) {
-                        p.print("globalThis.Bun");
-                    }
-                    return;
+                switch (record.tag) {
+                    .bun => {
+                        if (record.kind == .dynamic) {
+                            p.print("Promise.resolve(globalThis.Bun)");
+                        } else if (record.kind == .require) {
+                            p.print("globalThis.Bun");
+                        }
+                        return;
+                    },
+                    .bun_test => {
+                        if (record.kind == .dynamic) {
+                            if (p.options.module_type == .cjs) {
+                                p.print("Promise.resolve(globalThis.Bun.jest(__filename))");
+                            } else {
+                                p.print("Promise.resolve(globalThis.Bun.jest(import.meta.path))");
+                            }
+                        } else if (record.kind == .require) {
+                            if (p.options.module_type == .cjs) {
+                                p.print("globalThis.Bun.jest(__filename)");
+                            } else {
+                                p.print("globalThis.Bun.jest(import.meta.path)");
+                            }
+                        }
+                        return;
+                    },
+                    else => {},
                 }
             }
 

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -104,6 +104,62 @@ describe("bun test", () => {
     });
     expect(stderr).toContain(path);
   });
+  test("works with require", () => {
+    const stderr = runTest({
+      args: [],
+      input: [
+        `
+          const { test, expect } = require("bun:test");
+          test("test #1", () => {
+            expect().pass();
+          })
+        `,
+      ],
+    });
+    expect(stderr).toContain("test #1");
+  });
+  test("works with dynamic import", () => {
+    const stderr = runTest({
+      args: [],
+      input: `
+        const { test, expect } = await import("bun:test");
+        test("test #1", () => {
+          expect().pass();
+        })
+      `,
+    });
+    expect(stderr).toContain("test #1");
+  });
+  test("works with cjs require", () => {
+    const cwd = createTest(
+      `
+        const { test, expect } = require("bun:test");
+        test("test #1", () => {
+          expect().pass();
+        })
+      `,
+      "test.test.cjs",
+    );
+    const stderr = runTest({
+      cwd,
+    });
+    expect(stderr).toContain("test #1");
+  });
+  test("works with cjs dynamic import", () => {
+    const cwd = createTest(
+      `
+        const { test, expect } = await import("bun:test");
+        test("test #1", () => {
+          expect().pass();
+        })
+      `,
+      "test.test.cjs",
+    );
+    const stderr = runTest({
+      cwd,
+    });
+    expect(stderr).toContain("test #1");
+  });
   test.todo("can provide a mix of files and directories");
   describe("--rerun-each", () => {
     test.todo("can rerun with a default value");


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
