### PR TITLE
Replace unmodified variable declarations with const

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -33,7 +33,7 @@ const color_map = std.ComptimeStringMap([]const u8, .{
 });
 
 fn addInternalPackages(b: *Build, step: *CompileStep, _: std.mem.Allocator, _: []const u8, target: anytype) !void {
-    var io: *Module = brk: {
+    const io: *Module = brk: {
         if (target.isDarwin()) {
             break :brk b.createModule(.{
                 .source_file = FileSource.relative("src/io/io_darwin.zig"),
@@ -63,7 +63,7 @@ fn addInternalPackages(b: *Build, step: *CompileStep, _: std.mem.Allocator, _: [
         break :brk b.createModule(.{ .source_file = FileSource.relative("src/deps/zlib.posix.zig") });
     });
 
-    var async_: *Module = brk: {
+    const async_: *Module = brk: {
         if (target.isDarwin() or target.isLinux() or target.isFreeBSD()) {
             break :brk b.createModule(.{
                 .source_file = FileSource.relative("src/async/posix_event_loop.zig"),
@@ -226,7 +226,7 @@ pub fn build_(b: *Build) !void {
     }
 
     var output_dir_buf = std.mem.zeroes([4096]u8);
-    var bin_label = if (optimize == std.builtin.OptimizeMode.Debug) "packages/debug-bun-" else "packages/bun-";
+    const bin_label = if (optimize == std.builtin.OptimizeMode.Debug) "packages/debug-bun-" else "packages/bun-";
 
     var triplet_buf: [64]u8 = undefined;
     var os_tagname = @tagName(target.getOs().tag);
@@ -244,7 +244,7 @@ pub fn build_(b: *Build) !void {
         &triplet_buf,
         os_tagname,
     );
-    var osname = triplet_buf[0..os_tagname.len];
+    const osname = triplet_buf[0..os_tagname.len];
     triplet_buf[osname.len] = '-';
 
     std.mem.copy(u8, triplet_buf[osname.len + 1 ..], @tagName(target.getCpuArch()));
@@ -255,7 +255,7 @@ pub fn build_(b: *Build) !void {
         cpuArchName = cpuArchName[0..3];
     }
 
-    var triplet = triplet_buf[0 .. osname.len + cpuArchName.len + 1];
+    const triplet = triplet_buf[0 .. osname.len + cpuArchName.len + 1];
 
     const outfile_maybe = b.option([]const u8, "output-file", "target to install to");
 
@@ -573,9 +573,9 @@ pub fn build_(b: *Build) !void {
     {
         const headers_step = b.step("test", "Build test");
 
-        var test_file = b.option([]const u8, "test-file", "Input file for test");
-        var test_bin_ = b.option([]const u8, "test-bin", "Emit bin to");
-        var test_filter = b.option([]const u8, "test-filter", "Filter for test");
+        const test_file = b.option([]const u8, "test-file", "Input file for test");
+        const test_bin_ = b.option([]const u8, "test-bin", "Emit bin to");
+        const test_filter = b.option([]const u8, "test-filter", "Filter for test");
 
         var headers_obj: *CompileStep = b.addTest(.{
             .root_source_file = FileSource.relative(test_file orelse "src/main.zig"),

--- a/src/ArenaAllocator.zig
+++ b/src/ArenaAllocator.zig
@@ -257,7 +257,7 @@ test "ArenaAllocator (reset with preheating)" {
         rounds -= 1;
         _ = arena_allocator.reset(.retain_capacity);
         var alloced_bytes: usize = 0;
-        var total_size: usize = random.intRangeAtMost(usize, 256, 16384);
+        const total_size: usize = random.intRangeAtMost(usize, 256, 16384);
         while (alloced_bytes < total_size) {
             const size = random.intRangeAtMost(usize, 16, 256);
             const alignment = 32;

--- a/src/allocators.zig
+++ b/src/allocators.zig
@@ -350,7 +350,7 @@ pub fn BSSStringList(comptime _count: usize, comptime _item_length: usize) type 
             for (_value, 0..) |c, i| {
                 lowercase_append_buf[i] = std.ascii.toLower(c);
             }
-            var slice = lowercase_append_buf[0.._value.len];
+            const slice = lowercase_append_buf[0.._value.len];
 
             return self.doAppend(
                 @TypeOf(slice),
@@ -490,7 +490,7 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
 
             self.mutex.lock();
             defer self.mutex.unlock();
-            var index = try self.index.getOrPut(self.allocator, _key);
+            const index = try self.index.getOrPut(self.allocator, _key);
 
             if (index.found_existing) {
                 return Result{
@@ -558,7 +558,7 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
                 if (self.overflow_list.len() == result.index.index) {
                     return self.overflow_list.append(value);
                 } else {
-                    var ptr = self.overflow_list.atIndexMut(result.index);
+                    const ptr = self.overflow_list.atIndexMut(result.index);
                     ptr.* = value;
                     return ptr;
                 }
@@ -654,7 +654,7 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
         }
 
         pub fn put(self: *Self, key: anytype, comptime store_key: bool, result: *Result, value: ValueType) !*ValueType {
-            var ptr = try self.map.put(result, value);
+            const ptr = try self.map.put(result, value);
             if (store_key) {
                 try self.putKey(key, result);
             }

--- a/src/analytics/analytics_schema.zig
+++ b/src/analytics/analytics_schema.zig
@@ -22,7 +22,7 @@ pub const Reader = struct {
             return error.EOF;
         }
 
-        var slice = this.remain[0..read_count];
+        const slice = this.remain[0..read_count];
 
         this.remain = this.remain[read_count..];
 
@@ -85,7 +85,7 @@ pub const Reader = struct {
                         switch (Struct.layout) {
                             .Packed => {
                                 const sizeof = @sizeOf(T);
-                                var slice = try this.read(sizeof * length);
+                                const slice = try this.read(sizeof * length);
                                 return std.mem.bytesAsSlice(T, slice);
                             },
                             else => {},
@@ -119,7 +119,7 @@ pub const Reader = struct {
     }
 
     pub inline fn readInt(this: *Self, comptime T: type) !T {
-        var slice = try this.read(@sizeOf(T));
+        const slice = try this.read(@sizeOf(T));
 
         return std.mem.readIntSliceNative(T, slice);
     }

--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -362,7 +362,7 @@ pub const GenerateHeader = struct {
                 break :brk try std.fs.openFileAbsoluteZ("/etc/machine-id", .{ .mode = .read_only });
             };
             defer file.close();
-            var read_count = try file.read(&linux_machine_id);
+            const read_count = try file.read(&linux_machine_id);
 
             const hash = bun.hash(std.mem.trim(u8, linux_machine_id[0..read_count], "\n\r "));
             var hash_bytes = std.mem.asBytes(&hash);

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -22,7 +22,7 @@ pub const Reader = struct {
             return error.EOF;
         }
 
-        var slice = this.remain[0..read_count];
+        const slice = this.remain[0..read_count];
 
         this.remain = this.remain[read_count..];
 
@@ -85,7 +85,7 @@ pub const Reader = struct {
                         switch (Struct.layout) {
                             .Packed => {
                                 const sizeof = @sizeOf(T);
-                                var slice = try this.read(sizeof * length);
+                                const slice = try this.read(sizeof * length);
                                 return std.mem.bytesAsSlice(T, slice);
                             },
                             else => {},
@@ -119,7 +119,7 @@ pub const Reader = struct {
     }
 
     pub inline fn readInt(this: *Self, comptime T: type) !T {
-        var slice = try this.read(@sizeOf(T));
+        const slice = try this.read(@sizeOf(T));
 
         return std.mem.readIntSliceNative(T, slice);
     }

--- a/src/async/posix_event_loop.zig
+++ b/src/async/posix_event_loop.zig
@@ -200,13 +200,13 @@ pub const FilePoll = struct {
 
     pub fn deinit(this: *FilePoll) void {
         var vm = JSC.VirtualMachine.get();
-        var loop = vm.event_loop_handle.?;
+        const loop = vm.event_loop_handle.?;
         this.deinitPossiblyDefer(vm, loop, vm.rareData().filePolls(vm), false);
     }
 
     pub fn deinitForceUnregister(this: *FilePoll) void {
         var vm = JSC.VirtualMachine.get();
-        var loop = vm.event_loop_handle.?;
+        const loop = vm.event_loop_handle.?;
         this.deinitPossiblyDefer(vm, loop, vm.rareData().filePolls(vm), true);
     }
 
@@ -221,7 +221,7 @@ pub const FilePoll = struct {
     }
 
     pub fn deinitWithVM(this: *FilePoll, vm: *JSC.VirtualMachine) void {
-        var loop = vm.event_loop_handle.?;
+        const loop = vm.event_loop_handle.?;
         this.deinitPossiblyDefer(vm, loop, vm.rareData().filePolls(vm), false);
     }
 
@@ -586,7 +586,7 @@ pub const FilePoll = struct {
 
             var event = linux.epoll_event{ .events = flags, .data = .{ .u64 = @intFromPtr(Pollable.init(this).ptr()) } };
 
-            var op: u32 = if (this.isRegistered() or this.flags.contains(.needs_rearm)) linux.EPOLL.CTL_MOD else linux.EPOLL.CTL_ADD;
+            const op: u32 = if (this.isRegistered() or this.flags.contains(.needs_rearm)) linux.EPOLL.CTL_MOD else linux.EPOLL.CTL_ADD;
 
             const ctl = linux.epoll_ctl(
                 watcher_fd,

--- a/src/baby_list.zig
+++ b/src/baby_list.zig
@@ -57,7 +57,7 @@ pub fn BabyList(comptime Type: type) type {
 
         pub fn clone(this: @This(), allocator: std.mem.Allocator) !@This() {
             var list_ = this.listManaged(allocator);
-            var copy = try list_.clone();
+            const copy = try list_.clone();
             return ListType{
                 .ptr = copy.items.ptr,
                 .len = @as(u32, @truncate(copy.items.len)),
@@ -74,14 +74,14 @@ pub fn BabyList(comptime Type: type) type {
         pub fn writableSlice(this: *@This(), allocator: std.mem.Allocator, cap: usize) ![]Type {
             var list_ = this.listManaged(allocator);
             try list_.ensureUnusedCapacity(cap);
-            var writable = list_.items.ptr[this.len .. this.len + @as(u32, @truncate(cap))];
+            const writable = list_.items.ptr[this.len .. this.len + @as(u32, @truncate(cap))];
             list_.items.len += cap;
             this.update(list_);
             return writable;
         }
 
         pub fn appendSliceAssumeCapacity(this: *@This(), values: []const Type) void {
-            var tail = this.ptr[this.len .. this.len + values.len];
+            const tail = this.ptr[this.len .. this.len + values.len];
             std.debug.assert(this.cap >= this.len + @as(u32, @truncate(values.len)));
             bun.copy(Type, tail, values);
             this.len += @as(u32, @truncate(values.len));
@@ -130,7 +130,7 @@ pub fn BabyList(comptime Type: type) type {
         }
 
         pub fn fromSlice(allocator: std.mem.Allocator, items: []const Elem) !ListType {
-            var allocated = try allocator.alloc(Elem, items.len);
+            const allocated = try allocator.alloc(Elem, items.len);
             bun.copy(Elem, allocated, items);
 
             return ListType{
@@ -269,7 +269,7 @@ pub fn BabyList(comptime Type: type) type {
                 while (remain.len > 0) {
                     const orig_len = list_.items.len;
 
-                    var slice_ = list_.items.ptr[orig_len..list_.capacity];
+                    const slice_ = list_.items.ptr[orig_len..list_.capacity];
                     const result = strings.copyUTF16IntoUTF8WithBuffer(slice_, []const u16, remain, trimmed, out_len, true);
                     remain = remain[result.read..];
                     list_.items.len += @as(usize, result.written);

--- a/src/base64/base64.zig
+++ b/src/base64/base64.zig
@@ -300,7 +300,7 @@ const zig_base64 = struct {
                 return error.InvalidPadding;
             }
             if (leftover_idx == null) return;
-            var leftover = source[leftover_idx.?..];
+            const leftover = source[leftover_idx.?..];
             if (decoder.pad_char) |pad_char| {
                 const padding_len = acc_len / 2;
                 var padding_chars: usize = 0;
@@ -387,7 +387,7 @@ const zig_base64 = struct {
                 const padding_len = acc_len / 2;
 
                 if (leftover_idx) |idx| {
-                    var leftover = source[idx..];
+                    const leftover = source[idx..];
                     var padding_chars: usize = 0;
                     for (leftover) |c| {
                         if (decoder_with_ignore.char_is_ignored[c]) continue;
@@ -498,7 +498,7 @@ const zig_base64 = struct {
         // Base64Decoder
         {
             var buffer: [0x100]u8 = undefined;
-            var decoded = buffer[0..try codecs.Decoder.calcSizeForSlice(expected_encoded)];
+            const decoded = buffer[0..try codecs.Decoder.calcSizeForSlice(expected_encoded)];
             try codecs.Decoder.decode(decoded, expected_encoded);
             try testing.expectEqualSlices(u8, expected_decoded, decoded);
         }
@@ -508,7 +508,7 @@ const zig_base64 = struct {
             const decoder_ignore_nothing = codecs.decoderWithIgnore("");
             var buffer: [0x100]u8 = undefined;
             var decoded = buffer[0..try decoder_ignore_nothing.calcSizeUpperBound(expected_encoded.len)];
-            var written = try decoder_ignore_nothing.decode(decoded, expected_encoded);
+            const written = try decoder_ignore_nothing.decode(decoded, expected_encoded);
             try testing.expect(written <= decoded.len);
             try testing.expectEqualSlices(u8, expected_decoded, decoded[0..written]);
         }
@@ -518,7 +518,7 @@ const zig_base64 = struct {
         const decoder_ignore_space = codecs.decoderWithIgnore(" ");
         var buffer: [0x100]u8 = undefined;
         var decoded = buffer[0..try decoder_ignore_space.calcSizeUpperBound(encoded.len)];
-        var written = try decoder_ignore_space.decode(decoded, encoded);
+        const written = try decoder_ignore_space.decode(decoded, encoded);
         try testing.expectEqualSlices(u8, expected_decoded, decoded[0..written]);
     }
 
@@ -526,7 +526,7 @@ const zig_base64 = struct {
         const decoder_ignore_space = codecs.decoderWithIgnore(" ");
         var buffer: [0x100]u8 = undefined;
         if (codecs.Decoder.calcSizeForSlice(encoded)) |decoded_size| {
-            var decoded = buffer[0..decoded_size];
+            const decoded = buffer[0..decoded_size];
             if (codecs.Decoder.decode(decoded, encoded)) |_| {
                 return error.ExpectedError;
             } else |err| if (err != expected_err) return err;
@@ -540,7 +540,7 @@ const zig_base64 = struct {
     fn testNoSpaceLeftError(codecs: Codecs, encoded: []const u8) !void {
         const decoder_ignore_space = codecs.decoderWithIgnore(" ");
         var buffer: [0x100]u8 = undefined;
-        var decoded = buffer[0 .. (try codecs.Decoder.calcSizeForSlice(encoded)) - 1];
+        const decoded = buffer[0 .. (try codecs.Decoder.calcSizeForSlice(encoded)) - 1];
         if (decoder_ignore_space.decode(decoded, encoded)) |_| {
             return error.ExpectedError;
         } else |err| if (err != error.NoSpaceLeft) return err;

--- a/src/blob.zig
+++ b/src/blob.zig
@@ -65,7 +65,7 @@ pub const Group = struct {
     allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator) !*Group {
-        var group = try allocator.create(Group);
+        const group = try allocator.create(Group);
         group.* = Group{ .persistent = Map.init(allocator), .temporary = Map.init(allocator), .allocator = allocator };
         return group;
     }

--- a/src/boringssl.zig
+++ b/src/boringssl.zig
@@ -28,7 +28,7 @@ var ctx_: ?*boring.SSL_CTX = null;
 pub fn initClient() *boring.SSL {
     if (ctx_ != null) _ = boring.SSL_CTX_up_ref(ctx_.?);
 
-    var ctx = ctx_ orelse brk: {
+    const ctx = ctx_ orelse brk: {
         ctx_ = boring.SSL_CTX.init().?;
         break :brk ctx_.?;
     };
@@ -139,7 +139,7 @@ pub fn checkX509ServerIdentity(
                 var canonicalIPBuf: [INET6_ADDRSTRLEN + 1]u8 = undefined;
                 var certIPBuf: [INET6_ADDRSTRLEN + 1]u8 = undefined;
                 // we try to canonicalize the IP before comparing
-                var host_ip = canonicalizeIP(hostname, &canonicalIPBuf) orelse hostname;
+                const host_ip = canonicalizeIP(hostname, &canonicalIPBuf) orelse hostname;
 
                 if (boring.X509V3_EXT_d2i(ext)) |names_| {
                     const names: *boring.struct_stack_st_GENERAL_NAME = bun.cast(*boring.struct_stack_st_GENERAL_NAME, names_);

--- a/src/bun.js/BuildMessage.zig
+++ b/src/bun.js/BuildMessage.zig
@@ -28,7 +28,7 @@ pub const BuildMessage = struct {
     }
 
     pub fn toStringFn(this: *BuildMessage, globalThis: *JSC.JSGlobalObject) JSC.JSValue {
-        var text = std.fmt.allocPrint(default_allocator, "BuildMessage: {s}", .{this.msg.data.text}) catch {
+        const text = std.fmt.allocPrint(default_allocator, "BuildMessage: {s}", .{this.msg.data.text}) catch {
             globalThis.throwOutOfMemory();
             return .zero;
         };

--- a/src/bun.js/ResolveMessage.zig
+++ b/src/bun.js/ResolveMessage.zig
@@ -71,7 +71,7 @@ pub const ResolveMessage = struct {
     }
 
     pub fn toStringFn(this: *ResolveMessage, globalThis: *JSC.JSGlobalObject) JSC.JSValue {
-        var text = std.fmt.allocPrint(default_allocator, "ResolveMessage: {s}", .{this.msg.data.text}) catch {
+        const text = std.fmt.allocPrint(default_allocator, "ResolveMessage: {s}", .{this.msg.data.text}) catch {
             globalThis.throwOutOfMemory();
             return .zero;
         };

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -638,7 +638,7 @@ pub const JSBundler = struct {
             completion.ref();
 
             this.js_task = AnyTask.init(this);
-            var concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch {
+            const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch {
                 completion.deref();
                 this.deinit();
                 return;
@@ -794,7 +794,7 @@ pub const JSBundler = struct {
             completion.ref();
 
             this.js_task = AnyTask.init(this);
-            var concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch {
+            const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch {
                 completion.deref();
                 this.deinit();
                 return;
@@ -827,7 +827,7 @@ pub const JSBundler = struct {
                     return;
                 }
             } else {
-                var buffer_or_string: JSC.Node.SliceOrBuffer = JSC.Node.SliceOrBuffer.fromJS(completion.globalThis, bun.default_allocator, source_code_value) orelse
+                const buffer_or_string: JSC.Node.SliceOrBuffer = JSC.Node.SliceOrBuffer.fromJS(completion.globalThis, bun.default_allocator, source_code_value) orelse
                     @panic("expected buffer or string");
 
                 const source_code = switch (buffer_or_string) {
@@ -855,7 +855,7 @@ pub const JSBundler = struct {
         extern fn JSBundlerPlugin__create(*JSC.JSGlobalObject, JSC.JSGlobalObject.BunPluginTarget) *Plugin;
         pub fn create(globalObject: *JSC.JSGlobalObject, target: JSC.JSGlobalObject.BunPluginTarget) *Plugin {
             JSC.markBinding(@src());
-            var plugin = JSBundlerPlugin__create(globalObject, target);
+            const plugin = JSBundlerPlugin__create(globalObject, target);
             JSC.JSValue.fromCell(plugin).protect();
             return plugin;
         }

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -166,7 +166,7 @@ pub const TransformTask = struct {
             return;
         }
 
-        var global_allocator = arena.backingAllocator();
+        const global_allocator = arena.backingAllocator();
         var buffer_writer = JSPrinter.BufferWriter.init(global_allocator) catch |err| {
             this.err = err;
             return;
@@ -288,10 +288,10 @@ fn exportReplacementValue(value: JSValue, globalThis: *JSGlobalObject) ?JSAst.Ex
     }
 
     if (value.isString()) {
-        var str = JSAst.E.String{
+        const str = JSAst.E.String{
             .data = std.fmt.allocPrint(bun.default_allocator, "{}", .{value.getZigString(globalThis)}) catch unreachable,
         };
-        var out = bun.default_allocator.create(JSAst.E.String) catch unreachable;
+        const out = bun.default_allocator.create(JSAst.E.String) catch unreachable;
         out.* = str;
         return Expr{
             .data = .{
@@ -305,7 +305,7 @@ fn exportReplacementValue(value: JSValue, globalThis: *JSGlobalObject) ?JSAst.Ex
 }
 
 fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std.mem.Allocator, args: *JSC.Node.ArgumentsSlice, exception: JSC.C.ExceptionRef) !TranspilerOptions {
-    var globalThis = globalObject;
+    const globalThis = globalObject;
     const object = args.next() orelse return TranspilerOptions{ .log = logger.Log.init(temp_allocator) };
     if (object.isUndefinedOrNull()) return TranspilerOptions{ .log = logger.Log.init(temp_allocator) };
 
@@ -611,7 +611,7 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
 
             var total_name_buf_len: u32 = 0;
             var string_count: u32 = 0;
-            var iter = JSC.JSArrayIterator.init(eliminate, globalThis);
+            const iter = JSC.JSArrayIterator.init(eliminate, globalThis);
             {
                 var length_iter = iter;
                 while (length_iter.next()) |value| {
@@ -630,7 +630,7 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
                     var length_iter = iter;
                     while (length_iter.next()) |value| {
                         if (!value.isString()) continue;
-                        var str = value.getZigString(globalThis);
+                        const str = value.getZigString(globalThis);
                         if (str.len == 0) continue;
                         const name = std.fmt.bufPrint(buf.items.ptr[buf.items.len..buf.capacity], "{}", .{str}) catch {
                             JSC.throwInvalidArguments("Error reading exports.eliminate. TODO: utf-16", .{}, globalObject, exception);
@@ -674,7 +674,7 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
                     const value = iter.value;
                     if (value.isEmpty()) continue;
 
-                    var key = try key_.toOwnedSlice(bun.default_allocator);
+                    const key = try key_.toOwnedSlice(bun.default_allocator);
 
                     if (!JSLexer.isIdentifier(key)) {
                         JSC.throwInvalidArguments("\"{s}\" is not a valid ECMAScript identifier", .{key}, globalObject, exception);
@@ -682,7 +682,7 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
                         return transpiler;
                     }
 
-                    var entry = replacements.getOrPutAssumeCapacity(key);
+                    const entry = replacements.getOrPutAssumeCapacity(key);
 
                     if (exportReplacementValue(value, globalThis)) |expr| {
                         entry.value_ptr.* = .{ .replace = expr };
@@ -694,7 +694,7 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
                         if (exportReplacementValue(replacementValue, globalThis)) |to_replace| {
                             const replacementKey = JSC.JSObject.getIndex(value, globalThis, 0);
                             var slice = (try replacementKey.toSlice(globalThis, bun.default_allocator).cloneIfNeeded(bun.default_allocator));
-                            var replacement_name = slice.slice();
+                            const replacement_name = slice.slice();
 
                             if (!JSLexer.isIdentifier(replacement_name)) {
                                 JSC.throwInvalidArguments("\"{s}\" is not a valid ECMAScript identifier", .{replacement_name}, globalObject, exception);
@@ -741,7 +741,7 @@ pub fn constructor(
 
     defer temp.deinit();
     var exception_ref = [_]JSC.C.JSValueRef{null};
-    var exception = &exception_ref[0];
+    const exception = &exception_ref[0];
     const transpiler_options: TranspilerOptions = if (arguments.len > 0)
         transformOptionsFromJSC(globalThis, temp.allocator(), &args, exception) catch {
             JSC.throwInvalidArguments("Failed to create transpiler", .{}, globalThis, exception);
@@ -825,7 +825,7 @@ pub fn constructor(
     bundler.options.jsx.supports_fast_refresh = bundler.options.hot_module_reloading and
         bundler.options.allow_runtime and transpiler_options.runtime.react_fast_refresh;
 
-    var transpiler = allocator.create(Transpiler) catch unreachable;
+    const transpiler = allocator.create(Transpiler) catch unreachable;
     transpiler.* = Transpiler{
         .transpiler_options = transpiler_options,
         .bundler = bundler,
@@ -913,7 +913,7 @@ pub fn scan(
     const code = code_holder.slice();
     args.protectEat();
     var exception_ref = [_]JSC.C.JSValueRef{null};
-    var exception: JSC.C.ExceptionRef = &exception_ref;
+    const exception: JSC.C.ExceptionRef = &exception_ref;
 
     const loader: ?Loader = brk: {
         if (args.next()) |arg| {
@@ -930,7 +930,7 @@ pub fn scan(
     }
 
     var arena = Mimalloc.Arena.init() catch unreachable;
-    var prev_allocator = this.bundler.allocator;
+    const prev_allocator = this.bundler.allocator;
     this.bundler.setAllocator(arena.allocator());
     var log = logger.Log.init(arena.backingAllocator());
     defer log.deinit();
@@ -996,7 +996,7 @@ pub fn transform(
 ) callconv(.C) JSC.JSValue {
     JSC.markBinding(@src());
     var exception_ref = [_]JSC.C.JSValueRef{null};
-    var exception: JSC.C.ExceptionRef = &exception_ref;
+    const exception: JSC.C.ExceptionRef = &exception_ref;
     const arguments = callframe.arguments(3);
     var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments.ptr[0..arguments.len]);
     defer args.arena.deinit();
@@ -1051,7 +1051,7 @@ pub fn transformSync(
 ) callconv(.C) JSC.JSValue {
     JSC.markBinding(@src());
     var exception_value = [_]JSC.C.JSValueRef{null};
-    var exception: JSC.C.ExceptionRef = &exception_value;
+    const exception: JSC.C.ExceptionRef = &exception_value;
     const arguments = callframe.arguments(3);
 
     var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments.ptr[0..arguments.len]);
@@ -1120,7 +1120,7 @@ pub fn transformSync(
         JSAst.Expr.Data.Store.reset();
     }
 
-    var prev_bundler = this.bundler;
+    const prev_bundler = this.bundler;
     this.bundler.setAllocator(arena.allocator());
     this.bundler.macro_context = null;
     var log = logger.Log.init(arena.backingAllocator());
@@ -1129,7 +1129,7 @@ pub fn transformSync(
     defer {
         this.bundler = prev_bundler;
     }
-    var parse_result = getParseResult(
+    const parse_result = getParseResult(
         this,
         arena.allocator(),
         code,
@@ -1235,7 +1235,7 @@ pub fn scanImports(
 ) callconv(.C) JSC.JSValue {
     const arguments = callframe.arguments(2);
     var exception_val = [_]JSC.C.JSValueRef{null};
-    var exception: JSC.C.ExceptionRef = &exception_val;
+    const exception: JSC.C.ExceptionRef = &exception_val;
     var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments.ptr[0..arguments.len]);
     defer args.deinit();
 
@@ -1275,7 +1275,7 @@ pub fn scanImports(
     }
 
     var arena = Mimalloc.Arena.init() catch unreachable;
-    var prev_allocator = this.bundler.allocator;
+    const prev_allocator = this.bundler.allocator;
     this.bundler.setAllocator(arena.allocator());
     var log = logger.Log.init(arena.backingAllocator());
     defer log.deinit();

--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -261,7 +261,7 @@ pub fn onImportCSS(
         css_imports_buf_loaded = true;
     }
 
-    var writer = css_imports_buf.writer();
+    const writer = css_imports_buf.writer();
     const offset = css_imports_buf.items.len;
     css_imports_list[css_imports_list_tail] = .{
         .offset = @as(u32, @truncate(offset)),
@@ -444,7 +444,7 @@ pub fn inspect(
     var buffered_writer_ = MutableString.BufferedWriter{ .context = &array };
     var buffered_writer = &buffered_writer_;
 
-    var writer = buffered_writer.writer();
+    const writer = buffered_writer.writer();
     const Writer = @TypeOf(writer);
     // we buffer this because it'll almost always be < 4096
     // when it's under 4096, we want to avoid the dynamic allocation
@@ -499,7 +499,7 @@ pub fn registerMacro(
         return .undefined;
     }
 
-    var get_or_put_result = VirtualMachine.get().macros.getOrPut(id) catch unreachable;
+    const get_or_put_result = VirtualMachine.get().macros.getOrPut(id) catch unreachable;
     if (get_or_put_result.found_existing) {
         get_or_put_result.value_ptr.*.?.value().unprotect();
     }
@@ -610,10 +610,10 @@ pub fn openInEditor(
         if (!opts.isUndefinedOrNull()) {
             if (opts.getTruthy(globalThis, "editor")) |editor_val| {
                 var sliced = editor_val.toSlice(globalThis, arguments.arena.allocator());
-                var prev_name = edit.name;
+                const prev_name = edit.name;
 
                 if (!strings.eqlLong(prev_name, sliced.slice(), true)) {
-                    var prev = edit.*;
+                    const prev = edit.*;
                     edit.name = sliced.slice();
                     edit.detectEditor(VirtualMachine.get().bundler.env);
                     editor_choice = edit.editor;
@@ -839,7 +839,7 @@ fn doResolveWithArgs(
 
 pub fn resolveSync(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) JSC.JSValue {
     var exception_ = [1]JSC.JSValueRef{null};
-    var exception = &exception_;
+    const exception = &exception_;
     const arguments = callframe.arguments(3);
     const result = doResolve(globalObject, arguments.slice(), exception);
 
@@ -852,7 +852,7 @@ pub fn resolveSync(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame)
 
 pub fn resolve(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) JSC.JSValue {
     var exception_ = [1]JSC.JSValueRef{null};
-    var exception = &exception_;
+    const exception = &exception_;
     const arguments = callframe.arguments(3);
     const value = doResolve(globalObject, arguments.slice(), exception) orelse {
         return JSC.JSPromise.rejectedPromiseValue(globalObject, exception_[0].?.value());
@@ -867,7 +867,7 @@ export fn Bun__resolve(
     is_esm: bool,
 ) JSC.JSValue {
     var exception_ = [1]JSC.JSValueRef{null};
-    var exception = &exception_;
+    const exception = &exception_;
     const value = doResolveWithArgs(global, specifier.toBunString(global), source.toBunString(global), exception, is_esm, true) orelse {
         return JSC.JSPromise.rejectedPromiseValue(global, exception_[0].?.value());
     };
@@ -881,7 +881,7 @@ export fn Bun__resolveSync(
     is_esm: bool,
 ) JSC.JSValue {
     var exception_ = [1]JSC.JSValueRef{null};
-    var exception = &exception_;
+    const exception = &exception_;
     return doResolveWithArgs(global, specifier.toBunString(global), source.toBunString(global), exception, is_esm, true) orelse {
         return JSC.JSValue.fromRef(exception[0]);
     };
@@ -894,7 +894,7 @@ export fn Bun__resolveSyncWithSource(
     is_esm: bool,
 ) JSC.JSValue {
     var exception_ = [1]JSC.JSValueRef{null};
-    var exception = &exception_;
+    const exception = &exception_;
     return doResolveWithArgs(global, specifier.toBunString(global), source.*, exception, is_esm, true) orelse {
         return JSC.JSValue.fromRef(exception[0]);
     };
@@ -927,7 +927,7 @@ pub fn getPublicPathJS(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFr
 fn fs(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) callconv(.C) JSC.JSValue {
     var module = globalObject.allocator().create(JSC.Node.NodeJSFS) catch unreachable;
     module.* = .{};
-    var vm = globalObject.bunVM();
+    const vm = globalObject.bunVM();
     if (vm.standalone_module_graph != null)
         module.node_fs.vm = vm;
 
@@ -1198,7 +1198,7 @@ pub const Crypto = struct {
         var outbuf: [128 + 1 + "BoringSSL error: ".len]u8 = undefined;
         @memset(&outbuf, 0);
         outbuf[0.."BoringSSL error: ".len].* = "BoringSSL error: ".*;
-        var message_buf = outbuf["BoringSSL error: ".len..];
+        const message_buf = outbuf["BoringSSL error: ".len..];
 
         _ = BoringSSL.ERR_error_string_n(err_code, message_buf, message_buf.len);
 
@@ -1575,7 +1575,7 @@ pub const Crypto = struct {
                     hash: []const u8,
 
                     pub fn toErrorInstance(this: Value, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
-                        var error_code = std.fmt.allocPrint(bun.default_allocator, "PASSWORD_{}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}) catch @panic("out of memory");
+                        const error_code = std.fmt.allocPrint(bun.default_allocator, "PASSWORD_{}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}) catch @panic("out of memory");
                         defer bun.default_allocator.free(error_code);
                         const instance = globalObject.createErrorInstance("Password hashing failed with error \"{s}\"", .{@errorName(this.err)});
                         instance.put(globalObject, ZigString.static("code"), JSC.ZigString.init(error_code).toValueGC(globalObject));
@@ -1587,7 +1587,7 @@ pub const Crypto = struct {
                     var promise = this.promise;
                     this.promise = .{};
                     this.ref.unref(this.global.bunVM());
-                    var global = this.global;
+                    const global = this.global;
                     switch (this.value) {
                         .err => {
                             const error_instance = this.value.toErrorInstance(global);
@@ -1631,7 +1631,7 @@ pub const Crypto = struct {
                 this.ref = .{};
                 this.promise.strong = .{};
 
-                var concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch @panic("out of memory");
+                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch @panic("out of memory");
                 concurrent_task.* = JSC.ConcurrentTask{
                     .task = JSC.Task.init(&result.task),
                     .auto_delete = true,
@@ -1825,7 +1825,7 @@ pub const Crypto = struct {
                     pass: bool,
 
                     pub fn toErrorInstance(this: Value, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
-                        var error_code = std.fmt.allocPrint(bun.default_allocator, "PASSWORD{}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}) catch @panic("out of memory");
+                        const error_code = std.fmt.allocPrint(bun.default_allocator, "PASSWORD{}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}) catch @panic("out of memory");
                         defer bun.default_allocator.free(error_code);
                         const instance = globalObject.createErrorInstance("Password verification failed with error \"{s}\"", .{@errorName(this.err)});
                         instance.put(globalObject, ZigString.static("code"), JSC.ZigString.init(error_code).toValueGC(globalObject));
@@ -1837,7 +1837,7 @@ pub const Crypto = struct {
                     var promise = this.promise;
                     this.promise = .{};
                     this.ref.unref(this.global.bunVM());
-                    var global = this.global;
+                    const global = this.global;
                     switch (this.value) {
                         .err => {
                             const error_instance = this.value.toErrorInstance(global);
@@ -1881,7 +1881,7 @@ pub const Crypto = struct {
                 this.ref = .{};
                 this.promise.strong = .{};
 
-                var concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch @panic("out of memory");
+                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch @panic("out of memory");
                 concurrent_task.* = JSC.ConcurrentTask{
                     .task = JSC.Task.init(&result.task),
                     .auto_delete = true,
@@ -2129,7 +2129,7 @@ pub const Crypto = struct {
         }
 
         pub fn constructor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) ?*CryptoHasher {
-            var arguments = callframe.arguments(2);
+            const arguments = callframe.arguments(2);
             if (arguments.len == 0) {
                 globalThis.throwInvalidArguments("Expected an algorithm name as an argument", .{});
                 return null;
@@ -2253,7 +2253,7 @@ pub const Crypto = struct {
         fn digestToEncoding(this: *CryptoHasher, globalThis: *JSGlobalObject, encoding: JSC.Node.Encoding) JSC.JSValue {
             var output_digest_buf: EVP.Digest = std.mem.zeroes(EVP.Digest);
 
-            var output_digest_slice: []u8 = &output_digest_buf;
+            const output_digest_slice: []u8 = &output_digest_buf;
 
             const out = this.evp.final(globalThis.bunVM().rareData().boringEngine(), output_digest_slice);
 
@@ -2365,7 +2365,7 @@ pub const Crypto = struct {
             }
 
             pub fn constructor(_: *JSC.JSGlobalObject, _: *JSC.CallFrame) callconv(.C) ?*@This() {
-                var this = bun.default_allocator.create(@This()) catch return null;
+                const this = bun.default_allocator.create(@This()) catch return null;
 
                 this.* = .{ .hashing = Hasher.init() };
                 return this;
@@ -2460,7 +2460,7 @@ pub const Crypto = struct {
                     break :brk bytes;
                 };
 
-                var output_digest_slice: *Hasher.Digest = &output_digest_buf;
+                const output_digest_slice: *Hasher.Digest = &output_digest_buf;
 
                 this.hashing.final(output_digest_slice);
 
@@ -2498,7 +2498,7 @@ pub fn serve(
     const arguments = callframe.arguments(2).slice();
     var config: JSC.API.ServerConfig = brk: {
         var exception_ = [1]JSC.JSValueRef{null};
-        var exception = &exception_;
+        const exception = &exception_;
 
         var args = JSC.Node.ArgumentsSlice.init(globalObject.bunVM(), arguments);
         const config_ = JSC.API.ServerConfig.fromJS(globalObject.ptr(), &args, exception);
@@ -3080,7 +3080,7 @@ const TOMLObject = struct {
         callframe: *JSC.CallFrame,
     ) callconv(.C) JSC.JSValue {
         var arena = @import("root").bun.ArenaAllocator.init(globalThis.allocator());
-        var allocator = arena.allocator();
+        const allocator = arena.allocator();
         defer arena.deinit();
         var log = logger.Log.init(default_allocator);
         const arguments = callframe.arguments(1).slice();
@@ -3088,13 +3088,13 @@ const TOMLObject = struct {
         var input_slice = arguments[0].toSlice(globalThis, bun.default_allocator);
         defer input_slice.deinit();
         var source = logger.Source.initPathString("input.toml", input_slice.slice());
-        var parse_result = TOMLParser.parse(&source, &log, allocator) catch {
+        const parse_result = TOMLParser.parse(&source, &log, allocator) catch {
             globalThis.throwValue(log.toJS(globalThis, default_allocator, "Failed to parse toml"));
             return .zero;
         };
 
         // for now...
-        var buffer_writer = js_printer.BufferWriter.init(allocator) catch {
+        const buffer_writer = js_printer.BufferWriter.init(allocator) catch {
             globalThis.throwValue(log.toJS(globalThis, default_allocator, "Failed to print toml"));
             return .zero;
         };
@@ -3104,7 +3104,7 @@ const TOMLObject = struct {
             return .zero;
         };
 
-        var slice = writer.ctx.buffer.toOwnedSliceLeaky();
+        const slice = writer.ctx.buffer.toOwnedSliceLeaky();
         var out = bun.String.fromUTF8(slice);
         defer out.deref();
 
@@ -3541,13 +3541,13 @@ pub const Timer = struct {
 
             var map = vm.timer.maps.get(timer_id.kind);
 
-            var this_: ?Timeout = map.get(
+            const this_: ?Timeout = map.get(
                 timer_id.id,
             ) orelse return;
             var this = this_ orelse
                 return;
 
-            var globalThis = this.globalThis;
+            const globalThis = this.globalThis;
 
             // Disable thundering herd of setInterval() calls
             // Skip setInterval() calls when the previous one has not been run yet.
@@ -3555,7 +3555,7 @@ pub const Timer = struct {
                 return;
             }
 
-            var cb: CallbackJob = .{
+            const cb: CallbackJob = .{
                 .callback = if (repeats)
                     JSC.Strong.create(
                         this.callback.get() orelse {
@@ -4516,13 +4516,13 @@ comptime {
 
 pub const JSZlib = struct {
     export fn reader_deallocator(_: ?*anyopaque, ctx: ?*anyopaque) void {
-        var reader: *zlib.ZlibReaderArrayList = bun.cast(*zlib.ZlibReaderArrayList, ctx.?);
+        const reader: *zlib.ZlibReaderArrayList = bun.cast(*zlib.ZlibReaderArrayList, ctx.?);
         reader.list.deinit(reader.allocator);
         reader.deinit();
     }
 
     export fn compressor_deallocator(_: ?*anyopaque, ctx: ?*anyopaque) void {
-        var compressor: *zlib.ZlibCompressorArrayList = bun.cast(*zlib.ZlibCompressorArrayList, ctx.?);
+        const compressor: *zlib.ZlibCompressorArrayList = bun.cast(*zlib.ZlibCompressorArrayList, ctx.?);
         compressor.list.deinit(compressor.allocator);
         compressor.deinit();
     }
@@ -4570,7 +4570,7 @@ pub const JSZlib = struct {
             }
         }
 
-        var compressed = buffer.slice();
+        const compressed = buffer.slice();
         const allocator = JSC.VirtualMachine.get().allocator;
         var list = std.ArrayListUnmanaged(u8).initCapacity(allocator, if (compressed.len > 512) compressed.len else 32) catch unreachable;
         var reader = zlib.ZlibCompressorArrayList.init(compressed, &list, allocator, opts) catch |err| {
@@ -4600,7 +4600,7 @@ pub const JSZlib = struct {
         globalThis: *JSGlobalObject,
         buffer: JSC.Node.StringOrBuffer,
     ) JSValue {
-        var compressed = buffer.slice();
+        const compressed = buffer.slice();
         const allocator = JSC.VirtualMachine.get().allocator;
         var list = std.ArrayListUnmanaged(u8).initCapacity(allocator, if (compressed.len > 512) compressed.len else 32) catch unreachable;
         var reader = zlib.ZlibReaderArrayList.initWithOptions(compressed, &list, allocator, .{
@@ -4632,7 +4632,7 @@ pub const JSZlib = struct {
         globalThis: *JSGlobalObject,
         buffer: JSC.Node.StringOrBuffer,
     ) JSValue {
-        var compressed = buffer.slice();
+        const compressed = buffer.slice();
         const allocator = JSC.VirtualMachine.get().allocator;
         var list = std.ArrayListUnmanaged(u8).initCapacity(allocator, if (compressed.len > 512) compressed.len else 32) catch unreachable;
         var reader = zlib.ZlibReaderArrayList.init(compressed, &list, allocator) catch |err| {

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -75,7 +75,7 @@ const LibInfo = struct {
 
         const getaddrinfo_async_start_ = LibInfo.getaddrinfo_async_start() orelse return LibC.lookup(this, query, globalThis);
 
-        var key = GetAddrInfoRequest.PendingCacheKey.init(query);
+        const key = GetAddrInfoRequest.PendingCacheKey.init(query);
         var cache = this.getOrPutIntoPendingCache(key, .pending_host_cache_native);
 
         if (cache == .inflight) {
@@ -90,7 +90,7 @@ const LibInfo = struct {
         _ = strings.copy(name_buf[0..], query.name);
 
         name_buf[query.name.len] = 0;
-        var name_z = name_buf[0..query.name.len :0];
+        const name_z = name_buf[0..query.name.len :0];
 
         var request = GetAddrInfoRequest.init(
             cache,
@@ -147,7 +147,7 @@ const LibC = struct {
             return dns_lookup.promise.value();
         }
 
-        var query = query_init.clone();
+        const query = query_init.clone();
 
         var request = GetAddrInfoRequest.init(
             cache,
@@ -258,7 +258,7 @@ pub fn addrInfoToJSArray(
     {
         defer arena.deinit();
 
-        var allocator = arena.allocator();
+        const allocator = arena.allocator();
         var j: u32 = 0;
         var current: ?*std.c.addrinfo = addr_info;
         while (current) |this_node| : (current = current.?.next) {
@@ -824,7 +824,7 @@ pub const CAresNameInfo = struct {
     name: []const u8,
 
     pub fn init(globalThis: *JSC.JSGlobalObject, allocator: std.mem.Allocator, name: []const u8) !*@This() {
-        var this = try allocator.create(@This());
+        const this = try allocator.create(@This());
         var poll_ref = bun.Async.KeepAlive.init();
         poll_ref.ref(globalThis.bunVM());
         this.* = .{ .globalThis = globalThis, .promise = JSC.JSPromise.Strong.init(globalThis), .poll_ref = poll_ref, .allocated = true, .name = name };
@@ -868,7 +868,7 @@ pub const CAresNameInfo = struct {
 
     pub fn onComplete(this: *@This(), result: JSC.JSValue) void {
         var promise = this.promise;
-        var globalThis = this.globalThis;
+        const globalThis = this.globalThis;
         this.promise = .{};
         promise.resolve(globalThis, result);
         this.deinit();
@@ -1094,14 +1094,14 @@ pub const GetAddrInfoRequest = struct {
                 defer bun.default_allocator.free(bun.constStrToU8(query.name));
                 var hints = query.options.toLibC();
                 var port_buf: [128]u8 = undefined;
-                var port = std.fmt.bufPrintIntToSlice(&port_buf, query.port, 10, .lower, .{});
+                const port = std.fmt.bufPrintIntToSlice(&port_buf, query.port, 10, .lower, .{});
                 port_buf[port.len] = 0;
-                var portZ = port_buf[0..port.len :0];
+                const portZ = port_buf[0..port.len :0];
                 var hostname: [bun.MAX_PATH_BYTES]u8 = undefined;
                 _ = strings.copy(hostname[0..], query.name);
                 hostname[query.name.len] = 0;
                 var addrinfo: ?*std.c.addrinfo = null;
-                var host = hostname[0..query.name.len :0];
+                const host = hostname[0..query.name.len :0];
                 const debug_timer = bun.Output.DebugTimer.start();
                 const err = std.c.getaddrinfo(
                     host.ptr,
@@ -1214,7 +1214,7 @@ pub const CAresReverse = struct {
     name: []const u8,
 
     pub fn init(globalThis: *JSC.JSGlobalObject, allocator: std.mem.Allocator, name: []const u8) !*@This() {
-        var this = try allocator.create(@This());
+        const this = try allocator.create(@This());
         var poll_ref = Async.KeepAlive.init();
         poll_ref.ref(globalThis.bunVM());
         this.* = .{ .globalThis = globalThis, .promise = JSC.JSPromise.Strong.init(globalThis), .poll_ref = poll_ref, .allocated = true, .name = name };
@@ -1258,7 +1258,7 @@ pub const CAresReverse = struct {
 
     pub fn onComplete(this: *@This(), result: JSC.JSValue) void {
         var promise = this.promise;
-        var globalThis = this.globalThis;
+        const globalThis = this.globalThis;
         this.promise = .{};
         promise.resolve(globalThis, result);
         this.deinit();
@@ -1285,7 +1285,7 @@ pub fn CAresLookup(comptime cares_type: type, comptime type_name: []const u8) ty
         name: []const u8,
 
         pub fn init(globalThis: *JSC.JSGlobalObject, allocator: std.mem.Allocator, name: []const u8) !*@This() {
-            var this = try allocator.create(@This());
+            const this = try allocator.create(@This());
             var poll_ref = Async.KeepAlive.init();
             poll_ref.ref(globalThis.bunVM());
             this.* = .{ .globalThis = globalThis, .promise = JSC.JSPromise.Strong.init(globalThis), .poll_ref = poll_ref, .allocated = true, .name = name };
@@ -1329,7 +1329,7 @@ pub fn CAresLookup(comptime cares_type: type, comptime type_name: []const u8) ty
 
         pub fn onComplete(this: *@This(), result: JSC.JSValue) void {
             var promise = this.promise;
-            var globalThis = this.globalThis;
+            const globalThis = this.globalThis;
             this.promise = .{};
             promise.resolve(globalThis, result);
             this.deinit();
@@ -1355,7 +1355,7 @@ pub const DNSLookup = struct {
     poll_ref: Async.KeepAlive,
 
     pub fn init(globalThis: *JSC.JSGlobalObject, allocator: std.mem.Allocator) !*DNSLookup {
-        var this = try allocator.create(DNSLookup);
+        const this = try allocator.create(DNSLookup);
         var poll_ref = Async.KeepAlive.init();
         poll_ref.ref(globalThis.bunVM());
 
@@ -1441,7 +1441,7 @@ pub const DNSLookup = struct {
 
     pub fn onCompleteWithArray(this: *DNSLookup, result: JSC.JSValue) void {
         var promise = this.promise;
-        var globalThis = this.globalThis;
+        const globalThis = this.globalThis;
         this.promise = .{};
 
         promise.resolve(globalThis, result);
@@ -1459,7 +1459,7 @@ pub const GlobalData = struct {
     resolver: DNSResolver,
 
     pub fn init(allocator: std.mem.Allocator, vm: *JSC.VirtualMachine) *GlobalData {
-        var global = allocator.create(GlobalData) catch unreachable;
+        const global = allocator.create(GlobalData) catch unreachable;
         global.* = .{
             .resolver = .{
                 .vm = vm,
@@ -1546,7 +1546,7 @@ pub const DNSResolver = struct {
         array.ensureStillAlive();
 
         while (pending) |value| {
-            var new_global = value.globalThis;
+            const new_global = value.globalThis;
             if (prev_global != new_global) {
                 array = addr.toJSResponse(this.vm.allocator, new_global, lookup_name);
                 prev_global = new_global;
@@ -1588,7 +1588,7 @@ pub const DNSResolver = struct {
         // std.c.addrinfo
 
         while (pending) |value| {
-            var new_global = value.globalThis;
+            const new_global = value.globalThis;
             if (prev_global != new_global) {
                 array = addr.toJSArray(this.vm.allocator, new_global);
                 prev_global = new_global;
@@ -1632,7 +1632,7 @@ pub const DNSResolver = struct {
         // std.c.addrinfo
 
         while (pending) |value| {
-            var new_global = value.globalThis;
+            const new_global = value.globalThis;
             pending = value.next;
             if (prev_global != new_global) {
                 array = result.toJS(new_global).?;
@@ -1675,7 +1675,7 @@ pub const DNSResolver = struct {
         array.ensureStillAlive();
 
         while (pending) |value| {
-            var new_global = value.globalThis;
+            const new_global = value.globalThis;
             if (prev_global != new_global) {
                 array = addr.toJSResponse(this.vm.allocator, new_global, "");
                 prev_global = new_global;
@@ -1716,7 +1716,7 @@ pub const DNSResolver = struct {
         array.ensureStillAlive();
 
         while (pending) |value| {
-            var new_global = value.globalThis;
+            const new_global = value.globalThis;
             if (prev_global != new_global) {
                 array = name_info.toJSResponse(this.vm.allocator, new_global);
                 prev_global = new_global;
@@ -1759,7 +1759,7 @@ pub const DNSResolver = struct {
         );
 
         while (inflight_iter.next()) |index| {
-            var entry: *request_type.PendingCacheKey = &cache.buffer[index];
+            const entry: *request_type.PendingCacheKey = &cache.buffer[index];
             if (entry.hash == key.hash and entry.len == key.len) {
                 return .{ .inflight = entry };
             }
@@ -1787,7 +1787,7 @@ pub const DNSResolver = struct {
         );
 
         while (inflight_iter.next()) |index| {
-            var entry: *GetAddrInfoRequest.PendingCacheKey = &cache.buffer[index];
+            const entry: *GetAddrInfoRequest.PendingCacheKey = &cache.buffer[index];
             if (entry.hash == key.hash and entry.len == key.len) {
                 return .{ .inflight = entry };
             }
@@ -1847,7 +1847,7 @@ pub const DNSResolver = struct {
             return;
         }
 
-        var vm = this.vm;
+        const vm = this.vm;
 
         if (!readable and !writable) {
             // read == 0 and write == 0 this is c-ares's way of notifying us that
@@ -1862,7 +1862,7 @@ pub const DNSResolver = struct {
             return;
         }
 
-        var poll_entry = this.polls.getOrPut(fd) catch unreachable;
+        const poll_entry = this.polls.getOrPut(fd) catch unreachable;
 
         if (!poll_entry.found_existing) {
             poll_entry.value_ptr.* = Async.FilePoll.init(vm, bun.toFD(fd), .{}, DNSResolver, this);
@@ -2481,7 +2481,7 @@ pub const DNSResolver = struct {
             return dns_lookup.promise.value();
         }
 
-        var hints_buf = &[_]c_ares.AddrInfo_hints{query.toCAres()};
+        const hints_buf = &[_]c_ares.AddrInfo_hints{query.toCAres()};
         var request = GetAddrInfoRequest.init(
             cache,
             .{
@@ -2511,7 +2511,7 @@ pub const DNSResolver = struct {
 
         var vm = globalThis.bunVM();
         var resolver = vm.rareData().globalDNSResolver(vm);
-        var channel: *c_ares.Channel = switch (resolver.getChannel()) {
+        const channel: *c_ares.Channel = switch (resolver.getChannel()) {
             .result => |res| res,
             .err => |err| {
                 const system_error = JSC.SystemError{

--- a/src/bun.js/api/bun/lshpack.translated.zig
+++ b/src/bun.js/api/bun/lshpack.translated.zig
@@ -213,11 +213,11 @@ pub fn lsxpack_header_get_value(hdr: *lsxpack_header_t) []const u8 {
     return "";
 }
 pub fn lsxpack_header_get_dec_size(arg_hdr: ?*const lsxpack_header_t) callconv(.C) usize {
-    var hdr = arg_hdr;
+    const hdr = arg_hdr;
     return @as(usize, @bitCast(@as(c_long, (@as(c_int, @bitCast(@as(c_uint, hdr.*.name_len))) + @as(c_int, @bitCast(@as(c_uint, hdr.*.val_len)))) + @as(c_int, @bitCast(@as(c_uint, hdr.*.dec_overhead))))));
 }
 pub fn lsxpack_header_mark_val_changed(arg_hdr: ?*lsxpack_header_t) callconv(.C) void {
-    var hdr = arg_hdr;
+    const hdr = arg_hdr;
     hdr.*.flags = @as(c_uint, @bitCast(@as(c_int, @bitCast(hdr.*.flags)) & ~((LSXPACK_HPACK_VAL_MATCHED | LSXPACK_VAL_MATCHED) | LSXPACK_NAMEVAL_HASH)));
 }
 pub const struct_lshpack_enc_table_entry = opaque {};

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -117,7 +117,7 @@ noinline fn getSSLException(globalThis: *JSC.JSGlobalObject, defaultMessage: []c
     }
 
     if (written > 0) {
-        var message = output_buf[0..written];
+        const message = output_buf[0..written];
         zig_str = ZigString.init(std.fmt.allocPrint(bun.default_allocator, "OpenSSL {s}", .{message}) catch unreachable);
         var encoded_str = zig_str.withEncoding();
         encoded_str.mark();
@@ -537,7 +537,7 @@ pub const Listener = struct {
 
         var exception: JSC.C.JSValueRef = null;
 
-        var socket_obj = opts.get(globalObject, "socket") orelse {
+        const socket_obj = opts.get(globalObject, "socket") orelse {
             globalObject.throw("Expected \"socket\" object", .{});
             return .zero;
         };
@@ -561,7 +561,7 @@ pub const Listener = struct {
     ) JSValue {
         log("listen", .{});
         var exception_ = [1]JSC.JSValueRef{null};
-        var exception: JSC.C.ExceptionRef = &exception_;
+        const exception: JSC.C.ExceptionRef = &exception_;
         defer {
             if (exception_[0] != null) {
                 globalObject.throwValue(exception_[0].?.value());
@@ -577,7 +577,7 @@ pub const Listener = struct {
         };
 
         var hostname_or_unix = socket_config.hostname_or_unix;
-        var port = socket_config.port;
+        const port = socket_config.port;
         var ssl = socket_config.ssl;
         var handlers = socket_config.handlers;
         var protos: ?[]const u8 = null;
@@ -593,7 +593,7 @@ pub const Listener = struct {
         defer if (ssl != null) ssl.?.deinit();
         globalObject.bunVM().eventLoop().ensureWaker();
 
-        var socket_context = uws.us_create_bun_socket_context(
+        const socket_context = uws.us_create_bun_socket_context(
             @intFromBool(ssl_enabled),
             uws.Loop.get(),
             @sizeOf(usize),
@@ -663,10 +663,10 @@ pub const Listener = struct {
             .unix = (hostname_or_unix.cloneIfNeeded(bun.default_allocator) catch unreachable).slice(),
         };
 
-        var listen_socket: *uws.ListenSocket = brk: {
+        const listen_socket: *uws.ListenSocket = brk: {
             switch (connection) {
                 .host => |c| {
-                    var host = bun.default_allocator.dupeZ(u8, c.host) catch unreachable;
+                    const host = bun.default_allocator.dupeZ(u8, c.host) catch unreachable;
                     defer bun.default_allocator.free(host);
 
                     const socket = uws.us_socket_context_listen(
@@ -684,7 +684,7 @@ pub const Listener = struct {
                     break :brk socket;
                 },
                 .unix => |u| {
-                    var host = bun.default_allocator.dupeZ(u8, u) catch unreachable;
+                    const host = bun.default_allocator.dupeZ(u8, u) catch unreachable;
                     defer bun.default_allocator.free(host);
                     break :brk uws.us_socket_context_listen_unix(@intFromBool(ssl_enabled), socket_context, host, socket_flags, 8);
                 },
@@ -740,7 +740,7 @@ pub const Listener = struct {
         this.* = socket;
         this.socket_context.?.ext(ssl_enabled, *Listener).?.* = this;
 
-        var this_value = this.toJS(globalObject);
+        const this_value = this.toJS(globalObject);
         this.strong_self.set(globalObject, this_value);
         this.poll_ref.ref(handlers.vm);
 
@@ -879,7 +879,7 @@ pub const Listener = struct {
     }
 
     pub fn ref(this: *Listener, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) JSValue {
-        var this_value = callframe.this();
+        const this_value = callframe.this();
         if (this.listener == null) return JSValue.jsUndefined();
         this.poll_ref.ref(globalObject.bunVM());
         this.strong_self.set(globalObject, this_value);
@@ -899,7 +899,7 @@ pub const Listener = struct {
         opts: JSValue,
     ) JSValue {
         var exception_ = [1]JSC.JSValueRef{null};
-        var exception: JSC.C.ExceptionRef = &exception_;
+        const exception: JSC.C.ExceptionRef = &exception_;
         defer {
             if (exception_[0] != null) {
                 globalObject.throwValue(exception_[0].?.value());
@@ -915,7 +915,7 @@ pub const Listener = struct {
         };
 
         var hostname_or_unix = socket_config.hostname_or_unix;
-        var port = socket_config.port;
+        const port = socket_config.port;
         var ssl = socket_config.ssl;
         var handlers = socket_config.handlers;
         var default_data = socket_config.default_data;
@@ -941,7 +941,7 @@ pub const Listener = struct {
             return .zero;
         };
 
-        var connection: Listener.UnixOrHost = if (port) |port_| .{
+        const connection: Listener.UnixOrHost = if (port) |port_| .{
             .host = .{ .host = (hostname_or_unix.cloneIfNeeded(bun.default_allocator) catch unreachable).slice(), .port = port_ },
         } else .{
             .unix = (hostname_or_unix.cloneIfNeeded(bun.default_allocator) catch unreachable).slice(),
@@ -994,7 +994,7 @@ pub const Listener = struct {
         handlers_ptr.is_server = false;
 
         var promise = JSC.JSPromise.create(globalObject);
-        var promise_value = promise.asValue(globalObject);
+        const promise_value = promise.asValue(globalObject);
         handlers_ptr.promise.set(globalObject, promise_value);
 
         if (ssl_enabled) {
@@ -1234,7 +1234,7 @@ fn NewSocket(comptime ssl: bool) type {
             this.poll_ref.unrefOnNextTick(vm);
 
             const callback = handlers.onConnectError;
-            var globalObject = handlers.globalObject;
+            const globalObject = handlers.globalObject;
             defer vm.drainMicrotasks();
             const err = JSC.SystemError{
                 .errno = errno,
@@ -1297,7 +1297,7 @@ fn NewSocket(comptime ssl: bool) type {
                     return;
                 }
                 this.is_active = false;
-                var vm = this.handlers.vm;
+                const vm = this.handlers.vm;
 
                 this.handlers.markInactive(ssl, this.socket.context(), this.wrapped);
                 this.poll_ref.unref(vm);
@@ -1317,7 +1317,7 @@ fn NewSocket(comptime ssl: bool) type {
                     if (this.server_name) |server_name| {
                         const host = normalizeHost(server_name);
                         if (host.len > 0) {
-                            var host__ = default_allocator.dupeZ(u8, host) catch unreachable;
+                            const host__ = default_allocator.dupeZ(u8, host) catch unreachable;
                             defer default_allocator.free(host__);
                             ssl_ptr.setHostname(host__);
                         }
@@ -1325,7 +1325,7 @@ fn NewSocket(comptime ssl: bool) type {
                         if (connection == .host) {
                             const host = normalizeHost(connection.host.host);
                             if (host.len > 0) {
-                                var host__ = default_allocator.dupeZ(u8, host) catch unreachable;
+                                const host__ = default_allocator.dupeZ(u8, host) catch unreachable;
                                 defer default_allocator.free(host__);
                                 ssl_ptr.setHostname(host__);
                             }
@@ -1509,7 +1509,7 @@ fn NewSocket(comptime ssl: bool) type {
             var scope = handlers.enter(socket.context());
             defer scope.exit(ssl, this.wrapped);
 
-            var globalObject = handlers.globalObject;
+            const globalObject = handlers.globalObject;
             const this_value = this.getThisValue(globalObject);
             const result = callback.callWithThis(globalObject, this_value, &[_]JSValue{
                 this_value,
@@ -2002,7 +2002,7 @@ fn NewSocket(comptime ssl: bool) type {
 
             var exception: JSC.C.JSValueRef = null;
 
-            var socket_obj = opts.get(globalObject, "socket") orelse {
+            const socket_obj = opts.get(globalObject, "socket") orelse {
                 globalObject.throw("Expected \"socket\" option", .{});
                 return .zero;
             };
@@ -2033,7 +2033,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return JSValue.jsUndefined();
             }
 
-            var ssl_ptr = this.socket.ssl();
+            const ssl_ptr = this.socket.ssl();
             const session = BoringSSL.SSL_get_session(ssl_ptr) orelse return JSValue.jsUndefined();
             var ticket: [*c]const u8 = undefined;
             var length: usize = 0;
@@ -2072,10 +2072,10 @@ fn NewSocket(comptime ssl: bool) type {
             defer arena.deinit();
 
             var exception_ref = [_]JSC.C.JSValueRef{null};
-            var exception: JSC.C.ExceptionRef = &exception_ref;
+            const exception: JSC.C.ExceptionRef = &exception_ref;
             if (JSC.Node.StringOrBuffer.fromJS(globalObject, arena.allocator(), session_arg, exception)) |sb| {
-                var session_slice = sb.slice();
-                var ssl_ptr = this.socket.ssl();
+                const session_slice = sb.slice();
+                const ssl_ptr = this.socket.ssl();
                 var tmp = @as([*c]const u8, @ptrCast(session_slice.ptr));
                 const session = BoringSSL.d2i_SSL_SESSION(null, &tmp, @as(c_long, @intCast(session_slice.len))) orelse return JSValue.jsUndefined();
                 if (BoringSSL.SSL_set_session(ssl_ptr, session) != 1) {
@@ -2105,7 +2105,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return JSValue.jsUndefined();
             }
 
-            var ssl_ptr = this.socket.ssl();
+            const ssl_ptr = this.socket.ssl();
             const session = BoringSSL.SSL_get_session(ssl_ptr) orelse return JSValue.jsUndefined();
             const size = BoringSSL.i2d_SSL_SESSION(session, null);
             if (size <= 0) {
@@ -2136,7 +2136,7 @@ fn NewSocket(comptime ssl: bool) type {
             var alpn_proto: [*c]const u8 = null;
             var alpn_proto_len: u32 = 0;
 
-            var ssl_ptr = this.socket.ssl();
+            const ssl_ptr = this.socket.ssl();
 
             BoringSSL.SSL_get0_alpn_selected(ssl_ptr, &alpn_proto, &alpn_proto_len);
             if (alpn_proto == null or alpn_proto_len == 0) {
@@ -2204,13 +2204,13 @@ fn NewSocket(comptime ssl: bool) type {
                 defer arena.deinit();
 
                 var exception_ref = [_]JSC.C.JSValueRef{null};
-                var exception: JSC.C.ExceptionRef = &exception_ref;
+                const exception: JSC.C.ExceptionRef = &exception_ref;
                 if (JSC.Node.StringOrBuffer.fromJS(globalObject, arena.allocator(), context_arg, exception)) |sb| {
                     const context_slice = sb.slice();
 
                     const buffer_size = @as(usize, @intCast(length));
                     var buffer = JSValue.createBufferFromLength(globalObject, buffer_size);
-                    var buffer_ptr = @as([*c]u8, @ptrCast(buffer.asArrayBuffer(globalObject).?.ptr));
+                    const buffer_ptr = @as([*c]u8, @ptrCast(buffer.asArrayBuffer(globalObject).?.ptr));
 
                     const result = BoringSSL.SSL_export_keying_material(ssl_ptr, buffer_ptr, buffer_size, @as([*c]const u8, @ptrCast(label_slice.ptr)), label_slice.len, @as([*c]const u8, @ptrCast(context_slice.ptr)), context_slice.len, 1);
                     if (result != 1) {
@@ -2228,7 +2228,7 @@ fn NewSocket(comptime ssl: bool) type {
             } else {
                 const buffer_size = @as(usize, @intCast(length));
                 var buffer = JSValue.createBufferFromLength(globalObject, buffer_size);
-                var buffer_ptr = @as([*c]u8, @ptrCast(buffer.asArrayBuffer(globalObject).?.ptr));
+                const buffer_ptr = @as([*c]u8, @ptrCast(buffer.asArrayBuffer(globalObject).?.ptr));
 
                 const result = BoringSSL.SSL_export_keying_material(ssl_ptr, buffer_ptr, buffer_size, @as([*c]const u8, @ptrCast(label_slice.ptr)), label_slice.len, null, 0, 0);
                 if (result != 1) {
@@ -2266,7 +2266,7 @@ fn NewSocket(comptime ssl: bool) type {
             // if (BoringSSL.SSL_get_server_tmp_key(ssl_ptr, @ptrCast([*c][*c]BoringSSL.EVP_PKEY, &raw_key)) == 0) {
             //     return result;
             // }
-            var raw_key: [*c]BoringSSL.EVP_PKEY = BoringSSL.SSL_get_privatekey(ssl_ptr);
+            const raw_key: [*c]BoringSSL.EVP_PKEY = BoringSSL.SSL_get_privatekey(ssl_ptr);
             if (raw_key == null) {
                 return result;
             }
@@ -2380,7 +2380,7 @@ fn NewSocket(comptime ssl: bool) type {
 
             const buffer_size = @as(usize, @intCast(size));
             var buffer = JSValue.createBufferFromLength(globalObject, buffer_size);
-            var buffer_ptr = @as(*anyopaque, @ptrCast(buffer.asArrayBuffer(globalObject).?.ptr));
+            const buffer_ptr = @as(*anyopaque, @ptrCast(buffer.asArrayBuffer(globalObject).?.ptr));
 
             const result_size = BoringSSL.SSL_get_peer_finished(ssl_ptr, buffer_ptr, buffer_size);
             std.debug.assert(result_size == size);
@@ -2412,7 +2412,7 @@ fn NewSocket(comptime ssl: bool) type {
 
             const buffer_size = @as(usize, @intCast(size));
             var buffer = JSValue.createBufferFromLength(globalObject, buffer_size);
-            var buffer_ptr = @as(*anyopaque, @ptrCast(buffer.asArrayBuffer(globalObject).?.ptr));
+            const buffer_ptr = @as(*anyopaque, @ptrCast(buffer.asArrayBuffer(globalObject).?.ptr));
 
             const result_size = BoringSSL.SSL_get_finished(ssl_ptr, buffer_ptr, buffer_size);
             std.debug.assert(result_size == size);
@@ -2696,7 +2696,7 @@ fn NewSocket(comptime ssl: bool) type {
                     globalObject.throw("Already started.", .{});
                     return .zero;
                 }
-                var host__ = default_allocator.dupeZ(u8, host) catch unreachable;
+                const host__ = default_allocator.dupeZ(u8, host) catch unreachable;
                 defer default_allocator.free(host__);
                 ssl_ptr.setHostname(host__);
             }
@@ -2736,7 +2736,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return .zero;
             }
 
-            var socket_obj = opts.get(globalObject, "socket") orelse {
+            const socket_obj = opts.get(globalObject, "socket") orelse {
                 globalObject.throw("Expected \"socket\" option", .{});
                 return .zero;
             };
@@ -2799,7 +2799,7 @@ fn NewSocket(comptime ssl: bool) type {
                 .server_name = if (socket_config.server_name) |server_name| (bun.default_allocator.dupe(u8, server_name[0..bun.len(server_name)]) catch unreachable) else null,
             };
 
-            var tls_js_value = tls.getThisValue(globalObject);
+            const tls_js_value = tls.getThisValue(globalObject);
             TLSSocket.dataSetCached(tls_js_value, globalObject, default_data);
 
             const TCPHandler = NewWrappedHandler(false);
@@ -2851,7 +2851,7 @@ fn NewSocket(comptime ssl: bool) type {
             };
             raw_handlers_ptr.protect();
 
-            var raw_js_value = raw.getThisValue(globalObject);
+            const raw_js_value = raw.getThisValue(globalObject);
             if (JSSocketType(ssl).dataGetCached(this.getThisValue(globalObject))) |raw_default_data| {
                 raw_default_data.ensureStillAlive();
                 TLSSocket.dataSetCached(raw_js_value, globalObject, raw_default_data);
@@ -2871,7 +2871,7 @@ fn NewSocket(comptime ssl: bool) type {
             //detach and invalidate the old instance
             this.detached = true;
             if (this.is_active) {
-                var vm = this.handlers.vm;
+                const vm = this.handlers.vm;
                 this.is_active = false;
                 // will free handlers and the old_context when hits 0 active connections
                 // the connection can be upgraded inside a handler call so we need to garantee that it will be still alive

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -131,7 +131,7 @@ pub const Subprocess = struct {
     }
 
     pub fn ref(this: *Subprocess) void {
-        var vm = this.globalThis.bunVM();
+        const vm = this.globalThis.bunVM();
 
         switch (this.poll) {
             .poll_ref => if (this.poll.poll_ref) |poll| {
@@ -157,7 +157,7 @@ pub const Subprocess = struct {
 
     /// This disables the keeping process alive flag on the poll and also in the stdin, stdout, and stderr
     pub fn unref(this: *Subprocess, comptime deactivate_poll_ref: bool) void {
-        var vm = this.globalThis.bunVM();
+        const vm = this.globalThis.bunVM();
 
         switch (this.poll) {
             .poll_ref => if (this.poll.poll_ref) |poll| {
@@ -340,7 +340,7 @@ pub const Subprocess = struct {
                     this.pipe.buffer.fifo.close_on_empty_read = true;
                     this.pipe.buffer.readAll();
 
-                    var bytes = this.pipe.buffer.internal_buffer.slice();
+                    const bytes = this.pipe.buffer.internal_buffer.slice();
                     this.pipe.buffer.internal_buffer = .{};
 
                     if (bytes.len > 0) {
@@ -750,9 +750,9 @@ pub const Subprocess = struct {
             if (this.auto_sizer) |auto_sizer| {
                 while (@as(usize, this.internal_buffer.len) < auto_sizer.max and this.status == .pending) {
                     var stack_buffer: [8096]u8 = undefined;
-                    var stack_buf: []u8 = stack_buffer[0..];
+                    const stack_buf: []u8 = stack_buffer[0..];
                     var buf_to_use = stack_buf;
-                    var available = this.internal_buffer.available();
+                    const available = this.internal_buffer.available();
                     if (available.len >= stack_buf.len) {
                         buf_to_use = available;
                     }
@@ -791,7 +791,7 @@ pub const Subprocess = struct {
                 }
             } else {
                 while (this.internal_buffer.len < this.internal_buffer.cap and this.status == .pending) {
-                    var buf_to_use = this.internal_buffer.available();
+                    const buf_to_use = this.internal_buffer.available();
 
                     const result = this.fifo.read(buf_to_use, this.fifo.to_read);
 
@@ -1227,7 +1227,7 @@ pub const Subprocess = struct {
                     var arg0 = first_cmd.toSlice(globalThis, allocator);
                     defer arg0.deinit();
                     var path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                    var resolved = Which.which(&path_buf, PATH, cwd, arg0.slice()) orelse {
+                    const resolved = Which.which(&path_buf, PATH, cwd, arg0.slice()) orelse {
                         globalThis.throwInvalidArguments("Executable not found in $PATH: \"{s}\"", .{arg0.slice()});
                         return .zero;
                     };
@@ -1609,7 +1609,7 @@ pub const Subprocess = struct {
             },
         };
         if (ipc_mode != .none) {
-            var ptr = socket.ext(*Subprocess);
+            const ptr = socket.ext(*Subprocess);
             ptr.?.* = subprocess;
             subprocess.ipc.writeVersionPacket();
         }
@@ -1629,7 +1629,7 @@ pub const Subprocess = struct {
 
         if (comptime !is_sync) {
             if (!WaiterThread.shouldUseWaiterThread()) {
-                var poll = Async.FilePoll.init(jsc_vm, watchfd, .{}, Subprocess, subprocess);
+                const poll = Async.FilePoll.init(jsc_vm, watchfd, .{}, Subprocess, subprocess);
                 subprocess.poll = .{ .poll_ref = poll };
                 switch (subprocess.poll.poll_ref.?.register(
                     jsc_vm.event_loop_handle.?,
@@ -1697,7 +1697,7 @@ pub const Subprocess = struct {
         subprocess.closeIO(.stdin);
 
         if (!WaiterThread.shouldUseWaiterThread()) {
-            var poll = Async.FilePoll.init(jsc_vm, watchfd, .{}, Subprocess, subprocess);
+            const poll = Async.FilePoll.init(jsc_vm, watchfd, .{}, Subprocess, subprocess);
             subprocess.poll = .{ .poll_ref = poll };
             switch (subprocess.poll.poll_ref.?.register(
                 jsc_vm.event_loop_handle.?,
@@ -1851,7 +1851,7 @@ pub const Subprocess = struct {
         }
 
         if (!sync and this.hasExited()) {
-            var vm = this.globalThis.bunVM();
+            const vm = this.globalThis.bunVM();
 
             // prevent duplicate notifications
             switch (this.poll) {
@@ -2252,7 +2252,7 @@ pub const Subprocess = struct {
             subprocess: *Subprocess,
 
             pub fn runFromJSThread(self: *@This()) void {
-                var result = self.result;
+                const result = self.result;
                 var subprocess = self.subprocess;
                 _ = subprocess.poll.wait_thread.ref_count.fetchSub(1, .Monotonic);
                 bun.default_allocator.destroy(self);
@@ -2274,7 +2274,7 @@ pub const Subprocess = struct {
                 process.poll.wait_thread.poll_ref.activate(process.globalThis.bunVM().event_loop_handle.?);
             }
 
-            var task = bun.default_allocator.create(WaitTask) catch unreachable;
+            const task = bun.default_allocator.create(WaitTask) catch unreachable;
             task.* = WaitTask{
                 .subprocess = process,
             };
@@ -2323,7 +2323,7 @@ pub const Subprocess = struct {
                         _ = this.queue.orderedRemove(i);
                         queue = this.queue.items;
 
-                        var task = bun.default_allocator.create(WaitPidResultTask) catch unreachable;
+                        const task = bun.default_allocator.create(WaitPidResultTask) catch unreachable;
                         task.* = WaitPidResultTask{
                             .result = result,
                             .subprocess = process,
@@ -2361,7 +2361,7 @@ pub const Subprocess = struct {
                 } else {
                     var mask = std.os.empty_sigset;
                     var signal: c_int = std.os.SIG.CHLD;
-                    var rc = std.c.sigwait(&mask, &signal);
+                    const rc = std.c.sigwait(&mask, &signal);
                     _ = rc;
                 }
             }

--- a/src/bun.js/api/bun/x509.zig
+++ b/src/bun.js/api/bun/x509.zig
@@ -520,7 +520,7 @@ pub fn toJS(cert: *BoringSSL.X509, globalObject: *JSGlobalObject) JSValue {
                     }
 
                     var buffer = JSValue.createBufferFromLength(globalObject, @as(usize, @intCast(size)));
-                    var buffer_ptr = @as([*c]u8, @ptrCast(buffer.asArrayBuffer(globalObject).?.ptr));
+                    const buffer_ptr = @as([*c]u8, @ptrCast(buffer.asArrayBuffer(globalObject).?.ptr));
 
                     const result_size = BoringSSL.EC_POINT_point2oct(group, point, form, buffer_ptr, size, null);
                     std.debug.assert(result_size == size);

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -126,7 +126,7 @@ pub const FFI = struct {
                 return ZigString.init("Failed to compile, but not sure why. Please report this bug").toErrorInstance(globalThis);
             },
             .compiled => {
-                var function_ = bun.default_allocator.create(Function) catch unreachable;
+                const function_ = bun.default_allocator.create(Function) catch unreachable;
                 function_.* = func.*;
                 return JSValue.createObject2(
                     globalThis,
@@ -328,7 +328,7 @@ pub const FFI = struct {
 
             // optional if the user passed "ptr"
             if (function.symbol_from_dynamic_library == null) {
-                var resolved_symbol = dylib.lookup(*anyopaque, function_name) orelse {
+                const resolved_symbol = dylib.lookup(*anyopaque, function_name) orelse {
                     const ret = JSC.toInvalidArguments("Symbol \"{s}\" not found in \"{s}\"", .{ bun.asByteSlice(function_name), name_slice.slice() }, global);
                     for (symbols.values()) |*value| {
                         allocator.free(bun.constStrToU8(bun.asByteSlice(value.base_name.?)));
@@ -713,7 +713,7 @@ pub const FFI = struct {
         const FFI_HEADER: string = @embedFile("./FFI.h");
         pub inline fn ffiHeader() string {
             if (comptime Environment.isDebug) {
-                var dirpath = comptime bun.Environment.base_path ++ std.fs.path.dirname(@src().file).?;
+                const dirpath = comptime bun.Environment.base_path ++ std.fs.path.dirname(@src().file).?;
                 var env = std.process.getEnvMap(default_allocator) catch unreachable;
 
                 const dir = std.mem.replaceOwned(
@@ -723,7 +723,7 @@ pub const FFI = struct {
                     "jarred",
                     env.get("USER").?,
                 ) catch unreachable;
-                var runtime_path = std.fs.path.join(default_allocator, &[_]string{ dir, "FFI.h" }) catch unreachable;
+                const runtime_path = std.fs.path.join(default_allocator, &[_]string{ dir, "FFI.h" }) catch unreachable;
                 const file = std.fs.openFileAbsolute(runtime_path, .{}) catch @panic("Missing bun/src/bun.js/api/FFI.h.");
                 defer file.close();
                 return file.readToEndAlloc(default_allocator, file.getEndPos() catch unreachable) catch unreachable;
@@ -782,7 +782,7 @@ pub const FFI = struct {
             try source_code.append(0);
             defer source_code.deinit();
 
-            var state = TCC.tcc_new() orelse return error.TCCMissing;
+            const state = TCC.tcc_new() orelse return error.TCCMissing;
             TCC.tcc_set_options(state, tcc_options);
             // addSharedLibPaths(state);
             TCC.tcc_set_error_func(state, this, handleTCCError);
@@ -834,7 +834,7 @@ pub const FFI = struct {
                 return;
             }
 
-            var relocation_size = TCC.tcc_relocate(state, null);
+            const relocation_size = TCC.tcc_relocate(state, null);
             if (this.step == .failed) {
                 return;
             }
@@ -845,7 +845,7 @@ pub const FFI = struct {
                 return;
             }
 
-            var bytes: []u8 = try allocator.alloc(u8, @as(usize, @intCast(relocation_size)));
+            const bytes: []u8 = try allocator.alloc(u8, @as(usize, @intCast(relocation_size)));
             defer {
                 if (this.step == .failed) {
                     allocator.free(bytes);
@@ -860,7 +860,7 @@ pub const FFI = struct {
                 pthread_jit_write_protect_np(true);
             }
 
-            var symbol = TCC.tcc_get_symbol(state, "JSFunctionCall") orelse {
+            const symbol = TCC.tcc_get_symbol(state, "JSFunctionCall") orelse {
                 this.step = .{ .failed = .{ .msg = "missing generated symbol in source code" } };
 
                 return;
@@ -949,7 +949,7 @@ pub const FFI = struct {
             JSC.markBinding(@src());
             var source_code = std.ArrayList(u8).init(allocator);
             var source_code_writer = source_code.writer();
-            var ffi_wrapper = Bun__createFFICallbackFunction(js_context, js_function);
+            const ffi_wrapper = Bun__createFFICallbackFunction(js_context, js_function);
             try this.printCallbackSourceCode(js_context, ffi_wrapper, &source_code_writer);
 
             if (comptime Environment.allow_assert and Environment.isPosix) {
@@ -963,7 +963,7 @@ pub const FFI = struct {
 
             try source_code.append(0);
             // defer source_code.deinit();
-            var state = TCC.tcc_new() orelse return error.TCCMissing;
+            const state = TCC.tcc_new() orelse return error.TCCMissing;
             TCC.tcc_set_options(state, tcc_options);
             TCC.tcc_set_error_func(state, this, handleTCCError);
             this.state = state;
@@ -1015,7 +1015,7 @@ pub const FFI = struct {
                     else => FFI_Callback_call,
                 },
             );
-            var relocation_size = TCC.tcc_relocate(state, null);
+            const relocation_size = TCC.tcc_relocate(state, null);
 
             if (relocation_size < 0) {
                 if (this.step != .failed)
@@ -1023,7 +1023,7 @@ pub const FFI = struct {
                 return;
             }
 
-            var bytes: []u8 = try allocator.alloc(u8, @as(usize, @intCast(relocation_size)));
+            const bytes: []u8 = try allocator.alloc(u8, @as(usize, @intCast(relocation_size)));
             defer {
                 if (this.step == .failed) {
                     allocator.free(bytes);
@@ -1038,7 +1038,7 @@ pub const FFI = struct {
                 pthread_jit_write_protect_np(true);
             }
 
-            var symbol = TCC.tcc_get_symbol(state, "my_callback_function") orelse {
+            const symbol = TCC.tcc_get_symbol(state, "my_callback_function") orelse {
                 this.step = .{ .failed = .{ .msg = "missing generated symbol in source code" } };
 
                 return;
@@ -1445,7 +1445,7 @@ pub const FFI = struct {
         pub const map_to_js_object = brk: {
             var count: usize = 2;
             for (map, 0..) |item, i| {
-                var fmt = EnumMapFormatter{ .name = item.@"0", .entry = item.@"1" };
+                const fmt = EnumMapFormatter{ .name = item.@"0", .entry = item.@"1" };
                 count += std.fmt.count("{}", .{fmt});
                 count += @intFromBool(i > 0);
             }
@@ -1455,7 +1455,7 @@ pub const FFI = struct {
             buf[buf.len - 1] = '}';
             var end: usize = 1;
             for (map, 0..) |item, i| {
-                var fmt = EnumMapFormatter{ .name = item.@"0", .entry = item.@"1" };
+                const fmt = EnumMapFormatter{ .name = item.@"0", .entry = item.@"1" };
                 if (i > 0) {
                     buf[end] = ',';
                     end += 1;

--- a/src/bun.js/api/filesystem_router.zig
+++ b/src/bun.js/api/filesystem_router.zig
@@ -102,7 +102,7 @@ pub const FileSystemRouter = struct {
         }
         var arena = globalThis.allocator().create(@import("root").bun.ArenaAllocator) catch unreachable;
         arena.* = @import("root").bun.ArenaAllocator.init(globalThis.allocator());
-        var allocator = arena.allocator();
+        const allocator = arena.allocator();
         var extensions = std.ArrayList(string).init(allocator);
         if (argument.get(globalThis, "fileExtensions")) |file_extensions| {
             if (!file_extensions.jsType().isArray()) {
@@ -139,14 +139,14 @@ pub const FileSystemRouter = struct {
 
             asset_prefix_slice = asset_prefix.toSlice(globalThis, allocator).clone(allocator) catch unreachable;
         }
-        var orig_log = vm.bundler.resolver.log;
+        const orig_log = vm.bundler.resolver.log;
         var log = Log.Log.init(allocator);
         vm.bundler.resolver.log = &log;
         defer vm.bundler.resolver.log = orig_log;
 
-        var path_to_use = (root_dir_path.cloneWithTrailingSlash(allocator) catch unreachable).slice();
+        const path_to_use = (root_dir_path.cloneWithTrailingSlash(allocator) catch unreachable).slice();
 
-        var root_dir_info = vm.bundler.resolver.readDirInfo(path_to_use) catch {
+        const root_dir_info = vm.bundler.resolver.readDirInfo(path_to_use) catch {
             globalThis.throwValue(log.toJS(globalThis, globalThis.allocator(), "reading root directory"));
             origin_str.deinit();
             arena.deinit();
@@ -212,7 +212,7 @@ pub const FileSystemRouter = struct {
     }
 
     pub fn reload(this: *FileSystemRouter, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) JSValue {
-        var this_value = callframe.this();
+        const this_value = callframe.this();
 
         var arena = globalThis.allocator().create(@import("root").bun.ArenaAllocator) catch unreachable;
         arena.* = @import("root").bun.ArenaAllocator.init(globalThis.allocator());
@@ -220,12 +220,12 @@ pub const FileSystemRouter = struct {
         var allocator = arena.allocator();
         var vm = globalThis.bunVM();
 
-        var orig_log = vm.bundler.resolver.log;
+        const orig_log = vm.bundler.resolver.log;
         var log = Log.Log.init(allocator);
         vm.bundler.resolver.log = &log;
         defer vm.bundler.resolver.log = orig_log;
 
-        var root_dir_info = vm.bundler.resolver.readDirInfo(this.router.config.dir) catch {
+        const root_dir_info = vm.bundler.resolver.readDirInfo(this.router.config.dir) catch {
             globalThis.throwValue(log.toJS(globalThis, globalThis.allocator(), "reading root directory"));
             return .zero;
         } orelse {
@@ -408,7 +408,7 @@ pub const MatchedRoute = struct {
         asset_prefix: ?*JSC.RefString,
         base_dir: *JSC.RefString,
     ) !*MatchedRoute {
-        var params_list = try match.params.clone(allocator);
+        const params_list = try match.params.clone(allocator);
 
         var route = try allocator.create(MatchedRoute);
 
@@ -541,7 +541,7 @@ pub const MatchedRoute = struct {
 
         var creator = QueryObjectCreator{ .query = map };
 
-        var value = JSObject.createWithInitializer(QueryObjectCreator, &creator, ctx, map.getNameCount());
+        const value = JSObject.createWithInitializer(QueryObjectCreator, &creator, ctx, map.getNameCount());
 
         return value;
     }

--- a/src/bun.js/api/glob.zig
+++ b/src/bun.js/api/glob.zig
@@ -46,7 +46,7 @@ const ScanOpts = struct {
                 const cwd_zig_str = cwdVal.getZigString(globalThis);
                 // Dupe if already utf-16
                 if (cwd_zig_str.is16Bit()) {
-                    var duped = allocator.dupe(u8, cwd_zig_str.slice()) catch {
+                    const duped = allocator.dupe(u8, cwd_zig_str.slice()) catch {
                         globalThis.throwOutOfMemory();
                         return null;
                     };
@@ -65,7 +65,7 @@ const ScanOpts = struct {
                     return null;
                 }) orelse brk: {
                     // All ascii
-                    var output = allocator.alloc(u16, cwd_zig_str.len) catch {
+                    const output = allocator.alloc(u16, cwd_zig_str.len) catch {
                         globalThis.throwOutOfMemory();
                         return null;
                     };
@@ -229,7 +229,7 @@ pub const WalkTask = struct {
         globWalker: *GlobWalker,
         has_pending_activity: *std.atomic.Atomic(usize),
     ) !*AsyncGlobWalkTask {
-        var walkTask = try alloc.create(WalkTask);
+        const walkTask = try alloc.create(WalkTask);
         walkTask.* = .{
             .walker = globWalker,
             .global = globalThis,
@@ -293,12 +293,12 @@ fn makeGlobWalker(
     arena: *Arena,
 ) ?*GlobWalker {
     const matchOpts = ScanOpts.fromJS(globalThis, arguments, fnName, arena) orelse return null;
-    var cwd = matchOpts.cwd;
-    var dot = matchOpts.dot;
-    var absolute = matchOpts.absolute;
-    var follow_symlinks = matchOpts.follow_symlinks;
-    var error_on_broken_symlinks = matchOpts.error_on_broken_symlinks;
-    var only_files = matchOpts.only_files;
+    const cwd = matchOpts.cwd;
+    const dot = matchOpts.dot;
+    const absolute = matchOpts.absolute;
+    const follow_symlinks = matchOpts.follow_symlinks;
+    const error_on_broken_symlinks = matchOpts.error_on_broken_symlinks;
+    const only_files = matchOpts.only_files;
 
     if (cwd != null) {
         var globWalker = alloc.create(GlobWalker) catch {
@@ -376,7 +376,7 @@ pub fn constructor(
         return null;
     }
 
-    var pat_str: []u8 = pat_arg.toBunString(globalThis).toOwnedSlice(bun.default_allocator) catch @panic("OOM");
+    const pat_str: []u8 = pat_arg.toBunString(globalThis).toOwnedSlice(bun.default_allocator) catch @panic("OOM");
 
     const all_ascii = isAllAscii(pat_str);
 
@@ -435,7 +435,7 @@ pub fn __scan(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.CallFram
     defer arguments.deinit();
 
     var arena = std.heap.ArenaAllocator.init(alloc);
-    var globWalker = this.makeGlobWalker(globalThis, &arguments, "scan", alloc, &arena) orelse {
+    const globWalker = this.makeGlobWalker(globalThis, &arguments, "scan", alloc, &arena) orelse {
         arena.deinit();
         return .undefined;
     };

--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -44,7 +44,7 @@ pub const HTMLRewriter = struct {
     pub usingnamespace JSC.Codegen.JSHTMLRewriter;
 
     pub fn constructor(_: *JSGlobalObject, _: *JSC.CallFrame) callconv(.C) ?*HTMLRewriter {
-        var rewriter = bun.default_allocator.create(HTMLRewriter) catch unreachable;
+        const rewriter = bun.default_allocator.create(HTMLRewriter) catch unreachable;
         rewriter.* = HTMLRewriter{
             .builder = LOLHTML.HTMLRewriter.Builder.init(),
             .context = .{},
@@ -59,12 +59,12 @@ pub const HTMLRewriter = struct {
         callFrame: *JSC.CallFrame,
         listener: JSValue,
     ) JSValue {
-        var selector_slice = std.fmt.allocPrint(bun.default_allocator, "{}", .{selector_name}) catch unreachable;
+        const selector_slice = std.fmt.allocPrint(bun.default_allocator, "{}", .{selector_name}) catch unreachable;
 
         var selector = LOLHTML.HTMLSelector.parse(selector_slice) catch
             return throwLOLHTMLError(global);
-        var handler_ = ElementHandler.init(global, listener) catch return .zero;
-        var handler = getAllocator(global).create(ElementHandler) catch unreachable;
+        const handler_ = ElementHandler.init(global, listener) catch return .zero;
+        const handler = getAllocator(global).create(ElementHandler) catch unreachable;
         handler.* = handler_;
 
         this.builder.addElementContentHandlers(
@@ -106,9 +106,9 @@ pub const HTMLRewriter = struct {
         listener: JSValue,
         callFrame: *JSC.CallFrame,
     ) JSValue {
-        var handler_ = DocumentHandler.init(global, listener) catch return .zero;
+        const handler_ = DocumentHandler.init(global, listener) catch return .zero;
 
-        var handler = getAllocator(global).create(DocumentHandler) catch unreachable;
+        const handler = getAllocator(global).create(DocumentHandler) catch unreachable;
         handler.* = handler_;
 
         // If this fails, subsequent calls to write or end should throw
@@ -407,7 +407,7 @@ pub const HTMLRewriter = struct {
             }
 
             result.url = original.url.clone();
-            var value = original.getBodyValue();
+            const value = original.getBodyValue();
             sink.bodyValueBufferer = JSC.WebCore.BodyValueBufferer.init(sink, onFinishedBuffering, sink.global, bun.default_allocator);
             sink.bodyValueBufferer.?.run(value) catch |buffering_error| {
                 return switch (buffering_error) {
@@ -487,7 +487,7 @@ pub const HTMLRewriter = struct {
             is_async: bool,
         ) ?JSValue {
             sink.bytes.growBy(bytes.len) catch unreachable;
-            var global = sink.global;
+            const global = sink.global;
             var response = sink.response;
 
             sink.rewriter.write(bytes) catch {
@@ -1448,7 +1448,7 @@ pub const Element = struct {
             return ZigString.init("Expected a function").withEncoding().toValueGC(globalObject);
         }
 
-        var end_tag_handler = bun.default_allocator.create(EndTag.Handler) catch unreachable;
+        const end_tag_handler = bun.default_allocator.create(EndTag.Handler) catch unreachable;
         end_tag_handler.* = .{ .global = globalObject, .callback = function };
 
         this.element.?.onEndTag(EndTag.Handler.onEndTagHandler, end_tag_handler) catch {
@@ -1712,7 +1712,7 @@ pub const Element = struct {
         if (this.element == null)
             return JSValue.jsUndefined();
 
-        var iter = this.element.?.attributes() orelse return throwLOLHTMLError(globalObject);
+        const iter = this.element.?.attributes() orelse return throwLOLHTMLError(globalObject);
         var attr_iter = bun.default_allocator.create(AttributeIterator) catch unreachable;
         attr_iter.* = .{ .iterator = iter };
         var js_attr_iter = attr_iter.toJS(globalObject);

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1319,7 +1319,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 return;
             }
 
-            var response = value.as(JSC.WebCore.Response) orelse {
+            const response = value.as(JSC.WebCore.Response) orelse {
                 Output.prettyErrorln("Expected a Response object", .{});
                 Output.flush();
                 ctx.renderMissing();
@@ -1437,7 +1437,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
             const allocator = this.allocator;
 
-            var fallback_container = allocator.create(Api.FallbackMessageContainer) catch unreachable;
+            const fallback_container = allocator.create(Api.FallbackMessageContainer) catch unreachable;
             defer allocator.destroy(fallback_container);
             fallback_container.* = Api.FallbackMessageContainer{
                 .message = std.fmt.allocPrint(allocator, comptime Output.prettyFmt(fmt, false), args) catch unreachable,
@@ -1456,7 +1456,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             Output.flush();
 
             var bb = std.ArrayList(u8).init(allocator);
-            var bb_writer = bb.writer();
+            const bb_writer = bb.writer();
 
             Fallback.renderBackend(
                 allocator,
@@ -1943,7 +1943,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             std.debug.assert(this.resp == resp);
             const write_offset: usize = write_offset_;
 
-            var bytes = bytes_[@min(bytes_.len, @as(usize, @truncate(write_offset)))..];
+            const bytes = bytes_[@min(bytes_.len, @as(usize, @truncate(write_offset)))..];
             if (resp.tryEnd(bytes, bytes_.len, this.shouldCloseConnection())) {
                 this.finalize();
                 return true;
@@ -1958,7 +1958,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             const write_offset: usize = write_offset_;
             std.debug.assert(this.resp == resp);
 
-            var bytes = bytes_[@min(bytes_.len, @as(usize, @truncate(write_offset)))..];
+            const bytes = bytes_[@min(bytes_.len, @as(usize, @truncate(write_offset)))..];
             if (resp.tryEnd(bytes, bytes_.len, this.shouldCloseConnection())) {
                 this.response_buf_owned.items.len = 0;
                 this.finalize();
@@ -2591,7 +2591,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             const args = callframe.arguments(2);
             var req = args.ptr[args.len - 1].asPromisePtr(@This());
             req.pending_promises_for_abort -|= 1;
-            var err = args.ptr[0];
+            const err = args.ptr[0];
             req.handleRejectStream(globalThis, err);
             return JSValue.jsUndefined();
         }
@@ -2776,7 +2776,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         }
 
         pub fn onPipe(this: *RequestContext, stream: JSC.WebCore.StreamResult, allocator: std.mem.Allocator) void {
-            var stream_needs_deinit = stream == .owned or stream == .owned_and_done;
+            const stream_needs_deinit = stream == .owned or stream == .owned_and_done;
 
             defer {
                 if (stream_needs_deinit) {
@@ -3321,7 +3321,7 @@ pub const WebSocketServer = struct {
 
         pub fn fromJS(globalObject: *JSC.JSGlobalObject, object: JSC.JSValue) ?Handler {
             var handler = Handler{ .globalObject = globalObject };
-            var vm = globalObject.vm();
+            const vm = globalObject.vm();
             var valid = false;
 
             if (object.getTruthy(globalObject, "message")) |message_| {
@@ -3802,7 +3802,7 @@ pub const ServerWebSocket = struct {
     pub fn onDrain(this: *ServerWebSocket, _: uws.AnyWebSocket) void {
         log("onDrain", .{});
 
-        var handler = this.handler;
+        const handler = this.handler;
         if (this.closed)
             return;
 
@@ -3967,7 +3967,7 @@ pub const ServerWebSocket = struct {
             return .zero;
         }
 
-        var app = this.handler.app orelse {
+        const app = this.handler.app orelse {
             log("publish() closed", .{});
             return JSValue.jsNumber(0);
         };
@@ -4048,7 +4048,7 @@ pub const ServerWebSocket = struct {
             return .zero;
         }
 
-        var app = this.handler.app orelse {
+        const app = this.handler.app orelse {
             log("publish() closed", .{});
             return JSValue.jsNumber(0);
         };
@@ -4106,7 +4106,7 @@ pub const ServerWebSocket = struct {
             return .zero;
         }
 
-        var app = this.handler.app orelse {
+        const app = this.handler.app orelse {
             log("publish() closed", .{});
             return JSValue.jsNumber(0);
         };
@@ -4160,7 +4160,7 @@ pub const ServerWebSocket = struct {
         topic_str: *JSC.JSString,
         array: *JSC.JSUint8Array,
     ) callconv(.C) JSC.JSValue {
-        var app = this.handler.app orelse {
+        const app = this.handler.app orelse {
             log("publish() closed", .{});
             return JSValue.jsNumber(0);
         };
@@ -4200,7 +4200,7 @@ pub const ServerWebSocket = struct {
         topic_str: *JSC.JSString,
         str: *JSC.JSString,
     ) callconv(.C) JSC.JSValue {
-        var app = this.handler.app orelse {
+        const app = this.handler.app orelse {
             log("publish() closed", .{});
             return JSValue.jsNumber(0);
         };
@@ -4530,7 +4530,7 @@ pub const ServerWebSocket = struct {
         if (args.len > 0) {
             var value = args.ptr[0];
             if (value.asArrayBuffer(globalThis)) |data| {
-                var buffer = data.slice();
+                const buffer = data.slice();
 
                 switch (this.websocket.send(buffer, opcode, false, true)) {
                     .backpressure => {
@@ -4549,7 +4549,7 @@ pub const ServerWebSocket = struct {
             } else if (value.isString()) {
                 var string_value = value.toString(globalThis).toSlice(globalThis, bun.default_allocator);
                 defer string_value.deinit();
-                var buffer = string_value.slice();
+                const buffer = string_value.slice();
 
                 switch (this.websocket.send(buffer, opcode, false, true)) {
                     .backpressure => {
@@ -4901,7 +4901,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             if (this.config.websocket == null)
                 return JSValue.jsNumber(0);
 
-            var app = this.app;
+            const app = this.app;
 
             if (topic.len == 0) {
                 httplog("publish() topic invalid", .{});
@@ -4975,7 +4975,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 return JSC.jsBoolean(false);
             }
             const resp = upgrader.resp.?;
-            var ctx = upgrader.upgrade_context.?;
+            const ctx = upgrader.upgrade_context.?;
 
             var sec_websocket_key_str = ZigString.Empty;
 
@@ -5070,7 +5070,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
 
             resp.clearAborted();
 
-            var ws = this.vm.allocator.create(ServerWebSocket) catch return .zero;
+            const ws = this.vm.allocator.create(ServerWebSocket) catch return .zero;
             ws.* = .{
                 .handler = &this.config.websocket.?.handler,
                 .this_value = data_value,
@@ -5139,7 +5139,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             var args_slice = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments);
             defer args_slice.deinit();
             var exception_ref = [_]JSC.C.JSValueRef{null};
-            var exception: JSC.C.ExceptionRef = &exception_ref;
+            const exception: JSC.C.ExceptionRef = &exception_ref;
             var new_config = ServerConfig.fromJS(globalThis, &args_slice, exception);
             if (exception.* != null) {
                 globalThis.throwValue(exception_ref[0].?.value());
@@ -5372,7 +5372,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 },
             };
 
-            var buf = std.fmt.allocPrint(default_allocator, "{any}", .{fmt}) catch @panic("Out of memory");
+            const buf = std.fmt.allocPrint(default_allocator, "{any}", .{fmt}) catch @panic("Out of memory");
             defer default_allocator.free(buf);
 
             var value = bun.String.create(buf);
@@ -5499,7 +5499,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 this.app.close();
             }
 
-            var task = bun.default_allocator.create(JSC.AnyTask) catch unreachable;
+            const task = bun.default_allocator.create(JSC.AnyTask) catch unreachable;
             task.* = JSC.AnyTask.New(ThisServer, deinit).init(this);
             this.vm.enqueueTask(JSC.Task.init(task));
         }
@@ -5594,7 +5594,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 }
 
                 if (written > 0) {
-                    var message = output_buf[0..written];
+                    const message = output_buf[0..written];
                     error_instance = this.globalThis.createErrorInstance("OpenSSL {s}", .{message});
                     BoringSSL.ERR_clear_error();
                 }
@@ -5605,7 +5605,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                     .tcp => |tcp| {
                         error_set: {
                             if (comptime Environment.isLinux) {
-                                var rc: i32 = -1;
+                                const rc: i32 = -1;
                                 const code = Sys.getErrno(rc);
                                 if (code == bun.C.E.ACCES) {
                                     error_instance = (JSC.SystemError{
@@ -5675,9 +5675,9 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             defer this.pending_requests -= 1;
             req.setYield(false);
             var stack_fallback = std.heap.stackFallback(8096, this.allocator);
-            var allocator = stack_fallback.get();
+            const allocator = stack_fallback.get();
 
-            var buffer_writer = js_printer.BufferWriter.init(allocator) catch unreachable;
+            const buffer_writer = js_printer.BufferWriter.init(allocator) catch unreachable;
             var writer = js_printer.BufferPrinter.init(buffer_writer);
             defer writer.ctx.buffer.deinit();
             var source = logger.Source.initEmptyFile("info.json");
@@ -5709,8 +5709,8 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
 
             var ctx = &JSC.VirtualMachine.get().rareData().editor_context;
             ctx.autoDetectEditor(JSC.VirtualMachine.get().bundler.env);
-            var line: ?string = req.header("editor-line");
-            var column: ?string = req.header("editor-column");
+            const line: ?string = req.header("editor-line");
+            const column: ?string = req.header("editor-column");
 
             if (ctx.editor) |editor| {
                 resp.writeStatus("200 Opened");

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -65,7 +65,7 @@ pub const To = struct {
                     globalThis: *JSC.JSGlobalObject,
                 ) callconv(.C) JSC.JSValue {
                     var exception_ref = [_]JSC.C.JSValueRef{null};
-                    var exception: JSC.C.ExceptionRef = &exception_ref;
+                    const exception: JSC.C.ExceptionRef = &exception_ref;
                     const result = toJS(globalThis, @call(.auto, @field(Type, @tagName(decl)), .{this}), exception);
                     if (exception.* != null) {
                         globalThis.throwValue(JSC.JSValue.c(exception.*));
@@ -99,7 +99,7 @@ pub const To = struct {
                     break :brk val.asObjectRef();
                 },
                 []const JSC.ZigString => {
-                    var array = JSC.JSValue.createStringArray(context.ptr(), value.ptr, value.len, clone).asObjectRef();
+                    const array = JSC.JSValue.createStringArray(context.ptr(), value.ptr, value.len, clone).asObjectRef();
                     const values: []const JSC.ZigString = value;
                     defer bun.default_allocator.free(values);
                     if (clone) {
@@ -141,7 +141,7 @@ pub const To = struct {
                     // there is a possible C ABI bug or something here when the ptr is null
                     // it should not be segfaulting but it is
                     // that's why we check at the top of this function
-                    var array = JSC.JSValue.createStringArray(context.ptr(), zig_strings.ptr, zig_strings.len, clone).asObjectRef();
+                    const array = JSC.JSValue.createStringArray(context.ptr(), zig_strings.ptr, zig_strings.len, clone).asObjectRef();
 
                     if (clone and value.len > 0) {
                         for (value) |path_string| {
@@ -207,7 +207,7 @@ pub const To = struct {
                             }
 
                             if (comptime !@hasDecl(Type, "toJS")) {
-                                var val = bun.default_allocator.create(Type) catch unreachable;
+                                const val = bun.default_allocator.create(Type) catch unreachable;
                                 val.* = value;
                                 return Type.Class.make(context, val);
                             }
@@ -311,7 +311,7 @@ pub fn createError(
         var fallback = std.heap.stackFallback(256, default_allocator);
         var allocator = fallback.get();
 
-        var buf = std.fmt.allocPrint(allocator, fmt, args) catch unreachable;
+        const buf = std.fmt.allocPrint(allocator, fmt, args) catch unreachable;
         var zig_str = JSC.ZigString.init(buf);
         zig_str.detectEncoding();
         // it alwayas clones
@@ -343,7 +343,7 @@ pub fn toTypeErrorWithCode(
         zig_str = JSC.ZigString.init(fmt);
         zig_str.detectEncoding();
     } else {
-        var buf = std.fmt.allocPrint(default_allocator, fmt, args) catch unreachable;
+        const buf = std.fmt.allocPrint(default_allocator, fmt, args) catch unreachable;
         zig_str = JSC.ZigString.init(buf);
         zig_str.detectEncoding();
         zig_str.mark();
@@ -633,7 +633,7 @@ pub const MarkedArrayBuffer = struct {
     }
 
     pub fn fromString(str: []const u8, allocator: std.mem.Allocator) !MarkedArrayBuffer {
-        var buf = try allocator.dupe(u8, str);
+        const buf = try allocator.dupe(u8, str);
         return MarkedArrayBuffer.fromBytes(buf, allocator, JSC.JSValue.JSType.Uint8Array);
     }
 
@@ -669,7 +669,7 @@ pub const MarkedArrayBuffer = struct {
 
     pub fn init(allocator: std.mem.Allocator, size: u32, typed_array_type: js.JSTypedArrayType) !*MarkedArrayBuffer {
         const bytes = try allocator.alloc(u8, size);
-        var container = try allocator.create(MarkedArrayBuffer);
+        const container = try allocator.create(MarkedArrayBuffer);
         container.* = MarkedArrayBuffer.fromBytes(bytes, allocator, typed_array_type);
         return container;
     }
@@ -788,7 +788,7 @@ pub export fn BlobArrayBuffer_deallocator(_: *anyopaque, blob: *anyopaque) void 
     // zig's memory allocator interface won't work here
     // mimalloc knows the size of things
     // but we don't
-    var store = bun.cast(*JSC.WebCore.Blob.Store, blob);
+    const store = bun.cast(*JSC.WebCore.Blob.Store, blob);
     store.deref();
 }
 
@@ -1242,7 +1242,7 @@ pub fn wrapInstanceMethod(
                 break :brk false;
             };
             var exception_value = [_]JSC.C.JSValueRef{null};
-            var exception: JSC.C.ExceptionRef = if (comptime has_exception_ref) &exception_value else undefined;
+            const exception: JSC.C.ExceptionRef = if (comptime has_exception_ref) &exception_value else undefined;
 
             comptime var i: usize = 0;
             inline while (i < FunctionTypeInfo.params.len) : (i += 1) {
@@ -1725,7 +1725,7 @@ pub const MemoryReportingAllocator = struct {
     const log = Output.scoped(.MEM, false);
 
     fn alloc(this: *MemoryReportingAllocator, n: usize, log2_ptr_align: u8, return_address: usize) ?[*]u8 {
-        var result = this.child_allocator.rawAlloc(n, log2_ptr_align, return_address) orelse return null;
+        const result = this.child_allocator.rawAlloc(n, log2_ptr_align, return_address) orelse return null;
         _ = this.memory_cost.fetchAdd(n, .Monotonic);
         if (comptime Environment.allow_assert)
             log("malloc({d}) = {d}", .{ n, this.memory_cost.loadUnchecked() });

--- a/src/bun.js/bindings/FFI.zig
+++ b/src/bun.js/bindings/FFI.zig
@@ -38,7 +38,7 @@ pub inline fn JSVALUE_IS_NUMBER(arg_val: EncodedJSValue) @"bool" {
     return (@as(c_ulonglong, @bitCast(val.asInt64)) & @as(c_ulonglong, 18446181123756130304)) != 0;
 }
 pub inline fn JSVALUE_TO_UINT64(arg_value: EncodedJSValue) u64 {
-    var value = arg_value;
+    const value = arg_value;
     if (JSVALUE_IS_INT32(value)) {
         return @as(u64, @bitCast(@as(c_longlong, JSVALUE_TO_INT32(value))));
     }
@@ -62,7 +62,7 @@ pub extern fn JSVALUE_TO_INT64_SLOW(value: EncodedJSValue) i64;
 pub const UINT64_TO_JSVALUE_SLOW = @import("./bindings.zig").JSValue.fromUInt64NoTruncate;
 pub const INT64_TO_JSVALUE_SLOW = @import("./bindings.zig").JSValue.fromInt64NoTruncate;
 pub inline fn UINT64_TO_JSVALUE(arg_globalObject: ?*anyopaque, arg_val: u64) EncodedJSValue {
-    var globalObject = arg_globalObject;
+    const globalObject = arg_globalObject;
     const val = arg_val;
     if (val < @as(c_ulonglong, @bitCast(@as(c_longlong, @as(c_long, 2147483648))))) {
         return INT32_TO_JSVALUE(@as(i32, @bitCast(@as(c_uint, @truncate(val)))));
@@ -73,8 +73,8 @@ pub inline fn UINT64_TO_JSVALUE(arg_globalObject: ?*anyopaque, arg_val: u64) Enc
     return UINT64_TO_JSVALUE_SLOW(@as(*@import("./bindings.zig").JSGlobalObject, @ptrCast(globalObject.?)), val).asEncoded();
 }
 pub inline fn INT64_TO_JSVALUE(arg_globalObject: ?*anyopaque, arg_val: i64) EncodedJSValue {
-    var globalObject = arg_globalObject;
-    var val = arg_val;
+    const globalObject = arg_globalObject;
+    const val = arg_val;
     if ((val >= @as(c_longlong, @bitCast(@as(c_longlong, -@as(c_long, 2147483648))))) and (val <= @as(c_longlong, @bitCast(@as(c_longlong, @as(c_long, 2147483648)))))) {
         return INT32_TO_JSVALUE(@as(i32, @bitCast(@as(c_int, @truncate(val)))));
     }
@@ -92,31 +92,31 @@ pub inline fn DOUBLE_TO_JSVALUE(arg_val: f64) EncodedJSValue {
     return res;
 }
 pub inline fn FLOAT_TO_JSVALUE(arg_val: f32) EncodedJSValue {
-    var val = arg_val;
+    const val = arg_val;
     return DOUBLE_TO_JSVALUE(@as(f64, @floatCast(val)));
 }
 pub inline fn BOOLEAN_TO_JSVALUE(arg_val: @"bool") EncodedJSValue {
-    var val = arg_val;
+    const val = arg_val;
     var res: EncodedJSValue = undefined;
     res.asInt64 = @as(i64, @bitCast(@as(c_longlong, if (@as(c_int, @intFromBool(val)) != 0) (@as(c_int, 2) | @as(c_int, 4)) | @as(c_int, 1) else (@as(c_int, 2) | @as(c_int, 4)) | @as(c_int, 0))));
     return res;
 }
 pub inline fn PTR_TO_JSVALUE(arg_ptr: ?*anyopaque) EncodedJSValue {
-    var ptr = arg_ptr;
+    const ptr = arg_ptr;
     var val: EncodedJSValue = undefined;
     val.asInt64 = @as(i64, @intCast(@intFromPtr(ptr))) + (@as(c_longlong, 1) << @as(@import("std").math.Log2Int(c_longlong), @intCast(49)));
     return val;
 }
 pub inline fn JSVALUE_TO_PTR(arg_val: EncodedJSValue) ?*anyopaque {
-    var val = arg_val;
+    const val = arg_val;
     return @as(?*anyopaque, @ptrFromInt(val.asInt64 - (@as(c_longlong, 1) << @as(@import("std").math.Log2Int(c_longlong), @intCast(49)))));
 }
 pub inline fn JSVALUE_TO_INT32(arg_val: EncodedJSValue) i32 {
-    var val = arg_val;
+    const val = arg_val;
     return @as(i32, @bitCast(@as(c_int, @truncate(val.asInt64))));
 }
 pub inline fn JSVALUE_TO_FLOAT(arg_val: EncodedJSValue) f32 {
-    var val = arg_val;
+    const val = arg_val;
     return @as(f32, @floatCast(JSVALUE_TO_DOUBLE(val)));
 }
 pub inline fn JSVALUE_TO_DOUBLE(arg_val: EncodedJSValue) f64 {
@@ -125,7 +125,7 @@ pub inline fn JSVALUE_TO_DOUBLE(arg_val: EncodedJSValue) f64 {
     return val.asDouble;
 }
 pub inline fn JSVALUE_TO_BOOL(arg_val: EncodedJSValue) @"bool" {
-    var val = arg_val;
+    const val = arg_val;
     return val.asInt64 == @as(c_longlong, @bitCast(@as(c_longlong, (@as(c_int, 2) | @as(c_int, 4)) | @as(c_int, 1))));
 }
 pub extern fn JSFunctionCall(globalObject: ?*anyopaque, callFrame: ?*anyopaque) ?*anyopaque;

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -145,7 +145,7 @@ pub const ZigString = extern struct {
     /// This function is not optimized!
     pub fn eqlCaseInsensitive(this: ZigString, other: ZigString) bool {
         var fallback = std.heap.stackFallback(1024, bun.default_allocator);
-        var fallback_allocator = fallback.get();
+        const fallback_allocator = fallback.get();
 
         var utf16_slice = this.toSliceLowercase(fallback_allocator);
         var latin1_slice = other.toSliceLowercase(fallback_allocator);
@@ -158,11 +158,11 @@ pub const ZigString = extern struct {
         if (this.len == 0)
             return Slice.empty;
         var fallback = std.heap.stackFallback(512, allocator);
-        var fallback_allocator = fallback.get();
+        const fallback_allocator = fallback.get();
 
-        var uppercase_buffer = this.toOwnedSlice(fallback_allocator) catch unreachable;
-        var buffer = allocator.alloc(u8, uppercase_buffer.len) catch unreachable;
-        var out = strings.copyLowercase(uppercase_buffer, buffer);
+        const uppercase_buffer = this.toOwnedSlice(fallback_allocator) catch unreachable;
+        const buffer = allocator.alloc(u8, uppercase_buffer.len) catch unreachable;
+        const out = strings.copyLowercase(uppercase_buffer, buffer);
 
         return Slice{
             .allocator = NullableAllocator.init(allocator),
@@ -451,7 +451,7 @@ pub const ZigString = extern struct {
                 return Slice{ .allocator = this.allocator, .ptr = this.ptr, .len = this.len };
             }
 
-            var duped = try allocator.dupe(u8, this.ptr[0..this.len]);
+            const duped = try allocator.dupe(u8, this.ptr[0..this.len]);
             return Slice{ .allocator = NullableAllocator.init(allocator), .ptr = duped.ptr, .len = this.len };
         }
 
@@ -460,12 +460,12 @@ pub const ZigString = extern struct {
                 return this;
             }
 
-            var duped = try allocator.dupe(u8, this.ptr[0..this.len]);
+            const duped = try allocator.dupe(u8, this.ptr[0..this.len]);
             return Slice{ .allocator = NullableAllocator.init(allocator), .ptr = duped.ptr, .len = this.len };
         }
 
         pub fn cloneWithTrailingSlash(this: Slice, allocator: std.mem.Allocator) !Slice {
-            var buf = try strings.cloneNormalizingSeparators(allocator, this.slice());
+            const buf = try strings.cloneNormalizingSeparators(allocator, this.slice());
             return Slice{ .allocator = NullableAllocator.init(allocator), .ptr = buf.ptr, .len = @as(u32, @truncate(buf.len)) };
         }
 
@@ -474,7 +474,7 @@ pub const ZigString = extern struct {
                 return this;
             }
 
-            var duped = try allocator.dupeZ(u8, this.ptr[0..this.len]);
+            const duped = try allocator.dupeZ(u8, this.ptr[0..this.len]);
             return Slice{ .allocator = NullableAllocator.init(allocator), .ptr = duped.ptr, .len = this.len };
         }
 
@@ -647,7 +647,7 @@ pub const ZigString = extern struct {
         const slice_ = this.slice();
         const size = std.base64.standard.Encoder.calcSize(slice_.len);
         var buf = try allocator.alloc(u8, size + "data:;base64,".len);
-        var encoded = std.base64.url_safe.Encoder.encode(buf["data:;base64,".len..], slice_);
+        const encoded = std.base64.url_safe.Encoder.encode(buf["data:;base64,".len..], slice_);
         buf[0.."data:;base64,".len].* = "data:;base64,".*;
         return buf[0 .. "data:;base64,".len + encoded.len];
     }
@@ -737,7 +737,7 @@ pub const ZigString = extern struct {
         if (this.len == 0)
             return Slice.empty;
         if (is16Bit(&this)) {
-            var buffer = this.toOwnedSlice(allocator) catch unreachable;
+            const buffer = this.toOwnedSlice(allocator) catch unreachable;
             return Slice{
                 .ptr = buffer.ptr,
                 .len = @as(u32, @truncate(buffer.len)),
@@ -796,7 +796,7 @@ pub const ZigString = extern struct {
             return Slice.empty;
 
         if (is16Bit(&this)) {
-            var buffer = this.toOwnedSliceZ(allocator) catch unreachable;
+            const buffer = this.toOwnedSliceZ(allocator) catch unreachable;
             return Slice{
                 .ptr = buffer.ptr,
                 .len = @as(u32, @truncate(buffer.len)),
@@ -1103,7 +1103,7 @@ pub const DOMFormData = opaque {
                 filename: ?*ZigString,
                 is_blob: u8,
             ) callconv(.C) void {
-                var ctx_ = bun.cast(*Context, ctx_ptr.?);
+                const ctx_ = bun.cast(*Context, ctx_ptr.?);
                 const value = if (is_blob == 0)
                     FormDataEntry{ .string = bun.cast(*ZigString, value_ptr).* }
                 else
@@ -1909,7 +1909,7 @@ pub const AbortSignal = extern opaque {
                 ptr: ?*anyopaque,
                 reason: JSValue,
             ) callconv(.C) void {
-                var val = bun.cast(*Context, ptr.?);
+                const val = bun.cast(*Context, ptr.?);
                 call(val, reason);
             }
         };
@@ -2047,7 +2047,7 @@ pub const JSPromise = extern struct {
         }
 
         pub fn swap(this: *Strong) *JSC.JSPromise {
-            var prom = this.strong.swap().asPromise().?;
+            const prom = this.strong.swap().asPromise().?;
             this.strong.deinit();
             return prom;
         }
@@ -2540,7 +2540,7 @@ pub const JSGlobalObject = extern struct {
         comptime fmt: string,
         args: anytype,
     ) void {
-        var err = JSC.toInvalidArguments(fmt, args, this);
+        const err = JSC.toInvalidArguments(fmt, args, this);
         this.vm().throwError(this, err);
     }
 
@@ -2817,7 +2817,7 @@ pub const JSGlobalObject = extern struct {
     ) void {
         var str = ZigString.init(std.fmt.allocPrint(this.bunVM().allocator, "{s} " ++ fmt, .{@errorName(err)}) catch return);
         str.markUTF8();
-        var err_value = str.toErrorInstance(this);
+        const err_value = str.toErrorInstance(this);
         this.vm().throwError(this, err_value);
         this.bunVM().allocator.free(ZigString.untagged(str._unsafe_ptr_do_not_use)[0..str.len]);
     }
@@ -3665,7 +3665,7 @@ pub const JSValue = enum(JSValueReprInt) {
 
     pub fn jestSnapshotPrettyFormat(this: JSValue, out: *MutableString, globalObject: *JSGlobalObject) !void {
         var buffered_writer = MutableString.BufferedWriter{ .context = out };
-        var writer = buffered_writer.writer();
+        const writer = buffered_writer.writer();
         const Writer = @TypeOf(writer);
 
         const fmt_options = JestPrettyFormat.FormatOptions{
@@ -3725,7 +3725,7 @@ pub const JSValue = enum(JSValueReprInt) {
 
     pub fn jestPrettyFormat(this: JSValue, out: *MutableString, globalObject: *JSGlobalObject) !void {
         var buffered_writer = MutableString.BufferedWriter{ .context = out };
-        var writer = buffered_writer.writer();
+        const writer = buffered_writer.writer();
         const Writer = @TypeOf(writer);
 
         const fmt_options = JSC.ZigConsoleClient.FormatOptions{
@@ -5323,7 +5323,7 @@ pub const CallFrame = opaque {
 
     pub fn arguments(self: *const CallFrame, comptime max: usize) Arguments(max) {
         const len = self.argumentsCount();
-        var ptr = self.argumentsPtr();
+        const ptr = self.argumentsPtr();
         return switch (@as(u4, @min(len, max))) {
             0 => .{ .ptr = undefined, .len = 0 },
             4 => Arguments(max).init(comptime @min(4, max), ptr),

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -46,7 +46,7 @@ pub const ZigGlobalObject = extern struct {
         mini_mode: bool,
         worker_ptr: ?*anyopaque,
     ) *JSGlobalObject {
-        var global = shim.cppFn("create", .{ console, context_id, mini_mode, worker_ptr });
+        const global = shim.cppFn("create", .{ console, context_id, mini_mode, worker_ptr });
         Backtrace.reloadHandlers() catch unreachable;
         return global;
     }
@@ -211,13 +211,13 @@ export fn ZigString__free(raw: [*]const u8, len: usize, allocator_: ?*anyopaque)
     if (comptime Environment.allow_assert) {
         std.debug.assert(Mimalloc.mi_is_in_heap_region(ptr));
     }
-    var str = ptr[0..len];
+    const str = ptr[0..len];
 
     allocator.free(str);
 }
 
 export fn ZigString__free_global(ptr: [*]const u8, len: usize) void {
-    var untagged = @as(*anyopaque, @ptrFromInt(@intFromPtr(ZigString.init(ptr[0..len]).slice().ptr)));
+    const untagged = @as(*anyopaque, @ptrFromInt(@intFromPtr(ZigString.init(ptr[0..len]).slice().ptr)));
     if (comptime Environment.allow_assert) {
         std.debug.assert(Mimalloc.mi_is_in_heap_region(ptr));
     }
@@ -416,7 +416,7 @@ pub const ZigStackTrace = extern struct {
         {
             var source_lines_iter = this.sourceLineIterator();
 
-            var source_line_len = source_lines_iter.getLength();
+            const source_line_len = source_lines_iter.getLength();
 
             if (source_line_len > 0) {
                 var source_lines = try allocator.alloc(Api.SourceLine, @as(usize, @intCast(@max(source_lines_iter.i + 1, 0))));
@@ -441,7 +441,7 @@ pub const ZigStackTrace = extern struct {
             }
         }
         {
-            var _frames = this.frames();
+            const _frames = this.frames();
             if (_frames.len > 0) {
                 var stack_frames = try allocator.alloc(Api.StackFrame, _frames.len);
                 stack_trace.frames = stack_frames;
@@ -1029,7 +1029,7 @@ pub const ZigConsoleClient = struct {
     pub fn writeTrace(comptime Writer: type, writer: Writer, global: *JSGlobalObject) void {
         var holder = ZigException.Holder.init();
 
-        var exception = holder.zigException();
+        const exception = holder.zigException();
         var err = ZigString.init("trace output").toErrorInstance(global);
         err.toZigException(global, exception);
         JS.VirtualMachine.get().remapZigException(exception, err, null);
@@ -1752,7 +1752,7 @@ pub const ZigConsoleClient = struct {
                 writer: Writer,
                 count: usize = 0,
                 pub fn forEach(_: [*c]JSC.VM, globalObject: [*c]JSGlobalObject, ctx: ?*anyopaque, nextValue: JSValue) callconv(.C) void {
-                    var this: *@This() = bun.cast(*@This(), ctx orelse return);
+                    const this: *@This() = bun.cast(*@This(), ctx orelse return);
                     if (!is_iterator) {
                         const key = JSC.JSObject.getIndex(nextValue, globalObject, 0);
                         const value = JSC.JSObject.getIndex(nextValue, globalObject, 1);
@@ -1803,7 +1803,7 @@ pub const ZigConsoleClient = struct {
                 formatter: *ZigConsoleClient.Formatter,
                 writer: Writer,
                 pub fn forEach(_: [*c]JSC.VM, globalObject: [*c]JSGlobalObject, ctx: ?*anyopaque, nextValue: JSValue) callconv(.C) void {
-                    var this: *@This() = bun.cast(*@This(), ctx orelse return);
+                    const this: *@This() = bun.cast(*@This(), ctx orelse return);
                     this.formatter.writeIndent(Writer, this.writer) catch {};
                     const key_tag = Tag.getAdvanced(nextValue, globalObject, .{ .hide_global = true });
                     this.formatter.format(
@@ -1860,9 +1860,9 @@ pub const ZigConsoleClient = struct {
                     if (key.eqlComptime("constructor")) return;
                     if (key.eqlComptime("call")) return;
 
-                    var ctx: *@This() = bun.cast(*@This(), ctx_ptr orelse return);
+                    const ctx: *@This() = bun.cast(*@This(), ctx_ptr orelse return);
                     var this = ctx.formatter;
-                    var writer_ = ctx.writer;
+                    const writer_ = ctx.writer;
                     var writer = WrappedWriter(Writer){
                         .ctx = writer_,
                         .failed = false,
@@ -2006,7 +2006,7 @@ pub const ZigConsoleClient = struct {
                     this.map = this.map_node.?.data;
                 }
 
-                var entry = this.map.getOrPut(@intFromEnum(value)) catch unreachable;
+                const entry = this.map.getOrPut(@intFromEnum(value)) catch unreachable;
                 if (entry.found_existing) {
                     writer.writeAll(comptime Output.prettyFmt("<r><cyan>[Circular]<r>", enable_ansi_colors));
                     return;
@@ -2067,7 +2067,7 @@ pub const ZigConsoleClient = struct {
                         writer.writeAll(str.slice());
                     } else if (str.len > 0) {
                         // slow path
-                        var buf = strings.allocateLatin1IntoUTF8(bun.default_allocator, []const u8, str.slice()) catch &[_]u8{};
+                        const buf = strings.allocateLatin1IntoUTF8(bun.default_allocator, []const u8, str.slice()) catch &[_]u8{};
                         if (buf.len > 0) {
                             defer bun.default_allocator.free(buf);
                             writer.writeAll(buf);
@@ -2097,7 +2097,7 @@ pub const ZigConsoleClient = struct {
                     writer.print(comptime Output.prettyFmt("<r><yellow>{d}<r>", enable_ansi_colors), .{int});
                 },
                 .BigInt => {
-                    var out_str = value.getZigString(this.globalThis).slice();
+                    const out_str = value.getZigString(this.globalThis).slice();
                     this.addForNewLine(out_str.len);
 
                     writer.print(comptime Output.prettyFmt("<r><yellow>{s}n<r>", enable_ansi_colors), .{out_str});
@@ -2232,9 +2232,9 @@ pub const ZigConsoleClient = struct {
 
                         this.addForNewLine(2);
 
-                        var ref = value.asObjectRef();
+                        const ref = value.asObjectRef();
 
-                        var prev_quote_strings = this.quote_strings;
+                        const prev_quote_strings = this.quote_strings;
                         this.quote_strings = true;
                         defer this.quote_strings = prev_quote_strings;
 
@@ -2762,7 +2762,7 @@ pub const ZigConsoleClient = struct {
                         }).init(this.globalThis, props.asObjectRef());
                         defer props_iter.deinit();
 
-                        var children_prop = props.get(this.globalThis, "children");
+                        const children_prop = props.get(this.globalThis, "children");
                         if (props_iter.len > 0) {
                             {
                                 this.indent += 1;
@@ -2773,7 +2773,7 @@ pub const ZigConsoleClient = struct {
                                     if (prop.eqlComptime("children"))
                                         continue;
 
-                                    var property_value = props_iter.value;
+                                    const property_value = props_iter.value;
                                     const tag = Tag.getAdvanced(property_value, this.globalThis, .{ .hide_global = true });
 
                                     if (tag.cell.isHidden()) continue;
@@ -2831,7 +2831,7 @@ pub const ZigConsoleClient = struct {
                                     print_children: {
                                         switch (tag.tag) {
                                             .String => {
-                                                var children_string = children.getZigString(this.globalThis);
+                                                const children_string = children.getZigString(this.globalThis);
                                                 if (children_string.len == 0) break :print_children;
                                                 if (comptime enable_ansi_colors) writer.writeAll(comptime Output.prettyFmt("<r>", true));
 
@@ -3114,7 +3114,7 @@ pub const ZigConsoleClient = struct {
             if (comptime is_bindgen) {
                 return;
             }
-            var prevGlobalThis = this.globalThis;
+            const prevGlobalThis = this.globalThis;
             defer this.globalThis = prevGlobalThis;
             this.globalThis = globalThis;
 
@@ -3179,7 +3179,7 @@ pub const ZigConsoleClient = struct {
         const slice = ptr[0..len];
         const hash = bun.hash(slice);
         // we don't want to store these strings, it will take too much memory
-        var counter = this.counts.getOrPut(globalThis.allocator(), hash) catch unreachable;
+        const counter = this.counts.getOrPut(globalThis.allocator(), hash) catch unreachable;
         const current = @as(u32, if (counter.found_existing) counter.value_ptr.* else @as(u32, 0)) + 1;
         counter.value_ptr.* = current;
 
@@ -3205,7 +3205,7 @@ pub const ZigConsoleClient = struct {
         const slice = ptr[0..len];
         const hash = bun.hash(slice);
         // we don't delete it because deleting is implemented via tombstoning
-        var entry = this.counts.getEntry(hash) orelse return;
+        const entry = this.counts.getEntry(hash) orelse return;
         entry.value_ptr.* = 0;
     }
 
@@ -3227,7 +3227,7 @@ pub const ZigConsoleClient = struct {
             pending_time_logs_loaded = true;
         }
 
-        var result = pending_time_logs.getOrPut(id) catch unreachable;
+        const result = pending_time_logs.getOrPut(id) catch unreachable;
 
         if (!result.found_existing or (result.found_existing and result.value_ptr.* == null)) {
             result.value_ptr.* = std.time.Timer.start() catch unreachable;
@@ -3246,7 +3246,7 @@ pub const ZigConsoleClient = struct {
         }
 
         const id = bun.hash(chars[0..len]);
-        var result = (pending_time_logs.fetchPut(id, null) catch null) orelse return;
+        const result = (pending_time_logs.fetchPut(id, null) catch null) orelse return;
         var value: std.time.Timer = result.value orelse return;
         // get the duration in microseconds
         // then display it in milliseconds

--- a/src/bun.js/bindings/shimmer.zig
+++ b/src/bun.js/bindings/shimmer.zig
@@ -110,7 +110,7 @@ pub fn Shimmer(comptime _namespace: []const u8, comptime _name: []const u8, comp
                     if (@typeInfo(Function) != .Fn) {
                         @compileError("Expected " ++ @typeName(Parent) ++ "." ++ @typeName(Function) ++ " to be a function but received " ++ @tagName(@typeInfo(Function)));
                     }
-                    var Fn: std.builtin.Type.Fn = @typeInfo(Function).Fn;
+                    const Fn: std.builtin.Type.Fn = @typeInfo(Function).Fn;
                     if (Fn.calling_convention != .C) {
                         @compileError("Expected " ++ @typeName(Parent) ++ "." ++ @typeName(Function) ++ " to have a C Calling Convention.");
                     }
@@ -139,7 +139,7 @@ pub fn Shimmer(comptime _namespace: []const u8, comptime _name: []const u8, comp
                         if (@typeInfo(Function) != .Fn) {
                             @compileError("Expected " ++ @typeName(Parent) ++ "." ++ @typeName(Function) ++ " to be a function but received " ++ @tagName(@typeInfo(Function)));
                         }
-                        var Fn: std.builtin.Type.Fn = @typeInfo(Function).Fn;
+                        const Fn: std.builtin.Type.Fn = @typeInfo(Function).Fn;
                         if (Fn.calling_convention != .C) {
                             @compileError("Expected " ++ @typeName(Parent) ++ "." ++ @typeName(Function) ++ " to have a C Calling Convention.");
                         }

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -61,7 +61,7 @@ pub fn ConcurrentPromiseTask(comptime Context: type) type {
         }
 
         pub fn runFromJS(this: *This) void {
-            var promise = this.promise.swap();
+            const promise = this.promise.swap();
             this.ref.unref(this.event_loop.virtual_machine);
 
             var ctx = this.ctx;
@@ -120,15 +120,15 @@ pub fn WorkTask(comptime Context: type, comptime async_io: bool) type {
 
         pub fn runFromThreadPool(task: *TaskType) void {
             JSC.markBinding(@src());
-            var this = @fieldParentPtr(This, "task", task);
+            const this = @fieldParentPtr(This, "task", task);
             Context.run(this.ctx, this);
         }
 
         pub fn runFromJS(this: *This) void {
             var ctx = this.ctx;
             const tracker = this.async_task_tracker;
-            var vm = this.event_loop.virtual_machine;
-            var globalThis = this.globalThis;
+            const vm = this.event_loop.virtual_machine;
+            const globalThis = this.globalThis;
             this.ref.unref(vm);
 
             tracker.willDispatch(globalThis);
@@ -137,7 +137,7 @@ pub fn WorkTask(comptime Context: type, comptime async_io: bool) type {
         }
 
         pub fn schedule(this: *This) void {
-            var vm = this.event_loop.virtual_machine;
+            const vm = this.event_loop.virtual_machine;
             this.ref.ref(vm);
             this.async_task_tracker.didSchedule(this.globalThis);
             if (comptime async_io) {
@@ -171,8 +171,8 @@ pub const AnyTask = struct {
 
     pub fn run(this: *AnyTask) void {
         @setRuntimeSafety(false);
-        var callback = this.callback;
-        var ctx = this.ctx;
+        const callback = this.callback;
+        const ctx = this.ctx;
         callback(ctx.?);
     }
 
@@ -202,8 +202,8 @@ pub const ManagedTask = struct {
 
     pub fn run(this: *ManagedTask) void {
         @setRuntimeSafety(false);
-        var callback = this.callback;
-        var ctx = this.ctx;
+        const callback = this.callback;
+        const ctx = this.ctx;
         callback(ctx.?);
         bun.default_allocator.destroy(this);
     }
@@ -233,8 +233,8 @@ pub const AnyTaskWithExtraContext = struct {
 
     pub fn run(this: *AnyTaskWithExtraContext, extra: *anyopaque) void {
         @setRuntimeSafety(false);
-        var callback = this.callback;
-        var ctx = this.ctx;
+        const callback = this.callback;
+        const ctx = this.ctx;
         callback(ctx.?, extra);
     }
 
@@ -419,7 +419,7 @@ pub const ConcurrentTask = struct {
         auto_deinit,
     };
     pub fn create(task: Task) *ConcurrentTask {
-        var created = bun.default_allocator.create(ConcurrentTask) catch @panic("out of memory!");
+        const created = bun.default_allocator.create(ConcurrentTask) catch @panic("out of memory!");
         created.* = .{
             .task = task,
             .next = null,
@@ -466,7 +466,7 @@ pub const GarbageCollectionController = struct {
     disabled: bool = false,
 
     pub fn init(this: *GarbageCollectionController, vm: *VirtualMachine) void {
-        var actual = uws.Loop.get();
+        const actual = uws.Loop.get();
         this.gc_timer = uws.Timer.createFallthrough(actual, this);
         this.gc_repeating_timer = uws.Timer.createFallthrough(actual, this);
 
@@ -667,7 +667,7 @@ pub const EventLoop = struct {
         var i: usize = 0;
         var last = this.deferred_microtask_map.count();
         while (i < last) {
-            var key = this.deferred_microtask_map.keys()[i] orelse {
+            const key = this.deferred_microtask_map.keys()[i] orelse {
                 this.deferred_microtask_map.swapRemoveAt(i);
                 last = this.deferred_microtask_map.count();
                 continue;
@@ -709,7 +709,7 @@ pub const EventLoop = struct {
                     transform_task.deinit();
                 },
                 @field(Task.Tag, typeBaseName(@typeName(JSC.napi.napi_async_work))) => {
-                    var transform_task: *JSC.napi.napi_async_work = task.get(JSC.napi.napi_async_work).?;
+                    const transform_task: *JSC.napi.napi_async_work = task.get(JSC.napi.napi_async_work).?;
                     transform_task.*.runFromJS();
                 },
                 .ThreadSafeFunction => {
@@ -1076,8 +1076,8 @@ pub const EventLoop = struct {
             this.next_immediate_tasks.head = 0;
             this.next_immediate_tasks.count = 0;
         } else if (this.next_immediate_tasks.count > 0) {
-            var prev_immediate = this.immediate_tasks;
-            var next_immediate = this.next_immediate_tasks;
+            const prev_immediate = this.immediate_tasks;
+            const next_immediate = this.next_immediate_tasks;
             this.immediate_tasks = next_immediate;
             this.next_immediate_tasks = prev_immediate;
         }
@@ -1152,7 +1152,7 @@ pub const EventLoop = struct {
     pub fn tick(this: *EventLoop) void {
         JSC.markBinding(@src());
 
-        var ctx = this.virtual_machine;
+        const ctx = this.virtual_machine;
         this.tickConcurrent();
         this.processGCTimer();
 
@@ -1194,7 +1194,7 @@ pub const EventLoop = struct {
     }
 
     pub fn waitForPromiseWithTermination(this: *EventLoop, promise: JSC.AnyPromise) void {
-        var worker = this.virtual_machine.worker orelse @panic("EventLoop.waitForPromiseWithTermination: worker is not initialized");
+        const worker = this.virtual_machine.worker orelse @panic("EventLoop.waitForPromiseWithTermination: worker is not initialized");
         switch (promise.status(this.virtual_machine.jsc)) {
             JSC.JSPromise.Status.Pending => {
                 while (!worker.requested_terminate and promise.status(this.virtual_machine.jsc) == .Pending) {
@@ -1217,7 +1217,7 @@ pub const EventLoop = struct {
                 if (timeout == 0) {
                     return false;
                 }
-                var start_time = std.time.milliTimestamp();
+                const start_time = std.time.milliTimestamp();
                 while (promise.status(this.virtual_machine.jsc) == .Pending) {
                     this.tick();
 
@@ -1253,13 +1253,13 @@ pub const EventLoop = struct {
         }
 
         // TODO: make this more efficient!
-        var loop = this.virtual_machine.event_loop_handle orelse @panic("EventLoop.enqueueTaskWithTimeout: uSockets event loop is not initialized");
+        const loop = this.virtual_machine.event_loop_handle orelse @panic("EventLoop.enqueueTaskWithTimeout: uSockets event loop is not initialized");
         var timer = uws.Timer.createFallthrough(loop, task.ptr());
         timer.set(task.ptr(), callTask, timeout, 0);
     }
 
     pub fn callTask(timer: *uws.Timer) callconv(.C) void {
-        var task = Task.from(timer.as(*anyopaque));
+        const task = Task.from(timer.as(*anyopaque));
         defer timer.deinit(true);
 
         JSC.VirtualMachine.get().enqueueTask(task);

--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -202,7 +202,7 @@ pub fn NewIPCHandler(comptime Context: type) type {
 
             // In the VirtualMachine case, `globalThis` is an optional, in case
             // the vm is freed before the socket closes.
-            var globalThis = switch (@typeInfo(@TypeOf(this.globalThis))) {
+            const globalThis = switch (@typeInfo(@TypeOf(this.globalThis))) {
                 .Pointer => this.globalThis,
                 .Optional => brk: {
                     if (this.globalThis) |global| {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -101,7 +101,7 @@ pub const OpaqueCallback = *const fn (current: ?*anyopaque) callconv(.C) void;
 pub fn OpaqueWrap(comptime Context: type, comptime Function: fn (this: *Context) void) OpaqueCallback {
     return struct {
         pub fn callback(ctx: ?*anyopaque) callconv(.C) void {
-            var context: *Context = @as(*Context, @ptrCast(@alignCast(ctx.?)));
+            const context: *Context = @as(*Context, @ptrCast(@alignCast(ctx.?)));
             @call(.auto, Function, .{context});
         }
     }.callback;
@@ -206,7 +206,7 @@ pub const SavedSourceMap = struct {
     pub fn putMappings(this: *SavedSourceMap, source: logger.Source, mappings: MutableString) !void {
         this.mutex.lock();
         defer this.mutex.unlock();
-        var entry = try this.map.getOrPut(bun.hash(source.path.text));
+        const entry = try this.map.getOrPut(bun.hash(source.path.text));
         if (entry.found_existing) {
             var value = Value.from(entry.value_ptr.*);
             if (value.get(ParsedSourceMap)) |source_map_| {
@@ -223,7 +223,7 @@ pub const SavedSourceMap = struct {
     }
 
     pub fn get(this: *SavedSourceMap, path: string) ?ParsedSourceMap {
-        var mapping = this.map.getEntry(bun.hash(path)) orelse return null;
+        const mapping = this.map.getEntry(bun.hash(path)) orelse return null;
         switch (Value.from(mapping.value_ptr.*).tag()) {
             Value.Tag.ParsedSourceMap => {
                 return Value.from(mapping.value_ptr.*).as(ParsedSourceMap).*;
@@ -231,7 +231,7 @@ pub const SavedSourceMap = struct {
             Value.Tag.SavedMappings => {
                 var saved = SavedMappings{ .data = @as([*]u8, @ptrCast(Value.from(mapping.value_ptr.*).as(ParsedSourceMap))) };
                 defer saved.deinit();
-                var result = default_allocator.create(ParsedSourceMap) catch unreachable;
+                const result = default_allocator.create(ParsedSourceMap) catch unreachable;
                 result.* = saved.toMapping(default_allocator, path) catch {
                     _ = this.map.remove(mapping.key_ptr.*);
                     return null;
@@ -292,7 +292,7 @@ pub export fn Bun__Process__send(
         globalObject.throwInvalidArguments("process.send requires at least one argument", .{});
         return .zero;
     }
-    var vm = globalObject.bunVM();
+    const vm = globalObject.bunVM();
     if (vm.ipc) |ipc_instance| {
         const success = ipc_instance.ipc.serializeAndSend(globalObject, callFrame.argument(0));
         return if (success) .undefined else .zero;
@@ -344,7 +344,7 @@ pub export fn Bun__reportUnhandledError(globalObject: *JSGlobalObject, value: JS
 pub export fn Bun__queueTaskConcurrently(global: *JSGlobalObject, task: *JSC.CppTask) void {
     JSC.markBinding(@src());
 
-    var concurrent = bun.default_allocator.create(JSC.ConcurrentTask) catch unreachable;
+    const concurrent = bun.default_allocator.create(JSC.ConcurrentTask) catch unreachable;
     concurrent.* = JSC.ConcurrentTask{
         .task = Task.init(task),
         .auto_delete = true,
@@ -412,7 +412,7 @@ pub const ExitHandler = struct {
 
     pub fn dispatchOnBeforeExit(this: *ExitHandler) void {
         JSC.markBinding(@src());
-        var vm = @fieldParentPtr(VirtualMachine, "exit_handler", this);
+        const vm = @fieldParentPtr(VirtualMachine, "exit_handler", this);
         Process__dispatchOnBeforeExit(vm.global, this.exit_code);
     }
 };
@@ -633,7 +633,7 @@ pub const VirtualMachine = struct {
 
     pub fn onAfterEventLoop(this: *VirtualMachine) void {
         if (this.after_event_loop_callback) |cb| {
-            var ctx = this.after_event_loop_callback_ctx;
+            const ctx = this.after_event_loop_callback_ctx;
             this.after_event_loop_callback = null;
             this.after_event_loop_callback_ctx = null;
             cb(ctx);
@@ -892,7 +892,7 @@ pub const VirtualMachine = struct {
     pub fn onExit(this: *VirtualMachine) void {
         this.exit_handler.dispatchOnExit();
 
-        var rare_data = this.rare_data orelse return;
+        const rare_data = this.rare_data orelse return;
         var hook = rare_data.cleanup_hook orelse return;
         hook.execute();
         while (hook.next) |next| {
@@ -1000,7 +1000,7 @@ pub const VirtualMachine = struct {
             JSC.markBinding(@src());
 
             var this = VirtualMachine.get();
-            var debugger = other_vm.debugger.?;
+            const debugger = other_vm.debugger.?;
 
             if (debugger.unix.len > 0) {
                 var url = bun.String.create(debugger.unix);
@@ -1142,9 +1142,9 @@ pub const VirtualMachine = struct {
         JSC.markBinding(@src());
         const allocator = opts.allocator;
         VMHolder.vm = try allocator.create(VirtualMachine);
-        var console = try allocator.create(ZigConsoleClient);
+        const console = try allocator.create(ZigConsoleClient);
         console.* = ZigConsoleClient.init(Output.errorWriter(), Output.writer());
-        var log = opts.log.?;
+        const log = opts.log.?;
         const bundler = try Bundler.init(
             allocator,
             log,
@@ -1218,7 +1218,7 @@ pub const VirtualMachine = struct {
         vm.jsc = vm.global.vm();
 
         if (source_code_printer == null) {
-            var writer = try js_printer.BufferWriter.init(allocator);
+            const writer = try js_printer.BufferWriter.init(allocator);
             source_code_printer = allocator.create(js_printer.BufferPrinter) catch unreachable;
             source_code_printer.?.* = js_printer.BufferPrinter.init(writer);
             source_code_printer.?.ctx.append_null_byte = false;
@@ -1252,7 +1252,7 @@ pub const VirtualMachine = struct {
         }
 
         VMHolder.vm = try allocator.create(VirtualMachine);
-        var console = try allocator.create(ZigConsoleClient);
+        const console = try allocator.create(ZigConsoleClient);
         console.* = ZigConsoleClient.init(Output.errorWriter(), Output.writer());
         const bundler = try Bundler.init(
             allocator,
@@ -1328,7 +1328,7 @@ pub const VirtualMachine = struct {
         vm.smol = opts.smol;
 
         if (source_code_printer == null) {
-            var writer = try js_printer.BufferWriter.init(allocator);
+            const writer = try js_printer.BufferWriter.init(allocator);
             source_code_printer = allocator.create(js_printer.BufferPrinter) catch unreachable;
             source_code_printer.?.* = js_printer.BufferPrinter.init(writer);
             source_code_printer.?.ctx.append_null_byte = false;
@@ -1340,9 +1340,9 @@ pub const VirtualMachine = struct {
     }
 
     fn configureDebugger(this: *VirtualMachine, debugger: bun.CLI.Command.Debugger) void {
-        var unix = bun.getenvZ("BUN_INSPECT") orelse "";
-        var set_breakpoint_on_first_line = unix.len > 0 and strings.endsWith(unix, "?break=1");
-        var wait_for_connection = set_breakpoint_on_first_line or (unix.len > 0 and strings.endsWith(unix, "?wait=1"));
+        const unix = bun.getenvZ("BUN_INSPECT") orelse "";
+        const set_breakpoint_on_first_line = unix.len > 0 and strings.endsWith(unix, "?break=1");
+        const wait_for_connection = set_breakpoint_on_first_line or (unix.len > 0 and strings.endsWith(unix, "?wait=1"));
 
         switch (debugger) {
             .unspecified => {
@@ -1388,7 +1388,7 @@ pub const VirtualMachine = struct {
         }
 
         VMHolder.vm = try allocator.create(VirtualMachine);
-        var console = try allocator.create(ZigConsoleClient);
+        const console = try allocator.create(ZigConsoleClient);
         console.* = ZigConsoleClient.init(Output.errorWriter(), Output.writer());
         const bundler = try Bundler.init(
             allocator,
@@ -1464,7 +1464,7 @@ pub const VirtualMachine = struct {
         vm.jsc = vm.global.vm();
         vm.bundler.setAllocator(allocator);
         if (source_code_printer == null) {
-            var writer = try js_printer.BufferWriter.init(allocator);
+            const writer = try js_printer.BufferWriter.init(allocator);
             source_code_printer = allocator.create(js_printer.BufferPrinter) catch unreachable;
             source_code_printer.?.* = js_printer.BufferPrinter.init(writer);
             source_code_printer.?.ctx.append_null_byte = false;
@@ -1503,14 +1503,14 @@ pub const VirtualMachine = struct {
         this.ref_strings_mutex.lock();
         defer this.ref_strings_mutex.unlock();
 
-        var entry = this.ref_strings.getOrPut(hash) catch unreachable;
+        const entry = this.ref_strings.getOrPut(hash) catch unreachable;
         if (!entry.found_existing) {
             const input = if (comptime dupe)
                 (this.allocator.dupe(u8, input_) catch unreachable)
             else
                 input_;
 
-            var ref = this.allocator.create(JSC.RefString) catch unreachable;
+            const ref = this.allocator.create(JSC.RefString) catch unreachable;
             ref.* = JSC.RefString{
                 .allocator = this.allocator,
                 .ptr = input.ptr,
@@ -1568,10 +1568,10 @@ pub const VirtualMachine = struct {
         var specifier_clone = _specifier.toUTF8(bun.default_allocator);
         defer specifier_clone.deinit();
         var display_slice = display_specifier.slice();
-        var specifier = ModuleLoader.normalizeSpecifier(jsc_vm, specifier_clone.slice(), &display_slice);
+        const specifier = ModuleLoader.normalizeSpecifier(jsc_vm, specifier_clone.slice(), &display_slice);
         const referrer_clone = referrer.toUTF8(bun.default_allocator);
         defer referrer_clone.deinit();
-        var path = Fs.Path.init(specifier_clone.slice());
+        const path = Fs.Path.init(specifier_clone.slice());
         var loader = jsc_vm.bundler.options.loaders.get(path.name.ext) orelse brk: {
             if (strings.eqlLong(specifier, jsc_vm.main, true)) {
                 break :brk options.Loader.js;
@@ -1843,7 +1843,7 @@ pub const VirtualMachine = struct {
             return;
         }
 
-        var old_log = jsc_vm.log;
+        const old_log = jsc_vm.log;
         var log = logger.Log.init(jsc_vm.allocator);
         defer log.deinit();
         jsc_vm.log = &log;
@@ -1857,7 +1857,7 @@ pub const VirtualMachine = struct {
         _resolve(&result, specifier_utf8.slice(), normalizeSource(source_utf8.slice()), is_esm, is_a_file_path) catch |err_| {
             var err = err_;
             const msg: logger.Msg = brk: {
-                var msgs: []logger.Msg = log.msgs.items;
+                const msgs: []logger.Msg = log.msgs.items;
 
                 for (msgs) |m| {
                     if (m.metadata == .resolve) {
@@ -1955,7 +1955,7 @@ pub const VirtualMachine = struct {
             else => {
                 var errors_stack: [256]*anyopaque = undefined;
 
-                var errors = errors_stack[0..@min(log.msgs.items.len, errors_stack.len)];
+                const errors = errors_stack[0..@min(log.msgs.items.len, errors_stack.len)];
 
                 for (log.msgs.items, errors) |msg, *current| {
                     current.* = switch (msg.metadata) {
@@ -2020,12 +2020,12 @@ pub const VirtualMachine = struct {
         if (!result.isEmptyOrUndefinedOrNull())
             this.last_reported_error_for_dedupe = result;
 
-        var prev_had_errors = this.had_errors;
+        const prev_had_errors = this.had_errors;
         this.had_errors = false;
         defer this.had_errors = prev_had_errors;
 
         if (result.isException(this.global.vm())) {
-            var exception = @as(*Exception, @ptrCast(result.asVoid()));
+            const exception = @as(*Exception, @ptrCast(result.asVoid()));
 
             this.printException(
                 exception,
@@ -2153,12 +2153,12 @@ pub const VirtualMachine = struct {
                 return promise;
             }
 
-            var promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.init(main_file_name)) orelse return error.JSError;
+            const promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.init(main_file_name)) orelse return error.JSError;
             this.pending_internal_promise = promise;
             JSC.JSValue.fromCell(promise).ensureStillAlive();
             return promise;
         } else {
-            var promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.init(this.main)) orelse return error.JSError;
+            const promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.init(this.main)) orelse return error.JSError;
             this.pending_internal_promise = promise;
             JSC.JSValue.fromCell(promise).ensureStillAlive();
 
@@ -2187,7 +2187,7 @@ pub const VirtualMachine = struct {
             }
         }
 
-        var promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.fromBytes(this.main)) orelse return error.JSError;
+        const promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.fromBytes(this.main)) orelse return error.JSError;
         this.pending_internal_promise = promise;
         JSC.JSValue.fromCell(promise).ensureStillAlive();
 
@@ -2196,7 +2196,7 @@ pub const VirtualMachine = struct {
 
     // worker dont has bun_watcher and also we dont wanna call autoTick before dispatchOnline
     pub fn loadEntryPointForWebWorker(this: *VirtualMachine, entry_path: string) anyerror!*JSInternalPromise {
-        var promise = try this.reloadEntryPoint(entry_path);
+        const promise = try this.reloadEntryPoint(entry_path);
         this.eventLoop().performGC();
         this.eventLoop().waitForPromiseWithTermination(JSC.AnyPromise{
             .Internal = promise,
@@ -2293,14 +2293,14 @@ pub const VirtualMachine = struct {
     }
 
     pub fn loadMacroEntryPoint(this: *VirtualMachine, entry_path: string, function_name: string, specifier: string, hash: i32) !*JSInternalPromise {
-        var entry_point_entry = try this.macro_entry_points.getOrPut(hash);
+        const entry_point_entry = try this.macro_entry_points.getOrPut(hash);
 
         if (!entry_point_entry.found_existing) {
             var macro_entry_pointer: *MacroEntryPoint = this.allocator.create(MacroEntryPoint) catch unreachable;
             entry_point_entry.value_ptr.* = macro_entry_pointer;
             try macro_entry_pointer.generate(&this.bundler, Fs.PathName.init(entry_path), function_name, hash, specifier);
         }
-        var entry_point = entry_point_entry.value_ptr.*;
+        const entry_point = entry_point_entry.value_ptr.*;
 
         var loader = MacroEntryPointLoader{
             .path = entry_point.source.path.text,
@@ -2395,7 +2395,7 @@ pub const VirtualMachine = struct {
                     iterator(_vm, globalObject, nextValue, ctx.?, false);
                 }
                 inline fn iterator(_: [*c]VM, _: [*c]JSGlobalObject, nextValue: JSValue, ctx: ?*anyopaque, comptime color: bool) void {
-                    var this_ = @as(*@This(), @ptrFromInt(@intFromPtr(ctx)));
+                    const this_ = @as(*@This(), @ptrFromInt(@intFromPtr(ctx)));
                     VirtualMachine.get().printErrorlikeObject(nextValue, null, this_.current_exception_list, Writer, this_.writer, color, allow_side_effects);
                 }
             };
@@ -2657,7 +2657,7 @@ pub const VirtualMachine = struct {
                 @memset(source_lines, String.empty);
                 @memset(source_line_numbers, 0);
 
-                var lines_ = lines[0..@min(lines.len, source_lines.len)];
+                const lines_ = lines[0..@min(lines.len, source_lines.len)];
                 for (lines_, 0..) |line, j| {
                     source_lines[(lines_.len - 1) - j] = String.init(line);
                     source_line_numbers[j] = top.position.line - @as(i32, @intCast(j)) + 1;
@@ -2697,7 +2697,7 @@ pub const VirtualMachine = struct {
         var exception = exception_holder.zigException();
         defer exception_holder.deinit();
         this.remapZigException(exception, error_instance, exception_list);
-        var prev_had_errors = this.had_errors;
+        const prev_had_errors = this.had_errors;
         this.had_errors = true;
         defer this.had_errors = prev_had_errors;
 
@@ -2707,7 +2707,7 @@ pub const VirtualMachine = struct {
             };
         }
 
-        var line_numbers = exception.stack.source_lines_numbers[0..exception.stack.source_lines_len];
+        const line_numbers = exception.stack.source_lines_numbers[0..exception.stack.source_lines_len];
         var max_line: i32 = -1;
         for (line_numbers) |line| max_line = @max(max_line, line);
         const max_line_number_pad = std.fmt.count("{d}", .{max_line});
@@ -2731,7 +2731,7 @@ pub const VirtualMachine = struct {
             );
         }
 
-        var name = exception.name;
+        const name = exception.name;
 
         const message = exception.message;
 
@@ -2743,7 +2743,7 @@ pub const VirtualMachine = struct {
             if (top_frame == null or top_frame.?.position.isInvalid()) {
                 defer did_print_name = true;
                 defer source.text.deinit();
-                var text = std.mem.trim(u8, source.text.slice(), "\n");
+                const text = std.mem.trim(u8, source.text.slice(), "\n");
 
                 try writer.print(
                     comptime Output.prettyFmt(
@@ -2763,7 +2763,7 @@ pub const VirtualMachine = struct {
                 try writer.writeByteNTimes(' ', pad);
                 defer source.text.deinit();
                 const text = source.text.slice();
-                var remainder = std.mem.trim(u8, text, "\n");
+                const remainder = std.mem.trim(u8, text, "\n");
 
                 try writer.print(
                     comptime Output.prettyFmt(
@@ -2805,7 +2805,7 @@ pub const VirtualMachine = struct {
             fd: bool = false,
         };
 
-        var show = Show{
+        const show = Show{
             .system_code = !exception.system_code.eql(name) and !exception.system_code.isEmpty(),
             .syscall = !exception.syscall.isEmpty(),
             .errno = exception.errno < 0,
@@ -2994,7 +2994,7 @@ pub const VirtualMachine = struct {
             .uws_context = context,
             .ipc = .{ .socket = socket },
         };
-        var ptr = socket.ext(*IPCInstance);
+        const ptr = socket.ext(*IPCInstance);
         ptr.?.* = instance;
         this.ipc = instance;
         instance.ipc.writeVersionPacket();
@@ -3044,7 +3044,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
             pub fn append(this: *HotReloadTask, id: u32) void {
                 if (this.count == 8) {
                     this.enqueue();
-                    var reloader = this.reloader;
+                    const reloader = this.reloader;
                     this.* = .{
                         .reloader = reloader,
                         .count = 0,
@@ -3198,7 +3198,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
             const kinds = slice.items(.kind);
             const hashes = slice.items(.hash);
             const parents = slice.items(.parent_hash);
-            var file_descriptors = slice.items(.fd);
+            const file_descriptors = slice.items(.fd);
             var ctx = this.getContext();
             defer ctx.flushEvictions();
             defer Output.flush();
@@ -3344,7 +3344,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
 
                                             break :brk path_string.slice();
                                         } else {
-                                            var file_path_without_trailing_slash = std.mem.trimRight(u8, file_path, std.fs.path.sep_str);
+                                            const file_path_without_trailing_slash = std.mem.trimRight(u8, file_path, std.fs.path.sep_str);
                                             @memcpy(_on_file_update_path_buf[0..file_path_without_trailing_slash.len], file_path_without_trailing_slash);
                                             _on_file_update_path_buf[file_path_without_trailing_slash.len] = std.fs.path.sep;
 

--- a/src/bun.js/javascript_core_c_api.zig
+++ b/src/bun.js/javascript_core_c_api.zig
@@ -83,7 +83,7 @@ pub const OpaqueJSString = opaque {
         }
 
         // also extremely inefficient
-        var utf8Z = allocator.dupeZ(u8, zig_str.slice()) catch unreachable;
+        const utf8Z = allocator.dupeZ(u8, zig_str.slice()) catch unreachable;
         const cloned = JSStringCreateWithUTF8CString(utf8Z);
         allocator.free(utf8Z);
         return cloned;
@@ -386,7 +386,7 @@ pub fn isObjectOfClassAndResolveIfNeeded(ctx: JSContextRef, obj: JSObjectRef, cl
         thenable_string = JSStringCreateWithUTF8CString(then_key[0.. :0]);
     }
 
-    var prop = JSObjectGetPropertyForKey(ctx, obj, JSValueMakeString(ctx, thenable_string), null);
+    const prop = JSObjectGetPropertyForKey(ctx, obj, JSValueMakeString(ctx, thenable_string), null);
     if (prop == null) {
         return null;
     }

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -132,7 +132,7 @@ fn jsModuleFromFile(from_path: string, comptime input: string) string {
         };
     }
 
-    var contents = file.readToEndAlloc(bun.default_allocator, std.math.maxInt(usize)) catch @panic("Cannot read file " ++ input);
+    const contents = file.readToEndAlloc(bun.default_allocator, std.math.maxInt(usize)) catch @panic("Cannot read file " ++ input);
     file.close();
     return contents;
 }
@@ -182,7 +182,7 @@ fn setBreakPointOnFirstLine() bool {
     const s = struct {
         var set_break_point: bool = true;
     };
-    var ret = s.set_break_point;
+    const ret = s.set_break_point;
     s.set_break_point = false;
     return ret;
 }
@@ -209,8 +209,8 @@ pub const RuntimeTranspilerStore = struct {
     ) *anyopaque {
         debug("transpile({s})", .{path.text});
         var job: *TranspilerJob = this.store.get();
-        var owned_path = Fs.Path.init(bun.default_allocator.dupe(u8, path.text) catch unreachable);
-        var promise = JSC.JSInternalPromise.create(globalObject);
+        const owned_path = Fs.Path.init(bun.default_allocator.dupe(u8, path.text) catch unreachable);
+        const promise = JSC.JSInternalPromise.create(globalObject);
         job.* = TranspilerJob{
             .path = owned_path,
             .globalThis = globalObject,
@@ -280,11 +280,11 @@ pub const RuntimeTranspilerStore = struct {
 
         pub fn runFromJSThread(this: *TranspilerJob) void {
             var vm = this.vm;
-            var promise = this.promise.swap();
-            var globalThis = this.globalThis;
+            const promise = this.promise.swap();
+            const globalThis = this.globalThis;
             this.poll_ref.unref(vm);
             var specifier = if (this.parse_error == null) this.resolved_source.specifier else bun.String.create(this.path.text);
-            var referrer = bun.String.create(this.referrer);
+            const referrer = bun.String.create(this.referrer);
             var log = this.log;
             this.log = logger.Log.init(bun.default_allocator);
             var resolved_source = this.resolved_source;
@@ -292,9 +292,9 @@ pub const RuntimeTranspilerStore = struct {
 
             resolved_source.tag = brk: {
                 if (resolved_source.commonjs_exports_len > 0) {
-                    var actual_package_json: *PackageJSON = brk2: {
+                    const actual_package_json: *PackageJSON = brk2: {
                         // this should already be cached virtually always so it's fine to do this
-                        var dir_info = (vm.bundler.resolver.readDirInfo(this.path.name.dir) catch null) orelse
+                        const dir_info = (vm.bundler.resolver.readDirInfo(this.path.name.dir) catch null) orelse
                             break :brk .javascript;
 
                         break :brk2 dir_info.package_json orelse dir_info.enclosing_package_json;
@@ -527,7 +527,7 @@ pub const RuntimeTranspilerStore = struct {
             }
 
             if (source_code_printer == null) {
-                var writer = try js_printer.BufferWriter.init(bun.default_allocator);
+                const writer = try js_printer.BufferWriter.init(bun.default_allocator);
                 source_code_printer = bun.default_allocator.create(js_printer.BufferPrinter) catch unreachable;
                 source_code_printer.?.* = js_printer.BufferPrinter.init(writer);
                 source_code_printer.?.ctx.append_null_byte = false;
@@ -692,7 +692,7 @@ pub const ModuleLoader = struct {
             pub fn onWakeHandler(ctx: *anyopaque, _: *PackageManager) void {
                 debug("onWake", .{});
                 var this = bun.cast(*Queue, ctx);
-                var concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch @panic("OOM");
+                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch @panic("OOM");
                 concurrent_task.* = .{
                     .task = JSC.Task.init(this),
                     .auto_delete = true,
@@ -756,16 +756,16 @@ pub const ModuleLoader = struct {
                 var i: usize = 0;
                 outer: for (modules) |module_| {
                     var module = module_;
-                    var tags = module.parse_result.pending_imports.items(.tag);
+                    const tags = module.parse_result.pending_imports.items(.tag);
                     for (tags, 0..) |tag, tag_i| {
                         if (tag == .resolve) {
-                            var esms = module.parse_result.pending_imports.items(.esm);
+                            const esms = module.parse_result.pending_imports.items(.esm);
                             const esm = esms[tag_i];
-                            var string_bufs = module.parse_result.pending_imports.items(.string_buf);
+                            const string_bufs = module.parse_result.pending_imports.items(.string_buf);
 
                             if (!strings.eql(esm.name.slice(string_bufs[tag_i]), name)) continue;
 
-                            var versions = module.parse_result.pending_imports.items(.dependency);
+                            const versions = module.parse_result.pending_imports.items(.dependency);
 
                             module.resolveError(
                                 this.vm(),
@@ -1033,9 +1033,9 @@ pub const ModuleLoader = struct {
         }
 
         pub fn resolveError(this: *AsyncModule, vm: *JSC.VirtualMachine, import_record_id: u32, result: PackageResolveError) !void {
-            var globalThis = this.globalThis;
+            const globalThis = this.globalThis;
 
-            var msg: []u8 = try switch (result.err) {
+            const msg: []u8 = try switch (result.err) {
                 error.PackageManifestHTTP400 => std.fmt.allocPrint(
                     bun.default_allocator,
                     "HTTP 400 while resolving package '{s}' at '{s}'",
@@ -1125,14 +1125,14 @@ pub const ModuleLoader = struct {
             promise.rejectAsHandled(globalThis, error_instance);
         }
         pub fn downloadError(this: *AsyncModule, vm: *JSC.VirtualMachine, import_record_id: u32, result: PackageDownloadError) !void {
-            var globalThis = this.globalThis;
+            const globalThis = this.globalThis;
 
             const msg_args = .{
                 result.name,
                 result.resolution.fmt(vm.packageManager().lockfile.buffers.string_bytes.items),
             };
 
-            var msg: []u8 = try switch (result.err) {
+            const msg: []u8 = try switch (result.err) {
                 error.TarballHTTP400 => std.fmt.allocPrint(
                     bun.default_allocator,
                     "HTTP 400 downloading package '{s}@{any}'",
@@ -1222,10 +1222,10 @@ pub const ModuleLoader = struct {
         pub fn resumeLoadingModule(this: *AsyncModule, log: *logger.Log) !ResolvedSource {
             debug("resumeLoadingModule: {s}", .{this.specifier});
             var parse_result = this.parse_result;
-            var path = this.path;
+            const path = this.path;
             var jsc_vm = JSC.VirtualMachine.get();
-            var specifier = this.specifier;
-            var old_log = jsc_vm.log;
+            const specifier = this.specifier;
+            const old_log = jsc_vm.log;
 
             jsc_vm.bundler.linker.log = log;
             jsc_vm.bundler.log = log;
@@ -1269,7 +1269,7 @@ pub const ModuleLoader = struct {
                 dumpSource(specifier, &printer);
             }
 
-            var commonjs_exports = try bun.default_allocator.alloc(ZigString, parse_result.ast.commonjs_export_names.len);
+            const commonjs_exports = try bun.default_allocator.alloc(ZigString, parse_result.ast.commonjs_export_names.len);
             for (parse_result.ast.commonjs_export_names, commonjs_exports) |name, *out| {
                 out.* = ZigString.fromUTF8(name);
             }
@@ -1394,7 +1394,7 @@ pub const ModuleLoader = struct {
                     }
 
                     // we must allocate the arena so that the pointer it points to is always valid.
-                    var arena = try jsc_vm.allocator.create(bun.ArenaAllocator);
+                    const arena = try jsc_vm.allocator.create(bun.ArenaAllocator);
                     arena.* = bun.ArenaAllocator.init(bun.default_allocator);
                     break :brk arena;
                 };
@@ -1418,7 +1418,7 @@ pub const ModuleLoader = struct {
                 }
 
                 var arena = arena_.?;
-                var allocator = arena.allocator();
+                const allocator = arena.allocator();
 
                 var fd: ?StoredFileDescriptorType = null;
                 var package_json: ?*PackageJSON = null;
@@ -1429,7 +1429,7 @@ pub const ModuleLoader = struct {
                     package_json = jsc_vm.bun_watcher.watchlist().items(.package_json)[index];
                 }
 
-                var old = jsc_vm.bundler.log;
+                const old = jsc_vm.bundler.log;
                 jsc_vm.bundler.log = log;
                 jsc_vm.bundler.linker.log = log;
                 jsc_vm.bundler.resolver.log = log;
@@ -1675,7 +1675,7 @@ pub const ModuleLoader = struct {
                     dumpSource(specifier, &printer);
                 }
 
-                var commonjs_exports = try bun.default_allocator.alloc(ZigString, parse_result.ast.commonjs_export_names.len);
+                const commonjs_exports = try bun.default_allocator.alloc(ZigString, parse_result.ast.commonjs_export_names.len);
                 for (parse_result.ast.commonjs_export_names, commonjs_exports) |name, *out| {
                     out.* = ZigString.fromUTF8(name);
                 }
@@ -1705,9 +1705,9 @@ pub const ModuleLoader = struct {
                 // Pass along package.json type "module" if set.
                 const tag = brk: {
                     if (parse_result.ast.exports_kind == .cjs and parse_result.source.path.isFile()) {
-                        var actual_package_json: *PackageJSON = package_json orelse brk2: {
+                        const actual_package_json: *PackageJSON = package_json orelse brk2: {
                             // this should already be cached virtually always so it's fine to do this
-                            var dir_info = (jsc_vm.bundler.resolver.readDirInfo(parse_result.source.path.name.dir) catch null) orelse
+                            const dir_info = (jsc_vm.bundler.resolver.readDirInfo(parse_result.source.path.name.dir) catch null) orelse
                                 break :brk .javascript;
 
                             break :brk2 dir_info.package_json orelse dir_info.enclosing_package_json;
@@ -1799,7 +1799,7 @@ pub const ModuleLoader = struct {
                     if (virtual_source) |source| {
                         if (globalObject) |globalThis| {
                             // attempt to avoid reading the WASM file twice.
-                            var encoded = JSC.EncodedJSValue{
+                            const encoded = JSC.EncodedJSValue{
                                 .asPtr = globalThis,
                             };
                             const globalValue = @as(JSC.JSValue, @enumFromInt(encoded.asInt64));
@@ -1839,7 +1839,7 @@ pub const ModuleLoader = struct {
 
             else => {
                 var stack_buf = std.heap.stackFallback(4096, jsc_vm.allocator);
-                var allocator = stack_buf.get();
+                const allocator = stack_buf.get();
                 var buf = MutableString.init2048(allocator) catch unreachable;
                 defer buf.deinit();
                 var writer = buf.writer();
@@ -1957,7 +1957,7 @@ pub const ModuleLoader = struct {
         defer _specifier.deinit();
         defer referrer_slice.deinit();
         var display_specifier: []const u8 = "";
-        var specifier = normalizeSpecifier(
+        const specifier = normalizeSpecifier(
             jsc_vm,
             _specifier.slice(),
             &display_specifier,

--- a/src/bun.js/node/fs_events.zig
+++ b/src/bun.js/node/fs_events.zig
@@ -239,8 +239,8 @@ pub const FSEventsLoop = struct {
         callback: *const (fn (*anyopaque) void),
 
         pub fn run(this: *Task) void {
-            var callback = this.callback;
-            var ctx = this.ctx;
+            const callback = this.callback;
+            const ctx = this.ctx;
             callback(ctx.?);
         }
 
@@ -327,7 +327,7 @@ pub const FSEventsLoop = struct {
             return error.FailedToCreateCoreFoudationSourceLoop;
         }
 
-        var fs_loop = FSEventsLoop{ .sem = Semaphore.init(0), .mutex = Mutex.init(), .signal_source = signal_source };
+        const fs_loop = FSEventsLoop{ .sem = Semaphore.init(0), .mutex = Mutex.init(), .signal_source = signal_source };
 
         this.* = fs_loop;
         this.thread = try std.Thread.spawn(.{}, FSEventsLoop.CFThreadLoop, .{this});
@@ -419,7 +419,7 @@ pub const FSEventsLoop = struct {
         this.has_scheduled_watchers = false;
         const watcher_count = this.watcher_count;
 
-        var watchers = this.watchers.slice();
+        const watchers = this.watchers.slice();
 
         const CF = CoreFoundation.get();
         const CS = CoreServices.get();
@@ -590,7 +590,7 @@ pub const FSEventsWatcher = struct {
     pub const UpdateEndCallback = *const fn (ctx: ?*anyopaque) void;
 
     pub fn init(loop: *FSEventsLoop, path: string, recursive: bool, callback: Callback, updateEnd: UpdateEndCallback, ctx: ?*anyopaque) *FSEventsWatcher {
-        var this = bun.default_allocator.create(FSEventsWatcher) catch unreachable;
+        const this = bun.default_allocator.create(FSEventsWatcher) catch unreachable;
 
         this.* = FSEventsWatcher{
             .path = path,

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -41,7 +41,7 @@ pub const StatWatcherScheduler = struct {
     task: JSC.WorkPoolTask = .{ .callback = &workPoolCallback },
 
     pub fn init(allocator: std.mem.Allocator, _: *bun.JSC.VirtualMachine) *StatWatcherScheduler {
-        var this = allocator.create(StatWatcherScheduler) catch @panic("out of memory");
+        const this = allocator.create(StatWatcherScheduler) catch @panic("out of memory");
         this.* = .{};
         return this;
     }
@@ -83,7 +83,7 @@ pub const StatWatcherScheduler = struct {
         // Instant.now will not fail on our target platforms.
         const now = std.time.Instant.now() catch unreachable;
 
-        var head: *StatWatcher = this.head.swap(null, .Monotonic).?;
+        const head: *StatWatcher = this.head.swap(null, .Monotonic).?;
 
         var prev = head;
         while (prev.closed) {
@@ -353,7 +353,7 @@ pub const StatWatcher = struct {
         }
 
         fn workPoolCallback(task: *JSC.WorkPoolTask) void {
-            var initial_stat_task: *InitialStatTask = @fieldParentPtr(InitialStatTask, "task", task);
+            const initial_stat_task: *InitialStatTask = @fieldParentPtr(InitialStatTask, "task", task);
             defer bun.default_allocator.destroy(initial_stat_task);
             const this = initial_stat_task.watcher;
 
@@ -464,14 +464,14 @@ pub const StatWatcher = struct {
             slice = slice[6..];
         }
         var parts = [_]string{slice};
-        var file_path = Path.joinAbsStringBuf(
+        const file_path = Path.joinAbsStringBuf(
             Fs.FileSystem.instance.top_level_dir,
             &buf,
             &parts,
             .auto,
         );
 
-        var alloc_file_path = try bun.default_allocator.allocSentinel(u8, file_path.len, 0);
+        const alloc_file_path = try bun.default_allocator.allocSentinel(u8, file_path.len, 0);
         errdefer bun.default_allocator.free(alloc_file_path);
         @memcpy(alloc_file_path, file_path);
 

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -76,7 +76,7 @@ pub const FSWatcher = struct {
         pub fn append(this: *FSWatchTask, file_path: string, event_type: EventType, needs_free: bool) void {
             if (this.count == 8) {
                 this.enqueue();
-                var ctx = this.ctx;
+                const ctx = this.ctx;
                 this.* = .{
                     .ctx = ctx,
                     .count = 0,
@@ -555,7 +555,7 @@ pub const FSWatcher = struct {
             slice,
         };
 
-        var file_path = Path.joinAbsStringBuf(
+        const file_path = Path.joinAbsStringBuf(
             Fs.FileSystem.instance.top_level_dir,
             &buf,
             &parts,
@@ -563,7 +563,7 @@ pub const FSWatcher = struct {
         );
 
         buf[file_path.len] = 0;
-        var file_path_z = buf[0..file_path.len :0];
+        const file_path_z = buf[0..file_path.len :0];
 
         var ctx = try bun.default_allocator.create(FSWatcher);
         const vm = args.global_this.bunVM();

--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -525,7 +525,7 @@ pub const Os = struct {
                     // Encode its link-layer address.  We need 2*6 bytes for the
                     //  hex characters and 5 for the colon separators
                     var mac_buf: [17]u8 = undefined;
-                    var addr_data = if (comptime Environment.isLinux) ll_addr.addr else if (comptime Environment.isMac) ll_addr.sdl_data[ll_addr.sdl_nlen..] else unreachable;
+                    const addr_data = if (comptime Environment.isLinux) ll_addr.addr else if (comptime Environment.isMac) ll_addr.sdl_data[ll_addr.sdl_nlen..] else unreachable;
                     const mac = std.fmt.bufPrint(&mac_buf, "{x:0>2}:{x:0>2}:{x:0>2}:{x:0>2}:{x:0>2}:{x:0>2}", .{
                         addr_data[0], addr_data[1], addr_data[2],
                         addr_data[3], addr_data[4], addr_data[5],

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -102,7 +102,7 @@ pub const PathWatcherManager = struct {
             return result;
         } else |err| {
             if (err == error.NotDir) {
-                var file = try std.fs.openFileAbsoluteZ(cloned_path, .{ .mode = .read_only });
+                const file = try std.fs.openFileAbsoluteZ(cloned_path, .{ .mode = .read_only });
                 const result = PathInfo{
                     .fd = file.handle,
                     .is_file = true,
@@ -130,7 +130,7 @@ pub const PathWatcherManager = struct {
             return err;
         };
         errdefer watchers.deinitWithAllocator(bun.default_allocator);
-        var manager = PathWatcherManager{
+        const manager = PathWatcherManager{
             .file_paths = bun.StringHashMap(PathInfo).init(bun.default_allocator),
             .current_fd_task = bun.FDHashMap(*DirectoryRegisterTask).init(bun.default_allocator),
             .watchers = watchers,
@@ -257,7 +257,7 @@ pub const PathWatcherManager = struct {
                         const changed_name: []const u8 = bun.asByteSlice(changed_name_.?);
                         if (changed_name.len == 0 or changed_name[0] == '~' or changed_name[0] == '.') continue;
 
-                        var file_path_without_trailing_slash = std.mem.trimRight(u8, file_path, std.fs.path.sep_str);
+                        const file_path_without_trailing_slash = std.mem.trimRight(u8, file_path, std.fs.path.sep_str);
 
                         @memcpy(_on_file_update_path_buf[0..file_path_without_trailing_slash.len], file_path_without_trailing_slash);
 
@@ -442,7 +442,7 @@ pub const PathWatcherManager = struct {
             // now we iterate over all files and directories
             while (try iter.next()) |entry| {
                 var parts = [2]string{ path.path, entry.name };
-                var entry_path = Path.joinAbsStringBuf(
+                const entry_path = Path.joinAbsStringBuf(
                     Fs.FileSystem.instance.topLevelDirWithoutTrailingSlash(),
                     buf,
                     &parts,
@@ -450,9 +450,9 @@ pub const PathWatcherManager = struct {
                 );
 
                 buf[entry_path.len] = 0;
-                var entry_path_z = buf[0..entry_path.len :0];
+                const entry_path_z = buf[0..entry_path.len :0];
 
-                var child_path = try manager._fdFromAbsolutePathZ(entry_path_z);
+                const child_path = try manager._fdFromAbsolutePathZ(entry_path_z);
                 {
                     watcher.mutex.lock();
                     defer watcher.mutex.unlock();

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -636,13 +636,13 @@ pub const Encoding = enum(u8) {
             },
             .base64url => {
                 var buf: [std.base64.url_safe_no_pad.Encoder.calcSize(size)]u8 = undefined;
-                var encoded = std.base64.url_safe_no_pad.Encoder.encode(&buf, input);
+                const encoded = std.base64.url_safe_no_pad.Encoder.encode(&buf, input);
 
                 return JSC.ZigString.init(buf[0..encoded.len]).toValueGC(globalThis);
             },
             .hex => {
                 var buf: [size * 4]u8 = undefined;
-                var out = std.fmt.bufPrint(&buf, "{}", .{std.fmt.fmtSliceHexLower(input)}) catch unreachable;
+                const out = std.fmt.bufPrint(&buf, "{}", .{std.fmt.fmtSliceHexLower(input)}) catch unreachable;
                 const result = JSC.ZigString.init(out).toValueGC(globalThis);
                 return result;
             },
@@ -666,19 +666,19 @@ pub const Encoding = enum(u8) {
         switch (encoding) {
             .base64 => {
                 var base64_buf: [std.base64.standard.Encoder.calcSize(max_size)]u8 = undefined;
-                var base64 = base64_buf[0..std.base64.standard.Encoder.calcSize(size)];
+                const base64 = base64_buf[0..std.base64.standard.Encoder.calcSize(size)];
                 const result = JSC.ZigString.init(std.base64.standard.Encoder.encode(base64, input)).toValueGC(globalThis);
                 return result;
             },
             .base64url => {
                 var buf: [std.base64.url_safe_no_pad.Encoder.calcSize(max_size)]u8 = undefined;
-                var encoded = std.base64.url_safe_no_pad.Encoder.encode(&buf, input);
+                const encoded = std.base64.url_safe_no_pad.Encoder.encode(&buf, input);
 
                 return JSC.ZigString.init(buf[0..encoded.len]).toValueGC(globalThis);
             },
             .hex => {
                 var buf: [max_size * 4]u8 = undefined;
-                var out = std.fmt.bufPrint(&buf, "{}", .{std.fmt.fmtSliceHexLower(input)}) catch unreachable;
+                const out = std.fmt.bufPrint(&buf, "{}", .{std.fmt.fmtSliceHexLower(input)}) catch unreachable;
                 const result = JSC.ZigString.init(out).toValueGC(globalThis);
                 return result;
             },
@@ -775,7 +775,7 @@ pub const PathLike = union(Tag) {
     }
 
     pub fn sliceZWithForceCopy(this: PathLike, buf: *[bun.MAX_PATH_BYTES]u8, comptime force: bool) [:0]const u8 {
-        var sliced = this.slice();
+        const sliced = this.slice();
 
         if (sliced.len == 0) return "";
 
@@ -999,7 +999,7 @@ pub const VectorArrayBuffer = struct {
                 return null;
             };
 
-            var buf = array_buffer.byteSlice();
+            const buf = array_buffer.byteSlice();
             bufferlist.append(std.os.iovec{
                 .iov_base = buf.ptr,
                 .iov_len = buf.len,
@@ -1021,7 +1021,7 @@ pub const ArgumentsSlice = struct {
 
     pub fn unprotect(this: *ArgumentsSlice) void {
         var iter = this.protected.iterator(.{});
-        var ctx = this.vm.global;
+        const ctx = this.vm.global;
         while (iter.next()) |i| {
             JSC.C.JSValueUnprotect(ctx, this.all[i].asObjectRef());
         }
@@ -1633,7 +1633,7 @@ pub fn StatType(comptime Big: bool) type {
         }
 
         pub fn initWithAllocator(allocator: std.mem.Allocator, stat: bun.Stat) *This {
-            var this = allocator.create(This) catch unreachable;
+            const this = allocator.create(This) catch unreachable;
             this.* = init(stat);
             return this;
         }
@@ -1647,15 +1647,15 @@ pub fn StatType(comptime Big: bool) type {
             // dev, mode, nlink, uid, gid, rdev, blksize, ino, size, blocks, atimeMs, mtimeMs, ctimeMs, birthtimeMs
             var args = callFrame.argumentsPtr()[0..@min(callFrame.argumentsCount(), 14)];
 
-            var this = globalThis.allocator().create(This) catch {
+            const this = globalThis.allocator().create(This) catch {
                 globalThis.throwOutOfMemory();
                 return null;
             };
 
-            var atime_ms: f64 = if (args.len > 10 and args[10].isNumber()) args[10].asNumber() else 0;
-            var mtime_ms: f64 = if (args.len > 11 and args[11].isNumber()) args[11].asNumber() else 0;
-            var ctime_ms: f64 = if (args.len > 12 and args[12].isNumber()) args[12].asNumber() else 0;
-            var birthtime_ms: f64 = if (args.len > 13 and args[13].isNumber()) args[13].asNumber() else 0;
+            const atime_ms: f64 = if (args.len > 10 and args[10].isNumber()) args[10].asNumber() else 0;
+            const mtime_ms: f64 = if (args.len > 11 and args[11].isNumber()) args[11].asNumber() else 0;
+            const ctime_ms: f64 = if (args.len > 12 and args[12].isNumber()) args[12].asNumber() else 0;
+            const birthtime_ms: f64 = if (args.len > 13 and args[13].isNumber()) args[13].asNumber() else 0;
             this.* = .{
                 .dev = if (args.len > 0 and args[0].isNumber()) args[0].toInt32() else 0,
                 .mode = if (args.len > 1 and args[1].isNumber()) args[1].toInt32() else 0,
@@ -1920,7 +1920,7 @@ pub const Path = struct {
             return JSC.toInvalidArguments("path is required", .{}, globalThis);
         }
         var stack_fallback = std.heap.stackFallback(4096, JSC.getAllocator(globalThis));
-        var allocator = stack_fallback.get();
+        const allocator = stack_fallback.get();
 
         var arguments: []JSC.JSValue = args_ptr[0..args_len];
         var path = arguments[0].toSlice(globalThis, allocator);
@@ -1929,7 +1929,7 @@ pub const Path = struct {
         var extname_ = if (args_len > 1) arguments[1].toSlice(globalThis, allocator) else JSC.ZigString.Slice.empty;
         defer extname_.deinit();
 
-        var base_slice = path.slice();
+        const base_slice = path.slice();
         var out: []const u8 = base_slice;
 
         if (!isWindows) {
@@ -2032,7 +2032,7 @@ pub const Path = struct {
             return JSC.toInvalidArguments("path is required", .{}, globalThis);
         }
         var stack_fallback = std.heap.stackFallback(4096, JSC.getAllocator(globalThis));
-        var allocator = stack_fallback.get();
+        const allocator = stack_fallback.get();
 
         var arguments: []JSC.JSValue = args_ptr[0..args_len];
         var path = arguments[0].toSlice(globalThis, allocator);
@@ -2053,7 +2053,7 @@ pub const Path = struct {
             return JSC.toInvalidArguments("path is required", .{}, globalThis);
         }
         var stack_fallback = std.heap.stackFallback(4096, JSC.getAllocator(globalThis));
-        var allocator = stack_fallback.get();
+        const allocator = stack_fallback.get();
         var arguments: []JSC.JSValue = args_ptr[0..args_len];
 
         var path = arguments[0].toSlice(globalThis, allocator);
@@ -2188,7 +2188,7 @@ pub const Path = struct {
         std.debug.assert(zig_str.len > 0); // caller must check
         if (zig_str.is16Bit()) {
             var buf = [4]u16{ 0, 0, 0, 0 };
-            var u16_slice = zig_str.utf16Slice();
+            const u16_slice = zig_str.utf16Slice();
 
             buf[0] = u16_slice[0];
             if (u16_slice.len > 1)
@@ -2216,7 +2216,7 @@ pub const Path = struct {
         var arena = @import("root").bun.ArenaAllocator.init(heap_allocator);
         defer arena.deinit();
 
-        var arena_allocator = arena.allocator();
+        const arena_allocator = arena.allocator();
         var stack_fallback_allocator = std.heap.stackFallback(
             ((32 * @sizeOf(string)) + 1024),
             arena_allocator,
@@ -2260,7 +2260,7 @@ pub const Path = struct {
         var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
         var str_slice = zig_str.toSlice(heap_allocator);
         defer str_slice.deinit();
-        var str = str_slice.slice();
+        const str = str_slice.slice();
 
         const out = if (!isWindows)
             PathHandler.normalizeStringNode(str, &buf, .posix)
@@ -2278,7 +2278,7 @@ pub const Path = struct {
         }
         var path_slice: JSC.ZigString.Slice = args_ptr[0].toSlice(globalThis, heap_allocator);
         defer path_slice.deinit();
-        var path = path_slice.slice();
+        const path = path_slice.slice();
         const path_name = Fs.NodeJSPathName.init(
             path,
             if (win32) std.fs.path.sep_windows else std.fs.path.sep_posix,
@@ -2324,10 +2324,10 @@ pub const Path = struct {
         var to_slice: JSC.ZigString.Slice = if (args_len > 1) arguments[1].toSlice(globalThis, heap_allocator) else JSC.ZigString.Slice.empty;
         defer to_slice.deinit();
 
-        var from = from_slice.slice();
-        var to = to_slice.slice();
+        const from = from_slice.slice();
+        const to = to_slice.slice();
 
-        var out = if (!isWindows)
+        const out = if (!isWindows)
             PathHandler.relativePlatform(from, to, .posix, true)
         else
             PathHandler.relativePlatform(from, to, .windows, true);
@@ -2351,7 +2351,7 @@ pub const Path = struct {
         defer allocator.free(parts);
 
         var arena = @import("root").bun.ArenaAllocator.init(heap_allocator);
-        var arena_allocator = arena.allocator();
+        const arena_allocator = arena.allocator();
         defer arena.deinit();
 
         var i: u16 = 0;
@@ -2430,7 +2430,7 @@ pub const Process = struct {
 
     pub fn getExecPath(globalObject: *JSC.JSGlobalObject) callconv(.C) JSC.JSValue {
         var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-        var out = std.fs.selfExePath(&buf) catch {
+        const out = std.fs.selfExePath(&buf) catch {
             // if for any reason we are unable to get the executable path, we just return argv[0]
             return getArgv0(globalObject);
         };
@@ -2440,7 +2440,7 @@ pub const Process = struct {
 
     pub fn getExecArgv(globalObject: *JSC.JSGlobalObject) callconv(.C) JSC.JSValue {
         const allocator = globalObject.allocator();
-        var vm = globalObject.bunVM();
+        const vm = globalObject.bunVM();
         var args = allocator.alloc(
             JSC.ZigString,
             // argv omits "bun" because it could be "bun run" or "bun" and it's kind of ambiguous
@@ -2471,7 +2471,7 @@ pub const Process = struct {
     }
 
     pub fn getArgv(globalObject: *JSC.JSGlobalObject) callconv(.C) JSC.JSValue {
-        var vm = globalObject.bunVM();
+        const vm = globalObject.bunVM();
 
         // Allocate up to 32 strings in stack
         var stack_fallback_allocator = std.heap.stackFallback(
@@ -2480,7 +2480,7 @@ pub const Process = struct {
         );
         var allocator = stack_fallback_allocator.get();
 
-        var args = allocator.alloc(
+        const args = allocator.alloc(
             JSC.ZigString,
             // argv omits "bun" because it could be "bun run" or "bun" and it's kind of ambiguous
             // argv also omits the script name

--- a/src/bun.js/rare_data.zig
+++ b/src/bun.js/rare_data.zig
@@ -120,7 +120,7 @@ pub const HotMap = struct {
     }
 
     pub fn insert(this: *HotMap, key: []const u8, ptr: anytype) void {
-        var entry = this._map.getOrPut(key) catch @panic("Out of memory");
+        const entry = this._map.getOrPut(key) catch @panic("Out of memory");
         if (entry.found_existing) {
             @panic("HotMap already contains key");
         }
@@ -130,7 +130,7 @@ pub const HotMap = struct {
     }
 
     pub fn remove(this: *HotMap, key: []const u8) void {
-        var entry = this._map.getEntry(key) orelse return;
+        const entry = this._map.getEntry(key) orelse return;
         bun.default_allocator.free(entry.key_ptr.*);
         _ = this._map.orderedRemove(key);
     }
@@ -238,7 +238,7 @@ pub fn pushCleanupHook(
     ctx: ?*anyopaque,
     func: CleanupHook.Function,
 ) void {
-    var hook = JSC.VirtualMachine.get().allocator.create(CleanupHook) catch unreachable;
+    const hook = JSC.VirtualMachine.get().allocator.create(CleanupHook) catch unreachable;
     hook.* = CleanupHook.from(globalThis, ctx, func);
     if (this.cleanup_hook == null) {
         this.cleanup_hook = hook;
@@ -257,7 +257,7 @@ pub fn boringEngine(rare: *RareData) *BoringSSL.ENGINE {
 
 pub fn stderr(rare: *RareData) *Blob.Store {
     return rare.stderr_store orelse brk: {
-        var store = default_allocator.create(Blob.Store) catch unreachable;
+        const store = default_allocator.create(Blob.Store) catch unreachable;
         var mode: bun.Mode = 0;
         switch (Syscall.fstat(bun.STDERR_FD)) {
             .result => |stat| {
@@ -287,7 +287,7 @@ pub fn stderr(rare: *RareData) *Blob.Store {
 
 pub fn stdout(rare: *RareData) *Blob.Store {
     return rare.stdout_store orelse brk: {
-        var store = default_allocator.create(Blob.Store) catch unreachable;
+        const store = default_allocator.create(Blob.Store) catch unreachable;
         var mode: bun.Mode = 0;
         switch (Syscall.fstat(bun.STDOUT_FD)) {
             .result => |stat| {
@@ -315,7 +315,7 @@ pub fn stdout(rare: *RareData) *Blob.Store {
 
 pub fn stdin(rare: *RareData) *Blob.Store {
     return rare.stdin_store orelse brk: {
-        var store = default_allocator.create(Blob.Store) catch unreachable;
+        const store = default_allocator.create(Blob.Store) catch unreachable;
         var mode: bun.Mode = 0;
         switch (Syscall.fstat(bun.STDIN_FD)) {
             .result => |stat| {
@@ -348,7 +348,7 @@ pub fn spawnIPCContext(rare: *RareData, vm: *JSC.VirtualMachine) *uws.SocketCont
         return ctx;
     }
 
-    var opts: uws.us_socket_context_options_t = .{};
+    const opts: uws.us_socket_context_options_t = .{};
     const ctx = uws.us_create_socket_context(0, vm.event_loop_handle.?, @sizeOf(usize), opts).?;
     IPC.Socket.configure(ctx, true, *Subprocess, Subprocess.IPCHandler);
     rare.spawn_ipc_usockets_context = ctx;

--- a/src/bun.js/test/diff_format.zig
+++ b/src/bun.js/test/diff_format.zig
@@ -91,7 +91,7 @@ pub const DiffFormatter = struct {
             var buffered_writer_ = MutableString.BufferedWriter{ .context = &received_buf };
             var buffered_writer = &buffered_writer_;
 
-            var buf_writer = buffered_writer.writer();
+            const buf_writer = buffered_writer.writer();
             const Writer = @TypeOf(buf_writer);
 
             const fmt_options = ZigConsoleClient.FormatOptions{

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -122,7 +122,7 @@ pub const Expect = struct {
         switch (this.flags.promise) {
             inline .resolves, .rejects => |resolution| {
                 if (value.asAnyPromise()) |promise| {
-                    var vm = globalThis.vm();
+                    const vm = globalThis.vm();
                     promise.setHandled(vm);
 
                     const now = std.time.Instant.now() catch unreachable;
@@ -1656,7 +1656,7 @@ pub const Expect = struct {
             vm.global.handleRejectedPromises();
 
             var scope = vm.unhandledRejectionScope();
-            var prev_unhandled_pending_rejection_to_capture = vm.unhandled_pending_rejection_to_capture;
+            const prev_unhandled_pending_rejection_to_capture = vm.unhandled_pending_rejection_to_capture;
             vm.unhandled_pending_rejection_to_capture = &return_value;
             vm.onUnhandledRejection = &VirtualMachine.onQuietUnhandledRejectionHandlerCaptureValue;
             const return_value_from_fucntion: JSValue = value.call(globalObject, &.{});
@@ -2039,7 +2039,7 @@ pub const Expect = struct {
         }
 
         if (property_matchers) |_prop_matchers| {
-            var prop_matchers = _prop_matchers;
+            const prop_matchers = _prop_matchers;
 
             if (!value.jestDeepMatch(prop_matchers, globalObject, true)) {
                 // TODO: print diff with properties from propertyMatchers
@@ -2686,8 +2686,8 @@ pub const Expect = struct {
         var pass = value.isString() and expected.isString();
 
         if (pass) {
-            var valueStr = value.toString(globalThis).toSlice(globalThis, default_allocator).slice();
-            var expectedStr = expected.toString(globalThis).toSlice(globalThis, default_allocator).slice();
+            const valueStr = value.toString(globalThis).toSlice(globalThis, default_allocator).slice();
+            const expectedStr = expected.toString(globalThis).toSlice(globalThis, default_allocator).slice();
 
             var left: usize = 0;
             var right: usize = 0;
@@ -2958,8 +2958,8 @@ pub const Expect = struct {
             _subStringAsStr.deinit();
         }
 
-        var expectStringAsStr = _expectStringAsStr.slice();
-        var subStringAsStr = _subStringAsStr.slice();
+        const expectStringAsStr = _expectStringAsStr.slice();
+        const subStringAsStr = _subStringAsStr.slice();
 
         if (subStringAsStr.len == 0) {
             globalThis.throw("toIncludeRepeated() requires the first argument to be a non-empty string", .{});

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -104,7 +104,7 @@ pub const TestRunner = struct {
     pub const Drainer = JSC.AnyTask.New(TestRunner, drain);
 
     pub fn onTestTimeout(timer: *bun.uws.Timer) callconv(.C) void {
-        var this = timer.ext(TestRunner).?;
+        const this = timer.ext(TestRunner).?;
 
         if (this.pending_test) |pending_test| {
             if (!pending_test.reported) {
@@ -169,7 +169,7 @@ pub const TestRunner = struct {
         }
         this.only = true;
 
-        var list = this.queue.readableSlice(0);
+        const list = this.queue.readableSlice(0);
         for (list) |task| {
             task.deinit();
         }
@@ -216,18 +216,18 @@ pub const TestRunner = struct {
         this.tests.ensureUnusedCapacity(this.allocator, count) catch unreachable;
         const start = @as(Test.ID, @truncate(this.tests.len));
         this.tests.len += count;
-        var statuses = this.tests.items(.status)[start..][0..count];
+        const statuses = this.tests.items(.status)[start..][0..count];
         @memset(statuses, Test.Status.pending);
         this.callback.onUpdateCount(this.callback, count, count + start);
         return start;
     }
 
     pub fn getOrPutFile(this: *TestRunner, file_path: string) *DescribeScope {
-        var entry = this.index.getOrPut(this.allocator, @as(u32, @truncate(bun.hash(file_path)))) catch unreachable;
+        const entry = this.index.getOrPut(this.allocator, @as(u32, @truncate(bun.hash(file_path)))) catch unreachable;
         if (entry.found_existing) {
             return this.files.items(.module_scope)[entry.value_ptr.*];
         }
-        var scope = this.allocator.create(DescribeScope) catch unreachable;
+        const scope = this.allocator.create(DescribeScope) catch unreachable;
         const file_id = @as(File.ID, @truncate(this.files.len));
         scope.* = DescribeScope{
             .file_id = file_id,
@@ -532,18 +532,18 @@ pub const Jest = struct {
         }
         var str = arguments[0].toSlice(globalObject, bun.default_allocator);
         defer str.deinit();
-        var slice = str.slice();
+        const slice = str.slice();
 
         if (str.len == 0 or slice[0] != '/') {
             globalObject.throw("Bun.jest() expects an absolute file path", .{});
             return .undefined;
         }
-        var vm = globalObject.bunVM();
+        const vm = globalObject.bunVM();
         if (vm.is_in_preload) {
             return Bun__Jest__testPreloadObject(globalObject);
         }
 
-        var filepath = Fs.FileSystem.instance.filename_store.append([]const u8, slice) catch unreachable;
+        const filepath = Fs.FileSystem.instance.filename_store.append([]const u8, slice) catch unreachable;
 
         var scope = runner_.getOrPutFile(filepath);
         scope.push();
@@ -967,7 +967,7 @@ pub const DescribeScope = struct {
                         false,
                         this,
                     );
-                    var result = callJSFunctionForTestRunner(vm, globalObject, cb, &.{done_func});
+                    const result = callJSFunctionForTestRunner(vm, globalObject, cb, &.{done_func});
                     vm.waitFor(&this.done);
                     break :brk result;
                 },
@@ -1142,7 +1142,7 @@ pub const DescribeScope = struct {
 
         const file = this.file_id;
         const allocator = getAllocator(globalObject);
-        var tests: []TestScope = this.tests.items;
+        const tests: []TestScope = this.tests.items;
         const end = @as(TestRunner.Test.ID, @truncate(tests.len));
         this.pending_tests = std.DynamicBitSetUnmanaged.initFull(allocator, end) catch unreachable;
 
@@ -1307,7 +1307,7 @@ pub const TestRunnerTask = struct {
         describe.current_test_id = test_id;
 
         if (test_.func == .zero or !describe.shouldEvaluateScope()) {
-            var tag = if (!describe.shouldEvaluateScope()) describe.tag else test_.tag;
+            const tag = if (!describe.shouldEvaluateScope()) describe.tag else test_.tag;
             switch (tag) {
                 .todo => {
                     this.processTestResult(globalThis, .{ .todo = {} }, test_, test_id, describe);
@@ -1407,7 +1407,7 @@ pub const TestRunnerTask = struct {
         this.reported = true;
 
         const test_id = this.test_id;
-        var test_ = this.describe.tests.items[test_id];
+        const test_ = this.describe.tests.items[test_id];
         var describe = this.describe;
         describe.tests.items[test_id] = test_;
         if (comptime from == .timeout) {
@@ -1603,7 +1603,7 @@ inline fn createScope(
                 buffer.reset();
                 appendParentLabel(&buffer, parent) catch @panic("Bun ran out of memory while filtering tests");
                 buffer.append(label) catch unreachable;
-                var str = bun.String.fromBytes(buffer.toOwnedSliceLeaky());
+                const str = bun.String.fromBytes(buffer.toOwnedSliceLeaky());
                 is_skip = !regex.matches(str);
                 if (is_skip) {
                     tag_to_use = .skip;
@@ -1625,7 +1625,7 @@ inline fn createScope(
             has_callback = true;
             arg_size = 1;
         }
-        var function_args = allocator.alloc(JSC.JSValue, arg_size) catch unreachable;
+        const function_args = allocator.alloc(JSC.JSValue, arg_size) catch unreachable;
 
         parent.tests.append(allocator, TestScope{
             .label = label,
@@ -1638,7 +1638,7 @@ inline fn createScope(
         }) catch unreachable;
 
         if (test_elapsed_timer == null) create_timer: {
-            var timer = allocator.create(std.time.Timer) catch unreachable;
+            const timer = allocator.create(std.time.Timer) catch unreachable;
             timer.* = std.time.Timer.start() catch break :create_timer;
             test_elapsed_timer = timer;
         }
@@ -1889,7 +1889,7 @@ fn eachBind(
     globalThis: *JSGlobalObject,
     callframe: *CallFrame,
 ) callconv(.C) JSValue {
-    comptime var signature = "eachBind";
+    comptime const signature = "eachBind";
     const callee = callframe.callee();
     const arguments = callframe.arguments(3);
     const args = arguments.ptr[0..arguments.len];
@@ -2011,7 +2011,7 @@ fn eachBind(
                 }) catch unreachable;
 
                 if (test_elapsed_timer == null) create_timer: {
-                    var timer = allocator.create(std.time.Timer) catch unreachable;
+                    const timer = allocator.create(std.time.Timer) catch unreachable;
                     timer.* = std.time.Timer.start() catch break :create_timer;
                     test_elapsed_timer = timer;
                 }
@@ -2058,8 +2058,8 @@ inline fn createEach(
 
     const allocator = getAllocator(globalThis);
     const name = ZigString.static(property);
-    var strong = JSC.Strong.create(array, globalThis);
-    var each_data = allocator.create(EachData) catch unreachable;
+    const strong = JSC.Strong.create(array, globalThis);
+    const each_data = allocator.create(EachData) catch unreachable;
     each_data.* = EachData{
         .strong = strong,
         .is_test = is_test,

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -793,7 +793,7 @@ pub const JestPrettyFormat = struct {
 
                     var ctx: *@This() = bun.cast(*@This(), ctx_ptr orelse return);
                     var this = ctx.formatter;
-                    var writer_ = ctx.writer;
+                    const writer_ = ctx.writer;
                     var writer = WrappedWriter(Writer){
                         .ctx = writer_,
                         .failed = false,
@@ -919,7 +919,7 @@ pub const JestPrettyFormat = struct {
                     this.map = this.map_node.?.data;
                 }
 
-                var entry = this.map.getOrPut(@intFromEnum(value)) catch unreachable;
+                const entry = this.map.getOrPut(@intFromEnum(value)) catch unreachable;
                 if (entry.found_existing) {
                     writer.writeAll(comptime Output.prettyFmt("<r><cyan>[Circular]<r>", enable_ansi_colors));
                     return;
@@ -1027,7 +1027,7 @@ pub const JestPrettyFormat = struct {
                         writer.writeAll(str.slice());
                     } else if (str.len > 0) {
                         // slow path
-                        var buf = strings.allocateLatin1IntoUTF8(bun.default_allocator, []const u8, str.slice()) catch &[_]u8{};
+                        const buf = strings.allocateLatin1IntoUTF8(bun.default_allocator, []const u8, str.slice()) catch &[_]u8{};
                         if (buf.len > 0) {
                             defer bun.default_allocator.free(buf);
                             writer.writeAll(buf);
@@ -1057,7 +1057,7 @@ pub const JestPrettyFormat = struct {
                     writer.print(comptime Output.prettyFmt("<r><yellow>{d}<r>", enable_ansi_colors), .{int});
                 },
                 .BigInt => {
-                    var out_str = value.getZigString(this.globalThis).slice();
+                    const out_str = value.getZigString(this.globalThis).slice();
                     this.addForNewLine(out_str.len);
 
                     writer.print(comptime Output.prettyFmt("<r><yellow>{s}n<r>", enable_ansi_colors), .{out_str});
@@ -1157,9 +1157,9 @@ pub const JestPrettyFormat = struct {
 
                         this.addForNewLine(2);
 
-                        var ref = value.asObjectRef();
+                        const ref = value.asObjectRef();
 
-                        var prev_quote_strings = this.quote_strings;
+                        const prev_quote_strings = this.quote_strings;
                         this.quote_strings = true;
                         defer this.quote_strings = prev_quote_strings;
 
@@ -1555,7 +1555,7 @@ pub const JestPrettyFormat = struct {
                         }).init(this.globalThis, props.asObjectRef());
                         defer props_iter.deinit();
 
-                        var children_prop = props.get(this.globalThis, "children");
+                        const children_prop = props.get(this.globalThis, "children");
                         if (props_iter.len > 0) {
                             {
                                 this.indent += 1;
@@ -1566,7 +1566,7 @@ pub const JestPrettyFormat = struct {
                                     if (prop.eqlComptime("children"))
                                         continue;
 
-                                    var property_value = props_iter.value;
+                                    const property_value = props_iter.value;
                                     const tag = Tag.get(property_value, this.globalThis);
 
                                     if (tag.cell.isHidden()) continue;
@@ -1624,7 +1624,7 @@ pub const JestPrettyFormat = struct {
                                     print_children: {
                                         switch (tag.tag) {
                                             .String => {
-                                                var children_string = children.getZigString(this.globalThis);
+                                                const children_string = children.getZigString(this.globalThis);
                                                 if (children_string.len == 0) break :print_children;
                                                 if (comptime enable_ansi_colors) writer.writeAll(comptime Output.prettyFmt("<r>", true));
 
@@ -1919,7 +1919,7 @@ pub const JestPrettyFormat = struct {
 
                             // Uint8Array, Uint8ClampedArray, DataView, ArrayBuffer
                             else => {
-                                var slice_with_type: []align(std.meta.alignment([]u8)) u8 = @alignCast(std.mem.bytesAsSlice(u8, slice));
+                                const slice_with_type: []align(std.meta.alignment([]u8)) u8 = @alignCast(std.mem.bytesAsSlice(u8, slice));
                                 this.indent += 1;
                                 defer this.indent -|= 1;
                                 for (slice_with_type) |el| {
@@ -1950,7 +1950,7 @@ pub const JestPrettyFormat = struct {
             if (comptime is_bindgen) {
                 return;
             }
-            var prevGlobalThis = this.globalThis;
+            const prevGlobalThis = this.globalThis;
             defer this.globalThis = prevGlobalThis;
             this.globalThis = globalThis;
 

--- a/src/bun.js/test/snapshot.zig
+++ b/src/bun.js/test/snapshot.zig
@@ -52,7 +52,7 @@ pub const Snapshots = struct {
         const snapshot_name = try expect.getSnapshotName(this.allocator, hint);
         this.total += 1;
 
-        var count_entry = try this.counts.getOrPut(snapshot_name);
+        const count_entry = try this.counts.getOrPut(snapshot_name);
         const counter = brk: {
             if (count_entry.found_existing) {
                 this.allocator.free(snapshot_name);
@@ -66,7 +66,7 @@ pub const Snapshots = struct {
         const name = count_entry.key_ptr.*;
 
         var counter_string_buf = [_]u8{0} ** 32;
-        var counter_string = try std.fmt.bufPrint(&counter_string_buf, "{d}", .{counter});
+        const counter_string = try std.fmt.bufPrint(&counter_string_buf, "{d}", .{counter});
 
         var name_with_counter = try this.allocator.alloc(u8, name.len + 1 + counter_string.len);
         defer this.allocator.free(name_with_counter);
@@ -100,7 +100,7 @@ pub const Snapshots = struct {
         if (this.file_buf.items.len == 0) return;
 
         const vm = VirtualMachine.get();
-        var opts = js_parser.Parser.Options.init(vm.bundler.options.jsx, .js);
+        const opts = js_parser.Parser.Options.init(vm.bundler.options.jsx, .js);
         var temp_log = logger.Log.init(this.allocator);
 
         const test_file = Jest.runner.?.files.get(this._current_file.?.id);
@@ -130,7 +130,7 @@ pub const Snapshots = struct {
             this.allocator,
         );
 
-        var parse_result = try parser.parse();
+        const parse_result = try parser.parse();
         var ast = if (parse_result == .ast) parse_result.ast else return error.ParseError;
         defer ast.deinit();
 

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -43,7 +43,7 @@ pub const WebWorker = struct {
     extern fn WebWorker__dispatchError(*JSC.JSGlobalObject, *anyopaque, bun.String, JSValue) void;
 
     export fn WebWorker__getParentWorker(vm: *JSC.VirtualMachine) ?*anyopaque {
-        var worker = vm.worker orelse return null;
+        const worker = vm.worker orelse return null;
         return worker.cpp_worker;
     }
 
@@ -77,7 +77,7 @@ pub const WebWorker = struct {
         log("[{d}] WebWorker.create", .{this_context_id});
         var spec_slice = specifier_str.toUTF8(bun.default_allocator);
         defer spec_slice.deinit();
-        var prev_log = parent.bundler.log;
+        const prev_log = parent.bundler.log;
         var temp_log = bun.logger.Log.init(bun.default_allocator);
         parent.bundler.setLog(&temp_log);
         defer parent.bundler.setLog(prev_log);
@@ -90,7 +90,7 @@ pub const WebWorker = struct {
             return null;
         };
 
-        var path = resolved_entry_point.path() orelse {
+        const path = resolved_entry_point.path() orelse {
             error_message.* = bun.String.static("Worker entry point is missing");
             return null;
         };
@@ -169,7 +169,7 @@ pub const WebWorker = struct {
         vm.is_main_thread = false;
         JSC.VirtualMachine.is_main_thread_vm = false;
         vm.onUnhandledRejection = onUnhandledRejection;
-        var callback = JSC.OpaqueWrap(WebWorker, WebWorker.spin);
+        const callback = JSC.OpaqueWrap(WebWorker, WebWorker.spin);
 
         this.vm = vm;
 
@@ -200,9 +200,9 @@ pub const WebWorker = struct {
 
         var buffered_writer_ = bun.MutableString.BufferedWriter{ .context = &array };
         var buffered_writer = &buffered_writer_;
-        var worker = vm.worker orelse @panic("Assertion failure: no worker");
+        const worker = vm.worker orelse @panic("Assertion failure: no worker");
 
-        var writer = buffered_writer.writer();
+        const writer = buffered_writer.writer();
         const Writer = @TypeOf(writer);
         // we buffer this because it'll almost always be < 4096
         // when it's under 4096, we want to avoid the dynamic allocation
@@ -325,7 +325,7 @@ pub const WebWorker = struct {
     pub fn exitAndDeinit(this: *WebWorker) noreturn {
         JSC.markBinding(@src());
         log("[{d}] exitAndDeinit", .{this.execution_context_id});
-        var cpp_worker = this.cpp_worker;
+        const cpp_worker = this.cpp_worker;
         var exit_code: i32 = 0;
         var globalObject: ?*JSC.JSGlobalObject = null;
         var vm_to_deinit: ?*JSC.VirtualMachine = null;

--- a/src/bun.js/webcore.zig
+++ b/src/bun.js/webcore.zig
@@ -107,11 +107,11 @@ fn confirm(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callcon
 
     // 6. Pause until the user responds either positively or negatively.
     var stdin = std.io.getStdIn();
-    var unbuffered_reader = stdin.reader();
+    const unbuffered_reader = stdin.reader();
     var buffered = std.io.bufferedReader(unbuffered_reader);
     var reader = buffered.reader();
 
-    var first_byte = reader.readByte() catch {
+    const first_byte = reader.readByte() catch {
         return .false;
     };
 
@@ -160,7 +160,7 @@ pub const Prompt = struct {
                 return error.StreamTooLong;
             }
 
-            var byte: u8 = try reader.readByte();
+            const byte: u8 = try reader.readByte();
 
             if (byte == delimiter) {
                 return;
@@ -178,7 +178,7 @@ pub const Prompt = struct {
         delimiter: u8,
     ) !void {
         while (true) {
-            var byte: u8 = try reader.readByte();
+            const byte: u8 = try reader.readByte();
 
             if (byte == delimiter) {
                 return;
@@ -583,7 +583,7 @@ pub const Crypto = struct {
             globalThis.throwInvalidArguments("Expected typed array but got {s}", .{@tagName(arguments[0].jsType())});
             return JSC.JSValue.jsUndefined();
         };
-        var slice = array_buffer.byteSlice();
+        const slice = array_buffer.byteSlice();
 
         randomData(globalThis, slice.ptr, slice.len);
 
@@ -595,7 +595,7 @@ pub const Crypto = struct {
         globalThis: *JSC.JSGlobalObject,
         array: *JSC.JSUint8Array,
     ) callconv(.C) JSC.JSValue {
-        var slice = array.slice();
+        const slice = array.slice();
         randomData(globalThis, slice.ptr, slice.len);
         return @as(JSC.JSValue, @enumFromInt(@as(i64, @bitCast(@intFromPtr(array)))));
     }
@@ -605,7 +605,7 @@ pub const Crypto = struct {
         ptr: [*]u8,
         len: usize,
     ) void {
-        var slice = ptr[0..len];
+        const slice = ptr[0..len];
 
         switch (slice.len) {
             0 => {},

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -261,7 +261,7 @@ pub const Blob = struct {
         _ = globalThis;
 
         const Writer = std.io.Writer(StructuredCloneWriter, StructuredCloneWriter.WriteError, StructuredCloneWriter.write);
-        var writer = Writer{
+        const writer = Writer{
             .context = .{
                 .ctx = ctx,
                 .impl = writeBytes,
@@ -319,8 +319,8 @@ pub const Blob = struct {
                 const bytes_len = try reader.readInt(u32, .little);
                 const bytes = try readSlice(reader, bytes_len, allocator);
 
-                var blob = Blob.init(bytes, allocator, globalThis);
-                var blob_ = try allocator.create(Blob);
+                const blob = Blob.init(bytes, allocator, globalThis);
+                const blob_ = try allocator.create(Blob);
                 blob_.* = blob;
 
                 break :brk blob_;
@@ -332,7 +332,7 @@ pub const Blob = struct {
                     .fd => {
                         const fd = @as(bun.FileDescriptor, @intCast(try reader.readInt(bun.FileDescriptor, .little)));
 
-                        var blob = try allocator.create(Blob);
+                        const blob = try allocator.create(Blob);
                         blob.* = Blob.findOrCreateFileFromPath(
                             JSC.Node.PathOrFileDescriptor{
                                 .fd = fd,
@@ -347,7 +347,7 @@ pub const Blob = struct {
 
                         const path = try readSlice(reader, path_len, default_allocator);
 
-                        var blob = try allocator.create(Blob);
+                        const blob = try allocator.create(Blob);
                         blob.* = Blob.findOrCreateFileFromPath(
                             JSC.Node.PathOrFileDescriptor{
                                 .path = .{
@@ -364,7 +364,7 @@ pub const Blob = struct {
                 return .zero;
             },
             .empty => brk: {
-                var blob = try allocator.create(Blob);
+                const blob = try allocator.create(Blob);
                 blob.* = Blob.initEmpty(globalThis);
                 break :brk blob;
             },
@@ -387,7 +387,7 @@ pub const Blob = struct {
     ) callconv(.C) JSValue {
         const total_length: usize = @intFromPtr(end) - @intFromPtr(ptr);
         var buffer_stream = std.io.fixedBufferStream(ptr[0..total_length]);
-        var reader = buffer_stream.reader();
+        const reader = buffer_stream.reader();
 
         const blob = _onStructuredCloneDeserialize(globalThis, @TypeOf(reader), reader) catch return .zero;
 
@@ -435,12 +435,12 @@ pub const Blob = struct {
         var arena = @import("root").bun.ArenaAllocator.init(allocator);
         defer arena.deinit();
         var stack_allocator = std.heap.stackFallback(1024, arena.allocator());
-        var stack_mem_all = stack_allocator.get();
+        const stack_mem_all = stack_allocator.get();
 
         var hex_buf: [70]u8 = undefined;
         const boundary = brk: {
             var random = globalThis.bunVM().rareData().nextUUID().bytes;
-            var formatter = std.fmt.fmtSliceHexLower(&random);
+            const formatter = std.fmt.fmtSliceHexLower(&random);
             break :brk std.fmt.bufPrint(&hex_buf, "-WebkitFormBoundary{any}", .{formatter}) catch unreachable;
         };
 
@@ -460,7 +460,7 @@ pub const Blob = struct {
         context.joiner.append(boundary, 0, null);
         context.joiner.append("--\r\n", 0, null);
 
-        var store = Blob.Store.init(context.joiner.done(allocator) catch unreachable, allocator) catch unreachable;
+        const store = Blob.Store.init(context.joiner.done(allocator) catch unreachable, allocator) catch unreachable;
         var blob = Blob.initWithStore(store, globalThis);
         blob.content_type = std.fmt.allocPrint(allocator, "multipart/form-data; boundary=\"{s}\"", .{boundary}) catch unreachable;
         blob.content_type_allocated = true;
@@ -478,7 +478,7 @@ pub const Blob = struct {
     }
 
     export fn Blob__dupeFromJS(value: JSC.JSValue) ?*Blob {
-        var this = Blob.fromJS(value) orelse return null;
+        const this = Blob.fromJS(value) orelse return null;
         return Blob__dupe(this);
     }
 
@@ -499,7 +499,7 @@ pub const Blob = struct {
     }
 
     export fn Blob__dupe(ptr: *anyopaque) *Blob {
-        var this = bun.cast(*Blob, ptr);
+        const this = bun.cast(*Blob, ptr);
         var new = bun.default_allocator.create(Blob) catch unreachable;
         new.* = this.dupeWithContentType(true);
         new.allocator = bun.default_allocator;
@@ -545,7 +545,7 @@ pub const Blob = struct {
         }
 
         {
-            var store = this.store.?;
+            const store = this.store.?;
             switch (store.data) {
                 .file => |file| {
                     try writer.writeAll(comptime Output.prettyFmt("<r>FileRef<r>", enable_ansi_colors));
@@ -618,9 +618,9 @@ pub const Blob = struct {
         globalThis: *JSGlobalObject,
         pub fn run(handler: *@This(), blob_: Store.CopyFile.ResultType) void {
             var promise = handler.promise;
-            var globalThis = handler.globalThis;
+            const globalThis = handler.globalThis;
             bun.default_allocator.destroy(handler);
-            var blob = blob_ catch |err| {
+            const blob = blob_ catch |err| {
                 var error_string = ZigString.init(
                     std.fmt.allocPrint(bun.default_allocator, "Failed to write file \"{s}\"", .{bun.asByteSlice(@errorName(err))}) catch unreachable,
                 );
@@ -722,7 +722,7 @@ pub const Blob = struct {
                 .globalThis = ctx.ptr(),
             };
 
-            var file_copier = Store.WriteFile.create(
+            const file_copier = Store.WriteFile.create(
                 bun.default_allocator,
                 destination_blob.*,
                 source_blob.*,
@@ -822,7 +822,7 @@ pub const Blob = struct {
             }
         }
 
-        var input_store: ?*Store = if (path_or_blob == .blob) path_or_blob.blob.store else null;
+        const input_store: ?*Store = if (path_or_blob == .blob) path_or_blob.blob.store else null;
         if (input_store) |st| st.ref();
         defer if (input_store) |st| st.deref();
 
@@ -934,7 +934,7 @@ pub const Blob = struct {
                         return JSC.JSPromise.rejectedPromiseValue(globalThis, err);
                     },
                     .Locked => {
-                        var task = bun.default_allocator.create(WriteFileWaitFromLockedValueTask) catch unreachable;
+                        const task = bun.default_allocator.create(WriteFileWaitFromLockedValueTask) catch unreachable;
                         var promise = JSC.JSPromise.create(globalThis);
                         task.* = WriteFileWaitFromLockedValueTask{
                             .globalThis = globalThis,
@@ -969,7 +969,7 @@ pub const Blob = struct {
                         return JSC.JSPromise.rejectedPromiseValue(globalThis, err);
                     },
                     .Locked => {
-                        var task = bun.default_allocator.create(WriteFileWaitFromLockedValueTask) catch unreachable;
+                        const task = bun.default_allocator.create(WriteFileWaitFromLockedValueTask) catch unreachable;
                         var promise = JSC.JSPromise.create(globalThis);
                         task.* = WriteFileWaitFromLockedValueTask{
                             .globalThis = globalThis,
@@ -1004,7 +1004,7 @@ pub const Blob = struct {
             };
         };
 
-        var destination_store = destination_blob.store;
+        const destination_store = destination_blob.store;
         if (destination_store) |store| {
             store.ref();
         }
@@ -1050,7 +1050,7 @@ pub const Blob = struct {
         };
 
         var truncate = needs_open or str.isEmpty();
-        var jsc_vm = globalThis.bunVM();
+        const jsc_vm = globalThis.bunVM();
         var written: usize = 0;
 
         defer {
@@ -1172,7 +1172,7 @@ pub const Blob = struct {
 
     pub export fn JSDOMFile__hasInstance(_: JSC.JSValue, _: *JSC.JSGlobalObject, value: JSC.JSValue) callconv(.C) bool {
         JSC.markBinding(@src());
-        var blob = value.as(Blob) orelse return false;
+        const blob = value.as(Blob) orelse return false;
         return blob.is_jsdom_file;
     }
 
@@ -1184,7 +1184,7 @@ pub const Blob = struct {
         var allocator = bun.default_allocator;
         var blob: Blob = undefined;
         var arguments = callframe.arguments(3);
-        var args = arguments.ptr[0..arguments.len];
+        const args = arguments.ptr[0..arguments.len];
 
         if (args.len < 2) {
             globalThis.throwInvalidArguments("new File(bits, name) expects at least 2 arguments", .{});
@@ -1223,7 +1223,7 @@ pub const Blob = struct {
                         if (content_type.isString()) {
                             var content_type_str = content_type.toSlice(globalThis, bun.default_allocator);
                             defer content_type_str.deinit();
-                            var slice = content_type_str.slice();
+                            const slice = content_type_str.slice();
                             if (!strings.isAllASCII(slice)) {
                                 break :inner;
                             }
@@ -1233,7 +1233,7 @@ pub const Blob = struct {
                                 blob.content_type = mime.value;
                                 break :inner;
                             }
-                            var content_type_buf = allocator.alloc(u8, slice.len) catch unreachable;
+                            const content_type_buf = allocator.alloc(u8, slice.len) catch unreachable;
                             blob.content_type = strings.copyLowercase(slice, content_type_buf);
                             blob.content_type_allocated = true;
                         }
@@ -1264,7 +1264,7 @@ pub const Blob = struct {
             return this.size;
         }
 
-        var store = this.store orelse return 0;
+        const store = this.store orelse return 0;
         if (store.data == .bytes) {
             return store.data.bytes.len;
         }
@@ -1302,7 +1302,7 @@ pub const Blob = struct {
         var args = JSC.Node.ArgumentsSlice.init(vm, arguments);
         defer args.deinit();
         var exception_ = [1]JSC.JSValueRef{null};
-        var exception = &exception_;
+        const exception = &exception_;
 
         const path = JSC.Node.PathOrFileDescriptor.fromJS(globalObject, &args, args.arena.allocator(), exception) orelse {
             if (exception_[0] == null) {
@@ -1335,7 +1335,7 @@ pub const Blob = struct {
                                 blob.content_type = entry.value;
                                 break :inner;
                             }
-                            var content_type_buf = allocator.alloc(u8, slice.len) catch unreachable;
+                            const content_type_buf = allocator.alloc(u8, slice.len) catch unreachable;
                             blob.content_type = strings.copyLowercase(slice, content_type_buf);
                             blob.content_type_allocated = true;
                         }
@@ -1368,7 +1368,7 @@ pub const Blob = struct {
                         }
                     }
 
-                    var cloned = (allocator.dupeZ(u8, slice) catch unreachable)[0..slice.len];
+                    const cloned = (allocator.dupeZ(u8, slice) catch unreachable)[0..slice.len];
 
                     break :brk .{
                         .path = .{
@@ -1429,12 +1429,12 @@ pub const Blob = struct {
 
         pub fn external(ptr: ?*anyopaque, _: ?*anyopaque, _: usize) callconv(.C) void {
             if (ptr == null) return;
-            var this = bun.cast(*Store, ptr);
+            const this = bun.cast(*Store, ptr);
             this.deref();
         }
 
         pub fn initFile(pathlike: JSC.Node.PathOrFileDescriptor, mime_type: ?http.MimeType, allocator: std.mem.Allocator) !*Store {
-            var store = try allocator.create(Blob.Store);
+            const store = try allocator.create(Blob.Store);
             store.* = .{
                 .data = .{
                     .file = FileStore.init(
@@ -1462,7 +1462,7 @@ pub const Blob = struct {
         }
 
         pub fn init(bytes: []u8, allocator: std.mem.Allocator) !*Store {
-            var store = try allocator.create(Blob.Store);
+            const store = try allocator.create(Blob.Store);
             store.* = .{
                 .data = .{ .bytes = ByteStore.init(bytes, allocator) },
                 .allocator = allocator,
@@ -1563,7 +1563,7 @@ pub const Blob = struct {
                     else
                         this.file_blob.store.?.data.file.pathlike.path;
 
-                    var path = path_string.sliceZ(&buf);
+                    const path = path_string.sliceZ(&buf);
 
                     this.opened_fd = switch (bun.sys.open(path, open_flags_, JSC.Node.default_permission)) {
                         .result => |fd| fd,
@@ -1616,7 +1616,7 @@ pub const Blob = struct {
                         const StateHolder = State;
                         pub fn onOpen(state: *State, completion: *http.NetworkThread.Completion, result: AsyncIO.OpenError!bun.FileDescriptor) void {
                             var this = state.context;
-                            var path_buffer = completion.operation.open.path;
+                            const path_buffer = completion.operation.open.path;
                             defer bun.default_allocator.free(bun.span(path_buffer));
                             defer bun.default_allocator.destroy(state);
                             if (comptime Environment.isPosix) {
@@ -1676,7 +1676,7 @@ pub const Blob = struct {
                     holder.* = .{
                         .context = this,
                     };
-                    var path_buffer = bun.default_allocator.dupeZ(u8, path_string.slice()) catch unreachable;
+                    const path_buffer = bun.default_allocator.dupeZ(u8, path_string.slice()) catch unreachable;
                     aio.open(
                         *State,
                         holder,
@@ -1758,7 +1758,7 @@ pub const Blob = struct {
                 off: SizeType,
                 max_len: SizeType,
             ) !*ReadFile {
-                var read_file = try allocator.create(ReadFile);
+                const read_file = try allocator.create(ReadFile);
                 read_file.* = ReadFile{
                     .file_store = store.data.file,
                     .offset = off,
@@ -1808,11 +1808,11 @@ pub const Blob = struct {
             pub const ReadFileTask = JSC.IOTask(@This());
 
             pub fn then(this: *ReadFile, _: *JSC.JSGlobalObject) void {
-                var cb = this.onCompleteCallback;
-                var cb_ctx = this.onCompleteCtx;
+                const cb = this.onCompleteCallback;
+                const cb_ctx = this.onCompleteCtx;
 
                 if (this.store == null and this.system_error != null) {
-                    var system_error = this.system_error.?;
+                    const system_error = this.system_error.?;
                     bun.default_allocator.destroy(this);
                     cb(cb_ctx, ResultType{ .err = system_error });
                     return;
@@ -1829,7 +1829,7 @@ pub const Blob = struct {
                 }
 
                 var store = this.store.?;
-                var buf = this.buffer;
+                const buf = this.buffer;
 
                 defer store.deref();
                 defer bun.default_allocator.destroy(this);
@@ -1978,7 +1978,7 @@ pub const Blob = struct {
 
             fn doReadLoop(this: *ReadFile) void {
                 this.read_off += this.read_len;
-                var remain = this.buffer[@min(this.read_off, @as(Blob.SizeType, @truncate(this.buffer.len)))..];
+                const remain = this.buffer[@min(this.read_off, @as(Blob.SizeType, @truncate(this.buffer.len)))..];
 
                 if (remain.len > 0 and this.errno == null and !this.read_eof) {
                     this.doRead();
@@ -2023,7 +2023,7 @@ pub const Blob = struct {
                 onWriteFileContext: *anyopaque,
                 onCompleteCallback: OnWriteFileCallback,
             ) !*WriteFile {
-                var read_file = try allocator.create(WriteFile);
+                const read_file = try allocator.create(WriteFile);
                 read_file.* = WriteFile{
                     .file_blob = file_blob,
                     .bytes_blob = bytes_blob,
@@ -2081,8 +2081,8 @@ pub const Blob = struct {
             pub const WriteFileTask = JSC.IOTask(@This());
 
             pub fn then(this: *WriteFile, _: *JSC.JSGlobalObject) void {
-                var cb = this.onCompleteCallback;
-                var cb_ctx = this.onCompleteCtx;
+                const cb = this.onCompleteCallback;
+                const cb_ctx = this.onCompleteCtx;
 
                 this.bytes_blob.store.?.deref();
                 this.file_blob.store.?.deref();
@@ -2148,7 +2148,7 @@ pub const Blob = struct {
 
             fn doWriteLoop(this: *WriteFile) void {
                 var remain = this.bytes_blob.sharedView();
-                var file_offset = this.file_blob.offset;
+                const file_offset = this.file_blob.offset;
 
                 const this_tick = file_offset + this.wrote;
                 remain = remain[@min(this.wrote, remain.len)..];
@@ -2211,7 +2211,7 @@ pub const Blob = struct {
                 max_len: SizeType,
                 globalThis: *JSC.JSGlobalObject,
             ) !*CopyFilePromiseTask {
-                var read_file = try allocator.create(CopyFile);
+                const read_file = try allocator.create(CopyFile);
                 read_file.* = CopyFile{
                     .store = store,
                     .source_store = source_store,
@@ -2241,7 +2241,7 @@ pub const Blob = struct {
             }
 
             pub fn reject(this: *CopyFile, promise: *JSC.JSPromise) void {
-                var globalThis = this.globalThis;
+                const globalThis = this.globalThis;
                 var system_error: SystemError = this.system_error orelse SystemError{};
                 if (this.source_file_store.pathlike == .path and system_error.path.isEmpty()) {
                     system_error.path = bun.String.create(this.source_file_store.pathlike.path.slice());
@@ -2251,7 +2251,7 @@ pub const Blob = struct {
                     system_error.message = bun.String.static("Failed to copy file");
                 }
 
-                var instance = system_error.toErrorInstance(this.globalThis);
+                const instance = system_error.toErrorInstance(this.globalThis);
                 if (this.store) |store| {
                     store.deref();
                 }
@@ -2795,7 +2795,7 @@ pub const Blob = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) callconv(.C) JSC.JSValue {
-        var store = this.store;
+        const store = this.store;
         if (store) |st| st.ref();
         defer if (store) |st| st.deref();
         return promisified(this.toString(globalThis, .clone), globalThis);
@@ -2805,7 +2805,7 @@ pub const Blob = struct {
         this: *Blob,
         globalObject: *JSC.JSGlobalObject,
     ) JSC.JSValue {
-        var store = this.store;
+        const store = this.store;
         if (store) |st| st.ref();
         defer if (store) |st| st.deref();
         return promisified(this.toString(globalObject, .transfer), globalObject);
@@ -2816,7 +2816,7 @@ pub const Blob = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) callconv(.C) JSC.JSValue {
-        var store = this.store;
+        const store = this.store;
         if (store) |st| st.ref();
         defer if (store) |st| st.deref();
 
@@ -2827,7 +2827,7 @@ pub const Blob = struct {
         this: *Blob,
         globalThis: *JSC.JSGlobalObject,
     ) JSC.JSValue {
-        var store = this.store;
+        const store = this.store;
         if (store) |st| st.ref();
         defer if (store) |st| st.deref();
 
@@ -2839,7 +2839,7 @@ pub const Blob = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) callconv(.C) JSValue {
-        var store = this.store;
+        const store = this.store;
         if (store) |st| st.ref();
         defer if (store) |st| st.deref();
         return promisified(this.toArrayBuffer(globalThis, .clone), globalThis);
@@ -2850,7 +2850,7 @@ pub const Blob = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) callconv(.C) JSValue {
-        var store = this.store;
+        const store = this.store;
         if (store) |st| st.ref();
         defer if (store) |st| st.deref();
 
@@ -2864,7 +2864,7 @@ pub const Blob = struct {
 
         // If there's no store that means it's empty and we just return true
         // it will not error to return an empty Blob
-        var store = this.store orelse return JSValue.jsBoolean(true);
+        const store = this.store orelse return JSValue.jsBoolean(true);
 
         if (store.data == .bytes) {
             // Bytes will never error
@@ -3034,7 +3034,7 @@ pub const Blob = struct {
                     var zig_str = content_type_.getZigString(globalThis);
                     var slicer = zig_str.toSlice(bun.default_allocator);
                     defer slicer.deinit();
-                    var slice = slicer.slice();
+                    const slice = slicer.slice();
                     if (!strings.isAllASCII(slice)) {
                         break :inner;
                     }
@@ -3045,7 +3045,7 @@ pub const Blob = struct {
                     }
 
                     content_type_was_allocated = slice.len > 0;
-                    var content_type_buf = allocator.alloc(u8, slice.len) catch unreachable;
+                    const content_type_buf = allocator.alloc(u8, slice.len) catch unreachable;
                     content_type = strings.copyLowercase(slice, content_type_buf);
                 }
             }
@@ -3284,11 +3284,11 @@ pub const Blob = struct {
         var allocator = globalThis.allocator();
         var blob: Blob = undefined;
         var arguments = callframe.arguments(2);
-        var args = arguments.ptr[0..arguments.len];
+        const args = arguments.ptr[0..arguments.len];
 
         switch (args.len) {
             0 => {
-                var empty: []u8 = &[_]u8{};
+                const empty: []u8 = &[_]u8{};
                 blob = Blob.init(empty, allocator, globalThis);
             },
             else => {
@@ -3313,7 +3313,7 @@ pub const Blob = struct {
                                 if (content_type.isString()) {
                                     var content_type_str = content_type.toSlice(globalThis, bun.default_allocator);
                                     defer content_type_str.deinit();
-                                    var slice = content_type_str.slice();
+                                    const slice = content_type_str.slice();
                                     if (!strings.isAllASCII(slice)) {
                                         break :inner;
                                     }
@@ -3323,7 +3323,7 @@ pub const Blob = struct {
                                         blob.content_type = mime.value;
                                         break :inner;
                                     }
-                                    var content_type_buf = allocator.alloc(u8, slice.len) catch unreachable;
+                                    const content_type_buf = allocator.alloc(u8, slice.len) catch unreachable;
                                     blob.content_type = strings.copyLowercase(slice, content_type_buf);
                                     blob.content_type_allocated = true;
                                 }
@@ -3385,7 +3385,7 @@ pub const Blob = struct {
         globalThis: *JSGlobalObject,
         was_string: bool,
     ) Blob {
-        var bytes = allocator.dupe(u8, bytes_) catch @panic("Out of memory");
+        const bytes = allocator.dupe(u8, bytes_) catch @panic("Out of memory");
         return Blob{
             .size = @as(SizeType, @truncate(bytes_.len)),
             .store = if (bytes.len > 0)
@@ -3507,7 +3507,7 @@ pub const Blob = struct {
                 var promise = handler.promise.swap();
                 var blob = handler.context;
                 blob.allocator = null;
-                var globalThis = handler.globalThis;
+                const globalThis = handler.globalThis;
                 bun.default_allocator.destroy(handler);
                 switch (bytes_) {
                     .result => |result| {
@@ -3536,7 +3536,7 @@ pub const Blob = struct {
         globalThis: *JSGlobalObject,
         pub fn run(handler: *@This(), count: Blob.Store.WriteFile.ResultType) void {
             var promise = handler.promise.swap();
-            var globalThis = handler.globalThis;
+            const globalThis = handler.globalThis;
             bun.default_allocator.destroy(handler);
             const value = promise.asValue(globalThis);
             value.ensureStillAlive();
@@ -3560,7 +3560,7 @@ pub const Blob = struct {
     }
 
     pub fn doReadFileInternal(this: *Blob, comptime Handler: type, ctx: Handler, comptime Function: anytype, global: *JSGlobalObject) void {
-        var file_read = Store.ReadFile.createWithCtx(
+        const file_read = Store.ReadFile.createWithCtx(
             bun.default_allocator,
             this.store.?,
             ctx,
@@ -3582,7 +3582,7 @@ pub const Blob = struct {
             .globalThis = global,
         };
 
-        var file_read = Store.ReadFile.create(
+        const file_read = Store.ReadFile.create(
             bun.default_allocator,
             this.store.?,
             this.offset,
@@ -3650,7 +3650,7 @@ pub const Blob = struct {
                 return ZigString.init(buf).external(global, this.store.?, Store.external);
             },
             .transfer => {
-                var store = this.store.?;
+                const store = this.store.?;
                 std.debug.assert(store.data == .bytes);
                 this.transfer();
                 return ZigString.init(buf).external(global, store, Store.external);
@@ -3686,7 +3686,7 @@ pub const Blob = struct {
             return this.doReadFile(toJSONWithBytes, global);
         }
 
-        var view_ = this.sharedView();
+        const view_ = this.sharedView();
 
         return toJSONWithBytes(this, global, view_, lifetime);
     }
@@ -3740,7 +3740,7 @@ pub const Blob = struct {
                 );
             },
             .transfer => {
-                var store = this.store.?;
+                const store = this.store.?;
                 this.transfer();
                 return JSC.ArrayBuffer.fromBytes(buf, .ArrayBuffer).toJSWithContext(
                     global,
@@ -3764,7 +3764,7 @@ pub const Blob = struct {
             return this.doReadFile(toArrayBufferWithBytes, global);
         }
 
-        var view_ = this.sharedView();
+        const view_ = this.sharedView();
         if (view_.len == 0)
             return JSC.ArrayBuffer.create(global, "", .ArrayBuffer);
 
@@ -3776,7 +3776,7 @@ pub const Blob = struct {
             return this.doReadFile(toFormDataWithBytes, global);
         }
 
-        var view_ = this.sharedView();
+        const view_ = this.sharedView();
 
         if (view_.len == 0)
             return JSC.DOMFormData.create(global);
@@ -3889,7 +3889,7 @@ pub const Blob = struct {
                 JSC.JSValue.JSType.BigUint64Array,
                 JSC.JSValue.JSType.DataView,
                 => {
-                    var buf = try bun.default_allocator.dupe(u8, top_value.asArrayBuffer(global).?.byteSlice());
+                    const buf = try bun.default_allocator.dupe(u8, top_value.asArrayBuffer(global).?.byteSlice());
 
                     return Blob.init(buf, bun.default_allocator, global);
                 },
@@ -3925,7 +3925,7 @@ pub const Blob = struct {
         }
 
         var stack_allocator = std.heap.stackFallback(1024, bun.default_allocator);
-        var stack_mem_all = stack_allocator.get();
+        const stack_mem_all = stack_allocator.get();
         var stack: std.ArrayList(JSValue) = std.ArrayList(JSValue).init(stack_mem_all);
         var joiner = StringJoiner{ .use_pool = false, .node_allocator = stack_mem_all };
         var could_have_non_ascii = false;
@@ -4075,7 +4075,7 @@ pub const Blob = struct {
             current = stack.popOrNull() orelse break;
         }
 
-        var joined = try joiner.done(bun.default_allocator);
+        const joined = try joiner.done(bun.default_allocator);
 
         if (!could_have_non_ascii) {
             return Blob.initWithAllASCII(joined, bun.default_allocator, global, true);
@@ -4205,7 +4205,7 @@ pub const AnyBlob = union(enum) {
                     return JSC.ArrayBuffer.create(global, "", .ArrayBuffer);
                 }
 
-                var bytes = this.InternalBlob.toOwnedSlice();
+                const bytes = this.InternalBlob.toOwnedSlice();
                 this.* = .{ .Blob = .{} };
                 const value = JSC.ArrayBuffer.fromBytes(
                     bytes,
@@ -4363,7 +4363,7 @@ pub const InternalBlob = struct {
     }
 
     pub fn toOwnedSlice(this: *@This()) []u8 {
-        var bytes = this.bytes.items;
+        const bytes = this.bytes.items;
         this.bytes.items = &.{};
         this.bytes.capacity = 0;
         return bytes;

--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -488,7 +488,7 @@ pub const Body = struct {
 
             if (js_type.isTypedArray()) {
                 if (value.asArrayBuffer(globalThis)) |buffer| {
-                    var bytes = buffer.byteSlice();
+                    const bytes = buffer.byteSlice();
 
                     if (bytes.len == 0) {
                         return Body.Value{
@@ -543,7 +543,7 @@ pub const Body = struct {
             if (JSC.WebCore.ReadableStream.fromJS(value, globalThis)) |readable| {
                 switch (readable.ptr) {
                     .Blob => |blob| {
-                        var result: Value = .{
+                        const result: Value = .{
                             .Blob = Blob.initWithStore(blob.store, globalThis),
                         };
                         blob.store.ref();
@@ -676,13 +676,13 @@ pub const Body = struct {
 
             switch (this.*) {
                 .Blob => {
-                    var new_blob = this.Blob;
+                    const new_blob = this.Blob;
                     std.debug.assert(new_blob.allocator == null); // owned by Body
                     this.* = .{ .Used = {} };
                     return new_blob;
                 },
                 .InternalBlob => {
-                    var new_blob = Blob.init(
+                    const new_blob = Blob.init(
                         this.InternalBlob.toOwnedSlice(),
                         // we will never resize it from here
                         // we have to use the default allocator
@@ -831,7 +831,7 @@ pub const Body = struct {
 
         pub fn toErrorString(this: *Value, comptime err: string, global: *JSGlobalObject) void {
             var error_str = ZigString.init(err);
-            var error_instance = error_str.toErrorInstance(global);
+            const error_instance = error_str.toErrorInstance(global);
             return this.toErrorInstance(error_instance, global);
         }
 
@@ -842,7 +842,7 @@ pub const Body = struct {
                 .{@errorName(err)},
             ) catch unreachable);
             error_str.mark();
-            var error_instance = error_str.toErrorInstance(global);
+            const error_instance = error_str.toErrorInstance(global);
             return this.toErrorInstance(error_instance, global);
         }
 
@@ -1238,7 +1238,7 @@ pub const BodyValueBufferer = struct {
         }
     }
     fn onStreamPipe(sink: *@This(), stream: JSC.WebCore.StreamResult, allocator: std.mem.Allocator) void {
-        var stream_needs_deinit = stream == .owned or stream == .owned_and_done;
+        const stream_needs_deinit = stream == .owned or stream == .owned_and_done;
 
         defer {
             if (stream_needs_deinit) {
@@ -1271,7 +1271,7 @@ pub const BodyValueBufferer = struct {
     pub fn onRejectStream(_: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) JSValue {
         const args = callframe.arguments(2);
         var sink = args.ptr[args.len - 1].asPromisePtr(@This());
-        var err = args.ptr[0];
+        const err = args.ptr[0];
         sink.handleRejectStream(err, true);
         return JSValue.jsUndefined();
     }

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -112,7 +112,7 @@ pub const TextEncoder = struct {
             @memcpy(array_buffer.slice()[0..result.written], buf[0..result.written]);
             return uint8array;
         } else {
-            var bytes = strings.toUTF8AllocWithType(
+            const bytes = strings.toUTF8AllocWithType(
                 default_allocator,
                 @TypeOf(slice),
                 slice,
@@ -132,7 +132,7 @@ pub const TextEncoder = struct {
         any_non_ascii: bool = false,
 
         pub fn append8(it: *JSC.JSString.Iterator, ptr: [*]const u8, len: u32) callconv(.C) void {
-            var this = bun.cast(*RopeStringEncoder, it.data.?);
+            const this = bun.cast(*RopeStringEncoder, it.data.?);
             const result = strings.copyLatin1IntoUTF8StopOnNonASCII(this.buf[this.tail..], []const u8, ptr[0..len], true);
             if (result.read == std.math.maxInt(u32) and result.written == std.math.maxInt(u32)) {
                 it.stop = 1;
@@ -142,12 +142,12 @@ pub const TextEncoder = struct {
             }
         }
         pub fn append16(it: *JSC.JSString.Iterator, _: [*]const u16, _: u32) callconv(.C) void {
-            var this = bun.cast(*RopeStringEncoder, it.data.?);
+            const this = bun.cast(*RopeStringEncoder, it.data.?);
             this.any_non_ascii = true;
             it.stop = 1;
         }
         pub fn write8(it: *JSC.JSString.Iterator, ptr: [*]const u8, len: u32, offset: u32) callconv(.C) void {
-            var this = bun.cast(*RopeStringEncoder, it.data.?);
+            const this = bun.cast(*RopeStringEncoder, it.data.?);
             const result = strings.copyLatin1IntoUTF8StopOnNonASCII(this.buf[offset..], []const u8, ptr[0..len], true);
             if (result.read == std.math.maxInt(u32) and result.written == std.math.maxInt(u32)) {
                 it.stop = 1;
@@ -155,7 +155,7 @@ pub const TextEncoder = struct {
             }
         }
         pub fn write16(it: *JSC.JSString.Iterator, _: [*]const u16, _: u32, _: u32) callconv(.C) void {
-            var this = bun.cast(*RopeStringEncoder, it.data.?);
+            const this = bun.cast(*RopeStringEncoder, it.data.?);
             this.any_non_ascii = true;
             it.stop = 1;
         }
@@ -217,7 +217,7 @@ pub const TextEncoder = struct {
         buf_ptr: [*]u8,
         buf_len: usize,
     ) u64 {
-        var output = buf_ptr[0..buf_len];
+        const output = buf_ptr[0..buf_len];
         const input = input_ptr[0..input_len];
         var result: strings.EncodeIntoResult = strings.copyUTF16IntoUTF8(output, []const u16, input, false);
         if (output.len >= 3 and (result.read == 0 or result.written == 0)) {
@@ -236,7 +236,7 @@ pub const TextEncoder = struct {
         buf_ptr: [*]u8,
         buf_len: usize,
     ) u64 {
-        var output = buf_ptr[0..buf_len];
+        const output = buf_ptr[0..buf_len];
         const input = input_ptr[0..input_len];
         const result: strings.EncodeIntoResult =
             strings.copyLatin1IntoUTF8(output, []const u8, input);
@@ -577,7 +577,7 @@ pub const TextDecoder = struct {
             }
         }
 
-        var full = buffer.toOwnedSlice(allocator) catch @panic("TODO");
+        const full = buffer.toOwnedSlice(allocator) catch @panic("TODO");
 
         var out = ZigString.init("");
         out._unsafe_ptr_do_not_use = @as([*]u8, @ptrCast(full.ptr));
@@ -626,7 +626,7 @@ pub const TextDecoder = struct {
                 //
                 // It's not clear why we couldn't jusst use Latin1 here, but tests failures proved it necessary.
                 const out_length = strings.elementLengthLatin1IntoUTF16([]const u8, buffer_slice);
-                var bytes = globalThis.allocator().alloc(u16, out_length) catch {
+                const bytes = globalThis.allocator().alloc(u16, out_length) catch {
                     globalThis.throwOutOfMemory();
                     return .zero;
                 };
@@ -755,7 +755,7 @@ pub const TextDecoder = struct {
             }
         }
 
-        var result = getAllocator(globalThis).create(TextDecoder) catch unreachable;
+        const result = getAllocator(globalThis).create(TextDecoder) catch unreachable;
         result.* = decoder;
         return result;
     }
@@ -815,7 +815,7 @@ pub const Encoder = struct {
         };
     }
     export fn Bun__encoding__constructFromLatin1(globalObject: *JSGlobalObject, input: [*]const u8, len: usize, encoding: u8) JSValue {
-        var slice = switch (@as(JSC.Node.Encoding, @enumFromInt(encoding))) {
+        const slice = switch (@as(JSC.Node.Encoding, @enumFromInt(encoding))) {
             .hex => constructFromU8(input, len, .hex),
             .ascii => constructFromU8(input, len, .ascii),
             .base64url => constructFromU8(input, len, .base64url),
@@ -828,7 +828,7 @@ pub const Encoder = struct {
         return JSC.JSValue.createBuffer(globalObject, slice, globalObject.bunVM().allocator);
     }
     export fn Bun__encoding__constructFromUTF16(globalObject: *JSGlobalObject, input: [*]const u16, len: usize, encoding: u8) JSValue {
-        var slice = switch (@as(JSC.Node.Encoding, @enumFromInt(encoding))) {
+        const slice = switch (@as(JSC.Node.Encoding, @enumFromInt(encoding))) {
             .base64 => constructFromU16(input, len, .base64),
             .hex => constructFromU16(input, len, .hex),
             .base64url => constructFromU16(input, len, .base64url),
@@ -934,7 +934,7 @@ pub const Encoder = struct {
                 var str = bun.String.createUninitialized(.latin1, len * 2) orelse return ZigString.init("Out of memory").toErrorInstance(global);
                 defer str.deref();
 
-                var output = @constCast(str.latin1());
+                const output = @constCast(str.latin1());
                 const wrote = strings.encodeBytesToHex(output, input);
                 std.debug.assert(wrote == output.len);
                 return str.toJS(global);
@@ -977,7 +977,7 @@ pub const Encoder = struct {
             .ascii => {
                 const written = @min(len, to_len);
 
-                var to = to_ptr[0..written];
+                const to = to_ptr[0..written];
                 var remain = input[0..written];
 
                 if (bun.simdutf.validate.ascii(remain)) {
@@ -998,16 +998,16 @@ pub const Encoder = struct {
                     return 0;
 
                 if (std.mem.isAligned(@intFromPtr(to_ptr), @alignOf([*]u16))) {
-                    var buf = input[0..len];
+                    const buf = input[0..len];
 
-                    var output = @as([*]u16, @ptrCast(@alignCast(to_ptr)))[0 .. to_len / 2];
-                    var written = strings.copyLatin1IntoUTF16([]u16, output, []const u8, buf).written;
+                    const output = @as([*]u16, @ptrCast(@alignCast(to_ptr)))[0 .. to_len / 2];
+                    const written = strings.copyLatin1IntoUTF16([]u16, output, []const u8, buf).written;
                     return written * 2;
                 } else {
-                    var buf = input[0..len];
-                    var output = @as([*]align(1) u16, @ptrCast(to_ptr))[0 .. to_len / 2];
+                    const buf = input[0..len];
+                    const output = @as([*]align(1) u16, @ptrCast(to_ptr))[0 .. to_len / 2];
 
-                    var written = strings.copyLatin1IntoUTF16([]align(1) u16, output, []const u8, buf).written;
+                    const written = strings.copyLatin1IntoUTF16([]align(1) u16, output, []const u8, buf).written;
                     return written * 2;
                 }
             },
@@ -1101,7 +1101,7 @@ pub const Encoder = struct {
 
                 // very very slow case!
                 // shouldn't really happen though
-                var transcoded = strings.toUTF8Alloc(bun.default_allocator, input[0..len]) catch return 0;
+                const transcoded = strings.toUTF8Alloc(bun.default_allocator, input[0..len]) catch return 0;
                 defer bun.default_allocator.free(transcoded);
                 return writeU8(transcoded.ptr, transcoded.len, to, to_len, encoding);
             },
@@ -1225,7 +1225,7 @@ pub const Encoder = struct {
             .base64, .base64url => {
                 // very very slow case!
                 // shouldn't really happen though
-                var transcoded = strings.toUTF8Alloc(allocator, input[0..len]) catch return &[_]u8{};
+                const transcoded = strings.toUTF8Alloc(allocator, input[0..len]) catch return &[_]u8{};
                 defer allocator.free(transcoded);
                 return constructFromU8(transcoded.ptr, transcoded.len, encoding);
             },

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -401,7 +401,7 @@ pub const Request = struct {
 
                     if (strings.isAllASCII(host) and strings.isAllASCII(req_url)) {
                         this.url = bun.String.createUninitializedLatin1(url_bytelength);
-                        var bytes = @constCast(this.url.byteSlice());
+                        const bytes = @constCast(this.url.byteSlice());
                         _ = std.fmt.bufPrint(bytes, "{s}{any}{s}", .{
                             this.getProtocol(),
                             fmt,
@@ -409,7 +409,7 @@ pub const Request = struct {
                         }) catch @panic("Unexpected error while printing URL");
                     } else {
                         // slow path
-                        var temp_url = std.fmt.allocPrint(bun.default_allocator, "{s}{any}{s}", .{
+                        const temp_url = std.fmt.allocPrint(bun.default_allocator, "{s}{any}{s}", .{
                             this.getProtocol(),
                             fmt,
                             req_url,
@@ -690,10 +690,10 @@ pub const Request = struct {
         const arguments_ = callframe.arguments(2);
         const arguments = arguments_.ptr[0..arguments_.len];
 
-        var request = constructInto(globalThis, arguments) orelse {
+        const request = constructInto(globalThis, arguments) orelse {
             return null;
         };
-        var request_ = getAllocator(globalThis).create(Request) catch {
+        const request_ = getAllocator(globalThis).create(Request) catch {
             return null;
         };
         request_.* = request;
@@ -771,11 +771,11 @@ pub const Request = struct {
         _ = allocator;
         this.ensureURL() catch {};
 
-        var body = InitRequestBodyValue(this.body.value.clone(globalThis)) catch {
+        const body = InitRequestBodyValue(this.body.value.clone(globalThis)) catch {
             globalThis.throw("Failed to clone request", .{});
             return;
         };
-        var original_url = req.url;
+        const original_url = req.url;
 
         req.* = Request{
             .body = body,
@@ -790,7 +790,7 @@ pub const Request = struct {
     }
 
     pub fn clone(this: *Request, allocator: std.mem.Allocator, globalThis: *JSGlobalObject) *Request {
-        var req = allocator.create(Request) catch unreachable;
+        const req = allocator.create(Request) catch unreachable;
         this.cloneInto(req, allocator, globalThis, false);
         return req;
     }

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -253,7 +253,7 @@ pub const Response = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) callconv(.C) JSValue {
-        var cloned = this.clone(getAllocator(globalThis), globalThis);
+        const cloned = this.clone(getAllocator(globalThis), globalThis);
         return Response.makeMaybePooled(globalThis, cloned);
     }
 
@@ -277,7 +277,7 @@ pub const Response = struct {
     }
 
     pub fn clone(this: *Response, allocator: std.mem.Allocator, globalThis: *JSGlobalObject) *Response {
-        var new_response = allocator.create(Response) catch unreachable;
+        const new_response = allocator.create(Response) catch unreachable;
         this.cloneInto(new_response, allocator, globalThis);
         return new_response;
     }
@@ -533,7 +533,7 @@ pub const Response = struct {
 
         pub fn clone(this: Init, ctx: *JSGlobalObject) Init {
             var that = this;
-            var headers = this.headers;
+            const headers = this.headers;
             if (headers) |head| {
                 that.headers = head.cloneThis(ctx);
             }
@@ -624,7 +624,7 @@ pub const Response = struct {
 
     inline fn emptyWithStatus(globalThis: *JSC.JSGlobalObject, status: u16) Response {
         var allocator = getAllocator(globalThis);
-        var response = allocator.create(Response) catch unreachable;
+        const response = allocator.create(Response) catch unreachable;
 
         response.* = Response{
             .body = Body{
@@ -863,7 +863,7 @@ pub const Fetch = struct {
                 this.has_schedule_callback.store(false, .Monotonic);
                 this.mutex.unlock();
                 if (is_done) {
-                    var vm = globalThis.bunVM();
+                    const vm = globalThis.bunVM();
                     this.poll_ref.unref(vm);
                     this.clearData();
                     this.deinit();
@@ -901,7 +901,7 @@ pub const Fetch = struct {
                 if (readable.ptr == .Bytes) {
                     readable.ptr.Bytes.size_hint = this.getSizeHint();
                     // body can be marked as used but we still need to pipe the data
-                    var scheduled_response_buffer = this.scheduled_response_buffer.list;
+                    const scheduled_response_buffer = this.scheduled_response_buffer.list;
 
                     const chunk = scheduled_response_buffer.items;
 
@@ -935,7 +935,7 @@ pub const Fetch = struct {
                             if (readable.ptr == .Bytes) {
                                 readable.ptr.Bytes.size_hint = this.getSizeHint();
 
-                                var scheduled_response_buffer = this.scheduled_response_buffer.list;
+                                const scheduled_response_buffer = this.scheduled_response_buffer.list;
 
                                 const chunk = scheduled_response_buffer.items;
 
@@ -970,7 +970,7 @@ pub const Fetch = struct {
 
                             // done resolve body
                             var old = body.value;
-                            var body_value = Body.Value{
+                            const body_value = Body.Value{
                                 .InternalBlob = .{
                                     .bytes = scheduled_response_buffer.toManaged(bun.default_allocator),
                                 },
@@ -1014,7 +1014,7 @@ pub const Fetch = struct {
                 }
                 this.mutex.unlock();
                 var poll_ref = this.poll_ref;
-                var vm = globalThis.bunVM();
+                const vm = globalThis.bunVM();
 
                 poll_ref.unref(vm);
                 this.clearData();
@@ -1026,7 +1026,7 @@ pub const Fetch = struct {
             const promise_value = ref.valueOrEmpty();
 
             var poll_ref = this.poll_ref;
-            var vm = globalThis.bunVM();
+            const vm = globalThis.bunVM();
 
             if (promise_value.isEmptyOrUndefinedOrNull()) {
                 log("onProgressUpdate: promise_value is null", .{});
@@ -1111,7 +1111,7 @@ pub const Fetch = struct {
 
                 pub fn resolve(held: *@This()) void {
                     var prom = held.promise.swap().asAnyPromise().?;
-                    var globalObject = held.globalObject;
+                    const globalObject = held.globalObject;
                     const res = held.held.swap();
                     held.held.deinit();
                     held.promise.deinit();
@@ -1123,7 +1123,7 @@ pub const Fetch = struct {
 
                 pub fn reject(held: *@This()) void {
                     var prom = held.promise.swap().asAnyPromise().?;
-                    var globalObject = held.globalObject;
+                    const globalObject = held.globalObject;
                     const res = held.held.swap();
                     held.held.deinit();
                     held.promise.deinit();
@@ -1154,7 +1154,7 @@ pub const Fetch = struct {
             if (this.check_server_identity.get()) |check_server_identity| {
                 check_server_identity.ensureStillAlive();
                 if (certificate_info.cert.len > 0) {
-                    var cert = certificate_info.cert;
+                    const cert = certificate_info.cert;
                     var cert_ptr = cert.ptr;
                     if (BoringSSL.d2i_X509(null, &cert_ptr, @intCast(cert.len))) |x509| {
                         defer BoringSSL.X509_free(x509);
@@ -1394,7 +1394,7 @@ pub const Fetch = struct {
             log("toResponse", .{});
             std.debug.assert(this.metadata != null);
             // at this point we always should have metadata
-            var metadata = this.metadata.?;
+            const metadata = this.metadata.?;
             const http_response = metadata.response;
             this.is_waiting_body = this.result.has_more;
             return Response{
@@ -1415,7 +1415,7 @@ pub const Fetch = struct {
         pub fn onResolve(this: *FetchTasklet) JSValue {
             log("onResolve", .{});
             const allocator = bun.default_allocator;
-            var response = allocator.create(Response) catch unreachable;
+            const response = allocator.create(Response) catch unreachable;
             response.* = this.toResponse(allocator);
             const response_js = Response.makeMaybePooled(@as(js.JSContextRef, this.global_this), response);
             response_js.ensureStillAlive();
@@ -1674,7 +1674,7 @@ pub const Fetch = struct {
         const arguments = callframe.arguments(2);
 
         var exception_val = [_]JSC.C.JSValueRef{null};
-        var exception: JSC.C.ExceptionRef = &exception_val;
+        const exception: JSC.C.ExceptionRef = &exception_val;
         var memory_reporter = bun.default_allocator.create(JSC.MemoryReportingAllocator) catch @panic("out of memory");
         var free_memory_reporter = false;
         var allocator = memory_reporter.wrap(bun.default_allocator);

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -392,7 +392,7 @@ pub const ReadableStream = struct {
             if (bytes[0] != 1) {
                 return bun.invalid_fd;
             }
-            var out: u64 = 0;
+            const out: u64 = 0;
             @as([8]u8, @bitCast(out))[0..7].* = bytes[1..8].*;
             return @as(bun.FileDescriptor, @intCast(out));
         }
@@ -663,7 +663,7 @@ pub const StreamResult = union(Tag) {
             };
 
             pub fn promise(this: *Writable.Pending, globalThis: *JSC.JSGlobalObject) *JSPromise {
-                var prom = JSPromise.create(globalThis);
+                const prom = JSPromise.create(globalThis);
                 this.future = .{
                     .promise = .{ .promise = prom, .globalThis = globalThis },
                 };
@@ -768,7 +768,7 @@ pub const StreamResult = union(Tag) {
         }
 
         pub fn promise(this: *Pending, globalObject: *JSC.JSGlobalObject) *JSC.JSPromise {
-            var prom = JSC.JSPromise.create(globalObject);
+            const prom = JSC.JSPromise.create(globalObject);
             this.future = .{
                 .promise = .{
                     .promise = prom,
@@ -1050,7 +1050,7 @@ pub const Sink = struct {
     pub const UTF8Fallback = struct {
         const stack_size = 1024;
         pub fn writeLatin1(comptime Ctx: type, ctx: *Ctx, input: StreamResult, comptime writeFn: anytype) StreamResult.Writable {
-            var str = input.slice();
+            const str = input.slice();
             if (strings.isAllASCII(str)) {
                 return writeFn(
                     ctx,
@@ -1086,7 +1086,7 @@ pub const Sink = struct {
         }
 
         pub fn writeUTF16(comptime Ctx: type, ctx: *Ctx, input: StreamResult, comptime writeFn: anytype) StreamResult.Writable {
-            var str: []const u16 = std.mem.bytesAsSlice(u16, input.slice());
+            const str: []const u16 = std.mem.bytesAsSlice(u16, input.slice());
 
             if (stack_size >= str.len * 2) {
                 var buf: [stack_size]u8 = undefined;
@@ -1103,7 +1103,7 @@ pub const Sink = struct {
             }
 
             {
-                var allocated = strings.toUTF8Alloc(bun.default_allocator, str) catch return .{ .err = Syscall.Error.oom };
+                const allocated = strings.toUTF8Alloc(bun.default_allocator, str) catch return .{ .err = Syscall.Error.oom };
                 if (input.isDone()) {
                     return writeFn(ctx, .{ .owned_and_done = bun.ByteList.init(allocated) });
                 } else {
@@ -1607,7 +1607,7 @@ pub const FileSink = struct {
     }
 
     pub fn init(allocator: std.mem.Allocator, next: ?Sink) !*FileSink {
-        var this = try allocator.create(FileSink);
+        const this = try allocator.create(FileSink);
         this.* = FileSink{
             .buffer = bun.ByteList{},
             .allocator = allocator,
@@ -1885,7 +1885,7 @@ pub const ArrayBufferSink = struct {
     }
 
     pub fn init(allocator: std.mem.Allocator, next: ?Sink) !*ArrayBufferSink {
-        var this = try allocator.create(ArrayBufferSink);
+        const this = try allocator.create(ArrayBufferSink);
         this.* = ArrayBufferSink{
             .bytes = bun.ByteList.init(&.{}),
             .allocator = allocator,
@@ -2120,7 +2120,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
             if (comptime !@hasField(SinkType, "signal"))
                 return;
 
-            var ptr = this.sink.signal.ptr;
+            const ptr = this.sink.signal.ptr;
             if (this.sink.signal.isDead())
                 return;
             this.sink.signal.clear();
@@ -2390,7 +2390,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
 
         pub fn updateRef(ptr: *anyopaque, value: bool) callconv(.C) void {
             JSC.markBinding(@src());
-            var this = bun.cast(*ThisSink, ptr);
+            const this = bun.cast(*ThisSink, ptr);
             if (comptime @hasDecl(SinkType, "updateRef"))
                 this.sink.updateRef(value);
         }
@@ -2491,7 +2491,7 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
 
         fn handleFirstWriteIfNecessary(this: *@This()) void {
             if (this.onFirstWrite) |onFirstWrite| {
-                var ctx = this.ctx;
+                const ctx = this.ctx;
                 this.ctx = null;
                 this.onFirstWrite = null;
                 onFirstWrite(ctx);
@@ -3255,7 +3255,7 @@ pub fn ReadableStreamSource(
 
             fn onClose(ptr: *anyopaque) void {
                 JSC.markBinding(@src());
-                var this = bun.cast(*ReadableStreamSourceType, ptr);
+                const this = bun.cast(*ReadableStreamSourceType, ptr);
                 _ = this.close_jsvalue.call(this.globalThis, &.{});
                 //    this.closer
             }
@@ -3390,7 +3390,7 @@ pub const ByteBlobLoader = struct {
         temporary = temporary[this.offset..];
         temporary = temporary[0..@min(16384, @min(temporary.len, this.remain))];
 
-        var cloned = bun.ByteList.init(temporary).listManaged(bun.default_allocator).clone() catch @panic("Out of memory");
+        const cloned = bun.ByteList.init(temporary).listManaged(bun.default_allocator).clone() catch @panic("Out of memory");
         this.offset +|= @as(Blob.SizeType, @truncate(cloned.items.len));
         this.remain -|= @as(Blob.SizeType, @truncate(cloned.items.len));
 
@@ -3528,7 +3528,7 @@ pub const ByteStream = struct {
 
         if (this.pending.state == .pending) {
             std.debug.assert(this.buffer.items.len == 0);
-            var to_copy = this.pending_buffer[0..@min(chunk.len, this.pending_buffer.len)];
+            const to_copy = this.pending_buffer[0..@min(chunk.len, this.pending_buffer.len)];
             const pending_buffer_len = this.pending_buffer.len;
             std.debug.assert(to_copy.ptr != chunk.ptr);
             @memcpy(to_copy, chunk[0..to_copy.len]);
@@ -3642,7 +3642,7 @@ pub const ByteStream = struct {
                 this.buffer.items.len - this.offset,
                 buffer.len,
             );
-            var remaining_in_buffer = this.buffer.items[this.offset..][0..to_write];
+            const remaining_in_buffer = this.buffer.items[this.offset..][0..to_write];
 
             @memcpy(buffer[0..to_write], this.buffer.items[this.offset..][0..to_write]);
 
@@ -4335,7 +4335,7 @@ pub const File = struct {
         concurrent_task: JSC.ConcurrentTask = .{},
 
         pub fn taskCallback(task: *NetworkThread.Task) void {
-            var this = @fieldParentPtr(File, "concurrent", @fieldParentPtr(Concurrent, "task", task));
+            const this = @fieldParentPtr(File, "concurrent", @fieldParentPtr(Concurrent, "task", task));
             runAsync(this);
         }
 

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -508,7 +508,7 @@ pub fn cloneWithType(comptime T: type, item: T, allocator: std.mem.Allocator) !T
         assertDefined(item);
 
         if (comptime hasCloneFn(Child)) {
-            var slice = try allocator.alloc(Child, item.len);
+            const slice = try allocator.alloc(Child, item.len);
             for (slice, 0..) |*val, i| {
                 val.* = try item[i].clone(allocator);
             }
@@ -549,7 +549,7 @@ pub fn assertDefined(val: anytype) void {
         std.debug.assert(val.len < std.math.maxInt(u32) + 1);
         std.debug.assert(val.len < std.math.maxInt(u32) + 1);
         std.debug.assert(val.len < std.math.maxInt(u32) + 1);
-        var slice: []Type = undefined;
+        const slice: []Type = undefined;
         if (val.len > 0) {
             std.debug.assert(@intFromPtr(val.ptr) != @intFromPtr(slice.ptr));
         }
@@ -557,7 +557,7 @@ pub fn assertDefined(val: anytype) void {
     }
 
     if (comptime @typeInfo(Type) == .Pointer) {
-        var slice: *Type = undefined;
+        const slice: *Type = undefined;
         std.debug.assert(@intFromPtr(val) != @intFromPtr(slice));
         return;
     }
@@ -943,7 +943,7 @@ pub const StringHashMapContext = struct {
         value: u64,
         input: []const u8,
         pub fn init(allocator: std.mem.Allocator, input: []const u8) PrehashedCaseInsensitive {
-            var out = allocator.alloc(u8, input.len) catch unreachable;
+            const out = allocator.alloc(u8, input.len) catch unreachable;
             _ = strings.copyLowercase(input, out);
             return PrehashedCaseInsensitive{
                 .value = StringHashMapContext.hash(.{}, out),
@@ -1157,13 +1157,13 @@ pub fn getcwd(buf_: []u8) ![]u8 {
     }
 
     var temp: [MAX_PATH_BYTES]u8 = undefined;
-    var temp_slice = try std.os.getcwd(&temp);
+    const temp_slice = try std.os.getcwd(&temp);
     return path.normalizeBuf(temp_slice, buf_, .loose);
 }
 
 pub fn getcwdAlloc(allocator: std.mem.Allocator) ![]u8 {
     var temp: [MAX_PATH_BYTES]u8 = undefined;
-    var temp_slice = try getcwd(&temp);
+    const temp_slice = try getcwd(&temp);
     return allocator.dupe(u8, temp_slice);
 }
 
@@ -1174,7 +1174,7 @@ pub fn getFdPath(fd_: anytype, buf: *[@This().MAX_PATH_BYTES]u8) ![]u8 {
 
     if (comptime Environment.isWindows) {
         var temp: [MAX_PATH_BYTES]u8 = undefined;
-        var temp_slice = try std.os.getFdPath(fd, &temp);
+        const temp_slice = try std.os.getFdPath(fd, &temp);
         return path.normalizeBuf(temp_slice, buf, .loose);
     }
 
@@ -1437,13 +1437,13 @@ pub fn reloadProcess(
 ) void {
     const PosixSpawn = @import("./bun.js/api/bun/spawn.zig").PosixSpawn;
     const bun = @This();
-    var dupe_argv = allocator.allocSentinel(?[*:0]const u8, bun.argv().len, null) catch unreachable;
+    const dupe_argv = allocator.allocSentinel(?[*:0]const u8, bun.argv().len, null) catch unreachable;
     for (bun.argv(), dupe_argv) |src, *dest| {
         dest.* = (allocator.dupeZ(u8, sliceTo(src, 0)) catch unreachable).ptr;
     }
 
-    var environ_slice = std.mem.span(std.c.environ);
-    var environ = allocator.allocSentinel(?[*:0]const u8, environ_slice.len, null) catch unreachable;
+    const environ_slice = std.mem.span(std.c.environ);
+    const environ = allocator.allocSentinel(?[*:0]const u8, environ_slice.len, null) catch unreachable;
     for (environ_slice, environ) |src, *dest| {
         if (src == null) {
             dest.* = null;
@@ -1518,7 +1518,7 @@ pub const StringSet = struct {
     }
 
     pub fn insert(self: *StringSet, key: []const u8) !void {
-        var entry = try self.map.getOrPut(key);
+        const entry = try self.map.getOrPut(key);
         if (!entry.found_existing) {
             entry.key_ptr.* = try self.map.allocator.dupe(u8, key);
         }
@@ -1568,7 +1568,7 @@ pub const StringMap = struct {
     }
 
     pub fn insert(self: *StringMap, key: []const u8, value: []const u8) !void {
-        var entry = try self.map.getOrPut(key);
+        const entry = try self.map.getOrPut(key);
         if (!entry.found_existing) {
             if (self.dupe_keys)
                 entry.key_ptr.* = try self.map.allocator.dupe(u8, key);
@@ -2003,7 +2003,7 @@ pub fn makePath(dir: std.fs.Dir, sub_path: []const u8) !void {
                 copy(u8, &path_buf2, component.path);
 
                 path_buf2[component.path.len] = 0;
-                var path_to_use = path_buf2[0..component.path.len :0];
+                const path_to_use = path_buf2[0..component.path.len :0];
                 const result = try sys.lstat(path_to_use).unwrap();
                 const is_dir = std.os.S.ISDIR(result.mode);
                 // dangling symlink

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -47,7 +47,7 @@ pub const Run = struct {
         JSC.markBinding(@src());
         bun.JSC.initialize();
 
-        var graph_ptr = try bun.default_allocator.create(bun.StandaloneModuleGraph);
+        const graph_ptr = try bun.default_allocator.create(bun.StandaloneModuleGraph);
         graph_ptr.* = graph;
 
         js_ast.Expr.Data.Store.create(default_allocator);
@@ -128,7 +128,7 @@ pub const Run = struct {
         vm.is_main_thread = true;
         JSC.VirtualMachine.is_main_thread_vm = true;
 
-        var callback = OpaqueWrap(Run, Run.start);
+        const callback = OpaqueWrap(Run, Run.start);
         vm.global.vm().holdAPILock(&run, callback);
     }
 
@@ -170,7 +170,7 @@ pub const Run = struct {
 
         if (ctx.runtime_options.eval_script.len > 0) {
             vm.module_loader.eval_script = ptr: {
-                var v = try bun.default_allocator.create(logger.Source);
+                const v = try bun.default_allocator.create(logger.Source);
                 v.* = logger.Source.initPathString(entry_path, ctx.runtime_options.eval_script);
                 break :ptr v;
             };
@@ -237,7 +237,7 @@ pub const Run = struct {
 
         vm.bundler.env.loadTracy();
 
-        var callback = OpaqueWrap(Run, Run.start);
+        const callback = OpaqueWrap(Run, Run.start);
         vm.global.vm().holdAPILock(&run, callback);
     }
 

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -293,7 +293,7 @@ pub const PluginRunner = struct {
         };
 
         // Our super slow way of cloning the string into memory owned by JSC
-        var combined_string = std.fmt.allocPrint(
+        const combined_string = std.fmt.allocPrint(
             this.allocator,
             "{any}:{any}",
             .{ user_namespace, file_path },
@@ -375,7 +375,7 @@ pub const Bundler = struct {
     ) !Bundler {
         js_ast.Expr.Data.Store.create(allocator);
         js_ast.Stmt.Data.Store.create(allocator);
-        var fs = try Fs.FileSystem.init(
+        const fs = try Fs.FileSystem.init(
             opts.absolute_working_dir,
         );
         const bundle_options = try options.BundleOptions.fromApi(
@@ -386,10 +386,10 @@ pub const Bundler = struct {
         );
 
         var env_loader: *DotEnv.Loader = env_loader_ orelse DotEnv.instance orelse brk: {
-            var map = try allocator.create(DotEnv.Map);
+            const map = try allocator.create(DotEnv.Map);
             map.* = DotEnv.Map.init(allocator);
 
-            var loader = try allocator.create(DotEnv.Loader);
+            const loader = try allocator.create(DotEnv.Loader);
             loader.* = DotEnv.Loader.init(map, allocator);
             break :brk loader;
         };
@@ -405,7 +405,7 @@ pub const Bundler = struct {
         // try pool.init(ThreadPool.InitConfig{
         //     .allocator = allocator,
         // });
-        var resolve_results = try allocator.create(ResolveResults);
+        const resolve_results = try allocator.create(ResolveResults);
         resolve_results.* = ResolveResults.init(allocator);
         return Bundler{
             .options = bundle_options,
@@ -463,7 +463,7 @@ pub const Bundler = struct {
                     this.options.jsx = tsconfig.mergeJSX(this.options.jsx);
                 }
 
-                var dir = dir_info.getEntries(this.resolver.generation) orelse return;
+                const dir = dir_info.getEntries(this.resolver.generation) orelse return;
 
                 // Process always has highest priority.
                 const was_production = this.options.production;
@@ -620,8 +620,8 @@ pub const Bundler = struct {
         }
 
         if (this.options.routes.routes_enabled) {
-            var dir_info_ = try this.resolver.readDirInfo(this.options.routes.dir);
-            var dir_info = dir_info_ orelse return error.MissingRoutesDir;
+            const dir_info_ = try this.resolver.readDirInfo(this.options.routes.dir);
+            const dir_info = dir_info_ orelse return error.MissingRoutesDir;
 
             this.options.routes.dir = dir_info.abs_path;
 
@@ -706,10 +706,10 @@ pub const Bundler = struct {
             file_path.pretty = allocator.dupe(u8, bundler.fs.relativeTo(file_path.text)) catch unreachable;
         }
 
-        var old_bundler_allocator = bundler.allocator;
+        const old_bundler_allocator = bundler.allocator;
         bundler.allocator = allocator;
         defer bundler.allocator = old_bundler_allocator;
-        var old_linker_allocator = bundler.linker.allocator;
+        const old_linker_allocator = bundler.linker.allocator;
         defer bundler.linker.allocator = old_linker_allocator;
         bundler.linker.allocator = allocator;
 
@@ -929,7 +929,7 @@ pub const Bundler = struct {
                         );
                 }
 
-                var buffer_writer = try js_printer.BufferWriter.init(bundler.allocator);
+                const buffer_writer = try js_printer.BufferWriter.init(bundler.allocator);
                 var writer = js_printer.BufferPrinter.init(buffer_writer);
 
                 output_file.size = switch (bundler.options.target) {
@@ -973,7 +973,7 @@ pub const Bundler = struct {
                 const CSSBuildContext = struct {
                     origin: URL,
                 };
-                var build_ctx = CSSBuildContext{ .origin = bundler.options.origin };
+                const build_ctx = CSSBuildContext{ .origin = bundler.options.origin };
 
                 const BufferedWriter = std.io.CountingWriter(std.io.BufferedWriter(8096, std.fs.File.Writer));
                 const CSSWriter = Css.NewWriter(
@@ -1028,7 +1028,7 @@ pub const Bundler = struct {
                 output_file.value = .{ .move = file_op };
             },
             .wasm, .file, .napi => {
-                var hashed_name = try bundler.linker.getHashedFilename(file_path, null);
+                const hashed_name = try bundler.linker.getHashedFilename(file_path, null);
                 var pathname = try bundler.allocator.alloc(u8, hashed_name.len + file_path.name.ext.len);
                 bun.copy(u8, pathname, hashed_name);
                 bun.copy(u8, pathname[hashed_name.len..], file_path.name.ext);
@@ -1063,7 +1063,7 @@ pub const Bundler = struct {
         const tracer = bun.tracy.traceNamed(@src(), if (enable_source_map) "JSPrinter.printWithSourceMap" else "JSPrinter.print");
         defer tracer.end();
 
-        var symbols = js_ast.Symbol.NestedList.init(&[_]js_ast.Symbol.List{ast.symbols});
+        const symbols = js_ast.Symbol.NestedList.init(&[_]js_ast.Symbol.List{ast.symbols});
 
         return switch (format) {
             .cjs => try js_printer.printCommonJS(
@@ -1400,9 +1400,9 @@ pub const Bundler = struct {
 
                 var symbols: []js_ast.Symbol = &.{};
 
-                var parts = brk: {
+                const parts = brk: {
                     if (expr.data == .e_object) {
-                        var properties: []js_ast.G.Property = expr.data.e_object.properties.slice();
+                        const properties: []js_ast.G.Property = expr.data.e_object.properties.slice();
                         if (properties.len > 0) {
                             var stmts = allocator.alloc(js_ast.Stmt, 3) catch return null;
                             var decls = allocator.alloc(js_ast.G.Decl, properties.len) catch return null;
@@ -1417,7 +1417,7 @@ pub const Bundler = struct {
                                 if (strings.eqlComptime(name, "default"))
                                     continue;
 
-                                var visited = duplicate_key_checker.getOrPut(name) catch continue;
+                                const visited = duplicate_key_checker.getOrPut(name) catch continue;
                                 if (visited.found_existing) {
                                     decls[visited.value_ptr.*].value = prop.value.?;
                                     continue;
@@ -1513,10 +1513,10 @@ pub const Bundler = struct {
             },
             // TODO: use lazy export AST
             .text => {
-                var expr = js_ast.Expr.init(js_ast.E.String, js_ast.E.String{
+                const expr = js_ast.Expr.init(js_ast.E.String, js_ast.E.String{
                     .data = source.contents,
                 }, logger.Loc.Empty);
-                var stmt = js_ast.Stmt.alloc(js_ast.S.ExportDefault, js_ast.S.ExportDefault{
+                const stmt = js_ast.Stmt.alloc(js_ast.S.ExportDefault, js_ast.S.ExportDefault{
                     .value = js_ast.StmtOrExpr{ .expr = expr },
                     .default_name = js_ast.LocRef{
                         .loc = logger.Loc{},
@@ -1576,7 +1576,7 @@ pub const Bundler = struct {
         path_to_use_: string,
         comptime client_entry_point_enabled: bool,
     ) !ServeResult {
-        var old_log = bundler.log;
+        const old_log = bundler.log;
 
         bundler.setLog(log);
         defer bundler.setLog(old_log);
@@ -1655,7 +1655,7 @@ pub const Bundler = struct {
                 };
             },
             else => {
-                var abs_path = path.text;
+                const abs_path = path.text;
                 const file = try std.fs.openFileAbsolute(abs_path, .{ .mode = .read_only });
                 const size = try file.getEndPos();
                 return ServeResult{
@@ -1705,7 +1705,7 @@ pub const Bundler = struct {
         var entry_point_i: usize = 0;
 
         for (bundler.options.entry_points) |_entry| {
-            var entry: string = if (comptime normalize_entry_point) bundler.normalizeEntryPointPath(_entry) else _entry;
+            const entry: string = if (comptime normalize_entry_point) bundler.normalizeEntryPointPath(_entry) else _entry;
 
             defer {
                 js_ast.Expr.Data.Store.reset();
@@ -1747,7 +1747,7 @@ pub const Bundler = struct {
             bundler.resolver.debug_logs = try DebugLogs.init(allocator);
         }
         bundler.options.transform_only = true;
-        var did_start = false;
+        const did_start = false;
 
         if (bundler.options.output_dir_handle == null) {
             const outstream = std.io.getStdOut();
@@ -1827,7 +1827,7 @@ pub const Bundler = struct {
             // defer count += 1;
 
             if (comptime wrap_entry_point) {
-                var path = item.pathConst() orelse unreachable;
+                const path = item.pathConst() orelse unreachable;
                 const loader = bundler.options.loader(path.name.ext);
 
                 if (item.import_kind == .entry_point and loader.supportsClientEntryPoint()) {

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -180,7 +180,7 @@ pub const ThreadPool = struct {
         {
             this.workers_assignments_lock.lock();
             defer this.workers_assignments_lock.unlock();
-            var entry = this.workers_assignments.getOrPut(id) catch unreachable;
+            const entry = this.workers_assignments.getOrPut(id) catch unreachable;
             if (entry.found_existing) {
                 return entry.value_ptr.*;
             }
@@ -383,7 +383,7 @@ pub const BundleV2 = struct {
                 const import_record_list_id = source_index;
                 // when there are no import records, v index will be invalid
                 if (import_record_list_id.get() < v.all_import_records.len) {
-                    var import_records = v.all_import_records[import_record_list_id.get()].slice();
+                    const import_records = v.all_import_records[import_record_list_id.get()].slice();
                     for (import_records) |*import_record| {
                         var other_source = import_record.source_index;
                         if (other_source.isValid()) {
@@ -484,7 +484,7 @@ pub const BundleV2 = struct {
         ) catch |err| {
             var handles_import_errors = false;
             var source: ?*const Logger.Source = null;
-            var log = &this.completion.?.log;
+            const log = &this.completion.?.log;
 
             if (import_record.importer_source_index) |importer| {
                 var record: *ImportRecord = &this.graph.ast.items(.import_records)[importer].slice()[import_record.import_record_index];
@@ -586,7 +586,7 @@ pub const BundleV2 = struct {
             }
         }
 
-        var entry = this.graph.path_to_source_index_map.getOrPut(this.graph.allocator, path.hashKey()) catch @panic("Ran out of memory");
+        const entry = this.graph.path_to_source_index_map.getOrPut(this.graph.allocator, path.hashKey()) catch @panic("Ran out of memory");
         if (!entry.found_existing) {
             path.* = path.dupeAlloc(this.graph.allocator) catch @panic("Ran out of memory");
 
@@ -651,7 +651,7 @@ pub const BundleV2 = struct {
 
         const loader = this.bundler.options.loaders.get(path.name.ext) orelse .file;
 
-        var entry = try this.graph.path_to_source_index_map.getOrPut(this.graph.allocator, hash orelse path.hashKey());
+        const entry = try this.graph.path_to_source_index_map.getOrPut(this.graph.allocator, hash orelse path.hashKey());
         if (entry.found_existing) {
             return null;
         }
@@ -713,7 +713,7 @@ pub const BundleV2 = struct {
         bundler.options.mark_builtins_as_external = bundler.options.target.isBun() or bundler.options.target == .node;
         bundler.resolver.opts.mark_builtins_as_external = bundler.options.target.isBun() or bundler.options.target == .node;
 
-        var this = generator;
+        const this = generator;
         generator.* = BundleV2{
             .bundler = bundler,
             .client_bundler = bundler,
@@ -853,7 +853,7 @@ pub const BundleV2 = struct {
         // TODO: make this not slow
         {
             // process redirects
-            var initial_reachable = try this.findReachableFiles();
+            const initial_reachable = try this.findReachableFiles();
             allocator.free(initial_reachable);
             this.dynamic_import_entry_points.deinit();
         }
@@ -1045,7 +1045,7 @@ pub const BundleV2 = struct {
 
         try this.cloneAST();
 
-        var chunks = try this.linker.link(
+        const chunks = try this.linker.link(
             this,
             this.graph.entry_points.items,
             this.graph.use_directive_entry_points,
@@ -1236,7 +1236,7 @@ pub const BundleV2 = struct {
                     );
                 },
                 .value => |*build| {
-                    var output_files: []options.OutputFile = build.output_files.items;
+                    const output_files: []options.OutputFile = build.output_files.items;
                     const output_files_js = JSC.JSValue.createEmptyArray(globalThis, output_files.len);
                     if (output_files_js == .zero) {
                         @panic("Unexpected pending JavaScript exception in JSBundleCompletionTask.onComplete. This is a bug in Bun.");
@@ -1446,7 +1446,7 @@ pub const BundleV2 = struct {
                         path.namespace = result.namespace;
                     }
 
-                    var existing = this.graph.path_to_source_index_map.getOrPut(this.graph.allocator, path.hashKey()) catch unreachable;
+                    const existing = this.graph.path_to_source_index_map.getOrPut(this.graph.allocator, path.hashKey()) catch unreachable;
                     if (!existing.found_existing) {
                         this.free_list.appendSlice(&.{ result.namespace, result.path }) catch {};
 
@@ -1552,7 +1552,7 @@ pub const BundleV2 = struct {
             while (instance.queue.pop()) |completion| {
                 generateInNewThread(completion, instance.generation) catch |err| {
                     completion.result = .{ .err = err };
-                    var concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch unreachable;
+                    const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch unreachable;
                     concurrent_task.* = JSC.ConcurrentTask{
                         .auto_delete = true,
                         .task = completion.task.task(),
@@ -1664,7 +1664,7 @@ pub const BundleV2 = struct {
             },
         };
 
-        var concurrent_task = try bun.default_allocator.create(JSC.ConcurrentTask);
+        const concurrent_task = try bun.default_allocator.create(JSC.ConcurrentTask);
         concurrent_task.* = JSC.ConcurrentTask{
             .auto_delete = true,
             .task = completion.task.task(),
@@ -1736,7 +1736,7 @@ pub const BundleV2 = struct {
 
         try this.processFilesToCopy(reachable_files);
 
-        var chunks = try this.linker.link(
+        const chunks = try this.linker.link(
             this,
             this.graph.entry_points.items,
             this.graph.use_directive_entry_points,
@@ -1974,7 +1974,7 @@ pub const BundleV2 = struct {
                 continue;
             }
 
-            var resolve_entry = resolve_queue.getOrPut(hash_key) catch @panic("Ran out of memory");
+            const resolve_entry = resolve_queue.getOrPut(hash_key) catch @panic("Ran out of memory");
             if (resolve_entry.found_existing) {
                 import_record.path = resolve_entry.value_ptr.*.path;
 
@@ -2486,12 +2486,12 @@ pub const ParseTask = struct {
                                 framework.resolved_dir,
                                 framework.override_modules.values[index],
                             };
-                            var override_path = bundler.fs.absBuf(
+                            const override_path = bundler.fs.absBuf(
                                 &relative_path,
                                 &override_file_path_buf,
                             );
                             override_file_path_buf[override_path.len] = 0;
-                            var override_pathZ = override_file_path_buf[0..override_path.len :0];
+                            const override_pathZ = override_file_path_buf[0..override_path.len :0];
                             debug("{s} -> {s}", .{ file_path.text, override_path });
                             break :brk try resolver.caches.fs.readFileWithAllocator(
                                 allocator,
@@ -2678,7 +2678,7 @@ pub const ParseTask = struct {
         var log = Logger.Log.init(worker.allocator);
         std.debug.assert(this.source_index.isValid()); // forgot to set source_index
 
-        var result = bun.default_allocator.create(Result) catch unreachable;
+        const result = bun.default_allocator.create(Result) catch unreachable;
         result.* = .{
             .value = brk: {
                 if (run_(
@@ -3145,7 +3145,7 @@ const LinkerGraph = struct {
                         break :brk out;
                     }
 
-                    var out = &self.graph.meta.items(.top_level_symbol_to_parts_overlay)[self.id];
+                    const out = &self.graph.meta.items(.top_level_symbol_to_parts_overlay)[self.id];
 
                     self.top_level_symbol_to_parts_overlay.* = out;
                     break :brk out;
@@ -3237,7 +3237,7 @@ const LinkerGraph = struct {
         // Pull in all parts that declare this symbol
         var dependencies = &part.dependencies;
         const part_ids = g.topLevelSymbolToParts(source_index_to_import_from.get(), ref);
-        var new_dependencies = try dependencies.writableSlice(g.allocator, part_ids.len);
+        const new_dependencies = try dependencies.writableSlice(g.allocator, part_ids.len);
         for (part_ids, new_dependencies) |part_id, *dependency| {
             dependency.* = .{
                 .source_index = source_index_to_import_from,
@@ -3277,7 +3277,7 @@ const LinkerGraph = struct {
 
         var entry_point_kinds = files.items(.entry_point_kind);
         {
-            var kinds = std.mem.sliceAsBytes(entry_point_kinds);
+            const kinds = std.mem.sliceAsBytes(entry_point_kinds);
             @memset(kinds, 0);
         }
 
@@ -3285,11 +3285,11 @@ const LinkerGraph = struct {
         {
             try this.entry_points.setCapacity(this.allocator, entry_points.len + use_directive_entry_points.len + dynamic_import_entry_points.len);
             this.entry_points.len = entry_points.len;
-            var source_indices = this.entry_points.items(.source_index);
+            const source_indices = this.entry_points.items(.source_index);
 
-            var path_strings: []bun.PathString = this.entry_points.items(.output_path);
+            const path_strings: []bun.PathString = this.entry_points.items(.output_path);
             {
-                var output_was_auto_generated = std.mem.sliceAsBytes(this.entry_points.items(.output_path_was_auto_generated));
+                const output_was_auto_generated = std.mem.sliceAsBytes(this.entry_points.items(.output_path_was_auto_generated));
                 @memset(output_was_auto_generated, 0);
             }
 
@@ -3455,8 +3455,8 @@ const LinkerGraph = struct {
             this.const_values = const_values;
         }
 
-        var in_resolved_exports: []ResolvedExports = this.meta.items(.resolved_exports);
-        var src_resolved_exports: []js_ast.Ast.NamedExports = this.ast.items(.named_exports);
+        const in_resolved_exports: []ResolvedExports = this.meta.items(.resolved_exports);
+        const src_resolved_exports: []js_ast.Ast.NamedExports = this.ast.items(.named_exports);
         for (src_resolved_exports, in_resolved_exports, 0..) |src, *dest, source_index| {
             var resolved = ResolvedExports{};
             resolved.ensureTotalCapacity(this.allocator, src.count()) catch unreachable;
@@ -3603,7 +3603,7 @@ const LinkerContext = struct {
 
         pub fn computeLineOffsets(this: *LinkerContext, allocator: std.mem.Allocator, source_index: Index.Int) void {
             debug("Computing LineOffsetTable: {d}", .{source_index});
-            var line_offset_table: *bun.sourcemap.LineOffsetTable.List = &this.graph.files.items(.line_offset_table)[source_index];
+            const line_offset_table: *bun.sourcemap.LineOffsetTable.List = &this.graph.files.items(.line_offset_table)[source_index];
 
             const source: *const Logger.Source = &this.parse_graph.input_files.items(.source)[source_index];
 
@@ -3620,10 +3620,10 @@ const LinkerContext = struct {
 
         pub fn computeQuotedSourceContents(this: *LinkerContext, allocator: std.mem.Allocator, source_index: Index.Int) void {
             debug("Computing Quoted Source Contents: {d}", .{source_index});
-            var quoted_source_contents: *string = &this.graph.files.items(.quoted_source_contents)[source_index];
+            const quoted_source_contents: *string = &this.graph.files.items(.quoted_source_contents)[source_index];
 
             const source: *const Logger.Source = &this.parse_graph.input_files.items(.source)[source_index];
-            var mutable = MutableString.initEmpty(allocator);
+            const mutable = MutableString.initEmpty(allocator);
             quoted_source_contents.* = (js_printer.quoteForJSON(source.contents, mutable, false) catch @panic("Out of memory")).list.items;
         }
     };
@@ -3805,7 +3805,7 @@ const LinkerContext = struct {
         defer trace.end();
 
         var stack_fallback = std.heap.stackFallback(4096, this.allocator);
-        var stack_all = stack_fallback.get();
+        const stack_all = stack_fallback.get();
         var arena = @import("root").bun.ArenaAllocator.init(stack_all);
         defer arena.deinit();
 
@@ -3824,7 +3824,7 @@ const LinkerContext = struct {
 
             // Create a chunk for the entry point here to ensure that the chunk is
             // always generated even if the resulting file is empty
-            var js_chunk_entry = try js_chunks.getOrPut(try temp_allocator.dupe(u8, entry_bits.bytes(this.graph.entry_points.len)));
+            const js_chunk_entry = try js_chunks.getOrPut(try temp_allocator.dupe(u8, entry_bits.bytes(this.graph.entry_points.len)));
 
             js_chunk_entry.value_ptr.* = .{
                 .entry_point = .{
@@ -3887,7 +3887,7 @@ const LinkerContext = struct {
 
         js_chunks.sort(strings.StringArrayByIndexSorter.init(try temp_allocator.dupe(string, js_chunks.keys())));
 
-        var chunks: []Chunk = js_chunks.values();
+        const chunks: []Chunk = js_chunks.values();
 
         var entry_point_chunk_indices: []u32 = this.graph.files.items(.entry_point_chunk_index);
         // Map from the entry point file to this chunk. We will need this later if
@@ -3971,7 +3971,7 @@ const LinkerContext = struct {
     ) !void {
         var chunk_order_array = try std.ArrayList(Chunk.Order).initCapacity(this.allocator, chunk.files_with_parts_in_chunk.count());
         defer chunk_order_array.deinit();
-        var distances = this.graph.files.items(.distance_from_entry_point);
+        const distances = this.graph.files.items(.distance_from_entry_point);
         for (chunk.files_with_parts_in_chunk.keys()) |source_index| {
             chunk_order_array.appendAssumeCapacity(
                 .{
@@ -4092,7 +4092,7 @@ const LinkerContext = struct {
                             part_index != js_ast.namespace_export_part_index and
                             v.c.shouldIncludePart(source_index, part))
                         {
-                            var js_parts = if (source_index == Index.runtime.value)
+                            const js_parts = if (source_index == Index.runtime.value)
                                 &v.parts_prefix
                             else
                                 &v.part_ranges;
@@ -4167,7 +4167,7 @@ const LinkerContext = struct {
             },
         }
 
-        var parts_in_chunk_order = try this.allocator.alloc(PartRange, visitor.part_ranges.items.len + visitor.parts_prefix.items.len);
+        const parts_in_chunk_order = try this.allocator.alloc(PartRange, visitor.part_ranges.items.len + visitor.parts_prefix.items.len);
         bun.concat(
             PartRange,
             parts_in_chunk_order,
@@ -4351,10 +4351,10 @@ const LinkerContext = struct {
             var named_imports: []js_ast.Ast.NamedImports = this.graph.ast.items(.named_imports);
             var flags: []JSMeta.Flags = this.graph.meta.items(.flags);
 
-            var export_star_import_records: [][]u32 = this.graph.ast.items(.export_star_import_records);
-            var exports_refs: []Ref = this.graph.ast.items(.exports_ref);
-            var module_refs: []Ref = this.graph.ast.items(.module_ref);
-            var ast_flags_list = this.graph.ast.items(.flags);
+            const export_star_import_records: [][]u32 = this.graph.ast.items(.export_star_import_records);
+            const exports_refs: []Ref = this.graph.ast.items(.exports_ref);
+            const module_refs: []Ref = this.graph.ast.items(.module_ref);
+            const ast_flags_list = this.graph.ast.items(.flags);
             var symbols = &this.graph.symbols;
             defer this.graph.symbols = symbols.*;
 
@@ -4367,7 +4367,7 @@ const LinkerContext = struct {
                 // does it have a JS AST?
                 if (!(id < import_records_list.len)) continue;
 
-                var import_records: []ImportRecord = import_records_list[id].slice();
+                const import_records: []ImportRecord = import_records_list[id].slice();
                 for (import_records) |record| {
                     if (!record.source_index.isValid()) {
                         continue;
@@ -4557,7 +4557,7 @@ const LinkerContext = struct {
                     // --
 
                     // Propagate exports for export star statements
-                    var export_star_ids = export_star_import_records[id];
+                    const export_star_ids = export_star_import_records[id];
                     if (export_star_ids.len > 0) {
                         if (export_star_ctx == null) {
                             export_star_ctx = ExportStarContext{
@@ -4680,7 +4680,7 @@ const LinkerContext = struct {
             var flags: []JSMeta.Flags = this.graph.meta.items(.flags);
             var ast_fields = this.graph.ast.slice();
 
-            var wrapper_refs = ast_fields.items(.wrapper_ref);
+            const wrapper_refs = ast_fields.items(.wrapper_ref);
             const exports_kind = ast_fields.items(.exports_kind);
             const exports_refs = ast_fields.items(.exports_ref);
             const module_refs = ast_fields.items(.module_ref);
@@ -4729,7 +4729,7 @@ const LinkerContext = struct {
                     break :brk count;
                 };
 
-                var string_buffer = this.allocator.alloc(u8, string_buffer_len) catch unreachable;
+                const string_buffer = this.allocator.alloc(u8, string_buffer_len) catch unreachable;
                 var builder = bun.StringBuilder{
                     .len = 0,
                     .cap = string_buffer.len,
@@ -4742,7 +4742,7 @@ const LinkerContext = struct {
                 // are necessary later. This is done now because the symbols map cannot be
                 // mutated later due to parallelism.
                 if (is_entry_point and this.options.output_format == .esm) {
-                    var copies = this.allocator.alloc(Ref, aliases.len) catch unreachable;
+                    const copies = this.allocator.alloc(Ref, aliases.len) catch unreachable;
 
                     for (aliases, copies) |alias, *copy| {
                         const original_name = builder.fmt("export_{}", .{strings.fmtIdentifier(alias)});
@@ -5102,7 +5102,7 @@ const LinkerContext = struct {
 
                         var happens_at_runtime = record.source_index.isInvalid() and (!is_entry_point or !output_format.keepES6ImportExportSyntax());
                         if (record.source_index.isValid()) {
-                            var other_source_index = record.source_index.get();
+                            const other_source_index = record.source_index.get();
                             const other_id = other_source_index;
                             std.debug.assert(@as(usize, @intCast(other_id)) < this.graph.meta.len);
                             const other_export_kind = exports_kind[other_id];
@@ -5287,8 +5287,8 @@ const LinkerContext = struct {
         }
 
         var declared_symbols = js_ast.DeclaredSymbol.List{};
-        var exports_ref = c.graph.ast.items(.exports_ref)[id];
-        var all_export_stmts: []js_ast.Stmt = stmts.head[0 .. @as(usize, @intFromBool(needs_exports_variable)) + @as(usize, @intFromBool(properties.items.len > 0))];
+        const exports_ref = c.graph.ast.items(.exports_ref)[id];
+        const all_export_stmts: []js_ast.Stmt = stmts.head[0 .. @as(usize, @intFromBool(needs_exports_variable)) + @as(usize, @intFromBool(properties.items.len > 0))];
         stmts.head = stmts.head[all_export_stmts.len..];
         var remaining_stmts = all_export_stmts;
         defer std.debug.assert(remaining_stmts.len == 0); // all must be used
@@ -5415,7 +5415,7 @@ const LinkerContext = struct {
 
         next_alias: while (alias_iter.next()) |entry| {
             var export_ = entry.value_ptr.*;
-            var alias = entry.key_ptr.*;
+            const alias = entry.key_ptr.*;
             const this_id = export_.data.source_index.get();
             var inner_count: usize = 0;
             // Re-exporting multiple symbols with the same name causes an ambiguous
@@ -5467,7 +5467,7 @@ const LinkerContext = struct {
         var local_dependencies = std.AutoHashMap(u32, u32).init(allocator_);
         defer local_dependencies.deinit();
         var parts = &c.graph.ast.items(.parts)[id];
-        var parts_slice: []js_ast.Part = parts.slice();
+        const parts_slice: []js_ast.Part = parts.slice();
         var named_imports: *js_ast.Ast.NamedImports = &c.graph.ast.items(.named_imports)[id];
         outer: for (parts_slice, 0..) |*part, part_index| {
 
@@ -5514,7 +5514,7 @@ const LinkerContext = struct {
                 }
             }
 
-            var symbol_uses = part.symbol_uses.keys();
+            const symbol_uses = part.symbol_uses.keys();
 
             // Now that we know this, we can determine cross-part dependencies
             for (symbol_uses, 0..) |ref, j| {
@@ -5525,7 +5525,7 @@ const LinkerContext = struct {
                 const other_parts = c.topLevelSymbolsToParts(id, ref);
 
                 for (other_parts) |other_part_index| {
-                    var local = local_dependencies.getOrPut(@as(u32, @intCast(other_part_index))) catch unreachable;
+                    const local = local_dependencies.getOrPut(@as(u32, @intCast(other_part_index))) catch unreachable;
                     if (!local.found_existing or local.value_ptr.* != part_index) {
                         local.value_ptr.* = @as(u32, @intCast(part_index));
                         // note: if we crash on append, it is due to threadlocal heaps in mimalloc
@@ -5588,12 +5588,12 @@ const LinkerContext = struct {
         const trace = tracer(@src(), "treeShakingAndCodeSplitting");
         defer trace.end();
 
-        var parts = c.graph.ast.items(.parts);
-        var import_records = c.graph.ast.items(.import_records);
-        var side_effects = c.parse_graph.input_files.items(.side_effects);
-        var entry_point_kinds = c.graph.files.items(.entry_point_kind);
+        const parts = c.graph.ast.items(.parts);
+        const import_records = c.graph.ast.items(.import_records);
+        const side_effects = c.parse_graph.input_files.items(.side_effects);
+        const entry_point_kinds = c.graph.files.items(.entry_point_kind);
         const entry_points = c.graph.entry_points.items(.source_index);
-        var distances = c.graph.files.items(.distance_from_entry_point);
+        const distances = c.graph.files.items(.distance_from_entry_point);
 
         {
             const trace2 = tracer(@src(), "markFileLiveForTreeShaking");
@@ -5614,7 +5614,7 @@ const LinkerContext = struct {
             const trace2 = tracer(@src(), "markFileReachableForCodeSplitting");
             defer trace2.end();
 
-            var file_entry_bits: []AutoBitSet = c.graph.files.items(.entry_bits);
+            const file_entry_bits: []AutoBitSet = c.graph.files.items(.entry_bits);
             // AutoBitSet needs to be initialized if it is dynamic
             if (AutoBitSet.needsDynamic(entry_points.len)) {
                 for (file_entry_bits) |*bits| {
@@ -5874,7 +5874,7 @@ const LinkerContext = struct {
             // tracked so we count them as dependencies of this chunk for the purpose
             // of hash calculation.
             if (chunk_meta.dynamic_imports.count() > 0) {
-                var dynamic_chunk_indices = chunk_meta.dynamic_imports.keys();
+                const dynamic_chunk_indices = chunk_meta.dynamic_imports.keys();
                 std.sort.block(Index.Int, dynamic_chunk_indices, {}, std.sort.asc(Index.Int));
 
                 var imports = chunk.cross_chunk_imports.listManaged(c.allocator);
@@ -5941,7 +5941,7 @@ const LinkerContext = struct {
 
                         if (clause_items.len > 0) {
                             var stmts = BabyList(js_ast.Stmt).initCapacity(c.allocator, 1) catch unreachable;
-                            var export_clause = c.allocator.create(js_ast.S.ExportClause) catch unreachable;
+                            const export_clause = c.allocator.create(js_ast.S.ExportClause) catch unreachable;
                             export_clause.* = .{
                                 .items = clause_items.slice(),
                                 .is_single_line = true,
@@ -5974,7 +5974,7 @@ const LinkerContext = struct {
                 var cross_chunk_prefix_stmts = BabyList(js_ast.Stmt){};
 
                 CrossChunkImport.sortedCrossChunkImports(&list, chunks, &repr.imports_from_other_chunks) catch unreachable;
-                var cross_chunk_imports_input: []CrossChunkImport = list.items;
+                const cross_chunk_imports_input: []CrossChunkImport = list.items;
                 var cross_chunk_imports = chunk.cross_chunk_imports;
                 for (cross_chunk_imports_input) |cross_chunk_import| {
                     switch (c.options.output_format) {
@@ -5997,7 +5997,7 @@ const LinkerContext = struct {
                                 .import_kind = .stmt,
                                 .chunk_index = cross_chunk_import.chunk_index,
                             }) catch unreachable;
-                            var import = c.allocator.create(js_ast.S.Import) catch unreachable;
+                            const import = c.allocator.create(js_ast.S.Import) catch unreachable;
                             import.* = .{
                                 .items = clauses.items,
                                 .import_record_index = import_record_index,
@@ -6029,7 +6029,7 @@ const LinkerContext = struct {
             return;
         }
 
-        var chunk_metas = try c.allocator.alloc(ChunkMeta, chunks.len);
+        const chunk_metas = try c.allocator.alloc(ChunkMeta, chunks.len);
         for (chunk_metas) |*meta| {
             // these must be global allocator
             meta.* = .{
@@ -6048,7 +6048,7 @@ const LinkerContext = struct {
         }
 
         {
-            var cross_chunk_dependencies = c.allocator.create(CrossChunkDependencies) catch unreachable;
+            const cross_chunk_dependencies = c.allocator.create(CrossChunkDependencies) catch unreachable;
             defer c.allocator.destroy(cross_chunk_dependencies);
 
             cross_chunk_dependencies.* = .{
@@ -6115,7 +6115,7 @@ const LinkerContext = struct {
         var sorted_imports_from_other_chunks: std.ArrayList(StableRef) = brk: {
             var list = std.ArrayList(StableRef).init(allocator);
             var count: u32 = 0;
-            var imports_from_other_chunks = chunk.content.javascript.imports_from_other_chunks.values();
+            const imports_from_other_chunks = chunk.content.javascript.imports_from_other_chunks.values();
             for (imports_from_other_chunks) |item| {
                 count += item.len;
             }
@@ -6156,7 +6156,7 @@ const LinkerContext = struct {
 
             var top_level_symbols_all = renamer.StableSymbolCount.Array.init(allocator);
 
-            var stable_source_indices = c.graph.stable_source_indices;
+            const stable_source_indices = c.graph.stable_source_indices;
             var freq = js_ast.CharFreq{
                 .freqs = [_]i32{0} ** 64,
             };
@@ -6771,13 +6771,13 @@ const LinkerContext = struct {
         }
         j.push("\n  ],\n  \"mappings\": \"");
 
-        var mapping_start = j.len;
+        const mapping_start = j.len;
         var prev_end_state = sourcemap.SourceMapState{};
         var prev_column_offset: i32 = 0;
         const source_map_chunks = results.items(.source_map_chunk);
         const offsets = results.items(.generated_offset);
         for (source_map_chunks, offsets, source_indices) |chunk, offset, current_source_index| {
-            var res = try source_index_to_sources_index.getOrPut(current_source_index);
+            const res = try source_index_to_sources_index.getOrPut(current_source_index);
             if (res.found_existing) continue;
             res.value_ptr.* = next_source_index;
             const source_index = @as(i32, @intCast(next_source_index));
@@ -7156,7 +7156,7 @@ const LinkerContext = struct {
 
                             if (flags.needs_synthetic_default_export and !had_default_export) {
                                 var properties = G.Property.List.initCapacity(allocator, items.items.len) catch unreachable;
-                                var getter_fn_body = allocator.alloc(Stmt, items.items.len) catch unreachable;
+                                const getter_fn_body = allocator.alloc(Stmt, items.items.len) catch unreachable;
                                 var remain_getter_fn_body = getter_fn_body;
                                 for (items.items) |export_item| {
                                     var fn_body = remain_getter_fn_body[0..1];
@@ -7876,7 +7876,7 @@ const LinkerContext = struct {
                         if (shouldStripExports) {
                             // Turn this statement into "import {foo} from 'path'"
                             // TODO: is this allocation necessary?
-                            var items = allocator.alloc(js_ast.ClauseItem, s.items.len) catch unreachable;
+                            const items = allocator.alloc(js_ast.ClauseItem, s.items.len) catch unreachable;
                             for (s.items, items) |src, *dest| {
                                 dest.* = .{
                                     .alias = src.original_name,
@@ -8118,7 +8118,7 @@ const LinkerContext = struct {
     ) js_printer.PrintResult {
 
         // var file = &c.graph.files.items(.input_file)[part.source_index.get()];
-        var parts: []js_ast.Part = c.graph.ast.items(.parts)[part_range.source_index.get()].slice()[part_range.part_index_begin..part_range.part_index_end];
+        const parts: []js_ast.Part = c.graph.ast.items(.parts)[part_range.source_index.get()].slice()[part_range.part_index_begin..part_range.part_index_end];
         // const resolved_exports: []ResolvedExports = c.graph.meta.items(.resolved_exports);
         const all_flags: []const JSMeta.Flags = c.graph.meta.items(.flags);
         const flags = all_flags[part_range.source_index.get()];
@@ -8231,7 +8231,7 @@ const LinkerContext = struct {
                 if (stmt.data != .s_export_default)
                     @panic("expected Lazy default export to be an export default statement");
 
-                var default_export = stmt.data.s_export_default;
+                const default_export = stmt.data.s_export_default;
                 var default_expr = default_export.value.expr;
 
                 // Be careful: the top-level value in a JSON file is not necessarily an object
@@ -8318,7 +8318,7 @@ const LinkerContext = struct {
         if (needs_wrapper) {
             switch (flags.wrap) {
                 .cjs => {
-                    var uses_exports_ref = ast.uses_exports_ref();
+                    const uses_exports_ref = ast.uses_exports_ref();
 
                     // Only include the arguments that are actually used
                     var args = std.ArrayList(js_ast.G.Arg).initCapacity(
@@ -8580,7 +8580,7 @@ const LinkerContext = struct {
             },
         };
 
-        var print_options = js_printer.Options{
+        const print_options = js_printer.Options{
             // TODO: IIFE
             .indent = 0,
 
@@ -8672,7 +8672,7 @@ const LinkerContext = struct {
                 c.allocator.destroy(wait_group);
             }
             wait_group.counter = @as(u32, @truncate(chunks.len));
-            var ctx = GenerateChunkCtx{ .chunk = &chunks[0], .wg = wait_group, .c = c, .chunks = chunks };
+            const ctx = GenerateChunkCtx{ .chunk = &chunks[0], .wg = wait_group, .c = c, .chunks = chunks };
             try c.parse_graph.pool.pool.doPtr(c.allocator, wait_group, ctx, generateJSRenamer, chunks);
         }
 
@@ -8684,7 +8684,7 @@ const LinkerContext = struct {
             c.source_maps.line_offset_tasks.len = 0;
         }
         {
-            var chunk_contexts = c.allocator.alloc(GenerateChunkCtx, chunks.len) catch unreachable;
+            const chunk_contexts = c.allocator.alloc(GenerateChunkCtx, chunks.len) catch unreachable;
             defer c.allocator.free(chunk_contexts);
             var wait_group = try c.allocator.create(sync.WaitGroup);
             wait_group.init();
@@ -8702,7 +8702,7 @@ const LinkerContext = struct {
 
                 debug(" START {d} compiling part ranges", .{total_count});
                 defer debug("  DONE {d} compiling part ranges", .{total_count});
-                var combined_part_ranges = c.allocator.alloc(PendingPartRange, total_count) catch unreachable;
+                const combined_part_ranges = c.allocator.alloc(PendingPartRange, total_count) catch unreachable;
                 defer c.allocator.free(combined_part_ranges);
                 var remaining_part_ranges = combined_part_ranges;
                 var batch = ThreadPoolLib.Batch{};
@@ -8765,10 +8765,10 @@ const LinkerContext = struct {
             }
         }
 
-        var react_client_components_manifest: []u8 = if (c.resolver.opts.react_server_components) brk: {
+        const react_client_components_manifest: []u8 = if (c.resolver.opts.react_server_components) brk: {
             var bytes = std.ArrayList(u8).init(c.allocator);
             defer bytes.deinit();
-            var all_sources = c.parse_graph.input_files.items(.source);
+            const all_sources = c.parse_graph.input_files.items(.source);
             var all_named_exports = c.graph.ast.items(.named_exports);
             var export_names = std.ArrayList(Api.StringPointer).init(c.allocator);
             defer export_names.deinit();
@@ -8816,7 +8816,7 @@ const LinkerContext = struct {
                 for (sorted_component_ids) |component_source_index| {
                     var source_index_for_named_exports = component_source_index;
 
-                    var chunk: *Chunk = brk2: {
+                    const chunk: *Chunk = brk2: {
                         for (chunks) |*chunk_| {
                             if (!chunk_.entry_point.is_entry_point) continue;
                             if (chunk_.entry_point.source_index == @as(u32, @intCast(component_source_index))) {
@@ -8957,7 +8957,7 @@ const LinkerContext = struct {
 
                 switch (c.options.source_maps) {
                     .external => {
-                        var output_source_map = chunk.output_source_map.finalize(bun.default_allocator, code_result.shifts) catch @panic("Failed to allocate memory for external source map");
+                        const output_source_map = chunk.output_source_map.finalize(bun.default_allocator, code_result.shifts) catch @panic("Failed to allocate memory for external source map");
                         var source_map_final_rel_path = default_allocator.alloc(u8, chunk.final_rel_path.len + ".map".len) catch unreachable;
                         bun.copy(u8, source_map_final_rel_path, chunk.final_rel_path);
                         bun.copy(u8, source_map_final_rel_path[chunk.final_rel_path.len..], ".map");
@@ -8980,7 +8980,7 @@ const LinkerContext = struct {
                         );
                     },
                     .@"inline" => {
-                        var output_source_map = chunk.output_source_map.finalize(bun.default_allocator, code_result.shifts) catch @panic("Failed to allocate memory for external source map");
+                        const output_source_map = chunk.output_source_map.finalize(bun.default_allocator, code_result.shifts) catch @panic("Failed to allocate memory for external source map");
                         const encode_len = base64.encodeLen(output_source_map);
 
                         const source_map_start = "//# sourceMappingURL=data:application/json;base64,";
@@ -9105,7 +9105,7 @@ const LinkerContext = struct {
             defer trace2.end();
             defer max_heap_allocator.reset();
 
-            var rel_path = chunk.final_rel_path;
+            const rel_path = chunk.final_rel_path;
             if (std.fs.path.dirname(rel_path)) |rel_parent| {
                 if (rel_parent.len > 0) {
                     root_dir.dir.makePath(rel_parent) catch |err| {
@@ -9151,7 +9151,7 @@ const LinkerContext = struct {
 
             switch (c.options.source_maps) {
                 .external => {
-                    var output_source_map = chunk.output_source_map.finalize(source_map_allocator, code_result.shifts) catch @panic("Failed to allocate memory for external source map");
+                    const output_source_map = chunk.output_source_map.finalize(source_map_allocator, code_result.shifts) catch @panic("Failed to allocate memory for external source map");
                     const source_map_final_rel_path = strings.concat(default_allocator, &.{
                         chunk.final_rel_path,
                         ".map",
@@ -9206,7 +9206,7 @@ const LinkerContext = struct {
                     );
                 },
                 .@"inline" => {
-                    var output_source_map = chunk.output_source_map.finalize(source_map_allocator, code_result.shifts) catch @panic("Failed to allocate memory for external source map");
+                    const output_source_map = chunk.output_source_map.finalize(source_map_allocator, code_result.shifts) catch @panic("Failed to allocate memory for external source map");
                     const encode_len = base64.encodeLen(output_source_map);
 
                     const source_map_start = "//# sourceMappingURL=data:application/json;base64,";
@@ -9550,7 +9550,7 @@ const LinkerContext = struct {
         const id = source_index;
         if (@as(usize, id) >= c.graph.ast.len)
             return;
-        var _parts = parts[id].slice();
+        const _parts = parts[id].slice();
         for (_parts, 0..) |part, part_index| {
             var can_be_removed_if_unused = part.can_be_removed_if_unused;
 
@@ -9872,9 +9872,9 @@ const LinkerContext = struct {
                             c.cycle_detector.clearRetainingCapacity();
                             c.swap_cycle_detector.clearRetainingCapacity();
 
-                            var old_cycle_detector = c.cycle_detector;
+                            const old_cycle_detector = c.cycle_detector;
                             c.cycle_detector = c.swap_cycle_detector;
-                            var ambig = c.matchImportWithExport(&ambiguous_tracker.data, re_exports);
+                            const ambig = c.matchImportWithExport(&ambiguous_tracker.data, re_exports);
                             c.cycle_detector.clearRetainingCapacity();
                             c.swap_cycle_detector = c.cycle_detector;
                             c.cycle_detector = old_cycle_detector;
@@ -9904,7 +9904,7 @@ const LinkerContext = struct {
                     // Depend on the statement(s) that declared this import symbol in the
                     // original file
                     {
-                        var deps = c.topLevelSymbolsToParts(other_id, tracker.import_ref);
+                        const deps = c.topLevelSymbolsToParts(other_id, tracker.import_ref);
                         re_exports.ensureUnusedCapacity(deps.len) catch unreachable;
                         for (deps) |dep| {
                             re_exports.appendAssumeCapacity(
@@ -9991,7 +9991,7 @@ const LinkerContext = struct {
 
                 for (common_js_parts) |part_id| {
                     var part: *js_ast.Part = &runtime_parts[part_id];
-                    var symbol_refs = part.symbol_uses.keys();
+                    const symbol_refs = part.symbol_uses.keys();
                     for (symbol_refs) |ref| {
                         if (ref.eql(c.cjs_runtime_ref)) continue;
                         total_dependencies_count += c.topLevelSymbolsToPartsForRuntime(ref).len;
@@ -9999,7 +9999,7 @@ const LinkerContext = struct {
                 }
 
                 // generate a dummy part that depends on the "__commonJS" symbol
-                var dependencies = c.allocator.alloc(js_ast.Dependency, common_js_parts.len) catch unreachable;
+                const dependencies = c.allocator.alloc(js_ast.Dependency, common_js_parts.len) catch unreachable;
                 for (common_js_parts, dependencies) |part, *cjs| {
                     cjs.* = .{
                         .part_index = part,
@@ -10053,7 +10053,7 @@ const LinkerContext = struct {
                 const esm_parts = c.topLevelSymbolsToPartsForRuntime(c.esm_runtime_ref);
 
                 // generate a dummy part that depends on the "__esm" symbol
-                var dependencies = c.allocator.alloc(js_ast.Dependency, esm_parts.len) catch unreachable;
+                const dependencies = c.allocator.alloc(js_ast.Dependency, esm_parts.len) catch unreachable;
                 for (esm_parts, dependencies) |part, *esm| {
                     esm.* = .{
                         .part_index = part,
@@ -10248,7 +10248,7 @@ const LinkerContext = struct {
                 return std.math.order(a_ref.innerIndex(), b_ref.innerIndex()) == .lt;
             }
         };
-        var sorter = Sorter{
+        const sorter = Sorter{
             .imports = &named_imports,
         };
         named_imports.sort(sorter);
@@ -10266,7 +10266,7 @@ const LinkerContext = struct {
                 },
             };
             var re_exports = std.ArrayList(js_ast.Dependency).init(c.allocator);
-            var result = c.matchImportWithExport(
+            const result = c.matchImportWithExport(
                 &import_tracker.data,
                 &re_exports,
             );
@@ -10849,7 +10849,7 @@ pub const Chunk = struct {
                     else
                         0;
 
-                    var total_buf = try (allocator_to_use orelse allocatorForSize(count)).alloc(u8, count + debug_id_len);
+                    const total_buf = try (allocator_to_use orelse allocatorForSize(count)).alloc(u8, count + debug_id_len);
                     var remain = total_buf;
 
                     for (pieces.slice()) |piece| {
@@ -10977,7 +10977,7 @@ pub const Chunk = struct {
             switch (this) {
                 .pieces => |*pieces| {
                     var count: usize = 0;
-                    var file_path_buf: [4096]u8 = undefined;
+                    const file_path_buf: [4096]u8 = undefined;
                     _ = file_path_buf;
                     var from_chunk_dir = std.fs.path.dirname(chunk.final_rel_path) orelse "";
                     if (strings.eqlComptime(from_chunk_dir, "."))
@@ -11018,7 +11018,7 @@ pub const Chunk = struct {
                     }
 
                     display_size.* = count;
-                    var total_buf = try (allocator_to_use orelse allocatorForSize(count)).alloc(u8, count);
+                    const total_buf = try (allocator_to_use orelse allocatorForSize(count)).alloc(u8, count);
                     var remain = total_buf;
 
                     for (pieces.slice()) |piece| {
@@ -11187,8 +11187,8 @@ pub const CrossChunkImport = struct {
         result.clearRetainingCapacity();
         try result.ensureTotalCapacity(imports_from_other_chunks.count());
 
-        var import_items_list = imports_from_other_chunks.values();
-        var chunk_indices = imports_from_other_chunks.keys();
+        const import_items_list = imports_from_other_chunks.values();
+        const chunk_indices = imports_from_other_chunks.keys();
         for (chunk_indices, import_items_list) |chunk_index, import_items| {
             var chunk = &chunks[chunk_index];
 

--- a/src/bundler/entry_points.zig
+++ b/src/bundler/entry_points.zig
@@ -94,7 +94,7 @@ pub const ClientEntryPoint = struct {
 
     pub fn decodeEntryPointPath(outbuffer: []u8, original_path: Fs.PathName) string {
         var joined_base_and_dir_parts = [_]string{ original_path.dir, original_path.base };
-        var generated_path = Fs.FileSystem.instance.absBuf(&joined_base_and_dir_parts, outbuffer);
+        const generated_path = Fs.FileSystem.instance.absBuf(&joined_base_and_dir_parts, outbuffer);
         var original_ext = original_path.ext;
         if (strings.indexOf(original_path.ext, "entry")) |entry_i| {
             original_ext = original_path.ext[entry_i + "entry".len ..];

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -295,7 +295,7 @@ pub const Bunfig = struct {
             if (comptime cmd.isNPMRelated() or cmd == .RunCommand or cmd == .AutoCommand) {
                 if (json.get("install")) |_bun| {
                     var install: *Api.BunInstall = this.ctx.install orelse brk: {
-                        var install_ = try this.allocator.create(Api.BunInstall);
+                        const install_ = try this.allocator.create(Api.BunInstall);
                         install_.* = std.mem.zeroes(Api.BunInstall);
                         this.ctx.install = install_;
                         break :brk install_;
@@ -692,7 +692,7 @@ pub const Bunfig = struct {
                 var loader_values = try this.allocator.alloc(Api.Loader, properties.len);
 
                 for (properties, 0..) |item, i| {
-                    var key = item.key.?.asString(allocator).?;
+                    const key = item.key.?.asString(allocator).?;
                     if (key.len == 0) continue;
                     if (key[0] != '.') {
                         try this.addError(item.key.?.loc, "file extension for loader must start with a '.'");
@@ -731,7 +731,7 @@ pub const Bunfig = struct {
     pub fn parse(allocator: std.mem.Allocator, source: logger.Source, ctx: *Command.Context, comptime cmd: Command.Tag) !void {
         const log_count = ctx.log.errors + ctx.log.warnings;
 
-        var expr = if (strings.eqlComptime(source.path.name.ext[1..], "toml")) TOML.parse(&source, ctx.log, allocator) catch |err| {
+        const expr = if (strings.eqlComptime(source.path.name.ext[1..], "toml")) TOML.parse(&source, ctx.log, allocator) catch |err| {
             if (ctx.log.errors + ctx.log.warnings == log_count) {
                 ctx.log.addErrorFmt(&source, logger.Loc.Empty, allocator, "Failed to parse", .{}) catch unreachable;
             }

--- a/src/c.zig
+++ b/src/c.zig
@@ -272,7 +272,7 @@ pub fn getSelfExeSharedLibPaths(allocator: std.mem.Allocator) error{OutOfMemory}
                 allocator.free(slice);
             }
 
-            var b = "/boot/system/runtime_loader";
+            const b = "/boot/system/runtime_loader";
             const item = try allocator.dupeZ(u8, mem.sliceTo(b, 0));
             errdefer allocator.free(item);
             try paths.append(item);

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -251,7 +251,7 @@ pub const Arguments = struct {
         };
 
         defer config_file.close();
-        var contents = config_file.readToEndAlloc(allocator, std.math.maxInt(usize)) catch |err| {
+        const contents = config_file.readToEndAlloc(allocator, std.math.maxInt(usize)) catch |err| {
             if (auto_loaded) return;
             Output.prettyErrorln("<r><red>error<r>: {s} reading config \"{s}\"", .{
                 @errorName(err),
@@ -266,7 +266,7 @@ pub const Arguments = struct {
             js_ast.Stmt.Data.Store.reset();
             js_ast.Expr.Data.Store.reset();
         }
-        var original_level = ctx.log.level;
+        const original_level = ctx.log.level;
         defer {
             ctx.log.level = original_level;
         }
@@ -321,7 +321,7 @@ pub const Arguments = struct {
         } else {
             if (ctx.args.absolute_working_dir == null) {
                 var secondbuf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                var cwd = bun.getcwd(&secondbuf) catch return;
+                const cwd = bun.getcwd(&secondbuf) catch return;
 
                 ctx.args.absolute_working_dir = try allocator.dupe(u8, cwd);
             }
@@ -464,7 +464,7 @@ pub const Arguments = struct {
 
         var opts: Api.TransformOptions = ctx.args;
 
-        var defines_tuple = try DefineColonList.resolve(allocator, args.options("--define"));
+        const defines_tuple = try DefineColonList.resolve(allocator, args.options("--define"));
 
         if (defines_tuple.keys.len > 0) {
             opts.define = .{
@@ -473,7 +473,7 @@ pub const Arguments = struct {
             };
         }
 
-        var loader_tuple = try LoaderColonList.resolve(allocator, args.options("--loader"));
+        const loader_tuple = try LoaderColonList.resolve(allocator, args.options("--loader"));
 
         if (loader_tuple.keys.len > 0) {
             opts.loaders = .{
@@ -587,8 +587,8 @@ pub const Arguments = struct {
             opts.origin = try std.fmt.allocPrint(allocator, "http://localhost:{d}/", .{opts.port.?});
         }
 
-        var output_dir: ?string = null;
-        var output_file: ?string = null;
+        const output_dir: ?string = null;
+        const output_file: ?string = null;
 
         if (cmd == .BuildCommand) {
             ctx.bundler_options.transform_only = args.flag("--no-bundle");
@@ -730,10 +730,10 @@ pub const Arguments = struct {
             opts.entry_points = entry_points;
         }
 
-        var jsx_factory = args.option("--jsx-factory");
-        var jsx_fragment = args.option("--jsx-fragment");
-        var jsx_import_source = args.option("--jsx-import-source");
-        var jsx_runtime = args.option("--jsx-runtime");
+        const jsx_factory = args.option("--jsx-factory");
+        const jsx_fragment = args.option("--jsx-fragment");
+        const jsx_import_source = args.option("--jsx-import-source");
+        const jsx_runtime = args.option("--jsx-runtime");
         const react_fast_refresh = true;
 
         if (cmd == .AutoCommand or cmd == .RunCommand) {
@@ -1284,7 +1284,7 @@ pub const Command = struct {
                 };
 
                 ctx.args.target = Api.Target.bun;
-                var argv = try bun.default_allocator.alloc(string, bun.argv().len -| 1);
+                const argv = try bun.default_allocator.alloc(string, bun.argv().len -| 1);
                 if (bun.argv().len > 1) {
                     for (argv, bun.argv()[1..]) |*dest, src| {
                         dest.* = bun.span(src);
@@ -1522,10 +1522,10 @@ pub const Command = struct {
                 var positional_i: usize = 0;
 
                 if (args.len > 2) {
-                    var remainder = args[2..];
+                    const remainder = args[2..];
                     var remainder_i: usize = 0;
                     while (remainder_i < remainder.len and positional_i < positionals.len) : (remainder_i += 1) {
-                        var slice = std.mem.trim(u8, bun.asByteSlice(remainder[remainder_i]), " \t\n;");
+                        const slice = std.mem.trim(u8, bun.asByteSlice(remainder[remainder_i]), " \t\n;");
                         if (slice.len > 0 and !strings.hasPrefixComptime(slice, "--")) {
                             if (positional_i == 0) {
                                 template_name_start = remainder_i + 2;
@@ -1574,7 +1574,7 @@ pub const Command = struct {
 
                 const create_command_info = try CreateCommand.extractInfo(ctx);
                 const template = create_command_info.template;
-                var example_tag = create_command_info.example_tag;
+                const example_tag = create_command_info.example_tag;
 
                 const use_bunx = !HardcodedNonBunXList.has(template_name) and
                     (!strings.containsComptime(template_name, "/") or
@@ -1775,7 +1775,7 @@ pub const Command = struct {
                 );
                 if (file_path.len == 0) return false;
                 script_name_buf[file_path.len] = 0;
-                var file_pathZ = script_name_buf[0..file_path.len :0];
+                const file_pathZ = script_name_buf[0..file_path.len :0];
                 break :brk bun.openFileZ(file_pathZ, .{ .mode = .read_only });
             }
         };
@@ -1785,7 +1785,7 @@ pub const Command = struct {
         Global.configureAllocator(.{ .long_running = true });
 
         // the case where this doesn't work is if the script name on disk doesn't end with a known JS-like file extension
-        var absolute_script_path = bun.getFdPath(file.handle, &script_name_buf) catch return false;
+        const absolute_script_path = bun.getFdPath(file.handle, &script_name_buf) catch return false;
 
         if (!ctx.debug.loaded_bunfig) {
             bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", ctx, .RunCommand) catch {};

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -40,7 +40,7 @@ pub const BuildCommand = struct {
     ) !void {
         Global.configureAllocator(.{ .long_running = true });
         var ctx = ctx_;
-        var allocator = ctx.allocator;
+        const allocator = ctx.allocator;
         var log = ctx.log;
         estimated_input_lines_of_code_ = 0;
         if (ctx.bundler_options.compile) {
@@ -309,13 +309,13 @@ pub const BuildCommand = struct {
                             unreachable;
                         };
 
-                    var all_paths = try ctx.allocator.alloc([]const u8, output_files.len);
+                    const all_paths = try ctx.allocator.alloc([]const u8, output_files.len);
                     var max_path_len: usize = 0;
                     for (all_paths, output_files) |*dest, src| {
                         dest.* = src.dest_path;
                     }
 
-                    var from_path = resolve_path.longestCommonPath(all_paths);
+                    const from_path = resolve_path.longestCommonPath(all_paths);
 
                     for (output_files) |f| {
                         max_path_len = @max(

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -80,7 +80,7 @@ pub const BunxCommand = struct {
                 if (bin_prop.expr.asString(bundler.allocator)) |dir_name| {
                     const bin_dir = try std.os.openat(dir_fd, dir_name, std.os.O.RDONLY, 0);
                     defer std.os.close(bin_dir);
-                    var dir = std.fs.Dir{ .fd = bin_dir };
+                    const dir = std.fs.Dir{ .fd = bin_dir };
                     var iterator = @import("../bun.js/node/dir_iterator.zig").iterate(dir);
                     var entry = iterator.next();
                     while (true) : (entry = iterator.next()) {
@@ -109,13 +109,13 @@ pub const BunxCommand = struct {
         subpath["node_modules/".len + package_name.len + 1 ..][0.."package.json".len].* = "package.json".*;
         subpath["node_modules/".len + package_name.len + 1 + "package.json".len] = 0;
 
-        var subpath_z: [:0]const u8 = subpath[0 .. "node_modules/".len + package_name.len + 1 + "package.json".len :0];
+        const subpath_z: [:0]const u8 = subpath[0 .. "node_modules/".len + package_name.len + 1 + "package.json".len :0];
         return try getBinNameFromSubpath(bundler, dir_fd, subpath_z);
     }
 
     fn getBinNameFromTempDirectory(bundler: *bun.Bundler, tempdir_name: []const u8, package_name: []const u8) ![]const u8 {
         var subpath: [bun.MAX_PATH_BYTES]u8 = undefined;
-        var subpath_z = std.fmt.bufPrintZ(
+        const subpath_z = std.fmt.bufPrintZ(
             &subpath,
             "{s}/node_modules/{s}/package.json",
             .{ tempdir_name, package_name },
@@ -190,7 +190,7 @@ pub const BunxCommand = struct {
             exit_with_usage();
         }
 
-        var update_requests = bun.PackageManager.UpdateRequest.parse(
+        const update_requests = bun.PackageManager.UpdateRequest.parse(
             ctx.allocator,
             ctx.log,
             &package_name_for_update_request,
@@ -363,14 +363,14 @@ pub const BunxCommand = struct {
             }
         }
 
-        var bunx_install_dir_path = try std.fmt.allocPrint(
+        const bunx_install_dir_path = try std.fmt.allocPrint(
             ctx.allocator,
             bun.fs.FileSystem.RealFS.PLATFORM_TMP_DIR ++ "/{s}--bunx",
             .{package_fmt},
         );
 
         // TODO: fix this after zig upgrade
-        var bunx_install_iterable_dir = try std.fs.cwd().makeOpenPathIterable(bunx_install_dir_path, .{});
+        const bunx_install_iterable_dir = try std.fs.cwd().makeOpenPathIterable(bunx_install_dir_path, .{});
         var bunx_install_dir = bunx_install_iterable_dir.dir;
 
         create_package_json: {

--- a/src/cli/colon_list_type.zig
+++ b/src/cli/colon_list_type.zig
@@ -13,8 +13,8 @@ const std = @import("std");
 pub fn ColonListType(comptime t: type, comptime value_resolver: anytype) type {
     return struct {
         pub fn init(allocator: std.mem.Allocator, count: usize) !@This() {
-            var keys = try allocator.alloc(string, count);
-            var values = try allocator.alloc(t, count);
+            const keys = try allocator.alloc(string, count);
+            const values = try allocator.alloc(t, count);
 
             return @This(){ .keys = keys, .values = values };
         }

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -245,7 +245,7 @@ pub const CreateCommand = struct {
 
         var filesystem = try fs.FileSystem.init(null);
         var env_loader: DotEnv.Loader = brk: {
-            var map = try ctx.allocator.create(DotEnv.Map);
+            const map = try ctx.allocator.create(DotEnv.Map);
             map.* = DotEnv.Map.init(ctx.allocator);
 
             break :brk DotEnv.Loader.init(map, ctx.allocator);
@@ -289,7 +289,7 @@ pub const CreateCommand = struct {
 
         switch (example_tag) {
             Example.Tag.github_repository, Example.Tag.official => {
-                var tarball_bytes: MutableString = switch (example_tag) {
+                const tarball_bytes: MutableString = switch (example_tag) {
                     .official => Example.fetch(ctx, &env_loader, template, &progress, node) catch |err| {
                         switch (err) {
                             error.HTTPForbidden, error.ExampleNotFound => {
@@ -357,7 +357,7 @@ pub const CreateCommand = struct {
 
                 progress.refresh();
 
-                var file_buf = try ctx.allocator.alloc(u8, 16384);
+                const file_buf = try ctx.allocator.alloc(u8, 16384);
 
                 var tarball_buf_list = std.ArrayListUnmanaged(u8){ .capacity = file_buf.len, .items = file_buf };
                 var gunzip = try Zlib.ZlibReaderArrayList.init(tarball_bytes.list.items, &tarball_buf_list, ctx.allocator);
@@ -432,7 +432,7 @@ pub const CreateCommand = struct {
                 );
 
                 if (!create_options.skip_package_json) {
-                    var plucker = pluckers[0];
+                    const plucker = pluckers[0];
 
                     if (plucker.found and plucker.fd != 0) {
                         node.name = "Updating package.json";
@@ -574,9 +574,9 @@ pub const CreateCommand = struct {
         node.end();
         progress.refresh();
 
-        var is_nextjs = false;
-        var is_create_react_app = false;
-        var create_react_app_entry_point_path: string = "";
+        const is_nextjs = false;
+        const is_create_react_app = false;
+        const create_react_app_entry_point_path: string = "";
         var preinstall_tasks = std.mem.zeroes(std.ArrayListUnmanaged([]const u8));
         var postinstall_tasks = std.mem.zeroes(std.ArrayListUnmanaged([]const u8));
         var has_dependencies: bool = false;
@@ -623,7 +623,7 @@ pub const CreateCommand = struct {
                     break :process_package_json;
                 }
 
-                var properties_list = std.ArrayList(js_ast.G.Property).fromOwnedSlice(default_allocator, package_json_expr.data.e_object.properties.slice());
+                const properties_list = std.ArrayList(js_ast.G.Property).fromOwnedSlice(default_allocator, package_json_expr.data.e_object.properties.slice());
 
                 if (ctx.log.errors > 0) {
                     if (Output.enable_ansi_colors) {
@@ -638,7 +638,7 @@ pub const CreateCommand = struct {
 
                 if (package_json_expr.asProperty("name")) |name_expr| {
                     if (name_expr.expr.data == .e_string) {
-                        var basename = std.fs.path.basename(destination);
+                        const basename = std.fs.path.basename(destination);
                         name_expr.expr.data.e_string.data = @as([*]u8, @ptrFromInt(@intFromPtr(basename.ptr)))[0..basename.len];
                     }
                 }
@@ -1346,7 +1346,7 @@ pub const CreateCommand = struct {
                     package_json_expr.data.e_object.properties = js_ast.G.Property.List.init(package_json_expr.data.e_object.properties.ptr[0..property_i]);
                 }
 
-                var package_json_writer = JSPrinter.NewFileWriter(package_json_file.?);
+                const package_json_writer = JSPrinter.NewFileWriter(package_json_file.?);
 
                 const written = JSPrinter.printJSON(@TypeOf(package_json_writer), package_json_writer, package_json_expr, &source) catch |err| {
                     Output.prettyErrorln("package.json failed to write due to error {s}", .{@errorName(err)});
@@ -1567,11 +1567,11 @@ pub const CreateCommand = struct {
         var example_tag = Example.Tag.unknown;
         var filesystem = try fs.FileSystem.init(null);
 
-        var create_options = try CreateOptions.parse(ctx);
+        const create_options = try CreateOptions.parse(ctx);
         const positionals = create_options.positionals;
 
         var env_loader: DotEnv.Loader = brk: {
-            var map = try ctx.allocator.create(DotEnv.Map);
+            const map = try ctx.allocator.create(DotEnv.Map);
             map.* = DotEnv.Map.init(ctx.allocator);
 
             break :brk DotEnv.Loader.init(map, ctx.allocator);
@@ -1587,9 +1587,9 @@ pub const CreateCommand = struct {
                 outer: {
                     if (env_loader.map.get("BUN_CREATE_DIR")) |home_dir| {
                         var parts = [_]string{ home_dir, positional };
-                        var outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
+                        const outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
                         home_dir_buf[outdir_path.len] = 0;
-                        var outdir_path_ = home_dir_buf[0..outdir_path.len :0];
+                        const outdir_path_ = home_dir_buf[0..outdir_path.len :0];
                         std.fs.accessAbsoluteZ(outdir_path_, .{}) catch break :outer;
                         example_tag = Example.Tag.local_folder;
                         break :brk outdir_path;
@@ -1598,9 +1598,9 @@ pub const CreateCommand = struct {
 
                 outer: {
                     var parts = [_]string{ filesystem.top_level_dir, BUN_CREATE_DIR, positional };
-                    var outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
+                    const outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
                     home_dir_buf[outdir_path.len] = 0;
-                    var outdir_path_ = home_dir_buf[0..outdir_path.len :0];
+                    const outdir_path_ = home_dir_buf[0..outdir_path.len :0];
                     std.fs.accessAbsoluteZ(outdir_path_, .{}) catch break :outer;
                     example_tag = Example.Tag.local_folder;
                     break :brk outdir_path;
@@ -1609,9 +1609,9 @@ pub const CreateCommand = struct {
                 outer: {
                     if (env_loader.map.get("HOME")) |home_dir| {
                         var parts = [_]string{ home_dir, BUN_CREATE_DIR, positional };
-                        var outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
+                        const outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
                         home_dir_buf[outdir_path.len] = 0;
-                        var outdir_path_ = home_dir_buf[0..outdir_path.len :0];
+                        const outdir_path_ = home_dir_buf[0..outdir_path.len :0];
                         std.fs.accessAbsoluteZ(outdir_path_, .{}) catch break :outer;
                         example_tag = Example.Tag.local_folder;
                         break :brk outdir_path;
@@ -1699,7 +1699,7 @@ pub const Example = struct {
     var app_name_buf: [512]u8 = undefined;
     pub fn print(examples: []const Example, default_app_name: ?string) void {
         for (examples) |example| {
-            var app_name = default_app_name orelse (std.fmt.bufPrint(&app_name_buf, "./{s}-app", .{example.name[0..@min(example.name.len, 492)]}) catch unreachable);
+            const app_name = default_app_name orelse (std.fmt.bufPrint(&app_name_buf, "./{s}-app", .{example.name[0..@min(example.name.len, 492)]}) catch unreachable);
 
             if (example.description.len > 0) {
                 Output.pretty("  <r># {s}<r>\n  <b>bun create <cyan>{s}<r><b> {s}<r>\n<d>  \n\n", .{
@@ -1733,19 +1733,19 @@ pub const Example = struct {
             };
             if (env_loader.map.get("BUN_CREATE_DIR")) |home_dir| {
                 var parts = [_]string{home_dir};
-                var outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
+                const outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
                 folders[0] = std.fs.cwd().openIterableDir(outdir_path, .{}) catch .{ .dir = .{ .fd = bun.fdcast(bun.invalid_fd) } };
             }
 
             {
                 var parts = [_]string{ filesystem.top_level_dir, BUN_CREATE_DIR };
-                var outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
+                const outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
                 folders[1] = std.fs.cwd().openIterableDir(outdir_path, .{}) catch .{ .dir = .{ .fd = bun.fdcast(bun.invalid_fd) } };
             }
 
             if (env_loader.map.get(bun.DotEnv.home_env)) |home_dir| {
                 var parts = [_]string{ home_dir, BUN_CREATE_DIR };
-                var outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
+                const outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
                 folders[2] = std.fs.cwd().openIterableDir(outdir_path, .{}) catch .{ .dir = .{ .fd = bun.fdcast(bun.invalid_fd) } };
             }
 
@@ -1773,7 +1773,7 @@ pub const Example = struct {
                                 bun.copy(u8, home_dir_buf[entry.name.len + 1 ..], "package.json");
                                 home_dir_buf[entry.name.len + 1 + "package.json".len] = 0;
 
-                                var path: [:0]u8 = home_dir_buf[0 .. entry.name.len + 1 + "package.json".len :0];
+                                const path: [:0]u8 = home_dir_buf[0 .. entry.name.len + 1 + "package.json".len :0];
 
                                 folder.accessZ(path, .{ .mode = .read_only }) catch continue :loop;
 
@@ -1805,8 +1805,8 @@ pub const Example = struct {
         refresher: *std.Progress,
         progress: *std.Progress.Node,
     ) !MutableString {
-        var owner_i = std.mem.indexOfScalar(u8, name, '/').?;
-        var owner = name[0..owner_i];
+        const owner_i = std.mem.indexOfScalar(u8, name, '/').?;
+        const owner = name[0..owner_i];
         var repository = name[owner_i + 1 ..];
 
         if (std.mem.indexOfScalar(u8, repository, '/')) |i| {
@@ -1823,7 +1823,7 @@ pub const Example = struct {
             }
         }
 
-        var api_url = URL.parse(
+        const api_url = URL.parse(
             try std.fmt.bufPrint(
                 &github_repository_url_buf,
                 "https://{s}/repos/{s}/{s}/tarball",
@@ -1853,8 +1853,8 @@ pub const Example = struct {
             }
         }
 
-        var http_proxy: ?URL = env_loader.getHttpProxy(api_url);
-        var mutable = try ctx.allocator.create(MutableString);
+        const http_proxy: ?URL = env_loader.getHttpProxy(api_url);
+        const mutable = try ctx.allocator.create(MutableString);
         mutable.* = try MutableString.init(ctx.allocator, 8096);
 
         // ensure very stable memory address
@@ -2064,10 +2064,10 @@ pub const Example = struct {
     pub fn fetchAll(ctx: Command.Context, env_loader: *DotEnv.Loader, progress_node: ?*std.Progress.Node) ![]Example {
         url = URL.parse(examples_url);
 
-        var http_proxy: ?URL = env_loader.getHttpProxy(url);
+        const http_proxy: ?URL = env_loader.getHttpProxy(url);
 
         var async_http: *HTTP.AsyncHTTP = ctx.allocator.create(HTTP.AsyncHTTP) catch unreachable;
-        var mutable = try ctx.allocator.create(MutableString);
+        const mutable = try ctx.allocator.create(MutableString);
         mutable.* = try MutableString.init(ctx.allocator, 2048);
 
         async_http.* = HTTP.AsyncHTTP.initSync(
@@ -2159,9 +2159,9 @@ pub const Example = struct {
 
 pub const CreateListExamplesCommand = struct {
     pub fn exec(ctx: Command.Context) !void {
-        var filesystem = try fs.FileSystem.init(null);
+        const filesystem = try fs.FileSystem.init(null);
         var env_loader: DotEnv.Loader = brk: {
-            var map = try ctx.allocator.create(DotEnv.Map);
+            const map = try ctx.allocator.create(DotEnv.Map);
             map.* = DotEnv.Map.init(ctx.allocator);
 
             break :brk DotEnv.Loader.init(map, ctx.allocator);
@@ -2170,7 +2170,7 @@ pub const CreateListExamplesCommand = struct {
         env_loader.loadProcess();
 
         var progress = std.Progress{};
-        var node = progress.start("Fetching manifest", 0);
+        const node = progress.start("Fetching manifest", 0);
         progress.supports_ansi_escape_codes = Output.enable_ansi_colors_stderr;
         progress.refresh();
 

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -329,7 +329,7 @@ pub const InitCommand = struct {
             if (package_json_file == null) {
                 package_json_file = try std.fs.cwd().createFileZ("package.json", .{});
             }
-            var package_json_writer = JSPrinter.NewFileWriter(package_json_file.?);
+            const package_json_writer = JSPrinter.NewFileWriter(package_json_file.?);
 
             const written = JSPrinter.printJSON(
                 @TypeOf(package_json_writer),

--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -58,7 +58,7 @@ pub const InstallCompletionsCommand = struct {
             return;
 
         // first try installing the symlink into the same directory as the bun executable
-        var exe = try std.fs.selfExePathAlloc(allocator);
+        const exe = try std.fs.selfExePathAlloc(allocator);
         var target_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
         var target = std.fmt.bufPrint(&target_buf, "{s}/" ++ bunx_name, .{std.fs.path.dirname(exe).?}) catch unreachable;
         std.os.symlink(exe, target) catch {
@@ -106,7 +106,7 @@ pub const InstallCompletionsCommand = struct {
             shell = ShellCompletions.Shell.fromEnv(@TypeOf(shell_name), shell_name);
         }
 
-        var cwd = bun.getcwd(&cwd_buf) catch {
+        const cwd = bun.getcwd(&cwd_buf) catch {
             // don't fail on this if we don't actually need to
             if (fail_exit_code == 1) {
                 if (!stdout.isTty()) {
@@ -385,7 +385,7 @@ pub const InstallCompletionsCommand = struct {
         // Check if they need to load the zsh completions file into their .zshrc
         if (shell == .zsh) {
             var completions_absolute_path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-            var completions_path = bun.getFdPath(output_file.handle, &completions_absolute_path_buf) catch unreachable;
+            const completions_path = bun.getFdPath(output_file.handle, &completions_absolute_path_buf) catch unreachable;
             var zshrc_filepath: [bun.MAX_PATH_BYTES]u8 = undefined;
             const needs_to_tell_them_to_add_completions_file = brk: {
                 var dot_zshrc: std.fs.File = zshrc: {
@@ -403,7 +403,7 @@ pub const InstallCompletionsCommand = struct {
                             bun.copy(u8, &zshrc_filepath, zdot_dir);
                             bun.copy(u8, zshrc_filepath[zdot_dir.len..], "/.zshrc");
                             zshrc_filepath[zdot_dir.len + "/.zshrc".len] = 0;
-                            var filepath = zshrc_filepath[0 .. zdot_dir.len + "/.zshrc".len :0];
+                            const filepath = zshrc_filepath[0 .. zdot_dir.len + "/.zshrc".len :0];
                             break :zshrc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :first;
                         }
                     }
@@ -413,7 +413,7 @@ pub const InstallCompletionsCommand = struct {
                             bun.copy(u8, &zshrc_filepath, zdot_dir);
                             bun.copy(u8, zshrc_filepath[zdot_dir.len..], "/.zshrc");
                             zshrc_filepath[zdot_dir.len + "/.zshrc".len] = 0;
-                            var filepath = zshrc_filepath[0 .. zdot_dir.len + "/.zshrc".len :0];
+                            const filepath = zshrc_filepath[0 .. zdot_dir.len + "/.zshrc".len :0];
                             break :zshrc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :second;
                         }
                     }
@@ -423,7 +423,7 @@ pub const InstallCompletionsCommand = struct {
                             bun.copy(u8, &zshrc_filepath, zdot_dir);
                             bun.copy(u8, zshrc_filepath[zdot_dir.len..], "/.zshenv");
                             zshrc_filepath[zdot_dir.len + "/.zshenv".len] = 0;
-                            var filepath = zshrc_filepath[0 .. zdot_dir.len + "/.zshenv".len :0];
+                            const filepath = zshrc_filepath[0 .. zdot_dir.len + "/.zshenv".len :0];
                             break :zshrc std.fs.openFileAbsoluteZ(filepath, .{ .mode = .read_write }) catch break :third;
                         }
                     }
@@ -442,7 +442,7 @@ pub const InstallCompletionsCommand = struct {
                     0,
                 ) catch break :brk true;
 
-                var contents = buf[0..read];
+                const contents = buf[0..read];
 
                 // Do they possibly have it in the file already?
                 if (std.mem.indexOf(u8, contents, completions_path) != null) {
@@ -452,8 +452,8 @@ pub const InstallCompletionsCommand = struct {
                 // Okay, we need to add it
 
                 // We need to add it to the end of the file
-                var remaining = buf[read..];
-                var extra = std.fmt.bufPrint(remaining, "\n# bun completions\n[ -s \"{s}\" ] && source \"{s}\"\n", .{
+                const remaining = buf[read..];
+                const extra = std.fmt.bufPrint(remaining, "\n# bun completions\n[ -s \"{s}\" ] && source \"{s}\"\n", .{
                     completions_path,
                     completions_path,
                 }) catch unreachable;

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -49,7 +49,7 @@ pub const PackageManagerCommand = struct {
         var lockfile_buffer: [bun.MAX_PATH_BYTES]u8 = undefined;
         @memcpy(lockfile_buffer[0..lockfile_.len], lockfile_);
         lockfile_buffer[lockfile_.len] = 0;
-        var lockfile = lockfile_buffer[0..lockfile_.len :0];
+        const lockfile = lockfile_buffer[0..lockfile_.len :0];
         var pm = try PackageManager.init(ctx, PackageManager.Subcommand.pm);
 
         const load_lockfile = pm.lockfile.loadFromDisk(ctx.allocator, ctx.log, lockfile);
@@ -122,7 +122,7 @@ pub const PackageManagerCommand = struct {
         }
 
         if (strings.eqlComptime(subcommand, "bin")) {
-            var output_path = Path.joinAbs(Fs.FileSystem.instance.top_level_dir, .auto, bun.asByteSlice(pm.options.bin_path));
+            const output_path = Path.joinAbs(Fs.FileSystem.instance.top_level_dir, .auto, bun.asByteSlice(pm.options.bin_path));
             Output.prettyln("{s}", .{output_path});
             if (Output.stdout_descriptor_type == .terminal) {
                 Output.prettyln("\n", .{});
@@ -175,8 +175,8 @@ pub const PackageManagerCommand = struct {
             Global.exit(0);
         } else if (strings.eqlComptime(subcommand, "cache")) {
             var dir: [bun.MAX_PATH_BYTES]u8 = undefined;
-            var fd = pm.getCacheDirectory();
-            var outpath = bun.getFdPath(fd.dir.fd, &dir) catch |err| {
+            const fd = pm.getCacheDirectory();
+            const outpath = bun.getFdPath(fd.dir.fd, &dir) catch |err| {
                 Output.prettyErrorln("{s} getting cache directory", .{@errorName(err)});
                 Global.crash();
             };
@@ -376,7 +376,7 @@ fn printNodeModulesFolderStructure(
     for (sorted_dependencies, 0..) |dependency_id, index| {
         const package_name = dependencies[dependency_id].name.slice(string_bytes);
 
-        var possible_path = try std.fmt.allocPrint(allocator, "{s}/{s}/node_modules", .{ directory.relative_path, package_name });
+        const possible_path = try std.fmt.allocPrint(allocator, "{s}/{s}/node_modules", .{ directory.relative_path, package_name });
         defer allocator.free(possible_path);
 
         if (index + 1 == sorted_dependencies.len) {

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -238,7 +238,7 @@ pub const RunCommand = struct {
     ) !bool {
         const shell_bin = findShell(env.map.get("PATH") orelse "", cwd) orelse return error.MissingShell;
 
-        var script = original_script;
+        const script = original_script;
         var copy_script = try std.ArrayList(u8).initCapacity(allocator, script.len);
 
         // We're going to do this slowly.
@@ -259,7 +259,7 @@ pub const RunCommand = struct {
             bun.copy(u8, combined_script_buf, script);
             var remaining_script_buf = combined_script_buf[script.len..];
             for (passthrough) |part| {
-                var p = part;
+                const p = part;
                 remaining_script_buf[0] = ' ';
                 bun.copy(u8, remaining_script_buf[1..], p);
                 remaining_script_buf = remaining_script_buf[p.len + 1 ..];
@@ -403,7 +403,7 @@ pub const RunCommand = struct {
     }
 
     pub fn ls(ctx: Command.Context) !void {
-        var args = ctx.args;
+        const args = ctx.args;
 
         var this_bundler = try bundler.Bundler.init(ctx.allocator, ctx.log, args, null);
         this_bundler.options.env.behavior = Api.DotEnvBehavior.load_all;
@@ -490,7 +490,7 @@ pub const RunCommand = struct {
         log_errors: bool,
         force_using_bun: bool,
     ) !*DirInfo {
-        var args = ctx.args;
+        const args = ctx.args;
         this_bundler.* = try bundler.Bundler.init(ctx.allocator, ctx.log, args, env);
         this_bundler.options.env.behavior = Api.DotEnvBehavior.load_all;
         this_bundler.env.quiet = true;
@@ -552,7 +552,7 @@ pub const RunCommand = struct {
             }
         }
 
-        var bin_dirs = this_bundler.resolver.binDirs();
+        const bin_dirs = this_bundler.resolver.binDirs();
 
         if (root_dir_info.enclosing_package_json) |package_json| {
             if (root_dir_info.package_json == null) {
@@ -681,7 +681,7 @@ pub const RunCommand = struct {
             }
         }
 
-        var args = ctx.args;
+        const args = ctx.args;
 
         var this_bundler = bundler.Bundler.init(ctx.allocator, ctx.log, args, null) catch return shell_out;
         this_bundler.options.env.behavior = Api.DotEnvBehavior.load_all;
@@ -697,7 +697,7 @@ pub const RunCommand = struct {
         }
         this_bundler.configureLinker();
 
-        var root_dir_info = (this_bundler.resolver.readDirInfo(this_bundler.fs.top_level_dir) catch null) orelse return shell_out;
+        const root_dir_info = (this_bundler.resolver.readDirInfo(this_bundler.fs.top_level_dir) catch null) orelse return shell_out;
 
         {
             this_bundler.env.loadProcess();
@@ -749,7 +749,7 @@ pub const RunCommand = struct {
                                 const base = value.base();
                                 bun.copy(u8, path_buf[dir_slice.len..], base);
                                 path_buf[dir_slice.len + base.len] = 0;
-                                var slice = path_buf[0 .. dir_slice.len + base.len :0];
+                                const slice = path_buf[0 .. dir_slice.len + base.len :0];
                                 if (!(bun.sys.isExecutableFilePath(slice))) continue;
                                 // we need to dupe because the string pay point to a pointer that only exists in the current scope
                                 _ = try results.getOrPut(this_bundler.fs.filename_store.append(@TypeOf(base), base) catch continue);
@@ -814,7 +814,7 @@ pub const RunCommand = struct {
                             continue :loop;
                         }
 
-                        var entry_item = results.getOrPutAssumeCapacity(key);
+                        const entry_item = results.getOrPutAssumeCapacity(key);
 
                         if (filter == Filter.script_and_descriptions and max_description_len > 0) {
                             var description = scripts.get(key).?;
@@ -864,7 +864,7 @@ pub const RunCommand = struct {
             }
         }
 
-        var all_keys = results.keys();
+        const all_keys = results.keys();
 
         strings.sortAsc(all_keys);
         shell_out.commands = all_keys;
@@ -1008,7 +1008,7 @@ pub const RunCommand = struct {
                             );
                             if (file_path.len == 0) break :possibly_open_with_bun_js;
                             path_buf2[file_path.len] = 0;
-                            var file_pathZ = path_buf2[0..file_path.len :0];
+                            const file_pathZ = path_buf2[0..file_path.len :0];
                             break :brk bun.openFileZ(file_pathZ, .{ .mode = .read_only });
                         }
                     };
@@ -1051,7 +1051,7 @@ pub const RunCommand = struct {
                     }
 
                     Global.configureAllocator(.{ .long_running = true });
-                    var out_path = ctx.allocator.dupe(u8, file_path) catch unreachable;
+                    const out_path = ctx.allocator.dupe(u8, file_path) catch unreachable;
                     if (must_normalize) {
                         if (comptime Environment.isWindows) {
                             std.mem.replaceScalar(u8, out_path, std.fs.path.sep_windows, std.fs.path.sep_posix);
@@ -1080,7 +1080,7 @@ pub const RunCommand = struct {
 
         var ORIGINAL_PATH: string = "";
         var this_bundler: bundler.Bundler = undefined;
-        var root_dir_info = try configureEnvForRun(ctx, &this_bundler, null, &ORIGINAL_PATH, log_errors, force_using_bun);
+        const root_dir_info = try configureEnvForRun(ctx, &this_bundler, null, &ORIGINAL_PATH, log_errors, force_using_bun);
         this_bundler.env.map.put("npm_lifecycle_event", script_name_to_search) catch unreachable;
         if (root_dir_info.enclosing_package_json) |package_json| {
             if (package_json.scripts) |scripts| {

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -116,7 +116,7 @@ pub const CommandLineReporter = struct {
             parent_ = scope.parent;
         }
 
-        var scopes: []*jest.DescribeScope = scopes_stack.slice();
+        const scopes: []*jest.DescribeScope = scopes_stack.slice();
 
         const display_label = if (label.len > 0) label else "test";
 
@@ -165,7 +165,7 @@ pub const CommandLineReporter = struct {
     }
 
     pub fn handleTestPass(cb: *TestRunner.Callback, id: Test.ID, _: string, label: string, expectations: u32, elapsed_ns: u64, parent: ?*jest.DescribeScope) void {
-        var writer_: std.fs.File.Writer = Output.errorWriter();
+        const writer_: std.fs.File.Writer = Output.errorWriter();
         var buffered_writer = std.io.bufferedWriter(writer_);
         var writer = buffered_writer.writer();
         defer buffered_writer.flush() catch unreachable;
@@ -275,7 +275,7 @@ pub const CommandLineReporter = struct {
 
         while (iter.next()) |entry| {
             const value: bun.sourcemap.ByteRangeMapping = entry.*;
-            var utf8 = value.source_url.slice();
+            const utf8 = value.source_url.slice();
             byte_ranges.appendAssumeCapacity(value);
             max_filepath_length = @max(bun.path.relative(relative_dir, utf8).len, max_filepath_length);
         }
@@ -288,7 +288,7 @@ pub const CommandLineReporter = struct {
 
         iter = map.valueIterator();
         var writer = Output.errorWriter();
-        var base_fraction = opts.fractions;
+        const base_fraction = opts.fractions;
         var failing = false;
 
         writer.writeAll(Output.prettyFmt("<r><d>", enable_ansi_colors)) catch return;
@@ -383,7 +383,7 @@ const Scanner = struct {
     }
 
     pub fn scan(this: *Scanner, path_literal: string) void {
-        var parts = &[_]string{ this.fs.top_level_dir, path_literal };
+        const parts = &[_]string{ this.fs.top_level_dir, path_literal };
         const path = this.fs.absBuf(parts, &this.scan_dir_buf);
 
         var root = this.readDirWithName(path, null) catch |err| {
@@ -409,14 +409,14 @@ const Scanner = struct {
         }
 
         while (this.dirs_to_scan.readItem()) |entry| {
-            var dir = std.fs.Dir{ .fd = bun.fdcast(entry.relative_dir) };
+            const dir = std.fs.Dir{ .fd = bun.fdcast(entry.relative_dir) };
             std.debug.assert(bun.toFD(dir.fd) != bun.invalid_fd);
 
-            var parts2 = &[_]string{ entry.dir_path, entry.name.slice() };
+            const parts2 = &[_]string{ entry.dir_path, entry.name.slice() };
             var path2 = this.fs.absBuf(parts2, &this.open_dir_buf);
             this.open_dir_buf[path2.len] = 0;
-            var pathZ = this.open_dir_buf[path2.len - entry.name.slice().len .. path2.len :0];
-            var child_dir = bun.openDir(dir, pathZ) catch continue;
+            const pathZ = this.open_dir_buf[path2.len - entry.name.slice().len .. path2.len :0];
+            const child_dir = bun.openDir(dir, pathZ) catch continue;
             path2 = this.fs.dirname_store.append(string, path2) catch unreachable;
             FileSystem.setMaxFd(child_dir.dir.fd);
             _ = this.readDirWithName(path2, child_dir.dir) catch continue;
@@ -532,7 +532,7 @@ const Scanner = struct {
                 this.search_count += 1;
                 if (!this.couldBeTestFile(name)) return;
 
-                var parts = &[_]string{ entry.dir, entry.base() };
+                const parts = &[_]string{ entry.dir, entry.base() };
                 const path = this.fs.absBuf(parts, &this.open_dir_buf);
 
                 if (!this.doesAbsolutePathMatchFilter(path)) {
@@ -566,11 +566,11 @@ pub const TestCommand = struct {
         Output.prettyErrorln("<r><b>bun test <r><d>v" ++ Global.package_json_version_with_sha ++ "<r>", .{});
         Output.flush();
 
-        var env_loader = brk: {
-            var map = try ctx.allocator.create(DotEnv.Map);
+        const env_loader = brk: {
+            const map = try ctx.allocator.create(DotEnv.Map);
             map.* = DotEnv.Map.init(ctx.allocator);
 
-            var loader = try ctx.allocator.create(DotEnv.Loader);
+            const loader = try ctx.allocator.create(DotEnv.Loader);
             loader.* = DotEnv.Loader.init(map, ctx.allocator);
             break :brk loader;
         };
@@ -862,10 +862,10 @@ pub const TestCommand = struct {
             files: []const PathString,
             allocator: std.mem.Allocator,
             pub fn begin(this: *@This()) void {
-                var reporter = this.reporter;
-                var vm = this.vm;
+                const reporter = this.reporter;
+                const vm = this.vm;
                 var files = this.files;
-                var allocator = this.allocator;
+                const allocator = this.allocator;
                 std.debug.assert(files.len > 0);
 
                 if (files.len > 1) {
@@ -913,8 +913,8 @@ pub const TestCommand = struct {
             Output.flush();
         }
 
-        var file_start = reporter.jest.files.len;
-        var resolution = try vm.bundler.resolveEntryPoint(file_name);
+        const file_start = reporter.jest.files.len;
+        const resolution = try vm.bundler.resolveEntryPoint(file_name);
         vm.clearEntryPoint();
 
         const file_path = resolution.path_pair.primary.text;
@@ -925,7 +925,7 @@ pub const TestCommand = struct {
         // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
         const file_prefix = if (Output.is_github_action) "::group::" else "";
 
-        var repeat_count = reporter.repeat_count;
+        const repeat_count = reporter.repeat_count;
         var repeat_index: u32 = 0;
         while (repeat_index < repeat_count) : (repeat_index += 1) {
             if (repeat_count > 1) {
@@ -940,7 +940,7 @@ pub const TestCommand = struct {
 
             switch (promise.status(vm.global.vm())) {
                 .Rejected => {
-                    var result = promise.result(vm.global.vm());
+                    const result = promise.result(vm.global.vm());
                     vm.runErrorHandler(result, null);
                     reporter.summary.fail += 1;
 

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -201,7 +201,7 @@ pub const UpgradeCommand = struct {
             }
         }
 
-        var api_url = URL.parse(
+        const api_url = URL.parse(
             try std.fmt.bufPrint(
                 &github_repository_url_buf,
                 "https://{s}/repos/Jarred-Sumner/bun-releases-for-updater/releases/latest",
@@ -230,7 +230,7 @@ pub const UpgradeCommand = struct {
             }
         }
 
-        var http_proxy: ?URL = env_loader.getHttpProxy(api_url);
+        const http_proxy: ?URL = env_loader.getHttpProxy(api_url);
 
         var metadata_body = try MutableString.init(allocator, 2048);
 
@@ -427,7 +427,7 @@ pub const UpgradeCommand = struct {
 
         var filesystem = try fs.FileSystem.init(null);
         var env_loader: DotEnv.Loader = brk: {
-            var map = try ctx.allocator.create(DotEnv.Map);
+            const map = try ctx.allocator.create(DotEnv.Map);
             map.* = DotEnv.Map.init(ctx.allocator);
 
             break :brk DotEnv.Loader.init(map, ctx.allocator);
@@ -492,8 +492,8 @@ pub const UpgradeCommand = struct {
             };
         }
 
-        var zip_url = URL.parse(version.zip_url);
-        var http_proxy: ?URL = env_loader.getHttpProxy(zip_url);
+        const zip_url = URL.parse(version.zip_url);
+        const http_proxy: ?URL = env_loader.getHttpProxy(zip_url);
 
         {
             var refresher = std.Progress{};
@@ -559,18 +559,18 @@ pub const UpgradeCommand = struct {
             const version_name = version.name().?;
 
             var save_dir_ = filesystem.tmpdir();
-            var save_dir_it = save_dir_.makeOpenPathIterable(version_name, .{}) catch {
+            const save_dir_it = save_dir_.makeOpenPathIterable(version_name, .{}) catch {
                 Output.prettyErrorln("<r><red>error:<r> Failed to open temporary directory", .{});
                 Global.exit(1);
             };
             const save_dir = save_dir_it.dir;
-            var tmpdir_path = bun.getFdPath(save_dir.fd, &tmpdir_path_buf) catch {
+            const tmpdir_path = bun.getFdPath(save_dir.fd, &tmpdir_path_buf) catch {
                 Output.prettyErrorln("<r><red>error:<r> Failed to read temporary directory", .{});
                 Global.exit(1);
             };
 
             tmpdir_path_buf[tmpdir_path.len] = 0;
-            var tmpdir_z = tmpdir_path_buf[0..tmpdir_path.len :0];
+            const tmpdir_z = tmpdir_path_buf[0..tmpdir_path.len :0];
             _ = bun.sys.chdir(tmpdir_z);
 
             const tmpname = "bun.zip";
@@ -633,7 +633,7 @@ pub const UpgradeCommand = struct {
                     }
                 } else if (Environment.isWindows) {
                     // Run a powershell script to unzip the file
-                    var unzip_script = try std.fmt.allocPrint(
+                    const unzip_script = try std.fmt.allocPrint(
                         ctx.allocator,
                         "Expand-Archive -Path {s} {s} -Force",
                         .{
@@ -717,16 +717,16 @@ pub const UpgradeCommand = struct {
                 }
             }
 
-            var destination_executable_ = std.fs.selfExePath(&current_executable_buf) catch return error.UpgradeFailedMissingExecutable;
+            const destination_executable_ = std.fs.selfExePath(&current_executable_buf) catch return error.UpgradeFailedMissingExecutable;
             current_executable_buf[destination_executable_.len] = 0;
 
-            var target_filename_ = std.fs.path.basename(destination_executable_);
-            var target_filename = current_executable_buf[destination_executable_.len - target_filename_.len ..][0..target_filename_.len :0];
-            var target_dir_ = std.fs.path.dirname(destination_executable_) orelse return error.UpgradeFailedBecauseOfMissingExecutableDir;
+            const target_filename_ = std.fs.path.basename(destination_executable_);
+            const target_filename = current_executable_buf[destination_executable_.len - target_filename_.len ..][0..target_filename_.len :0];
+            const target_dir_ = std.fs.path.dirname(destination_executable_) orelse return error.UpgradeFailedBecauseOfMissingExecutableDir;
             // safe because the slash will no longer be in use
             current_executable_buf[target_dir_.len] = 0;
-            var target_dirname = current_executable_buf[0..target_dir_.len :0];
-            var target_dir_it = std.fs.openIterableDirAbsoluteZ(target_dirname, .{}) catch |err| {
+            const target_dirname = current_executable_buf[0..target_dir_.len :0];
+            const target_dir_it = std.fs.openIterableDirAbsoluteZ(target_dirname, .{}) catch |err| {
                 save_dir_.deleteTree(version_name) catch {};
                 Output.prettyErrorln("<r><red>error:<r> Failed to open Bun's install directory {s}", .{@errorName(err)});
                 Global.exit(1);
@@ -749,7 +749,7 @@ pub const UpgradeCommand = struct {
                 };
 
                 if (target_stat.size == dest_stat.size and target_stat.size > 0) {
-                    var input_buf = try ctx.allocator.alloc(u8, target_stat.size);
+                    const input_buf = try ctx.allocator.alloc(u8, target_stat.size);
 
                     const target_hash = bun.hash(target_dir.readFile(target_filename, input_buf) catch |err| {
                         save_dir_.deleteTree(version_name) catch {};
@@ -872,7 +872,7 @@ pub const UpgradeCommand = struct {
             if (Environment.isWindows) {
                 if (outdated_filename) |to_remove| {
                     current_executable_buf[target_dir_.len] = '\\';
-                    var delete_old_script = try std.fmt.allocPrint(
+                    const delete_old_script = try std.fmt.allocPrint(
                         ctx.allocator,
                         // What is this?
                         // 1. spawns powershell

--- a/src/comptime_string_map.zig
+++ b/src/comptime_string_map.zig
@@ -439,7 +439,7 @@ const TestEnum2 = enum {
 };
 
 pub fn compareString(input: []const u8) !void {
-    var str = try std.heap.page_allocator.dupe(u8, input);
+    const str = try std.heap.page_allocator.dupe(u8, input);
     if (TestEnum2.map.has(str) != TestEnum2.official.has(str)) {
         std.debug.panic("{s} - TestEnum2.map.has(str) ({d}) != TestEnum2.official.has(str) ({d})", .{
             str,

--- a/src/css_scanner.zig
+++ b/src/css_scanner.zig
@@ -281,7 +281,7 @@ pub const Scanner = struct {
                 '\\' => {
                     text.needs_decode_escape = true;
                     if (!scanner.isValidEscape()) {
-                        var loc = logger.Loc{
+                        const loc = logger.Loc{
                             .start = @as(i32, @intCast(scanner.end)),
                         };
                         scanner.log.addError(scanner.source, loc, "Expected \")\" to end URL token") catch {};
@@ -411,7 +411,7 @@ pub const Scanner = struct {
                             continue :toplevel;
                         }
 
-                        var url_start = scanner.end;
+                        const url_start = scanner.end;
                         scanner.step();
                         switch (scanner.codepoint) {
                             'r', 'R' => {},
@@ -505,7 +505,7 @@ pub const Scanner = struct {
                                     scanner.step();
                                 }
 
-                                var word = scanner.source.contents[word_start..scanner.end];
+                                const word = scanner.source.contents[word_start..scanner.end];
 
                                 while (switch (scanner.codepoint) {
                                     ' ', '\n', '\r' => true,
@@ -675,7 +675,7 @@ pub const Scanner = struct {
                             },
                         }
 
-                        var suffix_start = scanner.end;
+                        const suffix_start = scanner.end;
 
                         get_suffix: while (true) {
                             switch (scanner.codepoint) {
@@ -751,7 +751,7 @@ pub const Scanner = struct {
     pub fn consumeEscape(scanner: *Scanner) CodePoint {
         scanner.step();
 
-        var c = scanner.codepoint;
+        const c = scanner.codepoint;
 
         if (isHex(c)) |__hex| {
             var hex = __hex;
@@ -1273,7 +1273,7 @@ pub fn NewBundler(
             const watcher_index = this.watcher.indexOf(hash);
 
             if (watcher_index == null) {
-                var file = try std.fs.openFileAbsolute(absolute_path, .{ .mode = .read_only });
+                const file = try std.fs.openFileAbsolute(absolute_path, .{ .mode = .read_only });
 
                 try this.watcher.appendFile(file.handle, absolute_path, hash, .css, 0, null, true);
                 if (this.watcher.watchloop_handle == null) {

--- a/src/defines.zig
+++ b/src/defines.zig
@@ -50,7 +50,7 @@ pub const DefineData = struct {
 
     // True if a call to this value is known to not have any side effects. For
     // example, a bare call to "Object()" can be removed because it does not
-    // have any observable side effects.
+    // have any observable side effects.`
     call_can_be_unwrapped_if_unused: bool = false,
 
     pub fn isUndefined(self: *const DefineData) bool {
@@ -113,7 +113,7 @@ pub const DefineData = struct {
                 // );
                 continue;
             }
-            var _log = log;
+            const _log = log;
             var source = logger.Source{
                 .contents = entry.value_ptr.*,
                 .path = defines_path,
@@ -223,7 +223,7 @@ pub const Define = struct {
                 var initial_values: []DotDefine = &([_]DotDefine{});
 
                 // "NODE_ENV"
-                var gpe_entry = try define.dots.getOrPut(tail);
+                const gpe_entry = try define.dots.getOrPut(tail);
 
                 if (gpe_entry.found_existing) {
                     for (gpe_entry.value_ptr.*) |*part| {
@@ -271,7 +271,7 @@ pub const Define = struct {
         // Step 1. Load the globals into the hash tables
         for (GlobalDefinesKey) |global| {
             const key = global[global.len - 1];
-            var gpe = try define.dots.getOrPut(key);
+            const gpe = try define.dots.getOrPut(key);
             if (gpe.found_existing) {
                 var list = try std.ArrayList(DotDefine).initCapacity(allocator, gpe.value_ptr.*.len + 1);
                 list.appendSliceAssumeCapacity(gpe.value_ptr.*);

--- a/src/deps/boringssl.translated.zig
+++ b/src/deps/boringssl.translated.zig
@@ -691,114 +691,114 @@ pub const sk_void_free_func = ?*const fn (?*anyopaque) callconv(.C) void;
 pub const sk_void_copy_func = ?*const fn (?*anyopaque) callconv(.C) ?*anyopaque;
 pub const sk_void_cmp_func = ?*const fn ([*c]?*const anyopaque, [*c]?*const anyopaque) callconv(.C) c_int;
 pub fn sk_void_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_void_free_func, @ptrCast(@alignCast(free_func))).?(ptr);
 }
 pub fn sk_void_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(sk_void_copy_func, @ptrCast(@alignCast(copy_func))).?(ptr);
 }
 pub fn sk_void_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const anyopaque = a.*;
     var b_ptr: ?*const anyopaque = b.*;
     return @as(sk_void_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_void_new(arg_comp: sk_void_cmp_func) callconv(.C) ?*struct_stack_st_void {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_void, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_void_new_null() callconv(.C) ?*struct_stack_st_void {
     return @as(?*struct_stack_st_void, @ptrCast(sk_new_null()));
 }
 pub fn sk_void_num(arg_sk: ?*const struct_stack_st_void) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_void_zero(arg_sk: ?*struct_stack_st_void) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_void_value(arg_sk: ?*const struct_stack_st_void, arg_i: usize) callconv(.C) ?*anyopaque {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @alignCast(@ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_void_set(arg_sk: ?*struct_stack_st_void, arg_i: usize, arg_p: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, p);
 }
 pub fn sk_void_free(arg_sk: ?*struct_stack_st_void) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_void_pop_free(arg_sk: ?*struct_stack_st_void, arg_free_func: sk_void_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_void_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_void_insert(arg_sk: ?*struct_stack_st_void, arg_p: ?*anyopaque, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), p, where);
 }
 pub fn sk_void_delete(arg_sk: ?*struct_stack_st_void, arg_where: usize) callconv(.C) ?*anyopaque {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where);
 }
 pub fn sk_void_delete_ptr(arg_sk: ?*struct_stack_st_void, arg_p: ?*const anyopaque) callconv(.C) ?*anyopaque {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), p);
 }
 pub fn sk_void_find(arg_sk: ?*const struct_stack_st_void, arg_out_index: [*c]usize, arg_p: ?*const anyopaque) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, p, &sk_void_call_cmp_func);
 }
 pub fn sk_void_shift(arg_sk: ?*struct_stack_st_void) callconv(.C) ?*anyopaque {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_void_push(arg_sk: ?*struct_stack_st_void, arg_p: ?*anyopaque) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), p);
 }
 pub fn sk_void_pop(arg_sk: ?*struct_stack_st_void) callconv(.C) ?*anyopaque {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_void_dup(arg_sk: ?*const struct_stack_st_void) callconv(.C) ?*struct_stack_st_void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_void, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_void_sort(arg_sk: ?*struct_stack_st_void) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_void_call_cmp_func);
 }
 pub fn sk_void_is_sorted(arg_sk: ?*const struct_stack_st_void) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_void_set_cmp_func(arg_sk: ?*struct_stack_st_void, arg_comp: sk_void_cmp_func) callconv(.C) sk_void_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_void_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_void_deep_copy(arg_sk: ?*const struct_stack_st_void, arg_copy_func: sk_void_copy_func, arg_free_func: sk_void_free_func) callconv(.C) ?*struct_stack_st_void {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_void, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_void_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_void_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub const struct_stack_st_OPENSSL_STRING = opaque {};
@@ -806,114 +806,114 @@ pub const sk_OPENSSL_STRING_free_func = ?*const fn ([*c]u8) callconv(.C) void;
 pub const sk_OPENSSL_STRING_copy_func = ?*const fn ([*c]u8) callconv(.C) [*c]u8;
 pub const sk_OPENSSL_STRING_cmp_func = ?*const fn ([*c][*c]const u8, [*c][*c]const u8) callconv(.C) c_int;
 pub fn sk_OPENSSL_STRING_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_OPENSSL_STRING_free_func, @ptrCast(@alignCast(free_func))).?(@as([*c]u8, @ptrCast(@alignCast(ptr))));
 }
 pub fn sk_OPENSSL_STRING_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_OPENSSL_STRING_copy_func, @ptrCast(@alignCast(copy_func))).?(@as([*c]u8, @ptrCast(@alignCast(ptr))))));
 }
 pub fn sk_OPENSSL_STRING_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: [*c]const u8 = @as([*c]const u8, @ptrCast(@alignCast(a.*)));
     var b_ptr: [*c]const u8 = @as([*c]const u8, @ptrCast(@alignCast(b.*)));
     return @as(sk_OPENSSL_STRING_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_OPENSSL_STRING_new(arg_comp: sk_OPENSSL_STRING_cmp_func) callconv(.C) ?*struct_stack_st_OPENSSL_STRING {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_OPENSSL_STRING, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_OPENSSL_STRING_new_null() callconv(.C) ?*struct_stack_st_OPENSSL_STRING {
     return @as(?*struct_stack_st_OPENSSL_STRING, @ptrCast(sk_new_null()));
 }
 pub fn sk_OPENSSL_STRING_num(arg_sk: ?*const struct_stack_st_OPENSSL_STRING) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_OPENSSL_STRING_zero(arg_sk: ?*struct_stack_st_OPENSSL_STRING) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_OPENSSL_STRING_value(arg_sk: ?*const struct_stack_st_OPENSSL_STRING, arg_i: usize) callconv(.C) [*c]u8 {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as([*c]u8, @ptrCast(@alignCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i))));
 }
 pub fn sk_OPENSSL_STRING_set(arg_sk: ?*struct_stack_st_OPENSSL_STRING, arg_i: usize, arg_p: [*c]u8) callconv(.C) [*c]u8 {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as([*c]u8, @ptrCast(@alignCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p))))));
 }
 pub fn sk_OPENSSL_STRING_free(arg_sk: ?*struct_stack_st_OPENSSL_STRING) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_OPENSSL_STRING_pop_free(arg_sk: ?*struct_stack_st_OPENSSL_STRING, arg_free_func: sk_OPENSSL_STRING_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_OPENSSL_STRING_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_OPENSSL_STRING_insert(arg_sk: ?*struct_stack_st_OPENSSL_STRING, arg_p: [*c]u8, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_OPENSSL_STRING_delete(arg_sk: ?*struct_stack_st_OPENSSL_STRING, arg_where: usize) callconv(.C) [*c]u8 {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as([*c]u8, @ptrCast(@alignCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where))));
 }
 pub fn sk_OPENSSL_STRING_delete_ptr(arg_sk: ?*struct_stack_st_OPENSSL_STRING, arg_p: [*c]const u8) callconv(.C) [*c]u8 {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as([*c]u8, @ptrCast(@alignCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p))))));
 }
 pub fn sk_OPENSSL_STRING_find(arg_sk: ?*const struct_stack_st_OPENSSL_STRING, arg_out_index: [*c]usize, arg_p: [*c]const u8) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_OPENSSL_STRING_call_cmp_func);
 }
 pub fn sk_OPENSSL_STRING_shift(arg_sk: ?*struct_stack_st_OPENSSL_STRING) callconv(.C) [*c]u8 {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]u8, @ptrCast(@alignCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_OPENSSL_STRING_push(arg_sk: ?*struct_stack_st_OPENSSL_STRING, arg_p: [*c]u8) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_OPENSSL_STRING_pop(arg_sk: ?*struct_stack_st_OPENSSL_STRING) callconv(.C) [*c]u8 {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]u8, @ptrCast(@alignCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_OPENSSL_STRING_dup(arg_sk: ?*const struct_stack_st_OPENSSL_STRING) callconv(.C) ?*struct_stack_st_OPENSSL_STRING {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_OPENSSL_STRING, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_OPENSSL_STRING_sort(arg_sk: ?*struct_stack_st_OPENSSL_STRING) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_OPENSSL_STRING_call_cmp_func);
 }
 pub fn sk_OPENSSL_STRING_is_sorted(arg_sk: ?*const struct_stack_st_OPENSSL_STRING) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_OPENSSL_STRING_set_cmp_func(arg_sk: ?*struct_stack_st_OPENSSL_STRING, arg_comp: sk_OPENSSL_STRING_cmp_func) callconv(.C) sk_OPENSSL_STRING_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_OPENSSL_STRING_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_OPENSSL_STRING_deep_copy(arg_sk: ?*const struct_stack_st_OPENSSL_STRING, arg_copy_func: sk_OPENSSL_STRING_copy_func, arg_free_func: sk_OPENSSL_STRING_free_func) callconv(.C) ?*struct_stack_st_OPENSSL_STRING {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_OPENSSL_STRING, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_OPENSSL_STRING_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_OPENSSL_STRING_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub const CRYPTO_EX_free = fn (?*anyopaque, ?*anyopaque, [*c]CRYPTO_EX_DATA, c_int, c_long, ?*anyopaque) callconv(.C) void;
@@ -946,114 +946,114 @@ pub const sk_BIO_free_func = ?*const fn ([*c]BIO) callconv(.C) void;
 pub const sk_BIO_copy_func = ?*const fn ([*c]BIO) callconv(.C) [*c]BIO;
 pub const sk_BIO_cmp_func = ?*const fn ([*c][*c]const BIO, [*c][*c]const BIO) callconv(.C) c_int;
 pub fn sk_BIO_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_BIO_free_func, @ptrCast(@alignCast(free_func))).?(@as([*c]BIO, @ptrCast(@alignCast(ptr))));
 }
 pub fn sk_BIO_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_BIO_copy_func, @ptrCast(@alignCast(copy_func))).?(@as([*c]BIO, @ptrCast(@alignCast(ptr))))));
 }
 pub fn sk_BIO_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: [*c]const BIO = @as([*c]const BIO, @ptrCast(@alignCast(a.*)));
     var b_ptr: [*c]const BIO = @as([*c]const BIO, @ptrCast(@alignCast(b.*)));
     return @as(sk_BIO_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_BIO_new(arg_comp: sk_BIO_cmp_func) callconv(.C) ?*struct_stack_st_BIO {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_BIO, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_BIO_new_null() callconv(.C) ?*struct_stack_st_BIO {
     return @as(?*struct_stack_st_BIO, @ptrCast(sk_new_null()));
 }
 pub fn sk_BIO_num(arg_sk: ?*const struct_stack_st_BIO) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_BIO_zero(arg_sk: ?*struct_stack_st_BIO) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_BIO_value(arg_sk: ?*const struct_stack_st_BIO, arg_i: usize) callconv(.C) [*c]BIO {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as([*c]BIO, @ptrCast(@alignCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i))));
 }
 pub fn sk_BIO_set(arg_sk: ?*struct_stack_st_BIO, arg_i: usize, arg_p: [*c]BIO) callconv(.C) [*c]BIO {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as([*c]BIO, @ptrCast(@alignCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p))))));
 }
 pub fn sk_BIO_free(arg_sk: ?*struct_stack_st_BIO) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_BIO_pop_free(arg_sk: ?*struct_stack_st_BIO, arg_free_func: sk_BIO_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_BIO_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_BIO_insert(arg_sk: ?*struct_stack_st_BIO, arg_p: [*c]BIO, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_BIO_delete(arg_sk: ?*struct_stack_st_BIO, arg_where: usize) callconv(.C) [*c]BIO {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as([*c]BIO, @ptrCast(@alignCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where))));
 }
 pub fn sk_BIO_delete_ptr(arg_sk: ?*struct_stack_st_BIO, arg_p: [*c]const BIO) callconv(.C) [*c]BIO {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as([*c]BIO, @ptrCast(@alignCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p))))));
 }
 pub fn sk_BIO_find(arg_sk: ?*const struct_stack_st_BIO, arg_out_index: [*c]usize, arg_p: [*c]const BIO) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_BIO_call_cmp_func);
 }
 pub fn sk_BIO_shift(arg_sk: ?*struct_stack_st_BIO) callconv(.C) [*c]BIO {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]BIO, @ptrCast(@alignCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_BIO_push(arg_sk: ?*struct_stack_st_BIO, arg_p: [*c]BIO) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_BIO_pop(arg_sk: ?*struct_stack_st_BIO) callconv(.C) [*c]BIO {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]BIO, @ptrCast(@alignCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_BIO_dup(arg_sk: ?*const struct_stack_st_BIO) callconv(.C) ?*struct_stack_st_BIO {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_BIO, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_BIO_sort(arg_sk: ?*struct_stack_st_BIO) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_BIO_call_cmp_func);
 }
 pub fn sk_BIO_is_sorted(arg_sk: ?*const struct_stack_st_BIO) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_BIO_set_cmp_func(arg_sk: ?*struct_stack_st_BIO, arg_comp: sk_BIO_cmp_func) callconv(.C) sk_BIO_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_BIO_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_BIO_deep_copy(arg_sk: ?*const struct_stack_st_BIO, arg_copy_func: sk_BIO_copy_func, arg_free_func: sk_BIO_free_func) callconv(.C) ?*struct_stack_st_BIO {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_BIO, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_BIO_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_BIO_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern fn BIO_new(method: [*c]const BIO_METHOD) ?*BIO;
@@ -1726,114 +1726,114 @@ pub const sk_ASN1_INTEGER_free_func = ?*const fn ([*c]ASN1_INTEGER) callconv(.C)
 pub const sk_ASN1_INTEGER_copy_func = ?*const fn ([*c]ASN1_INTEGER) callconv(.C) [*c]ASN1_INTEGER;
 pub const sk_ASN1_INTEGER_cmp_func = ?*const fn ([*c][*c]const ASN1_INTEGER, [*c][*c]const ASN1_INTEGER) callconv(.C) c_int;
 pub fn sk_ASN1_INTEGER_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_ASN1_INTEGER_free_func, @ptrCast(@alignCast(free_func))).?(@as([*c]ASN1_INTEGER, @ptrCast(@alignCast(ptr))));
 }
 pub fn sk_ASN1_INTEGER_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_ASN1_INTEGER_copy_func, @ptrCast(@alignCast(copy_func))).?(@as([*c]ASN1_INTEGER, @ptrCast(@alignCast(ptr))))));
 }
 pub fn sk_ASN1_INTEGER_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: [*c]const ASN1_INTEGER = @as([*c]const ASN1_INTEGER, @ptrCast(@alignCast(a.*)));
     var b_ptr: [*c]const ASN1_INTEGER = @as([*c]const ASN1_INTEGER, @ptrCast(@alignCast(b.*)));
     return @as(sk_ASN1_INTEGER_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_ASN1_INTEGER_new(arg_comp: sk_ASN1_INTEGER_cmp_func) callconv(.C) ?*struct_stack_st_ASN1_INTEGER {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_ASN1_INTEGER, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_ASN1_INTEGER_new_null() callconv(.C) ?*struct_stack_st_ASN1_INTEGER {
     return @as(?*struct_stack_st_ASN1_INTEGER, @ptrCast(sk_new_null()));
 }
 pub fn sk_ASN1_INTEGER_num(arg_sk: ?*const struct_stack_st_ASN1_INTEGER) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_INTEGER_zero(arg_sk: ?*struct_stack_st_ASN1_INTEGER) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_INTEGER_value(arg_sk: ?*const struct_stack_st_ASN1_INTEGER, arg_i: usize) callconv(.C) [*c]ASN1_INTEGER {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as([*c]ASN1_INTEGER, @ptrCast(@alignCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i))));
 }
 pub fn sk_ASN1_INTEGER_set(arg_sk: ?*struct_stack_st_ASN1_INTEGER, arg_i: usize, arg_p: [*c]ASN1_INTEGER) callconv(.C) [*c]ASN1_INTEGER {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as([*c]ASN1_INTEGER, @ptrCast(@alignCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p))))));
 }
 pub fn sk_ASN1_INTEGER_free(arg_sk: ?*struct_stack_st_ASN1_INTEGER) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_INTEGER_pop_free(arg_sk: ?*struct_stack_st_ASN1_INTEGER, arg_free_func: sk_ASN1_INTEGER_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_ASN1_INTEGER_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_ASN1_INTEGER_insert(arg_sk: ?*struct_stack_st_ASN1_INTEGER, arg_p: [*c]ASN1_INTEGER, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_ASN1_INTEGER_delete(arg_sk: ?*struct_stack_st_ASN1_INTEGER, arg_where: usize) callconv(.C) [*c]ASN1_INTEGER {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as([*c]ASN1_INTEGER, @ptrCast(@alignCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where))));
 }
 pub fn sk_ASN1_INTEGER_delete_ptr(arg_sk: ?*struct_stack_st_ASN1_INTEGER, arg_p: [*c]const ASN1_INTEGER) callconv(.C) [*c]ASN1_INTEGER {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as([*c]ASN1_INTEGER, @ptrCast(@alignCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p))))));
 }
 pub fn sk_ASN1_INTEGER_find(arg_sk: ?*const struct_stack_st_ASN1_INTEGER, arg_out_index: [*c]usize, arg_p: [*c]const ASN1_INTEGER) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_ASN1_INTEGER_call_cmp_func);
 }
 pub fn sk_ASN1_INTEGER_shift(arg_sk: ?*struct_stack_st_ASN1_INTEGER) callconv(.C) [*c]ASN1_INTEGER {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]ASN1_INTEGER, @ptrCast(@alignCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_ASN1_INTEGER_push(arg_sk: ?*struct_stack_st_ASN1_INTEGER, arg_p: [*c]ASN1_INTEGER) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_ASN1_INTEGER_pop(arg_sk: ?*struct_stack_st_ASN1_INTEGER) callconv(.C) [*c]ASN1_INTEGER {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]ASN1_INTEGER, @ptrCast(@alignCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_ASN1_INTEGER_dup(arg_sk: ?*const struct_stack_st_ASN1_INTEGER) callconv(.C) ?*struct_stack_st_ASN1_INTEGER {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_ASN1_INTEGER, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_ASN1_INTEGER_sort(arg_sk: ?*struct_stack_st_ASN1_INTEGER) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_ASN1_INTEGER_call_cmp_func);
 }
 pub fn sk_ASN1_INTEGER_is_sorted(arg_sk: ?*const struct_stack_st_ASN1_INTEGER) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_INTEGER_set_cmp_func(arg_sk: ?*struct_stack_st_ASN1_INTEGER, arg_comp: sk_ASN1_INTEGER_cmp_func) callconv(.C) sk_ASN1_INTEGER_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_ASN1_INTEGER_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_ASN1_INTEGER_deep_copy(arg_sk: ?*const struct_stack_st_ASN1_INTEGER, arg_copy_func: sk_ASN1_INTEGER_copy_func, arg_free_func: sk_ASN1_INTEGER_free_func) callconv(.C) ?*struct_stack_st_ASN1_INTEGER {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_ASN1_INTEGER, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_ASN1_INTEGER_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_ASN1_INTEGER_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern fn ASN1_INTEGER_new() [*c]ASN1_INTEGER;
@@ -1904,114 +1904,114 @@ pub const sk_ASN1_OBJECT_free_func = ?*const fn (?*ASN1_OBJECT) callconv(.C) voi
 pub const sk_ASN1_OBJECT_copy_func = ?*const fn (?*ASN1_OBJECT) callconv(.C) ?*ASN1_OBJECT;
 pub const sk_ASN1_OBJECT_cmp_func = ?*const fn ([*c]?*const ASN1_OBJECT, [*c]?*const ASN1_OBJECT) callconv(.C) c_int;
 pub fn sk_ASN1_OBJECT_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_ASN1_OBJECT_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*ASN1_OBJECT, @ptrCast(ptr)));
 }
 pub fn sk_ASN1_OBJECT_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_ASN1_OBJECT_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*ASN1_OBJECT, @ptrCast(ptr)))));
 }
 pub fn sk_ASN1_OBJECT_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const ASN1_OBJECT = @as(?*const ASN1_OBJECT, @ptrCast(a.*));
     var b_ptr: ?*const ASN1_OBJECT = @as(?*const ASN1_OBJECT, @ptrCast(b.*));
     return @as(sk_ASN1_OBJECT_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_ASN1_OBJECT_new(arg_comp: sk_ASN1_OBJECT_cmp_func) callconv(.C) ?*struct_stack_st_ASN1_OBJECT {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_ASN1_OBJECT, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_ASN1_OBJECT_new_null() callconv(.C) ?*struct_stack_st_ASN1_OBJECT {
     return @as(?*struct_stack_st_ASN1_OBJECT, @ptrCast(sk_new_null()));
 }
 pub fn sk_ASN1_OBJECT_num(arg_sk: ?*const struct_stack_st_ASN1_OBJECT) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_OBJECT_zero(arg_sk: ?*struct_stack_st_ASN1_OBJECT) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_OBJECT_value(arg_sk: ?*const struct_stack_st_ASN1_OBJECT, arg_i: usize) callconv(.C) ?*ASN1_OBJECT {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*ASN1_OBJECT, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_ASN1_OBJECT_set(arg_sk: ?*struct_stack_st_ASN1_OBJECT, arg_i: usize, arg_p: ?*ASN1_OBJECT) callconv(.C) ?*ASN1_OBJECT {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*ASN1_OBJECT, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_ASN1_OBJECT_free(arg_sk: ?*struct_stack_st_ASN1_OBJECT) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_OBJECT_pop_free(arg_sk: ?*struct_stack_st_ASN1_OBJECT, arg_free_func: sk_ASN1_OBJECT_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_ASN1_OBJECT_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_ASN1_OBJECT_insert(arg_sk: ?*struct_stack_st_ASN1_OBJECT, arg_p: ?*ASN1_OBJECT, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_ASN1_OBJECT_delete(arg_sk: ?*struct_stack_st_ASN1_OBJECT, arg_where: usize) callconv(.C) ?*ASN1_OBJECT {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*ASN1_OBJECT, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_ASN1_OBJECT_delete_ptr(arg_sk: ?*struct_stack_st_ASN1_OBJECT, arg_p: ?*const ASN1_OBJECT) callconv(.C) ?*ASN1_OBJECT {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*ASN1_OBJECT, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_ASN1_OBJECT_find(arg_sk: ?*const struct_stack_st_ASN1_OBJECT, arg_out_index: [*c]usize, arg_p: ?*const ASN1_OBJECT) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_ASN1_OBJECT_call_cmp_func);
 }
 pub fn sk_ASN1_OBJECT_shift(arg_sk: ?*struct_stack_st_ASN1_OBJECT) callconv(.C) ?*ASN1_OBJECT {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*ASN1_OBJECT, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_ASN1_OBJECT_push(arg_sk: ?*struct_stack_st_ASN1_OBJECT, arg_p: ?*ASN1_OBJECT) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_ASN1_OBJECT_pop(arg_sk: ?*struct_stack_st_ASN1_OBJECT) callconv(.C) ?*ASN1_OBJECT {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*ASN1_OBJECT, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_ASN1_OBJECT_dup(arg_sk: ?*const struct_stack_st_ASN1_OBJECT) callconv(.C) ?*struct_stack_st_ASN1_OBJECT {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_ASN1_OBJECT, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_ASN1_OBJECT_sort(arg_sk: ?*struct_stack_st_ASN1_OBJECT) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_ASN1_OBJECT_call_cmp_func);
 }
 pub fn sk_ASN1_OBJECT_is_sorted(arg_sk: ?*const struct_stack_st_ASN1_OBJECT) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_OBJECT_set_cmp_func(arg_sk: ?*struct_stack_st_ASN1_OBJECT, arg_comp: sk_ASN1_OBJECT_cmp_func) callconv(.C) sk_ASN1_OBJECT_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_ASN1_OBJECT_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_ASN1_OBJECT_deep_copy(arg_sk: ?*const struct_stack_st_ASN1_OBJECT, arg_copy_func: sk_ASN1_OBJECT_copy_func, arg_free_func: sk_ASN1_OBJECT_free_func) callconv(.C) ?*struct_stack_st_ASN1_OBJECT {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_ASN1_OBJECT, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_ASN1_OBJECT_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_ASN1_OBJECT_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern fn ASN1_OBJECT_create(nid: c_int, data: [*c]const u8, len: c_int, sn: [*c]const u8, ln: [*c]const u8) ?*ASN1_OBJECT;
@@ -2025,114 +2025,114 @@ pub const sk_ASN1_TYPE_free_func = ?*const fn ([*c]ASN1_TYPE) callconv(.C) void;
 pub const sk_ASN1_TYPE_copy_func = ?*const fn ([*c]ASN1_TYPE) callconv(.C) [*c]ASN1_TYPE;
 pub const sk_ASN1_TYPE_cmp_func = ?*const fn ([*c][*c]const ASN1_TYPE, [*c][*c]const ASN1_TYPE) callconv(.C) c_int;
 pub fn sk_ASN1_TYPE_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_ASN1_TYPE_free_func, @ptrCast(@alignCast(free_func))).?(@as([*c]ASN1_TYPE, @ptrCast(@alignCast(ptr))));
 }
 pub fn sk_ASN1_TYPE_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_ASN1_TYPE_copy_func, @ptrCast(@alignCast(copy_func))).?(@as([*c]ASN1_TYPE, @ptrCast(@alignCast(ptr))))));
 }
 pub fn sk_ASN1_TYPE_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: [*c]const ASN1_TYPE = @as([*c]const ASN1_TYPE, @ptrCast(@alignCast(a.*)));
     var b_ptr: [*c]const ASN1_TYPE = @as([*c]const ASN1_TYPE, @ptrCast(@alignCast(b.*)));
     return @as(sk_ASN1_TYPE_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_ASN1_TYPE_new(arg_comp: sk_ASN1_TYPE_cmp_func) callconv(.C) ?*struct_stack_st_ASN1_TYPE {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_ASN1_TYPE, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_ASN1_TYPE_new_null() callconv(.C) ?*struct_stack_st_ASN1_TYPE {
     return @as(?*struct_stack_st_ASN1_TYPE, @ptrCast(sk_new_null()));
 }
 pub fn sk_ASN1_TYPE_num(arg_sk: ?*const struct_stack_st_ASN1_TYPE) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_TYPE_zero(arg_sk: ?*struct_stack_st_ASN1_TYPE) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_TYPE_value(arg_sk: ?*const struct_stack_st_ASN1_TYPE, arg_i: usize) callconv(.C) [*c]ASN1_TYPE {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as([*c]ASN1_TYPE, @ptrCast(@alignCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i))));
 }
 pub fn sk_ASN1_TYPE_set(arg_sk: ?*struct_stack_st_ASN1_TYPE, arg_i: usize, arg_p: [*c]ASN1_TYPE) callconv(.C) [*c]ASN1_TYPE {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as([*c]ASN1_TYPE, @ptrCast(@alignCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p))))));
 }
 pub fn sk_ASN1_TYPE_free(arg_sk: ?*struct_stack_st_ASN1_TYPE) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_TYPE_pop_free(arg_sk: ?*struct_stack_st_ASN1_TYPE, arg_free_func: sk_ASN1_TYPE_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_ASN1_TYPE_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_ASN1_TYPE_insert(arg_sk: ?*struct_stack_st_ASN1_TYPE, arg_p: [*c]ASN1_TYPE, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_ASN1_TYPE_delete(arg_sk: ?*struct_stack_st_ASN1_TYPE, arg_where: usize) callconv(.C) [*c]ASN1_TYPE {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as([*c]ASN1_TYPE, @ptrCast(@alignCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where))));
 }
 pub fn sk_ASN1_TYPE_delete_ptr(arg_sk: ?*struct_stack_st_ASN1_TYPE, arg_p: [*c]const ASN1_TYPE) callconv(.C) [*c]ASN1_TYPE {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as([*c]ASN1_TYPE, @ptrCast(@alignCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p))))));
 }
 pub fn sk_ASN1_TYPE_find(arg_sk: ?*const struct_stack_st_ASN1_TYPE, arg_out_index: [*c]usize, arg_p: [*c]const ASN1_TYPE) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_ASN1_TYPE_call_cmp_func);
 }
 pub fn sk_ASN1_TYPE_shift(arg_sk: ?*struct_stack_st_ASN1_TYPE) callconv(.C) [*c]ASN1_TYPE {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]ASN1_TYPE, @ptrCast(@alignCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_ASN1_TYPE_push(arg_sk: ?*struct_stack_st_ASN1_TYPE, arg_p: [*c]ASN1_TYPE) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_ASN1_TYPE_pop(arg_sk: ?*struct_stack_st_ASN1_TYPE) callconv(.C) [*c]ASN1_TYPE {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]ASN1_TYPE, @ptrCast(@alignCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_ASN1_TYPE_dup(arg_sk: ?*const struct_stack_st_ASN1_TYPE) callconv(.C) ?*struct_stack_st_ASN1_TYPE {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_ASN1_TYPE, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_ASN1_TYPE_sort(arg_sk: ?*struct_stack_st_ASN1_TYPE) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_ASN1_TYPE_call_cmp_func);
 }
 pub fn sk_ASN1_TYPE_is_sorted(arg_sk: ?*const struct_stack_st_ASN1_TYPE) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_ASN1_TYPE_set_cmp_func(arg_sk: ?*struct_stack_st_ASN1_TYPE, arg_comp: sk_ASN1_TYPE_cmp_func) callconv(.C) sk_ASN1_TYPE_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_ASN1_TYPE_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_ASN1_TYPE_deep_copy(arg_sk: ?*const struct_stack_st_ASN1_TYPE, arg_copy_func: sk_ASN1_TYPE_copy_func, arg_free_func: sk_ASN1_TYPE_free_func) callconv(.C) ?*struct_stack_st_ASN1_TYPE {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_ASN1_TYPE, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_ASN1_TYPE_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_ASN1_TYPE_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern fn ASN1_TYPE_new() [*c]ASN1_TYPE;
@@ -2496,114 +2496,114 @@ pub const sk_CRYPTO_BUFFER_free_func = ?*const fn (?*CRYPTO_BUFFER) callconv(.C)
 pub const sk_CRYPTO_BUFFER_copy_func = ?*const fn (?*CRYPTO_BUFFER) callconv(.C) ?*CRYPTO_BUFFER;
 pub const sk_CRYPTO_BUFFER_cmp_func = ?*const fn ([*c]?*const CRYPTO_BUFFER, [*c]?*const CRYPTO_BUFFER) callconv(.C) c_int;
 pub fn sk_CRYPTO_BUFFER_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_CRYPTO_BUFFER_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*CRYPTO_BUFFER, @ptrCast(ptr)));
 }
 pub fn sk_CRYPTO_BUFFER_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_CRYPTO_BUFFER_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*CRYPTO_BUFFER, @ptrCast(ptr)))));
 }
 pub fn sk_CRYPTO_BUFFER_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const CRYPTO_BUFFER = @as(?*const CRYPTO_BUFFER, @ptrCast(a.*));
     var b_ptr: ?*const CRYPTO_BUFFER = @as(?*const CRYPTO_BUFFER, @ptrCast(b.*));
     return @as(sk_CRYPTO_BUFFER_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_CRYPTO_BUFFER_new(arg_comp: sk_CRYPTO_BUFFER_cmp_func) callconv(.C) ?*struct_stack_st_CRYPTO_BUFFER {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_CRYPTO_BUFFER, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_CRYPTO_BUFFER_new_null() callconv(.C) ?*struct_stack_st_CRYPTO_BUFFER {
     return @as(?*struct_stack_st_CRYPTO_BUFFER, @ptrCast(sk_new_null()));
 }
 pub fn sk_CRYPTO_BUFFER_num(arg_sk: ?*const struct_stack_st_CRYPTO_BUFFER) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_CRYPTO_BUFFER_zero(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_CRYPTO_BUFFER_value(arg_sk: ?*const struct_stack_st_CRYPTO_BUFFER, arg_i: usize) callconv(.C) ?*CRYPTO_BUFFER {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*CRYPTO_BUFFER, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_CRYPTO_BUFFER_set(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER, arg_i: usize, arg_p: ?*CRYPTO_BUFFER) callconv(.C) ?*CRYPTO_BUFFER {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*CRYPTO_BUFFER, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_CRYPTO_BUFFER_free(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_CRYPTO_BUFFER_pop_free(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER, arg_free_func: sk_CRYPTO_BUFFER_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_CRYPTO_BUFFER_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_CRYPTO_BUFFER_insert(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER, arg_p: ?*CRYPTO_BUFFER, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_CRYPTO_BUFFER_delete(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER, arg_where: usize) callconv(.C) ?*CRYPTO_BUFFER {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*CRYPTO_BUFFER, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_CRYPTO_BUFFER_delete_ptr(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER, arg_p: ?*const CRYPTO_BUFFER) callconv(.C) ?*CRYPTO_BUFFER {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*CRYPTO_BUFFER, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_CRYPTO_BUFFER_find(arg_sk: ?*const struct_stack_st_CRYPTO_BUFFER, arg_out_index: [*c]usize, arg_p: ?*const CRYPTO_BUFFER) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_CRYPTO_BUFFER_call_cmp_func);
 }
 pub fn sk_CRYPTO_BUFFER_shift(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER) callconv(.C) ?*CRYPTO_BUFFER {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*CRYPTO_BUFFER, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_CRYPTO_BUFFER_push(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER, arg_p: ?*CRYPTO_BUFFER) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_CRYPTO_BUFFER_pop(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER) callconv(.C) ?*CRYPTO_BUFFER {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*CRYPTO_BUFFER, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_CRYPTO_BUFFER_dup(arg_sk: ?*const struct_stack_st_CRYPTO_BUFFER) callconv(.C) ?*struct_stack_st_CRYPTO_BUFFER {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_CRYPTO_BUFFER, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_CRYPTO_BUFFER_sort(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_CRYPTO_BUFFER_call_cmp_func);
 }
 pub fn sk_CRYPTO_BUFFER_is_sorted(arg_sk: ?*const struct_stack_st_CRYPTO_BUFFER) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_CRYPTO_BUFFER_set_cmp_func(arg_sk: ?*struct_stack_st_CRYPTO_BUFFER, arg_comp: sk_CRYPTO_BUFFER_cmp_func) callconv(.C) sk_CRYPTO_BUFFER_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_CRYPTO_BUFFER_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_CRYPTO_BUFFER_deep_copy(arg_sk: ?*const struct_stack_st_CRYPTO_BUFFER, arg_copy_func: sk_CRYPTO_BUFFER_copy_func, arg_free_func: sk_CRYPTO_BUFFER_free_func) callconv(.C) ?*struct_stack_st_CRYPTO_BUFFER {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_CRYPTO_BUFFER, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_CRYPTO_BUFFER_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_CRYPTO_BUFFER_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern fn CRYPTO_BUFFER_POOL_new() ?*CRYPTO_BUFFER_POOL;
@@ -2716,114 +2716,114 @@ pub const sk_X509_free_func = ?*const fn (?*X509) callconv(.C) void;
 pub const sk_X509_copy_func = ?*const fn (?*X509) callconv(.C) ?*X509;
 pub const sk_X509_cmp_func = ?*const fn ([*c]?*const X509, [*c]?*const X509) callconv(.C) c_int;
 pub fn sk_X509_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*X509, @ptrCast(ptr)));
 }
 pub fn sk_X509_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*X509, @ptrCast(ptr)))));
 }
 pub fn sk_X509_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const X509 = @as(?*const X509, @ptrCast(a.*));
     var b_ptr: ?*const X509 = @as(?*const X509, @ptrCast(b.*));
     return @as(sk_X509_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_new(arg_comp: sk_X509_cmp_func) callconv(.C) ?*struct_stack_st_X509 {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_new_null() callconv(.C) ?*struct_stack_st_X509 {
     return @as(?*struct_stack_st_X509, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_num(arg_sk: ?*const struct_stack_st_X509) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_zero(arg_sk: ?*struct_stack_st_X509) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_value(arg_sk: ?*const struct_stack_st_X509, arg_i: usize) callconv(.C) ?*X509 {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*X509, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_X509_set(arg_sk: ?*struct_stack_st_X509, arg_i: usize, arg_p: ?*X509) callconv(.C) ?*X509 {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*X509, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_free(arg_sk: ?*struct_stack_st_X509) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_pop_free(arg_sk: ?*struct_stack_st_X509, arg_free_func: sk_X509_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_insert(arg_sk: ?*struct_stack_st_X509, arg_p: ?*X509, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_delete(arg_sk: ?*struct_stack_st_X509, arg_where: usize) callconv(.C) ?*X509 {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*X509, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_X509_delete_ptr(arg_sk: ?*struct_stack_st_X509, arg_p: ?*const X509) callconv(.C) ?*X509 {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*X509, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_find(arg_sk: ?*const struct_stack_st_X509, arg_out_index: [*c]usize, arg_p: ?*const X509) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_call_cmp_func);
 }
 pub fn sk_X509_shift(arg_sk: ?*struct_stack_st_X509) callconv(.C) ?*X509 {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_push(arg_sk: ?*struct_stack_st_X509, arg_p: ?*X509) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_pop(arg_sk: ?*struct_stack_st_X509) callconv(.C) ?*X509 {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_dup(arg_sk: ?*const struct_stack_st_X509) callconv(.C) ?*struct_stack_st_X509 {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_sort(arg_sk: ?*struct_stack_st_X509) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_call_cmp_func);
 }
 pub fn sk_X509_is_sorted(arg_sk: ?*const struct_stack_st_X509) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_set_cmp_func(arg_sk: ?*struct_stack_st_X509, arg_comp: sk_X509_cmp_func) callconv(.C) sk_X509_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_deep_copy(arg_sk: ?*const struct_stack_st_X509, arg_copy_func: sk_X509_copy_func, arg_free_func: sk_X509_free_func) callconv(.C) ?*struct_stack_st_X509 {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub const stack_free_func = ?*const fn (?*anyopaque) callconv(.C) void;
@@ -2885,8 +2885,8 @@ pub const sk_X509_CRL_free_func = ?*const fn (?*X509_CRL) callconv(.C) void;
 pub const sk_X509_CRL_copy_func = ?*const fn (?*X509_CRL) callconv(.C) ?*X509_CRL;
 pub const sk_X509_CRL_cmp_func = ?*const fn ([*c]?*const X509_CRL, [*c]?*const X509_CRL) callconv(.C) c_int;
 pub fn sk_X509_CRL_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_CRL_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*X509_CRL, @ptrCast(ptr)));
 }
 pub extern fn X509V3_EXT_d2i(ex: ?*X509_EXTENSION) ?*anyopaque;
@@ -2894,9 +2894,9 @@ pub extern fn X509V3_EXT_get(ex: ?*X509_EXTENSION) ?*X509V3_EXT_METHOD;
 pub const X509V3_EXT_METHOD = opaque {};
 pub extern fn X509V3_EXT_get_nid(ndi: c_int) ?*X509V3_EXT_METHOD;
 pub fn sk_X509_CRL_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const X509_CRL = @as(?*const X509_CRL, @ptrCast(a.*));
     var b_ptr: ?*const X509_CRL = @as(?*const X509_CRL, @ptrCast(b.*));
     return @as(sk_X509_CRL_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
@@ -2951,55 +2951,55 @@ pub const ACCESS_DESCRIPTION = extern struct {
 };
 
 pub fn sk_GENERAL_NAME_num(arg_sk: ?*const struct_stack_st_GENERAL_NAME) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @alignCast(@ptrCast(sk))));
 }
 pub fn sk_GENERAL_NAME_free(arg_sk: ?*struct_stack_st_GENERAL_NAME) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @alignCast(@ptrCast(sk))));
 }
 pub const stack_GENERAL_NAME_free_func = ?*const fn (?*struct_stack_st_GENERAL_NAME) callconv(.C) void;
 
 pub fn sk_GENERAL_NAME_call_free_func(arg_free_func: stack_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(stack_GENERAL_NAME_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*struct_stack_st_GENERAL_NAME, @ptrCast(ptr)));
 }
 pub fn sk_GENERAL_NAME_pop_free(arg_sk: ?*struct_stack_st_GENERAL_NAME, arg_free_func: stack_GENERAL_NAME_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @alignCast(@ptrCast(sk))), sk_GENERAL_NAME_call_free_func, @as(stack_free_func, @ptrCast(free_func)));
 }
 pub fn sk_GENERAL_NAME_value(arg_sk: ?*const struct_stack_st_GENERAL_NAME, arg_i: usize) callconv(.C) ?*GENERAL_NAME {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @alignCast(@ptrCast(sk_value(@as([*c]const _STACK, @alignCast(@ptrCast(sk))), i)));
 }
 
 pub fn sk_ACCESS_DESCRIPTION_num(arg_sk: ?*const AUTHORITY_INFO_ACCESS) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @alignCast(@ptrCast(sk))));
 }
 pub fn sk_ACCESS_DESCRIPTION_free(arg_sk: ?*AUTHORITY_INFO_ACCESS) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub const stack_ACCESS_DESCRIPTION_free_func = ?*const fn (?*AUTHORITY_INFO_ACCESS) callconv(.C) void;
 
 pub fn sk_ACCESS_DESCRIPTION_call_free_func(arg_free_func: stack_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(stack_ACCESS_DESCRIPTION_free_func, @ptrCast(free_func)).?(@as(?*AUTHORITY_INFO_ACCESS, @ptrCast(ptr)));
 }
 pub fn sk_ACCESS_DESCRIPTION_pop_free(arg_sk: ?*AUTHORITY_INFO_ACCESS, arg_free_func: stack_ACCESS_DESCRIPTION_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @alignCast(@ptrCast(sk))), sk_ACCESS_DESCRIPTION_call_free_func, @as(stack_free_func, @ptrCast(free_func)));
 }
 pub extern fn X509_get_serialNumber(x509: ?*X509) [*c]ASN1_INTEGER;
 pub fn sk_ACCESS_DESCRIPTION_value(arg_sk: ?*const AUTHORITY_INFO_ACCESS, arg_i: usize) callconv(.C) ?*ACCESS_DESCRIPTION {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @alignCast(@ptrCast(sk_value(@as([*c]const _STACK, @alignCast(@ptrCast(sk))), i)));
 }
 pub const NID_id_on_SmtpUTF8Mailbox = @as(c_int, 1208);
@@ -3011,101 +3011,101 @@ pub const stack_X509_CRL_free_func = ?*const fn (?*X509_CRL) callconv(.C) void;
 pub const stack_X509_CRL_copy_func = ?*const fn (?*X509_CRL) callconv(.C) ?*X509_CRL;
 pub const stack_X509_CRL_cmp_func = ?*const fn ([*c]?*const X509_CRL, [*c]?*const X509_CRL) callconv(.C) c_int;
 pub fn sk_X509_CRL_call_copy_func(arg_copy_func: stack_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(stack_X509_CRL_copy_func, @ptrCast(copy_func)).?(@as(?*X509_CRL, @ptrCast(ptr)))));
 }
 pub fn sk_X509_CRL_new(arg_comp: stack_X509_CRL_cmp_func) callconv(.C) ?*struct_stack_st_X509_CRL {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_CRL, @ptrCast(sk_new(@as(stack_cmp_func, @ptrCast(comp)))));
 }
 pub fn sk_X509_CRL_new_null() callconv(.C) ?*struct_stack_st_X509_CRL {
     return @as(?*struct_stack_st_X509_CRL, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_CRL_num(arg_sk: ?*const struct_stack_st_X509_CRL) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_CRL_zero(arg_sk: ?*struct_stack_st_X509_CRL) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_CRL_value(arg_sk: ?*const struct_stack_st_X509_CRL, arg_i: usize) callconv(.C) ?*X509_CRL {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*X509_CRL, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_X509_CRL_set(arg_sk: ?*struct_stack_st_X509_CRL, arg_i: usize, arg_p: ?*X509_CRL) callconv(.C) ?*X509_CRL {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*X509_CRL, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_CRL_free(arg_sk: ?*struct_stack_st_X509_CRL) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_CRL_pop_free(arg_sk: ?*struct_stack_st_X509_CRL, arg_free_func: sk_X509_CRL_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_CRL_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_CRL_insert(arg_sk: ?*struct_stack_st_X509_CRL, arg_p: ?*X509_CRL, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_CRL_delete(arg_sk: ?*struct_stack_st_X509_CRL, arg_where: usize) callconv(.C) ?*X509_CRL {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*X509_CRL, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_X509_CRL_delete_ptr(arg_sk: ?*struct_stack_st_X509_CRL, arg_p: ?*const X509_CRL) callconv(.C) ?*X509_CRL {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*X509_CRL, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_CRL_find(arg_sk: ?*const struct_stack_st_X509_CRL, arg_out_index: [*c]usize, arg_p: ?*const X509_CRL) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_CRL_call_cmp_func);
 }
 pub fn sk_X509_CRL_shift(arg_sk: ?*struct_stack_st_X509_CRL) callconv(.C) ?*X509_CRL {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_CRL, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_CRL_push(arg_sk: ?*struct_stack_st_X509_CRL, arg_p: ?*X509_CRL) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_CRL_pop(arg_sk: ?*struct_stack_st_X509_CRL) callconv(.C) ?*X509_CRL {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_CRL, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_CRL_dup(arg_sk: ?*const struct_stack_st_X509_CRL) callconv(.C) ?*struct_stack_st_X509_CRL {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_CRL, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_CRL_sort(arg_sk: ?*struct_stack_st_X509_CRL) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_CRL_call_cmp_func);
 }
 pub fn sk_X509_CRL_is_sorted(arg_sk: ?*const struct_stack_st_X509_CRL) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_CRL_set_cmp_func(arg_sk: ?*struct_stack_st_X509_CRL, arg_comp: sk_X509_CRL_cmp_func) callconv(.C) sk_X509_CRL_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_CRL_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_CRL_deep_copy(arg_sk: ?*const struct_stack_st_X509_CRL, arg_copy_func: sk_X509_CRL_copy_func, arg_free_func: sk_X509_CRL_free_func) callconv(.C) ?*struct_stack_st_X509_CRL {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_CRL, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_CRL_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_CRL_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern const X509_CRL_it: ASN1_ITEM;
@@ -3164,114 +3164,114 @@ pub const sk_X509_NAME_ENTRY_free_func = ?*const fn (?*X509_NAME_ENTRY) callconv
 pub const sk_X509_NAME_ENTRY_copy_func = ?*const fn (?*X509_NAME_ENTRY) callconv(.C) ?*X509_NAME_ENTRY;
 pub const sk_X509_NAME_ENTRY_cmp_func = ?*const fn ([*c]?*const X509_NAME_ENTRY, [*c]?*const X509_NAME_ENTRY) callconv(.C) c_int;
 pub fn sk_X509_NAME_ENTRY_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_NAME_ENTRY_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*X509_NAME_ENTRY, @ptrCast(ptr)));
 }
 pub fn sk_X509_NAME_ENTRY_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_NAME_ENTRY_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*X509_NAME_ENTRY, @ptrCast(ptr)))));
 }
 pub fn sk_X509_NAME_ENTRY_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const X509_NAME_ENTRY = @as(?*const X509_NAME_ENTRY, @ptrCast(a.*));
     var b_ptr: ?*const X509_NAME_ENTRY = @as(?*const X509_NAME_ENTRY, @ptrCast(b.*));
     return @as(sk_X509_NAME_ENTRY_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_NAME_ENTRY_new(arg_comp: sk_X509_NAME_ENTRY_cmp_func) callconv(.C) ?*struct_stack_st_X509_NAME_ENTRY {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_NAME_ENTRY, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_NAME_ENTRY_new_null() callconv(.C) ?*struct_stack_st_X509_NAME_ENTRY {
     return @as(?*struct_stack_st_X509_NAME_ENTRY, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_NAME_ENTRY_num(arg_sk: ?*const struct_stack_st_X509_NAME_ENTRY) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_NAME_ENTRY_zero(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_NAME_ENTRY_value(arg_sk: ?*const struct_stack_st_X509_NAME_ENTRY, arg_i: usize) callconv(.C) ?*X509_NAME_ENTRY {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*X509_NAME_ENTRY, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_X509_NAME_ENTRY_set(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY, arg_i: usize, arg_p: ?*X509_NAME_ENTRY) callconv(.C) ?*X509_NAME_ENTRY {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*X509_NAME_ENTRY, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_NAME_ENTRY_free(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_NAME_ENTRY_pop_free(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY, arg_free_func: sk_X509_NAME_ENTRY_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_NAME_ENTRY_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_NAME_ENTRY_insert(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY, arg_p: ?*X509_NAME_ENTRY, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_NAME_ENTRY_delete(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY, arg_where: usize) callconv(.C) ?*X509_NAME_ENTRY {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*X509_NAME_ENTRY, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_X509_NAME_ENTRY_delete_ptr(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY, arg_p: ?*const X509_NAME_ENTRY) callconv(.C) ?*X509_NAME_ENTRY {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*X509_NAME_ENTRY, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_NAME_ENTRY_find(arg_sk: ?*const struct_stack_st_X509_NAME_ENTRY, arg_out_index: [*c]usize, arg_p: ?*const X509_NAME_ENTRY) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_NAME_ENTRY_call_cmp_func);
 }
 pub fn sk_X509_NAME_ENTRY_shift(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY) callconv(.C) ?*X509_NAME_ENTRY {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_NAME_ENTRY, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_NAME_ENTRY_push(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY, arg_p: ?*X509_NAME_ENTRY) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_NAME_ENTRY_pop(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY) callconv(.C) ?*X509_NAME_ENTRY {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_NAME_ENTRY, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_NAME_ENTRY_dup(arg_sk: ?*const struct_stack_st_X509_NAME_ENTRY) callconv(.C) ?*struct_stack_st_X509_NAME_ENTRY {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_NAME_ENTRY, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_NAME_ENTRY_sort(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_NAME_ENTRY_call_cmp_func);
 }
 pub fn sk_X509_NAME_ENTRY_is_sorted(arg_sk: ?*const struct_stack_st_X509_NAME_ENTRY) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_NAME_ENTRY_set_cmp_func(arg_sk: ?*struct_stack_st_X509_NAME_ENTRY, arg_comp: sk_X509_NAME_ENTRY_cmp_func) callconv(.C) sk_X509_NAME_ENTRY_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_NAME_ENTRY_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_NAME_ENTRY_deep_copy(arg_sk: ?*const struct_stack_st_X509_NAME_ENTRY, arg_copy_func: sk_X509_NAME_ENTRY_copy_func, arg_free_func: sk_X509_NAME_ENTRY_free_func) callconv(.C) ?*struct_stack_st_X509_NAME_ENTRY {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_NAME_ENTRY, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_NAME_ENTRY_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_NAME_ENTRY_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub const struct_stack_st_X509_NAME = opaque {};
@@ -3279,114 +3279,114 @@ pub const sk_X509_NAME_free_func = ?*const fn (?*X509_NAME) callconv(.C) void;
 pub const sk_X509_NAME_copy_func = ?*const fn (?*X509_NAME) callconv(.C) ?*X509_NAME;
 pub const sk_X509_NAME_cmp_func = ?*const fn ([*c]?*const X509_NAME, [*c]?*const X509_NAME) callconv(.C) c_int;
 pub fn sk_X509_NAME_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_NAME_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*X509_NAME, @ptrCast(ptr)));
 }
 pub fn sk_X509_NAME_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_NAME_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*X509_NAME, @ptrCast(ptr)))));
 }
 pub fn sk_X509_NAME_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const X509_NAME = @as(?*const X509_NAME, @ptrCast(a.*));
     var b_ptr: ?*const X509_NAME = @as(?*const X509_NAME, @ptrCast(b.*));
     return @as(sk_X509_NAME_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_NAME_new(arg_comp: sk_X509_NAME_cmp_func) callconv(.C) ?*struct_stack_st_X509_NAME {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_NAME, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_NAME_new_null() callconv(.C) ?*struct_stack_st_X509_NAME {
     return @as(?*struct_stack_st_X509_NAME, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_NAME_num(arg_sk: ?*const struct_stack_st_X509_NAME) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_NAME_zero(arg_sk: ?*struct_stack_st_X509_NAME) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_NAME_value(arg_sk: ?*const struct_stack_st_X509_NAME, arg_i: usize) callconv(.C) ?*X509_NAME {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*X509_NAME, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_X509_NAME_set(arg_sk: ?*struct_stack_st_X509_NAME, arg_i: usize, arg_p: ?*X509_NAME) callconv(.C) ?*X509_NAME {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*X509_NAME, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_NAME_free(arg_sk: ?*struct_stack_st_X509_NAME) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_NAME_pop_free(arg_sk: ?*struct_stack_st_X509_NAME, arg_free_func: sk_X509_NAME_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_NAME_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_NAME_insert(arg_sk: ?*struct_stack_st_X509_NAME, arg_p: ?*X509_NAME, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_NAME_delete(arg_sk: ?*struct_stack_st_X509_NAME, arg_where: usize) callconv(.C) ?*X509_NAME {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*X509_NAME, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_X509_NAME_delete_ptr(arg_sk: ?*struct_stack_st_X509_NAME, arg_p: ?*const X509_NAME) callconv(.C) ?*X509_NAME {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*X509_NAME, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_NAME_find(arg_sk: ?*const struct_stack_st_X509_NAME, arg_out_index: [*c]usize, arg_p: ?*const X509_NAME) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_NAME_call_cmp_func);
 }
 pub fn sk_X509_NAME_shift(arg_sk: ?*struct_stack_st_X509_NAME) callconv(.C) ?*X509_NAME {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_NAME, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_NAME_push(arg_sk: ?*struct_stack_st_X509_NAME, arg_p: ?*X509_NAME) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_NAME_pop(arg_sk: ?*struct_stack_st_X509_NAME) callconv(.C) ?*X509_NAME {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_NAME, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_NAME_dup(arg_sk: ?*const struct_stack_st_X509_NAME) callconv(.C) ?*struct_stack_st_X509_NAME {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_NAME, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_NAME_sort(arg_sk: ?*struct_stack_st_X509_NAME) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_NAME_call_cmp_func);
 }
 pub fn sk_X509_NAME_is_sorted(arg_sk: ?*const struct_stack_st_X509_NAME) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_NAME_set_cmp_func(arg_sk: ?*struct_stack_st_X509_NAME, arg_comp: sk_X509_NAME_cmp_func) callconv(.C) sk_X509_NAME_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_NAME_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_NAME_deep_copy(arg_sk: ?*const struct_stack_st_X509_NAME, arg_copy_func: sk_X509_NAME_copy_func, arg_free_func: sk_X509_NAME_free_func) callconv(.C) ?*struct_stack_st_X509_NAME {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_NAME, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_NAME_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_NAME_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern const X509_NAME_it: ASN1_ITEM;
@@ -3438,114 +3438,114 @@ pub const sk_X509_EXTENSION_free_func = ?*const fn (?*X509_EXTENSION) callconv(.
 pub const sk_X509_EXTENSION_copy_func = ?*const fn (?*X509_EXTENSION) callconv(.C) ?*X509_EXTENSION;
 pub const sk_X509_EXTENSION_cmp_func = ?*const fn ([*c]?*const X509_EXTENSION, [*c]?*const X509_EXTENSION) callconv(.C) c_int;
 pub fn sk_X509_EXTENSION_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_EXTENSION_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*X509_EXTENSION, @ptrCast(ptr)));
 }
 pub fn sk_X509_EXTENSION_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_EXTENSION_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*X509_EXTENSION, @ptrCast(ptr)))));
 }
 pub fn sk_X509_EXTENSION_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const X509_EXTENSION = @as(?*const X509_EXTENSION, @ptrCast(a.*));
     var b_ptr: ?*const X509_EXTENSION = @as(?*const X509_EXTENSION, @ptrCast(b.*));
     return @as(sk_X509_EXTENSION_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_EXTENSION_new(arg_comp: sk_X509_EXTENSION_cmp_func) callconv(.C) ?*struct_stack_st_X509_EXTENSION {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_EXTENSION, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_EXTENSION_new_null() callconv(.C) ?*struct_stack_st_X509_EXTENSION {
     return @as(?*struct_stack_st_X509_EXTENSION, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_EXTENSION_num(arg_sk: ?*const struct_stack_st_X509_EXTENSION) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_EXTENSION_zero(arg_sk: ?*struct_stack_st_X509_EXTENSION) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_EXTENSION_value(arg_sk: ?*const struct_stack_st_X509_EXTENSION, arg_i: usize) callconv(.C) ?*X509_EXTENSION {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*X509_EXTENSION, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_X509_EXTENSION_set(arg_sk: ?*struct_stack_st_X509_EXTENSION, arg_i: usize, arg_p: ?*X509_EXTENSION) callconv(.C) ?*X509_EXTENSION {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*X509_EXTENSION, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_EXTENSION_free(arg_sk: ?*struct_stack_st_X509_EXTENSION) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_EXTENSION_pop_free(arg_sk: ?*struct_stack_st_X509_EXTENSION, arg_free_func: sk_X509_EXTENSION_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_EXTENSION_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_EXTENSION_insert(arg_sk: ?*struct_stack_st_X509_EXTENSION, arg_p: ?*X509_EXTENSION, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_EXTENSION_delete(arg_sk: ?*struct_stack_st_X509_EXTENSION, arg_where: usize) callconv(.C) ?*X509_EXTENSION {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*X509_EXTENSION, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_X509_EXTENSION_delete_ptr(arg_sk: ?*struct_stack_st_X509_EXTENSION, arg_p: ?*const X509_EXTENSION) callconv(.C) ?*X509_EXTENSION {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*X509_EXTENSION, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_EXTENSION_find(arg_sk: ?*const struct_stack_st_X509_EXTENSION, arg_out_index: [*c]usize, arg_p: ?*const X509_EXTENSION) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_EXTENSION_call_cmp_func);
 }
 pub fn sk_X509_EXTENSION_shift(arg_sk: ?*struct_stack_st_X509_EXTENSION) callconv(.C) ?*X509_EXTENSION {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_EXTENSION, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_EXTENSION_push(arg_sk: ?*struct_stack_st_X509_EXTENSION, arg_p: ?*X509_EXTENSION) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_EXTENSION_pop(arg_sk: ?*struct_stack_st_X509_EXTENSION) callconv(.C) ?*X509_EXTENSION {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_EXTENSION, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_EXTENSION_dup(arg_sk: ?*const struct_stack_st_X509_EXTENSION) callconv(.C) ?*struct_stack_st_X509_EXTENSION {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_EXTENSION, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_EXTENSION_sort(arg_sk: ?*struct_stack_st_X509_EXTENSION) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_EXTENSION_call_cmp_func);
 }
 pub fn sk_X509_EXTENSION_is_sorted(arg_sk: ?*const struct_stack_st_X509_EXTENSION) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_EXTENSION_set_cmp_func(arg_sk: ?*struct_stack_st_X509_EXTENSION, arg_comp: sk_X509_EXTENSION_cmp_func) callconv(.C) sk_X509_EXTENSION_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_EXTENSION_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_EXTENSION_deep_copy(arg_sk: ?*const struct_stack_st_X509_EXTENSION, arg_copy_func: sk_X509_EXTENSION_copy_func, arg_free_func: sk_X509_EXTENSION_free_func) callconv(.C) ?*struct_stack_st_X509_EXTENSION {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_EXTENSION, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_EXTENSION_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_EXTENSION_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub const X509_EXTENSIONS = struct_stack_st_X509_EXTENSION;
@@ -3564,114 +3564,114 @@ pub const sk_X509_ALGOR_free_func = ?*const fn ([*c]X509_ALGOR) callconv(.C) voi
 pub const sk_X509_ALGOR_copy_func = ?*const fn ([*c]X509_ALGOR) callconv(.C) [*c]X509_ALGOR;
 pub const sk_X509_ALGOR_cmp_func = ?*const fn ([*c][*c]const X509_ALGOR, [*c][*c]const X509_ALGOR) callconv(.C) c_int;
 pub fn sk_X509_ALGOR_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_ALGOR_free_func, @ptrCast(@alignCast(free_func))).?(@as([*c]X509_ALGOR, @ptrCast(@alignCast(ptr))));
 }
 pub fn sk_X509_ALGOR_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_ALGOR_copy_func, @ptrCast(@alignCast(copy_func))).?(@as([*c]X509_ALGOR, @ptrCast(@alignCast(ptr))))));
 }
 pub fn sk_X509_ALGOR_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: [*c]const X509_ALGOR = @as([*c]const X509_ALGOR, @ptrCast(@alignCast(a.*)));
     var b_ptr: [*c]const X509_ALGOR = @as([*c]const X509_ALGOR, @ptrCast(@alignCast(b.*)));
     return @as(sk_X509_ALGOR_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_ALGOR_new(arg_comp: sk_X509_ALGOR_cmp_func) callconv(.C) ?*struct_stack_st_X509_ALGOR {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_ALGOR, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_ALGOR_new_null() callconv(.C) ?*struct_stack_st_X509_ALGOR {
     return @as(?*struct_stack_st_X509_ALGOR, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_ALGOR_num(arg_sk: ?*const struct_stack_st_X509_ALGOR) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_ALGOR_zero(arg_sk: ?*struct_stack_st_X509_ALGOR) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_ALGOR_value(arg_sk: ?*const struct_stack_st_X509_ALGOR, arg_i: usize) callconv(.C) [*c]X509_ALGOR {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as([*c]X509_ALGOR, @ptrCast(@alignCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i))));
 }
 pub fn sk_X509_ALGOR_set(arg_sk: ?*struct_stack_st_X509_ALGOR, arg_i: usize, arg_p: [*c]X509_ALGOR) callconv(.C) [*c]X509_ALGOR {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as([*c]X509_ALGOR, @ptrCast(@alignCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p))))));
 }
 pub fn sk_X509_ALGOR_free(arg_sk: ?*struct_stack_st_X509_ALGOR) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_ALGOR_pop_free(arg_sk: ?*struct_stack_st_X509_ALGOR, arg_free_func: sk_X509_ALGOR_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_ALGOR_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_ALGOR_insert(arg_sk: ?*struct_stack_st_X509_ALGOR, arg_p: [*c]X509_ALGOR, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_ALGOR_delete(arg_sk: ?*struct_stack_st_X509_ALGOR, arg_where: usize) callconv(.C) [*c]X509_ALGOR {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as([*c]X509_ALGOR, @ptrCast(@alignCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where))));
 }
 pub fn sk_X509_ALGOR_delete_ptr(arg_sk: ?*struct_stack_st_X509_ALGOR, arg_p: [*c]const X509_ALGOR) callconv(.C) [*c]X509_ALGOR {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as([*c]X509_ALGOR, @ptrCast(@alignCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p))))));
 }
 pub fn sk_X509_ALGOR_find(arg_sk: ?*const struct_stack_st_X509_ALGOR, arg_out_index: [*c]usize, arg_p: [*c]const X509_ALGOR) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_ALGOR_call_cmp_func);
 }
 pub fn sk_X509_ALGOR_shift(arg_sk: ?*struct_stack_st_X509_ALGOR) callconv(.C) [*c]X509_ALGOR {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]X509_ALGOR, @ptrCast(@alignCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_X509_ALGOR_push(arg_sk: ?*struct_stack_st_X509_ALGOR, arg_p: [*c]X509_ALGOR) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_ALGOR_pop(arg_sk: ?*struct_stack_st_X509_ALGOR) callconv(.C) [*c]X509_ALGOR {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]X509_ALGOR, @ptrCast(@alignCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_X509_ALGOR_dup(arg_sk: ?*const struct_stack_st_X509_ALGOR) callconv(.C) ?*struct_stack_st_X509_ALGOR {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_ALGOR, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_ALGOR_sort(arg_sk: ?*struct_stack_st_X509_ALGOR) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_ALGOR_call_cmp_func);
 }
 pub fn sk_X509_ALGOR_is_sorted(arg_sk: ?*const struct_stack_st_X509_ALGOR) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_ALGOR_set_cmp_func(arg_sk: ?*struct_stack_st_X509_ALGOR, arg_comp: sk_X509_ALGOR_cmp_func) callconv(.C) sk_X509_ALGOR_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_ALGOR_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_ALGOR_deep_copy(arg_sk: ?*const struct_stack_st_X509_ALGOR, arg_copy_func: sk_X509_ALGOR_copy_func, arg_free_func: sk_X509_ALGOR_free_func) callconv(.C) ?*struct_stack_st_X509_ALGOR {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_ALGOR, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_ALGOR_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_ALGOR_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern const X509_ALGOR_it: ASN1_ITEM;
@@ -3758,114 +3758,114 @@ pub const sk_X509_ATTRIBUTE_free_func = ?*const fn (?*X509_ATTRIBUTE) callconv(.
 pub const sk_X509_ATTRIBUTE_copy_func = ?*const fn (?*X509_ATTRIBUTE) callconv(.C) ?*X509_ATTRIBUTE;
 pub const sk_X509_ATTRIBUTE_cmp_func = ?*const fn ([*c]?*const X509_ATTRIBUTE, [*c]?*const X509_ATTRIBUTE) callconv(.C) c_int;
 pub fn sk_X509_ATTRIBUTE_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_ATTRIBUTE_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*X509_ATTRIBUTE, @ptrCast(ptr)));
 }
 pub fn sk_X509_ATTRIBUTE_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_ATTRIBUTE_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*X509_ATTRIBUTE, @ptrCast(ptr)))));
 }
 pub fn sk_X509_ATTRIBUTE_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const X509_ATTRIBUTE = @as(?*const X509_ATTRIBUTE, @ptrCast(a.*));
     var b_ptr: ?*const X509_ATTRIBUTE = @as(?*const X509_ATTRIBUTE, @ptrCast(b.*));
     return @as(sk_X509_ATTRIBUTE_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_ATTRIBUTE_new(arg_comp: sk_X509_ATTRIBUTE_cmp_func) callconv(.C) ?*struct_stack_st_X509_ATTRIBUTE {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_ATTRIBUTE, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_ATTRIBUTE_new_null() callconv(.C) ?*struct_stack_st_X509_ATTRIBUTE {
     return @as(?*struct_stack_st_X509_ATTRIBUTE, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_ATTRIBUTE_num(arg_sk: ?*const struct_stack_st_X509_ATTRIBUTE) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_ATTRIBUTE_zero(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_ATTRIBUTE_value(arg_sk: ?*const struct_stack_st_X509_ATTRIBUTE, arg_i: usize) callconv(.C) ?*X509_ATTRIBUTE {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*X509_ATTRIBUTE, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_X509_ATTRIBUTE_set(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE, arg_i: usize, arg_p: ?*X509_ATTRIBUTE) callconv(.C) ?*X509_ATTRIBUTE {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*X509_ATTRIBUTE, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_ATTRIBUTE_free(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_ATTRIBUTE_pop_free(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE, arg_free_func: sk_X509_ATTRIBUTE_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_ATTRIBUTE_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_ATTRIBUTE_insert(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE, arg_p: ?*X509_ATTRIBUTE, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_ATTRIBUTE_delete(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE, arg_where: usize) callconv(.C) ?*X509_ATTRIBUTE {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*X509_ATTRIBUTE, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_X509_ATTRIBUTE_delete_ptr(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE, arg_p: ?*const X509_ATTRIBUTE) callconv(.C) ?*X509_ATTRIBUTE {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*X509_ATTRIBUTE, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_ATTRIBUTE_find(arg_sk: ?*const struct_stack_st_X509_ATTRIBUTE, arg_out_index: [*c]usize, arg_p: ?*const X509_ATTRIBUTE) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_ATTRIBUTE_call_cmp_func);
 }
 pub fn sk_X509_ATTRIBUTE_shift(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE) callconv(.C) ?*X509_ATTRIBUTE {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_ATTRIBUTE, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_ATTRIBUTE_push(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE, arg_p: ?*X509_ATTRIBUTE) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_ATTRIBUTE_pop(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE) callconv(.C) ?*X509_ATTRIBUTE {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_ATTRIBUTE, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_ATTRIBUTE_dup(arg_sk: ?*const struct_stack_st_X509_ATTRIBUTE) callconv(.C) ?*struct_stack_st_X509_ATTRIBUTE {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_ATTRIBUTE, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_ATTRIBUTE_sort(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_ATTRIBUTE_call_cmp_func);
 }
 pub fn sk_X509_ATTRIBUTE_is_sorted(arg_sk: ?*const struct_stack_st_X509_ATTRIBUTE) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_ATTRIBUTE_set_cmp_func(arg_sk: ?*struct_stack_st_X509_ATTRIBUTE, arg_comp: sk_X509_ATTRIBUTE_cmp_func) callconv(.C) sk_X509_ATTRIBUTE_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_ATTRIBUTE_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_ATTRIBUTE_deep_copy(arg_sk: ?*const struct_stack_st_X509_ATTRIBUTE, arg_copy_func: sk_X509_ATTRIBUTE_copy_func, arg_free_func: sk_X509_ATTRIBUTE_free_func) callconv(.C) ?*struct_stack_st_X509_ATTRIBUTE {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_ATTRIBUTE, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_ATTRIBUTE_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_ATTRIBUTE_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub const struct_stack_st_DIST_POINT = opaque {};
@@ -3875,228 +3875,228 @@ pub const sk_X509_TRUST_free_func = ?*const fn ([*c]X509_TRUST) callconv(.C) voi
 pub const sk_X509_TRUST_copy_func = ?*const fn ([*c]X509_TRUST) callconv(.C) [*c]X509_TRUST;
 pub const sk_X509_TRUST_cmp_func = ?*const fn ([*c][*c]const X509_TRUST, [*c][*c]const X509_TRUST) callconv(.C) c_int;
 pub fn sk_X509_TRUST_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_TRUST_free_func, @ptrCast(@alignCast(free_func))).?(@as([*c]X509_TRUST, @ptrCast(@alignCast(ptr))));
 }
 pub fn sk_X509_TRUST_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_TRUST_copy_func, @ptrCast(@alignCast(copy_func))).?(@as([*c]X509_TRUST, @ptrCast(@alignCast(ptr))))));
 }
 pub fn sk_X509_TRUST_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: [*c]const X509_TRUST = @as([*c]const X509_TRUST, @ptrCast(@alignCast(a.*)));
     var b_ptr: [*c]const X509_TRUST = @as([*c]const X509_TRUST, @ptrCast(@alignCast(b.*)));
     return @as(sk_X509_TRUST_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_TRUST_new(arg_comp: sk_X509_TRUST_cmp_func) callconv(.C) ?*struct_stack_st_X509_TRUST {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_TRUST, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_TRUST_new_null() callconv(.C) ?*struct_stack_st_X509_TRUST {
     return @as(?*struct_stack_st_X509_TRUST, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_TRUST_num(arg_sk: ?*const struct_stack_st_X509_TRUST) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_TRUST_zero(arg_sk: ?*struct_stack_st_X509_TRUST) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_TRUST_value(arg_sk: ?*const struct_stack_st_X509_TRUST, arg_i: usize) callconv(.C) [*c]X509_TRUST {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as([*c]X509_TRUST, @ptrCast(@alignCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i))));
 }
 pub fn sk_X509_TRUST_set(arg_sk: ?*struct_stack_st_X509_TRUST, arg_i: usize, arg_p: [*c]X509_TRUST) callconv(.C) [*c]X509_TRUST {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as([*c]X509_TRUST, @ptrCast(@alignCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p))))));
 }
 pub fn sk_X509_TRUST_free(arg_sk: ?*struct_stack_st_X509_TRUST) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_TRUST_pop_free(arg_sk: ?*struct_stack_st_X509_TRUST, arg_free_func: sk_X509_TRUST_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_TRUST_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_TRUST_insert(arg_sk: ?*struct_stack_st_X509_TRUST, arg_p: [*c]X509_TRUST, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_TRUST_delete(arg_sk: ?*struct_stack_st_X509_TRUST, arg_where: usize) callconv(.C) [*c]X509_TRUST {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as([*c]X509_TRUST, @ptrCast(@alignCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where))));
 }
 pub fn sk_X509_TRUST_delete_ptr(arg_sk: ?*struct_stack_st_X509_TRUST, arg_p: [*c]const X509_TRUST) callconv(.C) [*c]X509_TRUST {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as([*c]X509_TRUST, @ptrCast(@alignCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p))))));
 }
 pub fn sk_X509_TRUST_find(arg_sk: ?*const struct_stack_st_X509_TRUST, arg_out_index: [*c]usize, arg_p: [*c]const X509_TRUST) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_TRUST_call_cmp_func);
 }
 pub fn sk_X509_TRUST_shift(arg_sk: ?*struct_stack_st_X509_TRUST) callconv(.C) [*c]X509_TRUST {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]X509_TRUST, @ptrCast(@alignCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_X509_TRUST_push(arg_sk: ?*struct_stack_st_X509_TRUST, arg_p: [*c]X509_TRUST) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_TRUST_pop(arg_sk: ?*struct_stack_st_X509_TRUST) callconv(.C) [*c]X509_TRUST {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]X509_TRUST, @ptrCast(@alignCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_X509_TRUST_dup(arg_sk: ?*const struct_stack_st_X509_TRUST) callconv(.C) ?*struct_stack_st_X509_TRUST {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_TRUST, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_TRUST_sort(arg_sk: ?*struct_stack_st_X509_TRUST) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_TRUST_call_cmp_func);
 }
 pub fn sk_X509_TRUST_is_sorted(arg_sk: ?*const struct_stack_st_X509_TRUST) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_TRUST_set_cmp_func(arg_sk: ?*struct_stack_st_X509_TRUST, arg_comp: sk_X509_TRUST_cmp_func) callconv(.C) sk_X509_TRUST_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_TRUST_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_TRUST_deep_copy(arg_sk: ?*const struct_stack_st_X509_TRUST, arg_copy_func: sk_X509_TRUST_copy_func, arg_free_func: sk_X509_TRUST_free_func) callconv(.C) ?*struct_stack_st_X509_TRUST {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_TRUST, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_TRUST_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_TRUST_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub const sk_X509_REVOKED_free_func = ?*const fn (?*X509_REVOKED) callconv(.C) void;
 pub const sk_X509_REVOKED_copy_func = ?*const fn (?*X509_REVOKED) callconv(.C) ?*X509_REVOKED;
 pub const sk_X509_REVOKED_cmp_func = ?*const fn ([*c]?*const X509_REVOKED, [*c]?*const X509_REVOKED) callconv(.C) c_int;
 pub fn sk_X509_REVOKED_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_REVOKED_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*X509_REVOKED, @ptrCast(ptr)));
 }
 pub fn sk_X509_REVOKED_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_REVOKED_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*X509_REVOKED, @ptrCast(ptr)))));
 }
 pub fn sk_X509_REVOKED_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const X509_REVOKED = @as(?*const X509_REVOKED, @ptrCast(a.*));
     var b_ptr: ?*const X509_REVOKED = @as(?*const X509_REVOKED, @ptrCast(b.*));
     return @as(sk_X509_REVOKED_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_REVOKED_new(arg_comp: sk_X509_REVOKED_cmp_func) callconv(.C) ?*struct_stack_st_X509_REVOKED {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_REVOKED, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_REVOKED_new_null() callconv(.C) ?*struct_stack_st_X509_REVOKED {
     return @as(?*struct_stack_st_X509_REVOKED, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_REVOKED_num(arg_sk: ?*const struct_stack_st_X509_REVOKED) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_REVOKED_zero(arg_sk: ?*struct_stack_st_X509_REVOKED) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_REVOKED_value(arg_sk: ?*const struct_stack_st_X509_REVOKED, arg_i: usize) callconv(.C) ?*X509_REVOKED {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*X509_REVOKED, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_X509_REVOKED_set(arg_sk: ?*struct_stack_st_X509_REVOKED, arg_i: usize, arg_p: ?*X509_REVOKED) callconv(.C) ?*X509_REVOKED {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*X509_REVOKED, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_REVOKED_free(arg_sk: ?*struct_stack_st_X509_REVOKED) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_REVOKED_pop_free(arg_sk: ?*struct_stack_st_X509_REVOKED, arg_free_func: sk_X509_REVOKED_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_REVOKED_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_REVOKED_insert(arg_sk: ?*struct_stack_st_X509_REVOKED, arg_p: ?*X509_REVOKED, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_REVOKED_delete(arg_sk: ?*struct_stack_st_X509_REVOKED, arg_where: usize) callconv(.C) ?*X509_REVOKED {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*X509_REVOKED, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_X509_REVOKED_delete_ptr(arg_sk: ?*struct_stack_st_X509_REVOKED, arg_p: ?*const X509_REVOKED) callconv(.C) ?*X509_REVOKED {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*X509_REVOKED, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_REVOKED_find(arg_sk: ?*const struct_stack_st_X509_REVOKED, arg_out_index: [*c]usize, arg_p: ?*const X509_REVOKED) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_REVOKED_call_cmp_func);
 }
 pub fn sk_X509_REVOKED_shift(arg_sk: ?*struct_stack_st_X509_REVOKED) callconv(.C) ?*X509_REVOKED {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_REVOKED, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_REVOKED_push(arg_sk: ?*struct_stack_st_X509_REVOKED, arg_p: ?*X509_REVOKED) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_REVOKED_pop(arg_sk: ?*struct_stack_st_X509_REVOKED) callconv(.C) ?*X509_REVOKED {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_REVOKED, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_REVOKED_dup(arg_sk: ?*const struct_stack_st_X509_REVOKED) callconv(.C) ?*struct_stack_st_X509_REVOKED {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_REVOKED, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_REVOKED_sort(arg_sk: ?*struct_stack_st_X509_REVOKED) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_REVOKED_call_cmp_func);
 }
 pub fn sk_X509_REVOKED_is_sorted(arg_sk: ?*const struct_stack_st_X509_REVOKED) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_REVOKED_set_cmp_func(arg_sk: ?*struct_stack_st_X509_REVOKED, arg_comp: sk_X509_REVOKED_cmp_func) callconv(.C) sk_X509_REVOKED_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_REVOKED_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_REVOKED_deep_copy(arg_sk: ?*const struct_stack_st_X509_REVOKED, arg_copy_func: sk_X509_REVOKED_copy_func, arg_free_func: sk_X509_REVOKED_free_func) callconv(.C) ?*struct_stack_st_X509_REVOKED {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_REVOKED, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_REVOKED_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_REVOKED_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub const struct_stack_st_X509_INFO = opaque {};
@@ -4104,114 +4104,114 @@ pub const sk_X509_INFO_free_func = ?*const fn ([*c]X509_INFO) callconv(.C) void;
 pub const sk_X509_INFO_copy_func = ?*const fn ([*c]X509_INFO) callconv(.C) [*c]X509_INFO;
 pub const sk_X509_INFO_cmp_func = ?*const fn ([*c][*c]const X509_INFO, [*c][*c]const X509_INFO) callconv(.C) c_int;
 pub fn sk_X509_INFO_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_INFO_free_func, @ptrCast(@alignCast(free_func))).?(@as([*c]X509_INFO, @ptrCast(@alignCast(ptr))));
 }
 pub fn sk_X509_INFO_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_INFO_copy_func, @ptrCast(@alignCast(copy_func))).?(@as([*c]X509_INFO, @ptrCast(@alignCast(ptr))))));
 }
 pub fn sk_X509_INFO_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: [*c]const X509_INFO = @as([*c]const X509_INFO, @ptrCast(@alignCast(a.*)));
     var b_ptr: [*c]const X509_INFO = @as([*c]const X509_INFO, @ptrCast(@alignCast(b.*)));
     return @as(sk_X509_INFO_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_INFO_new(arg_comp: sk_X509_INFO_cmp_func) callconv(.C) ?*struct_stack_st_X509_INFO {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_INFO, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_INFO_new_null() callconv(.C) ?*struct_stack_st_X509_INFO {
     return @as(?*struct_stack_st_X509_INFO, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_INFO_num(arg_sk: ?*const struct_stack_st_X509_INFO) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_INFO_zero(arg_sk: ?*struct_stack_st_X509_INFO) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_INFO_value(arg_sk: ?*const struct_stack_st_X509_INFO, arg_i: usize) callconv(.C) [*c]X509_INFO {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as([*c]X509_INFO, @ptrCast(@alignCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i))));
 }
 pub fn sk_X509_INFO_set(arg_sk: ?*struct_stack_st_X509_INFO, arg_i: usize, arg_p: [*c]X509_INFO) callconv(.C) [*c]X509_INFO {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as([*c]X509_INFO, @ptrCast(@alignCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p))))));
 }
 pub fn sk_X509_INFO_free(arg_sk: ?*struct_stack_st_X509_INFO) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_INFO_pop_free(arg_sk: ?*struct_stack_st_X509_INFO, arg_free_func: sk_X509_INFO_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_INFO_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_INFO_insert(arg_sk: ?*struct_stack_st_X509_INFO, arg_p: [*c]X509_INFO, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_INFO_delete(arg_sk: ?*struct_stack_st_X509_INFO, arg_where: usize) callconv(.C) [*c]X509_INFO {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as([*c]X509_INFO, @ptrCast(@alignCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where))));
 }
 pub fn sk_X509_INFO_delete_ptr(arg_sk: ?*struct_stack_st_X509_INFO, arg_p: [*c]const X509_INFO) callconv(.C) [*c]X509_INFO {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as([*c]X509_INFO, @ptrCast(@alignCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p))))));
 }
 pub fn sk_X509_INFO_find(arg_sk: ?*const struct_stack_st_X509_INFO, arg_out_index: [*c]usize, arg_p: [*c]const X509_INFO) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_INFO_call_cmp_func);
 }
 pub fn sk_X509_INFO_shift(arg_sk: ?*struct_stack_st_X509_INFO) callconv(.C) [*c]X509_INFO {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]X509_INFO, @ptrCast(@alignCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_X509_INFO_push(arg_sk: ?*struct_stack_st_X509_INFO, arg_p: [*c]X509_INFO) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_INFO_pop(arg_sk: ?*struct_stack_st_X509_INFO) callconv(.C) [*c]X509_INFO {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]X509_INFO, @ptrCast(@alignCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_X509_INFO_dup(arg_sk: ?*const struct_stack_st_X509_INFO) callconv(.C) ?*struct_stack_st_X509_INFO {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_INFO, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_INFO_sort(arg_sk: ?*struct_stack_st_X509_INFO) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_INFO_call_cmp_func);
 }
 pub fn sk_X509_INFO_is_sorted(arg_sk: ?*const struct_stack_st_X509_INFO) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_INFO_set_cmp_func(arg_sk: ?*struct_stack_st_X509_INFO, arg_comp: sk_X509_INFO_cmp_func) callconv(.C) sk_X509_INFO_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_INFO_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_INFO_deep_copy(arg_sk: ?*const struct_stack_st_X509_INFO, arg_copy_func: sk_X509_INFO_copy_func, arg_free_func: sk_X509_INFO_free_func) callconv(.C) ?*struct_stack_st_X509_INFO {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_INFO, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_INFO_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_INFO_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern fn X509_get_notBefore(x509: ?*const X509) [*c]ASN1_TIME;
@@ -4402,114 +4402,114 @@ pub const sk_X509_LOOKUP_free_func = ?*const fn (?*X509_LOOKUP) callconv(.C) voi
 pub const sk_X509_LOOKUP_copy_func = ?*const fn (?*X509_LOOKUP) callconv(.C) ?*X509_LOOKUP;
 pub const sk_X509_LOOKUP_cmp_func = ?*const fn ([*c]?*const X509_LOOKUP, [*c]?*const X509_LOOKUP) callconv(.C) c_int;
 pub fn sk_X509_LOOKUP_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_LOOKUP_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*X509_LOOKUP, @ptrCast(ptr)));
 }
 pub fn sk_X509_LOOKUP_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_LOOKUP_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*X509_LOOKUP, @ptrCast(ptr)))));
 }
 pub fn sk_X509_LOOKUP_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const X509_LOOKUP = @as(?*const X509_LOOKUP, @ptrCast(a.*));
     var b_ptr: ?*const X509_LOOKUP = @as(?*const X509_LOOKUP, @ptrCast(b.*));
     return @as(sk_X509_LOOKUP_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_LOOKUP_new(arg_comp: sk_X509_LOOKUP_cmp_func) callconv(.C) ?*struct_stack_st_X509_LOOKUP {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_LOOKUP, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_LOOKUP_new_null() callconv(.C) ?*struct_stack_st_X509_LOOKUP {
     return @as(?*struct_stack_st_X509_LOOKUP, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_LOOKUP_num(arg_sk: ?*const struct_stack_st_X509_LOOKUP) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_LOOKUP_zero(arg_sk: ?*struct_stack_st_X509_LOOKUP) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_LOOKUP_value(arg_sk: ?*const struct_stack_st_X509_LOOKUP, arg_i: usize) callconv(.C) ?*X509_LOOKUP {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*X509_LOOKUP, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_X509_LOOKUP_set(arg_sk: ?*struct_stack_st_X509_LOOKUP, arg_i: usize, arg_p: ?*X509_LOOKUP) callconv(.C) ?*X509_LOOKUP {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*X509_LOOKUP, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_LOOKUP_free(arg_sk: ?*struct_stack_st_X509_LOOKUP) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_LOOKUP_pop_free(arg_sk: ?*struct_stack_st_X509_LOOKUP, arg_free_func: sk_X509_LOOKUP_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_LOOKUP_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_LOOKUP_insert(arg_sk: ?*struct_stack_st_X509_LOOKUP, arg_p: ?*X509_LOOKUP, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_LOOKUP_delete(arg_sk: ?*struct_stack_st_X509_LOOKUP, arg_where: usize) callconv(.C) ?*X509_LOOKUP {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*X509_LOOKUP, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_X509_LOOKUP_delete_ptr(arg_sk: ?*struct_stack_st_X509_LOOKUP, arg_p: ?*const X509_LOOKUP) callconv(.C) ?*X509_LOOKUP {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*X509_LOOKUP, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_LOOKUP_find(arg_sk: ?*const struct_stack_st_X509_LOOKUP, arg_out_index: [*c]usize, arg_p: ?*const X509_LOOKUP) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_LOOKUP_call_cmp_func);
 }
 pub fn sk_X509_LOOKUP_shift(arg_sk: ?*struct_stack_st_X509_LOOKUP) callconv(.C) ?*X509_LOOKUP {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_LOOKUP, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_LOOKUP_push(arg_sk: ?*struct_stack_st_X509_LOOKUP, arg_p: ?*X509_LOOKUP) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_LOOKUP_pop(arg_sk: ?*struct_stack_st_X509_LOOKUP) callconv(.C) ?*X509_LOOKUP {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_LOOKUP, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_LOOKUP_dup(arg_sk: ?*const struct_stack_st_X509_LOOKUP) callconv(.C) ?*struct_stack_st_X509_LOOKUP {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_LOOKUP, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_LOOKUP_sort(arg_sk: ?*struct_stack_st_X509_LOOKUP) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_LOOKUP_call_cmp_func);
 }
 pub fn sk_X509_LOOKUP_is_sorted(arg_sk: ?*const struct_stack_st_X509_LOOKUP) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_LOOKUP_set_cmp_func(arg_sk: ?*struct_stack_st_X509_LOOKUP, arg_comp: sk_X509_LOOKUP_cmp_func) callconv(.C) sk_X509_LOOKUP_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_LOOKUP_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_LOOKUP_deep_copy(arg_sk: ?*const struct_stack_st_X509_LOOKUP, arg_copy_func: sk_X509_LOOKUP_copy_func, arg_free_func: sk_X509_LOOKUP_free_func) callconv(.C) ?*struct_stack_st_X509_LOOKUP {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_LOOKUP, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_LOOKUP_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_LOOKUP_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub const struct_stack_st_X509_OBJECT = opaque {};
@@ -4517,114 +4517,114 @@ pub const sk_X509_OBJECT_free_func = ?*const fn (?*X509_OBJECT) callconv(.C) voi
 pub const sk_X509_OBJECT_copy_func = ?*const fn (?*X509_OBJECT) callconv(.C) ?*X509_OBJECT;
 pub const sk_X509_OBJECT_cmp_func = ?*const fn ([*c]?*const X509_OBJECT, [*c]?*const X509_OBJECT) callconv(.C) c_int;
 pub fn sk_X509_OBJECT_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_OBJECT_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*X509_OBJECT, @ptrCast(ptr)));
 }
 pub fn sk_X509_OBJECT_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_OBJECT_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*X509_OBJECT, @ptrCast(ptr)))));
 }
 pub fn sk_X509_OBJECT_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const X509_OBJECT = @as(?*const X509_OBJECT, @ptrCast(a.*));
     var b_ptr: ?*const X509_OBJECT = @as(?*const X509_OBJECT, @ptrCast(b.*));
     return @as(sk_X509_OBJECT_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_OBJECT_new(arg_comp: sk_X509_OBJECT_cmp_func) callconv(.C) ?*struct_stack_st_X509_OBJECT {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_OBJECT, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_OBJECT_new_null() callconv(.C) ?*struct_stack_st_X509_OBJECT {
     return @as(?*struct_stack_st_X509_OBJECT, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_OBJECT_num(arg_sk: ?*const struct_stack_st_X509_OBJECT) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_OBJECT_zero(arg_sk: ?*struct_stack_st_X509_OBJECT) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_OBJECT_value(arg_sk: ?*const struct_stack_st_X509_OBJECT, arg_i: usize) callconv(.C) ?*X509_OBJECT {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*X509_OBJECT, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_X509_OBJECT_set(arg_sk: ?*struct_stack_st_X509_OBJECT, arg_i: usize, arg_p: ?*X509_OBJECT) callconv(.C) ?*X509_OBJECT {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*X509_OBJECT, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_OBJECT_free(arg_sk: ?*struct_stack_st_X509_OBJECT) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_OBJECT_pop_free(arg_sk: ?*struct_stack_st_X509_OBJECT, arg_free_func: sk_X509_OBJECT_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_OBJECT_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_OBJECT_insert(arg_sk: ?*struct_stack_st_X509_OBJECT, arg_p: ?*X509_OBJECT, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_OBJECT_delete(arg_sk: ?*struct_stack_st_X509_OBJECT, arg_where: usize) callconv(.C) ?*X509_OBJECT {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*X509_OBJECT, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_X509_OBJECT_delete_ptr(arg_sk: ?*struct_stack_st_X509_OBJECT, arg_p: ?*const X509_OBJECT) callconv(.C) ?*X509_OBJECT {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*X509_OBJECT, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_OBJECT_find(arg_sk: ?*const struct_stack_st_X509_OBJECT, arg_out_index: [*c]usize, arg_p: ?*const X509_OBJECT) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_OBJECT_call_cmp_func);
 }
 pub fn sk_X509_OBJECT_shift(arg_sk: ?*struct_stack_st_X509_OBJECT) callconv(.C) ?*X509_OBJECT {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_OBJECT, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_OBJECT_push(arg_sk: ?*struct_stack_st_X509_OBJECT, arg_p: ?*X509_OBJECT) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_OBJECT_pop(arg_sk: ?*struct_stack_st_X509_OBJECT) callconv(.C) ?*X509_OBJECT {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_OBJECT, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_OBJECT_dup(arg_sk: ?*const struct_stack_st_X509_OBJECT) callconv(.C) ?*struct_stack_st_X509_OBJECT {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_OBJECT, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_OBJECT_sort(arg_sk: ?*struct_stack_st_X509_OBJECT) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_OBJECT_call_cmp_func);
 }
 pub fn sk_X509_OBJECT_is_sorted(arg_sk: ?*const struct_stack_st_X509_OBJECT) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_OBJECT_set_cmp_func(arg_sk: ?*struct_stack_st_X509_OBJECT, arg_comp: sk_X509_OBJECT_cmp_func) callconv(.C) sk_X509_OBJECT_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_OBJECT_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_OBJECT_deep_copy(arg_sk: ?*const struct_stack_st_X509_OBJECT, arg_copy_func: sk_X509_OBJECT_copy_func, arg_free_func: sk_X509_OBJECT_free_func) callconv(.C) ?*struct_stack_st_X509_OBJECT {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_OBJECT, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_OBJECT_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_OBJECT_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub const struct_stack_st_X509_VERIFY_PARAM = opaque {};
@@ -4632,114 +4632,114 @@ pub const sk_X509_VERIFY_PARAM_free_func = ?*const fn (?*X509_VERIFY_PARAM) call
 pub const sk_X509_VERIFY_PARAM_copy_func = ?*const fn (?*X509_VERIFY_PARAM) callconv(.C) ?*X509_VERIFY_PARAM;
 pub const sk_X509_VERIFY_PARAM_cmp_func = ?*const fn ([*c]?*const X509_VERIFY_PARAM, [*c]?*const X509_VERIFY_PARAM) callconv(.C) c_int;
 pub fn sk_X509_VERIFY_PARAM_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_X509_VERIFY_PARAM_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*X509_VERIFY_PARAM, @ptrCast(ptr)));
 }
 pub fn sk_X509_VERIFY_PARAM_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_X509_VERIFY_PARAM_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*X509_VERIFY_PARAM, @ptrCast(ptr)))));
 }
 pub fn sk_X509_VERIFY_PARAM_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const X509_VERIFY_PARAM = @as(?*const X509_VERIFY_PARAM, @ptrCast(a.*));
     var b_ptr: ?*const X509_VERIFY_PARAM = @as(?*const X509_VERIFY_PARAM, @ptrCast(b.*));
     return @as(sk_X509_VERIFY_PARAM_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_X509_VERIFY_PARAM_new(arg_comp: sk_X509_VERIFY_PARAM_cmp_func) callconv(.C) ?*struct_stack_st_X509_VERIFY_PARAM {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_X509_VERIFY_PARAM, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_X509_VERIFY_PARAM_new_null() callconv(.C) ?*struct_stack_st_X509_VERIFY_PARAM {
     return @as(?*struct_stack_st_X509_VERIFY_PARAM, @ptrCast(sk_new_null()));
 }
 pub fn sk_X509_VERIFY_PARAM_num(arg_sk: ?*const struct_stack_st_X509_VERIFY_PARAM) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_VERIFY_PARAM_zero(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_VERIFY_PARAM_value(arg_sk: ?*const struct_stack_st_X509_VERIFY_PARAM, arg_i: usize) callconv(.C) ?*X509_VERIFY_PARAM {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*X509_VERIFY_PARAM, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_X509_VERIFY_PARAM_set(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM, arg_i: usize, arg_p: ?*X509_VERIFY_PARAM) callconv(.C) ?*X509_VERIFY_PARAM {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*X509_VERIFY_PARAM, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_VERIFY_PARAM_free(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_VERIFY_PARAM_pop_free(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM, arg_free_func: sk_X509_VERIFY_PARAM_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_VERIFY_PARAM_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_X509_VERIFY_PARAM_insert(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM, arg_p: ?*X509_VERIFY_PARAM, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_X509_VERIFY_PARAM_delete(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM, arg_where: usize) callconv(.C) ?*X509_VERIFY_PARAM {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*X509_VERIFY_PARAM, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_X509_VERIFY_PARAM_delete_ptr(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM, arg_p: ?*const X509_VERIFY_PARAM) callconv(.C) ?*X509_VERIFY_PARAM {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*X509_VERIFY_PARAM, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_X509_VERIFY_PARAM_find(arg_sk: ?*const struct_stack_st_X509_VERIFY_PARAM, arg_out_index: [*c]usize, arg_p: ?*const X509_VERIFY_PARAM) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_X509_VERIFY_PARAM_call_cmp_func);
 }
 pub fn sk_X509_VERIFY_PARAM_shift(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM) callconv(.C) ?*X509_VERIFY_PARAM {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_VERIFY_PARAM, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_VERIFY_PARAM_push(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM, arg_p: ?*X509_VERIFY_PARAM) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_X509_VERIFY_PARAM_pop(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM) callconv(.C) ?*X509_VERIFY_PARAM {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*X509_VERIFY_PARAM, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_VERIFY_PARAM_dup(arg_sk: ?*const struct_stack_st_X509_VERIFY_PARAM) callconv(.C) ?*struct_stack_st_X509_VERIFY_PARAM {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_X509_VERIFY_PARAM, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_X509_VERIFY_PARAM_sort(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_X509_VERIFY_PARAM_call_cmp_func);
 }
 pub fn sk_X509_VERIFY_PARAM_is_sorted(arg_sk: ?*const struct_stack_st_X509_VERIFY_PARAM) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_X509_VERIFY_PARAM_set_cmp_func(arg_sk: ?*struct_stack_st_X509_VERIFY_PARAM, arg_comp: sk_X509_VERIFY_PARAM_cmp_func) callconv(.C) sk_X509_VERIFY_PARAM_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_X509_VERIFY_PARAM_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_X509_VERIFY_PARAM_deep_copy(arg_sk: ?*const struct_stack_st_X509_VERIFY_PARAM, arg_copy_func: sk_X509_VERIFY_PARAM_copy_func, arg_free_func: sk_X509_VERIFY_PARAM_free_func) callconv(.C) ?*struct_stack_st_X509_VERIFY_PARAM {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_X509_VERIFY_PARAM, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_VERIFY_PARAM_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_VERIFY_PARAM_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern fn X509_check_ca(x: ?*X509) c_int;
@@ -5186,114 +5186,114 @@ pub const sk_SSL_CIPHER_free_func = ?*const fn (?*const SSL_CIPHER) callconv(.C)
 pub const sk_SSL_CIPHER_copy_func = ?*const fn (?*const SSL_CIPHER) callconv(.C) ?*const SSL_CIPHER;
 pub const sk_SSL_CIPHER_cmp_func = ?*const fn ([*c]?*const SSL_CIPHER, [*c]?*const SSL_CIPHER) callconv(.C) c_int;
 pub fn sk_SSL_CIPHER_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_SSL_CIPHER_free_func, @ptrCast(@alignCast(free_func))).?(@as(?*const SSL_CIPHER, @ptrCast(ptr)));
 }
 pub fn sk_SSL_CIPHER_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@volatileCast(@constCast(@as(sk_SSL_CIPHER_copy_func, @ptrCast(@alignCast(copy_func))).?(@as(?*const SSL_CIPHER, @ptrCast(ptr)))))));
 }
 pub fn sk_SSL_CIPHER_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: ?*const SSL_CIPHER = @as(?*const SSL_CIPHER, @ptrCast(a.*));
     var b_ptr: ?*const SSL_CIPHER = @as(?*const SSL_CIPHER, @ptrCast(b.*));
     return @as(sk_SSL_CIPHER_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_SSL_CIPHER_new(arg_comp: sk_SSL_CIPHER_cmp_func) callconv(.C) ?*struct_stack_st_SSL_CIPHER {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_SSL_CIPHER, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_SSL_CIPHER_new_null() callconv(.C) ?*struct_stack_st_SSL_CIPHER {
     return @as(?*struct_stack_st_SSL_CIPHER, @ptrCast(sk_new_null()));
 }
 pub fn sk_SSL_CIPHER_num(arg_sk: ?*const struct_stack_st_SSL_CIPHER) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SSL_CIPHER_zero(arg_sk: ?*struct_stack_st_SSL_CIPHER) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SSL_CIPHER_value(arg_sk: ?*const struct_stack_st_SSL_CIPHER, arg_i: usize) callconv(.C) ?*const SSL_CIPHER {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as(?*const SSL_CIPHER, @ptrCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i)));
 }
 pub fn sk_SSL_CIPHER_set(arg_sk: ?*struct_stack_st_SSL_CIPHER, arg_i: usize, arg_p: ?*const SSL_CIPHER) callconv(.C) ?*const SSL_CIPHER {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as(?*const SSL_CIPHER, @ptrCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(@volatileCast(@constCast(p)))))));
 }
 pub fn sk_SSL_CIPHER_free(arg_sk: ?*struct_stack_st_SSL_CIPHER) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SSL_CIPHER_pop_free(arg_sk: ?*struct_stack_st_SSL_CIPHER, arg_free_func: sk_SSL_CIPHER_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_SSL_CIPHER_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_SSL_CIPHER_insert(arg_sk: ?*struct_stack_st_SSL_CIPHER, arg_p: ?*const SSL_CIPHER, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(@volatileCast(@constCast(p)))), where);
 }
 pub fn sk_SSL_CIPHER_delete(arg_sk: ?*struct_stack_st_SSL_CIPHER, arg_where: usize) callconv(.C) ?*const SSL_CIPHER {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as(?*const SSL_CIPHER, @ptrCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where)));
 }
 pub fn sk_SSL_CIPHER_delete_ptr(arg_sk: ?*struct_stack_st_SSL_CIPHER, arg_p: ?*const SSL_CIPHER) callconv(.C) ?*const SSL_CIPHER {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as(?*const SSL_CIPHER, @ptrCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p)))));
 }
 pub fn sk_SSL_CIPHER_find(arg_sk: ?*const struct_stack_st_SSL_CIPHER, arg_out_index: [*c]usize, arg_p: ?*const SSL_CIPHER) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_SSL_CIPHER_call_cmp_func);
 }
 pub fn sk_SSL_CIPHER_shift(arg_sk: ?*struct_stack_st_SSL_CIPHER) callconv(.C) ?*const SSL_CIPHER {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*const SSL_CIPHER, @ptrCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_SSL_CIPHER_push(arg_sk: ?*struct_stack_st_SSL_CIPHER, arg_p: ?*const SSL_CIPHER) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(@volatileCast(@constCast(p)))));
 }
 pub fn sk_SSL_CIPHER_pop(arg_sk: ?*struct_stack_st_SSL_CIPHER) callconv(.C) ?*const SSL_CIPHER {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*const SSL_CIPHER, @ptrCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_SSL_CIPHER_dup(arg_sk: ?*const struct_stack_st_SSL_CIPHER) callconv(.C) ?*struct_stack_st_SSL_CIPHER {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_SSL_CIPHER, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_SSL_CIPHER_sort(arg_sk: ?*struct_stack_st_SSL_CIPHER) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_SSL_CIPHER_call_cmp_func);
 }
 pub fn sk_SSL_CIPHER_is_sorted(arg_sk: ?*const struct_stack_st_SSL_CIPHER) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SSL_CIPHER_set_cmp_func(arg_sk: ?*struct_stack_st_SSL_CIPHER, arg_comp: sk_SSL_CIPHER_cmp_func) callconv(.C) sk_SSL_CIPHER_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_SSL_CIPHER_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_SSL_CIPHER_deep_copy(arg_sk: ?*const struct_stack_st_SSL_CIPHER, arg_copy_func: sk_SSL_CIPHER_copy_func, arg_free_func: sk_SSL_CIPHER_free_func) callconv(.C) ?*struct_stack_st_SSL_CIPHER {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_SSL_CIPHER, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_SSL_CIPHER_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_SSL_CIPHER_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern fn SSL_get_cipher_by_value(value: u16) ?*const SSL_CIPHER;
@@ -5494,114 +5494,114 @@ pub const sk_SRTP_PROTECTION_PROFILE_free_func = ?*const fn ([*c]const SRTP_PROT
 pub const sk_SRTP_PROTECTION_PROFILE_copy_func = ?*const fn ([*c]const SRTP_PROTECTION_PROFILE) callconv(.C) [*c]const SRTP_PROTECTION_PROFILE;
 pub const sk_SRTP_PROTECTION_PROFILE_cmp_func = ?*const fn ([*c][*c]const SRTP_PROTECTION_PROFILE, [*c][*c]const SRTP_PROTECTION_PROFILE) callconv(.C) c_int;
 pub fn sk_SRTP_PROTECTION_PROFILE_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_SRTP_PROTECTION_PROFILE_free_func, @ptrCast(@alignCast(free_func))).?(@as([*c]const SRTP_PROTECTION_PROFILE, @ptrCast(@alignCast(ptr))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@volatileCast(@constCast(@as(sk_SRTP_PROTECTION_PROFILE_copy_func, @ptrCast(@alignCast(copy_func))).?(@as([*c]const SRTP_PROTECTION_PROFILE, @ptrCast(@alignCast(ptr))))))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: [*c]const SRTP_PROTECTION_PROFILE = @as([*c]const SRTP_PROTECTION_PROFILE, @ptrCast(@alignCast(a.*)));
     var b_ptr: [*c]const SRTP_PROTECTION_PROFILE = @as([*c]const SRTP_PROTECTION_PROFILE, @ptrCast(@alignCast(b.*)));
     return @as(sk_SRTP_PROTECTION_PROFILE_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_new(arg_comp: sk_SRTP_PROTECTION_PROFILE_cmp_func) callconv(.C) ?*struct_stack_st_SRTP_PROTECTION_PROFILE {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_SRTP_PROTECTION_PROFILE, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_new_null() callconv(.C) ?*struct_stack_st_SRTP_PROTECTION_PROFILE {
     return @as(?*struct_stack_st_SRTP_PROTECTION_PROFILE, @ptrCast(sk_new_null()));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_num(arg_sk: ?*const struct_stack_st_SRTP_PROTECTION_PROFILE) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_zero(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_value(arg_sk: ?*const struct_stack_st_SRTP_PROTECTION_PROFILE, arg_i: usize) callconv(.C) [*c]const SRTP_PROTECTION_PROFILE {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as([*c]const SRTP_PROTECTION_PROFILE, @ptrCast(@alignCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_set(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE, arg_i: usize, arg_p: [*c]const SRTP_PROTECTION_PROFILE) callconv(.C) [*c]const SRTP_PROTECTION_PROFILE {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as([*c]const SRTP_PROTECTION_PROFILE, @ptrCast(@alignCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(@volatileCast(@constCast(p))))))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_free(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_pop_free(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE, arg_free_func: sk_SRTP_PROTECTION_PROFILE_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_SRTP_PROTECTION_PROFILE_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_insert(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE, arg_p: [*c]const SRTP_PROTECTION_PROFILE, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(@volatileCast(@constCast(p)))), where);
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_delete(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE, arg_where: usize) callconv(.C) [*c]const SRTP_PROTECTION_PROFILE {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as([*c]const SRTP_PROTECTION_PROFILE, @ptrCast(@alignCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_delete_ptr(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE, arg_p: [*c]const SRTP_PROTECTION_PROFILE) callconv(.C) [*c]const SRTP_PROTECTION_PROFILE {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as([*c]const SRTP_PROTECTION_PROFILE, @ptrCast(@alignCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p))))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_find(arg_sk: ?*const struct_stack_st_SRTP_PROTECTION_PROFILE, arg_out_index: [*c]usize, arg_p: [*c]const SRTP_PROTECTION_PROFILE) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_SRTP_PROTECTION_PROFILE_call_cmp_func);
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_shift(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE) callconv(.C) [*c]const SRTP_PROTECTION_PROFILE {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]const SRTP_PROTECTION_PROFILE, @ptrCast(@alignCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_push(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE, arg_p: [*c]const SRTP_PROTECTION_PROFILE) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(@volatileCast(@constCast(p)))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_pop(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE) callconv(.C) [*c]const SRTP_PROTECTION_PROFILE {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]const SRTP_PROTECTION_PROFILE, @ptrCast(@alignCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_dup(arg_sk: ?*const struct_stack_st_SRTP_PROTECTION_PROFILE) callconv(.C) ?*struct_stack_st_SRTP_PROTECTION_PROFILE {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_SRTP_PROTECTION_PROFILE, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_sort(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_SRTP_PROTECTION_PROFILE_call_cmp_func);
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_is_sorted(arg_sk: ?*const struct_stack_st_SRTP_PROTECTION_PROFILE) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_set_cmp_func(arg_sk: ?*struct_stack_st_SRTP_PROTECTION_PROFILE, arg_comp: sk_SRTP_PROTECTION_PROFILE_cmp_func) callconv(.C) sk_SRTP_PROTECTION_PROFILE_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_SRTP_PROTECTION_PROFILE_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_SRTP_PROTECTION_PROFILE_deep_copy(arg_sk: ?*const struct_stack_st_SRTP_PROTECTION_PROFILE, arg_copy_func: sk_SRTP_PROTECTION_PROFILE_copy_func, arg_free_func: sk_SRTP_PROTECTION_PROFILE_free_func) callconv(.C) ?*struct_stack_st_SRTP_PROTECTION_PROFILE {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_SRTP_PROTECTION_PROFILE, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_SRTP_PROTECTION_PROFILE_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_SRTP_PROTECTION_PROFILE_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 // pub extern fn SSL_CTX_set_srtp_profiles(ctx: ?*SSL_CTX, profiles: [*c]const u8) c_int;
@@ -5833,114 +5833,114 @@ pub const sk_SSL_COMP_free_func = ?*const fn ([*c]SSL_COMP) callconv(.C) void;
 pub const sk_SSL_COMP_copy_func = ?*const fn ([*c]SSL_COMP) callconv(.C) [*c]SSL_COMP;
 pub const sk_SSL_COMP_cmp_func = ?*const fn ([*c][*c]const SSL_COMP, [*c][*c]const SSL_COMP) callconv(.C) c_int;
 pub fn sk_SSL_COMP_call_free_func(arg_free_func: OPENSSL_sk_free_func, arg_ptr: ?*anyopaque) callconv(.C) void {
-    var free_func = arg_free_func;
-    var ptr = arg_ptr;
+    const free_func = arg_free_func;
+    const ptr = arg_ptr;
     @as(sk_SSL_COMP_free_func, @ptrCast(@alignCast(free_func))).?(@as([*c]SSL_COMP, @ptrCast(@alignCast(ptr))));
 }
 pub fn sk_SSL_COMP_call_copy_func(arg_copy_func: OPENSSL_sk_copy_func, arg_ptr: ?*anyopaque) callconv(.C) ?*anyopaque {
-    var copy_func = arg_copy_func;
-    var ptr = arg_ptr;
+    const copy_func = arg_copy_func;
+    const ptr = arg_ptr;
     return @as(?*anyopaque, @ptrCast(@as(sk_SSL_COMP_copy_func, @ptrCast(@alignCast(copy_func))).?(@as([*c]SSL_COMP, @ptrCast(@alignCast(ptr))))));
 }
 pub fn sk_SSL_COMP_call_cmp_func(arg_cmp_func: OPENSSL_sk_cmp_func, arg_a: [*c]const ?*const anyopaque, arg_b: [*c]const ?*const anyopaque) callconv(.C) c_int {
-    var cmp_func = arg_cmp_func;
-    var a = arg_a;
-    var b = arg_b;
+    const cmp_func = arg_cmp_func;
+    const a = arg_a;
+    const b = arg_b;
     var a_ptr: [*c]const SSL_COMP = @as([*c]const SSL_COMP, @ptrCast(@alignCast(a.*)));
     var b_ptr: [*c]const SSL_COMP = @as([*c]const SSL_COMP, @ptrCast(@alignCast(b.*)));
     return @as(sk_SSL_COMP_cmp_func, @ptrCast(@alignCast(cmp_func))).?(&a_ptr, &b_ptr);
 }
 pub fn sk_SSL_COMP_new(arg_comp: sk_SSL_COMP_cmp_func) callconv(.C) ?*struct_stack_st_SSL_COMP {
-    var comp = arg_comp;
+    const comp = arg_comp;
     return @as(?*struct_stack_st_SSL_COMP, @ptrCast(sk_new(@as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp))))));
 }
 pub fn sk_SSL_COMP_new_null() callconv(.C) ?*struct_stack_st_SSL_COMP {
     return @as(?*struct_stack_st_SSL_COMP, @ptrCast(sk_new_null()));
 }
 pub fn sk_SSL_COMP_num(arg_sk: ?*const struct_stack_st_SSL_COMP) callconv(.C) usize {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_num(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SSL_COMP_zero(arg_sk: ?*struct_stack_st_SSL_COMP) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_zero(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SSL_COMP_value(arg_sk: ?*const struct_stack_st_SSL_COMP, arg_i: usize) callconv(.C) [*c]SSL_COMP {
-    var sk = arg_sk;
-    var i = arg_i;
+    const sk = arg_sk;
+    const i = arg_i;
     return @as([*c]SSL_COMP, @ptrCast(@alignCast(sk_value(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), i))));
 }
 pub fn sk_SSL_COMP_set(arg_sk: ?*struct_stack_st_SSL_COMP, arg_i: usize, arg_p: [*c]SSL_COMP) callconv(.C) [*c]SSL_COMP {
-    var sk = arg_sk;
-    var i = arg_i;
-    var p = arg_p;
+    const sk = arg_sk;
+    const i = arg_i;
+    const p = arg_p;
     return @as([*c]SSL_COMP, @ptrCast(@alignCast(sk_set(@as([*c]_STACK, @ptrCast(@alignCast(sk))), i, @as(?*anyopaque, @ptrCast(p))))));
 }
 pub fn sk_SSL_COMP_free(arg_sk: ?*struct_stack_st_SSL_COMP) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_free(@as([*c]_STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SSL_COMP_pop_free(arg_sk: ?*struct_stack_st_SSL_COMP, arg_free_func: sk_SSL_COMP_free_func) callconv(.C) void {
-    var sk = arg_sk;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const free_func = arg_free_func;
     sk_pop_free_ex(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_SSL_COMP_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))));
 }
 pub fn sk_SSL_COMP_insert(arg_sk: ?*struct_stack_st_SSL_COMP, arg_p: [*c]SSL_COMP, arg_where: usize) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
-    var where = arg_where;
+    const sk = arg_sk;
+    const p = arg_p;
+    const where = arg_where;
     return sk_insert(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)), where);
 }
 pub fn sk_SSL_COMP_delete(arg_sk: ?*struct_stack_st_SSL_COMP, arg_where: usize) callconv(.C) [*c]SSL_COMP {
-    var sk = arg_sk;
-    var where = arg_where;
+    const sk = arg_sk;
+    const where = arg_where;
     return @as([*c]SSL_COMP, @ptrCast(@alignCast(sk_delete(@as([*c]_STACK, @ptrCast(@alignCast(sk))), where))));
 }
 pub fn sk_SSL_COMP_delete_ptr(arg_sk: ?*struct_stack_st_SSL_COMP, arg_p: [*c]const SSL_COMP) callconv(.C) [*c]SSL_COMP {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return @as([*c]SSL_COMP, @ptrCast(@alignCast(sk_delete_ptr(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*const anyopaque, @ptrCast(p))))));
 }
 pub fn sk_SSL_COMP_find(arg_sk: ?*const struct_stack_st_SSL_COMP, arg_out_index: [*c]usize, arg_p: [*c]const SSL_COMP) callconv(.C) c_int {
-    var sk = arg_sk;
-    var out_index = arg_out_index;
-    var p = arg_p;
+    const sk = arg_sk;
+    const out_index = arg_out_index;
+    const p = arg_p;
     return sk_find(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), out_index, @as(?*const anyopaque, @ptrCast(p)), &sk_SSL_COMP_call_cmp_func);
 }
 pub fn sk_SSL_COMP_shift(arg_sk: ?*struct_stack_st_SSL_COMP) callconv(.C) [*c]SSL_COMP {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]SSL_COMP, @ptrCast(@alignCast(sk_shift(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_SSL_COMP_push(arg_sk: ?*struct_stack_st_SSL_COMP, arg_p: [*c]SSL_COMP) callconv(.C) usize {
-    var sk = arg_sk;
-    var p = arg_p;
+    const sk = arg_sk;
+    const p = arg_p;
     return sk_push(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(?*anyopaque, @ptrCast(p)));
 }
 pub fn sk_SSL_COMP_pop(arg_sk: ?*struct_stack_st_SSL_COMP) callconv(.C) [*c]SSL_COMP {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as([*c]SSL_COMP, @ptrCast(@alignCast(sk_pop(@as([*c]_STACK, @ptrCast(@alignCast(sk)))))));
 }
 pub fn sk_SSL_COMP_dup(arg_sk: ?*const struct_stack_st_SSL_COMP) callconv(.C) ?*struct_stack_st_SSL_COMP {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return @as(?*struct_stack_st_SSL_COMP, @ptrCast(sk_dup(@as([*c]const _STACK, @ptrCast(@alignCast(sk))))));
 }
 pub fn sk_SSL_COMP_sort(arg_sk: ?*struct_stack_st_SSL_COMP) callconv(.C) void {
-    var sk = arg_sk;
+    const sk = arg_sk;
     sk_sort(@as([*c]_STACK, @ptrCast(@alignCast(sk))), &sk_SSL_COMP_call_cmp_func);
 }
 pub fn sk_SSL_COMP_is_sorted(arg_sk: ?*const struct_stack_st_SSL_COMP) callconv(.C) c_int {
-    var sk = arg_sk;
+    const sk = arg_sk;
     return sk_is_sorted(@as([*c]const _STACK, @ptrCast(@alignCast(sk))));
 }
 pub fn sk_SSL_COMP_set_cmp_func(arg_sk: ?*struct_stack_st_SSL_COMP, arg_comp: sk_SSL_COMP_cmp_func) callconv(.C) sk_SSL_COMP_cmp_func {
-    var sk = arg_sk;
-    var comp = arg_comp;
+    const sk = arg_sk;
+    const comp = arg_comp;
     return @as(sk_SSL_COMP_cmp_func, @ptrCast(@alignCast(sk_set_cmp_func(@as([*c]_STACK, @ptrCast(@alignCast(sk))), @as(OPENSSL_sk_cmp_func, @ptrCast(@alignCast(comp)))))));
 }
 pub fn sk_SSL_COMP_deep_copy(arg_sk: ?*const struct_stack_st_SSL_COMP, arg_copy_func: sk_SSL_COMP_copy_func, arg_free_func: sk_SSL_COMP_free_func) callconv(.C) ?*struct_stack_st_SSL_COMP {
-    var sk = arg_sk;
-    var copy_func = arg_copy_func;
-    var free_func = arg_free_func;
+    const sk = arg_sk;
+    const copy_func = arg_copy_func;
+    const free_func = arg_free_func;
     return @as(?*struct_stack_st_SSL_COMP, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_SSL_COMP_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_SSL_COMP_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern fn SSL_cache_hit(ssl: ?*SSL) c_int;
@@ -19031,7 +19031,7 @@ pub const SSL = opaque {
         _ = SSL_set_mode(ssl, mode);
         _ = SSL_clear_mode(ssl, mode);
 
-        var alpns = &[_]u8{ 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+        const alpns = &[_]u8{ 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
         std.debug.assert(SSL_set_alpn_protos(ssl, alpns, alpns.len) == 0);
 
         SSL_enable_signed_cert_timestamps(ssl);
@@ -19202,7 +19202,7 @@ pub const BIOMethod = struct {
         comptime gets__: ?gets,
         comptime ctrl__: ?ctrl,
     ) *BIO_METHOD {
-        var method = BIO_meth_new(BIO_get_new_index() | BIO_TYPE_SOURCE_SINK, name);
+        const method = BIO_meth_new(BIO_get_new_index() | BIO_TYPE_SOURCE_SINK, name);
         if (comptime create__) |create_| {
             std.debug.assert(BIO_meth_set_create(method, create_) > 0);
         }

--- a/src/deps/c_ares.zig
+++ b/src/deps/c_ares.zig
@@ -227,7 +227,7 @@ pub const struct_hostent = extern struct {
     ) ares_host_callback {
         return &struct {
             pub fn handle(ctx: ?*anyopaque, status: c_int, timeouts: c_int, hostent: ?*struct_hostent) callconv(.C) void {
-                var this = bun.cast(*Type, ctx.?);
+                const this = bun.cast(*Type, ctx.?);
                 if (status != ARES_SUCCESS) {
                     function(this, Error.get(status), timeouts, null);
                     return;
@@ -244,7 +244,7 @@ pub const struct_hostent = extern struct {
     ) ares_callback {
         return &struct {
             pub fn handle(ctx: ?*anyopaque, status: c_int, timeouts: c_int, buffer: [*c]u8, buffer_length: c_int) callconv(.C) void {
-                var this = bun.cast(*Type, ctx.?);
+                const this = bun.cast(*Type, ctx.?);
                 if (status != ARES_SUCCESS) {
                     function(this, Error.get(status), timeouts, null);
                     return;
@@ -252,14 +252,14 @@ pub const struct_hostent = extern struct {
 
                 var start: [*c]struct_hostent = undefined;
                 if (comptime strings.eqlComptime(lookup_name, "ns")) {
-                    var result = ares_parse_ns_reply(buffer, buffer_length, &start);
+                    const result = ares_parse_ns_reply(buffer, buffer_length, &start);
                     if (result != ARES_SUCCESS) {
                         function(this, Error.get(result), timeouts, null);
                         return;
                     }
                     function(this, null, timeouts, start);
                 } else if (comptime strings.eqlComptime(lookup_name, "ptr")) {
-                    var result = ares_parse_ptr_reply(buffer, buffer_length, null, 0, std.os.AF.INET, &start);
+                    const result = ares_parse_ptr_reply(buffer, buffer_length, null, 0, std.os.AF.INET, &start);
                     if (result != ARES_SUCCESS) {
                         function(this, Error.get(result), timeouts, null);
                         return;
@@ -269,7 +269,7 @@ pub const struct_hostent = extern struct {
                     var addrttls: [256]struct_ares_addrttl = undefined;
                     var naddrttls: i32 = 256;
 
-                    var result = ares_parse_a_reply(buffer, buffer_length, &start, &addrttls, &naddrttls);
+                    const result = ares_parse_a_reply(buffer, buffer_length, &start, &addrttls, &naddrttls);
                     if (result != ARES_SUCCESS) {
                         function(this, Error.get(result), timeouts, null);
                         return;
@@ -321,7 +321,7 @@ pub const struct_nameinfo = extern struct {
     ) ares_nameinfo_callback {
         return &struct {
             pub fn handle(ctx: ?*anyopaque, status: c_int, timeouts: c_int, node: [*c]u8, service: [*c]u8) callconv(.C) void {
-                var this = bun.cast(*Type, ctx.?);
+                const this = bun.cast(*Type, ctx.?);
                 if (status != ARES_SUCCESS) {
                     function(this, Error.get(status), timeouts, null);
                     return;
@@ -382,7 +382,7 @@ pub const AddrInfo = extern struct {
         {
             defer arena.deinit();
 
-            var allocator = arena.allocator();
+            const allocator = arena.allocator();
             var j: u32 = 0;
             var current: ?*AddrInfo_node = addr_info.node;
             while (current) |this_node| : (current = this_node.next) {
@@ -410,12 +410,12 @@ pub const AddrInfo = extern struct {
     }
 
     pub inline fn name(this: *const AddrInfo) []const u8 {
-        var name_ = this.name_ orelse return "";
+        const name_ = this.name_ orelse return "";
         return bun.span(name_);
     }
 
     pub inline fn cnames(this: *const AddrInfo) []const AddrInfo_node {
-        var cnames_ = this.cnames_ orelse return &.{};
+        const cnames_ = this.cnames_ orelse return &.{};
         return bun.span(cnames_);
     }
 
@@ -429,7 +429,7 @@ pub const AddrInfo = extern struct {
     ) ares_addrinfo_callback {
         return &struct {
             pub fn handleAddrInfo(ctx: ?*anyopaque, status: c_int, timeouts: c_int, addr_info: ?*AddrInfo) callconv(.C) void {
-                var this = bun.cast(*Type, ctx.?);
+                const this = bun.cast(*Type, ctx.?);
 
                 function(this, Error.get(status), timeouts, addr_info);
             }
@@ -462,7 +462,7 @@ pub const Channel = opaque {
         }
         const SockStateWrap = struct {
             pub fn onSockState(ctx: ?*anyopaque, socket: ares_socket_t, readable: c_int, writable: c_int) callconv(.C) void {
-                var container = bun.cast(*Container, ctx.?);
+                const container = bun.cast(*Container, ctx.?);
                 Container.onDNSSocketState(container, @as(i32, @intCast(socket)), readable != 0, writable != 0);
             }
         };
@@ -568,7 +568,7 @@ pub const Channel = opaque {
         for (hints[0..@min(hints.len, 2)], 0..) |hint, i| {
             hints_buf[i] = hint;
         }
-        var hints_: [*c]const AddrInfo_hints = if (hints.len > 0) &hints_buf else null;
+        const hints_: [*c]const AddrInfo_hints = if (hints.len > 0) &hints_buf else null;
         ares_getaddrinfo(this, host_ptr, port_ptr, hints_, AddrInfo.callbackWrapper(Type, callback), ctx);
     }
 
@@ -738,7 +738,7 @@ pub const struct_ares_caa_reply = extern struct {
         var arena = @import("root").bun.ArenaAllocator.init(stack.get());
         defer arena.deinit();
 
-        var allocator = arena.allocator();
+        const allocator = arena.allocator();
         var count: usize = 0;
         var caa: ?*struct_ares_caa_reply = this;
         while (caa != null) : (caa = caa.?.next) {
@@ -783,14 +783,14 @@ pub const struct_ares_caa_reply = extern struct {
     ) ares_callback {
         return &struct {
             pub fn handle(ctx: ?*anyopaque, status: c_int, timeouts: c_int, buffer: [*c]u8, buffer_length: c_int) callconv(.C) void {
-                var this = bun.cast(*Type, ctx.?);
+                const this = bun.cast(*Type, ctx.?);
                 if (status != ARES_SUCCESS) {
                     function(this, Error.get(status), timeouts, null);
                     return;
                 }
 
                 var start: [*c]struct_ares_caa_reply = undefined;
-                var result = ares_parse_caa_reply(buffer, buffer_length, &start);
+                const result = ares_parse_caa_reply(buffer, buffer_length, &start);
                 if (result != ARES_SUCCESS) {
                     function(this, Error.get(result), timeouts, null);
                     return;
@@ -816,7 +816,7 @@ pub const struct_ares_srv_reply = extern struct {
         var arena = @import("root").bun.ArenaAllocator.init(stack.get());
         defer arena.deinit();
 
-        var allocator = arena.allocator();
+        const allocator = arena.allocator();
         var count: usize = 0;
         var srv: ?*struct_ares_srv_reply = this;
         while (srv != null) : (srv = srv.?.next) {
@@ -868,14 +868,14 @@ pub const struct_ares_srv_reply = extern struct {
     ) ares_callback {
         return &struct {
             pub fn handleSrv(ctx: ?*anyopaque, status: c_int, timeouts: c_int, buffer: [*c]u8, buffer_length: c_int) callconv(.C) void {
-                var this = bun.cast(*Type, ctx.?);
+                const this = bun.cast(*Type, ctx.?);
                 if (status != ARES_SUCCESS) {
                     function(this, Error.get(status), timeouts, null);
                     return;
                 }
 
                 var srv_start: [*c]struct_ares_srv_reply = undefined;
-                var result = ares_parse_srv_reply(buffer, buffer_length, &srv_start);
+                const result = ares_parse_srv_reply(buffer, buffer_length, &srv_start);
                 if (result != ARES_SUCCESS) {
                     function(this, Error.get(result), timeouts, null);
                     return;
@@ -899,7 +899,7 @@ pub const struct_ares_mx_reply = extern struct {
         var arena = @import("root").bun.ArenaAllocator.init(stack.get());
         defer arena.deinit();
 
-        var allocator = arena.allocator();
+        const allocator = arena.allocator();
         var count: usize = 0;
         var mx: ?*struct_ares_mx_reply = this;
         while (mx != null) : (mx = mx.?.next) {
@@ -942,14 +942,14 @@ pub const struct_ares_mx_reply = extern struct {
     ) ares_callback {
         return &struct {
             pub fn handle(ctx: ?*anyopaque, status: c_int, timeouts: c_int, buffer: [*c]u8, buffer_length: c_int) callconv(.C) void {
-                var this = bun.cast(*Type, ctx.?);
+                const this = bun.cast(*Type, ctx.?);
                 if (status != ARES_SUCCESS) {
                     function(this, Error.get(status), timeouts, null);
                     return;
                 }
 
                 var start: [*c]struct_ares_mx_reply = undefined;
-                var result = ares_parse_mx_reply(buffer, buffer_length, &start);
+                const result = ares_parse_mx_reply(buffer, buffer_length, &start);
                 if (result != ARES_SUCCESS) {
                     function(this, Error.get(result), timeouts, null);
                     return;
@@ -973,7 +973,7 @@ pub const struct_ares_txt_reply = extern struct {
         var arena = @import("root").bun.ArenaAllocator.init(stack.get());
         defer arena.deinit();
 
-        var allocator = arena.allocator();
+        const allocator = arena.allocator();
         var count: usize = 0;
         var txt: ?*struct_ares_txt_reply = this;
         while (txt != null) : (txt = txt.?.next) {
@@ -1012,14 +1012,14 @@ pub const struct_ares_txt_reply = extern struct {
     ) ares_callback {
         return &struct {
             pub fn handleTxt(ctx: ?*anyopaque, status: c_int, timeouts: c_int, buffer: [*c]u8, buffer_length: c_int) callconv(.C) void {
-                var this = bun.cast(*Type, ctx.?);
+                const this = bun.cast(*Type, ctx.?);
                 if (status != ARES_SUCCESS) {
                     function(this, Error.get(status), timeouts, null);
                     return;
                 }
 
                 var srv_start: [*c]struct_ares_txt_reply = undefined;
-                var result = ares_parse_txt_reply(buffer, buffer_length, &srv_start);
+                const result = ares_parse_txt_reply(buffer, buffer_length, &srv_start);
                 if (result != ARES_SUCCESS) {
                     function(this, Error.get(result), timeouts, null);
                     return;
@@ -1053,7 +1053,7 @@ pub const struct_ares_naptr_reply = extern struct {
         var arena = @import("root").bun.ArenaAllocator.init(stack.get());
         defer arena.deinit();
 
-        var allocator = arena.allocator();
+        const allocator = arena.allocator();
         var count: usize = 0;
         var naptr: ?*struct_ares_naptr_reply = this;
         while (naptr != null) : (naptr = naptr.?.next) {
@@ -1110,14 +1110,14 @@ pub const struct_ares_naptr_reply = extern struct {
     ) ares_callback {
         return &struct {
             pub fn handleNaptr(ctx: ?*anyopaque, status: c_int, timeouts: c_int, buffer: [*c]u8, buffer_length: c_int) callconv(.C) void {
-                var this = bun.cast(*Type, ctx.?);
+                const this = bun.cast(*Type, ctx.?);
                 if (status != ARES_SUCCESS) {
                     function(this, Error.get(status), timeouts, null);
                     return;
                 }
 
                 var naptr_start: [*c]struct_ares_naptr_reply = undefined;
-                var result = ares_parse_naptr_reply(buffer, buffer_length, &naptr_start);
+                const result = ares_parse_naptr_reply(buffer, buffer_length, &naptr_start);
                 if (result != ARES_SUCCESS) {
                     function(this, Error.get(result), timeouts, null);
                     return;
@@ -1145,7 +1145,7 @@ pub const struct_ares_soa_reply = extern struct {
         var arena = @import("root").bun.ArenaAllocator.init(stack.get());
         defer arena.deinit();
 
-        var allocator = arena.allocator();
+        const allocator = arena.allocator();
 
         return this.toJS(globalThis, allocator);
     }
@@ -1181,14 +1181,14 @@ pub const struct_ares_soa_reply = extern struct {
     ) ares_callback {
         return &struct {
             pub fn handleSoa(ctx: ?*anyopaque, status: c_int, timeouts: c_int, buffer: [*c]u8, buffer_length: c_int) callconv(.C) void {
-                var this = bun.cast(*Type, ctx.?);
+                const this = bun.cast(*Type, ctx.?);
                 if (status != ARES_SUCCESS) {
                     function(this, Error.get(status), timeouts, null);
                     return;
                 }
 
                 var soa_start: [*c]struct_ares_soa_reply = undefined;
-                var result = ares_parse_soa_reply(buffer, buffer_length, &soa_start);
+                const result = ares_parse_soa_reply(buffer, buffer_length, &soa_start);
                 if (result != ARES_SUCCESS) {
                     function(this, Error.get(result), timeouts, null);
                     return;
@@ -1497,9 +1497,9 @@ pub export fn Bun__canonicalizeIP(
     // windows uses 65 bytes for ipv6 addresses and linux/macos uses 46
     const INET6_ADDRSTRLEN = if (comptime bun.Environment.isWindows) 65 else 46;
 
-    var script_ctx = globalThis.bunVM();
+    const script_ctx = globalThis.bunVM();
     var args = JSC.Node.ArgumentsSlice.init(script_ctx, arguments.ptr[0..arguments.len]);
-    var addr_arg = args.nextEat().?;
+    const addr_arg = args.nextEat().?;
 
     if (bun.String.tryFromJS(addr_arg, globalThis)) |addr| {
         const addr_slice = addr.toSlice(bun.default_allocator);

--- a/src/deps/diffz/DiffMatchPatch.zig
+++ b/src/deps/diffz/DiffMatchPatch.zig
@@ -126,8 +126,8 @@ pub fn diffLines(
     else
         @as(u64, @intCast(std.time.milliTimestamp())) + dmp.diff_timeout;
 
-    var a = try diffLinesToChars(allocator, text1_in, text2_in);
-    var diffs = try dmp.diffInternal(allocator, a.chars_1, a.chars_2, false, deadline);
+    const a = try diffLinesToChars(allocator, text1_in, text2_in);
+    const diffs = try dmp.diffInternal(allocator, a.chars_1, a.chars_2, false, deadline);
     try diffCharsToLines(allocator, diffs.items, a.line_array.items);
 
     return diffs;
@@ -158,7 +158,7 @@ fn diffInternal(
 
     // Trim off common suffix (speedup).
     common_length = diffCommonSuffix(trimmed_before, trimmed_after);
-    var common_suffix = trimmed_before[trimmed_before.len - common_length ..];
+    const common_suffix = trimmed_before[trimmed_before.len - common_length ..];
     trimmed_before = trimmed_before[0 .. trimmed_before.len - common_length];
     trimmed_after = trimmed_after[0 .. trimmed_after.len - common_length];
 
@@ -262,7 +262,7 @@ fn diffCompute(
         // A half-match was found, sort out the return data.
 
         // Send both pairs off for separate processing.
-        var diffs_a = try dmp.diffInternal(
+        const diffs_a = try dmp.diffInternal(
             allocator,
             half_match.prefix_before,
             half_match.prefix_after,
@@ -329,9 +329,9 @@ fn diffHalfMatch(
     }
 
     // First check if the second quarter is the seed for a half-match.
-    var half_match_1 = try dmp.diffHalfMatchInternal(allocator, long_text, short_text, (long_text.len + 3) / 4);
+    const half_match_1 = try dmp.diffHalfMatchInternal(allocator, long_text, short_text, (long_text.len + 3) / 4);
     // Check again based on the third quarter.
-    var half_match_2 = try dmp.diffHalfMatchInternal(allocator, long_text, short_text, (long_text.len + 1) / 2);
+    const half_match_2 = try dmp.diffHalfMatchInternal(allocator, long_text, short_text, (long_text.len + 1) / 2);
 
     var half_match: ?HalfMatchResult = null;
     if (half_match_1 == null and half_match_2 == null) {
@@ -392,8 +392,8 @@ fn diffHalfMatchInternal(
         j = @as(isize, @intCast(std.mem.indexOf(u8, short_text[@as(usize, @intCast(j + 1))..], seed) orelse break :b false)) + j + 1;
         break :b true;
     }) {
-        var prefix_length = diffCommonPrefix(long_text[i..], short_text[@as(usize, @intCast(j))..]);
-        var suffix_length = diffCommonSuffix(long_text[0..i], short_text[0..@as(usize, @intCast(j))]);
+        const prefix_length = diffCommonPrefix(long_text[i..], short_text[@as(usize, @intCast(j))..]);
+        const suffix_length = diffCommonSuffix(long_text[0..i], short_text[0..@as(usize, @intCast(j))]);
         if (best_common.items.len < suffix_length + prefix_length) {
             best_common.items.len = 0;
             try best_common.appendSlice(allocator, short_text[@as(usize, @intCast(j - @as(isize, @intCast(suffix_length)))) .. @as(usize, @intCast(j - @as(isize, @intCast(suffix_length)))) + suffix_length]);
@@ -471,7 +471,7 @@ fn diffBisect(
         // Walk the front path one step.
         var k1 = -d + k1start;
         while (k1 <= d - k1end) : (k1 += 2) {
-            var k1_offset = v_offset + k1;
+            const k1_offset = v_offset + k1;
             var x1: isize = 0;
             if (k1 == -d or (k1 != d and
                 v1.items[@as(usize, @intCast(k1_offset - 1))] < v1.items[@as(usize, @intCast(k1_offset + 1))]))
@@ -495,7 +495,7 @@ fn diffBisect(
                 // Ran off the bottom of the graph.
                 k1start += 2;
             } else if (front) {
-                var k2_offset = v_offset + delta - k1;
+                const k2_offset = v_offset + delta - k1;
                 if (k2_offset >= 0 and k2_offset < v_length and v2.items[@as(usize, @intCast(k2_offset))] != -1) {
                     // Mirror x2 onto top-left coordinate system.
                     const x2 = before_length - v2.items[@as(usize, @intCast(k2_offset))];
@@ -603,10 +603,10 @@ fn diffLineMode(
     deadline: u64,
 ) DiffError!DiffList {
     // Scan the text on a line-by-line basis first.
-    var a = try diffLinesToChars(allocator, text1_in, text2_in);
-    var text1 = a.chars_1;
-    var text2 = a.chars_2;
-    var line_array = a.line_array;
+    const a = try diffLinesToChars(allocator, text1_in, text2_in);
+    const text1 = a.chars_1;
+    const text2 = a.chars_2;
+    const line_array = a.line_array;
 
     var diffs: DiffList = try dmp.diffInternal(allocator, text1, text2, false, deadline);
 
@@ -653,7 +653,7 @@ fn diffLineMode(
                         &.{},
                     );
                     pointer = pointer - count_delete - count_insert;
-                    var sub_diff = try dmp.diffInternal(allocator, text_delete.items, text_insert.items, false, deadline);
+                    const sub_diff = try dmp.diffInternal(allocator, text_delete.items, text_insert.items, false, deadline);
                     // diffs.InsertRange(pointer, sub_diff);
                     try diffs.insertSlice(allocator, pointer, sub_diff.items);
                     pointer = pointer + sub_diff.items.len;
@@ -700,8 +700,8 @@ fn diffLinesToChars(
     try line_array.append(allocator, "");
 
     // Allocate 2/3rds of the space for text1, the rest for text2.
-    var chars1 = try diffLinesToCharsMunge(allocator, text1, &line_array, &line_hash, 170);
-    var chars2 = try diffLinesToCharsMunge(allocator, text2, &line_array, &line_hash, 255);
+    const chars1 = try diffLinesToCharsMunge(allocator, text1, &line_array, &line_hash, 170);
+    const chars2 = try diffLinesToCharsMunge(allocator, text2, &line_array, &line_hash, 255);
     return .{ .chars_1 = chars1, .chars_2 = chars2, .line_array = line_array };
 }
 
@@ -1043,8 +1043,8 @@ fn diffCleanupSemantic(allocator: std.mem.Allocator, diffs: *DiffList) DiffError
         {
             const deletion = diffs.items[@as(usize, @intCast(pointer - 1))].text;
             const insertion = diffs.items[@as(usize, @intCast(pointer))].text;
-            var overlap_length1: usize = diffCommonOverlap(deletion, insertion);
-            var overlap_length2: usize = diffCommonOverlap(insertion, deletion);
+            const overlap_length1: usize = diffCommonOverlap(deletion, insertion);
+            const overlap_length2: usize = diffCommonOverlap(insertion, deletion);
             if (overlap_length1 >= overlap_length2) {
                 if (@as(f32, @floatFromInt(overlap_length1)) >= @as(f32, @floatFromInt(deletion.len)) / 2.0 or
                     @as(f32, @floatFromInt(overlap_length1)) >= @as(f32, @floatFromInt(insertion.len)) / 2.0)
@@ -1360,8 +1360,8 @@ fn diffCommonOverlap(text1_in: []const u8, text2_in: []const u8) usize {
     var text2 = text2_in;
 
     // Cache the text lengths to prevent multiple calls.
-    var text1_length = text1.len;
-    var text2_length = text2.len;
+    const text1_length = text1.len;
+    const text2_length = text2.len;
     // Eliminate the null case.
     if (text1_length == 0 or text2_length == 0) {
         return 0;

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -527,7 +527,7 @@ pub const Loop = extern struct {
     }
 
     pub fn init() *Loop {
-        var this = get();
+        const this = get();
         uv_replace_allocator(
             this,
             @ptrCast(&bun.Mimalloc.mi_malloc),

--- a/src/deps/lol-html.zig
+++ b/src/deps/lol-html.zig
@@ -257,7 +257,7 @@ pub const HTMLRewriter = opaque {
                     auto_disable();
 
                     @setRuntimeSafety(false);
-                    var this = @as(*OutputSinkType, @ptrCast(@alignCast(user_data)));
+                    const this = @as(*OutputSinkType, @ptrCast(@alignCast(user_data)));
                     switch (len) {
                         0 => Done(this),
                         else => Writer(this, ptr[0..len]),

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -189,7 +189,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 }
             };
 
-            var events: us_socket_events_t = .{
+            const events: us_socket_events_t = .{
                 .on_open = SocketHandler.on_open,
                 .on_close = SocketHandler.on_close,
                 .on_data = SocketHandler.on_data,
@@ -231,7 +231,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             else
                 std.meta.alignment(ContextType);
 
-            var ptr = us_socket_ext(
+            const ptr = us_socket_ext(
                 comptime ssl_int,
                 this.socket,
             ) orelse return null;
@@ -414,10 +414,10 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
 
             var stack_fallback = std.heap.stackFallback(1024, bun.default_allocator);
             var allocator = stack_fallback.get();
-            var host_ = allocator.dupeZ(u8, host) catch return null;
+            const host_ = allocator.dupeZ(u8, host) catch return null;
             defer allocator.free(host_);
 
-            var socket = us_socket_context_connect(comptime ssl_int, socket_ctx, host_, port, null, 0, @sizeOf(Context)) orelse return null;
+            const socket = us_socket_context_connect(comptime ssl_int, socket_ctx, host_, port, null, 0, @sizeOf(Context)) orelse return null;
             const socket_ = ThisSocket{ .socket = socket };
 
             var holder = socket_.ext(Context) orelse {
@@ -463,13 +463,13 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             debug("connect(unix:{s})", .{path});
             var stack_fallback = std.heap.stackFallback(1024, bun.default_allocator);
             var allocator = stack_fallback.get();
-            var path_ = allocator.dupeZ(u8, path) catch return null;
+            const path_ = allocator.dupeZ(u8, path) catch return null;
             defer allocator.free(path_);
 
-            var socket = us_socket_context_connect_unix(comptime ssl_int, socket_ctx, path_, 0, 8) orelse return null;
+            const socket = us_socket_context_connect_unix(comptime ssl_int, socket_ctx, path_, 0, 8) orelse return null;
 
             const socket_ = ThisSocket{ .socket = socket };
-            var holder = socket_.ext(*anyopaque) orelse {
+            const holder = socket_.ext(*anyopaque) orelse {
                 if (comptime bun.Environment.allow_assert) unreachable;
                 _ = us_socket_close_connecting(comptime ssl_int, socket);
                 return null;
@@ -488,7 +488,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             var stack_fallback = std.heap.stackFallback(1024, bun.default_allocator);
             var allocator = stack_fallback.get();
 
-            var host_: ?[*:0]u8 = brk: {
+            const host_: ?[*:0]u8 = brk: {
                 // getaddrinfo expects `node` to be null if localhost
                 if (host.len < 6 and (bun.strings.eqlComptime(host, "[::1]") or bun.strings.eqlComptime(host, "[::]"))) {
                     break :brk null;
@@ -499,10 +499,10 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
 
             defer if (host_) |host__| allocator.free(host__[0..host.len]);
 
-            var socket = us_socket_context_connect(comptime ssl_int, socket_ctx, host_, port, null, 0, @sizeOf(*anyopaque)) orelse return null;
+            const socket = us_socket_context_connect(comptime ssl_int, socket_ctx, host_, port, null, 0, @sizeOf(*anyopaque)) orelse return null;
             const socket_ = ThisSocket{ .socket = socket };
 
-            var holder = socket_.ext(*anyopaque) orelse {
+            const holder = socket_.ext(*anyopaque) orelse {
                 if (comptime bun.Environment.allow_assert) unreachable;
                 _ = us_socket_close_connecting(comptime ssl_int, socket);
                 return null;
@@ -791,7 +791,7 @@ pub const Timer = opaque {
 
     pub fn set(this: *Timer, ptr: anytype, cb: ?*const fn (*Timer) callconv(.C) void, ms: i32, repeat_ms: i32) void {
         us_timer_set(this, cb, ms, repeat_ms);
-        var value_ptr = us_timer_ext(this);
+        const value_ptr = us_timer_ext(this);
         @setRuntimeSafety(false);
         @as(*@TypeOf(ptr), @ptrCast(@alignCast(value_ptr))).* = ptr;
     }
@@ -853,7 +853,7 @@ pub const SocketContext = opaque {
         else
             std.meta.alignment(ContextType);
 
-        var ptr = us_socket_context_ext(
+        const ptr = us_socket_context_ext(
             @intFromBool(ssl),
             this,
         ) orelse return null;
@@ -1375,12 +1375,12 @@ pub const WebSocketBehavior = extern struct {
 
             pub fn _open(raw_ws: *RawWebSocket) callconv(.C) void {
                 var ws = @unionInit(AnyWebSocket, active_field_name, @as(*WebSocket, @ptrCast(raw_ws)));
-                var this = ws.as(Type).?;
+                const this = ws.as(Type).?;
                 @call(.always_inline, Type.onOpen, .{ this, ws });
             }
             pub fn _message(raw_ws: *RawWebSocket, message: [*c]const u8, length: usize, opcode: Opcode) callconv(.C) void {
                 var ws = @unionInit(AnyWebSocket, active_field_name, @as(*WebSocket, @ptrCast(raw_ws)));
-                var this = ws.as(Type).?;
+                const this = ws.as(Type).?;
                 @call(
                     .always_inline,
                     Type.onMessage,
@@ -1389,7 +1389,7 @@ pub const WebSocketBehavior = extern struct {
             }
             pub fn _drain(raw_ws: *RawWebSocket) callconv(.C) void {
                 var ws = @unionInit(AnyWebSocket, active_field_name, @as(*WebSocket, @ptrCast(raw_ws)));
-                var this = ws.as(Type).?;
+                const this = ws.as(Type).?;
                 @call(.always_inline, Type.onDrain, .{
                     this,
                     ws,
@@ -1397,7 +1397,7 @@ pub const WebSocketBehavior = extern struct {
             }
             pub fn _ping(raw_ws: *RawWebSocket, message: [*c]const u8, length: usize) callconv(.C) void {
                 var ws = @unionInit(AnyWebSocket, active_field_name, @as(*WebSocket, @ptrCast(raw_ws)));
-                var this = ws.as(Type).?;
+                const this = ws.as(Type).?;
                 @call(.always_inline, Type.onPing, .{
                     this,
                     ws,
@@ -1406,7 +1406,7 @@ pub const WebSocketBehavior = extern struct {
             }
             pub fn _pong(raw_ws: *RawWebSocket, message: [*c]const u8, length: usize) callconv(.C) void {
                 var ws = @unionInit(AnyWebSocket, active_field_name, @as(*WebSocket, @ptrCast(raw_ws)));
-                var this = ws.as(Type).?;
+                const this = ws.as(Type).?;
                 @call(.always_inline, Type.onPong, .{
                     this,
                     ws,
@@ -1415,7 +1415,7 @@ pub const WebSocketBehavior = extern struct {
             }
             pub fn _close(raw_ws: *RawWebSocket, code: i32, message: [*c]const u8, length: usize) callconv(.C) void {
                 var ws = @unionInit(AnyWebSocket, active_field_name, @as(*WebSocket, @ptrCast(raw_ws)));
-                var this = ws.as(Type).?;
+                const this = ws.as(Type).?;
                 @call(
                     .always_inline,
                     Type.onClose,

--- a/src/deps/zig-clap/clap.zig
+++ b/src/deps/zig-clap/clap.zig
@@ -468,7 +468,7 @@ pub fn simpleHelp(
     const max_spacing = blk: {
         var res: usize = 2;
         for (params) |param| {
-            var flags_len = if (param.names.long) |l| l.len else 0;
+            const flags_len = if (param.names.long) |l| l.len else 0;
             if (res < flags_len)
                 res = flags_len;
         }
@@ -508,7 +508,7 @@ pub fn simpleHelpBunTopLevel(
     const computed_max_spacing = comptime blk: {
         var res: usize = 2;
         for (params) |param| {
-            var flags_len = if (param.names.long) |l| l.len else 0;
+            const flags_len = if (param.names.long) |l| l.len else 0;
             if (res < flags_len)
                 res = flags_len;
         }

--- a/src/deps/zig-datetime/src/datetime.zig
+++ b/src/deps/zig-datetime/src/datetime.zig
@@ -104,7 +104,7 @@ test "leapyear" {
 
 // Number of days before Jan 1st of year
 pub fn daysBeforeYear(year: u32) u32 {
-    var y: u32 = year - 1;
+    const y: u32 = year - 1;
     return y * 365 + @divFloor(y, 4) - @divFloor(y, 100) + @divFloor(y, 400);
 }
 
@@ -279,7 +279,7 @@ pub const Date = struct {
 
         // Now the year is correct, and n is the offset from January 1.  We find
         // the month via an estimate that's either exact or one too large.
-        var leapyear = (n1 == 3) and (n4 != 24 or n100 == 3);
+        const leapyear = (n1 == 3) and (n4 != 24 or n100 == 3);
         assert(leapyear == isLeapYear(year));
         var month = (n + 50) >> 5;
         if (month == 0) month = 12; // Loop around
@@ -352,7 +352,7 @@ pub const Date = struct {
         }
         const days_between = today - first_monday;
         var week = @divFloor(days_between, 7);
-        var day = @mod(days_between, 7);
+        const day = @mod(days_between, 7);
         if (week >= 52 and today >= daysBeforeFirstMonday(y + 1)) {
             y += 1;
             week = 0;
@@ -437,7 +437,7 @@ pub const Date = struct {
 
     // Return day of year starting with 1
     pub fn dayOfYear(self: Date) u16 {
-        var d = self.toOrdinal() - daysBeforeYear(self.year);
+        const d = self.toOrdinal() - daysBeforeYear(self.year);
         assert(d >= 1 and d <= 366);
         return @as(u16, @intCast(d));
     }
@@ -541,7 +541,7 @@ test "date-now" {
 
 test "date-compare" {
     var d1 = try Date.create(2019, 7, 3);
-    var d2 = try Date.create(2019, 7, 3);
+    const d2 = try Date.create(2019, 7, 3);
     var d3 = try Date.create(2019, 6, 3);
     var d4 = try Date.create(2020, 7, 3);
     try testing.expect(d1.eql(d2));
@@ -683,7 +683,7 @@ test "date-create" {
 
 test "date-copy" {
     var d1 = try Date.create(2020, 1, 1);
-    var d2 = try d1.copy();
+    const d2 = try d1.copy();
     try testing.expect(d1.eql(d2));
 }
 
@@ -696,7 +696,7 @@ test "date-parse-iso" {
 }
 
 test "date-format-iso" {
-    var date_strs = [_][]const u8{
+    const date_strs = [_][]const u8{
         "0959-02-05",
         "2018-12-15",
     };
@@ -710,7 +710,7 @@ test "date-format-iso" {
 }
 
 test "date-format-iso-buf" {
-    var date_strs = [_][]const u8{
+    const date_strs = [_][]const u8{
         "0959-02-05",
         "2018-12-15",
     };
@@ -723,7 +723,7 @@ test "date-format-iso-buf" {
 }
 
 test "date-write-iso" {
-    var date_strs = [_][]const u8{
+    const date_strs = [_][]const u8{
         "0959-02-05",
         "2018-12-15",
     };
@@ -1015,7 +1015,7 @@ test "time-from-seconds" {
 
 test "time-copy" {
     var t1 = try Time.create(8, 30, 0, 0);
-    var t2 = try t1.copy();
+    const t2 = try t1.copy();
     try testing.expect(t1.eql(t2));
 }
 
@@ -1023,7 +1023,7 @@ test "time-compare" {
     var t1 = try Time.create(8, 30, 0, 0);
     var t2 = try Time.create(9, 30, 0, 0);
     var t3 = try Time.create(8, 0, 0, 0);
-    var t4 = try Time.create(9, 30, 17, 0);
+    const t4 = try Time.create(9, 30, 17, 0);
 
     try testing.expect(t1.lt(t2));
     try testing.expect(t1.gt(t3));
@@ -1517,7 +1517,7 @@ test "datetime-compare" {
     var dt3 = Datetime.now();
     try testing.expect(dt3.gt(dt2));
 
-    var dt4 = try dt3.copy();
+    const dt4 = try dt3.copy();
     try testing.expect(dt3.eql(dt4));
 
     var dt5 = dt1.shiftTimezone(&timezones.America.Louisville);
@@ -1548,9 +1548,9 @@ test "datetime-parse-modified-since" {
 
 test "file-modified-date" {
     var f = try std.fs.cwd().openFile("README.md", .{});
-    var stat = try f.stat();
+    const stat = try f.stat();
     var buf: [32]u8 = undefined;
-    var str = try Datetime.formatHttpFromModifiedDate(&buf, stat.mtime);
+    const str = try Datetime.formatHttpFromModifiedDate(&buf, stat.mtime);
     std.log.warn("Modtime: {s}\n", .{str});
 }
 

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -123,7 +123,7 @@ pub fn directEnumArray(
 
 test "std.enums.directEnumArray" {
     const E = enum(i4) { a = 4, b = 6, c = 2 };
-    var runtime_false: bool = false;
+    const runtime_false: bool = false;
     const array = directEnumArray(E, bool, 4, .{
         .a = true,
         .b = runtime_false,
@@ -165,7 +165,7 @@ pub fn directEnumArrayDefault(
 
 test "std.enums.directEnumArrayDefault" {
     const E = enum(i4) { a = 4, b = 6, c = 2 };
-    var runtime_false: bool = false;
+    const runtime_false: bool = false;
     const array = directEnumArrayDefault(E, bool, false, 4, .{
         .a = true,
         .b = runtime_false,
@@ -179,7 +179,7 @@ test "std.enums.directEnumArrayDefault" {
 
 test "std.enums.directEnumArrayDefault slice" {
     const E = enum(i4) { a = 4, b = 6, c = 2 };
-    var runtime_b = "b";
+    const runtime_b = "b";
     const array = directEnumArrayDefault(E, []const u8, "default", 4, .{
         .a = "a",
         .b = runtime_b,
@@ -197,7 +197,7 @@ pub fn nameCast(comptime E: type, comptime value: anytype) E {
     return comptime blk: {
         const V = @TypeOf(value);
         if (V == E) break :blk value;
-        var name: ?[]const u8 = switch (@typeInfo(V)) {
+        const name: ?[]const u8 = switch (@typeInfo(V)) {
             .EnumLiteral, .Enum => @tagName(value),
             .Pointer => if (std.meta.trait.isZigString(V)) value else null,
             else => null,

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -173,7 +173,7 @@ pub const Loader = struct {
 
         var node_path_to_use = override_node;
         if (node_path_to_use.len == 0) {
-            var node = this.getNodePath(fs, &buf) orelse return false;
+            const node = this.getNodePath(fs, &buf) orelse return false;
             node_path_to_use = try fs.dirname_store.append([]const u8, bun.asByteSlice(node));
         }
         try this.map.put("NODE", node_path_to_use);
@@ -273,7 +273,7 @@ pub const Loader = struct {
                 errdefer allocator.free(e_strings);
                 errdefer allocator.free(key_buf);
                 var key_fixed_allocator = std.heap.FixedBufferAllocator.init(key_buf);
-                var key_allocator = key_fixed_allocator.allocator();
+                const key_allocator = key_fixed_allocator.allocator();
 
                 if (behavior == .prefix) {
                     while (iter.next()) |entry| {
@@ -288,7 +288,7 @@ pub const Loader = struct {
                                 else
                                     &[_]u8{},
                             };
-                            var expr_data = js_ast.Expr.Data{ .e_string = &e_strings[0] };
+                            const expr_data = js_ast.Expr.Data{ .e_string = &e_strings[0] };
 
                             _ = try to_string.getOrPutValue(
                                 key_str,
@@ -312,7 +312,7 @@ pub const Loader = struct {
                                         &[_]u8{},
                                 };
 
-                                var expr_data = js_ast.Expr.Data{ .e_string = &e_strings[0] };
+                                const expr_data = js_ast.Expr.Data{ .e_string = &e_strings[0] };
 
                                 _ = try to_string.getOrPutValue(
                                     framework_defaults.keys[key_i],
@@ -338,7 +338,7 @@ pub const Loader = struct {
                                 &[_]u8{},
                         };
 
-                        var expr_data = js_ast.Expr.Data{ .e_string = &e_strings[0] };
+                        const expr_data = js_ast.Expr.Data{ .e_string = &e_strings[0] };
 
                         _ = try to_string.getOrPutValue(
                             key,
@@ -355,7 +355,7 @@ pub const Loader = struct {
         }
 
         for (framework_defaults.keys, 0..) |key, i| {
-            var value = framework_defaults.values[i];
+            const value = framework_defaults.values[i];
 
             if (!to_string.contains(key) and !to_json.contains(key)) {
                 _ = try to_json.getOrPutValue(key, value);
@@ -380,8 +380,8 @@ pub const Loader = struct {
         for (std.os.environ) |_env| {
             var env = bun.span(_env);
             if (strings.indexOfChar(env, '=')) |i| {
-                var key = env[0..i];
-                var value = env[i + 1 ..];
+                const key = env[0..i];
+                const value = env[i + 1 ..];
                 if (key.len > 0) {
                     this.map.put(key, value) catch unreachable;
                 }
@@ -431,7 +431,7 @@ pub const Loader = struct {
         // iterate backwards, so the latest entry in the latest arg instance assumes the highest priority
         var i: usize = env_files.len;
         while (i > 0) : (i -= 1) {
-            var arg_value = std.mem.trim(u8, env_files[i - 1], " ");
+            const arg_value = std.mem.trim(u8, env_files[i - 1], " ");
             if (arg_value.len > 0) { // ignore blank args
                 var iter = std.mem.splitBackwardsScalar(u8, arg_value, ',');
                 while (iter.next()) |file_path| {
@@ -453,7 +453,7 @@ pub const Loader = struct {
         dir: *Fs.FileSystem.DirEntry,
         comptime suffix: DotEnvFileSuffix,
     ) !void {
-        var dir_handle: std.fs.Dir = std.fs.cwd();
+        const dir_handle: std.fs.Dir = std.fs.cwd();
 
         switch (comptime suffix) {
             .development => {
@@ -964,7 +964,7 @@ const Parser = struct {
                 continue;
             };
             const value = this.parseValue(is_process);
-            var entry = map.map.getOrPut(key) catch unreachable;
+            const entry = map.map.getOrPut(key) catch unreachable;
             if (entry.found_existing) {
                 if (entry.index < count) {
                     // Allow keys defined later in the same file to override keys defined earlier

--- a/src/exact_size_matcher.zig
+++ b/src/exact_size_matcher.zig
@@ -87,7 +87,7 @@ test "ExactSizeMatcher 5 letter" {
 
 test "ExactSizeMatcher 4 letter" {
     const Four = ExactSizeMatcher(4);
-    var word = "from".*;
+    const word = "from".*;
     try expect(Four.match(word) == Four.case("from"));
     try expect(Four.match(word) != Four.case("fro"));
 }

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -66,7 +66,7 @@ pub const FileSystem = struct {
 
     pub fn getFdPath(this: *const FileSystem, fd: FileDescriptorType) ![]const u8 {
         var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-        var dir = try bun.getFdPath(fd, &buf);
+        const dir = try bun.getFdPath(fd, &buf);
         return try this.dirname_store.append([]u8, dir);
     }
 
@@ -540,7 +540,7 @@ pub const FileSystem = struct {
                     if (bun.getenvZ("USERPROFILE")) |profile| {
                         var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
                         var parts = [_]string{"AppData/Local/Temp"};
-                        var out = bun.path.joinAbsStringBuf(profile, &buf, &parts, .loose);
+                        const out = bun.path.joinAbsStringBuf(profile, &buf, &parts, .loose);
                         break :brk bun.default_allocator.dupe(u8, out) catch unreachable;
                     }
 
@@ -646,7 +646,7 @@ pub const FileSystem = struct {
             }
 
             pub fn create(this: *TmpfilePosix, rfs: *RealFS, name: [:0]const u8) !void {
-                var tmpdir_ = try rfs.openTmpDir();
+                const tmpdir_ = try rfs.openTmpDir();
 
                 const flags = std.os.O.CREAT | std.os.O.RDWR | std.os.O.CLOEXEC;
                 this.dir_fd = bun.toFD(tmpdir_.fd);
@@ -693,11 +693,11 @@ pub const FileSystem = struct {
             }
 
             pub fn create(this: *TmpfileWindows, rfs: *RealFS, name: [:0]const u8) !void {
-                var tmpdir_ = try rfs.openTmpDir();
+                const tmpdir_ = try rfs.openTmpDir();
 
                 const flags = std.os.O.CREAT | std.os.O.WRONLY | std.os.O.CLOEXEC;
 
-                var result = try bun.sys.openat(bun.toFD(tmpdir_.fd), name, flags, 0).unwrap();
+                const result = try bun.sys.openat(bun.toFD(tmpdir_.fd), name, flags, 0).unwrap();
                 this.fd = bun.toFD(result);
                 var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
                 const existing_path = try bun.getFdPath(this.fd, &buf);
@@ -960,7 +960,7 @@ pub const FileSystem = struct {
         fn readDirectoryError(fs: *RealFS, dir: string, err: anyerror) !*EntriesOption {
             if (comptime FeatureFlags.enable_entry_cache) {
                 var get_or_put_result = try fs.entries.getOrPut(dir);
-                var opt = try fs.entries.put(&get_or_put_result, EntriesOption{
+                const opt = try fs.entries.put(&get_or_put_result, EntriesOption{
                     .err = DirEntry.Err{ .original_err = err, .canonical_error = err },
                 });
 
@@ -1053,7 +1053,7 @@ pub const FileSystem = struct {
             };
 
             if (comptime FeatureFlags.enable_entry_cache) {
-                var entries_ptr = in_place orelse bun.fs_allocator.create(DirEntry) catch unreachable;
+                const entries_ptr = in_place orelse bun.fs_allocator.create(DirEntry) catch unreachable;
                 if (in_place) |original| {
                     original.data.clearAndFree(bun.fs_allocator);
                 }
@@ -1065,7 +1065,7 @@ pub const FileSystem = struct {
                     .entries = entries_ptr,
                 };
 
-                var out = try fs.entries.put(&cache_result.?, result);
+                const out = try fs.entries.put(&cache_result.?, result);
 
                 return out;
             }
@@ -1208,7 +1208,7 @@ pub const FileSystem = struct {
         ) !Entry.Cache {
             var outpath: [bun.MAX_PATH_BYTES]u8 = undefined;
 
-            var stat = try C.lstat_absolute(absolute_path);
+            const stat = try C.lstat_absolute(absolute_path);
             const is_symlink = stat.kind == std.fs.File.Kind.SymLink;
             var _kind = stat.kind;
             var cache = Entry.Cache{
@@ -1266,10 +1266,10 @@ pub const FileSystem = struct {
                 .symlink = PathString.empty,
             };
 
-            var dir = _dir;
+            const dir = _dir;
             var combo = [2]string{ dir, base };
             var outpath: [bun.MAX_PATH_BYTES]u8 = undefined;
-            var entry_path = path_handler.joinAbsStringBuf(fs.cwd, &outpath, &combo, .auto);
+            const entry_path = path_handler.joinAbsStringBuf(fs.cwd, &outpath, &combo, .auto);
 
             outpath[entry_path.len + 1] = 0;
             outpath[entry_path.len] = 0;
@@ -1288,7 +1288,7 @@ pub const FileSystem = struct {
                 return cache;
             }
 
-            var stat = try C.lstat_absolute(absolute_path_c);
+            const stat = try C.lstat_absolute(absolute_path_c);
             const is_symlink = stat.kind == std.fs.File.Kind.sym_link;
             var _kind = stat.kind;
 
@@ -1400,7 +1400,7 @@ pub const NodeJSPathName = struct {
         // if only one character ext = "" even if filename it's "."
         if (filename.len > 1) {
             // Strip off the extension
-            var _dot = strings.lastIndexOfChar(filename, '.');
+            const _dot = strings.lastIndexOfChar(filename, '.');
             if (_dot) |dot| {
                 ext = filename[dot..];
                 if (dot > 0)
@@ -1684,7 +1684,7 @@ pub const Path = struct {
                 var buf = try allocator.alloc(u8, this.text.len + this.pretty.len + 2);
                 bun.copy(u8, buf, this.text);
                 buf.ptr[this.text.len] = 0;
-                var new_pretty = buf[this.text.len + 1 ..][0..this.pretty.len];
+                const new_pretty = buf[this.text.len + 1 ..][0..this.pretty.len];
                 bun.copy(u8, buf[this.text.len + 1 ..], this.pretty);
                 var new_path = Fs.Path.init(buf[0..this.text.len]);
                 buf.ptr[buf.len - 1] = 0;

--- a/src/glob.zig
+++ b/src/glob.zig
@@ -189,7 +189,7 @@ pub fn GlobWalker_(
                 const root_path = this.walker.cwd;
                 @memcpy(path_buf[0..root_path.len], root_path[0..root_path.len]);
                 path_buf[root_path.len] = 0;
-                var cwd_fd = switch (Syscall.open(@ptrCast(path_buf[0 .. root_path.len + 1]), std.os.O.DIRECTORY | std.os.O.RDONLY, 0)) {
+                const cwd_fd = switch (Syscall.open(@ptrCast(path_buf[0 .. root_path.len + 1]), std.os.O.DIRECTORY | std.os.O.RDONLY, 0)) {
                     .err => |err| return .{ .err = this.walker.handleSysErrWithPath(err, @ptrCast(path_buf[0 .. root_path.len + 1])) },
                     .result => |fd| fd,
                 };
@@ -247,7 +247,7 @@ pub fn GlobWalker_(
                 this.iter_state.directory.next_pattern = if (component_idx + 1 < this.walker.patternComponents.items.len) &this.walker.patternComponents.items[component_idx + 1] else null;
                 this.iter_state.directory.is_last = component_idx == this.walker.patternComponents.items.len - 1;
 
-                var fd: bun.FileDescriptor = fd: {
+                const fd: bun.FileDescriptor = fd: {
                     if (comptime root) {
                         if (had_dot_dot) break :fd switch (Syscall.openat(this.cwd_fd, dir_path, std.os.O.DIRECTORY | std.os.O.RDONLY, 0)) {
                             .err => |err| return .{
@@ -269,8 +269,8 @@ pub fn GlobWalker_(
                 };
 
                 this.iter_state.directory.fd = fd;
-                var dir = std.fs.Dir{ .fd = bun.fdcast(fd) };
-                var iterator = DirIterator.iterate(dir);
+                const dir = std.fs.Dir{ .fd = bun.fdcast(fd) };
+                const iterator = DirIterator.iterate(dir);
                 this.iter_state.directory.iter = iterator;
 
                 return Maybe(void).success;
@@ -568,7 +568,7 @@ pub fn GlobWalker_(
                     return .{ .err = err };
                 },
                 .result => |result| {
-                    var copiedCwd = try arena.allocator().alloc(u8, result.len);
+                    const copiedCwd = try arena.allocator().alloc(u8, result.len);
                     @memcpy(copiedCwd, result);
                     cwd = copiedCwd;
                 },
@@ -727,7 +727,7 @@ pub fn GlobWalker_(
         // NOTE you must check that the pattern at `idx` has `syntax_hint == .Double` first
         fn collapseSuccessiveDoubleWildcards(this: *GlobWalker, idx: u32) u32 {
             var component_idx = idx;
-            var pattern = this.patternComponents.items[idx];
+            const pattern = this.patternComponents.items[idx];
             _ = pattern;
             // Collapse successive double wildcards
             while (component_idx + 1 < this.patternComponents.items.len and
@@ -908,7 +908,7 @@ pub fn GlobWalker_(
         fn componentStringUnicodePosix(this: *GlobWalker, pattern_component: *Component) []const u32 {
             if (pattern_component.unicode_set) return this.pattern_codepoints[pattern_component.start_cp..pattern_component.end_cp];
 
-            var codepoints = this.pattern_codepoints[pattern_component.start_cp..pattern_component.end_cp];
+            const codepoints = this.pattern_codepoints[pattern_component.start_cp..pattern_component.end_cp];
             GlobWalker.convertUtf8ToCodepoints(
                 codepoints,
                 this.pattern[pattern_component.start .. pattern_component.start + pattern_component.len],
@@ -1181,7 +1181,7 @@ pub fn GlobWalker_(
 
             out_cp_len.* = cp_len;
 
-            var codepoints = try arena.allocator().alloc(u32, cp_len);
+            const codepoints = try arena.allocator().alloc(u32, cp_len);
             // On Windows filepaths are UTF-16 so its better to fill the codepoints buffer upfront
             if (comptime isWindows) {
                 GlobWalker.convertUtf8ToCodepoints(codepoints, pattern);

--- a/src/hive_array.zig
+++ b/src/hive_array.zig
@@ -121,12 +121,12 @@ test "HiveArray" {
     var a = HiveArray(Int, size).init();
 
     {
-        var b = a.get().?;
+        const b = a.get().?;
         try testing.expect(a.get().? != b);
         try testing.expectEqual(a.indexOf(b), 0);
         try testing.expect(a.put(b));
         try testing.expect(a.get().? == b);
-        var c = a.get().?;
+        const c = a.get().?;
         c.* = 123;
         var d: Int = 12345;
         try testing.expect(a.put(&d) == false);
@@ -137,7 +137,7 @@ test "HiveArray" {
     {
         var i: u63 = 0;
         while (i < size) {
-            var b = a.get().?;
+            const b = a.get().?;
             try testing.expectEqual(a.indexOf(b), i);
             try testing.expect(a.put(b));
             try testing.expect(a.get().? == b);

--- a/src/http.zig
+++ b/src/http.zig
@@ -192,7 +192,7 @@ const ProxySSLData = struct {
     partial: bool,
     temporary_slice: ?[]const u8,
     pub fn init() !ProxySSLData {
-        var buffer = try std.ArrayList(u8).initCapacity(bun.default_allocator, 16 * 1024);
+        const buffer = try std.ArrayList(u8).initCapacity(bun.default_allocator, 16 * 1024);
 
         return ProxySSLData{ .buffer = buffer, .partial = false, .temporary_slice = null };
     }
@@ -224,29 +224,29 @@ const ProxyTunnel = struct {
 
     pub fn init(comptime is_ssl: bool, client: *HTTPClient, socket: NewHTTPContext(is_ssl).HTTPSocket) ProxyTunnel {
         BoringSSL.load();
-        var context = BoringSSL.SSL_CTX.init();
+        const context = BoringSSL.SSL_CTX.init();
 
         if (context) |ssl_context| {
-            var ssl_ctx = ssl_context;
+            const ssl_ctx = ssl_context;
             var ssl = BoringSSL.SSL.init(ssl_context);
             ssl.setIsClient(true);
             var out_bio: *BoringSSL.BIO = undefined;
             if (comptime is_ssl) {
                 //TLS -> TLS
-                var proxy_ssl: *BoringSSL.SSL = @as(*BoringSSL.SSL, @ptrCast(socket.getNativeHandle()));
+                const proxy_ssl: *BoringSSL.SSL = @as(*BoringSSL.SSL, @ptrCast(socket.getNativeHandle()));
                 //create new SSL BIO
                 out_bio = BoringSSL.BIO_new(BoringSSL.BIO_f_ssl()) orelse unreachable;
                 //chain SSL bio with proxy BIO
-                var proxy_bio = BoringSSL.SSL_get_wbio(proxy_ssl);
+                const proxy_bio = BoringSSL.SSL_get_wbio(proxy_ssl);
                 _ = BoringSSL.BIO_push(out_bio, proxy_bio);
             } else {
                 // socket output bio for non-TLS -> TLS
-                var fd = @as(c_int, @intCast(@intFromPtr(socket.getNativeHandle())));
+                const fd = @as(c_int, @intCast(@intFromPtr(socket.getNativeHandle())));
                 out_bio = BoringSSL.BIO_new_fd(fd, BoringSSL.BIO_NOCLOSE);
             }
 
             // in memory bio to control input flow from onData handler
-            var in_bio = BoringSSL.BIO.init() catch {
+            const in_bio = BoringSSL.BIO.init() catch {
                 unreachable;
             };
             _ = BoringSSL.BIO_set_mem_eof_return(in_bio, -1);
@@ -359,7 +359,7 @@ fn NewHTTPContext(comptime ssl: bool) type {
 
         pub fn init(this: *@This()) !void {
             if (comptime ssl) {
-                var opts: uws.us_bun_socket_context_options_t = .{
+                const opts: uws.us_bun_socket_context_options_t = .{
                     // we request the cert so we load root certs and can verify it
                     .request_cert = 1,
                     // we manually abort the connection if the hostname doesn't match
@@ -369,7 +369,7 @@ fn NewHTTPContext(comptime ssl: bool) type {
 
                 this.sslCtx().setup();
             } else {
-                var opts: uws.us_socket_context_options_t = .{};
+                const opts: uws.us_socket_context_options_t = .{};
                 this.us_socket_context = uws.us_create_socket_context(ssl_int, http_thread.loop, @sizeOf(usize), opts).?;
             }
 
@@ -724,7 +724,7 @@ pub const HTTPThread = struct {
         Output.Source.configureNamedThread("HTTP Client");
         default_arena = Arena.init() catch unreachable;
         default_allocator = default_arena.allocator();
-        var loop = bun.uws.Loop.create(struct {
+        const loop = bun.uws.Loop.create(struct {
             pub fn wakeup(_: *uws.Loop) callconv(.C) void {
                 http_thread.drainEvents();
             }
@@ -803,7 +803,7 @@ pub const HTTPThread = struct {
             Output.flush();
             this.loop.run();
             if (comptime Environment.isDebug) {
-                var end = std.time.nanoTimestamp();
+                const end = std.time.nanoTimestamp();
                 threadlog("Waited {any}\n", .{std.fmt.fmtDurationSigned(@as(i64, @truncate(end - start_time)))});
                 Output.flush();
             }
@@ -833,7 +833,7 @@ pub const HTTPThread = struct {
         {
             var batch_ = batch;
             while (batch_.pop()) |task| {
-                var http: *AsyncHTTP = @fieldParentPtr(AsyncHTTP, "task", task);
+                const http: *AsyncHTTP = @fieldParentPtr(AsyncHTTP, "task", task);
                 this.queued_tasks.push(http);
             }
         }
@@ -866,7 +866,7 @@ pub fn checkServerIdentity(
                 if (client.signals.get(.cert_errors)) {
                     // clone the relevant data
                     const cert_size = BoringSSL.i2d_X509(x509, null);
-                    var cert = bun.default_allocator.alloc(u8, @intCast(cert_size)) catch @panic("OOM");
+                    const cert = bun.default_allocator.alloc(u8, @intCast(cert_size)) catch @panic("OOM");
                     var cert_ptr = cert.ptr;
                     const result_size = BoringSSL.i2d_X509(x509, &cert_ptr);
                     std.debug.assert(result_size == cert_size);
@@ -989,7 +989,7 @@ pub fn onClose(
         // a missing 0\r\n chunk
         if (client.state.isChunkedEncoding()) {
             if (picohttp.phr_decode_chunked_is_in_data(&client.state.chunked_decoder) == 0) {
-                var buf = client.state.getBodyBuffer();
+                const buf = client.state.getBodyBuffer();
                 if (buf.list.items.len > 0) {
                     client.state.received_last_chunk = true;
                     client.progressUpdate(comptime is_ssl, if (is_ssl) &http_thread.https_context else &http_thread.http_context, socket);
@@ -1050,7 +1050,7 @@ pub fn onEnd(
         // a missing 0\r\n chunk
         if (client.state.isChunkedEncoding()) {
             if (picohttp.phr_decode_chunked_is_in_data(&client.state.chunked_decoder) == 0) {
-                var buf = client.state.getBodyBuffer();
+                const buf = client.state.getBodyBuffer();
                 if (buf.list.items.len > 0) {
                     client.state.received_last_chunk = true;
                     client.progressUpdate(comptime is_ssl, if (is_ssl) &http_thread.https_context else &http_thread.http_context, socket);
@@ -1256,7 +1256,7 @@ pub const InternalState = struct {
         this.compressed_body.deinit();
         this.response_message_buffer.deinit();
 
-        var body_msg = this.body_out_str;
+        const body_msg = this.body_out_str;
         if (body_msg) |body| body.reset();
         if (this.zlib_reader) |reader| {
             this.zlib_reader = null;
@@ -1617,7 +1617,7 @@ pub const AsyncHTTP = struct {
 
     signals: Signals = .{},
 
-    pub var active_requests_count = std.atomic.Atomic(usize).init(0);
+    pub const active_requests_count = std.atomic.Atomic(usize).init(0);
     pub var max_simultaneous_requests = std.atomic.Atomic(usize).init(256);
 
     pub fn loadEnv(allocator: std.mem.Allocator, logger: *Log, env: *DotEnv.Loader) void {
@@ -1719,7 +1719,7 @@ pub const AsyncHTTP = struct {
                     var password_buffer: [4096]u8 = undefined;
                     @memset(&password_buffer, 0);
                     var password_stream = std.io.fixedBufferStream(&password_buffer);
-                    var password_writer = password_stream.writer();
+                    const password_writer = password_stream.writer();
                     const PassWriter = @TypeOf(password_writer);
                     const password_len = PercentEncoding.decode(PassWriter, password_writer, proxy.password) catch {
                         // Invalid proxy authorization
@@ -1731,7 +1731,7 @@ pub const AsyncHTTP = struct {
                     var username_buffer: [4096]u8 = undefined;
                     @memset(&username_buffer, 0);
                     var username_stream = std.io.fixedBufferStream(&username_buffer);
-                    var username_writer = username_stream.writer();
+                    const username_writer = username_stream.writer();
                     const UserWriter = @TypeOf(username_writer);
                     const username_len = PercentEncoding.decode(UserWriter, username_writer, proxy.username) catch {
                         // Invalid proxy authorization
@@ -1744,7 +1744,7 @@ pub const AsyncHTTP = struct {
                     defer allocator.free(auth);
                     const size = std.base64.standard.Encoder.calcSize(auth.len);
                     var buf = this.allocator.alloc(u8, size + "Basic ".len) catch unreachable;
-                    var encoded = std.base64.url_safe.Encoder.encode(buf["Basic ".len..], auth);
+                    const encoded = std.base64.url_safe.Encoder.encode(buf["Basic ".len..], auth);
                     buf[0.."Basic ".len].* = "Basic ".*;
                     this.client.proxy_authorization = buf[0 .. "Basic ".len + encoded.len];
                 } else {
@@ -1752,7 +1752,7 @@ pub const AsyncHTTP = struct {
                     var username_buffer: [4096]u8 = undefined;
                     @memset(&username_buffer, 0);
                     var username_stream = std.io.fixedBufferStream(&username_buffer);
-                    var username_writer = username_stream.writer();
+                    const username_writer = username_stream.writer();
                     const UserWriter = @TypeOf(username_writer);
                     const username_len = PercentEncoding.decode(UserWriter, username_writer, proxy.username) catch {
                         // Invalid proxy authorization
@@ -1763,7 +1763,7 @@ pub const AsyncHTTP = struct {
                     // only use user
                     const size = std.base64.standard.Encoder.calcSize(username_len);
                     var buf = allocator.alloc(u8, size + "Basic ".len) catch unreachable;
-                    var encoded = std.base64.url_safe.Encoder.encode(buf["Basic ".len..], username);
+                    const encoded = std.base64.url_safe.Encoder.encode(buf["Basic ".len..], username);
                     buf[0.."Basic ".len].* = "Basic ".*;
                     this.client.proxy_authorization = buf[0 .. "Basic ".len + encoded.len];
                 }
@@ -1804,7 +1804,7 @@ pub const AsyncHTTP = struct {
 
     fn reset(this: *AsyncHTTP) !void {
         const timeout = this.timeout;
-        var aborted = this.client.aborted;
+        const aborted = this.client.aborted;
         this.client = try HTTPClient.init(this.allocator, this.method, this.client.url, this.client.header_entries, this.client.header_buf, aborted);
         this.client.timeout = timeout;
         this.client.http_proxy = this.http_proxy;
@@ -1821,7 +1821,7 @@ pub const AsyncHTTP = struct {
                     var password_buffer: [4096]u8 = undefined;
                     @memset(&password_buffer, 0);
                     var password_stream = std.io.fixedBufferStream(&password_buffer);
-                    var password_writer = password_stream.writer();
+                    const password_writer = password_stream.writer();
                     const PassWriter = @TypeOf(password_writer);
                     const password_len = PercentEncoding.decode(PassWriter, password_writer, proxy.password) catch {
                         // Invalid proxy authorization
@@ -1833,7 +1833,7 @@ pub const AsyncHTTP = struct {
                     var username_buffer: [4096]u8 = undefined;
                     @memset(&username_buffer, 0);
                     var username_stream = std.io.fixedBufferStream(&username_buffer);
-                    var username_writer = username_stream.writer();
+                    const username_writer = username_stream.writer();
                     const UserWriter = @TypeOf(username_writer);
                     const username_len = PercentEncoding.decode(UserWriter, username_writer, proxy.username) catch {
                         // Invalid proxy authorization
@@ -1847,7 +1847,7 @@ pub const AsyncHTTP = struct {
                     defer this.allocator.free(auth);
                     const size = std.base64.standard.Encoder.calcSize(auth.len);
                     var buf = this.allocator.alloc(u8, size + "Basic ".len) catch unreachable;
-                    var encoded = std.base64.url_safe.Encoder.encode(buf["Basic ".len..], auth);
+                    const encoded = std.base64.url_safe.Encoder.encode(buf["Basic ".len..], auth);
                     buf[0.."Basic ".len].* = "Basic ".*;
                     this.client.proxy_authorization = buf[0 .. "Basic ".len + encoded.len];
                 } else {
@@ -1855,7 +1855,7 @@ pub const AsyncHTTP = struct {
                     var username_buffer: [4096]u8 = undefined;
                     @memset(&username_buffer, 0);
                     var username_stream = std.io.fixedBufferStream(&username_buffer);
-                    var username_writer = username_stream.writer();
+                    const username_writer = username_stream.writer();
                     const UserWriter = @TypeOf(username_writer);
                     const username_len = PercentEncoding.decode(UserWriter, username_writer, proxy.username) catch {
                         // Invalid proxy authorization
@@ -1866,7 +1866,7 @@ pub const AsyncHTTP = struct {
                     // only use user
                     const size = std.base64.standard.Encoder.calcSize(username_len);
                     var buf = this.allocator.alloc(u8, size + "Basic ".len) catch unreachable;
-                    var encoded = std.base64.url_safe.Encoder.encode(buf["Basic ".len..], username);
+                    const encoded = std.base64.url_safe.Encoder.encode(buf["Basic ".len..], username);
                     buf[0.."Basic ".len].* = "Basic ".*;
                     this.client.proxy_authorization = buf[0 .. "Basic ".len + encoded.len];
                 }
@@ -1976,8 +1976,8 @@ pub const AsyncHTTP = struct {
 pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
     var header_count: usize = 0;
     var header_entries = this.header_entries.slice();
-    var header_names = header_entries.items(.name);
-    var header_values = header_entries.items(.value);
+    const header_names = header_entries.items(.name);
+    const header_values = header_entries.items(.value);
     var request_headers_buf = &shared_request_headers_buf;
 
     var override_accept_encoding = false;
@@ -2081,7 +2081,7 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
 
 pub fn doRedirect(this: *HTTPClient) void {
     std.debug.assert(this.state.cloned_metadata == null);
-    var body_out_str = this.state.body_out_str.?;
+    const body_out_str = this.state.body_out_str.?;
     this.remaining_redirect_count -|= 1;
     std.debug.assert(this.redirect_type == FetchRedirect.follow);
 
@@ -2183,10 +2183,10 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
     switch (this.state.request_stage) {
         .pending, .headers => {
             var stack_fallback = std.heap.stackFallback(16384, default_allocator);
-            var allocator = stack_fallback.get();
+            const allocator = stack_fallback.get();
             var list = std.ArrayList(u8).initCapacity(allocator, stack_fallback.buffer.len) catch unreachable;
             defer if (list.capacity > stack_fallback.buffer.len) list.deinit();
-            var writer = &list.writer();
+            const writer = &list.writer();
 
             this.setTimeout(socket, 5);
 
@@ -2368,10 +2368,10 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
 
             this.setTimeout(socket, 5);
             var stack_fallback = std.heap.stackFallback(16384, default_allocator);
-            var allocator = stack_fallback.get();
+            const allocator = stack_fallback.get();
             var list = std.ArrayList(u8).initCapacity(allocator, stack_fallback.buffer.len) catch unreachable;
             defer if (list.capacity > stack_fallback.buffer.len) list.deinit();
-            var writer = &list.writer();
+            const writer = &list.writer();
 
             const request = this.buildRequest(this.state.request_body.len);
             writeRequest(
@@ -2570,7 +2570,7 @@ pub fn onData(this: *HTTPClient, comptime is_ssl: bool, incoming_data: []const u
             // we save the successful parsed response
             this.state.pending_response = response;
 
-            var body_buf = to_read[@min(@as(usize, @intCast(response.bytes_read)), to_read.len)..];
+            const body_buf = to_read[@min(@as(usize, @intCast(response.bytes_read)), to_read.len)..];
             // handle the case where we have a 100 Continue
             if (response.status_code == 100) {
                 // we still can have the 200 OK in the same buffer sometimes
@@ -2620,7 +2620,7 @@ pub fn onData(this: *HTTPClient, comptime is_ssl: bool, incoming_data: []const u
 
             if (this.state.content_encoding_i < response.headers.len and !this.state.did_set_content_encoding) {
                 // if it compressed with this header, it is no longer because we will decompress it
-                var mutable_headers = std.ArrayListUnmanaged(picohttp.Header){ .items = response.headers, .capacity = response.headers.len };
+                const mutable_headers = std.ArrayListUnmanaged(picohttp.Header){ .items = response.headers, .capacity = response.headers.len };
                 this.state.did_set_content_encoding = true;
                 response.headers = mutable_headers.items;
                 this.state.content_encoding_i = std.math.maxInt(@TypeOf(this.state.content_encoding_i));
@@ -2835,7 +2835,7 @@ fn cloneMetadata(this: *HTTPClient) void {
         builder.count(this.url.href);
         builder.allocate(this.allocator) catch unreachable;
         // headers_buf is owned by the cloned_response (aka cloned_response.headers)
-        var headers_buf = this.allocator.alloc(picohttp.Header, response.headers.len) catch unreachable;
+        const headers_buf = this.allocator.alloc(picohttp.Header, response.headers.len) catch unreachable;
         const cloned_response = response.clone(headers_buf, builder);
 
         // we clean the temporary response since cloned_metadata is now the owner
@@ -2867,8 +2867,8 @@ pub fn setTimeout(this: *HTTPClient, socket: anytype, minutes: c_uint) void {
 
 pub fn progressUpdate(this: *HTTPClient, comptime is_ssl: bool, ctx: *NewHTTPContext(is_ssl), socket: NewHTTPContext(is_ssl).HTTPSocket) void {
     if (this.state.stage != .done and this.state.stage != .fail) {
-        var out_str = this.state.body_out_str.?;
-        var body = out_str.*;
+        const out_str = this.state.body_out_str.?;
+        const body = out_str.*;
         const result = this.toResult();
         const is_done = !result.has_more;
 
@@ -2968,7 +2968,7 @@ pub const HTTPClientResult = struct {
                 }
 
                 pub fn wrapped_callback(ptr: *anyopaque, result: HTTPClientResult) void {
-                    var casted = @as(Type, @ptrCast(@alignCast(ptr)));
+                    const casted = @as(Type, @ptrCast(@alignCast(ptr)));
                     @call(.always_inline, callback, .{ casted, result });
                 }
             };
@@ -3123,7 +3123,7 @@ fn handleResponseBodyChunkedEncodingFromMultiplePackets(
     incoming_data: []const u8,
 ) !bool {
     var decoder = &this.state.chunked_decoder;
-    var buffer_ = this.state.getBodyBuffer();
+    const buffer_ = this.state.getBodyBuffer();
     var buffer = buffer_.*;
     try buffer.appendSlice(incoming_data);
 

--- a/src/http/url_path.zig
+++ b/src/http/url_path.zig
@@ -70,7 +70,7 @@ pub fn parse(possibly_encoded_pathname_: string) !URLPath {
         )];
 
         bun.copy(u8, possibly_encoded_pathname, possibly_encoded_pathname_[0..possibly_encoded_pathname.len]);
-        var clone = possibly_encoded_pathname[0..possibly_encoded_pathname.len];
+        const clone = possibly_encoded_pathname[0..possibly_encoded_pathname.len];
 
         var fbs = std.io.fixedBufferStream(
             // This is safe because:
@@ -80,7 +80,7 @@ pub fn parse(possibly_encoded_pathname_: string) !URLPath {
                 possibly_encoded_pathname,
             ),
         );
-        var writer = fbs.writer();
+        const writer = fbs.writer();
 
         decoded_pathname = possibly_encoded_pathname[0..try PercentEncoding.decodeFaultTolerant(@TypeOf(writer), writer, clone, &needs_redirect, true)];
     }

--- a/src/http/websocket.zig
+++ b/src/http/websocket.zig
@@ -149,7 +149,7 @@ pub const Websocket = struct {
         fd: std.os.fd_t,
         comptime flags: u32,
     ) Websocket {
-        var stream = ReadStream{
+        const stream = ReadStream{
             .buffer = &[_]u8{},
             .pos = 0,
         };
@@ -264,7 +264,7 @@ pub const Websocket = struct {
         @memset(&self.buf, 0);
 
         // Read and retry if we hit the end of the stream buffer
-        var start = try self.stream.read(&self.buf);
+        const start = try self.stream.read(&self.buf);
         if (start == 0) {
             return error.ConnectionClosed;
         }
@@ -322,7 +322,7 @@ pub const Websocket = struct {
         const end = start + length;
 
         if (end > self.read_stream.pos) {
-            var extend_length = try self.stream.read(self.buf[self.read_stream.pos..]);
+            const extend_length = try self.stream.read(self.buf[self.read_stream.pos..]);
             if (self.read_stream.pos + extend_length > self.buf.len) {
                 return error.MessageTooLarge;
             }

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -215,8 +215,8 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
 
         pub fn register(global: *JSC.JSGlobalObject, loop_: *anyopaque, ctx_: *anyopaque) callconv(.C) void {
             var vm = global.bunVM();
-            var loop: *bun.Async.Loop = @alignCast(@ptrCast(loop_));
-            var ctx: *uws.SocketContext = @as(*uws.SocketContext, @ptrCast(ctx_));
+            const loop: *bun.Async.Loop = @alignCast(@ptrCast(loop_));
+            const ctx: *uws.SocketContext = @as(*uws.SocketContext, @ptrCast(ctx_));
 
             if (vm.event_loop_handle) |other| {
                 std.debug.assert(other == loop);
@@ -260,7 +260,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             std.debug.assert(global.bunVM().event_loop_handle != null);
 
             var client_protocol_hash: u64 = 0;
-            var body = buildRequestBody(
+            const body = buildRequestBody(
                 global.bunVM(),
                 pathname,
                 ssl,
@@ -917,10 +917,10 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
         const WebSocket = @This();
 
         pub fn register(global: *JSC.JSGlobalObject, loop_: *anyopaque, ctx_: *anyopaque) callconv(.C) void {
-            var vm = global.bunVM();
-            var loop = @as(*uws.Loop, @ptrCast(@alignCast(loop_)));
+            const vm = global.bunVM();
+            const loop = @as(*uws.Loop, @ptrCast(@alignCast(loop_)));
 
-            var ctx: *uws.SocketContext = @as(*uws.SocketContext, @ptrCast(ctx_));
+            const ctx: *uws.SocketContext = @as(*uws.SocketContext, @ptrCast(ctx_));
 
             if (comptime Environment.isPosix) {
                 if (vm.event_loop_handle) |other| {
@@ -985,7 +985,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
             log("onHandshake({d})", .{success});
 
             if (this.outgoing_websocket) |ws| {
-                var reject_unauthorized = ws.rejectUnauthorized();
+                const reject_unauthorized = ws.rejectUnauthorized();
                 if (ssl_error.error_no != 0 and (reject_unauthorized or !authorized)) {
                     this.outgoing_websocket = null;
                     ws.didAbruptClose(ErrorCode.failed_to_connect);
@@ -1428,7 +1428,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
                 return false;
             }
             const expected = @as(usize, @intCast(wrote));
-            var readable = this.send_buffer.readableSlice(0);
+            const readable = this.send_buffer.readableSlice(0);
             if (readable.ptr == out_buf.ptr) {
                 this.send_buffer.discard(expected);
             }
@@ -1446,7 +1446,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
             header.final = true;
             header.opcode = .Pong;
 
-            var to_mask = this.ping_frame_bytes[6..][0..this.ping_len];
+            const to_mask = this.ping_frame_bytes[6..][0..this.ping_len];
 
             header.mask = to_mask.len > 0;
             header.len = @as(u7, @truncate(this.ping_len));
@@ -1482,7 +1482,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
             header.mask = true;
             header.len = @as(u7, @truncate(body_len + 2));
             final_body_bytes[0..2].* = @as([2]u8, @bitCast(@as(u16, @bitCast(header))));
-            var mask_buf: *[4]u8 = final_body_bytes[2..6];
+            const mask_buf: *[4]u8 = final_body_bytes[2..6];
             final_body_bytes[6..8].* = @bitCast(@byteSwap(code));
 
             var reason = bun.String.empty;
@@ -1675,8 +1675,8 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
             buffered_data: [*]u8,
             buffered_data_len: usize,
         ) callconv(.C) ?*anyopaque {
-            var tcp = @as(*uws.Socket, @ptrCast(input_socket));
-            var ctx = @as(*uws.SocketContext, @ptrCast(socket_ctx));
+            const tcp = @as(*uws.Socket, @ptrCast(input_socket));
+            const ctx = @as(*uws.SocketContext, @ptrCast(socket_ctx));
             var adopted = Socket.adopt(
                 tcp,
                 ctx,
@@ -1694,9 +1694,9 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
             adopted.receive_buffer.ensureTotalCapacity(2048) catch return null;
             adopted.poll_ref.ref(globalThis.bunVM());
 
-            var buffered_slice: []u8 = buffered_data[0..buffered_data_len];
+            const buffered_slice: []u8 = buffered_data[0..buffered_data_len];
             if (buffered_slice.len > 0) {
-                var initial_data = bun.default_allocator.create(InitialDataHandler) catch unreachable;
+                const initial_data = bun.default_allocator.create(InitialDataHandler) catch unreachable;
                 initial_data.* = .{
                     .adopted = adopted,
                     .slice = buffered_slice,

--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -218,11 +218,11 @@ pub const Bin = extern struct {
                 }
                 var parts = [_][]const u8{ this.package_name.slice(this.string_buffer), target };
 
-                var dir = this.package_installed_node_modules;
+                const dir = this.package_installed_node_modules;
 
-                var joined = Path.joinStringBuf(&this.buf, &parts, .auto);
+                const joined = Path.joinStringBuf(&this.buf, &parts, .auto);
                 this.buf[joined.len] = 0;
-                var joined_: [:0]u8 = this.buf[0..joined.len :0];
+                const joined_: [:0]u8 = this.buf[0..joined.len :0];
                 var child_dir = try bun.openDir(dir, joined_);
                 this.dir_iterator = child_dir.iterate();
             }
@@ -451,14 +451,14 @@ pub const Bin = extern struct {
                     const target_len = @intFromPtr(remain.ptr) - @intFromPtr(&dest_buf);
                     remain = remain[1..];
 
-                    var target_path: [:0]u8 = dest_buf[0..target_len :0];
+                    const target_path: [:0]u8 = dest_buf[0..target_len :0];
                     // we need to use the unscoped package name here
                     // this is why @babel/parser would fail to link
                     const unscoped_name = unscopedPackageName(name);
                     bun.copy(u8, from_remain, unscoped_name);
                     from_remain = from_remain[unscoped_name.len..];
                     from_remain[0] = 0;
-                    var dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
+                    const dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
 
                     this.setSimlinkAndPermissions(target_path, dest_path);
                 },
@@ -473,12 +473,12 @@ pub const Bin = extern struct {
                     const target_len = @intFromPtr(remain.ptr) - @intFromPtr(&dest_buf);
                     remain = remain[1..];
 
-                    var target_path: [:0]u8 = dest_buf[0..target_len :0];
-                    var name_to_use = this.bin.value.named_file[0].slice(this.string_buf);
+                    const target_path: [:0]u8 = dest_buf[0..target_len :0];
+                    const name_to_use = this.bin.value.named_file[0].slice(this.string_buf);
                     bun.copy(u8, from_remain, name_to_use);
                     from_remain = from_remain[name_to_use.len..];
                     from_remain[0] = 0;
-                    var dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
+                    const dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
 
                     this.setSimlinkAndPermissions(target_path, dest_path);
                 },
@@ -503,12 +503,12 @@ pub const Bin = extern struct {
                         const target_len = @intFromPtr(remain.ptr) - @intFromPtr(&dest_buf);
                         remain = remain[1..];
 
-                        var target_path: [:0]u8 = dest_buf[0..target_len :0];
-                        var name_to_use = name_in_terminal.slice(this.string_buf);
+                        const target_path: [:0]u8 = dest_buf[0..target_len :0];
+                        const name_to_use = name_in_terminal.slice(this.string_buf);
                         bun.copy(u8, from_remain, name_to_use);
                         from_remain = from_remain[name_to_use.len..];
                         from_remain[0] = 0;
-                        var dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
+                        const dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
 
                         this.setSimlinkAndPermissions(target_path, dest_path);
                     }
@@ -524,11 +524,11 @@ pub const Bin = extern struct {
                     bun.copy(u8, remain, target);
                     remain = remain[target.len..];
 
-                    var dir = std.fs.Dir{ .fd = bun.fdcast(this.package_installed_node_modules) };
+                    const dir = std.fs.Dir{ .fd = bun.fdcast(this.package_installed_node_modules) };
 
                     var joined = Path.joinStringBuf(&target_buf, &parts, .auto);
                     @as([*]u8, @ptrFromInt(@intFromPtr(joined.ptr)))[joined.len] = 0;
-                    var joined_: [:0]const u8 = joined.ptr[0..joined.len :0];
+                    const joined_: [:0]const u8 = joined.ptr[0..joined.len :0];
                     var child_dir = bun.openDir(dir, joined_) catch |err| {
                         this.err = err;
                         return;
@@ -537,13 +537,13 @@ pub const Bin = extern struct {
 
                     var iter = child_dir.iterate();
 
-                    var basedir_path = bun.getFdPath(child_dir.dir.fd, &target_buf) catch |err| {
+                    const basedir_path = bun.getFdPath(child_dir.dir.fd, &target_buf) catch |err| {
                         this.err = err;
                         return;
                     };
                     target_buf[basedir_path.len] = std.fs.path.sep;
                     var target_buf_remain = target_buf[basedir_path.len + 1 ..];
-                    var prev_target_buf_remain = target_buf_remain;
+                    const prev_target_buf_remain = target_buf_remain;
 
                     while (iter.next() catch null) |entry_| {
                         const entry: std.fs.IterableDir.Entry = entry_;
@@ -553,8 +553,8 @@ pub const Bin = extern struct {
                                 bun.copy(u8, target_buf_remain, entry.name);
                                 target_buf_remain = target_buf_remain[entry.name.len..];
                                 target_buf_remain[0] = 0;
-                                var from_path: [:0]u8 = target_buf[0 .. @intFromPtr(target_buf_remain.ptr) - @intFromPtr(&target_buf) :0];
-                                var to_path = if (!link_global)
+                                const from_path: [:0]u8 = target_buf[0 .. @intFromPtr(target_buf_remain.ptr) - @intFromPtr(&target_buf) :0];
+                                const to_path = if (!link_global)
                                     std.fmt.bufPrintZ(&dest_buf, dot_bin ++ "{s}", .{entry.name}) catch continue
                                 else
                                     std.fmt.bufPrintZ(&dest_buf, "{s}", .{entry.name}) catch continue;
@@ -623,16 +623,16 @@ pub const Bin = extern struct {
                     bun.copy(u8, from_remain, unscoped_name);
                     from_remain = from_remain[unscoped_name.len..];
                     from_remain[0] = 0;
-                    var dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
+                    const dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
 
                     std.os.unlinkatZ(this.root_node_modules_folder, dest_path, 0) catch {};
                 },
                 .named_file => {
-                    var name_to_use = this.bin.value.named_file[0].slice(this.string_buf);
+                    const name_to_use = this.bin.value.named_file[0].slice(this.string_buf);
                     bun.copy(u8, from_remain, name_to_use);
                     from_remain = from_remain[name_to_use.len..];
                     from_remain[0] = 0;
-                    var dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
+                    const dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
 
                     std.os.unlinkatZ(this.root_node_modules_folder, dest_path, 0) catch {};
                 },
@@ -656,11 +656,11 @@ pub const Bin = extern struct {
                         remain[0] = 0;
                         remain = remain[1..];
 
-                        var name_to_use = name_in_terminal.slice(this.string_buf);
+                        const name_to_use = name_in_terminal.slice(this.string_buf);
                         bun.copy(u8, from_remain, name_to_use);
                         from_remain = from_remain[name_to_use.len..];
                         from_remain[0] = 0;
-                        var dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
+                        const dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
 
                         std.os.unlinkatZ(this.root_node_modules_folder, dest_path, 0) catch {};
                     }
@@ -676,11 +676,11 @@ pub const Bin = extern struct {
                     bun.copy(u8, remain, target);
                     remain = remain[target.len..];
 
-                    var dir = std.fs.Dir{ .fd = bun.fdcast(this.package_installed_node_modules) };
+                    const dir = std.fs.Dir{ .fd = bun.fdcast(this.package_installed_node_modules) };
 
                     var joined = Path.joinStringBuf(&target_buf, &parts, .auto);
                     @as([*]u8, @ptrFromInt(@intFromPtr(joined.ptr)))[joined.len] = 0;
-                    var joined_: [:0]const u8 = joined.ptr[0..joined.len :0];
+                    const joined_: [:0]const u8 = joined.ptr[0..joined.len :0];
                     var child_dir = bun.openDir(dir, joined_) catch |err| {
                         this.err = err;
                         return;
@@ -689,13 +689,13 @@ pub const Bin = extern struct {
 
                     var iter = child_dir.iterate();
 
-                    var basedir_path = bun.getFdPath(child_dir.dir.fd, &target_buf) catch |err| {
+                    const basedir_path = bun.getFdPath(child_dir.dir.fd, &target_buf) catch |err| {
                         this.err = err;
                         return;
                     };
                     target_buf[basedir_path.len] = std.fs.path.sep;
                     var target_buf_remain = target_buf[basedir_path.len + 1 ..];
-                    var prev_target_buf_remain = target_buf_remain;
+                    const prev_target_buf_remain = target_buf_remain;
 
                     while (iter.next() catch null) |entry_| {
                         const entry: std.fs.IterableDir.Entry = entry_;
@@ -705,7 +705,7 @@ pub const Bin = extern struct {
                                 bun.copy(u8, target_buf_remain, entry.name);
                                 target_buf_remain = target_buf_remain[entry.name.len..];
                                 target_buf_remain[0] = 0;
-                                var to_path = if (!link_global)
+                                const to_path = if (!link_global)
                                     std.fmt.bufPrintZ(&dest_buf, dot_bin ++ "{s}", .{entry.name}) catch continue
                                 else
                                     std.fmt.bufPrintZ(&dest_buf, "{s}", .{entry.name}) catch continue;

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -167,7 +167,7 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
     };
 
     var resolved: string = "";
-    var tmpname = try FileSystem.instance.tmpname(basename[0..@min(basename.len, 32)], &tmpname_buf, tgz_bytes.len);
+    const tmpname = try FileSystem.instance.tmpname(basename[0..@min(basename.len, 32)], &tmpname_buf, tgz_bytes.len);
     {
         var extract_destination = tmpdir.makeOpenPathIterable(std.mem.span(tmpname), .{}) catch |err| {
             this.package_manager.log.addErrorFmt(
@@ -305,7 +305,7 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
 
     defer final_dir.close();
     // and get the fd path
-    var final_path = bun.getFdPath(
+    const final_path = bun.getFdPath(
         final_dir.fd,
         &final_path_buf,
     ) catch |err| {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -177,7 +177,7 @@ pub const Aligner = struct {
     pub fn write(comptime Type: type, comptime Writer: type, writer: Writer, pos: usize) !usize {
         const to_write = skipAmount(Type, pos);
 
-        var remainder: string = alignment_bytes_to_repeat_buffer[0..@min(to_write, alignment_bytes_to_repeat_buffer.len)];
+        const remainder: string = alignment_bytes_to_repeat_buffer[0..@min(to_write, alignment_bytes_to_repeat_buffer.len)];
         try writer.writeAll(remainder);
 
         return to_write;
@@ -612,7 +612,7 @@ const Task = struct {
 
         switch (this.tag) {
             .package_manifest => {
-                var allocator = bun.default_allocator;
+                const allocator = bun.default_allocator;
                 const body = this.request.package_manifest.network.response_buffer.move();
 
                 defer {
@@ -920,7 +920,7 @@ const PackageInstall = struct {
     // 1. verify that .bun-tag exists (was it installed from bun?)
     // 2. check .bun-tag against the resolved version
     fn verifyGitResolution(this: *PackageInstall, repo: *const Repository, buf: []const u8) bool {
-        var allocator = this.allocator;
+        const allocator = this.allocator;
 
         var total: usize = 0;
         var read: usize = 0;
@@ -983,13 +983,13 @@ const PackageInstall = struct {
     }
 
     fn verifyPackageJSONNameAndVersion(this: *PackageInstall) bool {
-        var allocator = this.allocator;
+        const allocator = this.allocator;
         var total: usize = 0;
         var read: usize = 0;
 
         bun.copy(u8, this.destination_dir_subpath_buf[this.destination_dir_subpath.len..], std.fs.path.sep_str ++ "package.json");
         this.destination_dir_subpath_buf[this.destination_dir_subpath.len + std.fs.path.sep_str.len + "package.json".len] = 0;
-        var package_json_path: [:0]u8 = this.destination_dir_subpath_buf[0 .. this.destination_dir_subpath.len + std.fs.path.sep_str.len + "package.json".len :0];
+        const package_json_path: [:0]u8 = this.destination_dir_subpath_buf[0 .. this.destination_dir_subpath.len + std.fs.path.sep_str.len + "package.json".len :0];
         defer this.destination_dir_subpath_buf[this.destination_dir_subpath.len] = 0;
 
         var package_json_file = this.destination_dir.dir.openFileZ(package_json_path, .{ .mode = .read_only }) catch return false;
@@ -1115,8 +1115,8 @@ const PackageInstall = struct {
                         .file => {
                             bun.copy(u8, &stackpath, entry.path);
                             stackpath[entry.path.len] = 0;
-                            var path: [:0]u8 = stackpath[0..entry.path.len :0];
-                            var basename: [:0]u8 = stackpath[entry.path.len - entry.basename.len .. entry.path.len :0];
+                            const path: [:0]u8 = stackpath[0..entry.path.len :0];
+                            const basename: [:0]u8 = stackpath[entry.path.len - entry.basename.len .. entry.path.len :0];
                             switch (C.clonefileat(
                                 entry.dir.dir.fd,
                                 basename,
@@ -1170,7 +1170,7 @@ const PackageInstall = struct {
         if (this.destination_dir_subpath[0] == '@') {
             if (strings.indexOfCharZ(this.destination_dir_subpath, std.fs.path.sep)) |slash| {
                 this.destination_dir_subpath_buf[slash] = 0;
-                var subdir = this.destination_dir_subpath_buf[0..slash :0];
+                const subdir = this.destination_dir_subpath_buf[0..slash :0];
                 this.destination_dir.dir.makeDirZ(subdir) catch {};
                 this.destination_dir_subpath_buf[slash] = std.fs.path.sep;
             }
@@ -1344,14 +1344,14 @@ const PackageInstall = struct {
                                     entry.path,
                                 );
                                 head1[entry.path.len + (head1.len - to_copy_into1.len)] = 0;
-                                var dest: [:0]u16 = head1[0 .. entry.path.len + head1.len - to_copy_into1.len :0];
+                                const dest: [:0]u16 = head1[0 .. entry.path.len + head1.len - to_copy_into1.len :0];
 
                                 strings.copyU8IntoU16(
                                     to_copy_into2,
                                     entry.path,
                                 );
                                 head2[entry.path.len + (head1.len - to_copy_into2.len)] = 0;
-                                var src: [:0]u16 = head2[0 .. entry.path.len + head2.len - to_copy_into2.len :0];
+                                const src: [:0]u16 = head2[0 .. entry.path.len + head2.len - to_copy_into2.len :0];
 
                                 // Windows limits hardlinks to 1023 per file
                                 if (bun.windows.CreateHardLinkW(dest, src, null) == 0) {
@@ -1444,7 +1444,7 @@ const PackageInstall = struct {
             ) !u32 {
                 var real_file_count: u32 = 0;
                 var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                var cache_dir_path = try bun.getFdPath(cache_dir_fd, &buf);
+                const cache_dir_path = try bun.getFdPath(cache_dir_fd, &buf);
 
                 var remain = buf[cache_dir_path.len..];
                 var cache_dir_offset = cache_dir_path.len;
@@ -1454,7 +1454,7 @@ const PackageInstall = struct {
                     remain = remain[1..];
                 }
                 var dest_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                var dest_base = try bun.getFdPath(dest_dir_fd, &dest_buf);
+                const dest_base = try bun.getFdPath(dest_dir_fd, &dest_buf);
                 var dest_remaining = dest_buf[dest_base.len..];
                 var dest_dir_offset = dest_base.len;
                 if (dest_base.len > 0 and dest_buf[dest_base.len - 1] != std.fs.path.sep) {
@@ -1473,11 +1473,11 @@ const PackageInstall = struct {
                         .file => {
                             @memcpy(remain[0..entry.path.len], entry.path);
                             remain[entry.path.len] = 0;
-                            var from_path = buf[0 .. cache_dir_offset + entry.path.len :0];
+                            const from_path = buf[0 .. cache_dir_offset + entry.path.len :0];
 
                             @memcpy(dest_remaining[0..entry.path.len], entry.path);
                             dest_remaining[entry.path.len] = 0;
-                            var to_path = dest_buf[0 .. dest_dir_offset + entry.path.len :0];
+                            const to_path = dest_buf[0 .. dest_dir_offset + entry.path.len :0];
 
                             try std.os.symlinkZ(from_path, to_path);
 
@@ -2358,7 +2358,7 @@ pub const PackageManager = struct {
         }
 
         const spanned = bun.span(basename);
-        var available = buf[spanned.len..];
+        const available = buf[spanned.len..];
         var end: []u8 = undefined;
         if (scope.url.hostname.len > 32 or available.len < 64) {
             const visible_hostname = scope.url.hostname[0..@min(scope.url.hostname.len, 12)];
@@ -2368,7 +2368,7 @@ pub const PackageManager = struct {
         }
 
         buf[spanned.len + end.len] = 0;
-        var result: [:0]u8 = buf[0 .. spanned.len + end.len :0];
+        const result: [:0]u8 = buf[0 .. spanned.len + end.len :0];
         return result;
     }
 
@@ -2453,7 +2453,7 @@ pub const PackageManager = struct {
     ) ![]u8 {
         var package_name_version_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
 
-        var subpath = std.fmt.bufPrintZ(
+        const subpath = std.fmt.bufPrintZ(
             &package_name_version_buf,
             "{s}" ++ std.fs.path.sep_str ++ "{any}",
             .{
@@ -2537,11 +2537,11 @@ pub const PackageManager = struct {
 
         var arena = @import("root").bun.ArenaAllocator.init(this.allocator);
         defer arena.deinit();
-        var arena_alloc = arena.allocator();
+        const arena_alloc = arena.allocator();
         var stack_fallback = std.heap.stackFallback(4096, arena_alloc);
-        var allocator = stack_fallback.get();
+        const allocator = stack_fallback.get();
         var tags_buf = std.ArrayList(u8).init(allocator);
-        var installed_versions = this.getInstalledVersionsFromDiskCache(&tags_buf, package_name, allocator) catch |err| {
+        const installed_versions = this.getInstalledVersionsFromDiskCache(&tags_buf, package_name, allocator) catch |err| {
             Output.debug("error getting installed versions from disk cache: {s}", .{bun.span(@errorName(err))});
             return null;
         };
@@ -2556,7 +2556,7 @@ pub const PackageManager = struct {
         for (installed_versions.items) |installed_version| {
             if (version.value.npm.version.satisfies(installed_version, this.lockfile.buffers.string_bytes.items, tags_buf.items)) {
                 var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                var npm_package_path = this.pathForCachedNPMPath(&buf, package_name, installed_version) catch |err| {
+                const npm_package_path = this.pathForCachedNPMPath(&buf, package_name, installed_version) catch |err| {
                     Output.debug("error getting path for cached npm path: {s}", .{bun.span(@errorName(err))});
                     return null;
                 };
@@ -3166,11 +3166,11 @@ pub const PackageManager = struct {
         };
 
         var file = tmpfile.file();
-        var file_writer = file.writer();
+        const file_writer = file.writer();
         var buffered_writer = std.io.BufferedWriter(std.mem.page_size, @TypeOf(file_writer)){
             .unbuffered_writer = file_writer,
         };
-        var writer = buffered_writer.writer();
+        const writer = buffered_writer.writer();
         try Lockfile.Printer.Yarn.print(&printer, @TypeOf(writer), writer);
         try buffered_writer.flush();
 
@@ -3418,7 +3418,7 @@ pub const PackageManager = struct {
                                 );
 
                             if (!dependency.behavior.isPeer() or install_peer) {
-                                var network_entry = try this.network_dedupe_map.getOrPutContext(this.allocator, task_id, .{});
+                                const network_entry = try this.network_dedupe_map.getOrPutContext(this.allocator, task_id, .{});
                                 if (!network_entry.found_existing) {
                                     if (this.options.enable.manifest_cache) {
                                         if (Npm.PackageManifest.Serializer.load(this.allocator, this.getCacheDirectory(), name_str) catch null) |manifest_| {
@@ -4416,7 +4416,7 @@ pub const PackageManager = struct {
                     if (response.status_code == 304) {
                         // The HTTP request was cached
                         if (manifest_req.loaded_manifest) |manifest| {
-                            var entry = try manager.manifests.getOrPut(manager.allocator, manifest.pkg.name.hash);
+                            const entry = try manager.manifests.getOrPut(manager.allocator, manifest.pkg.name.hash);
                             entry.value_ptr.* = manifest;
 
                             if (timestamp_this_tick == null) {
@@ -4428,9 +4428,9 @@ pub const PackageManager = struct {
                                 Npm.PackageManifest.Serializer.save(entry.value_ptr, manager.getTemporaryDirectory(), manager.getCacheDirectory()) catch {};
                             }
 
-                            var dependency_list_entry = manager.task_queue.getEntry(task.task_id).?;
+                            const dependency_list_entry = manager.task_queue.getEntry(task.task_id).?;
 
-                            var dependency_list = dependency_list_entry.value_ptr.*;
+                            const dependency_list = dependency_list_entry.value_ptr.*;
                             dependency_list_entry.value_ptr.* = .{};
 
                             try manager.processDependencyList(
@@ -4612,8 +4612,8 @@ pub const PackageManager = struct {
                     const manifest = task.data.package_manifest;
                     _ = try manager.manifests.getOrPutValue(manager.allocator, manifest.pkg.name.hash, manifest);
 
-                    var dependency_list_entry = manager.task_queue.getEntry(task.id).?;
-                    var dependency_list = dependency_list_entry.value_ptr.*;
+                    const dependency_list_entry = manager.task_queue.getEntry(task.id).?;
+                    const dependency_list = dependency_list_entry.value_ptr.*;
                     dependency_list_entry.value_ptr.* = .{};
 
                     try manager.processDependencyList(dependency_list, ExtractCompletionContext, extract_ctx, callbacks, install_peer);
@@ -4714,7 +4714,7 @@ pub const PackageManager = struct {
                         manager.lockfile.str(&manager.lockfile.packages.items(.name)[package_id]),
                     ))) |dependency_list_entry| {
                         // Peer dependencies do not initiate any downloads of their own, thus need to be resolved here instead
-                        var dependency_list = dependency_list_entry.value_ptr.*;
+                        const dependency_list = dependency_list_entry.value_ptr.*;
                         dependency_list_entry.value_ptr.* = .{};
 
                         try manager.processDependencyList(dependency_list, void, {}, {}, install_peer);
@@ -4767,8 +4767,8 @@ pub const PackageManager = struct {
                         continue;
                     }
 
-                    var dependency_list_entry = manager.task_queue.getEntry(task.id).?;
-                    var dependency_list = dependency_list_entry.value_ptr.*;
+                    const dependency_list_entry = manager.task_queue.getEntry(task.id).?;
+                    const dependency_list = dependency_list_entry.value_ptr.*;
                     dependency_list_entry.value_ptr.* = .{};
 
                     try manager.processDependencyList(dependency_list, ExtractCompletionContext, extract_ctx, callbacks, install_peer);
@@ -4977,7 +4977,7 @@ pub const PackageManager = struct {
             if (bun.getenvZ("BUN_INSTALL")) |home_dir| {
                 var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
                 var parts = [_]string{ "install", "global" };
-                var path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
+                const path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
                 return try std.fs.cwd().makeOpenPathIterable(path, .{});
             }
 
@@ -4985,14 +4985,14 @@ pub const PackageManager = struct {
                 if (bun.getenvZ("XDG_CACHE_HOME") orelse bun.getenvZ("HOME")) |home_dir| {
                     var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
                     var parts = [_]string{ ".bun", "install", "global" };
-                    var path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
+                    const path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
                     return try std.fs.cwd().makeOpenPathIterable(path, .{});
                 }
             } else {
                 if (bun.getenvZ("USERPROFILE")) |home_dir| {
                     var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
                     var parts = [_]string{ ".bun", "install", "global" };
-                    var path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
+                    const path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
                     return try std.fs.cwd().makeOpenPathIterable(path, .{});
                 }
             }
@@ -5018,7 +5018,7 @@ pub const PackageManager = struct {
                 var parts = [_]string{
                     "bin",
                 };
-                var path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
+                const path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
                 return try std.fs.cwd().makeOpenPathIterable(path, .{});
             }
 
@@ -5028,7 +5028,7 @@ pub const PackageManager = struct {
                     ".bun",
                     "bin",
                 };
-                var path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
+                const path = Path.joinAbsStringBuf(home_dir, &buf, &parts, .auto);
                 return try std.fs.cwd().makeOpenPathIterable(path, .{});
             }
 
@@ -5701,7 +5701,7 @@ pub const PackageManager = struct {
         }
 
         var fs = try Fs.FileSystem.init(null);
-        var original_cwd = strings.withoutTrailingSlash(fs.top_level_dir);
+        const original_cwd = strings.withoutTrailingSlash(fs.top_level_dir);
 
         bun.copy(u8, &cwd_buf, original_cwd);
 
@@ -5828,16 +5828,16 @@ pub const PackageManager = struct {
         fs.top_level_dir = cwd_buf[0 .. fs.top_level_dir.len + 1];
         package_json_cwd = try bun.getFdPath(package_json_file.handle, &package_json_cwd_buf);
 
-        var entries_option = try fs.fs.readDirectory(fs.top_level_dir, null, 0, true);
-        var options = Options{
+        const entries_option = try fs.fs.readDirectory(fs.top_level_dir, null, 0, true);
+        const options = Options{
             .global = cli.global,
         };
 
         var env: *DotEnv.Loader = brk: {
-            var map = try ctx.allocator.create(DotEnv.Map);
+            const map = try ctx.allocator.create(DotEnv.Map);
             map.* = DotEnv.Map.init(ctx.allocator);
 
-            var loader = try ctx.allocator.create(DotEnv.Loader);
+            const loader = try ctx.allocator.create(DotEnv.Loader);
             loader.* = DotEnv.Loader.init(map, ctx.allocator);
             break :brk loader;
         };
@@ -6041,14 +6041,14 @@ pub const PackageManager = struct {
             var parts = [_]string{
                 "./bun.lockb",
             };
-            var lockfile_path = Path.joinAbsStringBuf(
+            const lockfile_path = Path.joinAbsStringBuf(
                 Fs.FileSystem.instance.top_level_dir,
                 &buf,
                 &parts,
                 .auto,
             );
             buf[lockfile_path.len] = 0;
-            var lockfile_path_z = buf[0..lockfile_path.len :0];
+            const lockfile_path_z = buf[0..lockfile_path.len :0];
 
             switch (manager.lockfile.loadFromDisk(
                 allocator,
@@ -6122,7 +6122,7 @@ pub const PackageManager = struct {
 
             // Step 1. parse the nearest package.json file
             {
-                var current_package_json_stat_size = try manager.root_package_json_file.getEndPos();
+                const current_package_json_stat_size = try manager.root_package_json_file.getEndPos();
                 var current_package_json_buf = try ctx.allocator.alloc(u8, current_package_json_stat_size + 64);
                 const current_package_json_contents_len = try manager.root_package_json_file.preadAll(
                     current_package_json_buf,
@@ -6277,7 +6277,7 @@ pub const PackageManager = struct {
 
             // Step 1. parse the nearest package.json file
             {
-                var current_package_json_stat_size = try manager.root_package_json_file.getEndPos();
+                const current_package_json_stat_size = try manager.root_package_json_file.getEndPos();
                 var current_package_json_buf = try ctx.allocator.alloc(u8, current_package_json_stat_size + 64);
                 const current_package_json_contents_len = try manager.root_package_json_file.preadAll(
                     current_package_json_buf,
@@ -6634,7 +6634,7 @@ pub const PackageManager = struct {
         pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !CommandLineArguments {
             Output.is_verbose = Output.isVerbose();
 
-            comptime var params: []const ParamType = &switch (subcommand) {
+            comptime const params: []const ParamType = &switch (subcommand) {
                 .install => install_params,
                 .update => update_params,
                 .pm => pm_params,
@@ -6715,9 +6715,9 @@ pub const PackageManager = struct {
                 var buf2: [bun.MAX_PATH_BYTES]u8 = undefined;
                 var final_path: [:0]u8 = undefined;
                 if (cwd_.len > 0 and cwd_[0] == '.') {
-                    var cwd = try bun.getcwd(&buf);
+                    const cwd = try bun.getcwd(&buf);
                     var parts = [_]string{cwd_};
-                    var path_ = Path.joinAbsStringBuf(cwd, &buf2, &parts, .auto);
+                    const path_ = Path.joinAbsStringBuf(cwd, &buf2, &parts, .auto);
                     buf2[path_.len] = 0;
                     final_path = buf2[0..path_.len :0];
                 } else {
@@ -6912,7 +6912,7 @@ pub const PackageManager = struct {
         var update_requests = try UpdateRequest.Array.init(0);
 
         if (manager.options.positionals.len <= 1) {
-            var examples_to_print: [3]string = undefined;
+            const examples_to_print: [3]string = undefined;
             _ = examples_to_print;
 
             const off = @as(u64, @intCast(std.time.milliTimestamp()));
@@ -6937,7 +6937,7 @@ pub const PackageManager = struct {
             }
         }
 
-        var updates = UpdateRequest.parse(ctx.allocator, ctx.log, manager.options.positionals[1..], &update_requests, op);
+        const updates = UpdateRequest.parse(ctx.allocator, ctx.log, manager.options.positionals[1..], &update_requests, op);
         try manager.updatePackageJSONAndInstallWithManagerWithUpdates(
             ctx,
             updates,
@@ -6966,7 +6966,7 @@ pub const PackageManager = struct {
             Global.crash();
         }
 
-        var current_package_json_stat_size = try manager.root_package_json_file.getEndPos();
+        const current_package_json_stat_size = try manager.root_package_json_file.getEndPos();
         var current_package_json_buf = try ctx.allocator.alloc(u8, current_package_json_stat_size + 64);
         const current_package_json_contents_len = try manager.root_package_json_file.preadAll(
             current_package_json_buf,
@@ -7121,7 +7121,7 @@ pub const PackageManager = struct {
         var new_package_json_source = try ctx.allocator.dupe(u8, package_json_writer.ctx.writtenWithoutTrailingZero());
 
         // Do not free the old package.json AST nodes
-        var old_ast_nodes = JSAst.Expr.Data.Store.toOwnedSlice();
+        const old_ast_nodes = JSAst.Expr.Data.Store.toOwnedSlice();
         // haha unless
         defer if (auto_free) bun.default_allocator.free(old_ast_nodes);
 
@@ -7183,7 +7183,7 @@ pub const PackageManager = struct {
                 // This is not exactly correct
                 var node_modules_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
                 bun.copy(u8, &node_modules_buf, "node_modules" ++ std.fs.path.sep_str);
-                var offset_buf = node_modules_buf["node_modules/".len..];
+                const offset_buf = node_modules_buf["node_modules/".len..];
                 const name_hashes = manager.lockfile.packages.items(.name_hash);
                 for (updates) |request| {
                     // If the package no longer exists in the updated lockfile, delete the directory
@@ -7209,7 +7209,7 @@ pub const PackageManager = struct {
                                 // note that using access won't work here, because access doesn't resolve symlinks
                                 bun.copy(u8, &node_modules_buf, entry.name);
                                 node_modules_buf[entry.name.len] = 0;
-                                var buf: [:0]u8 = node_modules_buf[0..entry.name.len :0];
+                                const buf: [:0]u8 = node_modules_buf[0..entry.name.len :0];
 
                                 var file = node_modules_bin.dir.openFileZ(buf, .{ .mode = .read_only }) catch {
                                     node_modules_bin.dir.deleteFileZ(buf) catch {};
@@ -7249,7 +7249,7 @@ pub const PackageManager = struct {
             Output.flush();
         }
 
-        var package_json_contents = manager.root_package_json_file.readToEndAlloc(ctx.allocator, std.math.maxInt(usize)) catch |err| {
+        const package_json_contents = manager.root_package_json_file.readToEndAlloc(ctx.allocator, std.math.maxInt(usize)) catch |err| {
             if (manager.options.log_level != .silent) {
                 Output.prettyErrorln("<r><red>{s} reading package.json<r> :(", .{@errorName(err)});
                 Output.flush();
@@ -7355,7 +7355,7 @@ pub const PackageManager = struct {
 
             var resolution_buf: [512]u8 = undefined;
             const extern_string_buf = this.lockfile.buffers.extern_strings.items;
-            var resolution_label = std.fmt.bufPrint(&resolution_buf, "{}", .{resolution.fmt(buf)}) catch unreachable;
+            const resolution_label = std.fmt.bufPrint(&resolution_buf, "{}", .{resolution.fmt(buf)}) catch unreachable;
             var installer = PackageInstall{
                 .progress = this.progress,
                 .cache_dir = undefined,
@@ -7489,7 +7489,7 @@ pub const PackageManager = struct {
                         const bin = this.bins[package_id];
                         if (bin.tag != .none) {
                             const bin_task_id = Task.Id.forBinLink(package_id);
-                            var task_queue = this.manager.task_queue.getOrPut(this.manager.allocator, bin_task_id) catch unreachable;
+                            const task_queue = this.manager.task_queue.getOrPut(this.manager.allocator, bin_task_id) catch unreachable;
                             if (!task_queue.found_existing) {
                                 run_bin_link: {
                                     if (std.mem.indexOfScalar(PackageNameHash, this.options.native_bin_link_allowlist, String.Builder.stringHash(name)) != null) {
@@ -7879,7 +7879,7 @@ pub const PackageManager = struct {
         // no need to download packages you've already installed!!
         var skip_verify_installed_version_number = false;
         const cwd = std.fs.cwd();
-        var node_modules_folder = cwd.openIterableDir("node_modules", .{}) catch brk: {
+        const node_modules_folder = cwd.openIterableDir("node_modules", .{}) catch brk: {
             skip_verify_installed_version_number = true;
             bun.sys.mkdir("node_modules", 0o755).unwrap() catch |err| {
                 if (err != error.EEXIST) {
@@ -8030,7 +8030,7 @@ pub const PackageManager = struct {
             summary.successfully_installed = installer.successfully_installed;
             {
                 var parts = lockfile.packages.slice();
-                var metas = parts.items(.meta);
+                const metas = parts.items(.meta);
                 var names = parts.items(.name);
                 var dependencies = lockfile.buffers.dependencies.items;
                 const resolutions_buffer: []const PackageID = lockfile.buffers.resolutions.items;
@@ -8115,9 +8115,9 @@ pub const PackageManager = struct {
     pub fn setupGlobalDir(manager: *PackageManager, ctx: *const Command.Context) !void {
         manager.options.global_bin_dir = try Options.openGlobalBinDir(ctx.install);
         var out_buffer: [bun.MAX_PATH_BYTES]u8 = undefined;
-        var result = try bun.getFdPath(manager.options.global_bin_dir.dir.fd, &out_buffer);
+        const result = try bun.getFdPath(manager.options.global_bin_dir.dir.fd, &out_buffer);
         out_buffer[result.len] = 0;
-        var result_: [:0]u8 = out_buffer[0..result.len :0];
+        const result_: [:0]u8 = out_buffer[0..result.len :0];
         manager.options.bin_path = bun.cstring(try FileSystem.instance.dirname_store.append([:0]u8, result_));
     }
 
@@ -8173,7 +8173,7 @@ pub const PackageManager = struct {
         manager.progress = .{};
 
         // Step 2. Parse the package.json file
-        var package_json_source = logger.Source.initPathString(package_json_cwd, package_json_contents);
+        const package_json_source = logger.Source.initPathString(package_json_cwd, package_json_contents);
 
         switch (load_lockfile_result) {
             .err => |cause| {
@@ -8235,7 +8235,7 @@ pub const PackageManager = struct {
                         package_json_source,
                         Features.main,
                     );
-                    var mapping = try manager.lockfile.allocator.alloc(PackageID, maybe_root.dependencies.len);
+                    const mapping = try manager.lockfile.allocator.alloc(PackageID, maybe_root.dependencies.len);
                     @memset(mapping, invalid_package_id);
 
                     manager.summary = try Package.Diff.generate(
@@ -8308,7 +8308,7 @@ pub const PackageManager = struct {
                         try manager.lockfile.buffers.dependencies.ensureUnusedCapacity(manager.lockfile.allocator, len);
                         try manager.lockfile.buffers.resolutions.ensureUnusedCapacity(manager.lockfile.allocator, len);
 
-                        var old_resolutions = old_resolutions_list.get(manager.lockfile.buffers.resolutions.items);
+                        const old_resolutions = old_resolutions_list.get(manager.lockfile.buffers.resolutions.items);
 
                         var dependencies = manager.lockfile.buffers.dependencies.items.ptr[off .. off + len];
                         var resolutions = manager.lockfile.buffers.resolutions.items.ptr[off .. off + len];
@@ -8796,7 +8796,7 @@ test "UpdateRequests.parse" {
 }
 
 test "PackageManager.Options - default registry, default values" {
-    var allocator = default_allocator;
+    const allocator = default_allocator;
     var log = logger.Log.init(allocator);
     defer log.deinit();
     var env = DotEnv.Loader.init(&DotEnv.Map.init(allocator), allocator);
@@ -8811,7 +8811,7 @@ test "PackageManager.Options - default registry, default values" {
 }
 
 test "PackageManager.Options - default registry, custom token" {
-    var allocator = default_allocator;
+    const allocator = default_allocator;
     var log = logger.Log.init(allocator);
     defer log.deinit();
     var env = DotEnv.Loader.init(&DotEnv.Map.init(allocator), allocator);
@@ -8835,7 +8835,7 @@ test "PackageManager.Options - default registry, custom token" {
 }
 
 test "PackageManager.Options - default registry, custom URL" {
-    var allocator = default_allocator;
+    const allocator = default_allocator;
     var log = logger.Log.init(allocator);
     defer log.deinit();
     var env = DotEnv.Loader.init(&DotEnv.Map.init(allocator), allocator);
@@ -8859,7 +8859,7 @@ test "PackageManager.Options - default registry, custom URL" {
 }
 
 test "PackageManager.Options - scoped registry" {
-    var allocator = default_allocator;
+    const allocator = default_allocator;
     var log = logger.Log.init(allocator);
     defer log.deinit();
     var env = DotEnv.Loader.init(&DotEnv.Map.init(allocator), allocator);
@@ -8888,7 +8888,7 @@ test "PackageManager.Options - scoped registry" {
     try std.testing.expectEqualStrings(Npm.Registry.default_url, options.scope.url.href);
     try std.testing.expectEqualStrings("", options.scope.token);
 
-    var scoped = options.registries.getPtr(Npm.Registry.Scope.hash(Npm.Registry.Scope.getName("foo")));
+    const scoped = options.registries.getPtr(Npm.Registry.Scope.hash(Npm.Registry.Scope.getName("foo")));
 
     try std.testing.expect(scoped != null);
     if (scoped) |scope| {
@@ -8900,7 +8900,7 @@ test "PackageManager.Options - scoped registry" {
 }
 
 test "PackageManager.Options - mixed default/scoped registry" {
-    var allocator = default_allocator;
+    const allocator = default_allocator;
     var log = logger.Log.init(allocator);
     defer log.deinit();
     var env = DotEnv.Loader.init(&DotEnv.Map.init(allocator), allocator);
@@ -8935,7 +8935,7 @@ test "PackageManager.Options - mixed default/scoped registry" {
     try std.testing.expectEqualStrings("https://example.com/", options.scope.url.href);
     try std.testing.expectEqualStrings("foo", options.scope.token);
 
-    var scoped = options.registries.getPtr(Npm.Registry.Scope.hash(Npm.Registry.Scope.getName("bar")));
+    const scoped = options.registries.getPtr(Npm.Registry.Scope.hash(Npm.Registry.Scope.getName("bar")));
 
     try std.testing.expect(scoped != null);
     if (scoped) |scope| {

--- a/src/install/integrity.zig
+++ b/src/install/integrity.zig
@@ -168,25 +168,25 @@ pub const Integrity = extern struct {
         switch (tag) {
             .sha1 => {
                 const len = std.crypto.hash.Sha1.digest_length;
-                var ptr: *[len]u8 = digest[0..len];
+                const ptr: *[len]u8 = digest[0..len];
                 Crypto.SHA1.hash(bytes, ptr);
                 return strings.eqlLong(ptr, sum[0..len], true);
             },
             .sha512 => {
                 const len = std.crypto.hash.sha2.Sha512.digest_length;
-                var ptr: *[len]u8 = digest[0..len];
+                const ptr: *[len]u8 = digest[0..len];
                 Crypto.SHA512.hash(bytes, ptr);
                 return strings.eqlLong(ptr, sum[0..len], true);
             },
             .sha256 => {
                 const len = std.crypto.hash.sha2.Sha256.digest_length;
-                var ptr: *[len]u8 = digest[0..len];
+                const ptr: *[len]u8 = digest[0..len];
                 Crypto.SHA256.hash(bytes, ptr);
                 return strings.eqlLong(ptr, sum[0..len], true);
             },
             .sha384 => {
                 const len = std.crypto.hash.sha2.Sha384.digest_length;
-                var ptr: *[len]u8 = digest[0..len];
+                const ptr: *[len]u8 = digest[0..len];
                 Crypto.SHA384.hash(bytes, ptr);
                 return strings.eqlLong(ptr, sum[0..len], true);
             },
@@ -197,7 +197,7 @@ pub const Integrity = extern struct {
     }
 
     comptime {
-        var integrity = Integrity{ .tag = Tag.sha1 };
+        const integrity = Integrity{ .tag = Tag.sha1 };
         for (integrity.value) |c| {
             if (c != 0) {
                 @compileError("Integrity buffer is not zeroed");

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -196,7 +196,7 @@ pub fn loadFromDisk(this: *Lockfile, allocator: Allocator, log: *logger.Log, fil
         std.io.getStdIn();
 
     defer file.close();
-    var buf = file.readToEndAlloc(allocator, std.math.maxInt(usize)) catch |err| {
+    const buf = file.readToEndAlloc(allocator, std.math.maxInt(usize)) catch |err| {
         return LoadFromDiskResult{ .err = .{ .step = .read_file, .value = err } };
     };
 
@@ -355,7 +355,7 @@ pub const Tree = struct {
             }
 
             this.tree_id += 1;
-            var relative_path: [:0]u8 = this.path_buf[0..this.path_buf_len :0];
+            const relative_path: [:0]u8 = this.path_buf[0..this.path_buf_len :0];
             return .{
                 .relative_path = relative_path,
                 .dependencies = tree.dependencies.get(this.dependency_ids),
@@ -402,8 +402,8 @@ pub const Tree = struct {
             const end = @as(Id, @truncate(this.list.len));
             var i: Id = 0;
             var total: u32 = 0;
-            var trees = this.list.items(.tree);
-            var dependencies = this.list.items(.dependencies);
+            const trees = this.list.items(.tree);
+            const dependencies = this.list.items(.dependencies);
 
             while (i < end) : (i += 1) {
                 total += trees[i].dependencies.len;
@@ -568,7 +568,7 @@ pub fn maybeCloneFilteringRootPackages(
     const old_root_dependenices_list = old.packages.items(.dependencies)[0];
     var old_root_resolutions = old.packages.items(.resolutions)[0];
     const root_dependencies = old_root_dependenices_list.get(old.buffers.dependencies.items);
-    var resolutions = old_root_resolutions.mut(old.buffers.resolutions.items);
+    const resolutions = old_root_resolutions.mut(old.buffers.resolutions.items);
     var any_changes = false;
     const end = @as(PackageID, @truncate(old.packages.len));
 
@@ -620,7 +620,7 @@ fn preprocessUpdateRequests(old: *Lockfile, updates: []PackageManager.UpdateRequ
         {
             var temp_buf: [513]u8 = undefined;
 
-            var root_deps: []Dependency = root_deps_list.mut(old.buffers.dependencies.items);
+            const root_deps: []Dependency = root_deps_list.mut(old.buffers.dependencies.items);
             const old_resolutions_list_lists = old.packages.items(.resolutions);
             const old_resolutions_list = old_resolutions_list_lists[0];
             const old_resolutions: []const PackageID = old_resolutions_list.get(old.buffers.resolutions.items);
@@ -632,7 +632,7 @@ fn preprocessUpdateRequests(old: *Lockfile, updates: []PackageManager.UpdateRequ
                         if (dep.name_hash == String.Builder.stringHash(update.name)) {
                             if (old_resolution > old.packages.len) continue;
                             const res = resolutions_of_yore[old_resolution];
-                            var buf = switch (exact_versions) {
+                            const buf = switch (exact_versions) {
                                 false => std.fmt.bufPrint(&temp_buf, "^{}", .{res.value.npm.fmt(old.buffers.string_bytes.items)}) catch break,
                                 true => std.fmt.bufPrint(&temp_buf, "{}", .{res.value.npm.fmt(old.buffers.string_bytes.items)}) catch break,
                             };
@@ -745,12 +745,12 @@ pub fn cleanWithLogger(
     // Step 1. Recreate the lockfile with only the packages that are still alive
     const root = old.rootPackage() orelse return error.NoPackage;
 
-    var package_id_mapping = try old.allocator.alloc(PackageID, old.packages.len);
+    const package_id_mapping = try old.allocator.alloc(PackageID, old.packages.len);
     @memset(
         package_id_mapping,
         invalid_package_id,
     );
-    var clone_queue_ = PendingResolutions.init(old.allocator);
+    const clone_queue_ = PendingResolutions.init(old.allocator);
     var cloner = Cloner{
         .old = old,
         .lockfile = new,
@@ -931,7 +931,7 @@ const Cloner = struct {
     fn hoist(this: *Cloner) anyerror!void {
         if (this.lockfile.packages.len == 0) return;
 
-        var allocator = this.lockfile.allocator;
+        const allocator = this.lockfile.allocator;
         var slice = this.lockfile.packages.slice();
         var builder = Tree.Builder{
             .name_hashes = slice.items(.name_hash),
@@ -987,7 +987,7 @@ pub const Printer = struct {
         @setCold(true);
 
         // We truncate longer than allowed paths. We should probably throw an error instead.
-        var path = input_lockfile_path[0..@min(input_lockfile_path.len, bun.MAX_PATH_BYTES)];
+        const path = input_lockfile_path[0..@min(input_lockfile_path.len, bun.MAX_PATH_BYTES)];
 
         var lockfile_path_buf1: [bun.MAX_PATH_BYTES]u8 = undefined;
         var lockfile_path_buf2: [bun.MAX_PATH_BYTES]u8 = undefined;
@@ -995,9 +995,9 @@ pub const Printer = struct {
         var lockfile_path: stringZ = "";
 
         if (!std.fs.path.isAbsolute(path)) {
-            var cwd = try bun.getcwd(&lockfile_path_buf1);
+            const cwd = try bun.getcwd(&lockfile_path_buf1);
             var parts = [_]string{path};
-            var lockfile_path__ = Path.joinAbsStringBuf(cwd, &lockfile_path_buf2, &parts, .auto);
+            const lockfile_path__ = Path.joinAbsStringBuf(cwd, &lockfile_path_buf2, &parts, .auto);
             lockfile_path_buf2[lockfile_path__.len] = 0;
             lockfile_path = lockfile_path_buf2[0..lockfile_path__.len :0];
         } else if (path.len > 0) {
@@ -1049,7 +1049,7 @@ pub const Printer = struct {
             .ok => {},
         }
 
-        var writer = Output.writer();
+        const writer = Output.writer();
         try printWithLockfile(allocator, lockfile, format, @TypeOf(writer), writer);
         Output.flush();
     }
@@ -1064,13 +1064,13 @@ pub const Printer = struct {
         var fs = &FileSystem.instance;
         var options = PackageManager.Options{};
 
-        var entries_option = try fs.fs.readDirectory(fs.top_level_dir, null, 0, true);
+        const entries_option = try fs.fs.readDirectory(fs.top_level_dir, null, 0, true);
 
         var env_loader: *DotEnv.Loader = brk: {
-            var map = try allocator.create(DotEnv.Map);
+            const map = try allocator.create(DotEnv.Map);
             map.* = DotEnv.Map.init(allocator);
 
-            var loader = try allocator.create(DotEnv.Loader);
+            const loader = try allocator.create(DotEnv.Loader);
             loader.* = DotEnv.Loader.init(map, allocator);
             break :brk loader;
         };
@@ -1119,7 +1119,7 @@ pub const Printer = struct {
             const resolutions_buffer: []const PackageID = this.lockfile.buffers.resolutions.items;
             const dependencies_buffer: []const Dependency = this.lockfile.buffers.dependencies.items;
             const string_buf = this.lockfile.buffers.string_bytes.items;
-            var id_map = try default_allocator.alloc(DependencyID, this.updates.len);
+            const id_map = try default_allocator.alloc(DependencyID, this.updates.len);
             @memset(id_map, invalid_package_id);
             defer if (id_map.len > 0) default_allocator.free(id_map);
 
@@ -1368,7 +1368,7 @@ pub const Printer = struct {
                         resolutions = resolutions[k + 1 ..];
                     }
 
-                    var dependency_versions = requested_version_start[0..j];
+                    const dependency_versions = requested_version_start[0..j];
                     if (dependency_versions.len > 1) std.sort.insertion(Dependency.Version, dependency_versions, string_buf, Dependency.Version.isLessThanWithTag);
                     try requested_versions.put(i, dependency_versions);
                 }
@@ -1592,7 +1592,7 @@ pub fn saveToDisk(this: *Lockfile, filename: stringZ) void {
         Global.crash();
     };
 
-    var file = tmpfile.file();
+    const file = tmpfile.file();
     {
         var bytes = std.ArrayList(u8).init(bun.default_allocator);
         defer bytes.deinit();
@@ -1731,10 +1731,10 @@ pub fn getPackageID(
 }
 
 pub fn getOrPutID(this: *Lockfile, id: PackageID, name_hash: PackageNameHash) !void {
-    var gpe = try this.package_index.getOrPut(name_hash);
+    const gpe = try this.package_index.getOrPut(name_hash);
 
     if (gpe.found_existing) {
-        var index: *PackageIndex.Entry = gpe.value_ptr;
+        const index: *PackageIndex.Entry = gpe.value_ptr;
 
         switch (index.*) {
             .PackageID => |existing_id| {
@@ -1906,7 +1906,7 @@ pub const StringBuilder = struct {
             std.debug.assert(this.ptr != null); // must call allocate first
         }
 
-        var string_entry = this.lockfile.string_pool.getOrPut(hash) catch unreachable;
+        const string_entry = this.lockfile.string_pool.getOrPut(hash) catch unreachable;
         if (!string_entry.found_existing) {
             bun.copy(u8, this.ptr.?[this.len..this.cap], slice);
             const final_slice = this.ptr.?[this.len..this.cap][0..slice.len];
@@ -2064,7 +2064,7 @@ pub const OverrideMap = struct {
 
         for (expr.data.e_object.properties.slice()) |prop| {
             const key = prop.key.?;
-            var k = key.asString(lockfile.allocator).?;
+            const k = key.asString(lockfile.allocator).?;
             if (k.len == 0) {
                 try log.addWarningFmt(&source, key.loc, lockfile.allocator, "Missing overridden package name", .{});
                 continue;
@@ -2378,7 +2378,7 @@ pub const Package = extern struct {
             subpath: [:0]const u8,
             cwd: string,
         ) !void {
-            var json_file_fd = try bun.sys.openat(
+            const json_file_fd = try bun.sys.openat(
                 bun.toFD(node_modules.fd),
                 bun.path.joinZ([_]string{ subpath, "package.json" }, .auto),
                 std.os.O.RDONLY,
@@ -2491,10 +2491,10 @@ pub const Package = extern struct {
         new.buffers.resolutions.items = new.buffers.resolutions.items.ptr[0..end];
 
         new.buffers.extern_strings.items.len += new_extern_string_count;
-        var new_extern_strings = new.buffers.extern_strings.items[new.buffers.extern_strings.items.len - new_extern_string_count ..];
+        const new_extern_strings = new.buffers.extern_strings.items[new.buffers.extern_strings.items.len - new_extern_string_count ..];
 
-        var dependencies: []Dependency = new.buffers.dependencies.items[prev_len..end];
-        var resolutions: []PackageID = new.buffers.resolutions.items[prev_len..end];
+        const dependencies: []Dependency = new.buffers.dependencies.items[prev_len..end];
+        const resolutions: []PackageID = new.buffers.resolutions.items[prev_len..end];
 
         const id = @as(PackageID, @truncate(new.packages.len));
         const new_package = try new.appendPackageWithID(
@@ -2589,7 +2589,7 @@ pub const Package = extern struct {
         {
             string_builder.count(package_json.name);
             string_builder.count(package_json.version);
-            var dependencies = package_json.dependencies.map.values();
+            const dependencies = package_json.dependencies.map.values();
             for (dependencies) |dep| {
                 if (dep.behavior.isEnabled(features)) {
                     dep.count(package_json.dependencies.source_buf, @TypeOf(&string_builder), &string_builder);
@@ -2744,7 +2744,7 @@ pub const Package = extern struct {
         try resolutions_list.ensureUnusedCapacity(lockfile.allocator, total_dependencies_count);
         try extern_strings_list.ensureUnusedCapacity(lockfile.allocator, bin_extern_strings_count);
         extern_strings_list.items.len += bin_extern_strings_count;
-        var extern_strings_slice = extern_strings_list.items[extern_strings_list.items.len - bin_extern_strings_count ..];
+        const extern_strings_slice = extern_strings_list.items[extern_strings_list.items.len - bin_extern_strings_count ..];
 
         // -- Cloning
         {
@@ -2959,7 +2959,7 @@ pub const Package = extern struct {
                             .workspace => if (to_lockfile.workspace_paths.getPtr(from_dep.name_hash)) |path_ptr| brk: {
                                 const path = to_lockfile.str(path_ptr);
                                 var local_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                                var package_json_path = Path.joinZBuf(
+                                const package_json_path = Path.joinZBuf(
                                     &local_buf,
                                     &[_]string{ path, "package.json" },
                                     .auto,
@@ -3089,7 +3089,7 @@ pub const Package = extern struct {
         value_loc: logger.Loc,
     ) !?Dependency {
         const external_version = string_builder.append(String, version);
-        var buf = lockfile.buffers.string_bytes.items;
+        const buf = lockfile.buffers.string_bytes.items;
         const sliced = external_version.sliced(buf);
 
         var dependency_version = Dependency.parseWithOptionalTag(
@@ -3211,7 +3211,7 @@ pub const Package = extern struct {
                 dependency_version.literal = path;
                 dependency_version.value.workspace = path;
 
-                var workspace_entry = try lockfile.workspace_paths.getOrPut(allocator, name_hash);
+                const workspace_entry = try lockfile.workspace_paths.getOrPut(allocator, name_hash);
                 const found_matching_workspace = workspace_entry.found_existing or PackageManager.instance.workspaces.contains(lockfile.str(&external_alias.value));
 
                 if (workspace_version) |ver| {
@@ -3257,7 +3257,7 @@ pub const Package = extern struct {
 
         // `peerDependencies` may be specified on existing dependencies
         if (comptime features.check_for_duplicate_dependencies and !group.behavior.isPeer()) {
-            var entry = lockfile.scratch.duplicate_checker_map.getOrPutAssumeCapacity(external_alias.hash);
+            const entry = lockfile.scratch.duplicate_checker_map.getOrPutAssumeCapacity(external_alias.hash);
             if (entry.found_existing) {
                 // duplicate dependencies are allowed in optionalDependencies
                 if (comptime group.behavior.isOptional()) {
@@ -3321,7 +3321,7 @@ pub const Package = extern struct {
         }
 
         pub fn insert(self: *WorkspaceMap, key: string, value: Entry) !void {
-            var entry = try self.map.getOrPut(key);
+            const entry = try self.map.getOrPut(key);
             if (!entry.found_existing) {
                 entry.key_ptr.* = try self.map.allocator.dupe(u8, key);
             } else {
@@ -3413,15 +3413,15 @@ pub const Package = extern struct {
         if (arr.items.len == 0) return 0;
 
         var fallback = std.heap.stackFallback(1024, allocator);
-        var workspace_allocator = fallback.get();
-        var workspace_name_buf = allocator.create([1024]u8) catch unreachable;
+        const workspace_allocator = fallback.get();
+        const workspace_name_buf = allocator.create([1024]u8) catch unreachable;
         defer allocator.destroy(workspace_name_buf);
 
         const orig_msgs_len = log.msgs.items.len;
 
         var asterisked_workspace_paths = std.ArrayList(string).init(allocator);
         defer asterisked_workspace_paths.deinit();
-        var filepath_buf = allocator.create([bun.MAX_PATH_BYTES]u8) catch unreachable;
+        const filepath_buf = allocator.create([bun.MAX_PATH_BYTES]u8) catch unreachable;
         defer allocator.destroy(filepath_buf);
 
         for (arr.slice()) |item| {
@@ -3524,7 +3524,7 @@ pub const Package = extern struct {
 
         if (asterisked_workspace_paths.items.len > 0) {
             // max path bytes is not enough in real codebases
-            var second_buf = allocator.create([4096]u8) catch unreachable;
+            const second_buf = allocator.create([4096]u8) catch unreachable;
             var second_buf_fixed = std.heap.FixedBufferAllocator.init(second_buf);
             defer allocator.destroy(second_buf);
 
@@ -3582,7 +3582,7 @@ pub const Package = extern struct {
                     if (entry.kind(&Fs.FileSystem.instance.fs, true) != .dir) continue;
 
                     var parts = [2]string{ entry.dir, entry.base() };
-                    var entry_path = Path.joinAbsStringBufZ(
+                    const entry_path = Path.joinAbsStringBufZ(
                         Fs.FileSystem.instance.topLevelDirWithoutTrailingSlash(),
                         filepath_buf,
                         &parts,
@@ -4085,7 +4085,7 @@ pub const Package = extern struct {
                 for (workspace_names.values(), workspace_names.keys()) |entry, path| {
 
                     // workspace names from their package jsons. duplicates not allowed
-                    var gop = try seen_workspace_names.getOrPut(allocator, @truncate(String.Builder.stringHash(entry.name)));
+                    const gop = try seen_workspace_names.getOrPut(allocator, @truncate(String.Builder.stringHash(entry.name)));
                     if (gop.found_existing) {
                         log.addErrorFmt(&source, logger.Loc.Empty, allocator, "Workspace name \"{s}\" already exists", .{
                             entry.name,
@@ -4385,7 +4385,7 @@ pub const Package = extern struct {
                 const value = sliced.items(@field(Lockfile.Package.List.Field, field.name));
 
                 comptime assertNoUninitializedPadding(@TypeOf(value));
-                var bytes = std.mem.sliceAsBytes(value);
+                const bytes = std.mem.sliceAsBytes(value);
                 const end_pos = stream.pos + bytes.len;
                 if (end_pos <= end_at) {
                     @memcpy(bytes, stream.buffer[stream.pos..][0..bytes.len]);
@@ -4567,7 +4567,7 @@ const Buffers = struct {
             // Dependencies have to be converted to .toExternal first
             // We store pointers in Version.Value, so we can't just write it directly
             if (comptime strings.eqlComptime(name, "dependencies")) {
-                var remaining = this.dependencies.items;
+                const remaining = this.dependencies.items;
 
                 // It would be faster to buffer these instead of one big allocation
                 var to_clone = try std.ArrayListUnmanaged(Dependency.External).initCapacity(allocator, remaining.len);
@@ -4579,7 +4579,7 @@ const Buffers = struct {
 
                 try writeArray(StreamType, stream, Writer, writer, []Dependency.External, to_clone.items);
             } else {
-                var list = @field(this, name);
+                const list = @field(this, name);
                 const items = list.items;
                 const Type = @TypeOf(items);
                 if (comptime Type == Tree) {
@@ -4663,7 +4663,7 @@ const Buffers = struct {
             // }
         }
 
-        var external_dependency_list = external_dependency_list_.items;
+        const external_dependency_list = external_dependency_list_.items;
         // Dependencies are serialized separately.
         // This is unfortunate. However, not using pointers for Semver Range's make the code a lot more complex.
         this.dependencies = try DependencyList.initCapacity(allocator, external_dependency_list.len);
@@ -4679,7 +4679,7 @@ const Buffers = struct {
 
         {
             var external_deps = external_dependency_list.ptr;
-            var dependencies = this.dependencies.items;
+            const dependencies = this.dependencies.items;
             if (comptime Environment.allow_assert) std.debug.assert(external_dependency_list.len == dependencies.len);
             for (dependencies) |*dep| {
                 dep.* = Dependency.toDependency(external_deps[0], extern_context);
@@ -4847,13 +4847,13 @@ pub const Serializer = struct {
     ) !void {
         var reader = stream.reader();
         var header_buf_: [header_bytes.len]u8 = undefined;
-        var header_buf = header_buf_[0..try reader.readAll(&header_buf_)];
+        const header_buf = header_buf_[0..try reader.readAll(&header_buf_)];
 
         if (!strings.eqlComptime(header_buf, header_bytes)) {
             return error.InvalidLockfile;
         }
 
-        var format = try reader.readInt(u32, .little);
+        const format = try reader.readInt(u32, .little);
         if (format != @intFromEnum(Lockfile.FormatVersion.current)) {
             return error.@"Outdated lockfile version";
         }
@@ -4878,7 +4878,7 @@ pub const Serializer = struct {
             return error.@"Lockfile is malformed (expected 0 at the end)";
         }
 
-        var has_workspace_name_hashes = false;
+        const has_workspace_name_hashes = false;
         // < Bun v1.0.4 stopped right here when reading the lockfile
         // So we add an extra 8 byte tag to say "hey, there's more data here"
         {
@@ -4984,7 +4984,7 @@ pub const Serializer = struct {
                     defer lockfile.overrides.map = map;
 
                     try map.ensureTotalCapacity(allocator, overrides_name_hashes.items.len);
-                    var override_versions_external = try Lockfile.Buffers.readArray(
+                    const override_versions_external = try Lockfile.Buffers.readArray(
                         stream,
                         allocator,
                         std.ArrayListUnmanaged(Dependency.External),
@@ -5079,7 +5079,7 @@ pub fn generateMetaHash(this: *Lockfile, print_name_version_string: bool) !MetaH
     var has_scripts = false;
 
     inline for (comptime std.meta.fieldNames(Lockfile.Scripts)) |field_name| {
-        var scripts = @field(this.scripts, field_name);
+        const scripts = @field(this.scripts, field_name);
         for (scripts.items) |script| {
             if (script.script.len > 0) {
                 string_builder.fmtCount("{s}@{s}: {s}\n", .{ field_name, script.cwd, script.script });
@@ -5115,7 +5115,7 @@ pub fn generateMetaHash(this: *Lockfile, print_name_version_string: bool) !MetaH
     if (has_scripts) {
         _ = string_builder.append(scripts_begin);
         inline for (comptime std.meta.fieldNames(Lockfile.Scripts)) |field_name| {
-            var scripts = @field(this.scripts, field_name);
+            const scripts = @field(this.scripts, field_name);
             for (scripts.items) |script| {
                 if (script.script.len > 0) {
                     _ = string_builder.fmt("{s}@{s}: {s}\n", .{ field_name, script.cwd, script.script });
@@ -5433,7 +5433,7 @@ pub fn jsonStringify(this: *const Lockfile, w: anytype) !void {
                 defer w.endObject() catch {};
 
                 inline for (comptime std.meta.fieldNames(Lockfile.Scripts)) |field_name| {
-                    var script = @field(pkg.scripts, field_name).slice(sb);
+                    const script = @field(pkg.scripts, field_name).slice(sb);
                     if (script.len > 0) {
                         try w.objectField(field_name);
                         try w.write(script);

--- a/src/install/migration.zig
+++ b/src/install/migration.zig
@@ -53,7 +53,7 @@ pub fn detectAndLoadOtherLockfile(this: *Lockfile, allocator: Allocator, log: *l
         var timer = std.time.Timer.start() catch unreachable;
         const file = cwd.openFileZ(lockfile_path, .{ .mode = .read_only }) catch break :npm;
         defer file.close();
-        var data = file.readToEndAlloc(allocator, std.math.maxInt(usize)) catch |err| {
+        const data = file.readToEndAlloc(allocator, std.math.maxInt(usize)) catch |err| {
             return LoadFromDiskResult{ .err = .{ .step = .migrating, .value = err } };
         };
         const lockfile = migrateNPMLockfile(this, allocator, log, data, lockfile_path) catch |err| {
@@ -337,7 +337,7 @@ pub fn migrateNPMLockfile(this: *Lockfile, allocator: Allocator, log: *logger.Lo
                 const version_str = version_prop.?.asString(allocator) orelse return error.InvalidNPMLockfile;
                 count += "-.tgz".len + version_str.len;
 
-                var resolved_url = allocator.alloc(u8, count) catch unreachable;
+                const resolved_url = allocator.alloc(u8, count) catch unreachable;
                 var remain = resolved_url;
                 @memcpy(remain[0..registry.url.href.len], registry.url.href);
                 remain = remain[registry.url.href.len..];
@@ -742,7 +742,7 @@ pub fn migrateNPMLockfile(this: *Lockfile, allocator: Allocator, log: *logger.Lo
 
                             const id = found.new_package_id;
 
-                            var is_workspace = resolutions[id].tag == .workspace;
+                            const is_workspace = resolutions[id].tag == .workspace;
 
                             dependencies_buf[0] = Dependency{
                                 .name = dep_name,

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -102,7 +102,7 @@ pub const Registry = struct {
                             }
 
                             const eql_i = strings.indexOfChar(segment, '=') orelse continue;
-                            var value = segment[eql_i + 1 ..];
+                            const value = segment[eql_i + 1 ..];
                             segment = segment[0..eql_i];
 
                             // https://github.com/yarnpkg/yarn/blob/6db39cf0ff684ce4e7de29669046afb8103fce3d/src/registries/npm-registry.js#L364
@@ -134,7 +134,7 @@ pub const Registry = struct {
                                 var remain = pathname[last_slash + 1 ..];
                                 if (strings.indexOfChar(remain, '=')) |eql_i| {
                                     const segment = remain[0..eql_i];
-                                    var value = remain[eql_i + 1 ..];
+                                    const value = remain[eql_i + 1 ..];
 
                                     // https://github.com/yarnpkg/yarn/blob/6db39cf0ff684ce4e7de29669046afb8103fce3d/src/registries/npm-registry.js#L364
                                     // Bearer Token
@@ -641,7 +641,7 @@ pub const PackageManifest = struct {
                 .truncate = true,
             });
             defer tmpfile.close();
-            var writer = tmpfile.writer();
+            const writer = tmpfile.writer();
             try Serializer.write(this, @TypeOf(writer), writer);
         }
 
@@ -656,9 +656,9 @@ pub const PackageManifest = struct {
             const hex_timestamp_fmt = bun.fmt.hexIntLower(hex_timestamp);
             try dest_path_stream_writer.print("{any}.npm-{any}", .{ hex_fmt, hex_timestamp_fmt });
             try dest_path_stream_writer.writeByte(0);
-            var tmp_path: [:0]u8 = dest_path_buf[0 .. dest_path_stream.pos - 1 :0];
+            const tmp_path: [:0]u8 = dest_path_buf[0 .. dest_path_stream.pos - 1 :0];
             try writeFile(this, tmp_path, tmpdir);
-            var out_path = std.fmt.bufPrintZ(&out_path_buf, "{any}.npm", .{hex_fmt}) catch unreachable;
+            const out_path = std.fmt.bufPrintZ(&out_path_buf, "{any}.npm", .{hex_fmt}) catch unreachable;
             try std.os.renameatZ(tmpdir.dir.fd, tmp_path, cache_dir.dir.fd, out_path);
         }
 
@@ -666,7 +666,7 @@ pub const PackageManifest = struct {
             const file_id = bun.Wyhash.hash(0, package_name);
             var file_path_buf: [512 + 64]u8 = undefined;
             const hex_fmt = bun.fmt.hexIntLower(file_id);
-            var file_path = try std.fmt.bufPrintZ(&file_path_buf, "{any}.npm", .{hex_fmt});
+            const file_path = try std.fmt.bufPrintZ(&file_path_buf, "{any}.npm", .{hex_fmt});
             var cache_file = cache_dir.dir.openFileZ(
                 file_path,
                 .{ .mode = .read_only },
@@ -676,7 +676,7 @@ pub const PackageManifest = struct {
                 timer = std.time.Timer.start() catch @panic("timer fail");
             }
             defer cache_file.close();
-            var bytes = try cache_file.readToEndAllocOptions(
+            const bytes = try cache_file.readToEndAllocOptions(
                 allocator,
                 std.math.maxInt(u32),
                 cache_file.getEndPos() catch null,
@@ -1051,7 +1051,7 @@ pub const PackageManifest = struct {
         }
 
         var versioned_packages = try allocator.alloc(PackageVersion, release_versions_len + pre_versions_len);
-        var all_semver_versions = try allocator.alloc(Semver.Version, release_versions_len + pre_versions_len + dist_tags_count);
+        const all_semver_versions = try allocator.alloc(Semver.Version, release_versions_len + pre_versions_len + dist_tags_count);
         var all_extern_strings = try allocator.alloc(ExternalString, extern_string_count + tarball_urls_count);
         var version_extern_strings = try allocator.alloc(ExternalString, dependency_sum);
         var extern_strings_bin_entries = try allocator.alloc(ExternalString, extern_string_count_bin);
@@ -1060,30 +1060,30 @@ pub const PackageManifest = struct {
         var tarball_url_strings = all_tarball_url_strings;
 
         if (versioned_packages.len > 0) {
-            var versioned_packages_bytes = std.mem.sliceAsBytes(versioned_packages);
+            const versioned_packages_bytes = std.mem.sliceAsBytes(versioned_packages);
             @memset(versioned_packages_bytes, 0);
         }
         if (all_semver_versions.len > 0) {
-            var all_semver_versions_bytes = std.mem.sliceAsBytes(all_semver_versions);
+            const all_semver_versions_bytes = std.mem.sliceAsBytes(all_semver_versions);
             @memset(all_semver_versions_bytes, 0);
         }
         if (all_extern_strings.len > 0) {
-            var all_extern_strings_bytes = std.mem.sliceAsBytes(all_extern_strings);
+            const all_extern_strings_bytes = std.mem.sliceAsBytes(all_extern_strings);
             @memset(all_extern_strings_bytes, 0);
         }
         if (version_extern_strings.len > 0) {
-            var version_extern_strings_bytes = std.mem.sliceAsBytes(version_extern_strings);
+            const version_extern_strings_bytes = std.mem.sliceAsBytes(version_extern_strings);
             @memset(version_extern_strings_bytes, 0);
         }
 
         var versioned_package_releases = versioned_packages[0..release_versions_len];
-        var all_versioned_package_releases = versioned_package_releases;
+        const all_versioned_package_releases = versioned_package_releases;
         var versioned_package_prereleases = versioned_packages[release_versions_len..][0..pre_versions_len];
-        var all_versioned_package_prereleases = versioned_package_prereleases;
+        const all_versioned_package_prereleases = versioned_package_prereleases;
         var _versions_open = all_semver_versions;
-        var all_release_versions = _versions_open[0..release_versions_len];
+        const all_release_versions = _versions_open[0..release_versions_len];
         _versions_open = _versions_open[release_versions_len..];
-        var all_prerelease_versions = _versions_open[0..pre_versions_len];
+        const all_prerelease_versions = _versions_open[0..pre_versions_len];
         _versions_open = _versions_open[pre_versions_len..];
         var dist_tag_versions = _versions_open[0..dist_tags_count];
         var release_versions = all_release_versions;
@@ -1114,7 +1114,7 @@ pub const PackageManifest = struct {
 
                 const versions = versions_q.expr.data.e_object.properties.slice();
 
-                var all_dependency_names_and_values = all_extern_strings[0..dependency_sum];
+                const all_dependency_names_and_values = all_extern_strings[0..dependency_sum];
 
                 // versions change more often than names
                 // so names go last because we are better able to dedupe at the end
@@ -1438,7 +1438,7 @@ pub const PackageManifest = struct {
                                     const name_map_hash = name_hasher.final();
                                     const version_map_hash = version_hasher.final();
 
-                                    var name_entry = try external_string_maps.getOrPut(name_map_hash);
+                                    const name_entry = try external_string_maps.getOrPut(name_map_hash);
                                     if (name_entry.found_existing) {
                                         name_list = name_entry.value_ptr.*;
                                         this_names = name_list.mut(all_extern_strings);
@@ -1447,7 +1447,7 @@ pub const PackageManifest = struct {
                                         dependency_names = dependency_names[count..];
                                     }
 
-                                    var version_entry = try external_string_maps.getOrPut(version_map_hash);
+                                    const version_entry = try external_string_maps.getOrPut(version_map_hash);
                                     if (version_entry.found_existing) {
                                         version_list = version_entry.value_ptr.*;
                                         this_versions = version_list.mut(version_extern_strings);
@@ -1630,7 +1630,7 @@ pub const PackageManifest = struct {
 
                 var all_indices = try bun.default_allocator.alloc(Int, max_versions_count);
                 defer bun.default_allocator.free(all_indices);
-                var releases_list = .{ &result.pkg.releases, &result.pkg.prereleases };
+                const releases_list = .{ &result.pkg.releases, &result.pkg.prereleases };
 
                 var all_cloned_versions = try bun.default_allocator.alloc(Semver.Version, max_versions_count);
                 defer bun.default_allocator.free(all_cloned_versions);
@@ -1640,11 +1640,11 @@ pub const PackageManifest = struct {
 
                 inline for (0..2) |release_i| {
                     var release = releases_list[release_i];
-                    var indices = all_indices[0..release.keys.len];
-                    var cloned_packages = all_cloned_packages[0..release.keys.len];
-                    var cloned_versions = all_cloned_versions[0..release.keys.len];
-                    var versioned_packages_ = @constCast(release.values.get(versioned_packages));
-                    var semver_versions_ = @constCast(release.keys.get(all_semver_versions));
+                    const indices = all_indices[0..release.keys.len];
+                    const cloned_packages = all_cloned_packages[0..release.keys.len];
+                    const cloned_versions = all_cloned_versions[0..release.keys.len];
+                    const versioned_packages_ = @constCast(release.values.get(versioned_packages));
+                    const semver_versions_ = @constCast(release.keys.get(all_semver_versions));
                     @memcpy(cloned_packages, versioned_packages_);
                     @memcpy(cloned_versions, semver_versions_);
 
@@ -1652,7 +1652,7 @@ pub const PackageManifest = struct {
                         dest.* = @truncate(i);
                     }
 
-                    var sorter = ExternVersionSorter{
+                    const sorter = ExternVersionSorter{
                         .string_bytes = string_buf,
                         .all_versions = semver_versions_,
                         .all_versioned_packages = versioned_packages_,
@@ -1684,7 +1684,7 @@ pub const PackageManifest = struct {
         }
 
         if (extern_strings.len + tarball_urls_count > 0) {
-            var src = std.mem.sliceAsBytes(all_tarball_url_strings[0 .. all_tarball_url_strings.len - tarball_url_strings.len]);
+            const src = std.mem.sliceAsBytes(all_tarball_url_strings[0 .. all_tarball_url_strings.len - tarball_url_strings.len]);
             if (src.len > 0) {
                 var dst = std.mem.sliceAsBytes(all_extern_strings[all_extern_strings.len - extern_strings.len ..]);
                 std.debug.assert(dst.len >= src.len);

--- a/src/install/repository.zig
+++ b/src/install/repository.zig
@@ -307,7 +307,7 @@ pub const Repository = extern struct {
         };
         defer json_file.close();
         const size = try json_file.getEndPos();
-        var json_buf = try allocator.alloc(u8, size + 64);
+        const json_buf = try allocator.alloc(u8, size + 64);
         const json_len = try json_file.preadAll(json_buf, 0);
 
         const json_path = bun.getFdPath(

--- a/src/install/resolvers/folder_resolver.zig
+++ b/src/install/resolvers/folder_resolver.zig
@@ -205,7 +205,7 @@ pub const FolderResolution = union(Tag) {
         const abs = paths.abs;
         const rel = paths.rel;
 
-        var entry = manager.folders.getOrPut(manager.allocator, hash(abs)) catch unreachable;
+        const entry = manager.folders.getOrPut(manager.allocator, hash(abs)) catch unreachable;
         if (entry.found_existing) return entry.value_ptr.*;
 
         const package: Lockfile.Package = switch (global_or_relative) {

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -76,8 +76,8 @@ pub const String = extern struct {
     }
 
     pub fn isUndefined(this: *const String) bool {
-        var num: u64 = undefined;
-        var bytes = @as(u64, @bitCast(this.bytes));
+        const num: u64 = undefined;
+        const bytes = @as(u64, @bitCast(this.bytes));
         return @as(u63, @truncate(bytes)) == @as(u63, @truncate(num));
     }
 
@@ -334,7 +334,7 @@ pub const String = extern struct {
                 &[_]u8{};
         }
         pub fn allocate(this: *Builder, allocator: Allocator) !void {
-            var ptr_ = try allocator.alloc(u8, this.cap);
+            const ptr_ = try allocator.alloc(u8, this.cap);
             this.ptr = ptr_.ptr;
         }
 
@@ -432,7 +432,7 @@ pub const String = extern struct {
                 std.debug.assert(this.ptr != null); // must call allocate first
             }
 
-            var string_entry = this.string_pool.getOrPut(hash) catch unreachable;
+            const string_entry = this.string_pool.getOrPut(hash) catch unreachable;
             if (!string_entry.found_existing) {
                 bun.copy(u8, this.ptr.?[this.len..this.cap], slice_);
                 const final_slice = this.ptr.?[this.len..this.cap][0..slice_.len];
@@ -468,7 +468,7 @@ pub const String = extern struct {
 test "String works" {
     {
         var buf: string = "hello world";
-        var world: string = buf[6..];
+        const world: string = buf[6..];
         var str = String.init(
             buf,
             world,
@@ -477,8 +477,8 @@ test "String works" {
     }
 
     {
-        var buf: string = "hello";
-        var world: string = buf;
+        const buf: string = "hello";
+        const world: string = buf;
         var str = String.init(
             buf,
             world,
@@ -488,8 +488,8 @@ test "String works" {
     }
 
     {
-        var buf: string = &[8]u8{ 'h', 'e', 'l', 'l', 'o', 'k', 'k', 129 };
-        var world: string = buf;
+        const buf: string = &[8]u8{ 'h', 'e', 'l', 'l', 'o', 'k', 'k', 129 };
+        const world: string = buf;
         var str = String.init(
             buf,
             world,
@@ -794,8 +794,8 @@ pub const Version = extern struct {
             var rhs_itr = strings.split(rhs_str, ".");
 
             while (true) {
-                var lhs_part = lhs_itr.next();
-                var rhs_part = rhs_itr.next();
+                const lhs_part = lhs_itr.next();
+                const rhs_part = rhs_itr.next();
 
                 if (lhs_part == null and rhs_part == null) return .eq;
 
@@ -1495,7 +1495,7 @@ pub const Query = struct {
             if (!lhs.head.eql(&rhs.head)) return false;
 
             var lhs_next = lhs.next orelse return rhs.next == null;
-            var rhs_next = rhs.next orelse return false;
+            const rhs_next = rhs.next orelse return false;
 
             return lhs_next.eql(rhs_next);
         }

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -130,7 +130,7 @@ pub fn NewBaseStore(comptime Union: anytype, comptime count: usize) type {
                 used_list.len += 1;
             }
 
-            var used = overflow.allocator.dupe(*Block, used_list) catch unreachable;
+            const used = overflow.allocator.dupe(*Block, used_list) catch unreachable;
 
             for (to_move, overflow.ptrs[0..to_move.len]) |b, *out| {
                 b.* = Block{
@@ -157,7 +157,7 @@ pub fn NewBaseStore(comptime Union: anytype, comptime count: usize) type {
             for (blocks) |b| {
                 if (comptime Environment.isDebug) {
                     // ensure we crash if we use a freed value
-                    var bytes = std.mem.asBytes(&b.items);
+                    const bytes = std.mem.asBytes(&b.items);
                     @memset(bytes, undefined);
                 }
                 b.used = 0;
@@ -184,14 +184,14 @@ pub fn NewBaseStore(comptime Union: anytype, comptime count: usize) type {
         fn deinit() void {
             if (_self) |this| {
                 _self = null;
-                var sliced = this.overflow.slice();
+                const sliced = this.overflow.slice();
                 var allocator = this.overflow.allocator;
 
                 if (sliced.len > 1) {
                     var i: usize = 1;
                     const end = sliced.len;
                     while (i < end) {
-                        var ptrs = @as(*[2]Block, @ptrCast(sliced[i]));
+                        const ptrs = @as(*[2]Block, @ptrCast(sliced[i]));
                         allocator.free(ptrs);
                         i += 2;
                     }
@@ -407,7 +407,7 @@ pub const Binding = struct {
                 return Expr.init(E.Array, E.Array{ .items = ExprNodeList.init(exprs), .is_single_line = b.is_single_line }, loc);
             },
             .b_object => |b| {
-                var properties = wrapper
+                const properties = wrapper
                     .allocator
                     .alloc(G.Property, b.properties.len) catch unreachable;
                 for (properties, b.properties) |*property, item| {
@@ -479,22 +479,22 @@ pub const Binding = struct {
         icount += 1;
         switch (@TypeOf(t)) {
             B.Identifier => {
-                var data = allocator.create(B.Identifier) catch unreachable;
+                const data = allocator.create(B.Identifier) catch unreachable;
                 data.* = t;
                 return Binding{ .loc = loc, .data = B{ .b_identifier = data } };
             },
             B.Array => {
-                var data = allocator.create(B.Array) catch unreachable;
+                const data = allocator.create(B.Array) catch unreachable;
                 data.* = t;
                 return Binding{ .loc = loc, .data = B{ .b_array = data } };
             },
             B.Property => {
-                var data = allocator.create(B.Property) catch unreachable;
+                const data = allocator.create(B.Property) catch unreachable;
                 data.* = t;
                 return Binding{ .loc = loc, .data = B{ .b_property = data } };
             },
             B.Object => {
-                var data = allocator.create(B.Object) catch unreachable;
+                const data = allocator.create(B.Object) catch unreachable;
                 data.* = t;
                 return Binding{ .loc = loc, .data = B{ .b_object = data } };
             },
@@ -607,7 +607,7 @@ pub const CharFreq = struct {
         std.debug.assert(remain.len >= scan_big_chunk_size);
 
         const unrolled = remain.len - (remain.len % scan_big_chunk_size);
-        var remain_end = remain.ptr + unrolled;
+        const remain_end = remain.ptr + unrolled;
         var unrolled_ptr = remain.ptr;
         remain = remain[unrolled..];
 
@@ -1304,7 +1304,7 @@ pub const Symbol = struct {
         }
 
         pub fn init(sourceCount: usize, allocator: std.mem.Allocator) !Map {
-            var symbols_for_source: NestedList = NestedList.init(try allocator.alloc([]Symbol, sourceCount));
+            const symbols_for_source: NestedList = NestedList.init(try allocator.alloc([]Symbol, sourceCount));
             return Map{ .symbols_for_source = symbols_for_source };
         }
 
@@ -1810,7 +1810,7 @@ pub const E = struct {
                     return try next.append(expr, allocator);
                 }
 
-                var rope = try allocator.create(Rope);
+                const rope = try allocator.create(Rope);
                 rope.* = .{
                     .head = expr,
                 };
@@ -2266,7 +2266,7 @@ pub const E = struct {
 
             if (s.isUTF8()) {
                 if (comptime !Environment.isNative) {
-                    var allocated = (strings.toUTF16Alloc(bun.default_allocator, s.data, false) catch return 0) orelse return s.data.len;
+                    const allocated = (strings.toUTF16Alloc(bun.default_allocator, s.data, false) catch return 0) orelse return s.data.len;
                     defer bun.default_allocator.free(allocated);
                     return @as(u32, @truncate(allocated.len));
                 }
@@ -2757,7 +2757,7 @@ pub const Stmt = struct {
     }
 
     fn allocateData(allocator: std.mem.Allocator, comptime tag_name: string, comptime typename: type, origData: anytype, loc: logger.Loc) Stmt {
-        var value = allocator.create(@TypeOf(origData)) catch unreachable;
+        const value = allocator.create(@TypeOf(origData)) catch unreachable;
         value.* = origData;
 
         return comptime_init(tag_name, *typename, value, loc);
@@ -3088,7 +3088,7 @@ pub const Expr = struct {
         log: *logger.Log,
         loc: logger.Loc,
     ) !Expr {
-        var bytes = blob.sharedView();
+        const bytes = blob.sharedView();
 
         const mime_type = mime_type_ orelse MimeType.init(blob.content_type, null, null);
 
@@ -3412,7 +3412,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_array = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3424,7 +3424,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_class = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3436,7 +3436,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_unary = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3448,7 +3448,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_binary = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3500,7 +3500,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_new = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3520,7 +3520,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_function = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3540,7 +3540,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_call = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3552,7 +3552,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_dot = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3564,7 +3564,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_index = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3576,7 +3576,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_arrow = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3631,7 +3631,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_jsx_element = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3654,7 +3654,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_big_int = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3666,7 +3666,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_object = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3678,7 +3678,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_spread = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3696,7 +3696,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_string = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3708,7 +3708,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_template_part = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3720,7 +3720,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_template = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3732,7 +3732,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_reg_exp = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3744,7 +3744,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_await = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3756,7 +3756,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_yield = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3768,7 +3768,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_if = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3788,7 +3788,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_import = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st;
                             break :brk item;
                         },
@@ -3808,7 +3808,7 @@ pub const Expr = struct {
                     .loc = loc,
                     .data = Data{
                         .e_string = brk: {
-                            var item = allocator.create(Type) catch unreachable;
+                            const item = allocator.create(Type) catch unreachable;
                             item.* = st.*;
                             break :brk item;
                         },
@@ -4873,112 +4873,112 @@ pub const Expr = struct {
         pub fn clone(this: Expr.Data, allocator: std.mem.Allocator) !Data {
             return switch (this) {
                 .e_array => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_array)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_array)));
                     item.* = el.*;
                     return .{ .e_array = item };
                 },
                 .e_unary => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_unary)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_unary)));
                     item.* = el.*;
                     return .{ .e_unary = item };
                 },
                 .e_binary => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_binary)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_binary)));
                     item.* = el.*;
                     return .{ .e_binary = item };
                 },
                 .e_class => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_class)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_class)));
                     item.* = el.*;
                     return .{ .e_class = item };
                 },
                 .e_new => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_new)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_new)));
                     item.* = el.*;
                     return .{ .e_new = item };
                 },
                 .e_function => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_function)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_function)));
                     item.* = el.*;
                     return .{ .e_function = item };
                 },
                 .e_call => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_call)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_call)));
                     item.* = el.*;
                     return .{ .e_call = item };
                 },
                 .e_dot => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_dot)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_dot)));
                     item.* = el.*;
                     return .{ .e_dot = item };
                 },
                 .e_index => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_index)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_index)));
                     item.* = el.*;
                     return .{ .e_index = item };
                 },
                 .e_arrow => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_arrow)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_arrow)));
                     item.* = el.*;
                     return .{ .e_arrow = item };
                 },
                 .e_jsx_element => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_jsx_element)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_jsx_element)));
                     item.* = el.*;
                     return .{ .e_jsx_element = item };
                 },
                 .e_object => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_object)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_object)));
                     item.* = el.*;
                     return .{ .e_object = item };
                 },
                 .e_spread => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_spread)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_spread)));
                     item.* = el.*;
                     return .{ .e_spread = item };
                 },
                 .e_template_part => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_template_part)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_template_part)));
                     item.* = el.*;
                     return .{ .e_template_part = item };
                 },
                 .e_template => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_template)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_template)));
                     item.* = el.*;
                     return .{ .e_template = item };
                 },
                 .e_reg_exp => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_reg_exp)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_reg_exp)));
                     item.* = el.*;
                     return .{ .e_reg_exp = item };
                 },
                 .e_await => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_await)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_await)));
                     item.* = el.*;
                     return .{ .e_await = item };
                 },
                 .e_yield => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_yield)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_yield)));
                     item.* = el.*;
                     return .{ .e_yield = item };
                 },
                 .e_if => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_if)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_if)));
                     item.* = el.*;
                     return .{ .e_if = item };
                 },
                 .e_import => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_import)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_import)));
                     item.* = el.*;
                     return .{ .e_import = item };
                 },
                 .e_big_int => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_big_int)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_big_int)));
                     item.* = el.*;
                     return .{ .e_big_int = item };
                 },
                 .e_string => |el| {
-                    var item = try allocator.create(std.meta.Child(@TypeOf(this.e_string)));
+                    const item = try allocator.create(std.meta.Child(@TypeOf(this.e_string)));
                     item.* = el.*;
                     return .{ .e_string = item };
                 },
@@ -6309,7 +6309,7 @@ pub const DeclaredSymbol = struct {
         }
 
         pub fn toOwnedSlice(this: *List) List {
-            var new = this.*;
+            const new = this.*;
 
             this.* = .{};
             return new;
@@ -6832,7 +6832,7 @@ pub const Macro = struct {
                 &specifier_buf_len,
             );
 
-            var macro_entry = this.macros.getOrPut(hash) catch unreachable;
+            const macro_entry = this.macros.getOrPut(hash) catch unreachable;
             if (!macro_entry.found_existing) {
                 macro_entry.value_ptr.* = Macro.init(
                     default_allocator,
@@ -6910,7 +6910,7 @@ pub const Macro = struct {
         var vm: *JavaScript.VirtualMachine = if (JavaScript.VirtualMachine.isLoaded())
             JavaScript.VirtualMachine.get()
         else brk: {
-            var old_transform_options = resolver.opts.transform_options;
+            const old_transform_options = resolver.opts.transform_options;
             defer resolver.opts.transform_options = old_transform_options;
 
             // JSC needs to be initialized if building from CLI
@@ -6980,9 +6980,9 @@ pub const Macro = struct {
                 id: i32,
             ) MacroError!Expr {
                 if (comptime is_bindgen) return undefined;
-                var macro_callback = macro.vm.macros.get(id) orelse return caller;
+                const macro_callback = macro.vm.macros.get(id) orelse return caller;
 
-                var result = js.JSObjectCallAsFunctionReturnValueHoldingAPILock(
+                const result = js.JSObjectCallAsFunctionReturnValueHoldingAPILock(
                     macro.vm.global,
                     macro_callback,
                     null,
@@ -7056,13 +7056,13 @@ pub const Macro = struct {
                     .Null => return Expr.init(E.Null, E.Null{}, this.caller.loc),
                     .Private => {
                         this.is_top_level = false;
-                        var _entry = this.visited.getOrPut(this.allocator, value) catch unreachable;
+                        const _entry = this.visited.getOrPut(this.allocator, value) catch unreachable;
                         if (_entry.found_existing) {
                             return _entry.value_ptr.*;
                         }
 
                         var blob_: ?JSC.WebCore.Blob = null;
-                        var mime_type: ?MimeType = null;
+                        const mime_type: ?MimeType = null;
 
                         if (value.jsType() == .DOMWrapper) {
                             if (value.as(JSC.WebCore.Response)) |resp| {
@@ -7105,7 +7105,7 @@ pub const Macro = struct {
                     JSC.ZigConsoleClient.Formatter.Tag.Array => {
                         this.is_top_level = false;
 
-                        var _entry = this.visited.getOrPut(this.allocator, value) catch unreachable;
+                        const _entry = this.visited.getOrPut(this.allocator, value) catch unreachable;
                         if (_entry.found_existing) {
                             switch (_entry.value_ptr.*.data) {
                                 .e_object, .e_array => {
@@ -7156,7 +7156,7 @@ pub const Macro = struct {
                     // TODO: optimize this
                     JSC.ZigConsoleClient.Formatter.Tag.Object => {
                         this.is_top_level = false;
-                        var _entry = this.visited.getOrPut(this.allocator, value) catch unreachable;
+                        const _entry = this.visited.getOrPut(this.allocator, value) catch unreachable;
                         if (_entry.found_existing) {
                             switch (_entry.value_ptr.*.data) {
                                 .e_object, .e_array => {
@@ -7168,7 +7168,7 @@ pub const Macro = struct {
                             return _entry.value_ptr.*;
                         }
 
-                        var object = value.asObjectRef();
+                        const object = value.asObjectRef();
                         var object_iter = JSC.JSPropertyIterator(.{
                             .skip_empty_name = false,
                             .include_value = true,
@@ -7224,11 +7224,11 @@ pub const Macro = struct {
 
                         // encode into utf16 so the printer escapes the string correctly
                         var utf16_bytes = this.allocator.alloc(u16, bun_str.length()) catch unreachable;
-                        var out_slice = utf16_bytes[0 .. (bun_str.encodeInto(std.mem.sliceAsBytes(utf16_bytes), .utf16le) catch 0) / 2];
+                        const out_slice = utf16_bytes[0 .. (bun_str.encodeInto(std.mem.sliceAsBytes(utf16_bytes), .utf16le) catch 0) / 2];
                         return Expr.init(E.String, E.String.init(out_slice), this.caller.loc);
                     },
                     .Promise => {
-                        var _entry = this.visited.getOrPut(this.allocator, value) catch unreachable;
+                        const _entry = this.visited.getOrPut(this.allocator, value) catch unreachable;
                         if (_entry.found_existing) {
                             return _entry.value_ptr.*;
                         }
@@ -7295,7 +7295,7 @@ pub const Macro = struct {
                 allocator.free(js_args);
             }
 
-            var globalObject = JSC.VirtualMachine.get().global;
+            const globalObject = JSC.VirtualMachine.get().global;
 
             switch (caller.data) {
                 .e_call => |call| {
@@ -7389,7 +7389,7 @@ pub const ASTMemoryAllocator = struct {
     }
 
     pub fn pop(this: *ASTMemoryAllocator) void {
-        var prev = this.previous;
+        const prev = this.previous;
         std.debug.assert(prev != this);
         Stmt.Data.Store.memory_allocator = prev;
         Expr.Data.Store.memory_allocator = prev;
@@ -7490,7 +7490,7 @@ pub const GlobalStoreHandle = struct {
             global_store_ast = global;
         }
 
-        var prev = Stmt.Data.Store.memory_allocator;
+        const prev = Stmt.Data.Store.memory_allocator;
         Stmt.Data.Store.memory_allocator = global_store_ast;
         Expr.Data.Store.memory_allocator = global_store_ast;
         return prev;

--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -78,7 +78,7 @@ pub const JSONOptions = struct {
 pub fn decodeUTF8(bytes: string, allocator: std.mem.Allocator) ![]const u16 {
     var log = logger.Log.init(allocator);
     defer log.deinit();
-    var source = logger.Source.initEmptyFile("");
+    const source = logger.Source.initEmptyFile("");
     var lexer = try NewLexer(.{}).init(&log, source, allocator);
     defer lexer.deinit();
 
@@ -1994,7 +1994,7 @@ fn NewLexer_(
         }
 
         pub fn initTSConfig(log: *logger.Log, source: logger.Source, allocator: std.mem.Allocator) !LexerType {
-            var empty_string_literal: JavascriptString = &emptyJavaScriptString;
+            const empty_string_literal: JavascriptString = &emptyJavaScriptString;
             var lex = LexerType{
                 .log = log,
                 .source = source,
@@ -2013,7 +2013,7 @@ fn NewLexer_(
         }
 
         pub fn initJSON(log: *logger.Log, source: logger.Source, allocator: std.mem.Allocator) !LexerType {
-            var empty_string_literal: JavascriptString = &emptyJavaScriptString;
+            const empty_string_literal: JavascriptString = &emptyJavaScriptString;
             var lex = LexerType{
                 .log = log,
                 .string_literal_buffer = std.ArrayList(u16).init(allocator),
@@ -2031,7 +2031,7 @@ fn NewLexer_(
         }
 
         pub fn initWithoutReading(log: *logger.Log, source: logger.Source, allocator: std.mem.Allocator) LexerType {
-            var empty_string_literal: JavascriptString = &emptyJavaScriptString;
+            const empty_string_literal: JavascriptString = &emptyJavaScriptString;
             return LexerType{
                 .log = log,
                 .source = source,
@@ -2468,7 +2468,7 @@ fn NewLexer_(
 
             var decoded = jsx_decode_buf;
             defer jsx_decode_buf = decoded;
-            var decoded_ptr = &decoded;
+            const decoded_ptr = &decoded;
 
             var after_last_non_whitespace: ?u32 = null;
 
@@ -2682,7 +2682,7 @@ fn NewLexer_(
 
         fn parseNumericLiteralOrDot(lexer: *LexerType) !void {
             // Number or dot;
-            var first = lexer.code_point;
+            const first = lexer.code_point;
             lexer.step();
 
             // Dot without a digit after it;
@@ -2806,11 +2806,11 @@ fn NewLexer_(
                     isFirst = false;
                 }
 
-                var isBigIntegerLiteral = lexer.code_point == 'n' and !hasDotOrExponent;
+                const isBigIntegerLiteral = lexer.code_point == 'n' and !hasDotOrExponent;
 
                 // Slow path: do we need to re-scan the input as text?
                 if (isBigIntegerLiteral or isInvalidLegacyOctalLiteral) {
-                    var text = lexer.raw();
+                    const text = lexer.raw();
 
                     // Can't use a leading zero for bigint literals;
                     if (isBigIntegerLiteral and lexer.is_legacy_octal_literal) {
@@ -2842,7 +2842,7 @@ fn NewLexer_(
                 }
             } else {
                 // Floating-point literal;
-                var isInvalidLegacyOctalLiteral = first == '0' and (lexer.code_point == '8' or lexer.code_point == '9');
+                const isInvalidLegacyOctalLiteral = first == '0' and (lexer.code_point == '8' or lexer.code_point == '9');
 
                 // Initial digits;
                 while (true) {

--- a/src/js_lexer/identifier_data.zig
+++ b/src/js_lexer/identifier_data.zig
@@ -65,7 +65,7 @@ const id_start: IDStartType = brk: {
     @setEvalBranchQuota(999999);
     while (i < start_codepoints_including_ascii.len) : (i += 2) {
         var min = start_codepoints_including_ascii[i];
-        var max = start_codepoints_including_ascii[i + 1];
+        const max = start_codepoints_including_ascii[i + 1];
         while (min <= max) : (min += 1) {
             @setEvalBranchQuota(999999);
             bits.set(id_start_range[1] - min);
@@ -80,7 +80,7 @@ const id_continue: IDContinueType = brk: {
 
     while (i < part_codepoints_including_ascii.len) : (i += 2) {
         var min = part_codepoints_including_ascii[i];
-        var max = part_codepoints_including_ascii[i + 1];
+        const max = part_codepoints_including_ascii[i + 1];
         @setEvalBranchQuota(999999);
         while (min <= max) : (min += 1) {
             @setEvalBranchQuota(999999);
@@ -96,8 +96,8 @@ pub fn main() anyerror!void {
     var id_start_cached = Cache.CachedBitset{ .range = id_start_range, .len = id_start_count + 1 };
     var id_continue_cached = Cache.CachedBitset{ .range = id_end_range, .len = id_end_count + 1 };
 
-    var id_continue_data = std.mem.asBytes(&id_continue.masks);
-    var id_start_data = std.mem.asBytes(&id_start.masks);
+    const id_continue_data = std.mem.asBytes(&id_continue.masks);
+    const id_start_data = std.mem.asBytes(&id_start.masks);
 
     try std.os.chdir(std.fs.path.dirname(@src().file).?);
     var start = try std.fs.cwd().createFileZ("id_start_bitset.meta.blob", .{ .truncate = true });
@@ -122,19 +122,19 @@ test "Check" {
     const id_continue_cached_correct = Cache.CachedBitset{ .range = id_end_range, .len = id_end_count + 1 };
     try std.os.chdir(std.fs.path.dirname(@src().file).?);
     var start_cached = try std.fs.cwd().openFileZ("id_start_bitset.meta.blob", .{ .mode = .read_only });
-    var start_cached_data = try start_cached.readToEndAlloc(std.heap.c_allocator, 4096);
+    const start_cached_data = try start_cached.readToEndAlloc(std.heap.c_allocator, 4096);
 
     try std.testing.expectEqualSlices(u8, start_cached_data, std.mem.asBytes(&id_start_cached_correct));
 
     var continue_cached = try std.fs.cwd().openFileZ("id_continue_bitset.meta.blob", .{ .mode = .read_only });
-    var continue_cached_data = try continue_cached.readToEndAlloc(std.heap.c_allocator, 4096);
+    const continue_cached_data = try continue_cached.readToEndAlloc(std.heap.c_allocator, 4096);
 
     try std.testing.expectEqualSlices(u8, continue_cached_data, std.mem.asBytes(&id_continue_cached_correct));
 
     var start_blob_file = try std.fs.cwd().openFileZ("id_start_bitset.blob", .{ .mode = .read_only });
-    var start_blob_data = try start_blob_file.readToEndAlloc(std.heap.c_allocator, try start_blob_file.getEndPos());
+    const start_blob_data = try start_blob_file.readToEndAlloc(std.heap.c_allocator, try start_blob_file.getEndPos());
     var continue_blob_file = try std.fs.cwd().openFileZ("id_continue_bitset.blob", .{ .mode = .read_only });
-    var continue_blob_data = try continue_blob_file.readToEndAlloc(std.heap.c_allocator, try continue_blob_file.getEndPos());
+    const continue_blob_data = try continue_blob_file.readToEndAlloc(std.heap.c_allocator, try continue_blob_file.getEndPos());
 
     try std.testing.expectEqualSlices(u8, start_blob_data, std.mem.asBytes(&id_start.masks));
     try std.testing.expectEqualSlices(u8, continue_blob_data, std.mem.asBytes(&id_continue.masks));
@@ -144,16 +144,16 @@ test "Check #2" {
     const id_start_cached_correct = Cache.CachedBitset{ .range = id_start_range, .len = id_start_count + 1 };
     const id_continue_cached_correct = Cache.CachedBitset{ .range = id_end_range, .len = id_end_count + 1 };
     try std.os.chdir(std.fs.path.dirname(@src().file).?);
-    var start_cached_data = std.mem.asBytes(&Cache.id_start_meta);
+    const start_cached_data = std.mem.asBytes(&Cache.id_start_meta);
 
     try std.testing.expectEqualSlices(u8, start_cached_data, std.mem.asBytes(&id_start_cached_correct));
 
-    var continue_cached_data = std.mem.asBytes(&Cache.id_continue_meta);
+    const continue_cached_data = std.mem.asBytes(&Cache.id_continue_meta);
 
     try std.testing.expectEqualSlices(u8, continue_cached_data, std.mem.asBytes(&id_continue_cached_correct));
 
-    var start_blob_data = Cache.id_start_masks;
-    var continue_blob_data = Cache.id_continue_masks;
+    const start_blob_data = Cache.id_start_masks;
+    const continue_blob_data = Cache.id_continue_masks;
 
     try std.testing.expectEqualSlices(u8, start_blob_data, std.mem.asBytes(&id_start.masks));
     try std.testing.expectEqualSlices(u8, continue_blob_data, std.mem.asBytes(&id_continue.masks));

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -1083,7 +1083,7 @@ pub const ImportScanner = struct {
 
                     if (p.options.bundle) {
                         if (st.star_name_loc != null and existing_items.count() > 0) {
-                            var sorted = try allocator.alloc(string, existing_items.count());
+                            const sorted = try allocator.alloc(string, existing_items.count());
                             defer allocator.free(sorted);
                             for (sorted, existing_items.keys()) |*result, alias| {
                                 result.* = alias;
@@ -1780,7 +1780,7 @@ pub const SideEffects = enum(u1) {
                         for (properties_slice) |prop_| {
                             var prop = prop_;
                             if (prop_.kind != .spread) {
-                                var value = simpifyUnusedExpr(p, prop.value.?);
+                                const value = simpifyUnusedExpr(p, prop.value.?);
                                 if (value != null) {
                                     prop.value = value;
                                 } else if (!prop.flags.contains(.is_computed)) {
@@ -1834,7 +1834,7 @@ pub const SideEffects = enum(u1) {
                     if (item.data == .e_spread) {
                         var end: usize = 0;
                         for (items) |item__| {
-                            var item_ = item__;
+                            const item_ = item__;
                             if (item_.data != .e_missing) {
                                 items[end] = item_;
                                 end += 1;
@@ -2918,7 +2918,7 @@ pub const Parser = struct {
         p.lexer.track_comments = this.options.features.minify_identifiers;
         p.should_fold_typescript_constant_expressions = this.options.features.should_fold_typescript_constant_expressions;
         defer p.lexer.deinit();
-        var result: js_ast.Result = undefined;
+        const result: js_ast.Result = undefined;
         _ = result;
         try p.prepareForVisitPass();
 
@@ -2931,7 +2931,7 @@ pub const Parser = struct {
             final_expr = try p.callRuntime(expr.loc, runtime_api_call, args);
         }
 
-        var ns_export_part = js_ast.Part{
+        const ns_export_part = js_ast.Part{
             .can_be_removed_if_unused = true,
         };
 
@@ -2942,7 +2942,7 @@ pub const Parser = struct {
             },
             .loc = expr.loc,
         };
-        var part = js_ast.Part{
+        const part = js_ast.Part{
             .stmts = stmts,
             .symbol_uses = p.symbol_uses,
         };
@@ -3018,11 +3018,11 @@ pub const Parser = struct {
                         return data.len;
                     }
                 };
-                var writer = std.io.Writer(fakeWriter, anyerror, fakeWriter.writeAll){
+                const writer = std.io.Writer(fakeWriter, anyerror, fakeWriter.writeAll){
                     .context = fakeWriter{},
                 };
                 var buffered_writer = std.io.bufferedWriter(writer);
-                var actual = buffered_writer.writer();
+                const actual = buffered_writer.writer();
                 for (self.log.msgs.items) |msg| {
                     var m: logger.Msg = msg;
                     m.writeFormat(actual, true) catch {};
@@ -3052,7 +3052,7 @@ pub const Parser = struct {
         try ParserType.init(self.allocator, self.log, self.source, self.define, self.lexer, self.options, &p);
         p.should_fold_typescript_constant_expressions = self.options.features.should_fold_typescript_constant_expressions;
         defer p.lexer.deinit();
-        var result: js_ast.Result = undefined;
+        const result: js_ast.Result = undefined;
         _ = result;
 
         // defer {
@@ -3176,7 +3176,7 @@ pub const Parser = struct {
                         }
                     },
                     .s_import, .s_export_from, .s_export_star => {
-                        var parts_list = if (p.options.bundle)
+                        const parts_list = if (p.options.bundle)
                             // Move imports (and import-like exports) to the top of the file to
                             // ensure that if they are converted to a require() call, the effects
                             // will take place before any other statements are evaluated.
@@ -3312,7 +3312,7 @@ pub const Parser = struct {
             }) catch unreachable;
         }
 
-        var did_import_fast_refresh = false;
+        const did_import_fast_refresh = false;
         _ = did_import_fast_refresh;
 
         // This is a workaround for broken module environment checks in packages like lodash-es
@@ -3321,7 +3321,7 @@ pub const Parser = struct {
 
         if (comptime FeatureFlags.unwrap_commonjs_to_esm) {
             if (p.imports_to_convert_from_require.items.len > 0) {
-                var all_stmts = p.allocator.alloc(Stmt, p.imports_to_convert_from_require.items.len) catch unreachable;
+                const all_stmts = p.allocator.alloc(Stmt, p.imports_to_convert_from_require.items.len) catch unreachable;
                 before.ensureUnusedCapacity(p.imports_to_convert_from_require.items.len) catch unreachable;
 
                 var remaining_stmts = all_stmts;
@@ -3352,8 +3352,8 @@ pub const Parser = struct {
             }
 
             if (p.commonjs_named_exports.count() > 0) {
-                var export_refs = p.commonjs_named_exports.values();
-                var export_names = p.commonjs_named_exports.keys();
+                const export_refs = p.commonjs_named_exports.values();
+                const export_names = p.commonjs_named_exports.keys();
 
                 break_optimize: {
                     if (!p.commonjs_named_exports_deoptimized) {
@@ -3401,7 +3401,7 @@ pub const Parser = struct {
             //
             if (parts.items.len == 1 and parts.items[0].stmts.len == 1) {
                 var part = &parts.items[0];
-                var stmt: Stmt = part.stmts[0];
+                const stmt: Stmt = part.stmts[0];
                 if (p.symbols.items[p.module_ref.innerIndex()].use_count_estimate == 1) {
                     if (stmt.data == .s_expr) {
                         const value: Expr = stmt.data.s_expr.value;
@@ -3571,7 +3571,7 @@ pub const Parser = struct {
                 // note: export_star_import_records are not filled in yet
 
                 if (before.items.len > 0 and p.import_records.items.len == 1) {
-                    var export_star_redirect: ?*S.ExportStar = brk: {
+                    const export_star_redirect: ?*S.ExportStar = brk: {
                         var export_star: ?*S.ExportStar = null;
                         for (before.items) |part| {
                             for (part.stmts) |stmt| {
@@ -3683,7 +3683,7 @@ pub const Parser = struct {
                 }
             } else if (!p.options.bundle and !p.options.features.commonjs_at_runtime and (!p.options.transform_only or p.options.features.dynamic_require)) {
                 if (p.options.legacy_transform_require_to_import or p.options.features.dynamic_require) {
-                    var args = p.allocator.alloc(Expr, 2) catch unreachable;
+                    const args = p.allocator.alloc(Expr, 2) catch unreachable;
 
                     if (p.runtime_imports.__exportDefault == null and p.has_export_default) {
                         p.runtime_imports.__exportDefault = try p.declareGeneratedSymbol(.other, "__exportDefault");
@@ -3904,7 +3904,7 @@ pub const Parser = struct {
             const after_len = after.items.len;
             const parts_len = parts.items.len;
 
-            var _parts = try p.allocator.alloc(
+            const _parts = try p.allocator.alloc(
                 js_ast.Part,
                 before_len +
                     after_len +
@@ -4972,7 +4972,7 @@ fn NewParser_(
                     }
 
                     if (first_none_part < parts_.len) {
-                        var stmts_list = p.allocator.alloc(Stmt, stmts_count) catch unreachable;
+                        const stmts_list = p.allocator.alloc(Stmt, stmts_count) catch unreachable;
                         var stmts_remain = stmts_list;
 
                         for (parts_) |part| {
@@ -4995,7 +4995,7 @@ fn NewParser_(
 
             while (parts_.len > 1) {
                 var parts_end: usize = 0;
-                var last_end = parts_.len;
+                const last_end = parts_.len;
 
                 for (parts_) |part| {
                     const is_dead = part.can_be_removed_if_unused and can_remove_part: {
@@ -5098,8 +5098,8 @@ fn NewParser_(
         };
 
         fn clearSymbolUsagesFromDeadPart(p: *P, part: js_ast.Part) void {
-            var symbol_use_refs = part.symbol_uses.keys();
-            var symbol_use_values = part.symbol_uses.values();
+            const symbol_use_refs = part.symbol_uses.keys();
+            const symbol_use_values = part.symbol_uses.values();
             var symbols = p.symbols.items;
 
             for (symbol_use_refs, symbol_use_values) |ref, prev| {
@@ -5325,7 +5325,7 @@ fn NewParser_(
                     };
                 }
 
-                var gpe = p.module_scope.getOrPutMemberWithHash(allocator, name, hash) catch unreachable;
+                const gpe = p.module_scope.getOrPutMemberWithHash(allocator, name, hash) catch unreachable;
 
                 // I don't think this happens?
                 if (gpe.found_existing) {
@@ -5442,12 +5442,12 @@ fn NewParser_(
 
         fn logArrowArgErrors(p: *P, errors: *DeferredArrowArgErrors) void {
             if (errors.invalid_expr_await.len > 0) {
-                var r = errors.invalid_expr_await;
+                const r = errors.invalid_expr_await;
                 p.log.addRangeError(p.source, r, "Cannot use an \"await\" expression here") catch unreachable;
             }
 
             if (errors.invalid_expr_yield.len > 0) {
-                var r = errors.invalid_expr_yield;
+                const r = errors.invalid_expr_yield;
                 p.log.addRangeError(p.source, r, "Cannot use a \"yield\" expression here") catch unreachable;
             }
         }
@@ -5549,9 +5549,9 @@ fn NewParser_(
             if (comptime is_internal)
                 import_record.path.namespace = "runtime";
             import_record.is_internal = is_internal;
-            var import_path_identifier = try import_record.path.name.nonUniqueNameString(allocator);
+            const import_path_identifier = try import_record.path.name.nonUniqueNameString(allocator);
             var namespace_identifier = try allocator.alloc(u8, import_path_identifier.len + suffix.len);
-            var clause_items = try allocator.alloc(js_ast.ClauseItem, imports.len);
+            const clause_items = try allocator.alloc(js_ast.ClauseItem, imports.len);
             var stmts = try allocator.alloc(Stmt, 1 + if (additional_stmt != null) @as(usize, 1) else @as(usize, 0));
             var declared_symbols = DeclaredSymbol.List{};
             try declared_symbols.ensureTotalCapacity(allocator, imports.len + 1);
@@ -5609,7 +5609,7 @@ fn NewParser_(
         }
 
         fn substituteSingleUseSymbolInStmt(p: *P, stmt: Stmt, ref: Ref, replacement: Expr) bool {
-            var expr: *Expr = brk: {
+            const expr: *Expr = brk: {
                 switch (stmt.data) {
                     .s_expr => |exp| {
                         break :brk &exp.value;
@@ -6458,7 +6458,7 @@ fn NewParser_(
                                 {
                                     // Silently merge this symbol into the existing symbol
                                     symbol.link = member_in_scope.ref;
-                                    var entry = _scope.getOrPutMemberWithHash(p.allocator, name, hash.?) catch unreachable;
+                                    const entry = _scope.getOrPutMemberWithHash(p.allocator, name, hash.?) catch unreachable;
                                     entry.value_ptr.* = member_in_scope;
                                     entry.key_ptr.* = name;
                                     continue :nextMember;
@@ -6496,13 +6496,13 @@ fn NewParser_(
                                 // If this is a catch identifier, silently merge the existing symbol
                                 // into this symbol but continue hoisting past this catch scope
                                 existing_symbol.link = value.ref;
-                                var entry = _scope.getOrPutMemberWithHash(p.allocator, name, hash.?) catch unreachable;
+                                const entry = _scope.getOrPutMemberWithHash(p.allocator, name, hash.?) catch unreachable;
                                 entry.value_ptr.* = value;
                                 entry.key_ptr.* = name;
                             }
 
                             if (_scope.kindStopsHoisting()) {
-                                var entry = _scope.getOrPutMemberWithHash(allocator, name, hash.?) catch unreachable;
+                                const entry = _scope.getOrPutMemberWithHash(allocator, name, hash.?) catch unreachable;
                                 entry.value_ptr.* = value;
                                 entry.key_ptr.* = name;
                                 break;
@@ -6693,7 +6693,7 @@ fn NewParser_(
                             }) catch unreachable;
                             continue;
                         }
-                        var value = &item.value.?;
+                        const value = &item.value.?;
                         const tup = p.convertExprToBindingAndInitializer(value, invalid_loc, false);
                         const initializer = tup.expr orelse item.initializer;
                         const is_spread = item.kind == .spread or item.flags.contains(.is_spread);
@@ -6736,7 +6736,7 @@ fn NewParser_(
                 else => {},
             }
 
-            var bind = p.convertExprToBinding(expr.*, invalid_log);
+            const bind = p.convertExprToBinding(expr.*, invalid_log);
             if (initializer) |initial| {
                 const equalsRange = p.source.rangeOfOperatorBefore(initial.loc, "=");
                 if (is_spread) {
@@ -6815,7 +6815,7 @@ fn NewParser_(
 
             // The name is optional for "export default function() {}" pseudo-statements
             if (!opts.is_name_optional or p.lexer.token == T.t_identifier) {
-                var nameLoc = p.lexer.loc();
+                const nameLoc = p.lexer.loc();
                 nameText = p.lexer.identifier;
                 try p.lexer.expect(T.t_identifier);
                 // Difference
@@ -6833,12 +6833,12 @@ fn NewParser_(
 
             // Introduce a fake block scope for function declarations inside if statements
             var ifStmtScopeIndex: usize = 0;
-            var hasIfScope = opts.lexical_decl == .allow_fn_inside_if;
+            const hasIfScope = opts.lexical_decl == .allow_fn_inside_if;
             if (hasIfScope) {
                 ifStmtScopeIndex = try p.pushScopeForParsePass(js_ast.Scope.Kind.block, loc);
             }
 
-            var scopeIndex = try p.pushScopeForParsePass(js_ast.Scope.Kind.function_args, p.lexer.loc());
+            const scopeIndex = try p.pushScopeForParsePass(js_ast.Scope.Kind.function_args, p.lexer.loc());
             var func = try p.parseFn(name, FnOrArrowDataParse{
                 .async_range = asyncRange orelse logger.Range.None,
                 .has_async_range = asyncRange != null,
@@ -6905,8 +6905,8 @@ fn NewParser_(
 
         fn popAndDiscardScope(p: *P, scope_index: usize) void {
             // Move up to the parent scope
-            var to_discard = p.current_scope;
-            var parent = to_discard.parent orelse unreachable;
+            const to_discard = p.current_scope;
+            const parent = to_discard.parent orelse unreachable;
 
             p.current_scope = parent;
 
@@ -6915,7 +6915,7 @@ fn NewParser_(
 
             var children = parent.children;
             // Remove the last child from the parent scope
-            var last = children.len - 1;
+            const last = children.len - 1;
             if (children.slice()[last] != to_discard) {
                 p.panic("Internal error", .{});
             }
@@ -6994,7 +6994,7 @@ fn NewParser_(
                 }
 
                 var is_typescript_ctor_field = false;
-                var is_identifier = p.lexer.token == T.t_identifier;
+                const is_identifier = p.lexer.token == T.t_identifier;
                 var text = p.lexer.identifier;
                 var arg = try p.parseBinding();
                 var ts_metadata = TypeScript.Metadata.default;
@@ -8345,7 +8345,7 @@ fn NewParser_(
         }
 
         fn createDefaultName(p: *P, loc: logger.Loc) !js_ast.LocRef {
-            var identifier = try std.fmt.allocPrint(p.allocator, "{s}_default", .{try p.source.path.name.nonUniqueNameString(p.allocator)});
+            const identifier = try std.fmt.allocPrint(p.allocator, "{s}_default", .{try p.source.path.name.nonUniqueNameString(p.allocator)});
 
             const name = js_ast.LocRef{ .loc = loc, .ref = try p.newSymbol(Symbol.Kind.other, identifier) };
 
@@ -8601,7 +8601,7 @@ fn NewParser_(
                             }
 
                             if (p.lexer.isContextualKeyword("async")) {
-                                var asyncRange = p.lexer.range();
+                                const asyncRange = p.lexer.range();
                                 try p.lexer.next();
                                 if (p.lexer.has_newline_before) {
                                     try p.log.addRangeError(p.source, asyncRange, "Unexpected newline after \"async\"");
@@ -8656,7 +8656,7 @@ fn NewParser_(
                                 return error.SyntaxError;
                             }
 
-                            var defaultLoc = p.lexer.loc();
+                            const defaultLoc = p.lexer.loc();
                             try p.lexer.next();
 
                             // TypeScript decorators only work on class declarations
@@ -8687,7 +8687,7 @@ fn NewParser_(
                                     } else {
                                         defaultName = try p.createDefaultName(defaultLoc);
                                     }
-                                    var value = js_ast.StmtOrExpr{ .stmt = stmt };
+                                    const value = js_ast.StmtOrExpr{ .stmt = stmt };
                                     return p.s(S.ExportDefault{ .default_name = defaultName, .value = value }, loc);
                                 }
 
@@ -8707,7 +8707,7 @@ fn NewParser_(
                                     .is_name_optional = true,
                                     .lexical_decl = .allow_all,
                                 };
-                                var stmt = try p.parseStmt(&_opts);
+                                const stmt = try p.parseStmt(&_opts);
 
                                 const default_name: js_ast.LocRef = default_name_getter: {
                                     switch (stmt.data) {
@@ -8741,7 +8741,7 @@ fn NewParser_(
 
                             const is_identifier = p.lexer.token == .t_identifier;
                             const name = p.lexer.identifier;
-                            var expr = try p.parseExpr(.comma);
+                            const expr = try p.parseExpr(.comma);
 
                             // Handle the default export of an abstract class in TypeScript
                             if (is_typescript_enabled and is_identifier and (p.lexer.token == .t_class or opts.ts_decorators != null) and strings.eqlComptime(name, "abstract")) {
@@ -8827,7 +8827,7 @@ fn NewParser_(
                                 namespace_ref = try p.storeNameInRef(name);
                             }
 
-                            var import_record_index = p.addImportRecord(
+                            const import_record_index = p.addImportRecord(
                                 ImportKind.stmt,
                                 path.loc,
                                 path.text,
@@ -9267,7 +9267,7 @@ fn NewParser_(
                     }
 
                     var decls: G.Decl.List = .{};
-                    var init_loc = p.lexer.loc();
+                    const init_loc = p.lexer.loc();
                     var is_var = false;
                     switch (p.lexer.token) {
                         // for (var )
@@ -9432,7 +9432,7 @@ fn NewParser_(
                                 try p.lexer.unexpected();
                                 return error.SyntaxError;
                             }
-                            var importClause = try p.parseImportClause();
+                            const importClause = try p.parseImportClause();
                             if (comptime is_typescript_enabled) {
                                 if (importClause.had_type_only_imports and importClause.items.len == 0) {
                                     try p.lexer.expectContextualKeyword("from");
@@ -9625,7 +9625,7 @@ fn NewParser_(
                     // Parse either an async function, an async expression, or a normal expression
                     var expr: Expr = Expr{ .loc = loc, .data = Expr.Data{ .e_missing = .{} } };
                     if (is_identifier and strings.eqlComptime(p.lexer.raw(), "async")) {
-                        var async_range = p.lexer.range();
+                        const async_range = p.lexer.range();
                         try p.lexer.next();
                         if (p.lexer.token == .t_function and !p.lexer.has_newline_before) {
                             try p.lexer.next();
@@ -9665,7 +9665,7 @@ fn NewParser_(
                                         },
                                         else => {},
                                     }
-                                    var stmt = try p.parseStmt(&nestedOpts);
+                                    const stmt = try p.parseStmt(&nestedOpts);
                                     return p.s(S.Label{ .name = _name, .stmt = stmt }, loc);
                                 }
                             },
@@ -9799,7 +9799,7 @@ fn NewParser_(
 
         fn discardScopesUpTo(p: *P, scope_index: usize) void {
             // Remove any direct children from their parent
-            var scope = p.current_scope;
+            const scope = p.current_scope;
             var children = scope.children;
 
             for (p.scopes_in_order.items[scope_index..]) |_child| {
@@ -11078,7 +11078,7 @@ fn NewParser_(
                 // },
             };
 
-            var scope = p.current_scope;
+            const scope = p.current_scope;
             if (p.isStrictMode()) {
                 var why: string = "";
                 var where: logger.Range = logger.Range.None;
@@ -11199,7 +11199,7 @@ fn NewParser_(
             var ref = try p.newSymbol(kind, name);
 
             const scope = p.current_scope;
-            var entry = try scope.members.getOrPut(p.allocator, name);
+            const entry = try scope.members.getOrPut(p.allocator, name);
             if (entry.found_existing) {
                 const existing = entry.value_ptr.*;
                 var symbol: *Symbol = &p.symbols.items[existing.ref.innerIndex()];
@@ -11316,8 +11316,8 @@ fn NewParser_(
         }
 
         fn parseFnBody(p: *P, data: *FnOrArrowDataParse) !G.FnBody {
-            var oldFnOrArrowData = p.fn_or_arrow_data_parse;
-            var oldAllowIn = p.allow_in;
+            const oldFnOrArrowData = p.fn_or_arrow_data_parse;
+            const oldAllowIn = p.allow_in;
             p.fn_or_arrow_data_parse = data.*;
             p.allow_in = true;
 
@@ -11368,7 +11368,7 @@ fn NewParser_(
             var old_fn_or_arrow_data = std.mem.toBytes(p.fn_or_arrow_data_parse);
 
             p.fn_or_arrow_data_parse = data.*;
-            var expr = try p.parseExpr(Level.comma);
+            const expr = try p.parseExpr(Level.comma);
             p.fn_or_arrow_data_parse = std.mem.bytesToValue(@TypeOf(p.fn_or_arrow_data_parse), &old_fn_or_arrow_data);
 
             var stmts = try p.allocator.alloc(Stmt, 1);
@@ -11409,7 +11409,7 @@ fn NewParser_(
         // We can handle errors via the log.
         // We'll have to deal with @wasmHeapGrow or whatever that thing is.
         pub inline fn mm(self: *P, comptime ast_object_type: type, instance: anytype) *ast_object_type {
-            var obj = self.allocator.create(ast_object_type) catch unreachable;
+            const obj = self.allocator.create(ast_object_type) catch unreachable;
             obj.* = instance;
             return obj;
         }
@@ -11471,7 +11471,7 @@ fn NewParser_(
                             ) };
                             _ = p.pushScopeForParsePass(.function_args, async_range.loc) catch unreachable;
                             var data = FnOrArrowDataParse{};
-                            var arrow_body = try p.parseArrowBody(args, &data);
+                            const arrow_body = try p.parseArrowBody(args, &data);
                             p.popScope();
                             return p.newExpr(arrow_body, async_range.loc);
                         }
@@ -11740,7 +11740,7 @@ fn NewParser_(
         }
 
         pub fn addImportRecordByRangeAndPath(p: *P, kind: ImportKind, range: logger.Range, path: fs.Path) u32 {
-            var index = p.import_records.items.len;
+            const index = p.import_records.items.len;
             const record = ImportRecord{
                 .kind = kind,
                 .range = range,
@@ -11853,7 +11853,7 @@ fn NewParser_(
 
         pub fn parseProperty(p: *P, kind: Property.Kind, opts: *PropertyOpts, errors: ?*DeferredErrors) anyerror!?G.Property {
             var key: Expr = Expr{ .loc = logger.Loc.Empty, .data = .{ .e_missing = E.Missing{} } };
-            var key_range = p.lexer.range();
+            const key_range = p.lexer.range();
             var is_computed = false;
 
             switch (p.lexer.token) {
@@ -12021,14 +12021,14 @@ fn NewParser_(
 
                             _ = try p.pushScopeForParsePass(.class_static_init, loc);
                             var _parse_opts = ParseStatementOptions{};
-                            var stmts = try p.parseStmtsUpTo(.t_close_brace, &_parse_opts);
+                            const stmts = try p.parseStmtsUpTo(.t_close_brace, &_parse_opts);
 
                             p.popScope();
 
                             p.fn_or_arrow_data_parse = old_fn_or_arrow_data_parse;
                             try p.lexer.expect(.t_close_brace);
 
-                            var block = p.allocator.create(
+                            const block = p.allocator.create(
                                 G.ClassStaticBlock,
                             ) catch unreachable;
 
@@ -12386,7 +12386,7 @@ fn NewParser_(
                 }
             }
 
-            var body_loc = p.lexer.loc();
+            const body_loc = p.lexer.loc();
             try p.lexer.expect(T.t_open_brace);
             var properties = ListManaged(G.Property).init(p.allocator);
 
@@ -12488,7 +12488,7 @@ fn NewParser_(
         pub fn parseTemplateParts(p: *P, include_raw: bool) ![]E.TemplatePart {
             var parts = ListManaged(E.TemplatePart).initCapacity(p.allocator, 1) catch unreachable;
             // Allow "in" inside template literals
-            var oldAllowIn = p.allow_in;
+            const oldAllowIn = p.allow_in;
             p.allow_in = true;
 
             parseTemplatePart: while (true) {
@@ -13369,7 +13369,7 @@ fn NewParser_(
                     const import_hash_name = clause.original_name;
 
                     if (strings.eqlComptime(clause.alias, "default")) {
-                        var non_unique_name = record.path.name.nonUniqueNameString(p.allocator) catch unreachable;
+                        const non_unique_name = record.path.name.nonUniqueNameString(p.allocator) catch unreachable;
                         clause.original_name = std.fmt.allocPrint(p.allocator, "{s}_default", .{non_unique_name}) catch unreachable;
                         record.contains_default_alias = true;
                     }
@@ -14043,7 +14043,7 @@ fn NewParser_(
         fn jsxStringsToMemberExpression(p: *P, loc: logger.Loc, parts: []const []const u8) !Expr {
             const result = try p.findSymbol(loc, parts[0]);
 
-            var value = p.handleIdentifier(
+            const value = p.handleIdentifier(
                 loc,
                 E.Identifier{
                     .ref = result.ref,
@@ -14117,7 +14117,7 @@ fn NewParser_(
             }
 
             // allow "in" inside call arguments;
-            var old_allow_in = p.allow_in;
+            const old_allow_in = p.allow_in;
             p.allow_in = true;
 
             p.lexer.preserve_all_comments_before = true;
@@ -14186,7 +14186,7 @@ fn NewParser_(
                 p.needs_jsx_import = true;
             }
 
-            var tag = try JSXTag.parse(P, p);
+            const tag = try JSXTag.parse(P, p);
 
             // The tag may have TypeScript type arguments: "<Foo<T>/>"
             if (is_typescript_enabled) {
@@ -14216,7 +14216,7 @@ fn NewParser_(
                         .t_identifier => {
                             defer i += 1;
                             // Parse the prop name
-                            var key_range = p.lexer.range();
+                            const key_range = p.lexer.range();
                             const prop_name_literal = p.lexer.identifier;
                             const special_prop = E.JSXElement.SpecialProp.Map.get(prop_name_literal) orelse E.JSXElement.SpecialProp.any;
                             try p.lexer.nextInsideJSXElement();
@@ -14493,7 +14493,7 @@ fn NewParser_(
             if (p.relocated_top_level_vars.items.len > 0) {
                 var already_declared = RefMap{};
                 var already_declared_allocator_stack = std.heap.stackFallback(1024, allocator);
-                var already_declared_allocator = already_declared_allocator_stack.get();
+                const already_declared_allocator = already_declared_allocator_stack.get();
                 defer if (already_declared_allocator_stack.fixed_buffer_allocator.end_index >= 1023) already_declared.deinit(already_declared_allocator);
 
                 for (p.relocated_top_level_vars.items) |*local| {
@@ -14506,7 +14506,7 @@ fn NewParser_(
                         local.ref = symbol.link;
                     }
                     const ref = local.ref orelse continue;
-                    var declaration_entry = try already_declared.getOrPut(already_declared_allocator, ref);
+                    const declaration_entry = try already_declared.getOrPut(already_declared_allocator, ref);
                     if (!declaration_entry.found_existing) {
                         const decls = try allocator.alloc(G.Decl, 1);
                         decls[0] = Decl{
@@ -15024,7 +15024,7 @@ fn NewParser_(
 
                                     const num_props = e_.properties.len;
                                     if (num_props > 0) {
-                                        var props = p.allocator.alloc(G.Property, num_props) catch unreachable;
+                                        const props = p.allocator.alloc(G.Property, num_props) catch unreachable;
                                         bun.copy(G.Property, props, e_.properties.slice());
                                         args[1] = p.newExpr(E.Object{ .properties = G.Property.List.init(props) }, expr.loc);
                                     } else {
@@ -15065,7 +15065,7 @@ fn NewParser_(
 
                                     {
                                         var last_child: u32 = 0;
-                                        var children = e_.children.slice()[0..children_count];
+                                        const children = e_.children.slice()[0..children_count];
                                         for (children) |child| {
                                             e_.children.ptr[last_child] = p.visitExpr(child);
                                             // if tree-shaking removes the element, we must also remove it here.
@@ -16129,7 +16129,7 @@ fn NewParser_(
                     if (in.assign_target != .none) {
                         p.maybeCommaSpreadError(e_.comma_after_spread);
                     }
-                    var items = e_.items.slice();
+                    const items = e_.items.slice();
                     var spread_item_count: usize = 0;
                     for (items) |*item| {
                         switch (item.data) {
@@ -16485,7 +16485,7 @@ fn NewParser_(
                     p.fn_only_data_visit.is_inside_async_arrow_fn = e_.is_async or p.fn_only_data_visit.is_inside_async_arrow_fn;
 
                     p.pushScopeForVisitPass(.function_args, expr.loc) catch unreachable;
-                    var dupe = p.allocator.dupe(Stmt, e_.body.stmts) catch unreachable;
+                    const dupe = p.allocator.dupe(Stmt, e_.body.stmts) catch unreachable;
 
                     p.visitArgs(e_.args, VisitArgsOpts{
                         .has_rest_arg = e_.has_rest_arg,
@@ -16560,7 +16560,7 @@ fn NewParser_(
                 duplicate_args_check = StringVoidMap.get(bun.default_allocator);
             }
 
-            var duplicate_args_check_ptr: ?*StringVoidMap = if (duplicate_args_check != null)
+            const duplicate_args_check_ptr: ?*StringVoidMap = if (duplicate_args_check != null)
                 &duplicate_args_check.?.data
             else
                 null;
@@ -17408,7 +17408,7 @@ fn NewParser_(
 
                                     // We are doing `module.exports = { ... }`
                                     // lets rewrite it to a series of what will become export assignemnts
-                                    var named_export_entry = p.commonjs_named_exports.getOrPut(p.allocator, key) catch unreachable;
+                                    const named_export_entry = p.commonjs_named_exports.getOrPut(p.allocator, key) catch unreachable;
                                     if (!named_export_entry.found_existing) {
                                         const new_ref = p.newSymbol(
                                             .other,
@@ -17514,7 +17514,7 @@ fn NewParser_(
                                     return null;
                                 }
 
-                                var named_export_entry = p.commonjs_named_exports.getOrPut(p.allocator, name) catch unreachable;
+                                const named_export_entry = p.commonjs_named_exports.getOrPut(p.allocator, name) catch unreachable;
                                 if (!named_export_entry.found_existing) {
                                     const new_ref = p.newSymbol(
                                         .other,
@@ -17852,7 +17852,7 @@ fn NewParser_(
                             }
 
                             if (mark_for_replace) {
-                                var entry = p.options.features.replace_exports.getPtr("default").?;
+                                const entry = p.options.features.replace_exports.getPtr("default").?;
                                 if (entry.* == .replace) {
                                     data.value.expr = entry.replace;
                                 } else {
@@ -17884,7 +17884,7 @@ fn NewParser_(
                                     }
 
                                     if (mark_for_replace) {
-                                        var entry = p.options.features.replace_exports.getPtr("default").?;
+                                        const entry = p.options.features.replace_exports.getPtr("default").?;
                                         if (entry.* == .replace) {
                                             data.value = .{ .expr = entry.replace };
                                         } else {
@@ -17912,7 +17912,7 @@ fn NewParser_(
                                         return;
 
                                     if (mark_for_replace) {
-                                        var entry = p.options.features.replace_exports.getPtr("default").?;
+                                        const entry = p.options.features.replace_exports.getPtr("default").?;
                                         if (entry.* == .replace) {
                                             data.value = .{ .expr = entry.replace };
                                         } else {
@@ -18476,7 +18476,7 @@ fn NewParser_(
                     {
                         p.pushScopeForVisitPass(.block, data.body_loc) catch unreachable;
                         defer p.popScope();
-                        var old_is_inside_Swsitch = p.fn_or_arrow_data_visit.is_inside_switch;
+                        const old_is_inside_Swsitch = p.fn_or_arrow_data_visit.is_inside_switch;
                         p.fn_or_arrow_data_visit.is_inside_switch = true;
                         defer p.fn_or_arrow_data_visit.is_inside_switch = old_is_inside_Swsitch;
                         var i: usize = 0;
@@ -19704,7 +19704,7 @@ fn NewParser_(
 
                     current_expr.* = try p.checkIfDefinedHelper(dot_identifier);
 
-                    var root = p.newExpr(
+                    const root = p.newExpr(
                         E.If{
                             .yes = p.newExpr(
                                 E.Identifier{
@@ -20050,7 +20050,7 @@ fn NewParser_(
             p.log.addRangeErrorFmt(p.source, r, p.allocator, "There is no containing label named \"{s}\"", .{name}) catch unreachable;
 
             // Allocate an "unbound" symbol
-            var ref = p.newSymbol(.unbound, name) catch unreachable;
+            const ref = p.newSymbol(.unbound, name) catch unreachable;
 
             // Track how many times we've referenced this symbol
             p.recordUsage(ref);
@@ -20113,8 +20113,8 @@ fn NewParser_(
                     var property = &class.properties[i];
 
                     if (property.kind == .class_static_block) {
-                        var old_fn_or_arrow_data = p.fn_or_arrow_data_visit;
-                        var old_fn_only_data = p.fn_only_data_visit;
+                        const old_fn_or_arrow_data = p.fn_or_arrow_data_visit;
+                        const old_fn_only_data = p.fn_only_data_visit;
                         p.fn_or_arrow_data_visit = .{};
                         p.fn_only_data_visit = .{
                             .is_this_nested = true,
@@ -20365,13 +20365,13 @@ fn NewParser_(
                 @compileError("only_scan_imports_and_do_not_visit must not run this.");
             }
 
-            var initial_scope: *Scope = if (comptime Environment.allow_assert) p.current_scope else undefined;
+            const initial_scope: *Scope = if (comptime Environment.allow_assert) p.current_scope else undefined;
 
             {
 
                 // Save the current control-flow liveness. This represents if we are
                 // currently inside an "if (false) { ... }" block.
-                var old_is_control_flow_dead = p.is_control_flow_dead;
+                const old_is_control_flow_dead = p.is_control_flow_dead;
                 defer p.is_control_flow_dead = old_is_control_flow_dead;
 
                 var before = ListManaged(Stmt).init(p.allocator);
@@ -20452,7 +20452,7 @@ fn NewParser_(
                                     continue;
                                 }
 
-                                var gpe = fn_stmts.getOrPut(name_ref) catch unreachable;
+                                const gpe = fn_stmts.getOrPut(name_ref) catch unreachable;
                                 var index = gpe.value_ptr.*;
                                 if (!gpe.found_existing) {
                                     index = @as(u32, @intCast(let_decls.items.len));
@@ -20584,7 +20584,7 @@ fn NewParser_(
                 // Inlined constants are not removed if they are in a top-level scope or
                 // if they are exported (which could be in a nested TypeScript namespace).
                 if (p.const_values.count() > 0) {
-                    var items: []Stmt = stmts.items;
+                    const items: []Stmt = stmts.items;
                     for (items) |*stmt| {
                         switch (stmt.data) {
                             .s_empty, .s_comment, .s_directive, .s_debugger, .s_type_script => continue,
@@ -20664,7 +20664,7 @@ fn NewParser_(
                         // should have visited all the uses of "let" and "const" declarations
                         // by now since they are scoped to this block which we just finished
                         // visiting.
-                        var prev_statement = &output.items[output.items.len - 1];
+                        const prev_statement = &output.items[output.items.len - 1];
                         switch (prev_statement.data) {
                             .s_local => {
                                 var local = prev_statement.data.s_local;
@@ -20672,7 +20672,7 @@ fn NewParser_(
                                     break;
                                 }
 
-                                var last: *Decl = local.decls.last().?;
+                                const last: *Decl = local.decls.last().?;
                                 // The variable must be initialized, since we will be substituting
                                 // the value into the usage.
                                 if (last.value == null)
@@ -20772,7 +20772,7 @@ fn NewParser_(
                                 prev_stmt.data.s_local.kind == .k_var)
                             {
                                 var prev_local = prev_stmt.data.s_local;
-                                var bin_assign = s_expr.value.data.e_binary;
+                                const bin_assign = s_expr.value.data.e_binary;
 
                                 if (bin_assign.left.data == .e_identifier) {
                                     var decl = &prev_local.decls.slice()[0];
@@ -20902,7 +20902,7 @@ fn NewParser_(
             const scope_index = try p.pushScopeForParsePass(.function_args, loc);
 
             // Allow "in" inside parentheses
-            var oldAllowIn = p.allow_in;
+            const oldAllowIn = p.allow_in;
             p.allow_in = true;
 
             // Forbid "await" and "yield", but only for arrow functions
@@ -21145,7 +21145,7 @@ fn NewParser_(
                     p.import_records_for_current_part.clearRetainingCapacity();
                     p.declared_symbols.clearRetainingCapacity();
 
-                    var result = try ImportScanner.scan(P, p, part.stmts, commonjs_wrapper_expr != .none);
+                    const result = try ImportScanner.scan(P, p, part.stmts, commonjs_wrapper_expr != .none);
                     kept_import_equals = kept_import_equals or result.kept_import_equals;
                     removed_import_equals = removed_import_equals or result.removed_import_equals;
 
@@ -21232,7 +21232,7 @@ fn NewParser_(
                     }
 
                     var new_stmts_list = allocator.alloc(Stmt, exports_from_count + imports_count + 1) catch unreachable;
-                    var final_stmts_list = allocator.alloc(Stmt, final_part_stmts_count) catch unreachable;
+                    const final_stmts_list = allocator.alloc(Stmt, final_part_stmts_count) catch unreachable;
                     var remaining_final_stmts = final_stmts_list;
                     var imports_list = new_stmts_list[0..imports_count];
 
@@ -21335,7 +21335,7 @@ fn NewParser_(
                         total_stmts_count += part.stmts.len;
                     }
 
-                    var stmts_to_copy = allocator.alloc(Stmt, total_stmts_count) catch unreachable;
+                    const stmts_to_copy = allocator.alloc(Stmt, total_stmts_count) catch unreachable;
                     {
                         var remaining_stmts = stmts_to_copy;
                         for (parts) |part| {
@@ -21472,7 +21472,7 @@ fn NewParser_(
 
                 .none => {
                     if (p.options.features.hot_module_reloading and p.options.features.allow_runtime) {
-                        var named_exports_count: usize = p.named_exports.count();
+                        const named_exports_count: usize = p.named_exports.count();
                         const named_imports: js_ast.Ast.NamedImports = p.named_imports;
 
                         // To transform to something HMR'able, we must:
@@ -21582,7 +21582,7 @@ fn NewParser_(
                         const new_call_args_count: usize = if (p.options.features.react_fast_refresh) 3 else 2;
                         var call_args = try allocator.alloc(Expr, new_call_args_count + 1);
                         var new_call_args = call_args[0..new_call_args_count];
-                        var hmr_module_ident = p.newExpr(E.Identifier{ .ref = p.hmr_module.ref }, logger.Loc.Empty);
+                        const hmr_module_ident = p.newExpr(E.Identifier{ .ref = p.hmr_module.ref }, logger.Loc.Empty);
 
                         new_call_args[0] = p.newExpr(E.Number{ .value = @as(f64, @floatFromInt(p.options.filepath_hash_for_hmr)) }, logger.Loc.Empty);
                         // This helps us provide better error messages
@@ -21635,9 +21635,9 @@ fn NewParser_(
                             export_name_string_length += named_export.key_ptr.len + "$$hmr_".len;
                         }
 
-                        var export_name_string_all = try allocator.alloc(u8, export_name_string_length);
+                        const export_name_string_all = try allocator.alloc(u8, export_name_string_length);
                         var export_name_string_remainder = export_name_string_all;
-                        var hmr_module_exports_dot = p.newExpr(
+                        const hmr_module_exports_dot = p.newExpr(
                             E.Dot{
                                 .target = hmr_module_ident,
                                 .name = "exports",
@@ -21648,7 +21648,7 @@ fn NewParser_(
                         var exports_decls = decls[first_decl.len..];
                         named_exports_iter = p.named_exports.iterator();
                         var update_function_args = try allocator.alloc(G.Arg, 1);
-                        var exports_ident = p.newExpr(E.Identifier{ .ref = p.exports_ref }, logger.Loc.Empty);
+                        const exports_ident = p.newExpr(E.Identifier{ .ref = p.exports_ref }, logger.Loc.Empty);
                         update_function_args[0] = G.Arg{ .binding = p.b(B.Identifier{ .ref = p.exports_ref }, logger.Loc.Empty) };
 
                         while (named_exports_iter.next()) |named_export| {
@@ -21666,7 +21666,7 @@ fn NewParser_(
                             bun.copy(u8, export_name_string, "$$hmr_");
                             bun.copy(u8, export_name_string["$$hmr_".len..], named_export.key_ptr.*);
 
-                            var name_ref = try p.declareSymbol(.other, logger.Loc.Empty, export_name_string);
+                            const name_ref = try p.declareSymbol(.other, logger.Loc.Empty, export_name_string);
 
                             var body_stmts = export_all_function_body_stmts[named_export_i .. named_export_i + 1];
                             body_stmts[0] = p.s(
@@ -21690,7 +21690,7 @@ fn NewParser_(
                                 .name = .{ .ref = name_ref, .loc = logger.Loc.Empty },
                             };
 
-                            var decl_value = p.newExpr(
+                            const decl_value = p.newExpr(
                                 E.Dot{ .target = hmr_module_exports_dot, .name = named_export.key_ptr.*, .name_loc = logger.Loc.Empty },
                                 logger.Loc.Empty,
                             );
@@ -21765,7 +21765,7 @@ fn NewParser_(
 
                         const is_async = !p.top_level_await_keyword.isEmpty();
 
-                        var func = p.newExpr(
+                        const func = p.newExpr(
                             E.Function{
                                 .func = .{
                                     .body = .{ .loc = logger.Loc.Empty, .stmts = part_stmts[0 .. part_stmts_i + 1] },
@@ -21907,7 +21907,7 @@ fn NewParser_(
 
                 // Each part tracks the other parts it depends on within this file
                 for (parts, 0..) |*part, part_index| {
-                    var decls = &part.declared_symbols;
+                    const decls = &part.declared_symbols;
                     const ctx = Ctx{
                         .allocator = p.allocator,
                         .top_level_symbols_to_parts = top_level,
@@ -22012,7 +22012,7 @@ fn NewParser_(
             this: *P,
         ) anyerror!void {
             var scope_order = try ScopeOrderList.initCapacity(allocator, 1);
-            var scope = try allocator.create(Scope);
+            const scope = try allocator.create(Scope);
             scope.* = Scope{
                 .members = @TypeOf(scope.members){},
                 .children = @TypeOf(scope.children){},
@@ -22162,7 +22162,7 @@ pub fn newLazyExportAST(
     comptime runtime_api_call: []const u8,
 ) anyerror!?js_ast.Ast {
     var temp_log = logger.Log.init(allocator);
-    var log = &temp_log;
+    const log = &temp_log;
     var parser = Parser{
         .options = opts,
         .allocator = allocator,

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -199,7 +199,7 @@ pub fn quoteForJSON(text: []const u8, output_: MutableString, comptime ascii_onl
     try bytes.growIfNeeded(estimateLengthForJSON(text, ascii_only));
     try bytes.appendChar('"');
     var i: usize = 0;
-    var n: usize = text.len;
+    const n: usize = text.len;
     while (i < n) {
         const width = strings.wtf8ByteSequenceLengthWithInvalid(text[i]);
         const c = strings.decodeWTF8RuneT(text.ptr[i .. i + 4][0..4], width, i32, 0);
@@ -444,7 +444,7 @@ pub fn writeJSONString(input: []const u8, comptime Writer: type, writer: Writer,
 }
 
 test "quoteForJSON" {
-    var allocator = default_allocator;
+    const allocator = default_allocator;
     try std.testing.expectEqualStrings(
         "\"I don't need any quotes.\"",
         (try quoteForJSON("I don't need any quotes.", MutableString.init(allocator, 0) catch unreachable, false)).list.items,
@@ -1356,7 +1356,7 @@ fn NewPrinter(
                         p.print("10");
                     },
                     11...99 => {
-                        var buf: *[2]u8 = (p.writer.reserve(2) catch unreachable)[0..2];
+                        const buf: *[2]u8 = (p.writer.reserve(2) catch unreachable)[0..2];
                         formatUnsignedIntegerBetween(2, buf, val);
                         p.writer.advance(2);
                     },
@@ -1364,7 +1364,7 @@ fn NewPrinter(
                         p.print("100");
                     },
                     101...999 => {
-                        var buf: *[3]u8 = (p.writer.reserve(3) catch unreachable)[0..3];
+                        const buf: *[3]u8 = (p.writer.reserve(3) catch unreachable)[0..3];
                         formatUnsignedIntegerBetween(3, buf, val);
                         p.writer.advance(3);
                     },
@@ -1373,7 +1373,7 @@ fn NewPrinter(
                         p.print("1000");
                     },
                     1001...9999 => {
-                        var buf: *[4]u8 = (p.writer.reserve(4) catch unreachable)[0..4];
+                        const buf: *[4]u8 = (p.writer.reserve(4) catch unreachable)[0..4];
                         formatUnsignedIntegerBetween(4, buf, val);
                         p.writer.advance(4);
                     },
@@ -1397,32 +1397,32 @@ fn NewPrinter(
                     },
 
                     10001...99999 => {
-                        var buf: *[5]u8 = (p.writer.reserve(5) catch unreachable)[0..5];
+                        const buf: *[5]u8 = (p.writer.reserve(5) catch unreachable)[0..5];
                         formatUnsignedIntegerBetween(5, buf, val);
                         p.writer.advance(5);
                     },
                     100001...999999 => {
-                        var buf: *[6]u8 = (p.writer.reserve(6) catch unreachable)[0..6];
+                        const buf: *[6]u8 = (p.writer.reserve(6) catch unreachable)[0..6];
                         formatUnsignedIntegerBetween(6, buf, val);
                         p.writer.advance(6);
                     },
                     1_000_001...9_999_999 => {
-                        var buf: *[7]u8 = (p.writer.reserve(7) catch unreachable)[0..7];
+                        const buf: *[7]u8 = (p.writer.reserve(7) catch unreachable)[0..7];
                         formatUnsignedIntegerBetween(7, buf, val);
                         p.writer.advance(7);
                     },
                     10_000_001...99_999_999 => {
-                        var buf: *[8]u8 = (p.writer.reserve(8) catch unreachable)[0..8];
+                        const buf: *[8]u8 = (p.writer.reserve(8) catch unreachable)[0..8];
                         formatUnsignedIntegerBetween(8, buf, val);
                         p.writer.advance(8);
                     },
                     100_000_001...999_999_999 => {
-                        var buf: *[9]u8 = (p.writer.reserve(9) catch unreachable)[0..9];
+                        const buf: *[9]u8 = (p.writer.reserve(9) catch unreachable)[0..9];
                         formatUnsignedIntegerBetween(9, buf, val);
                         p.writer.advance(9);
                     },
                     1_000_000_001...9_999_999_999 => {
-                        var buf: *[10]u8 = (p.writer.reserve(10) catch unreachable)[0..10];
+                        const buf: *[10]u8 = (p.writer.reserve(10) catch unreachable)[0..10];
                         formatUnsignedIntegerBetween(10, buf, val);
                         p.writer.advance(10);
                     },
@@ -1575,7 +1575,7 @@ fn NewPrinter(
                                             const len = count_ - 1;
                                             i += len;
                                             var ptr = e.writer.reserve(len) catch unreachable;
-                                            var to_copy = ptr[0..len];
+                                            const to_copy = ptr[0..len];
 
                                             strings.copyU16IntoU8(to_copy, []const u16, remain[0..len]);
                                             e.writer.advance(len);
@@ -1583,7 +1583,7 @@ fn NewPrinter(
                                         } else {
                                             const count = @as(u32, @truncate(remain.len));
                                             var ptr = e.writer.reserve(count) catch unreachable;
-                                            var to_copy = ptr[0..count];
+                                            const to_copy = ptr[0..count];
                                             strings.copyU16IntoU8(to_copy, []const u16, remain);
                                             e.writer.advance(count);
                                             i += count;
@@ -2463,7 +2463,7 @@ fn NewPrinter(
                 },
                 .e_function => |e| {
                     const n = p.writer.written;
-                    var wrap = p.stmt_start == n or p.export_default_start == n;
+                    const wrap = p.stmt_start == n or p.export_default_start == n;
 
                     if (wrap) {
                         p.print("(");
@@ -2493,7 +2493,7 @@ fn NewPrinter(
                 },
                 .e_class => |e| {
                     const n = p.writer.written;
-                    var wrap = p.stmt_start == n or p.export_default_start == n;
+                    const wrap = p.stmt_start == n or p.export_default_start == n;
                     if (wrap) {
                         p.print("(");
                     }
@@ -5445,7 +5445,7 @@ const FileWriterInternal = struct {
         ctx: *FileWriterInternal,
     ) anyerror!void {
         defer buffer.reset();
-        var result_ = buffer.toOwnedSliceLeaky();
+        const result_ = buffer.toOwnedSliceLeaky();
         var result = result_;
 
         while (result.len > 0) {
@@ -5610,7 +5610,7 @@ pub const FileWriter = NewWriter(
     FileWriterInternal.advanceBy,
 );
 pub fn NewFileWriter(file: std.fs.File) FileWriter {
-    var internal = FileWriterInternal.init(file);
+    const internal = FileWriterInternal.init(file);
     return FileWriter.init(internal);
 }
 
@@ -5758,7 +5758,7 @@ pub fn printAst(
         false,
         generate_source_map,
     );
-    var writer = _writer;
+    const writer = _writer;
 
     var printer = PrinterType.init(
         writer,
@@ -5808,16 +5808,16 @@ pub fn printJSON(
     source: *const logger.Source,
 ) !usize {
     const PrinterType = NewPrinter(false, Writer, false, false, true, false);
-    var writer = _writer;
+    const writer = _writer;
     var s_expr = S.SExpr{ .value = expr };
-    var stmt = Stmt{ .loc = logger.Loc.Empty, .data = .{
+    const stmt = Stmt{ .loc = logger.Loc.Empty, .data = .{
         .s_expr = &s_expr,
     } };
     var stmts = [_]js_ast.Stmt{stmt};
     var parts = [_]js_ast.Part{.{ .stmts = &stmts }};
     const ast = Ast.initTest(&parts);
-    var list = js_ast.Symbol.List.init(ast.symbols.slice());
-    var nested_list = js_ast.Symbol.NestedList.init(&[_]js_ast.Symbol.List{list});
+    const list = js_ast.Symbol.List.init(ast.symbols.slice());
+    const nested_list = js_ast.Symbol.NestedList.init(&[_]js_ast.Symbol.List{list});
     var renamer = rename.NoOpRenamer.init(js_ast.Symbol.Map.initList(nested_list), source);
 
     var printer = PrinterType.init(
@@ -5851,7 +5851,7 @@ pub fn print(
     const trace = bun.tracy.traceNamed(@src(), "JSPrinter.print");
     defer trace.end();
 
-    var buffer_writer = BufferWriter.init(allocator) catch |err| return .{ .err = err };
+    const buffer_writer = BufferWriter.init(allocator) catch |err| return .{ .err = err };
     var buffer_printer = BufferPrinter.init(buffer_writer);
 
     return printWithWriter(
@@ -5917,7 +5917,7 @@ pub fn printWithWriterAndPlatform(
         false,
         generate_source_maps,
     );
-    var writer = _writer;
+    const writer = _writer;
     var printer = PrinterType.init(
         writer,
         import_records,
@@ -5973,7 +5973,7 @@ pub fn printCommonJS(
     comptime generate_source_map: bool,
 ) !usize {
     const PrinterType = NewPrinter(ascii_only, Writer, true, false, false, generate_source_map);
-    var writer = _writer;
+    const writer = _writer;
     var renamer = rename.NoOpRenamer.init(symbols, source);
     var printer = PrinterType.init(
         writer,

--- a/src/json_parser.zig
+++ b/src/json_parser.zig
@@ -68,7 +68,7 @@ const HashMapPool = struct {
             }
         }
 
-        var new_node = default_allocator.create(LinkedList.Node) catch unreachable;
+        const new_node = default_allocator.create(LinkedList.Node) catch unreachable;
         new_node.* = LinkedList.Node{ .data = HashMap.initContext(default_allocator, IdentityContext{}) };
         return new_node;
     }
@@ -409,7 +409,7 @@ pub const PackageJSONVersionChecker = struct {
                 return newExpr(E.Null{}, loc);
             },
             .t_string_literal => {
-                var str: E.String = p.lexer.toEString();
+                const str: E.String = p.lexer.toEString();
 
                 try p.lexer.next();
                 return newExpr(str, loc);
@@ -937,7 +937,7 @@ fn expectPrintedJSON(_contents: string, expected: string) !void {
         Global.panic("--FAIL--\nExpr {s}\nLog: {s}\n--FAIL--", .{ expr, log.msgs.items[0].data.text });
     }
 
-    var buffer_writer = try js_printer.BufferWriter.init(default_allocator);
+    const buffer_writer = try js_printer.BufferWriter.init(default_allocator);
     var writer = js_printer.BufferPrinter.init(buffer_writer);
     const written = try js_printer.printJSON(@TypeOf(&writer), &writer, expr, &source);
     var js = writer.ctx.buffer.list.items.ptr[0 .. written + 1];

--- a/src/libarchive/libarchive.zig
+++ b/src/libarchive/libarchive.zig
@@ -400,7 +400,7 @@ pub const Archive = struct {
         stream.init(file_buffer);
         defer stream.deinit();
         _ = stream.openRead();
-        var archive = stream.archive;
+        const archive = stream.archive;
         const dir: std.fs.IterableDir = brk: {
             const cwd = std.fs.cwd();
 
@@ -458,7 +458,7 @@ pub const Archive = struct {
                                 path_to_use = temp_buf[0 .. path_to_use_.len + 1];
                             }
 
-                            var overwrite_entry = try ctx.overwrite_list.getOrPut(path_to_use);
+                            const overwrite_entry = try ctx.overwrite_list.getOrPut(path_to_use);
                             if (!overwrite_entry.found_existing) {
                                 overwrite_entry.key_ptr.* = try appender.append(@TypeOf(path_to_use), path_to_use);
                             }
@@ -485,7 +485,7 @@ pub const Archive = struct {
         stream.init(file_buffer);
         defer stream.deinit();
         _ = stream.openRead();
-        var archive = stream.archive;
+        const archive = stream.archive;
         var count: u32 = 0;
         const dir = dir_.dir;
         const dir_fd = dir.fd;
@@ -513,7 +513,7 @@ pub const Archive = struct {
                         if (tokenizer.next() == null) continue :loop;
                     }
 
-                    var pathname_ = tokenizer.rest();
+                    const pathname_ = tokenizer.rest();
                     pathname = @as([*]const u8, @ptrFromInt(@intFromPtr(pathname_.ptr)))[0..pathname_.len :0];
                     if (pathname.len == 0) continue;
 
@@ -600,7 +600,7 @@ pub const Archive = struct {
                                         @as(u64, 0);
 
                                     if (comptime ContextType != void and @hasDecl(std.meta.Child(ContextType), "appendMutable")) {
-                                        var result = ctx.?.all_files.getOrPutAdapted(hash, Context.U64Context{}) catch unreachable;
+                                        const result = ctx.?.all_files.getOrPutAdapted(hash, Context.U64Context{}) catch unreachable;
                                         if (!result.found_existing) {
                                             result.value_ptr.* = (try appender.appendMutable(@TypeOf(slice), slice)).ptr;
                                         }
@@ -610,7 +610,7 @@ pub const Archive = struct {
                                         if (plucker_.filename_hash == hash) {
                                             try plucker_.contents.inflate(size);
                                             plucker_.contents.list.expandToCapacity();
-                                            var read = lib.archive_read_data(archive, plucker_.contents.list.items.ptr, size);
+                                            const read = lib.archive_read_data(archive, plucker_.contents.list.items.ptr, size);
                                             try plucker_.contents.inflate(@as(usize, @intCast(read)));
                                             plucker_.found = read > 0;
                                             plucker_.fd = bun.toFD(file.handle);

--- a/src/linear_fifo.zig
+++ b/src/linear_fifo.zig
@@ -133,10 +133,10 @@ pub fn LinearFifo(
             if (self.buf.len >= size) return;
             if (buffer_type == .Dynamic) {
                 const new_size = if (powers_of_two) math.ceilPowerOfTwo(usize, size) catch return error.OutOfMemory else size;
-                var buf = try self.allocator.alloc(T, new_size);
+                const buf = try self.allocator.alloc(T, new_size);
                 if (self.count > 0) {
                     var new_bytes = std.mem.sliceAsBytes(buf);
-                    var old_bytes = std.mem.sliceAsBytes(self.readableSlice(0));
+                    const old_bytes = std.mem.sliceAsBytes(self.readableSlice(0));
                     @memcpy(new_bytes[0..old_bytes.len], old_bytes);
                     self.allocator.free(self.buf);
                 }

--- a/src/linker.zig
+++ b/src/linker.zig
@@ -119,8 +119,8 @@ pub const Linker = struct {
         fd: ?FileDescriptorType,
     ) !string {
         if (Bundler.isCacheEnabled) {
-            var hashed = bun.hash(file_path.text);
-            var hashed_result = try this.hashed_filenames.getOrPut(hashed);
+            const hashed = bun.hash(file_path.text);
+            const hashed_result = try this.hashed_filenames.getOrPut(hashed);
             if (hashed_result.found_existing) {
                 return hashed_result.value_ptr.*;
             }
@@ -130,7 +130,7 @@ pub const Linker = struct {
         const hash_name = modkey.hashName(file_path.text);
 
         if (Bundler.isCacheEnabled) {
-            var hashed = bun.hash(file_path.text);
+            const hashed = bun.hash(file_path.text);
             try this.hashed_filenames.put(hashed, try this.allocator.dupe(u8, hash_name));
         }
 
@@ -692,7 +692,7 @@ pub const Linker = struct {
                 }
 
                 if (strings.eqlComptime(namespace, "bun") or strings.eqlComptime(namespace, "file") or namespace.len == 0) {
-                    var relative_name = linker.fs.relative(source_dir, source_path);
+                    const relative_name = linker.fs.relative(source_dir, source_path);
                     return Fs.Path.initWithPretty(source_path, relative_name);
                 } else {
                     return Fs.Path.initWithNamespace(source_path, namespace);
@@ -705,7 +705,7 @@ pub const Linker = struct {
                 if (use_hashed_name) {
                     var basepath = Fs.Path.init(source_path);
                     const basename = try linker.getHashedFilename(basepath, null);
-                    var dir = basepath.name.dirWithTrailingSlash();
+                    const dir = basepath.name.dirWithTrailingSlash();
                     var _pretty = try linker.allocator.alloc(u8, dir.len + basename.len + basepath.name.ext.len);
                     bun.copy(u8, _pretty, dir);
                     var remaining_pretty = _pretty[dir.len..];
@@ -754,12 +754,12 @@ pub const Linker = struct {
                         base = base[0..dot];
                     }
 
-                    var dirname = std.fs.path.dirname(base) orelse "";
+                    const dirname = std.fs.path.dirname(base) orelse "";
 
                     var basename = std.fs.path.basename(base);
 
                     if (use_hashed_name) {
-                        var basepath = Fs.Path.init(source_path);
+                        const basepath = Fs.Path.init(source_path);
 
                         if (linker.options.serve) {
                             var hash_buf: [64]u8 = undefined;

--- a/src/linux_c.zig
+++ b/src/linux_c.zig
@@ -548,14 +548,14 @@ const posix_spawn_file_actions_addchdir_np_type = *const fn (actions: *posix_spa
 
 /// When not available, these functions will return 0.
 pub fn posix_spawn_file_actions_addfchdir_np(actions: *posix_spawn_file_actions_t, filedes: std.os.fd_t) c_int {
-    var function = bun.C.dlsym(posix_spawn_file_actions_addfchdir_np_type, "posix_spawn_file_actions_addfchdir_np") orelse
+    const function = bun.C.dlsym(posix_spawn_file_actions_addfchdir_np_type, "posix_spawn_file_actions_addfchdir_np") orelse
         return 0;
     return function(actions, filedes);
 }
 
 /// When not available, these functions will return 0.
 pub fn posix_spawn_file_actions_addchdir_np(actions: *posix_spawn_file_actions_t, path: [*:0]const u8) c_int {
-    var function = bun.C.dlsym(posix_spawn_file_actions_addchdir_np_type, "posix_spawn_file_actions_addchdir_np") orelse
+    const function = bun.C.dlsym(posix_spawn_file_actions_addchdir_np_type, "posix_spawn_file_actions_addchdir_np") orelse
         return 0;
     return function(actions, path);
 }

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -177,7 +177,7 @@ pub const Location = struct {
 
     pub fn init_or_nil(_source: ?*const Source, r: Range) ?Location {
         if (_source) |source| {
-            var data = source.initErrorPosition(r.loc);
+            const data = source.initErrorPosition(r.loc);
             var full_line = source.contents[data.line_start..data.line_end];
             if (full_line.len > 80 + data.column_count) {
                 full_line = full_line[@max(data.column_count, 40) - 40 .. @min(data.column_count + 40, full_line.len - 40) + 40];
@@ -217,7 +217,7 @@ pub const Data = struct {
         if (!should or this.location == null or this.location.?.line_text == null)
             return this;
 
-        var new_line_text = try allocator.dupe(u8, this.location.?.line_text.?);
+        const new_line_text = try allocator.dupe(u8, this.location.?.line_text.?);
         var new_location = this.location.?;
         new_location.line_text = new_line_text;
         return Data{
@@ -331,7 +331,7 @@ pub const Data = struct {
                             break :brk 1;
                         };
 
-                        var middle_segment: []const u8 = rest_of_line[0..end_of_segment];
+                        const middle_segment: []const u8 = rest_of_line[0..end_of_segment];
 
                         if (middle_segment.len > 0) {
                             try to.writeAll(Output.color_map.get("b").?);
@@ -521,7 +521,7 @@ pub const Msg = struct {
             Api.MessageData,
             notes_len,
         );
-        var msg = Api.Message{
+        const msg = Api.Message{
             .level = this.kind.toAPI(),
             .data = this.data.toAPI(),
             .notes = _notes,
@@ -783,7 +783,7 @@ pub const Log = struct {
 
     pub fn toJSArray(this: Log, global: *JSC.JSGlobalObject, allocator: std.mem.Allocator) JSC.JSValue {
         const msgs: []const Msg = this.msgs.items;
-        var errors_stack: [256]*anyopaque = undefined;
+        const errors_stack: [256]*anyopaque = undefined;
 
         const count = @as(u16, @intCast(@min(msgs.len, errors_stack.len)));
         var arr = JSC.JSValue.createEmptyArray(global, count);
@@ -812,7 +812,7 @@ pub const Log = struct {
             var note_i: usize = 0;
             for (self.msgs.items) |*msg| {
                 if (msg.notes) |current_notes| {
-                    var start_note_i: usize = note_i;
+                    const start_note_i: usize = note_i;
                     for (current_notes) |note| {
                         notes[note_i] = note;
                         note_i += 1;
@@ -1403,7 +1403,7 @@ pub const Source = struct {
     }
 
     pub fn initPathString(pathString: string, contents: string) Source {
-        var path = fs.Path.init(pathString);
+        const path = fs.Path.init(pathString);
         return Source{ .key_path = path, .path = path, .contents = contents };
     }
 
@@ -1466,7 +1466,7 @@ pub const Source = struct {
 
     pub fn initErrorPosition(self: *const Source, _offset: Loc) ErrorPosition {
         var prev_code_point: i32 = 0;
-        var offset: usize = @min(if (_offset.start < 0) 0 else @as(usize, @intCast(_offset.start)), @max(self.contents.len, 1) - 1);
+        const offset: usize = @min(if (_offset.start < 0) 0 else @as(usize, @intCast(_offset.start)), @max(self.contents.len, 1) - 1);
 
         const contents = self.contents;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -33,8 +33,8 @@ pub fn main() void {
 
     bun.start_time = std.time.nanoTimestamp();
 
-    var stdout = std.io.getStdOut();
-    var stderr = std.io.getStdErr();
+    const stdout = std.io.getStdOut();
+    const stderr = std.io.getStdErr();
     var output_source = Output.Source.init(stdout, stderr);
 
     Output.Source.set(&output_source);

--- a/src/memory_allocator.zig
+++ b/src/memory_allocator.zig
@@ -59,7 +59,7 @@ const CAllocator = struct {
     fn alignedAlloc(len: usize, alignment: usize) ?[*]u8 {
         if (comptime FeatureFlags.log_allocations) std.debug.print("Malloc: {d}\n", .{len});
 
-        var ptr: ?*anyopaque = if (mimalloc.canUseAlignedAlloc(len, alignment))
+        const ptr: ?*anyopaque = if (mimalloc.canUseAlignedAlloc(len, alignment))
             mimalloc.mi_malloc_aligned(len, alignment)
         else
             mimalloc.mi_malloc(len);
@@ -120,7 +120,7 @@ const ZAllocator = struct {
     fn alignedAlloc(len: usize, alignment: usize) ?[*]u8 {
         if (comptime FeatureFlags.log_allocations) std.debug.print("Malloc: {d}\n", .{len});
 
-        var ptr = if (mimalloc.canUseAlignedAlloc(len, alignment))
+        const ptr = if (mimalloc.canUseAlignedAlloc(len, alignment))
             mimalloc.mi_zalloc_aligned(len, alignment)
         else
             mimalloc.mi_zalloc(len);
@@ -180,7 +180,7 @@ const HugeAllocator = struct {
         assert(len > 0);
         assert(std.math.isPowerOfTwo(alignment));
 
-        var slice = std.os.mmap(
+        const slice = std.os.mmap(
             null,
             len,
             std.os.PROT.READ | std.os.PROT.WRITE,

--- a/src/mimalloc_arena.zig
+++ b/src/mimalloc_arena.zig
@@ -83,7 +83,7 @@ const ArenaRegistry = struct {
         if (comptime Environment.allow_assert and Environment.isNative) {
             registry.mutex.lock();
             defer registry.mutex.unlock();
-            var entry = registry.arenas.getOrPut(arena.heap.?) catch unreachable;
+            const entry = registry.arenas.getOrPut(arena.heap.?) catch unreachable;
             const received = std.Thread.getCurrentId();
 
             if (entry.found_existing) {
@@ -204,7 +204,7 @@ pub const Arena = struct {
     fn alignedAlloc(heap: *mimalloc.Heap, len: usize, alignment: usize) ?[*]u8 {
         if (comptime FeatureFlags.log_allocations) std.debug.print("Malloc: {d}\n", .{len});
 
-        var ptr: ?*anyopaque = if (mimalloc.canUseAlignedAlloc(len, alignment))
+        const ptr: ?*anyopaque = if (mimalloc.canUseAlignedAlloc(len, alignment))
             mimalloc.mi_heap_malloc_aligned(heap, len, alignment)
         else
             mimalloc.mi_heap_malloc(heap, len);
@@ -227,7 +227,7 @@ pub const Arena = struct {
     }
 
     fn alloc(arena: *anyopaque, len: usize, log2_align: u8, _: usize) ?[*]u8 {
-        var this = bun.cast(*mimalloc.Heap, arena);
+        const this = bun.cast(*mimalloc.Heap, arena);
         // if (comptime Environment.allow_assert)
         //     ArenaRegistry.assert(.{ .heap = this });
         if (comptime FeatureFlags.alignment_tweak) {

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -355,7 +355,7 @@ inline fn maybeAppendNull(ptr: anytype, doit: bool) void {
 pub export fn napi_get_value_string_latin1(env: napi_env, value: napi_value, buf_ptr_: ?[*:0]c_char, bufsize: usize, result_ptr: ?*usize) napi_status {
     log("napi_get_value_string_latin1", .{});
     defer value.ensureStillAlive();
-    var buf_ptr = @as(?[*:0]u8, @ptrCast(buf_ptr_));
+    const buf_ptr = @as(?[*:0]u8, @ptrCast(buf_ptr_));
 
     const str = value.toBunString(env);
     var buf = buf_ptr orelse {
@@ -712,7 +712,7 @@ pub export fn napi_is_arraybuffer(_: napi_env, value: napi_value, result: *bool)
 }
 pub export fn napi_create_arraybuffer(env: napi_env, byte_length: usize, data: [*]const u8, result: *napi_value) napi_status {
     log("napi_create_arraybuffer", .{});
-    var typed_array = JSC.C.JSObjectMakeTypedArray(env.ref(), .kJSTypedArrayTypeArrayBuffer, byte_length, TODO_EXCEPTION);
+    const typed_array = JSC.C.JSObjectMakeTypedArray(env.ref(), .kJSTypedArrayTypeArrayBuffer, byte_length, TODO_EXCEPTION);
     var array_buffer = JSValue.c(typed_array).asArrayBuffer(env) orelse return genericFailure();
     const len = @min(array_buffer.len, @as(u32, @truncate(byte_length)));
     @memcpy(array_buffer.ptr[0..len], data[0..len]);
@@ -725,7 +725,7 @@ pub extern fn napi_create_external_arraybuffer(env: napi_env, external_data: ?*a
 pub export fn napi_get_arraybuffer_info(env: napi_env, arraybuffer: napi_value, data: ?*[*]u8, byte_length: ?*usize) napi_status {
     log("napi_get_arraybuffer_info", .{});
     const array_buffer = arraybuffer.asArrayBuffer(env) orelse return .arraybuffer_expected;
-    var slice = array_buffer.slice();
+    const slice = array_buffer.slice();
     if (data) |dat|
         dat.* = slice.ptr;
     if (byte_length) |len|
@@ -792,7 +792,7 @@ pub export fn napi_is_dataview(_: napi_env, value: napi_value, result: *bool) na
 }
 pub export fn napi_get_dataview_info(env: napi_env, dataview: napi_value, bytelength: *usize, data: *?[*]u8, arraybuffer: *napi_value, byte_offset: *usize) napi_status {
     log("napi_get_dataview_info", .{});
-    var array_buffer = dataview.asArrayBuffer(env) orelse return .object_expected;
+    const array_buffer = dataview.asArrayBuffer(env) orelse return .object_expected;
     bytelength.* = array_buffer.byte_len;
     data.* = array_buffer.ptr;
 
@@ -841,7 +841,7 @@ pub export fn napi_is_promise(_: napi_env, value: napi_value, is_promise: *bool)
 pub export fn napi_run_script(env: napi_env, script: napi_value, result: *napi_value) napi_status {
     log("napi_run_script", .{});
     // TODO: don't copy
-    var ref = JSC.C.JSValueToStringCopy(env.ref(), script.asObjectRef(), TODO_EXCEPTION);
+    const ref = JSC.C.JSValueToStringCopy(env.ref(), script.asObjectRef(), TODO_EXCEPTION);
     defer JSC.C.JSStringRelease(ref);
 
     var exception = [_]JSC.C.JSValueRef{null};
@@ -935,7 +935,7 @@ pub const napi_async_work = struct {
     };
 
     pub fn create(global: napi_env, execute: napi_async_execute_callback, complete: napi_async_complete_callback, ctx: ?*anyopaque) !*napi_async_work {
-        var work = try bun.default_allocator.create(napi_async_work);
+        const work = try bun.default_allocator.create(napi_async_work);
         work.* = .{
             .global = global,
             .execute = execute,
@@ -1273,7 +1273,7 @@ pub const ThreadSafeFunction = struct {
                     };
                 },
                 else => {
-                    var slice = allocator.alloc(?*anyopaque, size) catch unreachable;
+                    const slice = allocator.alloc(?*anyopaque, size) catch unreachable;
                     return .{
                         .sized = Channel(?*anyopaque, .Slice).init(slice),
                     };
@@ -1311,7 +1311,7 @@ pub const ThreadSafeFunction = struct {
     };
 
     pub fn call(this: *ThreadSafeFunction) void {
-        var task = this.channel.tryReadItem() catch null orelse return;
+        const task = this.channel.tryReadItem() catch null orelse return;
         switch (this.callback) {
             .js => |js_function| {
                 if (js_function.isEmptyOrUndefinedOrNull()) {

--- a/src/network_thread.zig
+++ b/src/network_thread.zig
@@ -123,7 +123,7 @@ fn processEvents_(this: *@This()) !void {
         var count: usize = 0;
 
         while (this.processing_tasks.pop()) |task| {
-            var callback = task.callback;
+            const callback = task.callback;
             callback(task);
             if (comptime Environment.allow_assert) {
                 count += 1;
@@ -142,7 +142,7 @@ fn processEvents_(this: *@This()) !void {
         Output.flush();
         this.io.wait(this, queueEvents);
         if (comptime Environment.isDebug) {
-            var end = std.time.nanoTimestamp();
+            const end = std.time.nanoTimestamp();
             log("Waited {any}\n", .{std.fmt.fmtDurationSigned(@as(i64, @truncate(end - start)))});
             Output.flush();
         }

--- a/src/open.zig
+++ b/src/open.zig
@@ -274,7 +274,7 @@ pub const Editor = enum(u8) {
             },
             .textmate => {
                 try file_path_buf_writer.writeAll(file);
-                var file_path = file_path_buf_stream.getWritten();
+                const file_path = file_path_buf_stream.getWritten();
 
                 if (line) |line_| {
                     if (line_.len > 0) {
@@ -288,7 +288,7 @@ pub const Editor = enum(u8) {
                                 try file_path_buf_writer.print(":{s}", .{col});
                         }
 
-                        var line_column = file_path_buf_stream.getWritten()[file_path.len..];
+                        const line_column = file_path_buf_stream.getWritten()[file_path.len..];
                         if (line_column.len > 0) {
                             args_buf[i] = line_column;
                             i += 1;
@@ -304,7 +304,7 @@ pub const Editor = enum(u8) {
             else => {
                 if (file.len > 0) {
                     try file_path_buf_writer.writeAll(file);
-                    var file_path = file_path_buf_stream.getWritten();
+                    const file_path = file_path_buf_stream.getWritten();
                     args_buf[i] = file_path;
                     i += 1;
                 }

--- a/src/options.zig
+++ b/src/options.zig
@@ -413,7 +413,7 @@ pub const Target = enum {
         var zig_str = JSC.ZigString.init("");
         value.toZigString(&zig_str, global);
 
-        var slice = zig_str.slice();
+        const slice = zig_str.slice();
 
         const Eight = strings.ExactSizeMatcher(8);
 
@@ -990,7 +990,7 @@ pub const JSX = struct {
             if (str.len == 0) return str;
             if (str[0] == '@') {
                 if (strings.indexOfChar(str[1..], '/')) |first_slash| {
-                    var remainder = str[1 + first_slash + 1 ..];
+                    const remainder = str[1 + first_slash + 1 ..];
 
                     if (strings.indexOfChar(remainder, '/')) |last_slash| {
                         return str[0 .. first_slash + 1 + last_slash + 1];
@@ -1161,7 +1161,7 @@ pub fn definesFromTransformOptions(
     debugger: bool,
 ) !*defines.Define {
     _ = debugger;
-    var input_user_define = _input_define orelse std.mem.zeroes(Api.StringMap);
+    const input_user_define = _input_define orelse std.mem.zeroes(Api.StringMap);
 
     var user_defines = try stringHashMapFromArrays(
         defines.RawDefines,
@@ -1199,7 +1199,7 @@ pub fn definesFromTransformOptions(
         }
     }
 
-    var quoted_node_env: string = brk: {
+    const quoted_node_env: string = brk: {
         if (NODE_ENV) |node_env| {
             if (node_env.len > 0) {
                 if ((strings.startsWithChar(node_env, '"') and strings.endsWithChar(node_env, '"')) or
@@ -1252,7 +1252,7 @@ pub fn definesFromTransformOptions(
         }
     }
 
-    var resolved_defines = try defines.DefineData.from_input(user_defines, log, allocator);
+    const resolved_defines = try defines.DefineData.from_input(user_defines, log, allocator);
 
     return try defines.Define.init(
         allocator,
@@ -1321,8 +1321,8 @@ pub const ResolveFileExtensions = struct {
 };
 
 pub fn loadersFromTransformOptions(allocator: std.mem.Allocator, _loaders: ?Api.LoaderMap, target: Target) !bun.StringArrayHashMap(Loader) {
-    var input_loaders = _loaders orelse std.mem.zeroes(Api.LoaderMap);
-    var loader_values = try allocator.alloc(Loader, input_loaders.loaders.len);
+    const input_loaders = _loaders orelse std.mem.zeroes(Api.LoaderMap);
+    const loader_values = try allocator.alloc(Loader, input_loaders.loaders.len);
 
     for (loader_values, input_loaders.loaders) |*loader, input| {
         loader.* = Loader.fromAPI(input);
@@ -1771,7 +1771,7 @@ pub fn openOutputDir(output_dir: string) !std.fs.Dir {
             Global.crash();
         };
 
-        var handle = std.fs.cwd().openDir(output_dir, .{}) catch |err2| {
+        const handle = std.fs.cwd().openDir(output_dir, .{}) catch |err2| {
             Output.printErrorln("error: Unable to open \"{s}\": \"{s}\"", .{ output_dir, @errorName(err2) });
             Global.crash();
         };
@@ -1800,7 +1800,7 @@ pub const TransformOptions = struct {
     pub fn initUncached(allocator: std.mem.Allocator, entryPointName: string, code: string) !TransformOptions {
         assert(entryPointName.len > 0);
 
-        var entryPoint = Fs.File{
+        const entryPoint = Fs.File{
             .path = Fs.Path.init(entryPointName),
             .contents = code,
         };
@@ -2056,7 +2056,7 @@ pub const OutputFile = struct {
             .noop => JSC.JSValue.undefined,
             .copy => |copy| brk: {
                 var build_output = bun.default_allocator.create(JSC.API.BuildArtifact) catch @panic("Unable to allocate Artifact");
-                var file_blob = JSC.WebCore.Blob.Store.initFile(
+                const file_blob = JSC.WebCore.Blob.Store.initFile(
                     if (copy.fd != 0)
                         JSC.Node.PathOrFileDescriptor{
                             .fd = copy.fd,
@@ -2085,7 +2085,7 @@ pub const OutputFile = struct {
                 var build_output = bun.default_allocator.create(JSC.API.BuildArtifact) catch @panic("Unable to allocate Artifact");
                 const path_to_use = owned_pathname orelse this.src_path.text;
 
-                var file_blob = JSC.WebCore.Blob.Store.initFile(
+                const file_blob = JSC.WebCore.Blob.Store.initFile(
                     JSC.Node.PathOrFileDescriptor{
                         .path = JSC.Node.PathLike{ .string = bun.PathString.init(owned_pathname orelse (bun.default_allocator.dupe(u8, this.src_path.text) catch unreachable)) },
                     },
@@ -2530,8 +2530,8 @@ pub const RouteConfig = struct {
     pub fn fromApi(router_: Api.RouteConfig, allocator: std.mem.Allocator) !RouteConfig {
         var router = zero();
 
-        var static_dir: string = std.mem.trimRight(u8, router_.static_dir orelse "", "/\\");
-        var asset_prefix: string = std.mem.trimRight(u8, router_.asset_prefix orelse "", "/\\");
+        const static_dir: string = std.mem.trimRight(u8, router_.static_dir orelse "", "/\\");
+        const asset_prefix: string = std.mem.trimRight(u8, router_.asset_prefix orelse "", "/\\");
 
         switch (router_.dir.len) {
             0 => {},
@@ -2572,7 +2572,7 @@ pub const RouteConfig = struct {
                 count += 1;
             }
 
-            var extensions = try allocator.alloc(string, count);
+            const extensions = try allocator.alloc(string, count);
             var remainder = extensions;
 
             for (router_.extensions) |_ext| {

--- a/src/output.zig
+++ b/src/output.zig
@@ -211,8 +211,8 @@ var _source_for_test_set = false;
 pub fn initTest() void {
     if (_source_for_test_set) return;
     _source_for_test_set = true;
-    var in = std.io.getStdErr();
-    var out = std.io.getStdOut();
+    const in = std.io.getStdErr();
+    const out = std.io.getStdOut();
     _source_for_test = Output.Source.init(out, in);
     Output.Source.set(&_source_for_test);
 }
@@ -589,7 +589,7 @@ pub fn prettyFmt(comptime fmt: string, comptime is_enabled: bool) string {
                 i += 1;
                 var is_reset = fmt[i] == '/';
                 if (is_reset) i += 1;
-                var start: usize = i;
+                const start: usize = i;
                 while (i < fmt.len and fmt[i] != '>') {
                     i += 1;
                 }

--- a/src/pool.zig
+++ b/src/pool.zig
@@ -159,7 +159,7 @@ pub fn ObjectPool(
             if (comptime @import("./env.zig").allow_assert)
                 std.debug.assert(!full());
 
-            var new_node = allocator.create(LinkedList.Node) catch unreachable;
+            const new_node = allocator.create(LinkedList.Node) catch unreachable;
             new_node.* = LinkedList.Node{
                 .allocator = allocator,
                 .data = pooled,
@@ -194,7 +194,7 @@ pub fn ObjectPool(
 
             if (comptime log_allocations) std.io.getStdErr().writeAll(comptime std.fmt.comptimePrint("Allocate {s} - {d} bytes\n", .{ @typeName(Type), @sizeOf(Type) })) catch {};
 
-            var new_node = allocator.create(LinkedList.Node) catch unreachable;
+            const new_node = allocator.create(LinkedList.Node) catch unreachable;
             new_node.* = LinkedList.Node{
                 .allocator = allocator,
                 .data = if (comptime Init) |init_|

--- a/src/renamer.zig
+++ b/src/renamer.zig
@@ -150,7 +150,7 @@ pub const MinifyRenamer = struct {
         first_top_level_slots: js_ast.SlotCounts,
         reserved_names: bun.StringHashMapUnmanaged(u32),
     ) !*MinifyRenamer {
-        var renamer = try allocator.create(MinifyRenamer);
+        const renamer = try allocator.create(MinifyRenamer);
         var slots = SymbolSlot.List.initUndefined();
 
         for (first_top_level_slots.slots.values, 0..) |count, ns| {
@@ -261,7 +261,7 @@ pub const MinifyRenamer = struct {
             const symbol = this.symbols.get(stable.ref).?;
             var slots = this.slots.getPtr(symbol.slotNamespace());
 
-            var existing = try this.top_level_symbol_to_slot.getOrPut(this.allocator, stable.ref);
+            const existing = try this.top_level_symbol_to_slot.getOrPut(this.allocator, stable.ref);
             if (existing.found_existing) {
                 var slot = &slots.items[existing.value_ptr.*];
                 slot.count += stable.count;
@@ -621,7 +621,7 @@ pub const NumberRenamer = struct {
 
         while (true) {
             if (scope.members.count() > 0 or scope.generated.len > 0) {
-                var new_child_scope = r.number_scope_pool.get();
+                const new_child_scope = r.number_scope_pool.get();
                 new_child_scope.* = .{
                     .parent = s,
                     .name_counts = .{},
@@ -755,7 +755,7 @@ pub const NumberRenamer = struct {
                             name = mutable_name.toOwnedSliceLeaky();
 
                             if (use == .same_scope) {
-                                var existing = this.name_counts.getOrPut(allocator, prefix) catch unreachable;
+                                const existing = this.name_counts.getOrPut(allocator, prefix) catch unreachable;
                                 if (!existing.found_existing) {
                                     if (strings.eqlLong(input_name, prefix, true)) {
                                         existing.key_ptr.* = input_name;
@@ -777,7 +777,7 @@ pub const NumberRenamer = struct {
                                 switch (NameUse.find(this, mutable_name.toOwnedSliceLeaky())) {
                                     .unused => {
                                         if (cur_use == .same_scope) {
-                                            var existing = this.name_counts.getOrPut(allocator, prefix) catch unreachable;
+                                            const existing = this.name_counts.getOrPut(allocator, prefix) catch unreachable;
                                             if (!existing.found_existing) {
                                                 if (strings.eqlLong(input_name, prefix, true)) {
                                                     existing.key_ptr.* = input_name;
@@ -846,7 +846,7 @@ pub const ExportRenamer = struct {
                 var writer = this.string_buffer.writer();
                 writer.print("{s}{d}", .{ input, tries }) catch unreachable;
                 tries += 1;
-                var attempt = this.string_buffer.toOwnedSliceLeaky();
+                const attempt = this.string_buffer.toOwnedSliceLeaky();
                 entry = this.used.getOrPut(attempt) catch unreachable;
                 if (!entry.found_existing) {
                     const to_use = this.string_buffer.allocator.dupe(u8, attempt) catch unreachable;

--- a/src/report.zig
+++ b/src/report.zig
@@ -117,7 +117,7 @@ pub fn printMetadata() void {
     else
         "x64";
 
-    var analytics_platform = Platform.forOS();
+    const analytics_platform = Platform.forOS();
 
     crash_report_writer.print(
         \\
@@ -507,7 +507,7 @@ pub noinline fn globalError(err: anyerror, trace_: @TypeOf(@errorReturnTrace()))
         error.NotOpenForReading, error.Unexpected => {
             if (trace_) |trace| {
                 print_stacktrace: {
-                    var debug_info = std.debug.getSelfDebugInfo() catch break :print_stacktrace;
+                    const debug_info = std.debug.getSelfDebugInfo() catch break :print_stacktrace;
                     Output.disableBuffering();
                     std.debug.writeStackTrace(trace.*, Output.errorWriter(), default_allocator, debug_info, std.io.tty.detectConfig(std.io.getStdErr())) catch break :print_stacktrace;
                 }
@@ -586,7 +586,7 @@ pub noinline fn globalError(err: anyerror, trace_: @TypeOf(@errorReturnTrace()))
 
             if (trace_) |trace| {
                 print_stacktrace: {
-                    var debug_info = std.debug.getSelfDebugInfo() catch break :print_stacktrace;
+                    const debug_info = std.debug.getSelfDebugInfo() catch break :print_stacktrace;
                     Output.disableBuffering();
                     std.debug.writeStackTrace(trace.*, Output.errorWriter(), default_allocator, debug_info, std.io.tty.detectConfig(std.io.getStdErr())) catch break :print_stacktrace;
                 }
@@ -602,7 +602,7 @@ pub noinline fn globalError(err: anyerror, trace_: @TypeOf(@errorReturnTrace()))
 
             if (trace_) |trace| {
                 print_stacktrace: {
-                    var debug_info = std.debug.getSelfDebugInfo() catch break :print_stacktrace;
+                    const debug_info = std.debug.getSelfDebugInfo() catch break :print_stacktrace;
                     Output.disableBuffering();
                     std.debug.writeStackTrace(trace.*, Output.errorWriter(), default_allocator, debug_info, std.io.tty.detectConfig(std.io.getStdErr())) catch break :print_stacktrace;
                 }
@@ -616,7 +616,7 @@ pub noinline fn globalError(err: anyerror, trace_: @TypeOf(@errorReturnTrace()))
     Report.fatal(err, null);
     if (trace_) |trace| {
         print_stacktrace: {
-            var debug_info = std.debug.getSelfDebugInfo() catch break :print_stacktrace;
+            const debug_info = std.debug.getSelfDebugInfo() catch break :print_stacktrace;
             Output.disableBuffering();
             std.debug.writeStackTrace(trace.*, Output.errorWriter(), default_allocator, debug_info, std.io.tty.detectConfig(std.io.getStdErr())) catch break :print_stacktrace;
         }

--- a/src/resolver/data_url.zig
+++ b/src/resolver/data_url.zig
@@ -93,7 +93,7 @@ pub const DataURL = struct {
             return null;
         }
 
-        var result = try parseWithoutCheck(url);
+        const result = try parseWithoutCheck(url);
         return result;
     }
 
@@ -121,7 +121,7 @@ pub const DataURL = struct {
         const percent_decoded = PercentEncoding.decodeUnstrict(allocator, url.data) catch url.data orelse url.data;
         if (url.is_base64) {
             const len = bun.base64.decodeLen(percent_decoded);
-            var buf = try allocator.alloc(u8, len);
+            const buf = try allocator.alloc(u8, len);
             const result = bun.base64.decode(buf, percent_decoded);
             if (result.fail or result.written != len) {
                 return error.Base64DecodeError;

--- a/src/resolver/dir_info.zig
+++ b/src/resolver/dir_info.zig
@@ -89,7 +89,7 @@ pub fn getFileDescriptor(dirinfo: *const DirInfo) StoredFileDescriptorType {
 }
 
 pub fn getEntries(dirinfo: *const DirInfo, generation: bun.Generation) ?*Fs.FileSystem.DirEntry {
-    var entries_ptr = Fs.FileSystem.instance.fs.entriesAt(dirinfo.entries, generation) orelse return null;
+    const entries_ptr = Fs.FileSystem.instance.fs.entriesAt(dirinfo.entries, generation) orelse return null;
     switch (entries_ptr.*) {
         .entries => {
             return entries_ptr.entries;

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -722,7 +722,7 @@ pub const PackageJSON = struct {
 
                             // Remap all files in the browser field
                             for (obj.properties.slice()) |*prop| {
-                                var _key_str = (prop.key orelse continue).asString(allocator) orelse continue;
+                                const _key_str = (prop.key orelse continue).asString(allocator) orelse continue;
                                 const value: js_ast.Expr = prop.value orelse continue;
 
                                 // Normalize the path so we can compare against it without getting
@@ -1077,7 +1077,7 @@ pub const ExportsMap = struct {
                     };
                 },
                 .e_array => |e_array| {
-                    var array = this.allocator.alloc(Entry, e_array.items.len) catch unreachable;
+                    const array = this.allocator.alloc(Entry, e_array.items.len) catch unreachable;
                     for (e_array.items.slice(), array) |item, *dest| {
                         dest.* = this.visit(item);
                     }
@@ -1107,7 +1107,7 @@ pub const ExportsMap = struct {
 
                         // If exports is an Object with both a key starting with "." and a key
                         // not starting with ".", throw an Invalid Package Configuration error.
-                        var cur_is_conditional_sugar = !strings.startsWithChar(key, '.');
+                        const cur_is_conditional_sugar = !strings.startsWithChar(key, '.');
                         if (i == 0) {
                             is_conditional_sugar = cur_is_conditional_sugar;
                         } else if (is_conditional_sugar != cur_is_conditional_sugar) {
@@ -1152,7 +1152,7 @@ pub const ExportsMap = struct {
                     // or containing only a single "*", sorted by the sorting function
                     // PATTERN_KEY_COMPARE which orders in descending order of specificity.
                     const GlobLengthSorter: type = strings.NewGlobLengthSorter(Entry.Data.Map.MapEntry, "key");
-                    var sorter = GlobLengthSorter{};
+                    const sorter = GlobLengthSorter{};
                     std.sort.block(Entry.Data.Map.MapEntry, expansion_keys, sorter, GlobLengthSorter.lessThan);
 
                     return Entry{
@@ -1707,7 +1707,7 @@ pub const ESModule = struct {
 
                             return Resolution{ .path = result, .status = .PackageResolve, .debug = .{ .token = target.first_token } };
                         } else {
-                            var parts2 = [_]string{ str, subpath };
+                            const parts2 = [_]string{ str, subpath };
                             const result = resolve_path.joinStringBuf(&resolve_target_buf2, parts2, .auto);
                             if (r.debug_logs) |log| {
                                 log.addNoteFmt("Resolved \".{s}\" to \".{s}\"", .{ str, result });
@@ -1731,7 +1731,7 @@ pub const ESModule = struct {
                 }
 
                 // Let resolvedTarget be the URL resolution of the concatenation of packageURL and target.
-                var parts = [_]string{ package_url, str };
+                const parts = [_]string{ package_url, str };
                 const resolved_target = resolve_path.joinStringBuf(&resolve_target_buf, parts, .auto);
 
                 // If target split on "/" or "\" contains any ".", ".." or "node_modules"
@@ -1759,7 +1759,7 @@ pub const ESModule = struct {
                         .Exact;
                     return Resolution{ .path = result, .status = status, .debug = .{ .token = target.first_token } };
                 } else {
-                    var parts2 = [_]string{ package_url, str, subpath };
+                    const parts2 = [_]string{ package_url, str, subpath };
                     const result = resolve_path.joinStringBuf(&resolve_target_buf2, parts2, .auto);
                     if (r.debug_logs) |log| {
                         log.addNoteFmt("Substituted \"{s}\" for \"*\" in \".{s}\" to get \".{s}\" ", .{ subpath, resolved_target, result });
@@ -1780,7 +1780,7 @@ pub const ESModule = struct {
                             log.addNoteFmt("The key \"{s}\" matched", .{key});
                         }
 
-                        var prev_module_type = r.module_type.*;
+                        const prev_module_type = r.module_type.*;
                         var result = r.resolveTarget(package_url, slice.items(.value)[i], subpath, internal, pattern);
                         if (result.status.isUndefined()) {
                             did_find_map_entry = true;
@@ -1881,7 +1881,7 @@ pub const ESModule = struct {
 
                 for (array) |targetValue| {
                     // Let resolved be the result, continuing the loop on any Invalid Package Target error.
-                    var prev_module_type = r.module_type.*;
+                    const prev_module_type = r.module_type.*;
                     const result = r.resolveTarget(package_url, targetValue, subpath, internal, pattern);
                     if (result.status == .InvalidPackageTarget or result.status == .Null) {
                         last_debug = result.debug;
@@ -1939,8 +1939,8 @@ pub const ESModule = struct {
 
         if (!strings.endsWithChar(query, "*")) {
             var slices = map.list.slice();
-            var keys = slices.items(.key);
-            var values = slices.items(.value);
+            const keys = slices.items(.key);
+            const values = slices.items(.value);
             for (keys, 0..) |key, i| {
                 if (r.resolveTargetReverse(query, key, values[i], .exact)) |result| {
                     return result;
@@ -2055,7 +2055,7 @@ pub const ESModule = struct {
 };
 
 fn findInvalidSegment(path_: string) ?string {
-    var slash = strings.indexAnyComptime(path_, "/\\") orelse return "";
+    const slash = strings.indexAnyComptime(path_, "/\\") orelse return "";
     var path = path_[slash + 1 ..];
 
     while (path.len > 0) {

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -464,7 +464,7 @@ pub fn relative(from: []const u8, to: []const u8) []const u8 {
 
 pub fn relativePlatform(from: []const u8, to: []const u8, comptime platform: Platform, comptime always_copy: bool) []const u8 {
     const normalized_from = if (from.len > 0 and from[0] == platform.separator()) brk: {
-        var path = normalizeStringBuf(from, relative_from_buf[1..], true, platform, true);
+        const path = normalizeStringBuf(from, relative_from_buf[1..], true, platform, true);
         relative_from_buf[0] = platform.separator();
         break :brk relative_from_buf[0 .. path.len + 1];
     } else joinAbsStringBuf(
@@ -477,7 +477,7 @@ pub fn relativePlatform(from: []const u8, to: []const u8, comptime platform: Pla
     );
 
     const normalized_to = if (to.len > 0 and to[0] == platform.separator()) brk: {
-        var path = normalizeStringBuf(to, relative_to_buf[1..], true, platform, true);
+        const path = normalizeStringBuf(to, relative_to_buf[1..], true, platform, true);
         relative_to_buf[0] = platform.separator();
         break :brk relative_to_buf[0 .. path.len + 1];
     } else joinAbsStringBuf(
@@ -825,7 +825,7 @@ pub fn joinZ(_parts: anytype, comptime _platform: Platform) [:0]const u8 {
 }
 
 pub fn joinZBuf(buf: []u8, _parts: anytype, comptime _platform: Platform) [:0]const u8 {
-    var joined = joinStringBuf(buf[0 .. buf.len - 1], _parts, _platform);
+    const joined = joinStringBuf(buf[0 .. buf.len - 1], _parts, _platform);
     std.debug.assert(bun.isSliceInBuffer(joined, buf));
     const start_offset = @intFromPtr(joined.ptr) - @intFromPtr(buf.ptr);
     buf[joined.len + start_offset] = 0;
@@ -936,7 +936,7 @@ fn _joinAbsStringBuf(comptime is_sentinel: bool, comptime ReturnType: type, _cwd
             continue;
         }
 
-        var part = _part;
+        const part = _part;
 
         if (out > 0 and temp_buf[out - 1] != _platform.separator()) {
             temp_buf[out] = _platform.separator();
@@ -948,7 +948,7 @@ fn _joinAbsStringBuf(comptime is_sentinel: bool, comptime ReturnType: type, _cwd
     }
 
     const leading_separator: []const u8 = if (_platform.leadingSeparatorIndex(temp_buf[0..out])) |i| brk: {
-        var outdir = temp_buf[0 .. i + 1];
+        const outdir = temp_buf[0 .. i + 1];
         if (_platform == .windows or _platform == .loose) {
             for (outdir) |*c| {
                 if (c.* == '\\') {
@@ -1338,7 +1338,7 @@ test "joinStringBuf" {
     };
     inline for (fixtures) |fixture| {
         const expected = fixture[1];
-        var buf = try default_allocator.alloc(u8, 2048);
+        const buf = try default_allocator.alloc(u8, 2048);
         _ = t.expect(expected, joinStringBuf(buf, fixture[0], .posix), @src());
     }
 }

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -283,7 +283,7 @@ pub const Result = struct {
         const module = this.path_pair.primary.text;
         const node_module_root = std.fs.path.sep_str ++ "node_modules" ++ std.fs.path.sep_str;
         if (strings.lastIndexOf(module, node_module_root)) |end_| {
-            var end: usize = end_ + node_module_root.len;
+            const end: usize = end_ + node_module_root.len;
 
             return @as(u32, @truncate(bun.hash(module[end..])));
         }
@@ -307,7 +307,7 @@ pub const DebugLogs = struct {
     pub const FlushMode = enum { fail, success };
 
     pub fn init(allocator: std.mem.Allocator) !DebugLogs {
-        var mutable = try MutableString.init(allocator, 0);
+        const mutable = try MutableString.init(allocator, 0);
         return DebugLogs{
             .indent = mutable,
             .notes = std.ArrayList(logger.Data).init(allocator),
@@ -381,8 +381,8 @@ pub const PendingResolution = struct {
 
     pub fn deinitListItems(list_: List, allocator: std.mem.Allocator) void {
         var list = list_;
-        var dependencies = list.items(.dependency);
-        var string_bufs = list.items(.string_buf);
+        const dependencies = list.items(.dependency);
+        const string_bufs = list.items(.string_buf);
         for (dependencies) |*dependency| {
             dependency.deinit();
         }
@@ -1210,7 +1210,7 @@ pub const Resolver = struct {
             }
 
             if (check_relative) {
-                var prev_extension_order = r.extension_order;
+                const prev_extension_order = r.extension_order;
                 defer {
                     r.extension_order = prev_extension_order;
                 }
@@ -1294,7 +1294,7 @@ pub const Resolver = struct {
 
                     // If the module "foo" has been marked as external, we also want to treat
                     // paths into that module such as "foo/bar" as external too.
-                    var slash = strings.lastIndexOfChar(query, '/') orelse break;
+                    const slash = strings.lastIndexOfChar(query, '/') orelse break;
                     query = query[0..slash];
                 }
             }
@@ -1493,7 +1493,7 @@ pub const Resolver = struct {
         }
 
         {
-            var dir_info = (r.dirInfoCached(slice) catch null) orelse return null;
+            const dir_info = (r.dirInfoCached(slice) catch null) orelse return null;
             return RootPathPair{
                 .base_path = slice,
                 .package_json = dir_info.package_json orelse return null,
@@ -1563,7 +1563,7 @@ pub const Resolver = struct {
 
         const esm_ = ESModule.Package.parse(import_path, bufs(.esm_subpath));
 
-        var source_dir_info = dir_info;
+        const source_dir_info = dir_info;
         var any_node_modules_folder = false;
         const use_node_module_resolver = global_cache != .force;
 
@@ -1578,7 +1578,7 @@ pub const Resolver = struct {
                 if (r.debug_logs) |*debug| {
                     debug.addNoteFmt("Checking for a package in the directory \"{s}\"", .{abs_path});
                 }
-                var prev_extension_order = r.extension_order;
+                const prev_extension_order = r.extension_order;
                 defer r.extension_order = prev_extension_order;
 
                 if (esm_) |esm| {
@@ -2034,7 +2034,7 @@ pub const Resolver = struct {
 
         // We must initialize it as empty so that the result index is correct.
         // This is important so that browser_scope has a valid index.
-        var dir_info_ptr = r.dir_cache.put(&dir_cache_info_result, .{}) catch unreachable;
+        const dir_info_ptr = r.dir_cache.put(&dir_cache_info_result, .{}) catch unreachable;
 
         try r.dirInfoUncached(
             dir_info_ptr,
@@ -2297,7 +2297,7 @@ pub const Resolver = struct {
             return r.loadNodeModules(import_path, kind, source_dir_info, global_cache, false);
         } else {
             const paths = [_]string{ source_dir_info.abs_path, import_path };
-            var resolved = r.fs.absBuf(&paths, bufs(.resolve_without_remapping));
+            const resolved = r.fs.absBuf(&paths, bufs(.resolve_without_remapping));
             if (r.loadAsFileOrDirectory(resolved, kind)) |result| {
                 return .{ .success = result };
             }
@@ -2390,7 +2390,7 @@ pub const Resolver = struct {
             ) orelse return null;
         }
 
-        var _pkg = try bun.default_allocator.create(PackageJSON);
+        const _pkg = try bun.default_allocator.create(PackageJSON);
         _pkg.* = pkg;
         return _pkg;
     }
@@ -2463,7 +2463,7 @@ pub const Resolver = struct {
         defer rfs.entries_mutex.unlock();
 
         while (!strings.eql(top, root_path)) : (top = Dirname.dirname(top)) {
-            var result = try r.dir_cache.getOrPut(top);
+            const result = try r.dir_cache.getOrPut(top);
 
             if (result.status != .unknown) {
                 top_parent = result;
@@ -2483,7 +2483,7 @@ pub const Resolver = struct {
         }
 
         if (strings.eql(top, root_path)) {
-            var result = try r.dir_cache.getOrPut(root_path);
+            const result = try r.dir_cache.getOrPut(root_path);
             if (result.status != .unknown) {
                 top_parent = result;
             } else {
@@ -2510,7 +2510,7 @@ pub const Resolver = struct {
 
             // Anything
             if (open_dir_count > 0 and (!r.store_fd or r.fs.fs.needToCloseFiles())) {
-                var open_dirs: []std.fs.IterableDir = bufs(.open_dirs)[0..open_dir_count];
+                const open_dirs: []std.fs.IterableDir = bufs(.open_dirs)[0..open_dir_count];
                 for (open_dirs) |*open_dir| {
                     _ = bun.sys.close(bun.toFD(open_dir.dir.fd));
                 }
@@ -2545,7 +2545,7 @@ pub const Resolver = struct {
                 const prev_char = path.ptr[queue_top.unsafe_path.len];
                 path.ptr[queue_top.unsafe_path.len] = 0;
                 defer path.ptr[queue_top.unsafe_path.len] = prev_char;
-                var sentinel = path.ptr[0..queue_top.unsafe_path.len :0];
+                const sentinel = path.ptr[0..queue_top.unsafe_path.len :0];
 
                 if (comptime Environment.isPosix) {
                     _open_dir = std.fs.openIterableDirAbsoluteZ(
@@ -2587,7 +2587,7 @@ pub const Resolver = struct {
                     },
 
                     else => {
-                        var cached_dir_entry_result = rfs.entries.getOrPut(queue_top.unsafe_path) catch unreachable;
+                        const cached_dir_entry_result = rfs.entries.getOrPut(queue_top.unsafe_path) catch unreachable;
                         r.dir_cache.markNotFound(queue_top.result);
                         rfs.entries.markNotFound(cached_dir_entry_result);
                         if (comptime enable_logging) {
@@ -2623,7 +2623,7 @@ pub const Resolver = struct {
                 if (_safe_path == null) {
                     // Now that we've opened the topmost directory successfully, it's reasonable to store the slice.
                     if (path[path.len - 1] != std.fs.path.sep) {
-                        var parts = [_]string{ path, std.fs.path.sep_str };
+                        const parts = [_]string{ path, std.fs.path.sep_str };
                         _safe_path = try r.fs.dirname_store.append(@TypeOf(parts), parts);
                     } else {
                         _safe_path = try r.fs.dirname_store.append(string, path);
@@ -2632,7 +2632,7 @@ pub const Resolver = struct {
 
                 const safe_path = _safe_path.?;
 
-                var dir_path_i = std.mem.indexOf(u8, safe_path, queue_top.unsafe_path) orelse unreachable;
+                const dir_path_i = std.mem.indexOf(u8, safe_path, queue_top.unsafe_path) orelse unreachable;
                 var end = dir_path_i +
                     queue_top.unsafe_path.len;
 
@@ -2688,7 +2688,7 @@ pub const Resolver = struct {
 
             // We must initialize it as empty so that the result index is correct.
             // This is important so that browser_scope has a valid index.
-            var dir_info_ptr = try r.dir_cache.put(&queue_top.result, DirInfo{});
+            const dir_info_ptr = try r.dir_cache.put(&queue_top.result, DirInfo{});
 
             try r.dirInfoUncached(
                 dir_info_ptr,
@@ -2814,7 +2814,7 @@ pub const Resolver = struct {
 
                 // 1. Normalize the base path
                 // so that "/Users/foo/project/", "../components/*" => "/Users/foo/components/""
-                var prefix = r.fs.absBuf(&prefix_parts, bufs(.tsconfig_match_full_buf2));
+                const prefix = r.fs.absBuf(&prefix_parts, bufs(.tsconfig_match_full_buf2));
 
                 // 2. Join the new base path with the matched result
                 // so that "/Users/foo/components/", "/foo/bar" => /Users/foo/components/foo/bar
@@ -2823,7 +2823,7 @@ pub const Resolver = struct {
                     if (total_length != null) std.mem.trimLeft(u8, matched_text, "/") else "",
                     std.mem.trimLeft(u8, longest_match.suffix, "/"),
                 };
-                var absolute_original_path = r.fs.absBuf(
+                const absolute_original_path = r.fs.absBuf(
                     &parts,
                     bufs(.tsconfig_match_full_buf),
                 );
@@ -2987,7 +2987,7 @@ pub const Resolver = struct {
         }
 
         // Normalize the path so we can compare against it without getting confused by "./"
-        var cleaned = r.fs.normalizeBuf(bufs(.check_browser_map), input_path);
+        const cleaned = r.fs.normalizeBuf(bufs(.check_browser_map), input_path);
 
         if (cleaned.len == 1 and cleaned[0] == '.') {
             // No bundler supports remapping ".", so we don't either
@@ -3127,7 +3127,7 @@ pub const Resolver = struct {
         }
 
         const in_str = argument.toBunString(globalThis);
-        var r = &globalThis.bunVM().bundler.resolver;
+        const r = &globalThis.bunVM().bundler.resolver;
         return nodeModulePathsJSValue(r, in_str, globalThis);
     }
 
@@ -3135,7 +3135,7 @@ pub const Resolver = struct {
         bun.JSC.markBinding(@src());
 
         const in_str = bun.String.create(".");
-        var r = &globalThis.bunVM().bundler.resolver;
+        const r = &globalThis.bunVM().bundler.resolver;
         return nodeModulePathsJSValue(r, in_str, globalThis);
     }
 
@@ -3152,7 +3152,7 @@ pub const Resolver = struct {
 
         const str = brk: {
             if (std.fs.path.isAbsolute(sliced.slice())) break :brk sliced.slice();
-            var dir_path_buf = bufs(.node_modules_paths_buf);
+            const dir_path_buf = bufs(.node_modules_paths_buf);
             break :brk r.fs.joinBuf(&[_]string{ r.fs.top_level_dir, sliced.slice() }, dir_path_buf);
         };
         var arena = std.heap.ArenaAllocator.init(bun.default_allocator);
@@ -3205,7 +3205,7 @@ pub const Resolver = struct {
     }
 
     pub fn loadAsIndex(r: *ThisResolver, dir_info: *DirInfo, extension_order: []const string) ?MatchResult {
-        var rfs = &r.fs.fs;
+        const rfs = &r.fs.fs;
         // Try the "index" file with extensions
         for (extension_order) |ext| {
             var ext_buf = bufs(.extension_path);
@@ -3621,11 +3621,11 @@ pub const Resolver = struct {
                                 .path = brk: {
                                     if (query.entry.abs_path.isEmpty()) {
                                         if (query.entry.dir.len > 0 and query.entry.dir[query.entry.dir.len - 1] == std.fs.path.sep) {
-                                            var parts = [_]string{ query.entry.dir, buffer };
+                                            const parts = [_]string{ query.entry.dir, buffer };
                                             query.entry.abs_path = PathString.init(r.fs.filename_store.append(@TypeOf(parts), parts) catch unreachable);
                                             // the trailing path CAN be missing here
                                         } else {
-                                            var parts = [_]string{ query.entry.dir, "/", buffer };
+                                            const parts = [_]string{ query.entry.dir, "/", buffer };
                                             query.entry.abs_path = PathString.init(r.fs.filename_store.append(@TypeOf(parts), parts) catch unreachable);
                                         }
                                     }
@@ -3671,9 +3671,9 @@ pub const Resolver = struct {
         fd: FileDescriptorType,
         package_id: ?Install.PackageID,
     ) anyerror!void {
-        var result = _result;
+        const result = _result;
 
-        var rfs: *Fs.FileSystem.RealFS = &r.fs.fs;
+        const rfs: *Fs.FileSystem.RealFS = &r.fs.fs;
         var entries = _entries.entries;
 
         info.* = DirInfo{
@@ -3710,7 +3710,7 @@ pub const Resolver = struct {
                         const this_dir = std.fs.Dir{ .fd = bun.fdcast(fd) };
                         var file = this_dir.openDirZ(bun.pathLiteral("node_modules/.bin"), .{}, true) catch break :append_bin_dir;
                         defer file.close();
-                        var bin_path = bun.getFdPath(file.fd, bufs(.node_bin_path)) catch break :append_bin_dir;
+                        const bin_path = bun.getFdPath(file.fd, bufs(.node_bin_path)) catch break :append_bin_dir;
                         bin_folders_lock.lock();
                         defer bin_folders_lock.unlock();
 
@@ -3735,7 +3735,7 @@ pub const Resolver = struct {
                             const this_dir = std.fs.Dir{ .fd = bun.fdcast(fd) };
                             var file = this_dir.openDirZ(".bin", .{}, false) catch break :append_bin_dir;
                             defer file.close();
-                            var bin_path = bun.getFdPath(file.fd, bufs(.node_bin_path)) catch break :append_bin_dir;
+                            const bin_path = bun.getFdPath(file.fd, bufs(.node_bin_path)) catch break :append_bin_dir;
                             bin_folders_lock.lock();
                             defer bin_folders_lock.unlock();
 
@@ -3881,10 +3881,10 @@ pub const Resolver = struct {
                     try parent_configs.append(tsconfig_json);
                     var current = tsconfig_json;
                     while (current.extends.len > 0) {
-                        var ts_dir_name = Dirname.dirname(current.abs_path);
+                        const ts_dir_name = Dirname.dirname(current.abs_path);
                         // not sure why this needs cwd but we'll just pass in the dir of the tsconfig...
-                        var abs_path = ResolvePath.joinAbsStringBuf(ts_dir_name, bufs(.tsconfig_path_abs), &[_]string{ ts_dir_name, current.extends }, .auto);
-                        var parent_config_maybe = r.parseTSConfig(abs_path, 0) catch |err| {
+                        const abs_path = ResolvePath.joinAbsStringBuf(ts_dir_name, bufs(.tsconfig_path_abs), &[_]string{ ts_dir_name, current.extends }, .auto);
+                        const parent_config_maybe = r.parseTSConfig(abs_path, 0) catch |err| {
                             r.log.addDebugFmt(null, logger.Loc.Empty, r.allocator, "{s} loading tsconfig.json extends {}", .{
                                 @errorName(err),
                                 strings.QuotedFormatter{

--- a/src/resolver/tsconfig_json.zig
+++ b/src/resolver/tsconfig_json.zig
@@ -165,7 +165,7 @@ pub const TSConfigJSON = struct {
             // https://www.typescriptlang.org/docs/handbook/jsx.html#basic-usages
             if (compiler_opts.expr.asProperty("jsx")) |jsx_prop| {
                 if (jsx_prop.expr.asString(allocator)) |str| {
-                    var str_lower = allocator.alloc(u8, str.len) catch unreachable;
+                    const str_lower = allocator.alloc(u8, str.len) catch unreachable;
                     defer allocator.free(str_lower);
                     _ = strings.copyLowercase(str, str_lower);
                     // - We don't support "preserve" yet
@@ -319,7 +319,7 @@ pub const TSConfigJSON = struct {
             std.debug.assert(result.base_url.len > 0);
         }
 
-        var _result = allocator.create(TSConfigJSON) catch unreachable;
+        const _result = allocator.create(TSConfigJSON) catch unreachable;
         _result.* = result;
 
         if (Environment.isDebug and has_base_url) {

--- a/src/router.zig
+++ b/src/router.zig
@@ -243,7 +243,7 @@ const RouteLoader = struct {
     pub fn appendRoute(this: *RouteLoader, route: Route) void {
         // /index.js
         if (route.full_hash == index_route_hash) {
-            var new_route = this.allocator.create(Route) catch unreachable;
+            const new_route = this.allocator.create(Route) catch unreachable;
             this.index = new_route;
             new_route.* = route;
             this.all_routes.append(this.allocator, new_route) catch unreachable;
@@ -252,7 +252,7 @@ const RouteLoader = struct {
 
         // static route
         if (route.param_count == 0) {
-            var entry = this.static_list.getOrPut(route.match_name.slice()) catch unreachable;
+            const entry = this.static_list.getOrPut(route.match_name.slice()) catch unreachable;
 
             if (entry.found_existing) {
                 const source = Logger.Source.initEmptyFile(route.abs_path.slice());
@@ -266,7 +266,7 @@ const RouteLoader = struct {
                 return;
             }
 
-            var new_route = this.allocator.create(Route) catch unreachable;
+            const new_route = this.allocator.create(Route) catch unreachable;
             new_route.* = route;
 
             // Handle static routes with uppercase characters by ensuring exact case still matches
@@ -277,7 +277,7 @@ const RouteLoader = struct {
             // This hack is below the engineering quality bar I'm happy with.
             // It will cause unexpected behavior.
             if (route.has_uppercase) {
-                var static_entry = this.static_list.getOrPut(route.name[1..]) catch unreachable;
+                const static_entry = this.static_list.getOrPut(route.name[1..]) catch unreachable;
                 if (static_entry.found_existing) {
                     const source = Logger.Source.initEmptyFile(route.abs_path.slice());
                     this.log.addErrorFmt(
@@ -316,7 +316,7 @@ const RouteLoader = struct {
         }
 
         {
-            var new_route = this.allocator.create(Route) catch unreachable;
+            const new_route = this.allocator.create(Route) catch unreachable;
             new_route.* = route;
             this.all_routes.append(this.allocator, new_route) catch unreachable;
         }
@@ -652,9 +652,9 @@ pub const Route = struct {
         else
             entry.abs_path.slice();
 
-        var base = base_[0 .. base_.len - extname.len];
+        const base = base_[0 .. base_.len - extname.len];
 
-        var public_dir = std.mem.trim(u8, public_dir_, "/");
+        const public_dir = std.mem.trim(u8, public_dir_, "/");
 
         // this is a path like
         // "/pages/index.js"
@@ -742,7 +742,7 @@ pub const Route = struct {
                 var parts = [_]string{ entry.dir, entry.base() };
                 abs_path_str = FileSystem.instance.absBuf(&parts, &route_file_buf);
                 route_file_buf[abs_path_str.len] = 0;
-                var buf = route_file_buf[0..abs_path_str.len :0];
+                const buf = route_file_buf[0..abs_path_str.len :0];
                 file = std.fs.openFileAbsoluteZ(buf, .{ .mode = .read_only }) catch |err| {
                     log.addErrorFmt(null, Logger.Loc.Empty, allocator, "{s} opening route: {s}", .{ @errorName(err), abs_path_str }) catch unreachable;
                     return null;
@@ -753,7 +753,7 @@ pub const Route = struct {
                 if (!needs_close) entry.cache.fd = bun.toFD(file.handle);
             }
 
-            var _abs = bun.getFdPath(file.handle, &route_file_buf) catch |err| {
+            const _abs = bun.getFdPath(file.handle, &route_file_buf) catch |err| {
                 log.addErrorFmt(null, Logger.Loc.Empty, allocator, "{s} resolving route: {s}", .{ @errorName(err), abs_path_str }) catch unreachable;
                 return null;
             };
@@ -941,15 +941,15 @@ pub const Test = struct {
         const JSAst = bun.JSAst;
         JSAst.Expr.Data.Store.create(default_allocator);
         JSAst.Stmt.Data.Store.create(default_allocator);
-        var fs = try FileSystem.init(null);
-        var top_level_dir = fs.top_level_dir;
+        const fs = try FileSystem.init(null);
+        const top_level_dir = fs.top_level_dir;
 
         var pages_parts = [_]string{ top_level_dir, "pages" };
-        var pages_dir = try Fs.FileSystem.instance.absAlloc(default_allocator, &pages_parts);
+        const pages_dir = try Fs.FileSystem.instance.absAlloc(default_allocator, &pages_parts);
         // _ = try std.fs.makeDirAbsolute(
         //     pages_dir,
         // );
-        var router = try Router.init(&FileSystem.instance, default_allocator, Options.RouteConfig{
+        const router = try Router.init(&FileSystem.instance, default_allocator, Options.RouteConfig{
             .dir = pages_dir,
             .routes_enabled = true,
             .extensions = &.{"js"},
@@ -961,7 +961,7 @@ pub const Test = struct {
             logger.printForLogLevel(Output.errorWriter()) catch {};
         }
 
-        var opts = Options.BundleOptions{
+        const opts = Options.BundleOptions{
             .resolve_mode = .lazy,
             .target = .browser,
             .loaders = undefined,
@@ -983,7 +983,7 @@ pub const Test = struct {
 
         var resolver = Resolver.init1(default_allocator, &logger, &FileSystem.instance, opts);
 
-        var root_dir = (try resolver.readDirInfo(pages_dir)).?;
+        const root_dir = (try resolver.readDirInfo(pages_dir)).?;
         return RouteLoader.loadAll(default_allocator, opts.routes, &logger, Resolver, &resolver, root_dir);
         // try router.loadRoutes(root_dir, Resolver, &resolver, 0, true);
         // var entry_points = try router.getEntryPoints(default_allocator);
@@ -998,11 +998,11 @@ pub const Test = struct {
         const JSAst = bun.JSAst;
         JSAst.Expr.Data.Store.create(default_allocator);
         JSAst.Stmt.Data.Store.create(default_allocator);
-        var fs = try FileSystem.initWithForce(null, true);
-        var top_level_dir = fs.top_level_dir;
+        const fs = try FileSystem.initWithForce(null, true);
+        const top_level_dir = fs.top_level_dir;
 
         var pages_parts = [_]string{ top_level_dir, "pages" };
-        var pages_dir = try Fs.FileSystem.instance.absAlloc(default_allocator, &pages_parts);
+        const pages_dir = try Fs.FileSystem.instance.absAlloc(default_allocator, &pages_parts);
         // _ = try std.fs.makeDirAbsolute(
         //     pages_dir,
         // );
@@ -1018,7 +1018,7 @@ pub const Test = struct {
             logger.printForLogLevel(Output.errorWriter()) catch {};
         }
 
-        var opts = Options.BundleOptions{
+        const opts = Options.BundleOptions{
             .resolve_mode = .lazy,
             .target = .browser,
             .loaders = undefined,
@@ -1040,7 +1040,7 @@ pub const Test = struct {
 
         var resolver = Resolver.init1(default_allocator, &logger, &FileSystem.instance, opts);
 
-        var root_dir = (try resolver.readDirInfo(pages_dir)).?;
+        const root_dir = (try resolver.readDirInfo(pages_dir)).?;
         try router.loadRoutes(
             &logger,
             root_dir,
@@ -1048,7 +1048,7 @@ pub const Test = struct {
             &resolver,
             FileSystem.instance.top_level_dir,
         );
-        var entry_points = try router.getEntryPoints();
+        const entry_points = try router.getEntryPoints();
 
         try expectEqual(std.meta.fieldNames(@TypeOf(data)).len, entry_points.len);
         return router;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -35,7 +35,7 @@ pub const ErrorCSS = struct {
     pub inline fn sourceContent() string {
         if (comptime Environment.isDebug) {
             var out_buffer: [bun.MAX_PATH_BYTES]u8 = undefined;
-            var dirname = std.fs.selfExeDirPath(&out_buffer) catch unreachable;
+            const dirname = std.fs.selfExeDirPath(&out_buffer) catch unreachable;
             var paths = [_]string{ dirname, BUN_ROOT, content.error_css_path };
             const file = std.fs.cwd().openFile(
                 resolve_path.joinAbsString(dirname, &paths, .auto),
@@ -58,7 +58,7 @@ pub const ErrorJS = struct {
     pub inline fn sourceContent() string {
         if (comptime Environment.isDebug) {
             var out_buffer: [bun.MAX_PATH_BYTES]u8 = undefined;
-            var dirname = std.fs.selfExeDirPath(&out_buffer) catch unreachable;
+            const dirname = std.fs.selfExeDirPath(&out_buffer) catch unreachable;
             var paths = [_]string{ dirname, BUN_ROOT, content.error_js_path };
             const file = std.fs.cwd().openFile(
                 resolve_path.joinAbsString(dirname, &paths, .auto),
@@ -86,7 +86,7 @@ pub const Fallback = struct {
         pub fn format(this: Base64FallbackMessage, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
             var bb = std.ArrayList(u8).init(this.allocator);
             defer bb.deinit();
-            var bb_writer = bb.writer();
+            const bb_writer = bb.writer();
             const Encoder = Schema.Writer(@TypeOf(bb_writer));
             var encoder = Encoder.init(bb_writer);
             this.msg.encode(&encoder) catch {};
@@ -117,7 +117,7 @@ pub const Fallback = struct {
 
     pub inline fn scriptContent() string {
         if (comptime Environment.isDebug) {
-            var dirpath = comptime bun.Environment.base_path ++ std.fs.path.dirname(@src().file).?;
+            const dirpath = comptime bun.Environment.base_path ++ std.fs.path.dirname(@src().file).?;
             var env = std.process.getEnvMap(default_allocator) catch unreachable;
 
             const dir = std.mem.replaceOwned(
@@ -127,7 +127,7 @@ pub const Fallback = struct {
                 "jarred",
                 env.get("USER").?,
             ) catch unreachable;
-            var runtime_path = std.fs.path.join(default_allocator, &[_]string{ dir, "fallback.out.js" }) catch unreachable;
+            const runtime_path = std.fs.path.join(default_allocator, &[_]string{ dir, "fallback.out.js" }) catch unreachable;
             const file = std.fs.openFileAbsolute(runtime_path, .{}) catch return embedDebugFallback(
                 "Missing bun/src/fallback.out.js. " ++ "Please run \"make fallback_decoder\"",
                 ProdSourceContent,
@@ -204,7 +204,7 @@ pub const Runtime = struct {
 
     pub inline fn sourceContentWithoutRefresh() string {
         if (comptime Environment.isDebug) {
-            var dirpath = comptime bun.Environment.base_path ++ std.fs.path.dirname(@src().file).?;
+            const dirpath = comptime bun.Environment.base_path ++ std.fs.path.dirname(@src().file).?;
             var env = std.process.getEnvMap(default_allocator) catch unreachable;
 
             const dir = std.mem.replaceOwned(
@@ -214,7 +214,7 @@ pub const Runtime = struct {
                 "jarred",
                 env.get("USER").?,
             ) catch unreachable;
-            var runtime_path = std.fs.path.join(default_allocator, &[_]string{ dir, "runtime.out.js" }) catch unreachable;
+            const runtime_path = std.fs.path.join(default_allocator, &[_]string{ dir, "runtime.out.js" }) catch unreachable;
             const file = std.fs.openFileAbsolute(runtime_path, .{}) catch return embedDebugFallback(
                 "Missing bun/src/runtime.out.js. " ++ "Please run \"make runtime_js_dev\"",
                 ProdSourceContent,
@@ -241,7 +241,7 @@ pub const Runtime = struct {
 
     pub inline fn sourceContentWithRefresh() string {
         if (comptime Environment.isDebug) {
-            var dirpath = comptime bun.Environment.base_path ++ std.fs.path.dirname(@src().file).?;
+            const dirpath = comptime bun.Environment.base_path ++ std.fs.path.dirname(@src().file).?;
             var env = std.process.getEnvMap(default_allocator) catch unreachable;
 
             const dir = std.mem.replaceOwned(
@@ -251,7 +251,7 @@ pub const Runtime = struct {
                 "jarred",
                 env.get("USER").?,
             ) catch unreachable;
-            var runtime_path = std.fs.path.join(default_allocator, &[_]string{ dir, "runtime.out.refresh.js" }) catch unreachable;
+            const runtime_path = std.fs.path.join(default_allocator, &[_]string{ dir, "runtime.out.refresh.js" }) catch unreachable;
             const file = std.fs.openFileAbsolute(runtime_path, .{}) catch return embedDebugFallback(
                 "Missing bun/src/runtime.out.refresh.js. " ++ "Please run \"make runtime_js_dev\"",
                 ProdSourceContentWithRefresh,

--- a/src/sha.zig
+++ b/src/sha.zig
@@ -201,9 +201,9 @@ const labels = [_][]const u8{
 };
 pub fn main() anyerror!void {
     var file = try std.fs.cwd().openFileZ(bun.argv()[bun.argv().len - 1], .{});
-    var bytes = try file.readToEndAlloc(std.heap.c_allocator, std.math.maxInt(usize));
+    const bytes = try file.readToEndAlloc(std.heap.c_allocator, std.math.maxInt(usize));
 
-    var engine = BoringSSL.ENGINE_new().?;
+    const engine = BoringSSL.ENGINE_new().?;
 
     std.debug.print(
         "Hashing {any:3}\n\n",

--- a/src/sourcemap/CodeCoverage.zig
+++ b/src/sourcemap/CodeCoverage.zig
@@ -133,7 +133,7 @@ pub const CodeCoverageReport = struct {
         writer: anytype,
         comptime enable_colors: bool,
     ) !void {
-        var failing = fraction.*;
+        const failing = fraction.*;
         const fns = report.functionCoverageFraction();
         const lines = report.linesCoverageFraction();
         const stmts = report.stmtsCoverageFraction();
@@ -277,7 +277,7 @@ pub const CodeCoverageReport = struct {
         ignore_sourcemap_: bool,
     ) ?CodeCoverageReport {
         bun.JSC.markBinding(@src());
-        var vm = globalThis.vm();
+        const vm = globalThis.vm();
 
         var result: ?CodeCoverageReport = null;
 
@@ -353,7 +353,7 @@ pub const ByteRangeMapping = struct {
 
         var map_ = map orelse return null;
         const hash = bun.hash(slice.slice());
-        var entry = map_.getPtr(hash) orelse return null;
+        const entry = map_.getPtr(hash) orelse return null;
         return entry;
     }
 
@@ -365,7 +365,7 @@ pub const ByteRangeMapping = struct {
         function_blocks: []const BasicBlockRange,
         ignore_sourcemap: bool,
     ) !CodeCoverageReport {
-        var line_starts = this.line_offset_table.items(.byte_offset_to_start_of_line);
+        const line_starts = this.line_offset_table.items(.byte_offset_to_start_of_line);
 
         var executable_lines: Bitset = Bitset{};
         var lines_which_have_executed: Bitset = Bitset{};

--- a/src/sourcemap/sourcemap.zig
+++ b/src/sourcemap/sourcemap.zig
@@ -154,8 +154,8 @@ pub const Mapping = struct {
         var count = generated.len;
         var index: usize = 0;
         while (count > 0) {
-            var step = count / 2;
-            var i: usize = index + step;
+            const step = count / 2;
+            const i: usize = index + step;
             const mapping = generated[i];
             if (mapping.lines < line or (mapping.lines == line and mapping.columns <= column)) {
                 index = i + 1;
@@ -541,20 +541,20 @@ pub const SourceMapPieces = struct {
                 continue;
             }
 
-            var potential_end_of_run = current;
+            const potential_end_of_run = current;
 
-            var decode_result = decodeVLQ(mappings, current);
+            const decode_result = decodeVLQ(mappings, current);
             generated.columns += decode_result.value;
             current = decode_result.start;
 
-            var potential_start_of_run = current;
+            const potential_start_of_run = current;
 
             current = decodeVLQ(mappings, current).start;
             current = decodeVLQ(mappings, current).start;
             current = decodeVLQ(mappings, current).start;
 
             if (current < mappings.len) {
-                var c = mappings[current];
+                const c = mappings[current];
                 if (c != ',' and c != ';') {
                     current = decodeVLQ(mappings, current).start;
                 }
@@ -574,7 +574,7 @@ pub const SourceMapPieces = struct {
                 continue;
             }
 
-            var shift = shifts[0];
+            const shift = shifts[0];
             if (shift.after.lines != generated.lines) {
                 continue;
             }
@@ -583,7 +583,7 @@ pub const SourceMapPieces = struct {
 
             std.debug.assert(shift.before.lines == shift.after.lines);
 
-            var shift_column_delta = shift.after.columns - shift.before.columns;
+            const shift_column_delta = shift.after.columns - shift.before.columns;
             const encode = encodeVLQ(decode_result.value + shift_column_delta - prev_shift_column_delta);
             j.push(encode.bytes[0..encode.len]);
             prev_shift_column_delta = shift_column_delta;

--- a/src/standalone_bun.zig
+++ b/src/standalone_bun.zig
@@ -74,14 +74,14 @@ pub const StandaloneModuleGraph = struct {
             if (this.* == .decompressed) return &this.decompressed;
 
             var decompressed = try allocator.alloc(u8, bun.zstd.getDecompressedSize(this.compressed));
-            var result = bun.zstd.decompress(decompressed, this.compressed);
+            const result = bun.zstd.decompress(decompressed, this.compressed);
             if (result == .err) {
                 allocator.free(decompressed);
                 log.addError(null, bun.logger.Loc.Empty, bun.span(result.err)) catch unreachable;
                 return error.@"Failed to decompress sourcemap";
             }
             errdefer allocator.free(decompressed);
-            var bytes = decompressed[0..result.success];
+            const bytes = decompressed[0..result.success];
 
             this.* = .{ .decompressed = try bun.sourcemap.parse(allocator, &bun.logger.Source.initPathString("sourcemap.json", bytes), log) };
             return &this.decompressed;
@@ -200,7 +200,7 @@ pub const StandaloneModuleGraph = struct {
                 .contents = string_builder.appendCount(output_file.value.buffer.bytes),
             };
             if (output_file.source_map_index != std.math.maxInt(u32)) {
-                var remaining_slice = string_builder.allocatedSlice()[string_builder.len..];
+                const remaining_slice = string_builder.allocatedSlice()[string_builder.len..];
                 const compressed_result = bun.zstd.compress(remaining_slice, output_files[output_file.source_map_index].value.buffer.bytes, 1);
                 if (compressed_result == .err) {
                     bun.Output.panic("Unexpected error compressing sourcemap: {s}", .{bun.span(compressed_result.err)});
@@ -245,13 +245,13 @@ pub const StandaloneModuleGraph = struct {
 
         const cloned_executable_fd: bun.FileDescriptor = brk: {
             var self_buf: [bun.MAX_PATH_BYTES + 1]u8 = undefined;
-            var self_exe = std.fs.selfExePath(&self_buf) catch |err| {
+            const self_exe = std.fs.selfExePath(&self_buf) catch |err| {
                 Output.prettyErrorln("<r><red>error<r><d>:<r> failed to get self executable path: {s}", .{@errorName(err)});
                 Global.exit(1);
                 return -1;
             };
             self_buf[self_exe.len] = 0;
-            var self_exeZ = self_buf[0..self_exe.len :0];
+            const self_exeZ = self_buf[0..self_exe.len :0];
 
             if (comptime Environment.isMac) {
                 // if we're on a mac, use clonefile() if we can

--- a/src/string.zig
+++ b/src/string.zig
@@ -202,7 +202,7 @@ pub const WTFStringImplStruct = extern struct {
 
 pub const StringImplAllocator = struct {
     fn alloc(ptr: *anyopaque, len: usize, _: u8, _: usize) ?[*]u8 {
-        var this = bun.cast(WTFStringImpl, ptr);
+        const this = bun.cast(WTFStringImpl, ptr);
         const len_ = this.byteLength();
 
         if (len_ != len) {
@@ -226,7 +226,7 @@ pub const StringImplAllocator = struct {
         _: u8,
         _: usize,
     ) void {
-        var this = bun.cast(WTFStringImpl, ptr);
+        const this = bun.cast(WTFStringImpl, ptr);
         std.debug.assert(this.byteSlice().ptr == buf.ptr);
         std.debug.assert(this.byteSlice().len == buf.len);
         this.deref();

--- a/src/string_builder.zig
+++ b/src/string_builder.zig
@@ -28,7 +28,7 @@ pub fn count(this: *StringBuilder, slice: string) void {
 }
 
 pub fn allocate(this: *StringBuilder, allocator: Allocator) !void {
-    var slice = try allocator.alloc(u8, this.cap);
+    const slice = try allocator.alloc(u8, this.cap);
     this.ptr = slice.ptr;
     this.len = 0;
 }
@@ -101,7 +101,7 @@ pub fn fmt(this: *StringBuilder, comptime str: string, args: anytype) string {
         assert(this.ptr != null); // must call allocate first
     }
 
-    var buf = this.ptr.?[this.len..this.cap];
+    const buf = this.ptr.?[this.len..this.cap];
     const out = std.fmt.bufPrint(buf, str, args) catch unreachable;
     this.len += out.len;
 
@@ -116,7 +116,7 @@ pub fn fmtAppendCount(this: *StringBuilder, comptime str: string, args: anytype)
         assert(this.ptr != null); // must call allocate first
     }
 
-    var buf = this.ptr.?[this.len..this.cap];
+    const buf = this.ptr.?[this.len..this.cap];
     const out = std.fmt.bufPrint(buf, str, args) catch unreachable;
     const off = this.len;
     this.len += out.len;

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -188,7 +188,7 @@ pub inline fn indexEqualAny(in: anytype, target: string) ?usize {
 }
 
 pub fn repeatingAlloc(allocator: std.mem.Allocator, count: usize, char: u8) ![]u8 {
-    var buf = try allocator.alloc(u8, count);
+    const buf = try allocator.alloc(u8, count);
     repeatingBuf(buf, char);
     return buf;
 }
@@ -647,16 +647,16 @@ test "eqlComptimeUTF16" {
 
 test "copyLowercase" {
     {
-        var in = "Hello, World!";
+        const in = "Hello, World!";
         var out = std.mem.zeroes([in.len]u8);
-        var out_ = copyLowercase(in, &out);
+        const out_ = copyLowercase(in, &out);
         try std.testing.expectEqualStrings(out_, "hello, world!");
     }
 
     {
-        var in = "_ListCache";
+        const in = "_ListCache";
         var out = std.mem.zeroes([in.len]u8);
-        var out_ = copyLowercase(in, &out);
+        const out_ = copyLowercase(in, &out);
         try std.testing.expectEqualStrings(out_, "_listcache");
     }
 }
@@ -807,7 +807,7 @@ pub fn githubAction(self: string) strings.GithubActionFormatter {
 }
 
 pub fn quotedWriter(writer: anytype, self: string) !void {
-    var remain = self;
+    const remain = self;
     if (strings.containsNewlineOrNonASCIIOrQuote(remain)) {
         try bun.js_printer.writeJSONString(self, @TypeOf(writer), writer, strings.Encoding.utf8);
     } else {
@@ -1156,8 +1156,8 @@ pub inline fn appendUTF8MachineWordToUTF16MachineWord(output: *[@sizeOf(usize) /
 }
 
 pub inline fn copyU8IntoU16(output_: []u16, input_: []const u8) void {
-    var output = output_;
-    var input = input_;
+    const output = output_;
+    const input = input_;
     if (comptime Environment.allow_assert) std.debug.assert(input.len <= output.len);
 
     // https://zig.godbolt.org/z/9rTn1orcY
@@ -1283,8 +1283,8 @@ pub fn copyLatin1IntoASCII(dest: []u8, src: []const u8) void {
     if (to.len >= 16 and bun.Environment.enableSIMD) {
         const vector_size = 16;
         // https://zig.godbolt.org/z/qezsY8T3W
-        var remain_in_u64 = remain[0 .. remain.len - (remain.len % vector_size)];
-        var to_in_u64 = to[0 .. to.len - (to.len % vector_size)];
+        const remain_in_u64 = remain[0 .. remain.len - (remain.len % vector_size)];
+        const to_in_u64 = to[0 .. to.len - (to.len % vector_size)];
         var remain_as_u64 = std.mem.bytesAsSlice(u64, remain_in_u64);
         var to_as_u64 = std.mem.bytesAsSlice(u64, to_in_u64);
         const end_vector_len = @min(remain_as_u64.len, to_as_u64.len);
@@ -1710,7 +1710,7 @@ pub fn toWPathMaybeDir(wbuf: []u16, utf8: []const u8, comptime add_trailing_lash
 
 pub fn convertUTF16ToUTF8(list_: std.ArrayList(u8), comptime Type: type, utf16: Type) !std.ArrayList(u8) {
     var list = list_;
-    var result = bun.simdutf.convert.utf16.to.utf8.with_errors.le(
+    const result = bun.simdutf.convert.utf16.to.utf8.with_errors.le(
         utf16,
         list.items.ptr[0..list.capacity],
     );
@@ -1762,7 +1762,7 @@ pub fn toUTF8FromLatin1(allocator: std.mem.Allocator, latin1: []const u8) !?std.
     if (isAllASCII(latin1))
         return null;
 
-    var list = try std.ArrayList(u8).initCapacity(allocator, latin1.len);
+    const list = try std.ArrayList(u8).initCapacity(allocator, latin1.len);
     return try allocateLatin1IntoUTF8WithList(list, 0, []const u8, latin1);
 }
 
@@ -1823,7 +1823,7 @@ pub fn allocateLatin1IntoUTF8(allocator: std.mem.Allocator, comptime Type: type,
         return out;
     }
 
-    var list = try std.ArrayList(u8).initCapacity(allocator, latin1_.len);
+    const list = try std.ArrayList(u8).initCapacity(allocator, latin1_.len);
     var foo = try allocateLatin1IntoUTF8WithList(list, 0, Type, latin1_);
     return try foo.toOwnedSlice();
 }
@@ -2358,7 +2358,7 @@ pub fn escapeHTMLForLatin1Input(allocator: std.mem.Allocator, latin1: []const u8
                 return .{ .original = {} };
             }
 
-            var output = allo.alloc(u8, total) catch unreachable;
+            const output = allo.alloc(u8, total) catch unreachable;
             var head = output.ptr;
             inline for (comptime bun.range(0, len)) |i| {
                 head += @This().append(head, chars[i]);
@@ -2745,7 +2745,7 @@ pub fn escapeHTMLForUTF16Input(allocator: std.mem.Allocator, utf16: []const u16)
 
                         if (comptime Environment.allow_assert) std.debug.assert(@intFromPtr(remaining.ptr + i) >= @intFromPtr(utf16.ptr));
                         const to_copy = std.mem.sliceAsBytes(utf16)[0 .. @intFromPtr(remaining.ptr + i) - @intFromPtr(utf16.ptr)];
-                        var to_copy_16 = std.mem.bytesAsSlice(u16, to_copy);
+                        const to_copy_16 = std.mem.bytesAsSlice(u16, to_copy);
                         buf = try std.ArrayList(u16).initCapacity(allocator, utf16.len + 6);
                         try buf.appendSlice(to_copy_16);
 
@@ -2858,7 +2858,7 @@ pub fn escapeHTMLForUTF16Input(allocator: std.mem.Allocator, utf16: []const u16)
                             if (comptime Environment.allow_assert) std.debug.assert(@intFromPtr(ptr) >= @intFromPtr(utf16.ptr));
 
                             const to_copy = std.mem.sliceAsBytes(utf16)[0 .. @intFromPtr(ptr) - @intFromPtr(utf16.ptr)];
-                            var to_copy_16 = std.mem.bytesAsSlice(u16, to_copy);
+                            const to_copy_16 = std.mem.bytesAsSlice(u16, to_copy);
                             try buf.appendSlice(to_copy_16);
                             any_needs_escape = true;
                             break :scan_and_allocate_lazily;
@@ -2921,7 +2921,7 @@ pub fn escapeHTMLForUTF16Input(allocator: std.mem.Allocator, utf16: []const u16)
 }
 
 test "copyLatin1IntoUTF8 - ascii" {
-    var input: string = "hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!";
+    const input: string = "hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!hello world!";
     var output = std.mem.zeroes([500]u8);
     const result = copyLatin1IntoUTF8(&output, string, input);
     try std.testing.expectEqual(input.len, result.read);
@@ -2932,9 +2932,9 @@ test "copyLatin1IntoUTF8 - ascii" {
 
 test "copyLatin1IntoUTF8 - latin1" {
     {
-        var input: string = &[_]u8{ 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 32, 169 };
+        const input: string = &[_]u8{ 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 32, 169 };
         var output = std.mem.zeroes([500]u8);
-        var expected = "hello world ©";
+        const expected = "hello world ©";
         const result = copyLatin1IntoUTF8(&output, string, input);
         try std.testing.expectEqual(input.len, result.read);
 
@@ -2942,9 +2942,9 @@ test "copyLatin1IntoUTF8 - latin1" {
     }
 
     {
-        var input: string = &[_]u8{ 72, 169, 101, 108, 108, 169, 111, 32, 87, 111, 114, 169, 108, 100, 33 };
+        const input: string = &[_]u8{ 72, 169, 101, 108, 108, 169, 111, 32, 87, 111, 114, 169, 108, 100, 33 };
         var output = std.mem.zeroes([500]u8);
-        var expected = "H©ell©o Wor©ld!";
+        const expected = "H©ell©o Wor©ld!";
         const result = copyLatin1IntoUTF8(&output, string, input);
         try std.testing.expectEqual(input.len, result.read);
 
@@ -3878,7 +3878,7 @@ pub fn encodeBytesToHex(destination: []u8, source: []const u8) usize {
     var remaining = source[0..to_read];
     var remaining_dest = destination;
     if (comptime Environment.enableSIMD) {
-        var remaining_end = remaining.ptr + remaining.len - (remaining.len % 16);
+        const remaining_end = remaining.ptr + remaining.len - (remaining.len % 16);
         while (remaining.ptr != remaining_end) {
             const input_chunk: @Vector(16, u8) = remaining[0..16].*;
             const input_chunk_4: @Vector(16, u8) = input_chunk >> @as(@Vector(16, u8), @splat(@as(u8, 4)));
@@ -3952,11 +3952,11 @@ test "decodeHexToBytes" {
         buffer[i] = @as(u8, @truncate(i % 256));
     }
     var written: [2048]u8 = undefined;
-    var hex = std.fmt.bufPrint(&written, "{}", .{std.fmt.fmtSliceHexLower(&buffer)}) catch unreachable;
+    const hex = std.fmt.bufPrint(&written, "{}", .{std.fmt.fmtSliceHexLower(&buffer)}) catch unreachable;
     var good: [4096]u8 = undefined;
     var ours_buf: [4096]u8 = undefined;
-    var match = try std.fmt.hexToBytes(good[0..1024], hex);
-    var ours = decodeHexToBytes(&ours_buf, u8, hex);
+    const match = try std.fmt.hexToBytes(good[0..1024], hex);
+    const ours = decodeHexToBytes(&ours_buf, u8, hex);
     try std.testing.expectEqualSlices(u8, match, ours_buf[0..ours]);
     try std.testing.expectEqualSlices(u8, &buffer, ours_buf[0..ours]);
 }
@@ -3989,7 +3989,7 @@ pub fn firstNonASCII16(comptime Slice: type, slice: Slice) ?u32 {
 /// The final element is the end index of the desired line
 pub fn indexOfLineNumber(text: []const u8, line: u32, comptime line_range_count: usize) ?[line_range_count + 1]u32 {
     var ranges = std.mem.zeroes([line_range_count + 1]u32);
-    var remaining = text;
+    const remaining = text;
     if (remaining.len == 0 or line == 0) return null;
 
     var iter = CodepointIterator.init(text);
@@ -4398,7 +4398,7 @@ pub fn containsNonBmpCodePointUTF16(_text: []const u16) bool {
     const n = _text.len;
     if (n > 0) {
         var i: usize = 0;
-        var text = _text[0 .. n - 1];
+        const text = _text[0 .. n - 1];
         while (i < n - 1) : (i += 1) {
             switch (text[i]) {
                 // Check for a high surrogate
@@ -4875,9 +4875,9 @@ pub fn moveSlice(slice: string, from: string, to: string) string {
 
 test "moveSlice" {
     var input: string = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz";
-    var cloned = try std.heap.page_allocator.dupe(u8, input);
+    const cloned = try std.heap.page_allocator.dupe(u8, input);
 
-    var slice = input[20..][0..10];
+    const slice = input[20..][0..10];
 
     try std.testing.expectEqual(eqlLong(moveSlice(slice, input, cloned), slice, false), true);
 }
@@ -4893,7 +4893,7 @@ test "moveAllSlices" {
     var move = Move{ .foo = input[20..], .bar = input[30..], .baz = input[10..20], .wrong = "baz" };
     var cloned = try std.heap.page_allocator.dupe(u8, input);
     moveAllSlices(Move, &move, input, cloned);
-    var expected = Move{ .foo = cloned[20..], .bar = cloned[30..], .baz = cloned[10..20], .wrong = "bar" };
+    const expected = Move{ .foo = cloned[20..], .bar = cloned[30..], .baz = cloned[10..20], .wrong = "bar" };
     try std.testing.expectEqual(move.foo.ptr, expected.foo.ptr);
     try std.testing.expectEqual(move.bar.ptr, expected.bar.ptr);
     try std.testing.expectEqual(move.baz.ptr, expected.baz.ptr);
@@ -4904,7 +4904,7 @@ test "moveAllSlices" {
 }
 
 test "join" {
-    var string_list = &[_]string{ "abc", "def", "123", "hello" };
+    const string_list = &[_]string{ "abc", "def", "123", "hello" };
     const list = try join(string_list, "-", std.heap.page_allocator);
     try std.testing.expectEqualStrings("abc-def-123-hello", list);
 }
@@ -4912,9 +4912,9 @@ test "join" {
 test "sortAsc" {
     var string_list = [_]string{ "abc", "def", "123", "hello" };
     var sorted_string_list = [_]string{ "123", "abc", "def", "hello" };
-    var sorted_join = try join(&sorted_string_list, "-", std.heap.page_allocator);
+    const sorted_join = try join(&sorted_string_list, "-", std.heap.page_allocator);
     sortAsc(&string_list);
-    var string_join = try join(&string_list, "-", std.heap.page_allocator);
+    const string_join = try join(&string_list, "-", std.heap.page_allocator);
 
     try std.testing.expectEqualStrings(sorted_join, string_join);
 }
@@ -4922,9 +4922,9 @@ test "sortAsc" {
 test "sortDesc" {
     var string_list = [_]string{ "abc", "def", "123", "hello" };
     var sorted_string_list = [_]string{ "hello", "def", "abc", "123" };
-    var sorted_join = try join(&sorted_string_list, "-", std.heap.page_allocator);
+    const sorted_join = try join(&sorted_string_list, "-", std.heap.page_allocator);
     sortDesc(&string_list);
-    var string_join = try join(&string_list, "-", std.heap.page_allocator);
+    const string_join = try join(&string_list, "-", std.heap.page_allocator);
 
     try std.testing.expectEqualStrings(sorted_join, string_join);
 }
@@ -4955,7 +4955,7 @@ pub fn isIPAddress(input: []const u8) bool {
     @memcpy(max_ip_address_buffer[0..input.len], input);
     max_ip_address_buffer[input.len] = 0;
 
-    var ip_addr_str: [:0]const u8 = max_ip_address_buffer[0..input.len :0];
+    const ip_addr_str: [:0]const u8 = max_ip_address_buffer[0..input.len :0];
 
     return bun.c_ares.ares_inet_pton(std.os.AF.INET, ip_addr_str.ptr, &sockaddr) != 0 or bun.c_ares.ares_inet_pton(std.os.AF.INET6, ip_addr_str.ptr, &sockaddr) != 0;
 }
@@ -4969,7 +4969,7 @@ pub fn isIPV6Address(input: []const u8) bool {
     @memcpy(max_ip_address_buffer[0..input.len], input);
     max_ip_address_buffer[input.len] = 0;
 
-    var ip_addr_str: [:0]const u8 = max_ip_address_buffer[0..input.len :0];
+    const ip_addr_str: [:0]const u8 = max_ip_address_buffer[0..input.len :0];
     return bun.c_ares.ares_inet_pton(std.os.AF.INET6, ip_addr_str.ptr, &sockaddr) != 0;
 }
 
@@ -4978,7 +4978,7 @@ pub fn cloneNormalizingSeparators(
     input: []const u8,
 ) ![]u8 {
     // remove duplicate slashes in the file path
-    var base = withoutTrailingSlash(input);
+    const base = withoutTrailingSlash(input);
     var tokenized = std.mem.tokenize(u8, base, std.fs.path.sep_str);
     var buf = try allocator.alloc(u8, base.len + 2);
     if (comptime Environment.allow_assert) std.debug.assert(base.len > 0);
@@ -5036,7 +5036,7 @@ pub fn concatWithLength(
     args: []const string,
     length: usize,
 ) !string {
-    var out = try allocator.alloc(u8, length);
+    const out = try allocator.alloc(u8, length);
     var remain = out;
     for (args) |arg| {
         @memcpy(remain[0..arg.len], arg);
@@ -5088,7 +5088,7 @@ pub fn concatIfNeeded(
     }
 
     const is_needed = brk: {
-        var out = dest.*;
+        const out = dest.*;
         var remain = out;
 
         for (args) |arg| {

--- a/src/string_joiner.zig
+++ b/src/string_joiner.zig
@@ -34,7 +34,7 @@ pub const Watcher = struct {
 
 pub fn done(this: *Joiner, allocator: Allocator) ![]u8 {
     if (this.head == null) {
-        var out: []u8 = &[_]u8{};
+        const out: []u8 = &[_]u8{};
         return out;
     }
 
@@ -122,7 +122,7 @@ pub fn append(this: *Joiner, slice: string, offset: u32, allocator: ?Allocator) 
     const data = slice[offset..];
     this.len += @as(u32, @truncate(data.len));
 
-    var new_tail = if (this.use_pool)
+    const new_tail = if (this.use_pool)
         Joinable.Pool.get(default_allocator)
     else
         (this.node_allocator.create(Joinable.Pool.Node) catch unreachable);

--- a/src/string_mutable.zig
+++ b/src/string_mutable.zig
@@ -317,7 +317,7 @@ pub const MutableString = struct {
         }
 
         pub fn writeAll(this: *BufferedWriter, bytes: []const u8) anyerror!usize {
-            var pending = bytes;
+            const pending = bytes;
 
             if (pending.len >= max) {
                 try this.flush();
@@ -353,7 +353,7 @@ pub const MutableString = struct {
         /// This automatically encodes UTF-16 into UTF-8 using
         /// the same code path as TextEncoder
         pub fn writeAll16(this: *BufferedWriter, bytes: []const u16) anyerror!usize {
-            var pending = bytes;
+            const pending = bytes;
 
             if (pending.len >= max) {
                 try this.flush();

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1491,7 +1491,7 @@ pub fn setFileOffset(fd: bun.FileDescriptor, offset: usize) Maybe(void) {
 
 pub fn dup(fd: bun.FileDescriptor) Maybe(bun.FileDescriptor) {
     if (comptime Environment.isWindows) {
-        var target: *windows.HANDLE = undefined;
+        const target: *windows.HANDLE = undefined;
         const process = kernel32.GetCurrentProcess();
         const out = kernel32.DuplicateHandle(
             process,

--- a/src/tagged_pointer.zig
+++ b/src/tagged_pointer.zig
@@ -101,7 +101,7 @@ pub fn TaggedPointerUnion(comptime Types: anytype) type {
 
         const This = @This();
         fn assert_type(comptime Type: type) void {
-            var name = comptime typeBaseName(@typeName(Type));
+            const name = comptime typeBaseName(@typeName(Type));
             if (!comptime @hasField(Tag, name)) {
                 @compileError("TaggedPointerUnion does not have " ++ name ++ ".");
             }
@@ -185,7 +185,7 @@ test "TaggedPointerUnion" {
     //     wrong: bool = true,
     // };
     const Union = TaggedPointerUnion(.{ IntPrimitive, StringPrimitive, Object });
-    var str = try default_allocator.create(StringPrimitive);
+    const str = try default_allocator.create(StringPrimitive);
     str.* = StringPrimitive{ .val = "hello!" };
     var un = Union.init(str);
     try std.testing.expect(un.is(StringPrimitive));
@@ -231,7 +231,7 @@ test "TaggedPointer" {
         const what = try std.fmt.allocPrint(default_allocator, "hiiii {d}", .{i});
         hello_struct_ptr.* = Hello{ .what = what };
         try std.testing.expectEqualStrings(TaggedPointer.from(TaggedPointer.init(hello_struct_ptr, i).to()).get(Hello).what, what);
-        var this = TaggedPointer.from(TaggedPointer.init(hello_struct_ptr, i).to());
+        const this = TaggedPointer.from(TaggedPointer.init(hello_struct_ptr, i).to());
         try std.testing.expect(this.data == i);
         try std.testing.expect(this.data != i + 1);
     }

--- a/src/test/tester.zig
+++ b/src/test/tester.zig
@@ -36,7 +36,7 @@ pub const Tester = struct {
         }
         const PADDING = 0;
         pub fn print(self: *const @This()) void {
-            var pad = &([_]u8{' '} ** PADDING);
+            const pad = &([_]u8{' '} ** PADDING);
             var stderr = std.io.getStdErr();
 
             stderr.writeAll(RESET) catch unreachable;

--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -93,7 +93,7 @@ pub const Batch = struct {
         if (len == 0) {
             return null;
         }
-        var task = this.head.?;
+        const task = this.head.?;
         if (task.node.next) |node| {
             this.head = @fieldParentPtr(Task, "node", node);
         } else {
@@ -227,7 +227,7 @@ pub fn ConcurrentFunction(
             task: Task = .{ .callback = callback },
 
             pub fn callback(task: *Task) void {
-                var routine = @fieldParentPtr(@This(), "task", task);
+                const routine = @fieldParentPtr(@This(), "task", task);
                 @call(.always_inline, Fn, routine.args);
             }
         };
@@ -320,7 +320,7 @@ pub fn Do(
             runner_task.ctx.wait_group.finish();
         }
     };
-    var wait_context = allocator.create(WaitContext) catch unreachable;
+    const wait_context = allocator.create(WaitContext) catch unreachable;
     wait_context.* = .{
         .ctx = ctx,
         .wait_group = wait_group,
@@ -360,8 +360,8 @@ pub fn Do(
 test "parallel for loop" {
     Output.initTest();
     var thread_pool = ThreadPool.init(.{ .max_threads = 12 });
-    var sleepy_time: u32 = 100;
-    var huge_array = &[_]u32{
+    const sleepy_time: u32 = 100;
+    const huge_array = &[_]u32{
         sleepy_time + std.rand.DefaultPrng.init(1).random().uintAtMost(u32, 20),
         sleepy_time + std.rand.DefaultPrng.init(2).random().uintAtMost(u32, 20),
         sleepy_time + std.rand.DefaultPrng.init(3).random().uintAtMost(u32, 20),
@@ -392,7 +392,7 @@ test "parallel for loop" {
             std.debug.assert(ctx.completed <= ctx.total);
         }
     };
-    var runny = try std.heap.page_allocator.create(Runner);
+    const runny = try std.heap.page_allocator.create(Runner);
     runny.* = .{ .total = huge_array.len };
     try thread_pool.doAndWait(std.heap.page_allocator, null, runny, Runner.run, std.mem.span(huge_array));
     try std.testing.expectEqual(huge_array.len, runny.completed);
@@ -1103,11 +1103,11 @@ pub const Node = struct {
 
         fn pop(self: *Buffer) ?*Node {
             var head = self.head.load(.Monotonic);
-            var tail = self.tail.loadUnchecked(); // we're the only thread that can change this
+            const tail = self.tail.loadUnchecked(); // we're the only thread that can change this
 
             while (true) {
                 // Quick sanity check and return null when not empty
-                var size = tail -% head;
+                const size = tail -% head;
                 assert(size <= capacity);
                 if (size == 0) {
                     return null;

--- a/src/toml/toml_lexer.zig
+++ b/src/toml/toml_lexer.zig
@@ -180,7 +180,7 @@ pub const Lexer = struct {
 
     fn parseNumericLiteralOrDot(lexer: *Lexer) !void {
         // Number or dot;
-        var first = lexer.code_point;
+        const first = lexer.code_point;
         lexer.step();
 
         // Dot without a digit after it;
@@ -295,11 +295,11 @@ pub const Lexer = struct {
                 isFirst = false;
             }
 
-            var isBigIntegerLiteral = lexer.code_point == 'n' and !hasDotOrExponent;
+            const isBigIntegerLiteral = lexer.code_point == 'n' and !hasDotOrExponent;
 
             // Slow path: do we need to re-scan the input as text?
             if (isBigIntegerLiteral or isInvalidLegacyOctalLiteral) {
-                var text = lexer.raw();
+                const text = lexer.raw();
 
                 // Can't use a leading zero for bigint literals;
                 if (isBigIntegerLiteral and is_legacy_octal_literal) {
@@ -331,7 +331,7 @@ pub const Lexer = struct {
             }
         } else {
             // Floating-point literal;
-            var isInvalidLegacyOctalLiteral = first == '0' and (lexer.code_point == '8' or lexer.code_point == '9');
+            const isInvalidLegacyOctalLiteral = first == '0' and (lexer.code_point == '8' or lexer.code_point == '9');
 
             // Initial digits;
             while (true) {

--- a/src/toml/toml_parser.zig
+++ b/src/toml/toml_parser.zig
@@ -60,7 +60,7 @@ const HashMapPool = struct {
             }
         }
 
-        var new_node = default_allocator.create(LinkedList.Node) catch unreachable;
+        const new_node = default_allocator.create(LinkedList.Node) catch unreachable;
         new_node.* = LinkedList.Node{ .data = HashMap.initContext(default_allocator, IdentityContext{}) };
         return new_node;
     }
@@ -149,7 +149,7 @@ pub const TOML = struct {
 
     pub fn parseKey(p: *TOML, allocator: std.mem.Allocator) anyerror!*Rope {
         var rope = try allocator.create(Rope);
-        var head = rope;
+        const head = rope;
         rope.* = .{
             .head = (try p.parseKeySegment()) orelse {
                 try p.lexer.expectedString("key");
@@ -185,7 +185,7 @@ pub const TOML = struct {
         var head = root.data.e_object;
 
         var stack = std.heap.stackFallback(@sizeOf(Rope) * 6, p.allocator);
-        var key_allocator = stack.get();
+        const key_allocator = stack.get();
 
         while (true) {
             const loc = p.lexer.loc();
@@ -196,14 +196,14 @@ pub const TOML = struct {
                 // child table
                 .t_open_bracket => {
                     try p.lexer.next();
-                    var key = try p.parseKey(key_allocator);
+                    const key = try p.parseKey(key_allocator);
 
                     try p.lexer.expect(.t_close_bracket);
                     if (!p.lexer.has_newline_before) {
                         try p.lexer.expectedString("line break");
                     }
 
-                    var parent_object = root.data.e_object.getOrPutObject(key, p.allocator) catch |err| {
+                    const parent_object = root.data.e_object.getOrPutObject(key, p.allocator) catch |err| {
                         switch (err) {
                             error.Clobber => {
                                 try p.lexer.addDefaultError("Table already defined");
@@ -219,7 +219,7 @@ pub const TOML = struct {
                 .t_open_bracket_double => {
                     try p.lexer.next();
 
-                    var key = try p.parseKey(key_allocator);
+                    const key = try p.parseKey(key_allocator);
 
                     try p.lexer.expect(.t_close_bracket_double);
                     if (!p.lexer.has_newline_before) {
@@ -235,7 +235,7 @@ pub const TOML = struct {
                             else => return err,
                         }
                     };
-                    var new_head = p.e(E.Object{}, loc);
+                    const new_head = p.e(E.Object{}, loc);
                     try array.data.e_array.push(p.allocator, new_head);
                     head = new_head.data.e_object;
                     stack.fixed_buffer_allocator.reset();
@@ -250,7 +250,7 @@ pub const TOML = struct {
 
     pub fn parseAssignment(p: *TOML, obj: *E.Object, allocator: std.mem.Allocator) anyerror!void {
         p.lexer.allow_double_bracket = false;
-        var rope = try p.parseKey(allocator);
+        const rope = try p.parseKey(allocator);
 
         const is_array = p.lexer.token == .t_empty_array;
         if (is_array) {
@@ -292,13 +292,13 @@ pub const TOML = struct {
                 }, loc);
             },
             .t_string_literal => {
-                var str: E.String = p.lexer.toEString();
+                const str: E.String = p.lexer.toEString();
 
                 try p.lexer.next();
                 return p.e(str, loc);
             },
             .t_identifier => {
-                var str: E.String = E.String{ .data = p.lexer.identifier };
+                const str: E.String = E.String{ .data = p.lexer.identifier };
 
                 try p.lexer.next();
                 return p.e(str, loc);
@@ -326,9 +326,9 @@ pub const TOML = struct {
                 try p.lexer.next();
                 var is_single_line = !p.lexer.has_newline_before;
                 var stack = std.heap.stackFallback(@sizeOf(Rope) * 6, p.allocator);
-                var key_allocator = stack.get();
-                var expr = p.e(E.Object{}, loc);
-                var obj = expr.data.e_object;
+                const key_allocator = stack.get();
+                const expr = p.e(E.Object{}, loc);
+                const obj = expr.data.e_object;
 
                 while (p.lexer.token != .t_close_brace) {
                     if (obj.properties.len > 0) {
@@ -361,7 +361,7 @@ pub const TOML = struct {
             .t_open_bracket => {
                 try p.lexer.next();
                 var is_single_line = !p.lexer.has_newline_before;
-                var array_ = p.e(E.Array{}, loc);
+                const array_ = p.e(E.Array{}, loc);
                 var array = array_.data.e_array;
                 const allocator = p.allocator;
                 p.lexer.allow_double_bracket = false;

--- a/src/url.zig
+++ b/src/url.zig
@@ -521,7 +521,7 @@ pub const QueryStringMap = struct {
             this.i += 1;
 
             var remainder_hashes = slice.items(.name_hash)[this.i..];
-            var remainder_values = slice.items(.value)[this.i..];
+            const remainder_values = slice.items(.value)[this.i..];
 
             var target_i: usize = 1;
             var current_i: usize = 0;
@@ -647,7 +647,7 @@ pub const QueryStringMap = struct {
             try writer.writeAll(name_slice);
             buf_writer_pos += @as(u32, @truncate(name_slice.len));
 
-            var name_hash: u64 = bun.hash(name_slice);
+            const name_hash: u64 = bun.hash(name_slice);
 
             value.length = PercentEncoding.decode(Writer, writer, result.rawValue(scanner.pathname.pathname)) catch continue;
             value.offset = buf_writer_pos;
@@ -733,8 +733,8 @@ pub const QueryStringMap = struct {
                 if (Environment.allow_assert) std.debug.assert(!result.name_needs_decoding);
                 if (Environment.allow_assert) std.debug.assert(!result.value_needs_decoding);
 
-                var name = result.name;
-                var value = result.value;
+                const name = result.name;
+                const value = result.value;
                 const name_hash: u64 = bun.hash(result.rawName(query_string));
                 list.appendAssumeCapacity(Param{ .name = name, .value = value, .name_hash = name_hash });
             }
@@ -748,7 +748,7 @@ pub const QueryStringMap = struct {
         }
 
         var buf = try std.ArrayList(u8).initCapacity(allocator, estimated_str_len);
-        var writer = buf.writer();
+        const writer = buf.writer();
         var buf_writer_pos: u32 = 0;
 
         var list_slice = list.slice();
@@ -896,7 +896,7 @@ pub const FormData = struct {
         allocator: std.mem.Allocator,
 
         pub fn init(allocator: std.mem.Allocator, encoding: Encoding) !*AsyncFormData {
-            var this = try allocator.create(AsyncFormData);
+            const this = try allocator.create(AsyncFormData);
             this.* = AsyncFormData{
                 .encoding = switch (encoding) {
                     .Multipart => .{
@@ -1052,7 +1052,7 @@ pub const FormData = struct {
     ) !JSC.JSValue {
         const form_data_value = JSC.DOMFormData.create(globalThis);
         form_data_value.ensureStillAlive();
-        var form = JSC.DOMFormData.fromJS(form_data_value) orelse {
+        const form = JSC.DOMFormData.fromJS(form_data_value) orelse {
             log("failed to create DOMFormData.fromJS", .{});
             return error.@"failed to parse multipart data";
         };
@@ -1061,11 +1061,11 @@ pub const FormData = struct {
             form: *JSC.DOMFormData,
 
             pub fn onEntry(wrap: *@This(), name: bun.Semver.String, field: Field, buf: []const u8) void {
-                var value_str = field.value.slice(buf);
+                const value_str = field.value.slice(buf);
                 var key = JSC.ZigString.initUTF8(name.slice(buf));
 
                 if (field.is_file) {
-                    var filename_str = field.filename.slice(buf);
+                    const filename_str = field.filename.slice(buf);
 
                     var blob = JSC.WebCore.Blob.create(value_str, bun.default_allocator, wrap.globalThis, false);
                     defer blob.detach();
@@ -1376,7 +1376,7 @@ pub const Scanner = struct {
         loop: while (true) {
             if (this.i >= this.query_string.len) return null;
 
-            var slice = this.query_string[this.i..];
+            const slice = this.query_string[this.i..];
             relative_i = 0;
             var name = Api.StringPointer{ .offset = @as(u32, @truncate(this.i)), .length = 0 };
             var value = Api.StringPointer{ .offset = 0, .length = 0 };
@@ -1514,7 +1514,7 @@ test "PercentEncoding.decode" {
     @memset(&buffer, 0);
 
     var stream = std.io.fixedBufferStream(&buffer);
-    var writer = stream.writer();
+    const writer = stream.writer();
     const Writer = @TypeOf(writer);
 
     {
@@ -1649,7 +1649,7 @@ test "QueryStringMap Iterator" {
     var map = (try QueryStringMap.init(std.testing.allocator, url)) orelse return try std.testing.expect(false);
     defer map.deinit();
     var buf_: [48]string = undefined;
-    var buf = buf_[0..48];
+    const buf = buf_[0..48];
     var iter = map.iter();
 
     var result: QueryStringMap.Iterator.Result = iter.next(buf) orelse return try expect(false);

--- a/src/util.zig
+++ b/src/util.zig
@@ -235,7 +235,7 @@ pub fn fromSlice(
         }
 
         if (comptime std.meta.trait.isIndexable(DefaultType) and (std.meta.trait.isSlice(DefaultType) or std.meta.trait.is(.Array)(DefaultType))) {
-            var in = std.mem.sliceAsBytes(default);
+            const in = std.mem.sliceAsBytes(default);
             var out = std.mem.sliceAsBytes(slice);
             @memcpy(out[0..in.len], in);
         } else {
@@ -260,7 +260,7 @@ pub fn Batcher(comptime Type: type) type {
         head: []Type,
 
         pub fn init(allocator: std.mem.Allocator, count: usize) !@This() {
-            var all = try allocator.alloc(Type, count);
+            const all = try allocator.alloc(Type, count);
             return @This(){ .head = all };
         }
 
@@ -281,7 +281,7 @@ pub fn Batcher(comptime Type: type) type {
 
         pub inline fn next(this: *@This(), values: anytype) []Type {
             this.head[0..values.len].* = values;
-            var prev = this.head[0..values.len];
+            const prev = this.head[0..values.len];
             this.head = this.head[values.len..];
             return prev;
         }

--- a/src/walker_skippable.zig
+++ b/src/walker_skippable.zig
@@ -147,7 +147,7 @@ pub fn walk(
         skip_names[skip_name_i] = bun.hashWithSeed(seed, name);
         skip_name_i += 1;
     }
-    var skip_filenames_ = skip_names[0..skip_name_i];
+    const skip_filenames_ = skip_names[0..skip_name_i];
     var skip_dirnames_ = skip_names[skip_name_i..];
 
     for (skip_dirnames, 0..) |name, i| {

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -186,7 +186,7 @@ pub const INotify = struct {
                     var i: u32 = 0;
                     while (i < len) : (i += @sizeOf(INotifyEvent)) {
                         @setRuntimeSafety(false);
-                        var event = @as(*INotifyEvent, @ptrCast(@alignCast(eventlist[i..][0..@sizeOf(INotifyEvent)])));
+                        const event = @as(*INotifyEvent, @ptrCast(@alignCast(eventlist[i..][0..@sizeOf(INotifyEvent)])));
                         i += event.name_len;
 
                         eventlist_ptrs[count] = event;
@@ -382,7 +382,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
         }
 
         pub fn init(ctx: ContextType, fs: *Fs.FileSystem, allocator: std.mem.Allocator) !*Watcher {
-            var watcher = try allocator.create(Watcher);
+            const watcher = try allocator.create(Watcher);
             errdefer allocator.destroy(watcher);
 
             if (comptime bun.Environment.isWindows) {
@@ -508,7 +508,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
             );
 
             var slice = this.watchlist.slice();
-            var fds = slice.items(.fd);
+            const fds = slice.items(.fd);
             var last_item = NoWatchItem;
 
             for (evict_list[0..evict_list_i]) |item| {
@@ -772,7 +772,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
                 // bun.copy(u8, &buf, file_path_to_use_);
                 // buf[file_path_to_use_.len] = 0;
                 var buf = file_path_.ptr;
-                var slice: [:0]const u8 = buf[0..file_path_.len :0];
+                const slice: [:0]const u8 = buf[0..file_path_.len :0];
                 index = try INotify.watchPath(slice);
             }
 
@@ -849,11 +849,11 @@ pub fn NewWatcher(comptime ContextType: type) type {
                     null,
                 );
             } else if (Environment.isLinux) {
-                var file_path_to_use_ = std.mem.trimRight(u8, file_path_, "/");
+                const file_path_to_use_ = std.mem.trimRight(u8, file_path_, "/");
                 var buf: [bun.MAX_PATH_BYTES + 1]u8 = undefined;
                 bun.copy(u8, &buf, file_path_to_use_);
                 buf[file_path_to_use_.len] = 0;
-                var slice: [:0]u8 = buf[0..file_path_to_use_.len :0];
+                const slice: [:0]u8 = buf[0..file_path_to_use_.len :0];
                 index = try INotify.watchDir(slice);
             }
 
@@ -911,7 +911,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
             const pathname = Fs.PathName.init(file_path);
 
             const parent_dir = pathname.dirWithTrailingSlash();
-            var parent_dir_hash: HashType = Watcher.getHash(parent_dir);
+            const parent_dir_hash: HashType = Watcher.getHash(parent_dir);
 
             var parent_watch_item: ?WatchItemIndex = null;
             const autowatch_parent_dir = (comptime FeatureFlags.watch_directories) and this.isEligibleDirectory(parent_dir);
@@ -919,7 +919,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
                 var watchlist_slice = this.watchlist.slice();
 
                 if (dir_fd > 0) {
-                    var fds = watchlist_slice.items(.fd);
+                    const fds = watchlist_slice.items(.fd);
                     if (std.mem.indexOfScalar(StoredFileDescriptorType, fds, dir_fd)) |i| {
                         parent_watch_item = @as(WatchItemIndex, @truncate(i));
                     }

--- a/src/which.zig
+++ b/src/which.zig
@@ -20,7 +20,7 @@ pub fn which(buf: *[bun.MAX_PATH_BYTES]u8, path: []const u8, cwd: []const u8, bi
     if (std.fs.path.isAbsolute(bin)) {
         bun.copy(u8, buf, bin);
         buf[bin.len] = 0;
-        var binZ: [:0]u8 = buf[0..bin.len :0];
+        const binZ: [:0]u8 = buf[0..bin.len :0];
         if (bun.sys.isExecutableFilePath(binZ)) return binZ;
 
         // note that directories are often executable
@@ -46,8 +46,8 @@ pub fn which(buf: *[bun.MAX_PATH_BYTES]u8, path: []const u8, cwd: []const u8, bi
 
 test "which" {
     var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-    var realpath = bun.getenvZ("PATH") orelse unreachable;
-    var whichbin = which(&buf, realpath, try bun.getcwdAlloc(std.heap.c_allocator), "which");
+    const realpath = bun.getenvZ("PATH") orelse unreachable;
+    const whichbin = which(&buf, realpath, try bun.getcwdAlloc(std.heap.c_allocator), "which");
     try std.testing.expectEqualStrings(whichbin orelse return std.debug.assert(false), "/usr/bin/which");
     try std.testing.expect(null == which(&buf, realpath, try bun.getcwdAlloc(std.heap.c_allocator), "baconnnnnn"));
     try std.testing.expect(null != which(&buf, realpath, try bun.getcwdAlloc(std.heap.c_allocator), "zig"));


### PR DESCRIPTION
### What does this PR do?

There are a lot of declarations using var instead of const that are not mutated. Since Zig's build 0.12 (0.12.0-dev.1664+8ca4a5240) it is considered an error that prevents compilation.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

This PR replaces unmodified variable declarations with const.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [✔️] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

- [✔️ ] I included a test for the new code, or an existing test covers it

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
