### PR TITLE
Implement `recursive` option in `fs.readdir`

### DIFF
--- a/bench/snippets/readdir.mjs
+++ b/bench/snippets/readdir.mjs
@@ -4,6 +4,7 @@ import { bench, run } from "./runner.mjs";
 import { argv } from "process";
 import { fileURLToPath } from "url";
 import { relative, resolve } from "path";
+import { createHash } from "crypto";
 
 let dir = resolve(argv.length > 2 ? argv[2] : fileURLToPath(new URL("../../node_modules", import.meta.url)));
 if (dir.includes(process.cwd())) {
@@ -14,8 +15,27 @@ const result = await readdir(dir, { recursive: true });
 const count = result.length;
 const syncCount = readdirSync(dir, { recursive: true }).length;
 
+const hash = createHash("sha256").update(result.sort().join("\n")).digest("hex");
+
 bench(`await readdir("${dir}", {recursive: true})`, async () => {
   await readdir(dir, { recursive: true });
+});
+
+bench(`await readdir("${dir}", {recursive: true}) x 10`, async () => {
+  const promises = [
+    readdir(dir, { recursive: true }),
+    readdir(dir, { recursive: true }),
+    readdir(dir, { recursive: true }),
+    readdir(dir, { recursive: true }),
+    readdir(dir, { recursive: true }),
+    readdir(dir, { recursive: true }),
+    readdir(dir, { recursive: true }),
+    readdir(dir, { recursive: true }),
+    readdir(dir, { recursive: true }),
+    readdir(dir, { recursive: true }),
+    readdir(dir, { recursive: true }),
+  ];
+  await Promise.all(promises);
 });
 
 bench(`await readdir("${dir}", {recursive: false})`, async () => {
@@ -23,7 +43,7 @@ bench(`await readdir("${dir}", {recursive: false})`, async () => {
 });
 
 await run();
-console.log("\n", count, "files/dirs in", dir);
+console.log("\n", count, "files/dirs in", dir, "\n", "SHA256:", hash, "\n");
 
 if (count !== syncCount) {
   throw new Error(`Mismatched file counts: ${count} async !== ${syncCount} sync`);

--- a/bench/snippets/readdir.mjs
+++ b/bench/snippets/readdir.mjs
@@ -1,13 +1,30 @@
-import { readdirSync } from "fs";
+import { readdirSync, readdir as readdirCb } from "fs";
+import { readdir } from "fs/promises";
 import { bench, run } from "./runner.mjs";
 import { argv } from "process";
+import { fileURLToPath } from "url";
+import { relative, resolve } from "path";
 
-const dir = argv.length > 2 ? argv[2] : "/tmp";
+let dir = resolve(argv.length > 2 ? argv[2] : fileURLToPath(new URL("../../node_modules", import.meta.url)));
+if (dir.includes(process.cwd())) {
+  dir = relative(process.cwd(), dir);
+}
 
-const count = readdirSync(dir).length;
-bench(`readdir("${dir}")`, () => {
-  readdirSync(dir, { withFileTypes: true });
+const result = await readdir(dir, { recursive: true });
+const count = result.length;
+const syncCount = readdirSync(dir, { recursive: true }).length;
+
+bench(`await readdir("${dir}", {recursive: true})`, async () => {
+  await readdir(dir, { recursive: true });
+});
+
+bench(`await readdir("${dir}", {recursive: false})`, async () => {
+  await readdir(dir, { recursive: false });
 });
 
 await run();
-console.log("\n\nFor", count, "files/dirs in", dir);
+console.log("\n", count, "files/dirs in", dir);
+
+if (count !== syncCount) {
+  throw new Error(`Mismatched file counts: ${count} async !== ${syncCount} sync`);
+}

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -317,6 +317,7 @@ const Write = JSC.Node.Async.write;
 const Truncate = JSC.Node.Async.truncate;
 const FTruncate = JSC.Node.Async.ftruncate;
 const Readdir = JSC.Node.Async.readdir;
+const ReaddirRecursive = JSC.Node.Async.readdir_recursive;
 const Readv = JSC.Node.Async.readv;
 const Writev = JSC.Node.Async.writev;
 const Close = JSC.Node.Async.close;
@@ -375,6 +376,7 @@ pub const Task = TaggedPointerUnion(.{
     Truncate,
     FTruncate,
     Readdir,
+    ReaddirRecursive,
     Close,
     Rm,
     Rmdir,
@@ -819,6 +821,10 @@ pub const EventLoop = struct {
                 },
                 @field(Task.Tag, typeBaseName(@typeName(Readdir))) => {
                     var any: *Readdir = task.get(Readdir).?;
+                    any.runFromJSThread();
+                },
+                @field(Task.Tag, typeBaseName(@typeName(ReaddirRecursive))) => {
+                    var any: *ReaddirRecursive = task.get(ReaddirRecursive).?;
                     any.runFromJSThread();
                 },
                 @field(Task.Tag, typeBaseName(@typeName(Close))) => {

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -593,8 +593,17 @@ pub const AsyncReaddirRecursiveTask = struct {
         this.result_list.deinit();
         var batch = this.result_list_queue.popBatch();
         var iter = batch.iterator();
+        var to_destroy: ?*ResultListEntry = null;
+
         while (iter.next()) |val| {
             val.value.deinit();
+            if (to_destroy) |dest| {
+                bun.default_allocator.destroy(dest);
+            }
+            to_destroy = val;
+        }
+        if (to_destroy) |dest| {
+            bun.default_allocator.destroy(dest);
         }
         this.result_list_count.store(0, .Monotonic);
     }

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -346,7 +346,7 @@ pub const AsyncReaddirRecursiveTask = struct {
     /// All the subtasks will use this fd to open files
     root_fd: FileDescriptor = bun.invalid_fd,
 
-    ///
+    /// This isued when joining the file paths for error messages
     root_path: PathString = PathString.empty,
 
     pending_err: ?Syscall.Error = null,

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -102,6 +102,8 @@ pub const Async = struct {
 
     pub const cp = AsyncCpTask;
 
+    pub const readdir_recursive = AsyncReaddirRecursiveTask;
+
     fn NewAsyncFSTask(comptime ReturnType: type, comptime ArgumentType: type, comptime Function: anytype) type {
         return struct {
             promise: JSC.JSPromise.Strong,
@@ -313,6 +315,340 @@ pub const AsyncCpTask = struct {
         this.args.deinit();
         this.promise.strong.deinit();
         this.arena.deinit();
+        bun.default_allocator.destroy(this);
+    }
+};
+
+pub const AsyncReaddirRecursiveTask = struct {
+    promise: JSC.JSPromise.Strong,
+    args: Arguments.Readdir,
+    globalObject: *JSC.JSGlobalObject,
+    task: JSC.WorkPoolTask = .{ .callback = &workPoolCallback },
+    ref: bun.Async.KeepAlive = .{},
+    tracker: JSC.AsyncTaskTracker,
+
+    // It's not 100% clear this one is necessary
+    has_result: std.atomic.Atomic(bool),
+
+    subtask_count: std.atomic.Atomic(usize),
+
+    /// The final result list
+    result_list: ResultListEntry.Value = undefined,
+
+    /// When joining the result list, we use this to preallocate the joined array.
+    result_list_count: std.atomic.Atomic(usize) = std.atomic.Atomic(usize).init(0),
+
+    /// A lockless queue of result lists.
+    ///
+    /// Using a lockless queue instead of mutex + joining the lists as we go was a meaningful performance improvement
+    result_list_queue: ResultListEntry.Queue = ResultListEntry.Queue{},
+
+    /// All the subtasks will use this fd to open files
+    root_fd: FileDescriptor = bun.invalid_fd,
+
+    ///
+    root_path: PathString = PathString.empty,
+
+    pending_err: ?Syscall.Error = null,
+    pending_err_mutex: bun.Lock = bun.Lock.init(),
+
+    pub const ResultListEntry = struct {
+        pub const Value = union(Return.Readdir.Tag) {
+            with_file_types: std.ArrayList(Dirent),
+            buffers: std.ArrayList(Buffer),
+            files: std.ArrayList(bun.String),
+
+            pub fn deinit(this: *@This()) void {
+                switch (this.*) {
+                    .with_file_types => |*res| {
+                        for (res.items) |item| {
+                            item.name.deref();
+                        }
+                        res.clearAndFree();
+                    },
+                    .buffers => |*res| {
+                        for (res.items) |item| {
+                            bun.default_allocator.free(item.buffer.byteSlice());
+                        }
+                        res.clearAndFree();
+                    },
+                    .files => |*res| {
+                        for (res.items) |item| {
+                            item.deref();
+                        }
+
+                        res.clearAndFree();
+                    },
+                }
+            }
+        };
+        next: ?*ResultListEntry = null,
+        value: Value,
+
+        pub const Queue = bun.UnboundedQueue(ResultListEntry, .next);
+    };
+
+    pub const Subtask = struct {
+        readdir_task: *AsyncReaddirRecursiveTask,
+        basename: bun.PathString = bun.PathString.empty,
+        task: JSC.WorkPoolTask = .{ .callback = call },
+
+        pub fn call(task: *JSC.WorkPoolTask) void {
+            var this: *Subtask = @fieldParentPtr(Subtask, "task", task);
+            defer {
+                bun.default_allocator.free(this.basename.sliceAssumeZ());
+                bun.default_allocator.destroy(this);
+            }
+            var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+            this.readdir_task.performWork(this.basename.sliceAssumeZ(), &buf, false);
+        }
+    };
+
+    pub fn enqueue(
+        readdir_task: *AsyncReaddirRecursiveTask,
+        basename: [:0]const u8,
+    ) void {
+        var task = bun.default_allocator.create(Subtask) catch bun.outOfMemory();
+        task.* = Subtask{
+            .readdir_task = readdir_task,
+            .basename = bun.PathString.init(bun.default_allocator.dupeZ(u8, basename) catch bun.outOfMemory()),
+        };
+        std.debug.assert(readdir_task.subtask_count.fetchAdd(1, .Monotonic) > 0);
+        JSC.WorkPool.schedule(&task.task);
+    }
+
+    pub fn create(
+        globalObject: *JSC.JSGlobalObject,
+        args: Arguments.Readdir,
+        vm: *JSC.VirtualMachine,
+    ) JSC.JSValue {
+        if (comptime Environment.isWindows) {
+            globalObject.throwTODO("fs.promises.readdir is not implemented on Windows yet");
+            return .zero;
+        }
+
+        var task = bun.default_allocator.create(AsyncReaddirRecursiveTask) catch bun.outOfMemory();
+        task.* = AsyncReaddirRecursiveTask{
+            .promise = JSC.JSPromise.Strong.init(globalObject),
+            .args = args,
+            .has_result = .{ .value = false },
+            .globalObject = globalObject,
+            .tracker = JSC.AsyncTaskTracker.init(vm),
+            .subtask_count = .{ .value = 1 },
+            .root_path = PathString.init(bun.default_allocator.dupeZ(u8, args.path.slice()) catch bun.outOfMemory()),
+            .result_list = switch (args.tag()) {
+                .files => .{ .files = std.ArrayList(bun.String).init(bun.default_allocator) },
+                .with_file_types => .{ .with_file_types = std.ArrayList(Dirent).init(bun.default_allocator) },
+                .buffers => .{ .buffers = std.ArrayList(Buffer).init(bun.default_allocator) },
+            },
+        };
+        task.ref.ref(vm);
+        task.args.toThreadSafe();
+        task.tracker.didSchedule(globalObject);
+
+        JSC.WorkPool.schedule(&task.task);
+
+        return task.promise.value();
+    }
+
+    pub fn performWork(this: *AsyncReaddirRecursiveTask, basename: [:0]const u8, buf: *[bun.MAX_PATH_BYTES]u8, comptime is_root: bool) void {
+        switch (this.args.tag()) {
+            inline else => |tag| {
+                const ResultType = comptime switch (tag) {
+                    .files => bun.String,
+                    .with_file_types => Dirent,
+                    .buffers => Buffer,
+                };
+                var stack = std.heap.stackFallback(8192, bun.default_allocator);
+
+                // This is a stack-local copy to avoid resizing heap-allocated arrays in the common case of a small directory
+                var entries = std.ArrayList(ResultType).init(stack.get());
+
+                defer entries.deinit();
+
+                switch (NodeFS.readdirWithEntriesRecursiveAsync(
+                    buf,
+                    this.args,
+                    this,
+                    basename,
+                    ResultType,
+                    &entries,
+                    is_root,
+                )) {
+                    .err => |err| {
+                        for (entries.items) |*item| {
+                            switch (comptime ResultType) {
+                                bun.String => item.deref(),
+                                Dirent => item.name.deref(),
+                                Buffer => bun.default_allocator.free(item.buffer.byteSlice()),
+                                else => unreachable,
+                            }
+                        }
+
+                        {
+                            this.pending_err_mutex.lock();
+                            defer this.pending_err_mutex.unlock();
+                            if (this.pending_err == null) {
+                                const err_path = if (err.path.len > 0) err.path else this.args.path.slice();
+                                this.pending_err = err.withPath(bun.default_allocator.dupe(u8, err_path) catch "");
+                            }
+                        }
+
+                        if (this.subtask_count.fetchSub(1, .Monotonic) == 1) {
+                            this.finishConcurrently();
+                        }
+                    },
+                    .result => {
+                        this.writeResults(ResultType, &entries);
+                    },
+                }
+            },
+        }
+    }
+
+    fn workPoolCallback(task: *JSC.WorkPoolTask) void {
+        var this: *AsyncReaddirRecursiveTask = @fieldParentPtr(AsyncReaddirRecursiveTask, "task", task);
+        var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+        this.performWork(this.root_path.sliceAssumeZ(), &buf, true);
+    }
+
+    pub fn writeResults(this: *AsyncReaddirRecursiveTask, comptime ResultType: type, result: *std.ArrayList(ResultType)) void {
+        if (result.items.len > 0) {
+            const Field = comptime switch (ResultType) {
+                bun.String => .files,
+                Dirent => .with_file_types,
+                Buffer => .buffers,
+                else => unreachable,
+            };
+            var list = bun.default_allocator.create(ResultListEntry) catch bun.outOfMemory();
+            errdefer {
+                bun.default_allocator.destroy(list);
+            }
+            var clone = std.ArrayList(ResultType).initCapacity(bun.default_allocator, result.items.len) catch bun.outOfMemory();
+            clone.appendSliceAssumeCapacity(result.items);
+            _ = this.result_list_count.fetchAdd(clone.items.len, .Monotonic);
+            list.* = ResultListEntry{ .next = null, .value = @unionInit(ResultListEntry.Value, @tagName(Field), clone) };
+            this.result_list_queue.push(list);
+        }
+
+        if (this.subtask_count.fetchSub(1, .Monotonic) == 1) {
+            this.finishConcurrently();
+        }
+    }
+
+    /// May be called from any thread (the subtasks)
+    pub fn finishConcurrently(this: *AsyncReaddirRecursiveTask) void {
+        if (this.has_result.compareAndSwap(false, true, .Monotonic, .Monotonic)) |_| {
+            return;
+        }
+
+        std.debug.assert(this.subtask_count.load(.Monotonic) == 0);
+
+        const root_fd = this.root_fd;
+        if (root_fd != bun.invalid_fd) {
+            this.root_fd = bun.invalid_fd;
+            _ = Syscall.close(root_fd);
+            bun.default_allocator.free(this.root_path.slice());
+            this.root_path = PathString.empty;
+        }
+
+        if (this.pending_err != null) {
+            this.clearResultList();
+        }
+
+        {
+            var list = this.result_list_queue.popBatch();
+            var iter = list.iterator();
+
+            // we have to free only the previous one because the next value will
+            // be read by the iterator.
+            var to_destroy: ?*ResultListEntry = null;
+
+            switch (this.args.tag()) {
+                inline else => |tag| {
+                    var results = &@field(this.result_list, @tagName(tag));
+                    results.ensureTotalCapacityPrecise(this.result_list_count.swap(0, .Monotonic)) catch bun.outOfMemory();
+                    while (iter.next()) |val| {
+                        if (to_destroy) |dest| {
+                            bun.default_allocator.destroy(dest);
+                        }
+                        to_destroy = val;
+
+                        var to_copy = &@field(val.value, @tagName(tag));
+                        results.appendSliceAssumeCapacity(to_copy.items);
+                        to_copy.clearAndFree();
+                    }
+
+                    if (to_destroy) |dest| {
+                        bun.default_allocator.destroy(dest);
+                    }
+                },
+            }
+        }
+
+        this.globalObject.bunVMConcurrently().enqueueTaskConcurrent(JSC.ConcurrentTask.create(JSC.Task.init(this)));
+    }
+
+    fn clearResultList(this: *AsyncReaddirRecursiveTask) void {
+        this.result_list.deinit();
+        var batch = this.result_list_queue.popBatch();
+        var iter = batch.iterator();
+        while (iter.next()) |val| {
+            val.value.deinit();
+        }
+        this.result_list_count.store(0, .Monotonic);
+    }
+
+    pub fn runFromJSThread(this: *AsyncReaddirRecursiveTask) void {
+        var globalObject = this.globalObject;
+        var success = this.pending_err == null;
+        const result = if (this.pending_err) |*err| err.toJSC(globalObject) else brk: {
+            const res = switch (this.result_list) {
+                .with_file_types => |*res| Return.Readdir{ .with_file_types = res.moveToUnmanaged().items },
+                .buffers => |*res| Return.Readdir{ .buffers = res.moveToUnmanaged().items },
+                .files => |*res| Return.Readdir{ .files = res.moveToUnmanaged().items },
+            };
+            var exceptionref: JSC.C.JSValueRef = null;
+            const out = res.toJS(globalObject, &exceptionref);
+            const exception = JSC.JSValue.c(exceptionref);
+            if (exception != .zero) {
+                success = false;
+                break :brk exception;
+            }
+
+            break :brk out.?.value();
+        };
+        var promise_value = this.promise.value();
+        var promise = this.promise.get();
+        promise_value.ensureStillAlive();
+
+        const tracker = this.tracker;
+        tracker.willDispatch(globalObject);
+        defer tracker.didDispatch(globalObject);
+
+        this.deinit();
+        switch (success) {
+            false => {
+                promise.reject(globalObject, result);
+            },
+            true => {
+                promise.resolve(globalObject, result);
+            },
+        }
+    }
+
+    pub fn deinit(this: *AsyncReaddirRecursiveTask) void {
+        std.debug.assert(this.root_fd == bun.invalid_fd); // should already have closed it
+        if (this.pending_err) |*err| {
+            bun.default_allocator.free(err.path);
+        }
+
+        this.ref.unref(this.globalObject.bunVM());
+        this.args.deinit();
+        bun.default_allocator.free(this.root_path.slice());
+        this.clearResultList();
+        this.promise.strong.deinit();
+
         bun.default_allocator.destroy(this);
     }
 };
@@ -1644,6 +1980,7 @@ pub const Arguments = struct {
         path: PathLike,
         encoding: Encoding = Encoding.utf8,
         with_file_types: bool = false,
+        recursive: bool = false,
 
         pub fn deinit(this: Readdir) void {
             this.path.deinit();
@@ -1655,6 +1992,16 @@ pub const Arguments = struct {
 
         pub fn toThreadSafe(this: *Readdir) void {
             this.path.toThreadSafe();
+        }
+
+        pub fn tag(this: *const Readdir) Return.Readdir.Tag {
+            return switch (this.encoding) {
+                .buffer => .buffers,
+                else => if (this.with_file_types)
+                    .with_file_types
+                else
+                    .files,
+            };
         }
 
         pub fn fromJS(ctx: JSC.C.JSContextRef, arguments: *ArgumentsSlice, exception: JSC.C.ExceptionRef) ?Readdir {
@@ -1674,6 +2021,7 @@ pub const Arguments = struct {
 
             var encoding = Encoding.utf8;
             var with_file_types = false;
+            var recursive = false;
 
             if (arguments.next()) |val| {
                 arguments.eat();
@@ -1686,6 +2034,13 @@ pub const Arguments = struct {
                         if (val.isObject()) {
                             if (val.getIfPropertyExists(ctx.ptr(), "encoding")) |encoding_| {
                                 encoding = Encoding.fromJS(encoding_, ctx.ptr()) orelse Encoding.utf8;
+                            }
+
+                            if (val.getOptional(ctx.ptr(), "recursive", bool) catch {
+                                path.deinit();
+                                return null;
+                            }) |recursive_| {
+                                recursive = recursive_;
                             }
 
                             if (val.getOptional(ctx.ptr(), "withFileTypes", bool) catch {
@@ -1703,6 +2058,7 @@ pub const Arguments = struct {
                 .path = path,
                 .encoding = encoding,
                 .with_file_types = with_file_types,
+                .recursive = recursive,
             };
         }
     };
@@ -4121,62 +4477,31 @@ pub const NodeFS = struct {
     }
 
     pub fn readdir(this: *NodeFS, args: Arguments.Readdir, comptime flavor: Flavor) Maybe(Return.Readdir) {
-        return switch (args.encoding) {
-            .buffer => _readdir(
-                &this.sync_error_buf,
-                args,
-                Buffer,
-                flavor,
-            ),
-            else => {
-                if (!args.with_file_types) {
-                    return _readdir(
-                        &this.sync_error_buf,
-                        args,
-                        bun.String,
-                        flavor,
-                    );
-                }
+        if (comptime flavor != .sync) {
+            if (args.recursive) {
+                @panic("Assertion failure: this code path should never be reached.");
+            }
+        }
 
-                return _readdir(
-                    &this.sync_error_buf,
-                    args,
-                    Dirent,
-                    flavor,
-                );
+        return switch (args.recursive) {
+            inline else => |recursive| switch (args.tag()) {
+                .buffers => _readdir(&this.sync_error_buf, args, Buffer, recursive, flavor),
+                .with_file_types => _readdir(&this.sync_error_buf, args, Dirent, recursive, flavor),
+                .files => _readdir(&this.sync_error_buf, args, bun.String, recursive, flavor),
             },
         };
     }
 
-    pub fn _readdir(
-        buf: *[bun.MAX_PATH_BYTES]u8,
+    fn readdirWithEntries(
         args: Arguments.Readdir,
+        fd: bun.FileDescriptor,
         comptime ExpectedType: type,
-        comptime _: Flavor,
-    ) Maybe(Return.Readdir) {
-        const file_type = comptime switch (ExpectedType) {
-            Dirent => "with_file_types",
-            bun.String => "files",
-            Buffer => "buffers",
-            else => unreachable,
-        };
-
-        var path = args.path.sliceZ(buf);
-        const flags = os.O.DIRECTORY | os.O.RDONLY;
-        const fd = switch (Syscall.open(path, flags, 0)) {
-            .err => |err| return .{
-                .err = err.withPath(args.path.slice()),
-            },
-            .result => |fd_| fd_,
-        };
-        defer {
-            _ = Syscall.close(fd);
-        }
-
-        var entries = std.ArrayList(ExpectedType).init(bun.default_allocator);
+        entries: *std.ArrayList(ExpectedType),
+    ) Maybe(void) {
         var dir = std.fs.Dir{ .fd = bun.fdcast(fd) };
         var iterator = DirIterator.iterate(dir);
         var entry = iterator.next();
+
         while (switch (entry) {
             .err => |err| {
                 for (entries.items) |*item| {
@@ -4208,19 +4533,335 @@ pub const NodeFS = struct {
                     entries.append(.{
                         .name = bun.String.create(utf8_name),
                         .kind = current.kind,
-                    }) catch unreachable;
+                    }) catch bun.outOfMemory();
                 },
                 Buffer => {
-                    entries.append(Buffer.fromString(utf8_name, bun.default_allocator) catch unreachable) catch unreachable;
+                    entries.append(Buffer.fromString(utf8_name, bun.default_allocator) catch bun.outOfMemory()) catch bun.outOfMemory();
                 },
                 bun.String => {
-                    entries.append(bun.String.create(utf8_name)) catch unreachable;
+                    entries.append(bun.String.create(utf8_name)) catch bun.outOfMemory();
                 },
                 else => unreachable,
             }
         }
 
-        return .{ .result = @unionInit(Return.Readdir, file_type, entries.items) };
+        return Maybe(void).success;
+    }
+
+    pub fn readdirWithEntriesRecursiveAsync(
+        buf: *[bun.MAX_PATH_BYTES]u8,
+        args: Arguments.Readdir,
+        async_task: *AsyncReaddirRecursiveTask,
+        basename: [:0]const u8,
+        comptime ExpectedType: type,
+        entries: *std.ArrayList(ExpectedType),
+        comptime is_root: bool,
+    ) Maybe(void) {
+        const flags = os.O.DIRECTORY | os.O.RDONLY;
+        const fd = switch (Syscall.openat(if (comptime is_root) bun.toFD(std.fs.cwd().fd) else async_task.root_fd, basename, flags, 0)) {
+            .err => |err| {
+                if (comptime !is_root) {
+                    switch (err.getErrno()) {
+                        // These things can happen and there's nothing we can do about it.
+                        //
+                        // This is different than what Node does, at the time of writing.
+                        // Node doesn't gracefully handle errors like these. It fails the entire operation.
+                        .NOENT, .NOTDIR, .PERM => {
+                            return Maybe(void).success;
+                        },
+                        else => {},
+                    }
+
+                    const path_parts = [_]string{ async_task.root_path.slice(), basename };
+                    return .{
+                        .err = err.withPath(bun.path.joinZBuf(buf, &path_parts, .auto)),
+                    };
+                }
+
+                return .{
+                    .err = err.withPath(args.path.slice()),
+                };
+            },
+            .result => |fd_| fd_,
+        };
+
+        if (comptime is_root) {
+            async_task.root_fd = fd;
+        }
+
+        defer {
+            if (comptime !is_root) {
+                _ = Syscall.close(fd);
+            }
+        }
+
+        var iterator = DirIterator.iterate(.{ .fd = bun.fdcast(fd) });
+        var entry = iterator.next();
+
+        while (switch (entry) {
+            .err => |err| {
+                if (comptime !is_root) {
+                    const path_parts = [_]string{ async_task.root_path.slice(), basename };
+                    return .{
+                        .err = err.withPath(bun.path.joinZBuf(buf, &path_parts, .auto)),
+                    };
+                }
+
+                return .{
+                    .err = err.withPath(args.path.slice()),
+                };
+            },
+            .result => |ent| ent,
+        }) |current| : (entry = iterator.next()) {
+            const utf8_name = current.name.slice();
+
+            const name_to_copy: [:0]const u8 = brk: {
+                if (async_task.root_path.sliceAssumeZ().ptr == basename.ptr) {
+                    break :brk @ptrCast(utf8_name);
+                }
+
+                const path_parts = [_]string{ basename, utf8_name };
+                break :brk bun.path.joinZBuf(buf, &path_parts, .auto);
+            };
+
+            enqueue: {
+                switch (current.kind) {
+                    // a symlink might be a directory or might not be
+                    // if it's not a directory, the task will fail at that point.
+                    .sym_link,
+
+                    // we know for sure it's a directory
+                    .directory,
+                    => {
+                        // if the name is too long, we can't enqueue it regardless
+                        // the operating system would just return ENAMETOOLONG
+                        //
+                        // Technically, we could work around that due to the
+                        // usage of openat, but then we risk leaving too many
+                        // file descriptors open.
+                        if (current.name.len + 1 + name_to_copy.len > bun.MAX_PATH_BYTES) break :enqueue;
+
+                        async_task.enqueue(name_to_copy);
+                    },
+                    else => {},
+                }
+            }
+
+            switch (comptime ExpectedType) {
+                Dirent => {
+                    entries.append(.{
+                        .name = bun.String.create(name_to_copy),
+                        .kind = current.kind,
+                    }) catch bun.outOfMemory();
+                },
+                Buffer => {
+                    entries.append(Buffer.fromString(name_to_copy, bun.default_allocator) catch bun.outOfMemory()) catch bun.outOfMemory();
+                },
+                bun.String => {
+                    entries.append(bun.String.create(name_to_copy)) catch bun.outOfMemory();
+                },
+                else => bun.outOfMemory(),
+            }
+        }
+
+        return Maybe(void).success;
+    }
+
+    fn readdirWithEntriesRecursiveSync(
+        buf: *[bun.MAX_PATH_BYTES]u8,
+        args: Arguments.Readdir,
+        root_basename: [:0]const u8,
+        comptime ExpectedType: type,
+        entries: *std.ArrayList(ExpectedType),
+    ) Maybe(void) {
+        var iterator_stack = std.heap.stackFallback(128, bun.default_allocator);
+        var stack = std.fifo.LinearFifo([:0]const u8, .{ .Dynamic = {} }).init(iterator_stack.get());
+        var basename_stack = std.heap.stackFallback(8192 * 2, bun.default_allocator);
+        const basename_allocator = basename_stack.get();
+        defer {
+            while (stack.readItem()) |name| {
+                basename_allocator.free(name);
+            }
+            stack.deinit();
+        }
+
+        stack.writeItem(root_basename) catch unreachable;
+        var root_fd: bun.FileDescriptor = bun.invalid_fd;
+
+        defer {
+            // all other paths are relative to the root directory
+            // so we can only close it once we're 100% done
+            if (root_fd != bun.invalid_fd) {
+                _ = Syscall.close(root_fd);
+            }
+        }
+
+        while (stack.readItem()) |basename| {
+            defer {
+                if (root_basename.ptr != basename.ptr) {
+                    basename_allocator.free(basename);
+                }
+            }
+
+            const flags = os.O.DIRECTORY | os.O.RDONLY;
+            const fd = switch (Syscall.openat(if (root_fd == bun.invalid_fd) std.fs.cwd().fd else root_fd, basename, flags, 0)) {
+                .err => |err| {
+                    if (root_fd == bun.invalid_fd) {
+                        return .{
+                            .err = err.withPath(args.path.slice()),
+                        };
+                    }
+
+                    switch (err.getErrno()) {
+                        // These things can happen and there's nothing we can do about it.
+                        //
+                        // This is different than what Node does, at the time of writing.
+                        // Node doesn't gracefully handle errors like these. It fails the entire operation.
+                        .NOENT, .NOTDIR, .PERM => continue,
+                        else => {
+                            const path_parts = [_]string{ args.path.slice(), basename };
+                            return .{
+                                .err = err.withPath(bun.default_allocator.dupe(u8, bun.path.joinZBuf(buf, &path_parts, .auto)) catch ""),
+                            };
+                        },
+                    }
+                },
+                .result => |fd_| fd_,
+            };
+            if (root_fd == bun.invalid_fd) {
+                root_fd = fd;
+            }
+
+            defer {
+                if (fd != root_fd) {
+                    _ = Syscall.close(fd);
+                }
+            }
+
+            var iterator = DirIterator.iterate(.{ .fd = bun.fdcast(fd) });
+            var entry = iterator.next();
+
+            while (switch (entry) {
+                .err => |err| {
+                    return .{
+                        .err = err.withPath(args.path.slice()),
+                    };
+                },
+                .result => |ent| ent,
+            }) |current| : (entry = iterator.next()) {
+                const utf8_name = current.name.slice();
+
+                const name_to_copy = brk: {
+                    if (root_basename.ptr == basename.ptr) {
+                        break :brk utf8_name;
+                    }
+
+                    const path_parts = [_]string{ basename, utf8_name };
+                    break :brk bun.path.joinZBuf(buf, &path_parts, .auto);
+                };
+
+                enqueue: {
+                    switch (current.kind) {
+                        // a symlink might be a directory or might not be
+                        // if it's not a directory, the task will fail at that point.
+                        .sym_link,
+
+                        // we know for sure it's a directory
+                        .directory,
+                        => {
+                            if (current.name.len + 1 + name_to_copy.len > bun.MAX_PATH_BYTES) break :enqueue;
+                            stack.writeItem(basename_allocator.dupeZ(u8, name_to_copy) catch break :enqueue) catch break :enqueue;
+                        },
+                        else => {},
+                    }
+                }
+
+                switch (comptime ExpectedType) {
+                    Dirent => {
+                        entries.append(.{
+                            .name = bun.String.create(name_to_copy),
+                            .kind = current.kind,
+                        }) catch bun.outOfMemory();
+                    },
+                    Buffer => {
+                        entries.append(Buffer.fromString(name_to_copy, bun.default_allocator) catch bun.outOfMemory()) catch bun.outOfMemory();
+                    },
+                    bun.String => {
+                        entries.append(bun.String.create(name_to_copy)) catch bun.outOfMemory();
+                    },
+                    else => @compileError("Impossible"),
+                }
+            }
+        }
+
+        return Maybe(void).success;
+    }
+
+    fn _readdir(
+        buf: *[bun.MAX_PATH_BYTES]u8,
+        args: Arguments.Readdir,
+        comptime ExpectedType: type,
+        comptime recursive: bool,
+        comptime flavor: Flavor,
+    ) Maybe(Return.Readdir) {
+        const file_type = comptime switch (ExpectedType) {
+            Dirent => "with_file_types",
+            bun.String => "files",
+            Buffer => "buffers",
+            else => unreachable,
+        };
+
+        var path = args.path.sliceZ(buf);
+        if (comptime recursive and flavor == .sync) {
+            var buf_to_pass: [bun.MAX_PATH_BYTES]u8 = undefined;
+
+            var entries = std.ArrayList(ExpectedType).init(bun.default_allocator);
+            return switch (readdirWithEntriesRecursiveSync(&buf_to_pass, args, path, ExpectedType, &entries)) {
+                .err => |err| {
+                    for (entries.items) |*result| {
+                        switch (comptime ExpectedType) {
+                            Dirent => {
+                                result.name.deref();
+                            },
+                            Buffer => {
+                                result.destroy();
+                            },
+                            bun.String => {
+                                result.deref();
+                            },
+                            else => unreachable,
+                        }
+                    }
+
+                    entries.deinit();
+
+                    return .{
+                        .err = err,
+                    };
+                },
+                .result => .{ .result = @unionInit(Return.Readdir, file_type, entries.items) },
+            };
+        }
+
+        if (comptime recursive) {
+            @panic("This code path should never be reached. It should only go through readdirWithEntriesRecursiveAsync.");
+        }
+
+        const flags = os.O.DIRECTORY | os.O.RDONLY;
+        const fd = switch (Syscall.open(path, flags, 0)) {
+            .err => |err| return .{
+                .err = err.withPath(args.path.slice()),
+            },
+            .result => |fd_| fd_,
+        };
+
+        var entries = std.ArrayList(ExpectedType).init(bun.default_allocator);
+        return switch (readdirWithEntries(args, fd, ExpectedType, &entries)) {
+            .err => |err| return .{
+                .err = err,
+            },
+            .result => .{ .result = @unionInit(Return.Readdir, file_type, entries.items) },
+        };
     }
 
     pub const StringType = enum {

--- a/src/bun.js/node/node_fs_binding.zig
+++ b/src/bun.js/node/node_fs_binding.zig
@@ -139,6 +139,12 @@ fn call(comptime FunctionEnum: NodeFSFunctionEnum) NodeFSFunction {
             if (comptime FunctionEnum == .cp) {
                 return Task.create(globalObject, args, globalObject.bunVM(), slice.arena);
             } else {
+                if (comptime FunctionEnum == .readdir) {
+                    if (args.recursive) {
+                        return JSC.Node.Async.readdir_recursive.create(globalObject, args, globalObject.bunVM());
+                    }
+                }
+
                 return Task.create(globalObject, args, globalObject.bunVM());
             }
         }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2052,3 +2052,7 @@ pub fn exitThread() noreturn {
         @panic("Unsupported platform");
     }
 }
+
+pub fn outOfMemory() noreturn {
+    @panic("Out of memory");
+}

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { dirname } from "node:path";
+import { dirname, resolve, relative } from "node:path";
 import { promisify } from "node:util";
 import { bunEnv, bunExe, gc } from "harness";
 import fs, {
@@ -940,7 +940,7 @@ it("realpath async", async () => {
     err ? reject(err) : resolve(path);
   });
   expect(await promise).toBe(realpathSync(import.meta.path));
-});
+}, 30_000);
 
 describe("stat", () => {
   it("file metadata is correct", () => {
@@ -1720,6 +1720,79 @@ describe("fs/promises", () => {
     const files = await promises.readdir(import.meta.dir);
     expect(files.length).toBeGreaterThan(0);
   });
+
+  it("readdir(path, {recursive: true}) produces the same result as Node.js", async () => {
+    const full = resolve(import.meta.dir, "../");
+    const [bun, subprocess] = await Promise.all([
+      (async function () {
+        console.time("readdir(path, {recursive: true})");
+        const files = await promises.readdir(full, { recursive: true });
+        files.sort();
+        console.timeEnd("readdir(path, {recursive: true})");
+        return files;
+      })(),
+      (async function () {
+        const subprocess = Bun.spawn({
+          cmd: [
+            "node",
+            "-e",
+            `process.stdout.write(JSON.stringify(require("fs").readdirSync(${JSON.stringify(
+              full,
+            )}, { recursive: true }).sort()), null, 2)`,
+          ],
+          cwd: process.cwd(),
+          stdout: "pipe",
+          stderr: "inherit",
+          stdin: "inherit",
+        });
+        await subprocess.exited;
+        return subprocess;
+      })(),
+    ]);
+
+    expect(subprocess.exitCode).toBe(0);
+    const text = await new Response(subprocess.stdout).text();
+    const node = JSON.parse(text);
+    expect(bun).toEqual(node as string[]);
+  }, 100000);
+
+  for (let withFileTypes of [false, true] as const) {
+    const doIt = async () => {
+      const maxFD = openSync("/dev/null", "r");
+      closeSync(maxFD);
+      const full = resolve(import.meta.dir, "../");
+
+      const pending = new Array(100);
+      for (let i = 0; i < 100; i++) {
+        pending[i] = promises.readdir(full, { recursive: true, withFileTypes });
+      }
+
+      const results = await Promise.all(pending);
+      for (let i = 0; i < 100; i++) {
+        results[i].sort();
+      }
+      expect(results[0].length).toBeGreaterThan(0);
+      for (let i = 1; i < 100; i++) {
+        expect(results[i]).toEqual(results[0]);
+      }
+
+      if (!withFileTypes) {
+        expect(results[0]).toContain(relative(full, import.meta.path));
+      }
+
+      const newMaxFD = openSync("/dev/null", "r");
+      closeSync(newMaxFD);
+      expect(maxFD).toBe(newMaxFD); // assert we do not leak file descriptors
+    };
+
+    if (withFileTypes) {
+      describe("withFileTypes", () => {
+        it("readdir(path, {recursive: true} should work x 100", doIt, 10_000);
+      });
+    } else {
+      it("readdir(path, {recursive: true} should work x 100", doIt, 10_000);
+    }
+  }
 
   it("readdir() no args doesnt segfault", async () => {
     const fizz = [


### PR DESCRIPTION
### What does this PR do?

This implements support for `readdir(path, {recursive: true})`

```js
import {readdir} from 'fs/promises';
const results = await readdir(__dirname, { recursive: true });
console.log(results) // ["a.js", "b/c.js" ...
```

### How did you verify your code works?

There are tests.