### PR TITLE
fix: printf invalid option in download-zig

### DIFF
--- a/scripts/download-zig.sh
+++ b/scripts/download-zig.sh
@@ -73,7 +73,7 @@ if [ -e "${extract_at}/.version" ]; then
 fi
 
 if ! [ -e "${dest}" ]; then
-  printf "-- Downloading Zig v%s\n" "${zig_version}"
+  printf -- "-- Downloading Zig v%s\n" "${zig_version}"
   curl -o "$dest" -L "$url"
 fi
 


### PR DESCRIPTION
### What does this PR do?

`bun setup` was failing with:
```
...
-- Building for CPU Target: native
/Users/adrienbrault/Developer/js/bun/scripts/download-zig.sh: line 77: printf: --: invalid option
printf: usage: printf [-v var] format [arguments]
CMake Error at CMakeLists.txt:337 (message):
  Auto-installation of Zig failed.  Please pass -DZIG_COMPILER=system or a
  path to the Zig


-- Configuring incomplete, errors occurred!
error: script "setup" exited with code 1 (SIGHUP)
```

At first I thought the issue was mac's default bash version, however I also got the error with 5.2:
```
$ bash

bash-5.2$ printf '-- Downloading Zig v%s\n' 0.12.0-dev.1604+caae40c21
bash: printf: --: invalid option
printf: usage: printf [-v var] format [arguments]

bash-5.2$ printf -- '-- Downloading Zig v%s\n' 0.12.0-dev.1604+caae40c21
-- Downloading Zig v0.12.0-dev.1604+caae40c21
```