### PR TITLE
Clean up lifetime handling for `napi_create_string_utf16`

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -307,9 +307,9 @@ interface ImportMeta {
   readonly file: string;
   /**
    * The environment variables of the process
-   * 
+   *
    * ```ts
-   * import.meta.env === process.env 
+   * import.meta.env === process.env
    * ```
    */
   readonly env: import("bun").Env;

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -772,15 +772,7 @@ pub export fn napi_is_arraybuffer(_: napi_env, value: napi_value, result: *bool)
     result.* = !value.isNumber() and value.jsTypeLoose() == .ArrayBuffer;
     return .ok;
 }
-pub export fn napi_create_arraybuffer(env: napi_env, byte_length: usize, data: [*]const u8, result: *napi_value) napi_status {
-    log("napi_create_arraybuffer", .{});
-    var typed_array = JSC.C.JSObjectMakeTypedArray(env.ref(), .kJSTypedArrayTypeArrayBuffer, byte_length, TODO_EXCEPTION);
-    var array_buffer = JSValue.c(typed_array).asArrayBuffer(env) orelse return genericFailure();
-    const len = @min(array_buffer.len, @as(u32, @truncate(byte_length)));
-    @memcpy(array_buffer.ptr[0..len], data[0..len]);
-    result.* = JSValue.c(typed_array);
-    return .ok;
-}
+pub extern fn napi_create_arraybuffer(env: napi_env, byte_length: usize, data: [*]const u8, result: *napi_value) napi_status;
 
 pub extern fn napi_create_external_arraybuffer(env: napi_env, external_data: ?*anyopaque, byte_length: usize, finalize_cb: napi_finalize, finalize_hint: ?*anyopaque, result: *napi_value) napi_status;
 

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -49,7 +49,7 @@ napi_value test_napi_get_value_string_utf8_with_buffer(const Napi::CallbackInfo 
     std::cout << "Chars to copy: " << len << std::endl;
     std::cout << "Copied chars: " << copied << std::endl;
     std::cout << "Buffer: ";
-    for (int i = 0; i < BUF_SIZE; i++) {
+    for (size_t i = 0; i < BUF_SIZE; i++) {
         std::cout << (int)buf[i] << ", ";
     }
     std::cout << std::endl;


### PR DESCRIPTION

### What does this PR do?

1) `napi_create_string_utf16` had an assertion that it was globally allocated, which means it would be freed using mimalloc when the string was freed. This was incorrect. It must be cloned. 

We were also not checking for all the errors that napi in Node.js checks for. 

2) Fixes https://github.com/oven-sh/bun/issues/3618

The previous implementation of `napi_create_arraybuffer` simply didn't work. This works, but it needs a test.





### How did you verify your code works?

We really need tests for more of napi. I tried running this manually in a few different applications using napi and didn't find issues, but it is also a rarely used function.