### PR TITLE
Fix imports in run-tests example

### DIFF
--- a/docs/guides/test/run-tests.md
+++ b/docs/guides/test/run-tests.md
@@ -64,7 +64,7 @@ Ran 2 tests across 1 files. [15.00ms]
 All tests have a name, defined using the first parameter to the `test` function. Tests can also be grouped into suites with `describe`.
 
 ```ts
-import { test, expect } from "bun:test";
+import { test, expect, describe } from "bun:test";
 
 describe("math", () => {
   test("add", () => {


### PR DESCRIPTION
### What does this PR do?

Adds `describe` to the import statement in an example script for running tests. Without this, the example does not run properly and returns an error.

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)