### PR TITLE
Make `tsc --help` 2x faster

### DIFF
--- a/dockerhub/alpine/Dockerfile
+++ b/dockerhub/alpine/Dockerfile
@@ -91,6 +91,11 @@ RUN apk --no-cache add \
 
 FROM alpine:3.18
 
+# Disable the runtime transpiler cache by default inside Docker containers.
+# On ephemeral containers, the cache is not useful
+ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
+ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
+
 COPY --from=build /tmp/glibc.apk /tmp/
 COPY --from=build /tmp/glibc-bin.apk /tmp/
 COPY --from=build /usr/local/bin/bun /usr/local/bin/

--- a/dockerhub/debian-slim/Dockerfile
+++ b/dockerhub/debian-slim/Dockerfile
@@ -57,6 +57,11 @@ RUN apt-get update -qq \
 
 FROM debian:bullseye-slim
 
+# Disable the runtime transpiler cache by default inside Docker containers.
+# On ephemeral containers, the cache is not useful
+ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
+ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
+
 COPY docker-entrypoint.sh /usr/local/bin
 COPY --from=build /usr/local/bin/bun /usr/local/bin/bun
 

--- a/dockerhub/debian/Dockerfile
+++ b/dockerhub/debian/Dockerfile
@@ -58,6 +58,11 @@ FROM debian:bullseye
 COPY docker-entrypoint.sh /usr/local/bin
 COPY --from=build /usr/local/bin/bun /usr/local/bin/bun
 
+# Disable the runtime transpiler cache by default inside Docker containers.
+# On ephemeral containers, the cache is not useful
+ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
+ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
+
 RUN groupadd bun \
       --gid 1000 \
     && useradd bun \

--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -57,6 +57,11 @@ RUN apt-get update -qq \
 
 FROM gcr.io/distroless/base-nossl-debian11
 
+# Disable the runtime transpiler cache by default inside Docker containers.
+# On ephemeral containers, the cache is not useful
+ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
+ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
+
 COPY --from=build /usr/local/bin/bun /usr/local/bin/
 
 # Temporarily use the `build`-stage image binaries to create a symlink:

--- a/docs/runtime/env.md
+++ b/docs/runtime/env.md
@@ -137,6 +137,11 @@ These environment variables are read by Bun and configure aspects of its behavio
 
 ---
 
+- `BUN_RUNTIME_TRANSPILER_CACHE_PATH`
+- The runtime transpiler caches the transpiled output of source files larger than 50 kb. This makes CLIs using Bun load faster. If `BUN_RUNTIME_TRANSPILER_CACHE_PATH` is set, then the runtime transpiler will cache transpiled output to the specified directory. If `BUN_RUNTIME_TRANSPILER_CACHE_PATH` is set to an empty string or the string `"0"`, then the runtime transpiler will not cache transpiled output. If `BUN_RUNTIME_TRANSPILER_CACHE_PATH` is unset, then the runtime transpiler will cache transpiled output to the platform-specific cache directory.
+
+---
+
 - `TMPDIR`
 - Bun occasionally requires a directory to store intermediate assets during bundling or other operations. If unset, defaults to the platform-specific temporary directory: `/tmp` on Linux, `/private/tmp` on macOS.
 
@@ -153,6 +158,31 @@ These environment variables are read by Bun and configure aspects of its behavio
 ---
 
 - `DO_NOT_TRACK`
-- If `DO_NOT_TRACK=1`, then analytics are [disabled](https://do-not-track.dev/). Bun records bundle timings (so we can answer with data, "is Bun getting faster?") and feature usage (e.g., "are people actually using macros?"). The request body size is about 60 bytes, so it's not a lot of data. Equivalent of `telemetry=false` in bunfig.
+- Telemetry is not sent yet as of November 28th, 2023, but we are planning to add telemetry in the coming months. If `DO_NOT_TRACK=1`, then analytics are [disabled](https://do-not-track.dev/). Bun records bundle timings (so we can answer with data, "is Bun getting faster?") and feature usage (e.g., "are people actually using macros?"). The request body size is about 60 bytes, so it's not a lot of data. Equivalent of `telemetry=false` in bunfig.
 
 {% /table %}
+
+## Runtime transpiler caching
+
+For files larger than 50 KB, Bun caches transpiled output into `$BUN_RUNTIME_TRANSPILER_CACHE_PATH` or the platform-specific cache directory. This makes CLIs using Bun load faster.
+
+This transpiler cache is global and shared across all projects. It is safe to delete the cache at any time. It is a content-addressable cache, so it will never contain duplicate entries. It is also safe to delete the cache while a Bun process is running.
+
+It is recommended to disable this cache when using ephemeral filesystems like Docker. Bun's Docker images automatically disable this cache.
+
+### Disable the runtime transpiler cache
+
+To disable the runtime transpiler cache, set `BUN_RUNTIME_TRANSPILER_CACHE_PATH` to an empty string or the string `"0"`.
+
+```sh
+BUN_RUNTIME_TRANSPILER_CACHE_PATH=0 bun run dev
+```
+
+### What does it cache?
+
+It caches:
+
+- The transpiled output of source files larger than 50 KB.
+- The sourcemap for the transpiled output of the file
+
+The file extension `.pile` is used for these cached files.

--- a/packages/bun-internal-test/src/runner.node.mjs
+++ b/packages/bun-internal-test/src/runner.node.mjs
@@ -49,6 +49,7 @@ async function runTest(path) {
         FORCE_COLOR: "1",
         BUN_GARBAGE_COLLECTOR_LEVEL: "1",
         BUN_JSC_forceRAMSize,
+        BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
       },
     });
   } catch (e) {

--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -53,6 +53,7 @@ pub const Features = struct {
     pub var fetch = false;
     pub var bunfig = false;
     pub var extracted_packages = false;
+    pub var transpiler_cache = false;
 
     pub fn formatter() Formatter {
         return Formatter{};
@@ -81,6 +82,7 @@ pub const Features = struct {
                 "fetch",
                 "bunfig",
                 "extracted_packages",
+                "transpiler_cache",
             };
             inline for (fields) |field| {
                 if (@field(Features, field)) {

--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -201,6 +201,7 @@ export const enum DotEnvBehavior {
   disable = 1,
   prefix = 2,
   load_all = 3,
+  load_all_without_inlining = 4,
 }
 export const DotEnvBehaviorKeys: {
   1: "disable";
@@ -209,6 +210,8 @@ export const DotEnvBehaviorKeys: {
   prefix: "prefix";
   3: "load_all";
   load_all: "load_all";
+  4: "load_all_without_inlining";
+  load_all_without_inlining: "load_all_without_inlining";
 };
 export const enum SourceMapMode {
   inline_into_file = 1,

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -1101,17 +1101,21 @@ const DotEnvBehavior = {
   "1": 1,
   "2": 2,
   "3": 3,
+  "4": 4,
   "disable": 1,
   "prefix": 2,
   "load_all": 3,
+  "load_all_without_inlining": 4,
 };
 const DotEnvBehaviorKeys = {
   "1": "disable",
   "2": "prefix",
   "3": "load_all",
+  "4": "load_all_without_inlining",
   "disable": "disable",
   "prefix": "prefix",
   "load_all": "load_all",
+  "load_all_without_inlining": "load_all_without_inlining",
 };
 
 function decodeEnvConfig(bb) {

--- a/src/api/schema.peechy
+++ b/src/api/schema.peechy
@@ -241,6 +241,7 @@ enum DotEnvBehavior {
   disable = 1;
   prefix = 2;
   load_all = 3;
+  load_all_without_inlining = 4;
 }
 
 message EnvConfig {

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -1244,6 +1244,9 @@ pub const Api = struct {
         /// load_all
         load_all,
 
+        /// load_all_without_inlining
+        load_all_without_inlining,
+
         _,
 
         pub fn jsonStringify(self: @This(), writer: anytype) !void {

--- a/src/bun.js/RuntimeTranspilerCache.zig
+++ b/src/bun.js/RuntimeTranspilerCache.zig
@@ -357,10 +357,10 @@ pub const RuntimeTranspilerCache = struct {
                 return "";
             }
 
-            var dest = buf[0..@min(dir.len, bun.MAX_PATH_BYTES - 1)];
-            @memcpy(dest, dir[0..@min(dir.len, bun.MAX_PATH_BYTES - 1)]);
-            dest[dest.len - 1] = 0;
-            return dest[0.. :0];
+            const len = @min(dir.len, bun.MAX_PATH_BYTES - 1);
+            @memcpy(buf[0..len], dir[0..len]);
+            buf[len] = 0;
+            return buf[0..len :0];
         }
 
         if (bun.getenvZ("XDG_CACHE_HOME")) |dir| {

--- a/src/bun.js/RuntimeTranspilerCache.zig
+++ b/src/bun.js/RuntimeTranspilerCache.zig
@@ -1,0 +1,497 @@
+const bun = @import("root").bun;
+const std = @import("std");
+const Output = bun.Output;
+const JSC = bun.JSC;
+const expected_version = 1;
+
+const debug = Output.scoped(.cache, false);
+const MINIMUM_CACHE_SIZE = 50 * 1024;
+
+pub const RuntimeTranspilerCache = struct {
+    input_hash: ?u64 = null,
+    input_byte_length: ?u64 = null,
+    exports_kind: bun.JSAst.ExportsKind = .none,
+    output_code: ?bun.String = null,
+    entry: ?Entry = null,
+
+    sourcemap_allocator: std.mem.Allocator,
+    output_code_allocator: std.mem.Allocator,
+
+    const seed = 42;
+    pub const Metadata = struct {
+        cache_version: u32 = expected_version,
+        output_encoding: Encoding = Encoding.none,
+        module_type: ModuleType = ModuleType.none,
+
+        input_byte_length: u64 = 0,
+        input_hash: u64 = 0,
+
+        output_byte_offset: u64 = 0,
+        output_byte_length: u64 = 0,
+        output_hash: u64 = 0,
+
+        sourcemap_byte_offset: u64 = 0,
+        sourcemap_byte_length: u64 = 0,
+        sourcemap_hash: u64 = 0,
+
+        pub const size = brk: {
+            var count: usize = 0;
+            var meta: Metadata = undefined;
+            for (std.meta.fieldNames(Metadata)) |name| {
+                count += @sizeOf(@TypeOf(@field(meta, name)));
+            }
+
+            break :brk count;
+        };
+
+        pub fn encode(this: *const Metadata, writer: anytype) !void {
+            try writer.writeInt(u32, this.cache_version, .little);
+            try writer.writeInt(u8, @intFromEnum(this.module_type), .little);
+            try writer.writeInt(u8, @intFromEnum(this.output_encoding), .little);
+
+            try writer.writeInt(u64, this.input_byte_length, .little);
+            try writer.writeInt(u64, this.input_hash, .little);
+
+            try writer.writeInt(u64, this.output_byte_offset, .little);
+            try writer.writeInt(u64, this.output_byte_length, .little);
+            try writer.writeInt(u64, this.output_hash, .little);
+
+            try writer.writeInt(u64, this.sourcemap_byte_offset, .little);
+            try writer.writeInt(u64, this.sourcemap_byte_length, .little);
+            try writer.writeInt(u64, this.sourcemap_hash, .little);
+        }
+
+        pub fn decode(this: *Metadata, reader: anytype) !void {
+            this.cache_version = try reader.readInt(u32, .little);
+            this.module_type = @enumFromInt(try reader.readInt(u8, .little));
+            this.output_encoding = @enumFromInt(try reader.readInt(u8, .little));
+
+            this.input_byte_length = try reader.readInt(u64, .little);
+            this.input_hash = try reader.readInt(u64, .little);
+
+            this.output_byte_offset = try reader.readInt(u64, .little);
+            this.output_byte_length = try reader.readInt(u64, .little);
+            this.output_hash = try reader.readInt(u64, .little);
+
+            this.sourcemap_byte_offset = try reader.readInt(u64, .little);
+            this.sourcemap_byte_length = try reader.readInt(u64, .little);
+            this.sourcemap_hash = try reader.readInt(u64, .little);
+
+            if (this.cache_version != expected_version) {
+                return error.StaleCache;
+            }
+
+            switch (this.module_type) {
+                .esm, .cjs => {},
+                // Invalid module type
+                else => return error.InvalidModuleType,
+            }
+
+            switch (this.output_encoding) {
+                .utf8, .utf16, .latin1 => {},
+                // Invalid encoding
+                else => return error.UnknownEncoding,
+            }
+        }
+    };
+
+    pub const Entry = struct {
+        metadata: Metadata,
+        output_code: OutputCode = .{ .utf8 = "" },
+        sourcemap: []const u8 = "",
+
+        pub const OutputCode = union(enum) {
+            utf8: []const u8,
+            string: bun.String,
+
+            pub fn byteSlice(this: *const OutputCode) []const u8 {
+                switch (this.*) {
+                    .utf8 => return this.utf8,
+                    .string => return this.string.byteSlice(),
+                }
+            }
+        };
+
+        pub fn save(
+            destination_dir: bun.FileDescriptor,
+            destination_path: bun.PathString,
+            input_byte_length: u64,
+            input_hash: u64,
+            sourcemap: []const u8,
+            output_code: OutputCode,
+            exports_kind: bun.JSAst.ExportsKind,
+        ) !void {
+            var tracer = bun.tracy.traceNamed(@src(), "RuntimeTranspilerCache.save");
+            defer tracer.end();
+
+            // atomically write to a tmpfile and then move it to the final destination
+            var tmpname_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+            const tmpfilename = try bun.fs.FileSystem.instance.tmpname(std.fs.path.extension(destination_path.slice()), &tmpname_buf, input_hash);
+
+            const output_bytes = output_code.byteSlice();
+
+            // First we open the tmpfile, to avoid any other work in the event of failure.
+            const fd = try bun.sys.openat(bun.toFD(bun.fs.FileSystem.instance.tmpdir().fd), bun.sliceTo(tmpfilename, 0), std.os.O.CREAT | std.os.O.CLOEXEC | std.os.O.WRONLY, 0o644).unwrap();
+
+            defer _ = bun.sys.close(fd);
+
+            var metadata_buf = [_]u8{0} ** (Metadata.size * 2);
+            const metadata_bytes = brk: {
+                var metadata = Metadata{
+                    .input_byte_length = input_byte_length,
+                    .input_hash = input_hash,
+                    .module_type = switch (exports_kind) {
+                        .cjs => ModuleType.cjs,
+                        else => ModuleType.esm,
+                    },
+                    .output_encoding = switch (output_code) {
+                        .utf8 => Encoding.utf8,
+                        .string => |str| switch (str.encoding()) {
+                            .utf8 => Encoding.utf8,
+                            .utf16 => Encoding.utf16,
+                            .latin1 => Encoding.latin1,
+                            else => @panic("Unexpected encoding"),
+                        },
+                    },
+                    .sourcemap_byte_length = sourcemap.len,
+                    .output_byte_offset = Metadata.size,
+                    .output_byte_length = output_bytes.len,
+                    .sourcemap_byte_offset = Metadata.size + output_bytes.len,
+                };
+
+                metadata.output_hash = hash(output_bytes);
+                metadata.sourcemap_hash = hash(sourcemap);
+                var metadata_stream = std.io.fixedBufferStream(&metadata_buf);
+
+                try metadata.encode(metadata_stream.writer());
+
+                if (comptime bun.Environment.allow_assert) {
+                    var metadata_stream2 = std.io.fixedBufferStream(metadata_buf[0..Metadata.size]);
+                    var metadata2 = Metadata{};
+                    metadata2.decode(metadata_stream2.reader()) catch |err| bun.Output.panic("Metadata did not rountrip encode -> decode  successfully: {s}", .{@errorName(err)});
+                    std.debug.assert(std.meta.eql(metadata, metadata2));
+                }
+
+                break :brk metadata_buf[0..metadata_stream.pos];
+            };
+
+            var vecs: [3]std.os.iovec = .{
+                .{ .iov_base = metadata_bytes.ptr, .iov_len = metadata_bytes.len },
+                .{ .iov_base = @constCast(output_bytes.ptr), .iov_len = output_bytes.len },
+                .{ .iov_base = @constCast(sourcemap.ptr), .iov_len = sourcemap.len },
+            };
+
+            var position: isize = 0;
+            const end_position = Metadata.size + output_bytes.len + sourcemap.len;
+            std.debug.assert(end_position == @as(i64, @intCast(vecs[0].iov_len + vecs[1].iov_len + vecs[2].iov_len)));
+            std.debug.assert(end_position == @as(i64, @intCast(sourcemap.len + output_bytes.len + Metadata.size)));
+
+            bun.C.preallocate_file(fd, 0, @intCast(end_position)) catch {};
+            var current_vecs: []std.os.iovec = vecs[0..];
+            while (position < end_position) {
+                const written = try bun.sys.pwritev(fd, current_vecs, position).unwrap();
+                if (written <= 0) {
+                    return error.WriteFailed;
+                }
+
+                position += @intCast(written);
+            }
+
+            // In the extremely unlikely scenario where it already existed.
+            // _ = bun.sys.ftruncate(fd, @intCast(end_position));
+
+            bun.C.moveFileZWithHandle(bun.fdcast(fd), bun.fs.FileSystem.instance.tmpdir().fd, tmpfilename, bun.fdcast(destination_dir), destination_path.sliceAssumeZ()) catch {
+                std.fs.Dir.makePath(std.fs.Dir{ .fd = destination_dir }, std.fs.path.dirname(destination_path.slice()).?) catch {};
+                try bun.C.moveFileZWithHandle(bun.fdcast(fd), bun.fs.FileSystem.instance.tmpdir().fd, tmpfilename, bun.fdcast(destination_dir), destination_path.sliceAssumeZ());
+            };
+        }
+
+        pub fn load(
+            this: *Entry,
+            file: std.fs.File,
+            sourcemap_allocator: std.mem.Allocator,
+            output_code_allocator: std.mem.Allocator,
+        ) !void {
+            const stat_size = try file.getEndPos();
+            if (stat_size < Metadata.size + this.metadata.output_byte_length + this.metadata.sourcemap_byte_length) {
+                return error.MissingData;
+            }
+
+            std.debug.assert(this.output_code == .utf8 and this.output_code.utf8.len == 0); // this should be the default value
+
+            this.output_code = brk: {
+                switch (this.metadata.output_encoding) {
+                    .utf8 => {
+                        var utf8 = try output_code_allocator.alloc(u8, this.metadata.output_byte_length);
+                        errdefer output_code_allocator.free(utf8);
+                        const read_bytes = try file.preadAll(utf8, this.metadata.output_byte_offset);
+                        if (read_bytes != this.metadata.output_byte_length) {
+                            return error.MissingData;
+                        }
+
+                        if (this.metadata.output_hash != 0) {
+                            if (hash(utf8) != this.metadata.output_hash) {
+                                return error.InvalidHash;
+                            }
+                        }
+
+                        break :brk .{ .utf8 = utf8 };
+                    },
+                    .latin1 => {
+                        var latin1 = bun.String.createUninitializedLatin1(this.metadata.output_byte_length);
+                        errdefer latin1.deref();
+                        const read_bytes = try file.preadAll(@constCast(latin1.latin1()), this.metadata.output_byte_offset);
+
+                        if (this.metadata.output_hash != 0) {
+                            if (hash(latin1.latin1()) != this.metadata.output_hash) {
+                                return error.InvalidHash;
+                            }
+                        }
+
+                        if (read_bytes != this.metadata.output_byte_length) {
+                            return error.MissingData;
+                        }
+
+                        break :brk .{ .string = latin1 };
+                    },
+
+                    .utf16 => {
+                        var utf16 = bun.String.createUninitializedUTF16(this.metadata.output_byte_length / 2);
+                        errdefer utf16.deref();
+                        const read_bytes = try file.preadAll(std.mem.sliceAsBytes(@constCast(utf16.utf16())), this.metadata.output_byte_offset);
+                        if (read_bytes != this.metadata.output_byte_length) {
+                            return error.MissingData;
+                        }
+
+                        if (this.metadata.output_hash != 0) {
+                            if (hash(std.mem.sliceAsBytes(utf16.utf16())) != this.metadata.output_hash) {
+                                return error.InvalidHash;
+                            }
+                        }
+
+                        break :brk .{ .string = utf16 };
+                    },
+
+                    else => @panic("Unexpected output encoding"),
+                }
+            };
+
+            errdefer {
+                switch (this.output_code) {
+                    .utf8 => output_code_allocator.free(this.output_code.utf8),
+                    .string => this.output_code.string.deref(),
+                }
+            }
+
+            if (this.metadata.sourcemap_byte_length > 0) {
+                var sourcemap = try sourcemap_allocator.alloc(u8, this.metadata.sourcemap_byte_length);
+                errdefer sourcemap_allocator.free(sourcemap);
+                const read_bytes = try file.preadAll(sourcemap, this.metadata.sourcemap_byte_offset);
+                if (read_bytes != this.metadata.sourcemap_byte_length) {
+                    return error.MissingData;
+                }
+
+                this.sourcemap = sourcemap;
+            }
+        }
+    };
+
+    pub fn hash(bytes: []const u8) u64 {
+        return std.hash.Wyhash.hash(seed, bytes);
+    }
+
+    pub const ModuleType = enum(u8) {
+        none = 0,
+        esm = 1,
+        cjs = 2,
+    };
+
+    pub const Encoding = enum(u8) {
+        none = 0,
+        utf8 = 1,
+        utf16 = 2,
+        latin1 = 3,
+        _,
+    };
+
+    pub fn writeCacheFilename(
+        buf: []u8,
+        input_hash: u64,
+    ) !usize {
+        const fmt_name = if (comptime bun.Environment.allow_assert) "{any}.debug.pile" else "{any}.pile";
+
+        const printed = try std.fmt.bufPrint(buf, fmt_name, .{bun.fmt.fmtSliceHexLower(std.mem.asBytes(&input_hash))});
+        return printed.len;
+    }
+
+    pub fn getCacheFilePath(
+        buf: *[bun.MAX_PATH_BYTES]u8,
+        input_hash: u64,
+    ) ![:0]const u8 {
+        const cache_dir = getCacheDir(buf);
+        buf[cache_dir.len] = std.fs.path.sep;
+        const cache_filename_len = try writeCacheFilename(buf[cache_dir.len + 1 ..], input_hash);
+        buf[cache_dir.len + 1 + cache_filename_len] = 0;
+
+        return buf[0 .. cache_dir.len + 1 + cache_filename_len :0];
+    }
+
+    fn getCacheDir(
+        buf: *[bun.MAX_PATH_BYTES]u8,
+    ) [:0]const u8 {
+        if (comptime bun.Environment.isMac) {
+            // On a mac, default to ~/Library/Caches/bun/*
+            // This is different than ~/.bun/install/cache, and not configurable by the user.
+            if (bun.getenvZ("HOME")) |home| {
+                const parts = &[_][]const u8{
+                    home,
+                    "Library/",
+                    "Caches/",
+                    "bun",
+                    "@t@",
+                };
+                return bun.fs.FileSystem.instance.absBufZ(parts, buf);
+            }
+        }
+
+        if (bun.getenvZ("XDG_CACHE_HOME")) |dir| {
+            var parts = &[_][]const u8{ dir, "bun", "@t@" };
+            return bun.fs.FileSystem.instance.absBufZ(parts, buf);
+        }
+
+        if (bun.getenvZ(bun.DotEnv.home_env)) |dir| {
+            var parts = &[_][]const u8{ dir, ".bun", "install", "cache", "@t@" };
+            return bun.fs.FileSystem.instance.absBufZ(parts, buf);
+        }
+
+        {
+            var parts = &[_][]const u8{ bun.fs.FileSystem.instance.fs.tmpdirPath(), "bun", "@t@" };
+            return bun.fs.FileSystem.instance.absBufZ(parts, buf);
+        }
+    }
+
+    pub fn fromFile(
+        input_hash: u64,
+        input_stat_size: u64,
+        sourcemap_allocator: std.mem.Allocator,
+        output_code_allocator: std.mem.Allocator,
+    ) !Entry {
+        var tracer = bun.tracy.traceNamed(@src(), "RuntimeTranspilerCache.fromFile");
+        defer tracer.end();
+
+        var cache_file_path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+        const cache_file_path = try getCacheFilePath(&cache_file_path_buf, input_hash);
+        return fromFileWithCacheFilePath(bun.PathString.init(cache_file_path), input_hash, input_stat_size, sourcemap_allocator, output_code_allocator);
+    }
+
+    pub fn fromFileWithCacheFilePath(
+        cache_file_path: bun.PathString,
+        input_hash: u64,
+        input_stat_size: u64,
+        sourcemap_allocator: std.mem.Allocator,
+        output_code_allocator: std.mem.Allocator,
+    ) !Entry {
+        var metadata_bytes_buf: [Metadata.size * 2]u8 = undefined;
+        const cache_fd = try bun.sys.open(cache_file_path.sliceAssumeZ(), std.os.O.RDONLY, 0).unwrap();
+        defer _ = bun.sys.close(cache_fd);
+        errdefer {
+            // On any error, we delete the cache file
+            _ = bun.sys.unlink(cache_file_path.sliceAssumeZ());
+        }
+
+        const file = std.fs.File{ .handle = bun.fdcast(cache_fd) };
+        const metadata_bytes = try file.preadAll(&metadata_bytes_buf, 0);
+        var metadata_stream = std.io.fixedBufferStream(metadata_bytes_buf[0..metadata_bytes]);
+
+        var entry = Entry{
+            .metadata = Metadata{},
+            .output_code = .{ .utf8 = "" },
+            .sourcemap = "",
+        };
+        var reader = metadata_stream.reader();
+        try entry.metadata.decode(reader);
+        if (entry.metadata.input_hash != input_hash or entry.metadata.input_byte_length != input_stat_size) {
+            // delete the cache in this case
+            return error.InvalidHash;
+        }
+
+        try entry.load(file, sourcemap_allocator, output_code_allocator);
+
+        return entry;
+    }
+
+    pub fn isEligible(
+        _: *const @This(),
+        path: *const bun.fs.Path,
+    ) bool {
+        return path.isFile();
+    }
+
+    pub fn toFile(
+        input_byte_length: u64,
+        input_hash: u64,
+        sourcemap: []const u8,
+        source_code: bun.String,
+        exports_kind: bun.JSAst.ExportsKind,
+    ) !void {
+        var tracer = bun.tracy.traceNamed(@src(), "RuntimeTranspilerCache.toFile");
+        defer tracer.end();
+
+        var cache_file_path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+        const output_code: Entry.OutputCode = switch (source_code.encoding()) {
+            .utf8 => .{ .utf8 = source_code.byteSlice() },
+            else => .{ .string = source_code },
+        };
+
+        try Entry.save(
+            std.fs.cwd().fd,
+            bun.PathString.init(try getCacheFilePath(&cache_file_path_buf, input_hash)),
+            input_byte_length,
+            input_hash,
+            sourcemap,
+            output_code,
+            exports_kind,
+        );
+    }
+
+    pub fn get(this: *RuntimeTranspilerCache, source: *const bun.logger.Source) bool {
+        if (comptime !bun.FeatureFlags.runtime_transpiler_cache)
+            return false;
+
+        if (this.entry != null) return true;
+
+        if (source.contents.len < MINIMUM_CACHE_SIZE)
+            return false;
+
+        if (!source.path.isFile())
+            return false;
+
+        const input_hash = this.input_hash orelse hash(source.contents);
+        this.input_hash = input_hash;
+        this.input_byte_length = source.contents.len;
+
+        this.entry = fromFile(input_hash, source.contents.len, this.sourcemap_allocator, this.output_code_allocator) catch |err| {
+            debug("get(\"{s}\") = {s}", .{ source.path.text, @errorName(err) });
+            return false;
+        };
+        debug("get(\"{s}\") = {d} bytes", .{ source.path.text, this.entry.?.output_code.byteSlice().len });
+
+        return this.entry != null;
+    }
+
+    pub fn put(this: *RuntimeTranspilerCache, output_code_bytes: []const u8, sourcemap: []const u8) void {
+        if (this.input_hash == null) {
+            return;
+        }
+        std.debug.assert(this.entry == null);
+        const output_code = bun.String.createLatin1(output_code_bytes);
+        this.output_code = output_code;
+
+        toFile(this.input_byte_length.?, this.input_hash.?, sourcemap, output_code, this.exports_kind) catch |err| {
+            debug("put() = {s}", .{@errorName(err)});
+            return;
+        };
+
+        debug("put() = {d} bytes", .{output_code.latin1().len});
+    }
+};

--- a/src/bun.js/RuntimeTranspilerCache.zig
+++ b/src/bun.js/RuntimeTranspilerCache.zig
@@ -511,8 +511,8 @@ pub const RuntimeTranspilerCache = struct {
 
         const cache_dir_fd = brk: {
             if (std.fs.path.dirname(cache_file_path)) |dirname| {
-                const dir = try std.fs.cwd().makeOpenPath(dirname, .{ .access_sub_paths = true });
-                break :brk bun.toFD(dir.fd);
+                const dir = try std.fs.cwd().makeOpenPathIterable(dirname, .{ .access_sub_paths = true });
+                break :brk bun.toFD(dir.dir.fd);
             }
 
             break :brk bun.toFD(std.fs.cwd().fd);

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -426,7 +426,7 @@ pub const RuntimeTranspilerStore = struct {
                     vm.main_hash == hash and
                     strings.eqlLong(vm.main, path.text, false),
                 .set_breakpoint_on_first_line = vm.debugger != null and vm.debugger.?.set_breakpoint_on_first_line and strings.eqlLong(vm.main, path.text, true) and setBreakPointOnFirstLine(),
-                .runtime_transpiler_cache = &cache,
+                .runtime_transpiler_cache = if (!JSC.RuntimeTranspilerCache.is_disabled) &cache else null,
             };
 
             defer {
@@ -1528,7 +1528,7 @@ pub const ModuleLoader = struct {
                     .inject_jest_globals = jsc_vm.bundler.options.rewrite_jest_for_tests and is_main,
                     .set_breakpoint_on_first_line = is_main and jsc_vm.debugger != null and jsc_vm.debugger.?.set_breakpoint_on_first_line and setBreakPointOnFirstLine(),
 
-                    .runtime_transpiler_cache = if (!disable_transpilying) &cache else null,
+                    .runtime_transpiler_cache = if (!disable_transpilying and !JSC.RuntimeTranspilerCache.is_disabled) &cache else null,
                 };
                 defer {
                     if (should_close_input_file_fd and input_file_fd != bun.invalid_fd) {

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -159,6 +159,10 @@ const BunDebugHolder = struct {
 /// This can technically fail if concurrent access across processes happens, or permission issues.
 /// Errors here should always be ignored.
 fn dumpSource(specifier: string, printer: anytype) void {
+    dumpSourceString(specifier, printer.ctx.getWritten());
+}
+
+fn dumpSourceString(specifier: string, written: []const u8) void {
     if (comptime Environment.isWindows) return;
     if (BunDebugHolder.dir == null) {
         BunDebugHolder.dir = std.fs.cwd().makeOpenPathIterable("/tmp/bun-debug-src/", .{}) catch return;
@@ -172,9 +176,9 @@ fn dumpSource(specifier: string, printer: anytype) void {
     if (std.fs.path.dirname(specifier)) |dir_path| {
         var parent = dir.dir.makeOpenPathIterable(dir_path[1..], .{}) catch return;
         defer parent.close();
-        parent.dir.writeFile(std.fs.path.basename(specifier), printer.ctx.getWritten()) catch return;
+        parent.dir.writeFile(std.fs.path.basename(specifier), written) catch return;
     } else {
-        dir.dir.writeFile(std.fs.path.basename(specifier), printer.ctx.getWritten()) catch return;
+        dir.dir.writeFile(std.fs.path.basename(specifier), written) catch return;
     }
 }
 
@@ -356,6 +360,11 @@ pub const RuntimeTranspilerStore = struct {
             const loader = this.loader;
             this.log = logger.Log.init(bun.default_allocator);
 
+            var cache = JSC.RuntimeTranspilerCache{
+                .output_code_allocator = allocator,
+                .sourcemap_allocator = bun.default_allocator,
+            };
+
             var vm = this.vm;
             var bundler: bun.Bundler = undefined;
             bundler = vm.bundler;
@@ -417,6 +426,7 @@ pub const RuntimeTranspilerStore = struct {
                     vm.main_hash == hash and
                     strings.eqlLong(vm.main, path.text, false),
                 .set_breakpoint_on_first_line = vm.debugger != null and vm.debugger.?.set_breakpoint_on_first_line and strings.eqlLong(vm.main, path.text, true) and setBreakPointOnFirstLine(),
+                .runtime_transpiler_cache = &cache,
             };
 
             defer {
@@ -478,6 +488,37 @@ pub const RuntimeTranspilerStore = struct {
                         ) catch {};
                     }
                 }
+            }
+
+            if (cache.entry) |*entry| {
+                const duped = String.create(specifier);
+                vm.source_mappings.putMappings(parse_result.source, .{
+                    .list = .{ .items = @constCast(entry.sourcemap), .capacity = entry.sourcemap.len },
+                    .allocator = bun.default_allocator,
+                }) catch {};
+
+                if (comptime Environment.allow_assert) {
+                    dumpSourceString(specifier, entry.output_code.byteSlice());
+                }
+
+                this.resolved_source = ResolvedSource{
+                    .allocator = null,
+                    .source_code = switch (entry.output_code) {
+                        .string => entry.output_code.string,
+                        .utf8 => brk: {
+                            const result = bun.String.create(entry.output_code.utf8);
+                            cache.output_code_allocator.free(entry.output_code.utf8);
+                            entry.output_code.utf8 = "";
+                            break :brk result;
+                        },
+                    },
+                    .specifier = duped,
+                    .source_url = if (duped.eqlUTF8(path.text)) duped.dupeRef() else String.init(path.text),
+                    .hash = 0,
+                    .commonjs_exports_len = if (entry.metadata.module_type == .cjs) std.math.maxInt(u32) else 0,
+                };
+
+                return;
             }
 
             if (parse_result.already_bundled) {
@@ -560,7 +601,8 @@ pub const RuntimeTranspilerStore = struct {
                 .allocator = null,
                 .source_code = brk: {
                     const written = printer.ctx.getWritten();
-                    const result = bun.String.createLatin1(written);
+
+                    const result = cache.output_code orelse bun.String.createLatin1(written);
 
                     if (written.len > 1024 * 1024 * 2 or vm.smol) {
                         printer.ctx.buffer.deinit();
@@ -1429,6 +1471,11 @@ pub const ModuleLoader = struct {
                     package_json = jsc_vm.bun_watcher.watchlist().items(.package_json)[index];
                 }
 
+                var cache = JSC.RuntimeTranspilerCache{
+                    .output_code_allocator = allocator,
+                    .sourcemap_allocator = bun.default_allocator,
+                };
+
                 var old = jsc_vm.bundler.log;
                 jsc_vm.bundler.log = log;
                 jsc_vm.bundler.linker.log = log;
@@ -1480,6 +1527,8 @@ pub const ModuleLoader = struct {
                     .allow_commonjs = true,
                     .inject_jest_globals = jsc_vm.bundler.options.rewrite_jest_for_tests and is_main,
                     .set_breakpoint_on_first_line = is_main and jsc_vm.debugger != null and jsc_vm.debugger.?.set_breakpoint_on_first_line and setBreakPointOnFirstLine(),
+
+                    .runtime_transpiler_cache = if (!disable_transpilying) &cache else null,
                 };
                 defer {
                     if (should_close_input_file_fd and input_file_fd != bun.invalid_fd) {
@@ -1608,6 +1657,51 @@ pub const ModuleLoader = struct {
                     };
                 }
 
+                if (cache.entry) |*entry| {
+                    jsc_vm.source_mappings.putMappings(parse_result.source, .{
+                        .list = .{ .items = @constCast(entry.sourcemap), .capacity = entry.sourcemap.len },
+                        .allocator = bun.default_allocator,
+                    }) catch {};
+
+                    if (comptime Environment.allow_assert) {
+                        dumpSourceString(specifier, entry.output_code.byteSlice());
+                    }
+
+                    return ResolvedSource{
+                        .allocator = null,
+                        .source_code = switch (entry.output_code) {
+                            .string => entry.output_code.string,
+                            .utf8 => brk: {
+                                const result = bun.String.create(entry.output_code.utf8);
+                                cache.output_code_allocator.free(entry.output_code.utf8);
+                                entry.output_code.utf8 = "";
+                                break :brk result;
+                            },
+                        },
+                        .specifier = input_specifier,
+                        .source_url = if (input_specifier.eqlUTF8(path.text)) input_specifier.dupeRef() else String.init(path.text),
+                        .hash = 0,
+                        .commonjs_exports_len = if (entry.metadata.module_type == .cjs) std.math.maxInt(u32) else 0,
+                        .tag = brk: {
+                            if (entry.metadata.module_type == .cjs and parse_result.source.path.isFile()) {
+                                var actual_package_json: *PackageJSON = package_json orelse brk2: {
+                                    // this should already be cached virtually always so it's fine to do this
+                                    var dir_info = (jsc_vm.bundler.resolver.readDirInfo(parse_result.source.path.name.dir) catch null) orelse
+                                        break :brk .javascript;
+
+                                    break :brk2 dir_info.package_json orelse dir_info.enclosing_package_json;
+                                } orelse break :brk .javascript;
+
+                                if (actual_package_json.module_type == .esm) {
+                                    break :brk ResolvedSource.Tag.package_json_type_module;
+                                }
+                            }
+
+                            break :brk ResolvedSource.Tag.javascript;
+                        },
+                    };
+                }
+
                 const start_count = jsc_vm.bundler.linker.import_counter;
 
                 // We _must_ link because:
@@ -1725,7 +1819,7 @@ pub const ModuleLoader = struct {
                     .allocator = null,
                     .source_code = brk: {
                         const written = printer.ctx.getWritten();
-                        const result = bun.String.createLatin1(written);
+                        const result = cache.output_code orelse bun.String.createLatin1(written);
 
                         if (written.len > 1024 * 1024 * 2 or jsc_vm.smol) {
                             printer.ctx.buffer.deinit();

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2058,3 +2058,5 @@ pub fn exitThread() noreturn {
 pub fn outOfMemory() noreturn {
     @panic("Out of memory");
 }
+
+pub const Tmpfile = @import("./tmp.zig").Tmpfile;

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -31,6 +31,8 @@ pub const meta = @import("./meta.zig");
 pub const ComptimeStringMap = @import("./comptime_string_map.zig").ComptimeStringMap;
 pub const base64 = @import("./base64/base64.zig");
 pub const path = @import("./resolver/resolve_path.zig");
+pub const resolver = @import("./resolver//resolver.zig");
+pub const PackageJSON = @import("./resolver/package_json.zig").PackageJSON;
 pub const fmt = struct {
     pub usingnamespace std.fmt;
 

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -103,6 +103,8 @@ pub const Run = struct {
             .unspecified => {},
         }
 
+        b.options.env.behavior = .disable;
+
         b.configureRouter(false) catch {
             if (Output.enable_ansi_colors_stderr) {
                 vm.log.printForLogLevelWithEnableAnsiColors(Output.errorWriter(), true) catch {};
@@ -191,6 +193,7 @@ pub const Run = struct {
         b.resolver.opts.minify_identifiers = ctx.bundler_options.minify_identifiers;
         b.resolver.opts.minify_whitespace = ctx.bundler_options.minify_whitespace;
 
+        b.options.env.behavior = .disable;
         // b.options.minify_syntax = ctx.bundler_options.minify_syntax;
 
         switch (ctx.debug.macros) {

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -103,7 +103,7 @@ pub const Run = struct {
             .unspecified => {},
         }
 
-        b.options.env.behavior = .disable;
+        b.options.env.behavior = .load_all_without_inlining;
 
         b.configureRouter(false) catch {
             if (Output.enable_ansi_colors_stderr) {
@@ -193,7 +193,7 @@ pub const Run = struct {
         b.resolver.opts.minify_identifiers = ctx.bundler_options.minify_identifiers;
         b.resolver.opts.minify_whitespace = ctx.bundler_options.minify_whitespace;
 
-        b.options.env.behavior = .disable;
+        b.options.env.behavior = .load_all_without_inlining;
         // b.options.minify_syntax = ctx.bundler_options.minify_syntax;
 
         switch (ctx.debug.macros) {

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -457,7 +457,7 @@ pub const Bundler = struct {
 
     pub fn runEnvLoader(this: *Bundler) !void {
         switch (this.options.env.behavior) {
-            .prefix, .load_all => {
+            .prefix, .load_all, .load_all_without_inlining => {
                 // Step 1. Load the project root.
                 const dir_info = this.resolver.readDirInfo(this.fs.top_level_dir) catch return orelse return;
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -558,6 +558,8 @@ pub const Arguments = struct {
                     Command.Debugger{ .enable = .{
                         .path_or_port = inspect_flag,
                     } };
+
+                bun.JSC.RuntimeTranspilerCache.is_disabled = true;
             } else if (args.option("--inspect-wait")) |inspect_flag| {
                 ctx.runtime_options.debugger = if (inspect_flag.len == 0)
                     Command.Debugger{ .enable = .{
@@ -568,6 +570,8 @@ pub const Arguments = struct {
                         .path_or_port = inspect_flag,
                         .wait_for_connection = true,
                     } };
+
+                bun.JSC.RuntimeTranspilerCache.is_disabled = true;
             } else if (args.option("--inspect-brk")) |inspect_flag| {
                 ctx.runtime_options.debugger = if (inspect_flag.len == 0)
                     Command.Debugger{ .enable = .{
@@ -580,6 +584,8 @@ pub const Arguments = struct {
                         .wait_for_connection = true,
                         .set_breakpoint_on_first_line = true,
                     } };
+
+                bun.JSC.RuntimeTranspilerCache.is_disabled = true;
             }
         }
 
@@ -739,6 +745,11 @@ pub const Arguments = struct {
         if (cmd == .AutoCommand or cmd == .RunCommand) {
             ctx.debug.silent = args.flag("--silent");
             ctx.debug.run_in_bun = args.flag("--bun") or ctx.debug.run_in_bun;
+
+            if (opts.define) |define| {
+                if (define.keys.len > 0)
+                    bun.JSC.RuntimeTranspilerCache.is_disabled = true;
+            }
         }
 
         opts.resolve = Api.ResolveMode.lazy;

--- a/src/copy_file.zig
+++ b/src/copy_file.zig
@@ -27,7 +27,6 @@ pub fn copyFile(fd_in: os.fd_t, fd_out: os.fd_t) CopyFileError!void {
         const rc = os.system.fcopyfile(fd_in, fd_out, null, os.system.COPYFILE_DATA);
         switch (os.errno(rc)) {
             .SUCCESS => return,
-            .INVAL => unreachable,
             .NOMEM => return error.SystemResources,
             // The source file is not a directory, symbolic link, or regular file.
             // Try with the fallback path before giving up.

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -240,7 +240,7 @@ pub const Loader = struct {
         var key_buf_len: usize = 0;
         var e_strings_to_allocate: usize = 0;
 
-        if (behavior != .disable) {
+        if (behavior != .disable and behavior != .load_all_without_inlining) {
             if (behavior == .prefix) {
                 std.debug.assert(prefix.len > 0);
 

--- a/src/feature_flags.zig
+++ b/src/feature_flags.zig
@@ -181,3 +181,5 @@ pub const disable_on_windows_due_to_bugs = env.isWindows;
 
 // https://github.com/oven-sh/bun/issues/5426#issuecomment-1813865316
 pub const disable_auto_js_to_ts_in_node_modules = true;
+
+pub const runtime_transpiler_cache = true;

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -72,7 +72,7 @@ pub const FileSystem = struct {
 
     var tmpname_id_number = std.atomic.Atomic(u32).init(0);
     pub fn tmpname(_: *const FileSystem, extname: string, buf: []u8, hash: u64) ![*:0]u8 {
-        const hex_value = @as(u64, @truncate(@as(u128, @intCast(hash)) ^ @as(u128, @intCast(std.time.nanoTimestamp()))));
+        const hex_value = @as(u64, @truncate(@as(u128, @intCast(hash)) | @as(u128, @intCast(std.time.nanoTimestamp()))));
 
         return try std.fmt.bufPrintZ(buf, ".{any}-{any}.{s}", .{
             bun.fmt.hexIntLower(hex_value),

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -655,7 +655,7 @@ pub const FileSystem = struct {
                 std.debug.assert(this.fd != bun.invalid_fd);
                 std.debug.assert(this.dir_fd != bun.invalid_fd);
 
-                try C.moveFileZWithHandle(bun.fdcast(this.fd), bun.fdcast(this.dir_fd), from_name, std.fs.cwd().fd, name);
+                try C.moveFileZWithHandle(bun.fdcast(this.fd), bun.fdcast(this.dir_fd), bun.sliceTo(from_name, 0), std.fs.cwd().fd, bun.sliceTo(name, 0));
                 this.close();
             }
 

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1745,6 +1745,10 @@ pub const Path = struct {
     pub fn isNodeModule(this: *const Path) bool {
         return strings.lastIndexOf(this.name.dir, std.fs.path.sep_str ++ "node_modules" ++ std.fs.path.sep_str) != null;
     }
+
+    pub fn isJSXFile(this: *const Path) bool {
+        return strings.hasSuffixComptime(this.name.filename, ".jsx") or strings.hasSuffixComptime(this.name.filename, ".tsx");
+    }
 };
 
 // pub fn customRealpath(allocator: std.mem.Allocator, path: string) !string {

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -279,16 +279,19 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
     }
 
     // Now that we've extracted the archive, we rename.
-    std.os.renameatZ(tmpdir.fd, tmpname, cache_dir.fd, folder_name) catch |err| {
-        this.package_manager.log.addErrorFmt(
-            null,
-            logger.Loc.Empty,
-            this.package_manager.allocator,
-            "moving \"{s}\" to cache dir failed: {s}\n  From: {s}\n    To: {s}",
-            .{ name, @errorName(err), tmpname, folder_name },
-        ) catch unreachable;
-        return error.InstallFailed;
-    };
+    switch (bun.sys.renameat(tmpdir.fd, bun.sliceTo(tmpname, 0), cache_dir.fd, folder_name)) {
+        .err => |err| {
+            this.package_manager.log.addErrorFmt(
+                null,
+                logger.Loc.Empty,
+                this.package_manager.allocator,
+                "moving \"{s}\" to cache dir failed: {}\n  From: {s}\n    To: {s}",
+                .{ name, err, tmpname, folder_name },
+            ) catch unreachable;
+            return error.InstallFailed;
+        },
+        .result => {},
+    }
 
     // We return a resolved absolute absolute file path to the cache dir.
     // To get that directory, we open the directory again.

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -6470,6 +6470,7 @@ pub const Part = struct {
 
 pub const Result = union(enum) {
     already_bundled: void,
+    cached: void,
     ast: Ast,
 };
 

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -3934,7 +3934,7 @@ pub const Parser = struct {
             }) catch unreachable;
 
             // If we injected jest globals, we need to disable the runtime transpiler cache
-            if (p.options.runtime_transpiler_cache) |cache| {
+            if (p.options.features.runtime_transpiler_cache) |cache| {
                 cache.input_hash = null;
             }
         }

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -3869,7 +3869,7 @@ pub const Parser = struct {
             for (p.import_records.items) |*item| {
                 // skip if they did import it
                 if (strings.eqlComptime(item.path.text, "bun:test") or strings.eqlComptime(item.path.text, "@jest/globals") or strings.eqlComptime(item.path.text, "vitest")) {
-                    if (p.options.runtime_transpiler_cache) |cache| {
+                    if (p.options.features.runtime_transpiler_cache) |cache| {
                         // If we rewrote import paths, we need to disable the runtime transpiler cache
                         if (!strings.eqlComptime(item.path.text, "bun:test")) {
                             cache.input_hash = null;

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -2798,7 +2798,6 @@ pub const Parser = struct {
         jsx: options.JSX.Pragma,
         ts: bool = false,
         keep_names: bool = true,
-        omit_runtime_for_tests: bool = false,
         ignore_dce_annotations: bool = false,
         preserve_unused_imports_ts: bool = false,
         use_define_for_class_fields: bool = false,
@@ -2819,6 +2818,31 @@ pub const Parser = struct {
         module_type: options.ModuleType = .unknown,
 
         transform_only: bool = false,
+
+        pub fn hashForRuntimeTranspiler(this: *const Options, hasher: *std.hash.Wyhash, did_use_jsx: bool) void {
+            std.debug.assert(!this.bundle);
+
+            if (did_use_jsx) {
+                if (this.jsx.parse) {
+                    this.jsx.hashForRuntimeTranspiler(hasher);
+                    const jsx_optimizations = [_]bool{
+                        this.features.jsx_optimization_inline,
+                        this.features.jsx_optimization_hoist,
+                    };
+                    hasher.update(std.mem.asBytes(&jsx_optimizations));
+                } else {
+                    hasher.update("NO_JSX");
+                }
+            }
+
+            if (this.ts) {
+                hasher.update("TS");
+            } else {
+                hasher.update("NO_TS");
+            }
+
+            this.features.hashForRuntimeTranspiler(hasher);
+        }
 
         pub fn init(jsx: options.JSX.Pragma, loader: options.Loader) Options {
             var opts = Options{
@@ -3082,7 +3106,7 @@ pub const Parser = struct {
         if (comptime Environment.isNative and bun.FeatureFlags.runtime_transpiler_cache) {
             var runtime_transpiler_cache: ?*bun.JSC.RuntimeTranspilerCache = p.options.features.runtime_transpiler_cache;
             if (runtime_transpiler_cache) |cache| {
-                if (cache.get(p.source)) {
+                if (cache.get(p.source, &p.options, p.options.jsx.parse and (!p.source.path.isNodeModule() or p.source.path.isJSXFile()))) {
                     return js_ast.Result{
                         .cached = {},
                     };
@@ -3285,45 +3309,57 @@ pub const Parser = struct {
         const postvisit_tracer = bun.tracy.traceNamed(@src(), "JSParser.postvisit");
         defer postvisit_tracer.end();
 
-        const uses_dirname = p.symbols.items[p.dirname_ref.innerIndex()].use_count_estimate > 0;
-        const uses_filename = p.symbols.items[p.filename_ref.innerIndex()].use_count_estimate > 0;
+        var uses_dirname = p.symbols.items[p.dirname_ref.innerIndex()].use_count_estimate > 0;
+        var uses_filename = p.symbols.items[p.filename_ref.innerIndex()].use_count_estimate > 0;
 
-        if (uses_dirname or uses_filename) {
-            const count = @as(usize, @intFromBool(uses_dirname)) + @as(usize, @intFromBool(uses_filename));
-            var declared_symbols = DeclaredSymbol.List.initCapacity(p.allocator, count) catch unreachable;
-            var decls = p.allocator.alloc(G.Decl, count) catch unreachable;
-            if (uses_dirname) {
-                decls[0] = .{
-                    .binding = p.b(B.Identifier{ .ref = p.dirname_ref }, logger.Loc.Empty),
-                    .value = p.newExpr(
-                        // TODO: test UTF-8 file paths
-                        E.String.init(p.source.path.name.dir),
-                        logger.Loc.Empty,
-                    ),
-                };
-                declared_symbols.appendAssumeCapacity(.{ .ref = p.dirname_ref, .is_top_level = true });
-            }
-            if (uses_filename) {
-                decls[@as(usize, @intFromBool(uses_dirname))] = .{
-                    .binding = p.b(B.Identifier{ .ref = p.filename_ref }, logger.Loc.Empty),
-                    .value = p.newExpr(
-                        E.String.init(p.source.path.text),
-                        logger.Loc.Empty,
-                    ),
-                };
-                declared_symbols.appendAssumeCapacity(.{ .ref = p.filename_ref, .is_top_level = true });
-            }
+        // Handle dirname and filename at bundle-time
+        // We always inject it at the top of the module
+        //
+        // This inlines
+        //
+        //    var __dirname = "foo/bar"
+        //    var __filename = "foo/bar/baz.js"
+        //
+        if (p.options.bundle or !p.options.features.commonjs_at_runtime) {
+            if (uses_dirname or uses_filename) {
+                const count = @as(usize, @intFromBool(uses_dirname)) + @as(usize, @intFromBool(uses_filename));
+                var declared_symbols = DeclaredSymbol.List.initCapacity(p.allocator, count) catch unreachable;
+                var decls = p.allocator.alloc(G.Decl, count) catch unreachable;
+                if (uses_dirname) {
+                    decls[0] = .{
+                        .binding = p.b(B.Identifier{ .ref = p.dirname_ref }, logger.Loc.Empty),
+                        .value = p.newExpr(
+                            // TODO: test UTF-8 file paths
+                            E.String.init(p.source.path.name.dir),
+                            logger.Loc.Empty,
+                        ),
+                    };
+                    declared_symbols.appendAssumeCapacity(.{ .ref = p.dirname_ref, .is_top_level = true });
+                }
+                if (uses_filename) {
+                    decls[@as(usize, @intFromBool(uses_dirname))] = .{
+                        .binding = p.b(B.Identifier{ .ref = p.filename_ref }, logger.Loc.Empty),
+                        .value = p.newExpr(
+                            E.String.init(p.source.path.text),
+                            logger.Loc.Empty,
+                        ),
+                    };
+                    declared_symbols.appendAssumeCapacity(.{ .ref = p.filename_ref, .is_top_level = true });
+                }
 
-            var part_stmts = p.allocator.alloc(Stmt, 1) catch unreachable;
-            part_stmts[0] = p.s(S.Local{
-                .kind = .k_var,
-                .decls = Decl.List.init(decls),
-            }, logger.Loc.Empty);
-            before.append(js_ast.Part{
-                .stmts = part_stmts,
-                .declared_symbols = declared_symbols,
-                .tag = .dirname_filename,
-            }) catch unreachable;
+                var part_stmts = p.allocator.alloc(Stmt, 1) catch unreachable;
+                part_stmts[0] = p.s(S.Local{
+                    .kind = .k_var,
+                    .decls = Decl.List.init(decls),
+                }, logger.Loc.Empty);
+                before.append(js_ast.Part{
+                    .stmts = part_stmts,
+                    .declared_symbols = declared_symbols,
+                    .tag = .dirname_filename,
+                }) catch unreachable;
+                uses_dirname = false;
+                uses_filename = false;
+            }
         }
 
         var did_import_fast_refresh = false;
@@ -3766,6 +3802,62 @@ pub const Parser = struct {
             }
         }
 
+        // Handle dirname and filename at runtime.
+        //
+        // If we reach this point, it means:
+        //
+        // 1) we are building an ESM file that uses __dirname or __filename
+        // 2) we are targeting bun's runtime.
+        // 3) we are not bundling.
+        //
+        if (exports_kind == .esm and (uses_dirname or uses_filename)) {
+            std.debug.assert(!p.options.bundle);
+            const count = @as(usize, @intFromBool(uses_dirname)) + @as(usize, @intFromBool(uses_filename));
+            var declared_symbols = DeclaredSymbol.List.initCapacity(p.allocator, count) catch unreachable;
+            var decls = p.allocator.alloc(G.Decl, count) catch unreachable;
+            if (uses_dirname) {
+                // var __dirname = import.meta.dir
+                decls[0] = .{
+                    .binding = p.b(B.Identifier{ .ref = p.dirname_ref }, logger.Loc.Empty),
+                    .value = p.newExpr(
+                        E.Dot{
+                            .name = "dir",
+                            .name_loc = logger.Loc.Empty,
+                            .target = p.newExpr(E.ImportMeta{}, logger.Loc.Empty),
+                        },
+                        logger.Loc.Empty,
+                    ),
+                };
+                declared_symbols.appendAssumeCapacity(.{ .ref = p.dirname_ref, .is_top_level = true });
+            }
+            if (uses_filename) {
+                // var __filename = import.meta.path
+                decls[@as(usize, @intFromBool(uses_dirname))] = .{
+                    .binding = p.b(B.Identifier{ .ref = p.filename_ref }, logger.Loc.Empty),
+                    .value = p.newExpr(
+                        E.Dot{
+                            .name = "path",
+                            .name_loc = logger.Loc.Empty,
+                            .target = p.newExpr(E.ImportMeta{}, logger.Loc.Empty),
+                        },
+                        logger.Loc.Empty,
+                    ),
+                };
+                declared_symbols.appendAssumeCapacity(.{ .ref = p.filename_ref, .is_top_level = true });
+            }
+
+            var part_stmts = p.allocator.alloc(Stmt, 1) catch unreachable;
+            part_stmts[0] = p.s(S.Local{
+                .kind = .k_var,
+                .decls = Decl.List.init(decls),
+            }, logger.Loc.Empty);
+            before.append(js_ast.Part{
+                .stmts = part_stmts,
+                .declared_symbols = declared_symbols,
+                .tag = .dirname_filename,
+            }) catch unreachable;
+        }
+
         if (exports_kind == .esm and p.commonjs_named_exports.count() > 0 and !p.unwrap_all_requires and !force_esm) {
             exports_kind = .esm_with_dynamic_fallback_from_cjs;
         }
@@ -3954,7 +4046,13 @@ pub const Parser = struct {
         if (comptime Environment.isNative and bun.FeatureFlags.runtime_transpiler_cache) {
             var runtime_transpiler_cache: ?*bun.JSC.RuntimeTranspilerCache = p.options.features.runtime_transpiler_cache;
             if (runtime_transpiler_cache) |cache| {
-                cache.exports_kind = exports_kind;
+                if (p.macro_call_count != 0) {
+                    // disable this for:
+                    // - macros
+                    cache.input_hash = null;
+                } else {
+                    cache.exports_kind = exports_kind;
+                }
             }
         }
 
@@ -22114,6 +22212,11 @@ fn NewParser_(
             if (opts.features.top_level_await or comptime only_scan_imports_and_do_not_visit) {
                 this.fn_or_arrow_data_parse.allow_await = .allow_expr;
                 this.fn_or_arrow_data_parse.is_top_level = true;
+            }
+
+            if (comptime !is_typescript_enabled) {
+                // This is so it doesn't impact runtime transpiler caching when not in use
+                this.options.features.emit_decorator_metadata = false;
             }
         }
     };

--- a/src/jsc.zig
+++ b/src/jsc.zig
@@ -94,3 +94,5 @@ pub const Codegen = struct {
 };
 
 pub const GeneratedClassesList = @import("./bun.js/bindings/generated_classes_list.zig").Classes;
+
+pub const RuntimeTranspilerCache = @import("./bun.js/RuntimeTranspilerCache.zig").RuntimeTranspilerCache;

--- a/src/options.zig
+++ b/src/options.zig
@@ -979,6 +979,15 @@ pub const JSX = struct {
             production: string = "react/jsx-runtime",
         };
 
+        pub fn hashForRuntimeTranspiler(this: *const Pragma, hasher: *std.hash.Wyhash) void {
+            for (this.factory) |factory| hasher.update(factory);
+            for (this.fragment) |fragment| hasher.update(fragment);
+            hasher.update(this.import_source.development);
+            hasher.update(this.import_source.production);
+            hasher.update(this.classic_import_source);
+            hasher.update(this.package_name);
+        }
+
         pub fn importSource(this: *const Pragma) string {
             return switch (this.development) {
                 true => this.import_source.development,
@@ -1707,9 +1716,8 @@ pub const BundleOptions = struct {
                 opts.allow_runtime = false;
             },
             .bun => {
-                // If we're doing SSR, we want all the URLs to be the same as what it would be in the browser
-                // If we're not doing SSR, we want all the import paths to be absolute
                 opts.import_path_format = if (opts.import_path_format == .absolute_url) .absolute_url else .absolute_path;
+
                 opts.env.behavior = .load_all;
                 if (transform.extension_order.len == 0) {
                     // we must also support require'ing .node files

--- a/src/options.zig
+++ b/src/options.zig
@@ -2026,7 +2026,7 @@ pub const OutputFile = struct {
     }
 
     pub fn moveTo(file: *const OutputFile, _: string, rel_path: []u8, dir: FileDescriptorType) !void {
-        try bun.C.moveFileZ(bun.fdcast(file.value.move.dir), &(try std.os.toPosixPath(file.value.move.getPathname())), bun.fdcast(dir), &(try std.os.toPosixPath(rel_path)));
+        try bun.C.moveFileZ(bun.fdcast(file.value.move.dir), bun.sliceTo(&(try std.os.toPosixPath(file.value.move.getPathname())), 0), bun.fdcast(dir), bun.sliceTo(&(try std.os.toPosixPath(rel_path)), 0));
     }
 
     pub fn copyTo(file: *const OutputFile, _: string, rel_path: []u8, dir: FileDescriptorType) !void {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -293,6 +293,8 @@ pub const Runtime = struct {
 
         set_breakpoint_on_first_line: bool = false,
 
+        runtime_transpiler_cache: ?*bun.JSC.RuntimeTranspilerCache = null,
+
         /// Instead of jsx("div", {}, void 0)
         /// ->
         /// {

--- a/src/sha.zig
+++ b/src/sha.zig
@@ -222,7 +222,7 @@ pub fn main() anyerror!void {
 
     {
         var clock1 = try std.time.Timer.start();
-        std.mem.doNotOptimizeAway(std.hash.XxHash64.hash(bytes));
+        std.mem.doNotOptimizeAway(std.hash.XxHash64.hash(0, bytes));
         const zig_time = clock1.read();
         std.debug.print(
             "xxhash:\n\n     zig: {any}\n\n",

--- a/src/standalone_bun.zig
+++ b/src/standalone_bun.zig
@@ -446,9 +446,9 @@ pub const StandaloneModuleGraph = struct {
         bun.C.moveFileZWithHandle(
             fd,
             std.fs.cwd().fd,
-            &(try std.os.toPosixPath(temp_location)),
+            bun.sliceTo(&(try std.os.toPosixPath(temp_location)), 0),
             root_dir.dir.fd,
-            &(try std.os.toPosixPath(std.fs.path.basename(outfile))),
+            bun.sliceTo(&(try std.os.toPosixPath(std.fs.path.basename(outfile))), 0),
         ) catch |err| {
             if (err == error.IsDir) {
                 Output.prettyErrorln("<r><red>error<r><d>:<r> {} is a directory. Please choose a different --outfile or delete the directory", .{bun.fmt.quote(outfile)});

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1085,6 +1085,17 @@ pub fn unlink(from: [:0]const u8) Maybe(void) {
     unreachable;
 }
 
+pub fn unlinkat(dirfd: bun.FileDescriptor, to: [:0]const u8) Maybe(void) {
+    while (true) {
+        if (Maybe(void).errnoSys(sys.unlinkat(dirfd, to), .unlink)) |err| {
+            if (err.getErrno() == .INTR) continue;
+            return err;
+        }
+        return Maybe(void).success;
+    }
+    unreachable;
+}
+
 pub fn getFdPath(fd_: bun.FileDescriptor, out_buffer: *[MAX_PATH_BYTES]u8) Maybe([]u8) {
     const fd = bun.fdcast(fd_);
     switch (comptime builtin.os.tag) {

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1013,6 +1013,17 @@ pub fn rename(from: [:0]const u8, to: [:0]const u8) Maybe(void) {
     unreachable;
 }
 
+pub fn renameat(from_dir: bun.FileDescriptor, from: [:0]const u8, to_dir: bun.FileDescriptor, to: [:0]const u8) Maybe(void) {
+    while (true) {
+        if (Maybe(void).errnoSys(sys.renameat(from_dir, from, to_dir, to), .rename)) |err| {
+            if (err.getErrno() == .INTR) continue;
+            return err;
+        }
+        return Maybe(void).success;
+    }
+    unreachable;
+}
+
 pub fn chown(path: [:0]const u8, uid: os.uid_t, gid: os.gid_t) Maybe(void) {
     while (true) {
         if (Maybe(void).errnoSys(C.chown(path, uid, gid), .chown)) |err| {
@@ -1085,7 +1096,18 @@ pub fn unlink(from: [:0]const u8) Maybe(void) {
     unreachable;
 }
 
-pub fn unlinkat(dirfd: bun.FileDescriptor, to: [:0]const u8) Maybe(void) {
+pub fn rmdirat(dirfd: bun.FileDescriptor, to: anytype) Maybe(void) {
+    while (true) {
+        if (Maybe(void).errnoSys(sys.unlinkat(dirfd, to, 1), .unlink)) |err| {
+            if (err.getErrno() == .INTR) continue;
+            return err;
+        }
+        return Maybe(void).success;
+    }
+    unreachable;
+}
+
+pub fn unlinkat(dirfd: bun.FileDescriptor, to: anytype) Maybe(void) {
     while (true) {
         if (Maybe(void).errnoSys(sys.unlinkat(dirfd, to, 0), .unlink)) |err| {
             if (err.getErrno() == .INTR) continue;

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1087,7 +1087,7 @@ pub fn unlink(from: [:0]const u8) Maybe(void) {
 
 pub fn unlinkat(dirfd: bun.FileDescriptor, to: [:0]const u8) Maybe(void) {
     while (true) {
-        if (Maybe(void).errnoSys(sys.unlinkat(dirfd, to), .unlink)) |err| {
+        if (Maybe(void).errnoSys(sys.unlinkat(dirfd, to, 0), .unlink)) |err| {
             if (err.getErrno() == .INTR) continue;
             return err;
         }
@@ -1546,5 +1546,23 @@ pub fn linkat(dir_fd: bun.FileDescriptor, basename: []const u8, dest_dir_fd: bun
         ),
         .link,
         basename,
+    ) orelse Maybe(void).success;
+}
+
+pub fn linkatTmpfile(tmpfd: bun.FileDescriptor, dirfd: bun.FileDescriptor, name: [:0]const u8) Maybe(void) {
+    if (comptime !Environment.isLinux) {
+        @compileError("Linux only.");
+    }
+
+    return Maybe(void).errnoSysP(
+        std.os.linux.linkat(
+            bun.fdcast(tmpfd),
+            "",
+            dirfd,
+            name,
+            os.AT.EMPTY_PATH,
+        ),
+        .link,
+        name,
     ) orelse Maybe(void).success;
 }

--- a/src/tmp.zig
+++ b/src/tmp.zig
@@ -38,7 +38,7 @@ pub const Tmpfile = struct {
                 }
             }
 
-            tmpfile.fd = switch (bun.sys.openat(bun.toFD(bun.fs.FileSystem.instance.tmpdir().fd), tmpfilename, O.CREAT | O.CLOEXEC | O.WRONLY, perm)) {
+            tmpfile.fd = switch (bun.sys.openat(destination_dir, tmpfilename, O.CREAT | O.CLOEXEC | O.WRONLY, perm)) {
                 .result => |fd| fd,
                 .err => |err| return .{ .err = err },
             };
@@ -55,6 +55,6 @@ pub const Tmpfile = struct {
             }
         }
 
-        try bun.C.moveFileZWithHandle(bun.fdcast(this.fd), this.destination_dir, this.tmpfilename.ptr, bun.fdcast(this.destination_dir), destname.ptr);
+        try bun.C.moveFileZWithHandle(bun.fdcast(this.fd), this.destination_dir, this.tmpfilename, bun.fdcast(this.destination_dir), destname);
     }
 };

--- a/src/tmp.zig
+++ b/src/tmp.zig
@@ -22,7 +22,6 @@ pub const Tmpfile = struct {
 
         open: while (true) {
             if (comptime Environment.isLinux) {
-                
                 switch (bun.sys.openat(destination_dir, ".", O.WRONLY | O.TMPFILE | O.CLOEXEC, perm)) {
                     .result => |fd| {
                         tmpfile.fd = fd;

--- a/src/tmp.zig
+++ b/src/tmp.zig
@@ -22,7 +22,8 @@ pub const Tmpfile = struct {
 
         open: while (true) {
             if (comptime Environment.isLinux) {
-                switch (bun.sys.openat(destination_dir, ".", O.WRONLY | O.TMPFILE | O.CREAT | O.CLOEXEC, perm)) {
+                
+                switch (bun.sys.openat(destination_dir, ".", O.WRONLY | O.TMPFILE | O.CLOEXEC, perm)) {
                     .result => |fd| {
                         tmpfile.fd = fd;
                         break :open;

--- a/src/tmp.zig
+++ b/src/tmp.zig
@@ -29,7 +29,7 @@ pub const Tmpfile = struct {
                     },
                     .err => |err| {
                         switch (err.getErrno()) {
-                            .INVAL, .OPNOTSUP, .NOSYS => {
+                            .INVAL, .OPNOTSUPP, .NOSYS => {
                                 tmpfile.using_tmpfile = false;
                             },
                             else => return .{ .err = err },

--- a/src/tmp.zig
+++ b/src/tmp.zig
@@ -1,0 +1,60 @@
+const bun = @import("root").bun;
+const std = @import("std");
+const Environment = bun.Environment;
+const O = std.os.O;
+// To be used with files
+// not folders!
+pub const Tmpfile = struct {
+    destination_dir: bun.FileDescriptor = bun.invalid_fd,
+    tmpfilename: [:0]const u8 = "",
+    fd: bun.FileDescriptor = bun.invalid_fd,
+    using_tmpfile: bool = Environment.isLinux,
+
+    pub fn create(
+        destination_dir: bun.FileDescriptor,
+        tmpfilename: [:0]const u8,
+    ) bun.JSC.Maybe(Tmpfile) {
+        const perm = 0o644;
+        var tmpfile = Tmpfile{
+            .destination_dir = destination_dir,
+            .tmpfilename = tmpfilename,
+        };
+
+        open: while (true) {
+            if (comptime Environment.isLinux) {
+                switch (bun.sys.openat(destination_dir, ".", O.WRONLY | O.TMPFILE | O.CREAT | O.CLOEXEC, perm)) {
+                    .result => |fd| {
+                        tmpfile.fd = fd;
+                        break :open;
+                    },
+                    .err => |err| {
+                        switch (err.getErrno()) {
+                            .INVAL, .OPNOTSUP, .NOSYS => {
+                                tmpfile.using_tmpfile = false;
+                            },
+                            else => return .{ .err = err },
+                        }
+                    },
+                }
+            }
+
+            tmpfile.fd = switch (bun.sys.openat(bun.toFD(bun.fs.FileSystem.instance.tmpdir().fd), tmpfilename, O.CREAT | O.CLOEXEC | O.WRONLY, perm)) {
+                .result => |fd| fd,
+                .err => |err| return .{ .err = err },
+            };
+            break :open;
+        }
+
+        return .{ .result = tmpfile };
+    }
+
+    pub fn finish(this: *Tmpfile, destname: [:0]const u8) !void {
+        if (comptime Environment.isLinux) {
+            if (this.using_tmpfile) {
+                return try bun.sys.linkatTmpfile(this.fd, this.destination_dir, destname).unwrap();
+            }
+        }
+
+        try bun.C.moveFileZWithHandle(bun.fdcast(this.fd), this.destination_dir, this.tmpfilename.ptr, bun.fdcast(this.destination_dir), destname.ptr);
+    }
+};

--- a/test/cli/run/transpiler-cache-aggressive-remover.js
+++ b/test/cli/run/transpiler-cache-aggressive-remover.js
@@ -1,0 +1,7 @@
+import { rmSync } from "fs";
+
+while(1) {
+  try {
+    rmSync(process.argv[2], { recursive: true });
+  } catch (error) {}
+}

--- a/test/cli/run/transpiler-cache-aggressive-remover.js
+++ b/test/cli/run/transpiler-cache-aggressive-remover.js
@@ -2,6 +2,6 @@ import { rmSync } from "fs";
 
 while (1) {
   try {
-    rmSync(process.argv[2], { recursive: true });
+    rmSync(process.argv[2], { recursive: true, force: true });
   } catch (error) {}
 }

--- a/test/cli/run/transpiler-cache-aggressive-remover.js
+++ b/test/cli/run/transpiler-cache-aggressive-remover.js
@@ -1,6 +1,6 @@
 import { rmSync } from "fs";
 
-while(1) {
+while (1) {
   try {
     rmSync(process.argv[2], { recursive: true });
   } catch (error) {}

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -1,28 +1,28 @@
 import { describe, test, expect } from "bun:test";
-import { mkdtempSync , writeFileSync, existsSync, readdirSync, rmSync } from "fs";
-import { tmpdir } from 'os'
-import { join } from 'path'
-import { bunEnv, bunExe, bunRun } from 'harness'
-import assert from 'assert';
+import { mkdtempSync, writeFileSync, existsSync, readdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { bunEnv, bunExe, bunRun } from "harness";
+import assert from "assert";
 import { chmodSync } from "../../js/node/fs/export-star-from";
 import { Subprocess } from "bun";
 
 function dummyFile(size: number, cache_bust: string, value: string) {
   const data = Buffer.alloc(size);
-  data.write('/*' + cache_bust);
+  data.write("/*" + cache_bust);
   const end = `*/\nconsole.log(${JSON.stringify(value)});`;
-  data.fill('*', 2 + cache_bust.length, size - end.length, 'utf-8');
-  data.write(end, size - end.length, 'utf-8');
+  data.fill("*", 2 + cache_bust.length, size - end.length, "utf-8");
+  data.write(end, size - end.length, "utf-8");
   return data;
 }
 
 const temp_dir = mkdtempSync(`${tmpdir()}/bun-test-transpiler-cache-`);
-const cache_dir = join(temp_dir, '.cache');
+const cache_dir = join(temp_dir, ".cache");
 
 const env = {
   ...bunEnv,
   BUN_RUNTIME_TRANSPILER_CACHE_PATH: cache_dir,
-}
+};
 
 let prev_cache_count = 0;
 function newCacheCount() {
@@ -45,111 +45,113 @@ function removeCache() {
   }
 }
 
-console.log(temp_dir)
+console.log(temp_dir);
 
 assert(!existsSync(cache_dir));
 
-describe('transpiler cache', () => {
+describe("transpiler cache", () => {
   test("works", async () => {
-    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'a'));
-    const a = bunRun(join(temp_dir, 'a.js'), env);
-    expect(a.stdout == 'a');
+    writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "1", "a"));
+    const a = bunRun(join(temp_dir, "a.js"), env);
+    expect(a.stdout == "a");
     assert(existsSync(cache_dir));
     expect(newCacheCount()).toBe(1);
-    const b = bunRun(join(temp_dir, 'a.js'), env);
-    expect(b.stdout == 'a');
+    const b = bunRun(join(temp_dir, "a.js"), env);
+    expect(b.stdout == "a");
     expect(newCacheCount()).toBe(0);
   });
   test("ignores files under 50kb", async () => {
-    removeCache()
-    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024 - 1, '1', 'a'));
-    const a = bunRun(join(temp_dir, 'a.js'), env);
-    expect(a.stdout == 'a');
+    removeCache();
+    writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024 - 1, "1", "a"));
+    const a = bunRun(join(temp_dir, "a.js"), env);
+    expect(a.stdout == "a");
     assert(!existsSync(cache_dir));
   });
   test("it is indeed content addressable", async () => {
-    removeCache()
-    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'b'));
-    const a = bunRun(join(temp_dir, 'a.js'), env);
-    expect(a.stdout == 'b');
+    removeCache();
+    writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "1", "b"));
+    const a = bunRun(join(temp_dir, "a.js"), env);
+    expect(a.stdout == "b");
     expect(newCacheCount()).toBe(1);
 
-    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'c'));
-    const b = bunRun(join(temp_dir, 'a.js'), env);
-    expect(b.stdout == 'c');
+    writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "1", "c"));
+    const b = bunRun(join(temp_dir, "a.js"), env);
+    expect(b.stdout == "c");
     expect(newCacheCount()).toBe(1);
 
-    writeFileSync(join(temp_dir, 'b.js'), dummyFile(50 * 1024, '1', 'b'));
-    const c = bunRun(join(temp_dir, 'b.js'), env);
-    expect(b.stdout == 'b');
+    writeFileSync(join(temp_dir, "b.js"), dummyFile(50 * 1024, "1", "b"));
+    const c = bunRun(join(temp_dir, "b.js"), env);
+    expect(b.stdout == "b");
     expect(newCacheCount()).toBe(0);
   });
   test.todo("doing 500 buns at once does not crash", async () => {
-    removeCache()
-    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'b'));
-    writeFileSync(join(temp_dir, 'b.js'), dummyFile(50 * 1024, '2', 'b'));
+    removeCache();
+    writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "1", "b"));
+    writeFileSync(join(temp_dir, "b.js"), dummyFile(50 * 1024, "2", "b"));
 
     const remover = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, 'transpiler-cache-aggressive-remover.js'), cache_dir],
+      cmd: [bunExe(), join(import.meta.dir, "transpiler-cache-aggressive-remover.js"), cache_dir],
       env,
       cwd: temp_dir,
-    })
+    });
 
-    let processes: Subprocess<'ignore', 'pipe', 'inherit'>[] = [];
+    let processes: Subprocess<"ignore", "pipe", "inherit">[] = [];
     let killing = false;
     for (let i = 0; i < 500; i++) {
-      processes.push(Bun.spawn({
-        cmd: [bunExe(), i % 2 == 0 ? 'a.js' : 'b.js'],
-        env,
-        cwd: temp_dir,
-        onExit(subprocess, exitCode, signalCode, error) {
-          if(exitCode != 0 && !killing) {
-            killing = true;
-            processes.forEach(x => x.kill(9));
-            remover.kill(9);
-          }
-        },
-      }));
+      processes.push(
+        Bun.spawn({
+          cmd: [bunExe(), i % 2 == 0 ? "a.js" : "b.js"],
+          env,
+          cwd: temp_dir,
+          onExit(subprocess, exitCode, signalCode, error) {
+            if (exitCode != 0 && !killing) {
+              killing = true;
+              processes.forEach(x => x.kill(9));
+              remover.kill(9);
+            }
+          },
+        }),
+      );
     }
 
     await Promise.all(processes.map(x => x.exited));
-    
+
     assert(!killing);
 
     remover.kill(9);
 
-    for(const proc of processes) {
+    for (const proc of processes) {
       expect(proc.exitCode).toBe(0);
-      expect(await Bun.readableStreamToText(proc.stdout)).toBe('b\n')
+      expect(await Bun.readableStreamToText(proc.stdout)).toBe("b\n");
     }
   });
-  test('works if the cache is not user-readable', () => {
+  test("works if the cache is not user-readable", () => {
     removeCache();
-    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'b'));
-    const a = bunRun(join(temp_dir, 'a.js'), env);
-    expect(a.stdout == 'b');
+    writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "1", "b"));
+    const a = bunRun(join(temp_dir, "a.js"), env);
+    expect(a.stdout == "b");
     expect(newCacheCount()).toBe(1);
-    
+
     const cache_item = readdirSync(cache_dir)[0];
 
     chmodSync(join(cache_dir, cache_item), 0);
-    const b = bunRun(join(temp_dir, 'a.js'), env);
-    expect(b.stdout == 'b');
+    const b = bunRun(join(temp_dir, "a.js"), env);
+    expect(b.stdout == "b");
     expect(newCacheCount()).toBe(0);
 
-    chmodSync(join(cache_dir), '0');
-    const c = bunRun(join(temp_dir, 'a.js'), env);
-    expect(c.stdout == 'b');
+    chmodSync(join(cache_dir), "0");
+    const c = bunRun(join(temp_dir, "a.js"), env);
+    expect(c.stdout == "b");
   });
-  test('works if the cache is not user-writable', () => {
+  test("works if the cache is not user-writable", () => {
     removeCache();
-    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'b'));
+    writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "1", "b"));
 
-    chmodSync(join(cache_dir), '0');
+    chmodSync(join(cache_dir), "0");
 
-    const a = bunRun(join(temp_dir, 'a.js'), env);
-    expect(a.stdout == 'b');
+    const a = bunRun(join(temp_dir, "a.js"), env);
+    expect(a.stdout == "b");
 
-    chmodSync(join(cache_dir), '777');
+    chmodSync(join(cache_dir), "777");
   });
-})
+});

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -15,8 +15,8 @@ function dummyFile(size: number, cache_bust: string, value: string) {
   return data;
 }
 
-let temp_dir: string = "/dev/null";
-let cache_dir = join(temp_dir, ".cache");
+let temp_dir: string = "";
+let cache_dir = "";
 
 const env = {
   ...bunEnv,

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync , writeFileSync, existsSync, readdirSync, rmSync } from "fs";
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { bunEnv, bunExe, bunRun } from 'harness'
+import assert from 'assert';
+import { chmodSync } from "../../js/node/fs/export-star-from";
+import { Subprocess } from "bun";
+
+function dummyFile(size: number, cache_bust: string, value: string) {
+  const data = Buffer.alloc(size);
+  data.write('/*' + cache_bust);
+  const end = `*/\nconsole.log(${JSON.stringify(value)});`;
+  data.fill('*', 2 + cache_bust.length, size - end.length, 'utf-8');
+  data.write(end, size - end.length, 'utf-8');
+  return data;
+}
+
+const temp_dir = mkdtempSync(`${tmpdir()}/bun-test-transpiler-cache-`);
+const cache_dir = join(temp_dir, '.cache');
+
+const env = {
+  ...bunEnv,
+  BUN_RUNTIME_TRANSPILER_CACHE_PATH: cache_dir,
+}
+
+let prev_cache_count = 0;
+function newCacheCount() {
+  let new_count = readdirSync(cache_dir).length;
+  let delta = new_count - prev_cache_count;
+  prev_cache_count = new_count;
+  return delta;
+}
+
+function removeCache() {
+  prev_cache_count = 0;
+  try {
+    rmSync(cache_dir, { recursive: true, force: true });
+  } catch (error) {
+    chmodSync(cache_dir, 0o777);
+    readdirSync(cache_dir).forEach(item => {
+      chmodSync(join(cache_dir, item), 0o777);
+    });
+    rmSync(cache_dir, { recursive: true, force: true });
+  }
+}
+
+console.log(temp_dir)
+
+assert(!existsSync(cache_dir));
+
+describe('transpiler cache', () => {
+  test("works", async () => {
+    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'a'));
+    const a = bunRun(join(temp_dir, 'a.js'), env);
+    expect(a.stdout == 'a');
+    assert(existsSync(cache_dir));
+    expect(newCacheCount()).toBe(1);
+    const b = bunRun(join(temp_dir, 'a.js'), env);
+    expect(b.stdout == 'a');
+    expect(newCacheCount()).toBe(0);
+  });
+  test("ignores files under 50kb", async () => {
+    removeCache()
+    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024 - 1, '1', 'a'));
+    const a = bunRun(join(temp_dir, 'a.js'), env);
+    expect(a.stdout == 'a');
+    assert(!existsSync(cache_dir));
+  });
+  test("it is indeed content addressable", async () => {
+    removeCache()
+    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'b'));
+    const a = bunRun(join(temp_dir, 'a.js'), env);
+    expect(a.stdout == 'b');
+    expect(newCacheCount()).toBe(1);
+
+    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'c'));
+    const b = bunRun(join(temp_dir, 'a.js'), env);
+    expect(b.stdout == 'c');
+    expect(newCacheCount()).toBe(1);
+
+    writeFileSync(join(temp_dir, 'b.js'), dummyFile(50 * 1024, '1', 'b'));
+    const c = bunRun(join(temp_dir, 'b.js'), env);
+    expect(b.stdout == 'b');
+    expect(newCacheCount()).toBe(0);
+  });
+  test.todo("doing 500 buns at once does not crash", async () => {
+    removeCache()
+    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'b'));
+    writeFileSync(join(temp_dir, 'b.js'), dummyFile(50 * 1024, '2', 'b'));
+
+    const remover = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, 'transpiler-cache-aggressive-remover.js'), cache_dir],
+      env,
+      cwd: temp_dir,
+    })
+
+    let processes: Subprocess<'ignore', 'pipe', 'inherit'>[] = [];
+    let killing = false;
+    for (let i = 0; i < 500; i++) {
+      processes.push(Bun.spawn({
+        cmd: [bunExe(), i % 2 == 0 ? 'a.js' : 'b.js'],
+        env,
+        cwd: temp_dir,
+        onExit(subprocess, exitCode, signalCode, error) {
+          if(exitCode != 0 && !killing) {
+            killing = true;
+            processes.forEach(x => x.kill(9));
+            remover.kill(9);
+          }
+        },
+      }));
+    }
+
+    await Promise.all(processes.map(x => x.exited));
+    
+    assert(!killing);
+
+    remover.kill(9);
+
+    for(const proc of processes) {
+      expect(proc.exitCode).toBe(0);
+      expect(await Bun.readableStreamToText(proc.stdout)).toBe('b\n')
+    }
+  });
+  test('works if the cache is not user-readable', () => {
+    removeCache();
+    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'b'));
+    const a = bunRun(join(temp_dir, 'a.js'), env);
+    expect(a.stdout == 'b');
+    expect(newCacheCount()).toBe(1);
+    
+    const cache_item = readdirSync(cache_dir)[0];
+
+    chmodSync(join(cache_dir, cache_item), 0);
+    const b = bunRun(join(temp_dir, 'a.js'), env);
+    expect(b.stdout == 'b');
+    expect(newCacheCount()).toBe(0);
+
+    chmodSync(join(cache_dir), '0');
+    const c = bunRun(join(temp_dir, 'a.js'), env);
+    expect(c.stdout == 'b');
+  });
+  test('works if the cache is not user-writable', () => {
+    removeCache();
+    writeFileSync(join(temp_dir, 'a.js'), dummyFile(50 * 1024, '1', 'b'));
+
+    chmodSync(join(cache_dir), '0');
+
+    const a = bunRun(join(temp_dir, 'a.js'), env);
+    expect(a.stdout == 'b');
+
+    chmodSync(join(cache_dir), '777');
+  });
+})

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -8,6 +8,7 @@ export const bunEnv: any = {
   FORCE_COLOR: undefined,
   TZ: "Etc/UTC",
   CI: "1",
+  BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
 };
 
 export function bunExe() {


### PR DESCRIPTION
### What does this PR do?

This adds a content-addressable runtime transpiler cache for input files larger than 50 KB. On macOS, these files are stored in `~/Library/Caches/bun/@t@/*.pile` (`t` is for "transpiler").

The goal is mostly for CLIs executed more than once, like `tsc`. Transpiler overhead is severe in cases like that.

macoS arm64:
```zig
Benchmark 1: bun ./node_modules/typescript/lib/tsc.js --help
  Time (mean ± σ):      84.1 ms ±   1.7 ms    [User: 73.7 ms, System: 10.2 ms]
  Range (min … max):    82.4 ms …  90.8 ms    34 runs

Benchmark 2: bun-1.0.13 ./node_modules/typescript/lib/tsc.js --help
  Time (mean ± σ):     205.8 ms ±   2.6 ms    [User: 181.6 ms, System: 23.9 ms]
  Range (min … max):   203.4 ms … 210.7 ms    13 runs

Benchmark 3: node ./node_modules/typescript/lib/tsc.js --help
  Time (mean ± σ):      94.5 ms ±   1.4 ms    [User: 83.9 ms, System: 8.7 ms]
  Range (min … max):    93.4 ms …  99.9 ms    30 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  bun ./node_modules/typescript/lib/tsc.js --help ran
    1.12 ± 0.03 times faster than node ./node_modules/typescript/lib/tsc.js --help
    2.45 ± 0.06 times faster than bun-1.0.13 ./node_modules/typescript/lib/tsc.js --help
```

`vite --help` on macOS arm64:

```zig
Benchmark 1: bun --bun ./node_modules/.bin/vite --version
  Time (mean ± σ):      94.2 ms ±   1.1 ms    [User: 89.0 ms, System: 17.5 ms]
  Range (min … max):    91.8 ms …  96.0 ms    29 runs

Benchmark 2: bun-1.0.13 --bun ./node_modules/.bin/vite --version
  Time (mean ± σ):     117.6 ms ±   1.5 ms    [User: 164.2 ms, System: 26.2 ms]
  Range (min … max):   115.5 ms … 121.9 ms    23 runs

Benchmark 3: node ./node_modules/.bin/vite --version
  Time (mean ± σ):      99.9 ms ±   1.4 ms    [User: 95.5 ms, System: 10.5 ms]
  Range (min … max):    98.0 ms … 103.3 ms    27 runs

Summary
  bun --bun ./node_modules/.bin/vite --version ran
    1.06 ± 0.02 times faster than node ./node_modules/.bin/vite --version
    1.25 ± 0.02 times faster than bun-1.0.13 --bun ./node_modules/.bin/vite --version
```

### How did you verify your code works?

This needs tests. I didn't write them yet.