### PR TITLE
Fixes #7324

### DIFF
--- a/src/js_lexer_tables.zig
+++ b/src/js_lexer_tables.zig
@@ -250,11 +250,12 @@ pub const PropertyModifierKeyword = enum {
     });
 };
 
-pub const TypeScriptAccessibilityModifier = ComptimeStringMap(u1, .{
-    .{ "private", 1 },
-    .{ "protected", 1 },
-    .{ "public", 1 },
-    .{ "readonly", 1 },
+pub const TypeScriptAccessibilityModifier = ComptimeStringMap(void, .{
+    .{ "override", void },
+    .{ "private", void },
+    .{ "protected", void },
+    .{ "public", void },
+    .{ "readonly", void },
 });
 
 pub const TokenEnumType = std.EnumArray(T, []u8);

--- a/test/transpiler/7324.test.ts
+++ b/test/transpiler/7324.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test";
+
+test("override is an accessibility modifier", () => {
+  class FooParent {}
+
+  class FooChild extends FooParent {}
+
+  class BarParent {
+    constructor(readonly foo: FooParent) {}
+  }
+
+  class BarChild extends BarParent {
+    constructor(override foo: FooChild) {
+      super(foo);
+    }
+  }
+
+  new BarChild(new FooChild());
+
+  expect().pass();
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #7324 

Adds `override` as a TypeScript accessibility modifier. We must've forgotten this.

### How did you verify your code works?

There is a regression test
