### PR TITLE
docs: fix macos clang-16 PATH command

### DIFF
--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -95,7 +95,7 @@ If not, run this to manually link it:
 
 ```bash#macOS (Homebrew)
 # use fish_add_path if you're using fish
-$ export PATH="$PATH:$(brew --prefix llvm@16)/bin"
+$ export PATH="$(brew --prefix llvm@16)/bin:$PATH"
 ```
 
 ```bash#Arch


### PR DESCRIPTION
Even though I had run the export, `bun setup` was erroring with:
```
$ ./scripts/setup.sh
setup error: LLVM 16 is required. Detected CXX as '/usr/bin/clang++'
error: script "setup" exited with code 1 (SIGHUP)
```

Running `export PATH="$(brew --prefix llvm@16)/bin:$PATH"` fixed the error
