### PR TITLE
Add `import.meta.env` to `bun-types`

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -306,6 +306,14 @@ interface ImportMeta {
    */
   readonly file: string;
   /**
+   * The environment variables of the process
+   * 
+   * ```
+   * import.meta.env === process.env 
+   * ```
+   */
+  readonly env: import("bun").Env;
+  /**
    * Resolve a module ID the same as if you imported it
    *
    * On failure, throws a `ResolveMessage`

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -308,7 +308,7 @@ interface ImportMeta {
   /**
    * The environment variables of the process
    * 
-   * ```
+   * ```ts
    * import.meta.env === process.env 
    * ```
    */


### PR DESCRIPTION
### What does this PR do?

`import.meta.env` was missing from bun types, so I added.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
