### PR TITLE
dx: automatically install and update zig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ function(validate_zig validator_result_var item)
     endif()
 endfunction()
 
-if (WIN32 OR ZIG_COMPILER OR CI)
+if (WIN32 OR ZIG_COMPILER)
     if(ZIG_COMPILER STREQUAL "system")
         unset(ZIG_COMPILER)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ function(validate_zig validator_result_var item)
     endif()
 endfunction()
 
-if (WIN32 OR ZIG_COMPILER)
+if (WIN32 OR ZIG_COMPILER OR ENV{CI})
     if(ZIG_COMPILER STREQUAL "system")
         unset(ZIG_COMPILER)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ function(validate_zig validator_result_var item)
     endif()
 endfunction()
 
-if (WIN32 OR ZIG_COMPILER OR ENV{CI})
+if (WIN32 OR ZIG_COMPILER OR CI)
     if(ZIG_COMPILER STREQUAL "system")
         unset(ZIG_COMPILER)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,8 +320,24 @@ function(validate_zig validator_result_var item)
     endif()
 endfunction()
 
-find_program(ZIG_COMPILER zig ${REQUIRED_IF_NOT_ONLY_CPP_OR_LINK} DOC "Path to the Zig compiler" VALIDATOR validate_zig)
-message(STATUS "Found Zig Compiler: ${ZIG_COMPILER}")
+if (WIN32 OR ZIG_COMPILER)
+    if(ZIG_COMPILER STREQUAL "system")
+        unset(ZIG_COMPILER)
+    endif()
+    find_program(ZIG_COMPILER zig ${REQUIRED_IF_NOT_ONLY_CPP_OR_LINK} DOC "Path to the Zig compiler" VALIDATOR validate_zig)
+    message(STATUS "Found Zig Compiler: ${ZIG_COMPILER}")
+elseif(NOT BUN_CPP_ONLY AND NOT BUN_LINK_ONLY)
+    execute_process(
+        COMMAND "${SHELL}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/scripts/download-zig.${SCRIPT_EXTENSION}"
+    )
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.cache/zig/zig")
+        message(FATAL_ERROR "Auto-installation of Zig failed. Please pass -DZIG_COMPILER=system or a path to the Zig")
+    endif()
+    set(ZIG_COMPILER "${CMAKE_CURRENT_SOURCE_DIR}/.cache/zig/zig")
+    message(STATUS "Installed Zig Compiler: ${ZIG_COMPILER}")
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "build.zig")
+endif()
 
 # Bun
 if(NOT WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,9 +322,11 @@ endfunction()
 
 if (WIN32 OR ZIG_COMPILER)
     if(ZIG_COMPILER STREQUAL "system")
-        unset(ZIG_COMPILER)
+        message(STATUS "Using system Zig compiler")
+        unset(ZIG_COMPILER_)
     endif()
-    find_program(ZIG_COMPILER zig ${REQUIRED_IF_NOT_ONLY_CPP_OR_LINK} DOC "Path to the Zig compiler" VALIDATOR validate_zig)
+    find_program(ZIG_COMPILER_ zig ${REQUIRED_IF_NOT_ONLY_CPP_OR_LINK} DOC "Path to the Zig compiler" VALIDATOR validate_zig)
+    set(ZIG_COMPILER "${ZIG_COMPILER_}")
     message(STATUS "Found Zig Compiler: ${ZIG_COMPILER}")
 elseif(NOT BUN_CPP_ONLY AND NOT BUN_LINK_ONLY)
     execute_process(

--- a/Dockerfile
+++ b/Dockerfile
@@ -428,6 +428,7 @@ RUN mkdir -p build \
   -DNO_CODEGEN=1 \
   -DBUN_ZIG_OBJ="/tmp/bun-zig.o" \
   -DCANARY="${CANARY}" \
+  -DZIG_COMPILER=system \
   && ONLY_ZIG=1 ninja "/tmp/bun-zig.o" -v
 
 FROM scratch as build_release_obj
@@ -483,6 +484,7 @@ RUN cmake .. \
   -DCPU_TARGET="${CPU_TARGET}" \
   -DNO_CONFIGURE_DEPENDS=1 \
   -DCANARY="${CANARY}" \
+  -DZIG_COMPILER=system \
   && ninja -v \
   && ./bun --revision \
   && mkdir -p /build/out \
@@ -538,6 +540,7 @@ RUN cmake .. \
   -DCPU_TARGET="${CPU_TARGET}" \
   -DNO_CONFIGURE_DEPENDS=1 \
   -DCANARY="${CANARY}" \
+  -DZIG_COMPILER=system \
   && ninja -v \
   && ./bun --revision \
   && mkdir -p /build/out \

--- a/Dockerfile
+++ b/Dockerfile
@@ -373,7 +373,7 @@ ENV CCACHE_DIR=/ccache
 RUN --mount=type=cache,target=/ccache  mkdir ${BUN_DIR}/build \
   && cd ${BUN_DIR}/build \
   && mkdir -p tmp_modules tmp_functions js codegen \
-  && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_DEBUG_JSC=${ASSERTIONS} -DBUN_CPP_ONLY=1 -DWEBKIT_DIR=/build/bun/bun-webkit -DCANARY=${CANARY} \
+  && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_DEBUG_JSC=${ASSERTIONS} -DBUN_CPP_ONLY=1 -DWEBKIT_DIR=/build/bun/bun-webkit -DCANARY=${CANARY} -DZIG_COMPILER=system \
   && bash compile-cpp-only.sh -v
 
 FROM bun-base-with-zig as bun-codegen-for-zig

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -105,19 +105,6 @@ $ export PATH="$PATH:/usr/lib/llvm16/bin"
 
 {% /codetabs %}
 
-## Install Zig
-
-Zig can be installed either with our npm package [`@oven/zig`](https://www.npmjs.com/package/@oven/zig), or by using [zigup](https://github.com/marler8997/zigup).
-
-```bash
-$ bun install -g @oven/zig
-$ zigup 0.12.0-dev.1604+caae40c21
-```
-
-{% callout %}
-We last updated Zig on **October 26th, 2023**
-{% /callout %}
-
 ## Building Bun
 
 After cloning the repository, run the following command to run the first build. This may take a while as it will clone submodules and build dependencies.

--- a/scripts/download-webkit.sh
+++ b/scripts/download-webkit.sh
@@ -35,18 +35,9 @@ tar="$tar_dir/$PKG-$TAG.tar.gz"
 mkdir -p "$OUTDIR"
 mkdir -p "$tar_dir"
 
-# TODO: Remove this block, future builds may not include a package.json
-if [ -f "$OUTDIR/package.json" ]; then
-  read_version=$(grep -o '"version": "[^"]*"' "$OUTDIR/package.json" | sed 's/"version": "\(.*\)"/\1/' 2>/dev/null)
-  if [ "$read_version" == "0.0.1-$TAG" ]; then
-    echo "$TAG" > "$OUTDIR/.tag"
-    exit 0
-  fi
-fi
-
 if [ -f "$OUTDIR/.tag" ]; then
   read_tag="$(cat "$OUTDIR/.tag")"
-  if [ "$read_tag" == "$TAG" ]; then
+  if [ "$read_tag" == "$PKG" ]; then
     exit 0
   fi
 fi
@@ -63,4 +54,4 @@ fi
 
 tar -xzf "$tar" -C "$(dirname "$OUTDIR")" || (rm "$tar" && exit 1)
 
-echo "$TAG" > "$OUTDIR/.tag"
+echo "$PKG" > "$OUTDIR/.tag"

--- a/scripts/download-zig.sh
+++ b/scripts/download-zig.sh
@@ -36,8 +36,31 @@ url="https://ziglang.org/builds/zig-${platform}-${arch}-${zig_version}.tar.xz"
 dest=".cache/zig-${zig_version}.tar.xz"
 extract_at=".cache/zig"
 
+update_repo_if_needed() {
+  if [ "$update_repo" == "true" ]; then
+    files=(
+      build.zig
+      Dockerfile
+
+      .github/workflows/*
+
+      docs/project/contributing.md
+      docs/project/building-windows.md
+    );
+
+    zig_version_previous=$(grep 'recommended_zig_version = "' "build.zig" | cut -d'"' -f2)
+
+    for file in ${files[@]}; do
+      sed -i '' 's/'"${zig_version_previous}"'/'"${zig_version}"'/g' "$file"
+    done
+
+    printf "Zig was updated to ${zig_version}. Please commit new files."
+  fi
+}
+
 if [ -e "${extract_at}/.version" ]; then
   if [ "$(cat "${extract_at}/.version")" == "${zig_version}" ]; then
+    update_repo_if_needed
     exit 0
   fi
 fi
@@ -53,8 +76,4 @@ tar -xzf "${dest}" -C "${extract_at}" --strip-components=1
 
 echo "${zig_version}" > "${extract_at}/.version"
 
-printf "-- Installed Zig v%s to %s\n" "${zig_version}" "./.cache/zig"
-
-if [ "$update_repo" == "true" ]; then
-  # TODO:
-fi
+update_repo_if_needed

--- a/scripts/download-zig.sh
+++ b/scripts/download-zig.sh
@@ -14,27 +14,34 @@ else
   zig_version=$(grep 'recommended_zig_version = "' "build.zig" | cut -d'"' -f2)
 fi
 
-unamestr=$(uname)
-if [[ "$unamestr" == 'Linux' ]]; then
-  platform='linux'
-elif [[ "$unamestr" == 'Darwin' ]]; then
-  platform='macos'
-else
-  printf "error: cannot get platform name from '%s'\n" "${unamestr}"
-  exit 1
-fi
-
-# i dont think this works
-arch=$(uname -m)
-if [[ "$arch" == *'arm64'* ]]; then
-  arch="aarch64"
-elif [[ "$arch" == *"x86_64"* ]]; then
-  arch="x86_64"
-fi
+case $(uname -ms) in
+'Darwin x86_64')
+    target='macos'
+    arch='x86_64'
+    ;;
+'Darwin arm64')
+    target='macos'
+    arch='aarch64'
+    ;;
+'Linux aarch64' | 'Linux arm64')
+    target='linux'
+    arch='aarch64'
+    ;;
+'Linux x86_64')
+    target='linux'
+    arch='aarch64'
+    ;;
+*)
+    printf "error: cannot get platform name from '%s'\n" "${unamestr}"
+    exit 1
+    ;;
+esac
 
 url="https://ziglang.org/builds/zig-${platform}-${arch}-${zig_version}.tar.xz"
 dest=".cache/zig-${zig_version}.tar.xz"
 extract_at=".cache/zig"
+
+mkdir -p ".cache"
 
 update_repo_if_needed() {
   if [ "$update_repo" == "true" ]; then
@@ -59,21 +66,21 @@ update_repo_if_needed() {
 }
 
 if [ -e "${extract_at}/.version" ]; then
-  if [ "$(cat "${extract_at}/.version")" == "${zig_version}" ]; then
+  if [ "$(cat "${extract_at}/.version")" == "${url}" ]; then
     update_repo_if_needed
     exit 0
   fi
 fi
 
 if ! [ -e "${dest}" ]; then
-  printf "Downloading Zig v%s\n" "${zig_version}"
+  printf "-- Downloading Zig v%s\n" "${zig_version}"
   curl -o "$dest" -L "$url"
 fi
 
 rm -rf "${extract_at}"
-mkdir "${extract_at}"
+mkdir -p "${extract_at}"
 tar -xzf "${dest}" -C "${extract_at}" --strip-components=1
 
-echo "${zig_version}" > "${extract_at}/.version"
+echo "${url}" > "${extract_at}/.version"
 
 update_repo_if_needed

--- a/scripts/download-zig.sh
+++ b/scripts/download-zig.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -e
+cd $(dirname $(dirname "${BASH_SOURCE[0]}"))
+
+zig_version=""
+if [ -n "$1" ]; then
+  zig_version="$1"
+  update_repo=true
+
+  if [ "$zig_version" == "master" ]; then
+    zig_version=$(curl -fsSL https://ziglang.org/download/index.json | jq -r .master.version)
+  fi
+else
+  zig_version=$(grep 'recommended_zig_version = "' "build.zig" | cut -d'"' -f2)
+fi
+
+unamestr=$(uname)
+if [[ "$unamestr" == 'Linux' ]]; then
+  platform='linux'
+elif [[ "$unamestr" == 'Darwin' ]]; then
+  platform='macos'
+else
+  printf "error: cannot get platform name from '%s'\n" "${unamestr}"
+  exit 1
+fi
+
+# i dont think this works
+arch=$(uname -m)
+if [[ "$arch" == *'arm64'* ]]; then
+  arch="aarch64"
+elif [[ "$arch" == *"x86_64"* ]]; then
+  arch="x86_64"
+fi
+
+url="https://ziglang.org/builds/zig-${platform}-${arch}-${zig_version}.tar.xz"
+dest=".cache/zig-${zig_version}.tar.xz"
+extract_at=".cache/zig"
+
+if [ -e "${extract_at}/.version" ]; then
+  if [ "$(cat "${extract_at}/.version")" == "${zig_version}" ]; then
+    exit 0
+  fi
+fi
+
+if ! [ -e "${dest}" ]; then
+  printf "Downloading Zig v%s\n" "${zig_version}"
+  curl -o "$dest" -L "$url"
+fi
+
+rm -rf "${extract_at}"
+mkdir "${extract_at}"
+tar -xzf "${dest}" -C "${extract_at}" --strip-components=1
+
+echo "${zig_version}" > "${extract_at}/.version"
+
+printf "-- Installed Zig v%s to %s\n" "${zig_version}" "./.cache/zig"
+
+if [ "$update_repo" == "true" ]; then
+  # TODO:
+fi

--- a/scripts/setup-zig.ps1
+++ b/scripts/setup-zig.ps1
@@ -1,7 +1,0 @@
-# TODO(@paperdave): finalize this script out
-$ZigVersion = "0.12.0-dev.1604+caae40c21"
-
-$Url = "https://ziglang.org/builds/zig-windows-x86_64-${ZigVersion}.zip"
-
-Invoke-WebRequest $Url -OutFile .cache\zig-${ZigVersion}.zip
-Expand-Archive zig-${ZigVersion}.zip

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -71,7 +71,14 @@ make runtime_js fallback_decoder bun_error node-fallbacks
 
 mkdir -p build
 rm -f build/CMakeCache.txt
-cmake -B build -S . -DUSE_DEBUG_JSC=ON -DCMAKE_BUILD_TYPE=Debug -G Ninja -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX"
+cmake -B build -S . \
+  -G Ninja \
+  -DUSE_DEBUG_JSC=ON \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_C_COMPILER="$CC" \
+  -DCMAKE_CXX_COMPILER="$CXX" \
+  -UZIG_COMPILER "$*" \
+
 ninja -C build
 
 printf "Checking if built bun functions\n"


### PR DESCRIPTION
### What does this PR do?

this makes it much harder for someone to use the wrong version of zig when compiling. by default `bun setup` will auto-install the version specified in `build.zig`. this also makes cmake configure_depends on build.zig, which will make it so auto-updates happen here.

unless you manually specify -DZIG_COMPILER, you cant really mess this up

also if you run `zig build`, you get

```
Build darwin-aarch64 v11.0.0 - v13.6.1 (apple_m1)
Zig v0.12.0-dev.1685+994e19164

error: To build Bun from source, please use `bun run setup` instead of `zig build`"

If you want to build the zig code only, run:
  'zig build obj -Dgenerated-code=./build/codegen [...opts]'

For more info, see https://bun.sh/docs/project/contributing
```

also for new zig upgrades: `bash scripts/update-zig.sh master`