### PR TITLE
Fix error when parsing keys with hyphen in some JSON files

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -307,9 +307,9 @@ interface ImportMeta {
   readonly file: string;
   /**
    * The environment variables of the process
-   * 
+   *
    * ```ts
-   * import.meta.env === process.env 
+   * import.meta.env === process.env
    * ```
    */
   readonly env: import("bun").Env;

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -1435,18 +1435,12 @@ pub const Bundler = struct {
                                     }, prop.key.?.loc),
                                     .value = prop.value.?,
                                 };
-                                var maybe_quoted = name;
-                                if (strings.containsChar(name, '-')) {
-                                    var quote_buf = MutableString.init(allocator, name.len + 2) catch return null;
-                                    quote_buf = js_printer.quoteForJSON(name, quote_buf, false) catch return null;
-                                    maybe_quoted = quote_buf.list.items;
-                                }
                                 export_clauses[i] = js_ast.ClauseItem{
                                     .name = .{
                                         .ref = ref,
                                         .loc = prop.key.?.loc,
                                     },
-                                    .alias = maybe_quoted,
+                                    .alias = name,
                                     .alias_loc = prop.key.?.loc,
                                 };
                                 prop.value = js_ast.Expr.initIdentifier(ref, prop.value.?.loc);

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -1435,12 +1435,18 @@ pub const Bundler = struct {
                                     }, prop.key.?.loc),
                                     .value = prop.value.?,
                                 };
+                                var maybe_quoted = name;
+                                if (strings.containsChar(name, '-')) {
+                                    var quote_buf = MutableString.init(allocator, name.len + 2) catch return null;
+                                    quote_buf = js_printer.quoteForJSON(name, quote_buf, false) catch return null;
+                                    maybe_quoted = quote_buf.list.items;
+                                }
                                 export_clauses[i] = js_ast.ClauseItem{
                                     .name = .{
                                         .ref = ref,
                                         .loc = prop.key.?.loc,
                                     },
-                                    .alias = name,
+                                    .alias = maybe_quoted,
                                     .alias_loc = prop.key.?.loc,
                                 };
                                 prop.value = js_ast.Expr.initIdentifier(ref, prop.value.?.loc);

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1217,7 +1217,7 @@ fn NewPrinter(
         pub fn printClauseAlias(p: *Printer, alias: string) void {
             std.debug.assert(alias.len > 0);
 
-            if (!strings.containsNonBmpCodePoint(alias)) {
+            if (!strings.containsNonBmpCodePointOrIsInvalidIdentifier(alias)) {
                 p.printSpaceBeforeIdentifier();
                 p.printIdentifier(alias);
             } else {

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -7,6 +7,7 @@ const CodePoint = bun.CodePoint;
 const bun = @import("root").bun;
 pub const joiner = @import("./string_joiner.zig");
 const log = bun.Output.scoped(.STR, true);
+const js_lexer = @import("./js_lexer.zig");
 
 pub const Encoding = enum {
     ascii,
@@ -216,7 +217,6 @@ pub fn fmtIdentifier(name: string) FormatValidIdentifier {
 /// This will always allocate
 pub const FormatValidIdentifier = struct {
     name: string,
-    const js_lexer = @import("./js_lexer.zig");
     pub fn format(self: FormatValidIdentifier, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
         var iterator = strings.CodepointIterator.init(self.name);
         var cursor = strings.CodepointIterator.Cursor{};
@@ -4360,6 +4360,24 @@ pub fn containsNonBmpCodePoint(text: string) bool {
 
     while (iter.next(&curs)) {
         if (curs.c > 0xFFFF) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+pub fn containsNonBmpCodePointOrIsInvalidIdentifier(text: string) bool {
+    var iter = CodepointIterator.init(text);
+    var curs = CodepointIterator.Cursor{};
+
+    if (!iter.next(&curs)) return true;
+
+    if (curs.c > 0xFFFF or !js_lexer.isIdentifierStart(curs.c))
+        return true;
+
+    while (iter.next(&curs)) {
+        if (curs.c > 0xFFFF or !js_lexer.isIdentifierContinue(curs.c)) {
             return true;
         }
     }

--- a/test/regression/issue/07261.test.ts
+++ b/test/regression/issue/07261.test.ts
@@ -1,0 +1,23 @@
+import { bunEnv, bunExe } from "harness";
+import { mkdirSync, rmSync, writeFileSync, mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+it("imports tsconfig.json with abritary keys", async () => {
+  const testDir = mkdtempSync(join(tmpdir(), "issue7261-"));
+
+  // Clean up from prior runs if necessary
+  rmSync(testDir, { recursive: true, force: true });
+
+  // Create a directory with our test tsconfig.json
+  mkdirSync(testDir, { recursive: true });
+  writeFileSync(join(testDir, "tsconfig.json"), '{ "key-with-hyphen": true }');
+
+  const { exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "-e", `require('${join(testDir, "tsconfig.json")}')`],
+    env: bunEnv,
+    stderr: "inherit",
+  });
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fixes https://github.com/oven-sh/bun/issues/7261 introduced by https://github.com/oven-sh/bun/pull/4783.
The solution is to quote export aliases when required so that 

```JS
var key_with_hyphen = !0

export {
    key_with_hyphen as key-with-hyphen
};

export default { "key-with-hyphen": key_with_hyphen };
```
becomes
```JS
var key_with_hyphen = !0

export {
    key_with_hyphen as "key-with-hyphen"
};

export default { "key-with-hyphen": key_with_hyphen };
```

Relevant: https://github.com/tc39/ecma262/pull/2154 and https://bugs.webkit.org/show_bug.cgi?id=217576

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
I did not add allocations
- [x] I included a test for the new code, or an existing test covers it
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test 07261.test.ts`)



