### PR TITLE
feat(test): `toHaveBeenCalledWith` and `toHaveBeenLastCalledWith`

### DIFF
--- a/docs/guides/test/migrate-from-jest.md
+++ b/docs/guides/test/migrate-from-jest.md
@@ -32,7 +32,6 @@ Some notable missing features:
 
 - `expect.extend()`
 - `expect().toMatchInlineSnapshot()`
-- `expect().toHaveBeenCalledWith()`
 - `expect().toHaveReturned()`
 
 ---

--- a/docs/test/writing.md
+++ b/docs/test/writing.md
@@ -313,12 +313,12 @@ Bun implements the following matchers. Full Jest compatibility is on the roadmap
 
 ---
 
-- ❌
+- ✅
 - [`.toHaveBeenCalledWith()`](https://jestjs.io/docs/expect#tohavebeencalledwitharg1-arg2-)
 
 ---
 
-- ❌
+- ✅
 - [`.toHaveBeenLastCalledWith()`](https://jestjs.io/docs/expect#tohavebeenlastcalledwitharg1-arg2-)
 
 ---

--- a/packages/bun-types/bun-test.d.ts
+++ b/packages/bun-types/bun-test.d.ts
@@ -1144,7 +1144,11 @@ declare module "bun:test" {
     /**
      * Ensure that a mock function is called with specific arguments.
      */
-    // toHaveBeenCalledWith(...expected: Array<unknown>): void;
+    toHaveBeenCalledWith(...expected: Array<unknown>): void;
+    /**
+     * Ensure that a mock function is called with specific arguments for the last call.
+     */
+    toHaveBeenLastCalledWith(...expected: Array<unknown>): void;
   };
 }
 

--- a/src/bun.js/test/jest.classes.ts
+++ b/src/bun.js/test/jest.classes.ts
@@ -146,11 +146,9 @@ export default [
       },
       toHaveBeenCalledWith: {
         fn: "toHaveBeenCalledWith",
-        length: 1,
       },
       toHaveBeenLastCalledWith: {
         fn: "toHaveBeenLastCalledWith",
-        length: 1,
       },
       toHaveBeenNthCalledWith: {
         fn: "toHaveBeenNthCalledWith",

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -43,10 +43,13 @@ describe("mock()", () => {
     expect(fn).toHaveBeenCalledTimes(1);
     expect(fn.mock.calls).toHaveLength(1);
     expect(fn.mock.calls[0]).toBeEmpty();
+    expect(fn).toHaveBeenLastCalledWith();
     expect(fn()).toBe(42);
     expect(fn).toHaveBeenCalledTimes(2);
     expect(fn.mock.calls).toHaveLength(2);
     expect(fn.mock.calls[1]).toBeEmpty();
+    expect(fn).toHaveBeenLastCalledWith();
+    expect(fn).toHaveBeenCalledWith();
   });
   test("passes this value", () => {
     const fn = jest.fn(function hey() {
@@ -85,10 +88,13 @@ describe("mock()", () => {
     expect(fn).toHaveBeenCalledTimes(1);
     expect(fn.mock.calls).toHaveLength(1);
     expect(fn.mock.calls[0]).toBeEmpty();
+    expect(fn).toHaveBeenLastCalledWith();
     expect(Number(fn.call(234))).toBe(234);
     expect(fn).toHaveBeenCalledTimes(2);
     expect(fn.mock.calls).toHaveLength(2);
     expect(fn.mock.calls[1]).toBeEmpty();
+    expect(fn).toHaveBeenLastCalledWith();
+    expect(fn).toHaveBeenCalledWith();
   });
   test(".apply works", function () {
     const fn = jest.fn(function hey() {
@@ -99,10 +105,13 @@ describe("mock()", () => {
     expect(fn).toHaveBeenCalledTimes(1);
     expect(fn.mock.calls).toHaveLength(1);
     expect(fn.mock.calls[0]).toBeEmpty();
+    expect(fn).toHaveBeenLastCalledWith();
     expect(Number(fn.apply(234))).toBe(234);
     expect(fn).toHaveBeenCalledTimes(2);
     expect(fn.mock.calls).toHaveLength(2);
     expect(fn.mock.calls[1]).toBeEmpty();
+    expect(fn).toHaveBeenLastCalledWith();
+    expect(fn).toHaveBeenCalledWith();
   });
   test(".bind works", () => {
     const fn = jest.fn(function hey() {
@@ -113,10 +122,13 @@ describe("mock()", () => {
     expect(fn).toHaveBeenCalledTimes(1);
     expect(fn.mock.calls).toHaveLength(1);
     expect(fn.mock.calls[0]).toBeEmpty();
+    expect(fn).toHaveBeenLastCalledWith();
     expect(Number(fn.bind(234)())).toBe(234);
     expect(fn).toHaveBeenCalledTimes(2);
     expect(fn.mock.calls).toHaveLength(2);
     expect(fn.mock.calls[1]).toBeEmpty();
+    expect(fn).toHaveBeenLastCalledWith();
+    expect(fn).toHaveBeenCalledWith();
   });
   test(".name works", () => {
     const fn = jest.fn(function hey() {
@@ -159,6 +171,10 @@ describe("mock()", () => {
       value: 43,
     });
     expect(fn.mock.calls[0]).toEqual([43]);
+    expect(fn).toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenLastCalledWith(43);
+    expect(fn).toHaveBeenCalledWith(43);
   });
   test("works when throwing", () => {
     const instance = new Error("foo");
@@ -171,6 +187,8 @@ describe("mock()", () => {
       value: instance,
     });
     expect(fn.mock.calls[0]).toEqual([43]);
+    expect(fn).toHaveBeenLastCalledWith(43);
+    expect(fn).toHaveBeenCalledWith(43);
   });
   test("mockReset works", () => {
     const instance = new Error("foo");
@@ -183,11 +201,15 @@ describe("mock()", () => {
       value: instance,
     });
     expect(fn.mock.calls[0]).toEqual([43]);
+    expect(fn).toHaveBeenLastCalledWith(43);
+    expect(fn).toHaveBeenCalledWith(43);
     fn.mockReset();
     expect(fn.mock.calls).toBeEmpty();
     expect(fn.mock.results).toBeEmpty();
     expect(fn.mock.instances).toBeEmpty();
     expect(fn).not.toHaveBeenCalled();
+    expect(fn).not.toHaveBeenLastCalledWith(43);
+    expect(fn).not.toHaveBeenCalledWith(43);
     expect(() => expect(fn).toHaveBeenCalled()).toThrow();
     expect(fn(43)).toBe(undefined);
     expect(fn.mock.results).toEqual([
@@ -197,6 +219,8 @@ describe("mock()", () => {
       },
     ]);
     expect(fn.mock.calls).toEqual([[43]]);
+    expect(fn).toHaveBeenLastCalledWith(43);
+    expect(fn).toHaveBeenCalledWith(43);
   });
   test("mockClear works", () => {
     const instance = new Error("foo");
@@ -209,17 +233,23 @@ describe("mock()", () => {
       value: instance,
     });
     expect(fn.mock.calls[0]).toEqual([43]);
+    expect(fn).toHaveBeenLastCalledWith(43);
+    expect(fn).toHaveBeenCalledWith(43);
     fn.mockClear();
     expect(fn.mock.calls).toBeEmpty();
     expect(fn.mock.results).toBeEmpty();
     expect(fn.mock.instances).toBeEmpty();
     expect(fn).not.toHaveBeenCalled();
+    expect(fn).not.toHaveBeenLastCalledWith(43);
+    expect(fn).not.toHaveBeenCalledWith(43);
     expect(() => fn(43)).toThrow("foo");
     expect(fn.mock.results[0]).toEqual({
       type: "throw",
       value: instance,
     });
     expect(fn.mock.calls[0]).toEqual([43]);
+    expect(fn).toHaveBeenLastCalledWith(43);
+    expect(fn).toHaveBeenCalledWith(43);
   });
   // this is an implementation detail i don't think we *need* to support
   test("mockClear doesnt update existing object", () => {
@@ -233,10 +263,14 @@ describe("mock()", () => {
       value: instance,
     });
     expect(fn.mock.calls[0]).toEqual([43]);
+    expect(fn).toHaveBeenLastCalledWith(43);
+    expect(fn).toHaveBeenCalledWith(43);
     const stolen = fn.mock;
     fn.mockClear();
     expect(stolen).not.toBe(fn.mock);
     expect(fn.mock.calls).toBeEmpty();
+    expect(fn).not.toHaveBeenLastCalledWith(43);
+    expect(fn).not.toHaveBeenCalledWith(43);
     expect(stolen.calls).not.toBeEmpty();
     expect(fn.mock.results).toBeEmpty();
     expect(stolen.results).not.toBeEmpty();
@@ -249,22 +283,29 @@ describe("mock()", () => {
       value: instance,
     });
     expect(fn.mock.calls[0]).toEqual([43]);
+    expect(fn).toHaveBeenLastCalledWith(43);
+    expect(fn).toHaveBeenCalledWith(43);
   });
   test("multiple calls work", () => {
     const fn = jest.fn(f => f);
     expect(fn(43)).toBe(43);
+    expect(fn).toHaveBeenLastCalledWith(43);
     expect(fn(44)).toBe(44);
+    expect(fn).toHaveBeenLastCalledWith(44);
     expect(fn.mock.calls[0]).toEqual([43]);
     expect(fn.mock.results[0]).toEqual({
       type: "return",
       value: 43,
     });
     expect(fn.mock.calls[1]).toEqual([44]);
+    expect(fn).toHaveBeenLastCalledWith(44);
     expect(fn.mock.results[1]).toEqual({
       type: "return",
       value: 44,
     });
     expect(fn.mock.contexts).toEqual([undefined, undefined]);
+    expect(fn).toHaveBeenCalledWith(43);
+    expect(fn).toHaveBeenCalledWith(44);
   });
   test("this arg", () => {
     const fn = jest.fn(function (add) {
@@ -273,6 +314,8 @@ describe("mock()", () => {
     const obj = { foo: 42, fn };
     expect(obj.fn(2)).toBe(44);
     expect(fn.mock.calls[0]).toEqual([2]);
+    expect(fn).toHaveBeenLastCalledWith(2);
+    expect(fn).toHaveBeenCalledWith(2);
     expect(fn.mock.results[0]).toEqual({
       type: "return",
       value: 44,
@@ -298,19 +341,26 @@ describe("mock()", () => {
     });
     const obj = { foo: 42, fn };
     expect(obj.fn(2)).toBe(44);
+    expect(fn).toHaveBeenLastCalledWith(2);
     const this2 = { foo: 43 };
     expect(fn.call(this2, 2)).toBe(45);
+    expect(fn).toHaveBeenLastCalledWith(2);
     const this3 = { foo: 44 };
     expect(fn.apply(this3, [2])).toBe(46);
+    expect(fn).toHaveBeenLastCalledWith(2);
     const this4 = { foo: 45 };
     expect(fn.bind(this4)(3)).toBe(48);
+    expect(fn).toHaveBeenLastCalledWith(3);
     const this5 = { foo: 45 };
     expect(fn.bind(this5, 2)()).toBe(47);
+    expect(fn).toHaveBeenLastCalledWith(2);
     expect(fn.mock.calls[0]).toEqual([2]);
     expect(fn.mock.calls[1]).toEqual([2]);
     expect(fn.mock.calls[2]).toEqual([2]);
     expect(fn.mock.calls[3]).toEqual([3]);
     expect(fn.mock.calls[4]).toEqual([2]);
+    expect(fn).toHaveBeenCalledWith(2);
+    expect(fn).toHaveBeenCalledWith(3);
     expect(fn.mock.results[0]).toEqual({
       type: "return",
       value: 44,
@@ -486,6 +536,41 @@ describe("mock()", () => {
     expect(first).toBeGreaterThan(0);
     expect(fn1.mock.invocationCallOrder).toEqual([first, first + 3]);
     expect(fn2.mock.invocationCallOrder).toEqual([first + 1, first + 2]);
+  });
+
+  test("toHaveBeenCalledWith, toHaveBeenLastCalledWith works", () => {
+    const fn = jest.fn();
+    expect(() => expect(() => {}).not.toHaveBeenLastCalledWith()).toThrow();
+    expect(() => expect(() => {}).not.toHaveBeenCalledWith()).toThrow();
+    expect(fn).not.toHaveBeenCalledWith();
+    expect(fn).not.toHaveBeenLastCalledWith();
+    fn();
+    expect(fn).toHaveBeenCalledWith();
+    expect(fn).toHaveBeenLastCalledWith();
+    expect(fn).not.toHaveBeenCalledWith(1);
+    fn(1);
+    expect(fn).toHaveBeenCalledWith(1);
+    expect(fn).toHaveBeenLastCalledWith(1);
+    fn(1, 2, 3);
+    expect(fn).not.toHaveBeenCalledWith("123");
+    expect(fn).not.toHaveBeenLastCalledWith(1);
+    expect(fn).not.toHaveBeenLastCalledWith(1, 2);
+    expect(fn).not.toHaveBeenLastCalledWith("123");
+    expect(fn).toHaveBeenLastCalledWith(1, 2, 3);
+    expect(fn).not.toHaveBeenLastCalledWith(3, 2, 1);
+    fn("random string");
+    expect(fn).toHaveBeenCalledWith();
+    expect(fn).toHaveBeenCalledWith(1);
+    expect(fn).toHaveBeenCalledWith(1, 2, 3);
+    expect(fn).toHaveBeenCalledWith("random string");
+    expect(fn).toHaveBeenLastCalledWith("random string");
+    expect(fn).toHaveBeenCalledWith(expect.stringMatching(/^random \w+$/));
+    expect(fn).toHaveBeenLastCalledWith(expect.stringMatching(/^random \w+$/));
+    fn(1, undefined);
+    expect(fn).not.toHaveBeenLastCalledWith(1);
+    expect(fn).toHaveBeenLastCalledWith(1, undefined);
+    expect(fn).toHaveBeenCalledWith(1, undefined);
+    expect(fn).not.toHaveBeenCalledWith(undefined);
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

- Implements jest matchers `toHaveBeenCalledWith` and `toHaveBeenLastCalledWith`.
- Updates that they're supported in the docs.

I would note that the formatted expected and received output when a test fails is not properly aligned with what jest does because, well, I'm not sure how you would have liked that to be approached. These matchers are somewhat unique in that they allow an unlimited number of arguments that they try to match against the arguments in a call.

I'm still relatively new to zig, so I wasn't sure how to approach the trying to print the array of call arguments like jest does on test failures in this codebase. I don't view that as a blocker though, it's just a nice to have for failures that could be done down the road perhaps, or taken up by one you guys if you want it in this PR(?)

If this PR goes well, I'll probably try some of the other unimplemented matchers :).

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

If new methods, getters, or setters were added to a publicly exposed class:

- [x] I added TypeScript types for the new methods, getters, or setters
