### PR TITLE
Feat: add jsx spread children support

### DIFF
--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -1454,6 +1454,31 @@ export var ComponentThatHasSpreadCausesDeopt = <Hello {...spread} />
     });
   });
 
+  it("JSX spread children", () => {
+    var bun = new Bun.Transpiler({
+      loader: "jsx",
+      define: {
+        "process.env.NODE_ENV": JSON.stringify("development"),
+      },
+    });
+    expect(bun.transformSync("export var foo = <div>{...a}b</div>")).toBe(
+      `export var foo = jsxDEV("div", {
+  children: [
+    ...a,
+    "b"
+  ]
+}, undefined, true, undefined, this);
+`,
+    );
+
+    expect(bun.transformSync("export var foo = <div>{...a}</div>")).toBe(
+      `export var foo = jsxDEV("div", {
+  children: [...a]
+}, undefined, true, undefined, this);
+`,
+    );
+  });
+
   it("require with a dynamic non-string expression", () => {
     var nodeTranspiler = new Bun.Transpiler({ platform: "node" });
     expect(nodeTranspiler.transformSync("require('hi' + bar)")).toBe('require("hi" + bar);\n');


### PR DESCRIPTION
### What does this PR do?

#### Example
```js
const a = <h1>{...[123]}</h1>
```
#### Output
##### Before: 
```sh
error: Unexpected ...
```
##### After:
```js
var a = jsx_dev_runtime.jsxDEV("h1", {
  children: [...[123]]
}, undefined, true, undefined, this);
```


This feature is already supported by most transpilers, eg:
[Typescript](https://www.typescriptlang.org/play?target=99&jsx=5#code/MYewdgzgLgBAhjAvDAPACwIwD4DeA6AgbQwCYBmAXQF8UB6TLAKCA)
[Esbuild](https://esbuild.github.io/try/#dAAwLjE5LjcAewogIGxvYWRlcjogJ2pzeCcsCiAganN4OiAnYXV0b21hdGljJywKfQA8ZGl2PnsuLi5bXX08L2Rpdj4)
[SWC](https://play.swc.rs/?version=1.3.100-nightly-20231124.1&code=H4sIAAAAAAAAA0vOzysuUUhUsFWwSckss6vW09OLjq210QdxAHOBudocAAAA&config=H4sIAAAAAAAAA1WOMQrDMAxF95zCaO5QPPY2wijFIbaDJENL8N0rO2lJN%2F33kPT3yTlYJMDD7TZa2JCF%2BJeNyDsrvowAhYQSOG4Kt69dpCvlSoO0Q8BaipCJGVehkyljlrlwul5nwqAX0FHNGlPfBqxaEmoMcOr290WRn6Sjmvi796NWm9oHTYlQ69cAAAA%3D)


- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
I am willing to add test code for this feature, but I need some help.
As I understand it, the test code should be placed in `test/snippets`, `test/snapshots`.
However, the `scripts/browser.js` that tests them does not seem to be able to execute properly.



<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
