### PR TITLE
Fix error when installing zig

### DIFF
--- a/scripts/download-zig.sh
+++ b/scripts/download-zig.sh
@@ -73,7 +73,7 @@ if [ -e "${extract_at}/.version" ]; then
 fi
 
 if ! [ -e "${dest}" ]; then
-  printf "-- Downloading Zig v%s\n" "${zig_version}"
+  printf -- "-- Downloading Zig v%s\n" "${zig_version}"
   curl -o "$dest" -L "$url"
 fi
 


### PR DESCRIPTION
### What does this PR do?
Zig installation fails when running `bun setup` with the following error:

```
/Users/jake/development/bun/scripts/download-zig.sh: line 76: printf: --: invalid option printf: usage: printf [-v var] format [arguments]
CMake Error at CMakeLists.txt:337 (message):
  Auto-installation of Zig failed.  Please pass -DZIG_COMPILER=system or a
  path to the Zig
```

This is due to behavior of bash `printf` command:

```bash
# bash
printf "-- hello"

# results in:
# bash: printf: --: invalid option
# printf: usage: printf [-v var] format [arguments]
```

This PR tells printf to stop parsing arguments prior to interpolating string.

### How did you verify your code works?

I removed the `.cache` folder and re-ran `bun setup`. (Are there automated tests for `bun setup`?)
