### PR TITLE
Fix scripts/download-zig.sh

### DIFF
--- a/scripts/download-zig.sh
+++ b/scripts/download-zig.sh
@@ -79,7 +79,7 @@ fi
 
 rm -rf "${extract_at}"
 mkdir -p "${extract_at}"
-tar -xzf "${dest}" -C "${extract_at}" --strip-components=1
+tar -xf "${dest}" -C "${extract_at}" --strip-components=1
 
 echo "${url}" > "${extract_at}/.version"
 

--- a/scripts/download-zig.sh
+++ b/scripts/download-zig.sh
@@ -29,7 +29,7 @@ case $(uname -ms) in
     ;;
 'Linux x86_64')
     target='linux'
-    arch='aarch64'
+    arch='x86_64'
     ;;
 *)
     printf "error: cannot get platform name from '%s'\n" "${unamestr}"


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Ubuntu 22.04 x86_64 fresh install and bun build attempt using latest contributing guide.

`bun setup` was failing with:

![image](https://github.com/oven-sh/bun/assets/478247/ddacfcfd-d7b5-4faf-a79a-17293357339f)

Resulting from `scripts/download-zig.sh`

```bash
$ scripts/download-zig.sh

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

After removing the gzip flag, the following error then resulted

```bash
$ uname -i 
x86_64
$ scripts/download-zig.sh
$ .cache/zig/zig
bash: .cache/zig/zig: cannot execute binary file: Exec format error
```

### How did you verify your code works?

```bash
$ rm -rf .cache
$ scripts/download-zig.sh
$ .cache/zig/zig version
0.12.0-dev.1604+caae40c21
```

`bun setup`
![image](https://github.com/oven-sh/bun/assets/478247/e2d2236a-714e-4ba8-9713-67e3aba59e19)


<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
