### PR TITLE
fix duplicate workspace bug

### DIFF
--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -3231,26 +3231,6 @@ pub const Package = extern struct {
                             return null;
                         }
                     }
-                }
-
-                workspace_entry.value_ptr.* = path;
-
-                if (workspace_version) |ver| {
-                    try lockfile.workspace_versions.put(allocator, name_hash, ver);
-                    for (package_dependencies[0..dependencies_count]) |*package_dep| {
-                        if (switch (package_dep.version.tag) {
-                            // `dependencies` & `workspaces` defined within the same `package.json`
-                            .npm => String.Builder.stringHash(package_dep.realname().slice(buf)) == name_hash and
-                                package_dep.version.value.npm.version.satisfies(ver, buf, buf),
-                            // `workspace:*`
-                            .workspace => found_matching_workspace and
-                                String.Builder.stringHash(package_dep.realname().slice(buf)) == name_hash,
-                            else => false,
-                        }) {
-                            package_dep.version = dependency_version;
-                            return null;
-                        }
-                    }
                 } else if (workspace_entry.found_existing) {
                     for (package_dependencies[0..dependencies_count]) |*package_dep| {
                         if (package_dep.version.tag == .workspace and
@@ -3262,6 +3242,8 @@ pub const Package = extern struct {
                     }
                     return error.InstallFailed;
                 }
+
+                workspace_entry.value_ptr.* = path;
             },
             else => {},
         }

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -10,28 +10,28 @@ import { beforeAll, afterAll, beforeEach, afterEach, test, expect, describe } fr
 
 var verdaccioServer: ChildProcess;
 var testCounter: number = 0;
-var port: number = 4873;
+var port: number = 4783;
 var packageDir: string;
 
 ignoreMimallocWarning({ beforeAll, afterAll });
 
-// beforeAll(async done => {
-//   verdaccioServer = fork(
-//     await import.meta.resolve("verdaccio/bin/verdaccio"),
-//     ["-c", join(import.meta.dir, "verdaccio.yaml"), "-l", `${port}`],
-//     { silent: true, execPath: "bun" },
-//   );
+beforeAll(async done => {
+  verdaccioServer = fork(
+    await import.meta.resolve("verdaccio/bin/verdaccio"),
+    ["-c", join(import.meta.dir, "verdaccio.yaml"), "-l", `${port}`],
+    { silent: true, execPath: "bun" },
+  );
 
-//   verdaccioServer.on("message", (msg: { verdaccio_started: boolean }) => {
-//     if (msg.verdaccio_started) {
-//       done();
-//     }
-//   });
-// });
+  verdaccioServer.on("message", (msg: { verdaccio_started: boolean }) => {
+    if (msg.verdaccio_started) {
+      done();
+    }
+  });
+});
 
-// afterAll(() => {
-//   verdaccioServer.kill();
-// });
+afterAll(() => {
+  verdaccioServer.kill();
+});
 
 beforeEach(async () => {
   packageDir = mkdtempSync(join(realpathSync(tmpdir()), "bun-install-registry-" + testCounter++ + "-"));

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -10,7 +10,7 @@ import { beforeAll, afterAll, beforeEach, afterEach, test, expect, describe } fr
 
 var verdaccioServer: ChildProcess;
 var testCounter: number = 0;
-var port: number = 4783;
+var port: number = 4784;
 var packageDir: string;
 
 ignoreMimallocWarning({ beforeAll, afterAll });

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -896,7 +896,7 @@ describe("workspaces", async () => {
     expect(err).toContain('Workspace name "pkg1" already exists');
     expect(await exited).toBe(1);
   });
-  const versions = ["workspace:1.0.0", "workspace:*", "workspace:^1.0.0", "1.0.0"];
+  const versions = ["workspace:1.0.0", "workspace:*", "workspace:^1.0.0", "1.0.0", "*"];
 
   for (const rootVersion of versions) {
     for (const packageVersion of versions) {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
