### PR TITLE
fix(node:fs): fix `fs.promises.opendir` not having a `path` property

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -103,8 +103,13 @@ function cp(src, dest, options) {
 // This is currently stubbed for Next.js support.
 class Dir {
   #entries: Dirent[];
-  constructor(e: Dirent[]) {
+  #path: string;
+  constructor(e: Dirent[], path: string) {
     this.#entries = e;
+    this.#path = path;
+  }
+  get path() {
+    return this.#path;
   }
   readSync() {
     return this.#entries.shift() ?? null;
@@ -127,7 +132,7 @@ class Dir {
 }
 async function opendir(dir: string) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
-  return new Dir(entries);
+  return new Dir(entries, dir);
 }
 
 export default {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1775,6 +1775,10 @@ describe("fs/promises", () => {
       expect(await exists(path)).toBe(false);
     });
   });
+
+  it("opendir should have a path property, issue#4995", async () => {
+    expect((await fs.promises.opendir(".")).path).toBe(".");
+  });
 });
 
 it("stat on a large file", () => {


### PR DESCRIPTION
### What does this PR do?

Adds the path property to the Dir class returned by fs.promises.opendir. Closes #4995

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)