### PR TITLE
bunx: specify package with --package

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -182,11 +182,6 @@ pub const Arguments = struct {
     };
     pub const run_params = run_only_params ++ runtime_params_ ++ transpiler_params_ ++ base_params_;
 
-    const bunx_commands = [_]ParamType{
-        clap.parseParam("--silent                          Don't print the script command") catch unreachable,
-        clap.parseParam("-b, --bun                         Force a script or package to use Bun's runtime instead of Node.js (via symlinking node)") catch unreachable,
-    };
-
     const build_only_params = [_]ParamType{
         clap.parseParam("--compile                        Generate a standalone Bun executable containing your bundled code") catch unreachable,
         clap.parseParam("--watch                          Automatically restart the process on file change") catch unreachable,
@@ -1343,12 +1338,14 @@ pub const Command = struct {
                 if (comptime bun.fast_debug_build_mode and bun.fast_debug_build_cmd != .BunxCommand) unreachable;
                 const ctx = try Command.Context.create(allocator, log, .BunxCommand);
 
+                // TODO: This probably isn't right anymore
                 try BunxCommand.exec(ctx, bun.argv()[1..]);
                 return;
             },
             .ReplCommand => {
                 // TODO: Put this in native code.
                 if (comptime bun.fast_debug_build_mode and bun.fast_debug_build_cmd != .BunxCommand) unreachable;
+                // Why does .ReplCommand use .BunxCommand?
                 var ctx = try Command.Context.create(allocator, log, .BunxCommand);
                 ctx.debug.run_in_bun = true; // force the same version of bun used. fixes bun-debug for example
                 var args = bun.argv()[1..];
@@ -1894,12 +1891,14 @@ pub const Command = struct {
                         \\Execute an npm package executable (CLI), automatically installing into a global shared cache if not installed in node_modules.
                         \\
                         \\Flags:
-                        \\  <cyan>--bun<r>      Force the command to run with Bun instead of Node.js
+                        \\  <cyan>--bun<r>          Force the command to run with Bun instead of Node.js
+                        \\  <cyan>--package<r>      Specify package to install
                         \\
                         \\Examples<d>:<r>
                         \\  <b>bunx prisma migrate<r>
                         \\  <b>bunx prettier foo.js<r>
                         \\  <b>bunx<r> <cyan>--bun<r> <b>vite dev foo.js<r>
+                        \\  <b>bunx<r> <cyan>--package<r> <b>prettier prettier foo.js<r>
                         \\
                     , .{});
                 },

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1885,18 +1885,9 @@ pub const Command = struct {
 
                 Command.Tag.BunxCommand => {
                     Output.prettyErrorln(
-                        \\<b>Usage: bunx <r><cyan>[...flags]<r> \<package\><d>[@version] [...flags and arguments]<r>
                         \\Execute an npm package executable (CLI), automatically installing into a global shared cache if not installed in node_modules.
                         \\
-                        \\Flags:
-                        \\  <cyan>--bun<r>          Force the command to run with Bun instead of Node.js
-                        \\  <cyan>--package<r>      Specify package to install
-                        \\
-                        \\Examples<d>:<r>
-                        \\  <b>bunx prisma migrate<r>
-                        \\  <b>bunx prettier foo.js<r>
-                        \\  <b>bunx<r> <cyan>--bun<r> <b>vite dev foo.js<r>
-                        \\  <b>bunx<r> <cyan>--package<r> <b>prettier prettier foo.js<r>
+                        \\Run <cyan>bunx --help<r> for additional usage information.
                         \\
                     , .{});
                 },

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1338,14 +1338,12 @@ pub const Command = struct {
                 if (comptime bun.fast_debug_build_mode and bun.fast_debug_build_cmd != .BunxCommand) unreachable;
                 const ctx = try Command.Context.create(allocator, log, .BunxCommand);
 
-                // TODO: This probably isn't right anymore
                 try BunxCommand.exec(ctx, bun.argv()[1..]);
                 return;
             },
             .ReplCommand => {
                 // TODO: Put this in native code.
                 if (comptime bun.fast_debug_build_mode and bun.fast_debug_build_cmd != .BunxCommand) unreachable;
-                // Why does .ReplCommand use .BunxCommand?
                 var ctx = try Command.Context.create(allocator, log, .BunxCommand);
                 ctx.debug.run_in_bun = true; // force the same version of bun used. fixes bun-debug for example
                 var args = bun.argv()[1..];

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -226,7 +226,7 @@ pub const BunxCommand = struct {
                 \\
             ;
 
-            Output.pretty(text, .{ package_name_for_update_request[0], package_name_for_update_request[0] });
+            Output.prettyErrorln(text, .{ package_name_for_update_request[0], package_name_for_update_request[0] });
             Global.exit(1);
         }
 

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -153,7 +153,7 @@ pub const BunxCommand = struct {
         const cli = try CommandLineArguments.parse(ctx.allocator);
 
         var requests_buf = bun.PackageManager.UpdateRequest.Array.init(0) catch unreachable;
-        var run_in_bun = ctx.debug.run_in_bun;
+        var run_in_bun = ctx.debug.run_in_bun or cli.run_in_bun;
 
         var passthrough_list = try std.ArrayList(string).initCapacity(ctx.allocator, argv.len);
 
@@ -177,14 +177,6 @@ pub const BunxCommand = struct {
                             found_subcommand_name = true;
                             if (positional.len == 1 and positional[0] == 'x')
                                 continue;
-                        }
-                    }
-
-                    if (!run_in_bun and !found_subcommand_name) {
-                        // Hm, should we grab this from the parsed args now?
-                        if (strings.eqlComptime(positional, "--bun")) {
-                            run_in_bun = true;
-                            continue;
                         }
                     }
 
@@ -571,6 +563,7 @@ pub const BunxCommand = struct {
 
     pub const CommandLineArguments = struct {
         package: string = "",
+        run_in_bun: bool = false,
         pub fn parse(allocator: std.mem.Allocator) !CommandLineArguments {
             var cli = CommandLineArguments{};
 
@@ -593,6 +586,10 @@ pub const BunxCommand = struct {
 
             if (args.option("--package")) |package| {
                 cli.package = package;
+            }
+
+            if (args.flag("--bun")) {
+                cli.run_in_bun = true;
             }
 
             return cli;

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -161,8 +161,6 @@ pub const BunxCommand = struct {
 
         var package_name_for_update_request = [1]string{""};
 
-        // Current behavior:
-        // bunx cowsay "hi"
         if (cli.package.len == 0) {
             {
                 var found_subcommand_name = false;
@@ -190,18 +188,6 @@ pub const BunxCommand = struct {
                 }
             }
         } else {
-            // New behavior
-            // bun x cowsay hello // this is existing shortcut behavior
-            // bun x -- cowsay hello
-            // bun x --package=cowsay -- cowthink hello
-            // bunx -- cowsay hello
-            // bunx --package=cowsay -- cowthink hello
-            // bunx --package=cowsay -- cowthink --version
-
-            // current bug:
-            // when package is specified, the command that gets run is implicit
-            // but really the "what package should I run" logic should look like this:
-            // to_run = first item in passthrough
             package_name_for_update_request[0] = cli.package;
             var parsing_passthroughs = false;
             var captured_bin_name = false;
@@ -272,7 +258,6 @@ pub const BunxCommand = struct {
 
         var update_request = update_requests[0];
 
-        // TODO: test "tsc"
         // if you type "tsc" and TypeScript is not installed:
         // 1. Install TypeScript
         // 2. Run tsc
@@ -524,8 +509,6 @@ pub const BunxCommand = struct {
     }
 
     pub fn printHelp() void {
-
-        // TODO: Finish text
         const intro_text =
             \\<b>bunx<r>
             \\<b>Usage<r>: <b><green>bun install<r> <cyan>[flags]<r> [...\<pkg\>]

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -258,6 +258,13 @@ pub const BunxCommand = struct {
 
         var update_request = update_requests[0];
 
+        // Indicates that the package name follows the @user/package format,
+        // so the bin name should have the prefix removed
+        if (update_request.version.tag == .github)
+            bin_name[0] = update_request.version.value.github.repo.slice(update_request.version_buf)
+        else if (strings.lastIndexOfChar(update_request.name, '/')) |index|
+            bin_name[0] = update_request.name[index + 1 ..];
+
         // if you type "tsc" and TypeScript is not installed:
         // 1. Install TypeScript
         // 2. Run tsc

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -510,10 +510,10 @@ pub const BunxCommand = struct {
 
     pub fn printHelp() void {
         const intro_text =
-            \\<b>bunx<r>
-            \\<b>Usage<r>: <b><green>bun install<r> <cyan>[flags]<r> [...\<pkg\>]
-            \\<b>Alias: <b>bun i<r>
-            \\  Install the dependencies listed in package.json
+            \\<b>Usage<r>:
+            \\<b><green>bun x<r> <cyan>\<pkg\><r> [args...]
+            \\<b><green>bun x<r> <cyan>--package=\<pkg\>[\<version\>]<r> -- \<cmd\> [args...]
+            \\  Execute a package binary (CLI), installing if needed <d>(bunx)<r>
         ;
 
         const outro_text =

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -456,7 +456,6 @@ pub const BunxCommand = struct {
 
         absolute_in_cache_dir = std.fmt.bufPrint(&absolute_in_cache_dir_buf, "{s}/node_modules/.bin/{s}", .{ bunx_cache_dir, bin_name[0] }) catch unreachable;
 
-        // TODO: This section is duplicated. Make sure it matches above.
         // Similar to "npx":
         //
         //  1. Try the bin in the global cache

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -83,7 +83,7 @@ it("should output usage if no arguments are passed", async () => {
 
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err).toContain("Usage:\nbun x");
+  expect(err).toContain("Usage: bunx");
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out).toHaveLength(0);

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -270,3 +270,22 @@ it("with --package, should invoke bin with name that does not match package name
   expect(out.trim()).toContain("( moo )");
   expect(await exited).toBe(0);
 });
+
+it("with --package, arguments after -- should be passed to package", async () => {
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "x", "--package", "cowsay", "--", "cowthink", "--help"],
+    cwd: x_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr).toBeDefined();
+  const err = await new Response(stderr).text();
+  expect(err).not.toContain("error");
+  expect(stdout).toBeDefined();
+  const out = await new Response(stdout).text();
+  expect(out.trim()).toContain("Usage: cowthink");
+  expect(out.trim()).not.toContain("bun");
+  expect(await exited).toBe(0);
+});

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -83,7 +83,7 @@ it("should output usage if no arguments are passed", async () => {
 
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err).toContain("Usage: ");
+  expect(err).toContain("Usage:\nbun x");
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out).toHaveLength(0);
@@ -174,7 +174,7 @@ it("should work for github repository", async () => {
   expect(err).not.toContain("error");
   expect(withoutCache.stdout).toBeDefined();
   let out = await new Response(withoutCache.stdout).text();
-  expect(out.trim()).toContain("Usage: cowsay");
+  expect(out.trim()).toContain("Usage:\nbun x");
   expect(await withoutCache.exited).toBe(0);
 
   // cached
@@ -192,7 +192,7 @@ it("should work for github repository", async () => {
   expect(err).not.toContain("error");
   expect(cached.stdout).toBeDefined();
   out = await new Response(cached.stdout).text();
-  expect(out.trim()).toContain("Usage: cowsay");
+  expect(out.trim()).toContain("Usage:\nbun x");
   expect(await cached.exited).toBe(0);
 });
 
@@ -232,4 +232,41 @@ it("should work for github repository with committish", async () => {
   out = await new Response(cached.stdout).text();
   expect(out.trim()).toContain("hello bun!");
   expect(await cached.exited).toBe(0);
+});
+
+it("should handle --package flag", async () => {
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "x", "--package", "cowsay", "--", "cowsay", "--help"],
+    cwd: x_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr).toBeDefined();
+  const err = await new Response(stderr).text();
+  expect(err).not.toContain("error");
+  expect(stdout).toBeDefined();
+  const out = await new Response(stdout).text();
+  expect(out.trim()).toContain("Usage: cowsay");
+  expect(await exited).toBe(0);
+});
+
+it("with --package, should invoke bin with name that does not match package name", async () => {
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "x", "--package", "cowsay", "--", "cowthink", "moo"],
+    cwd: x_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr).toBeDefined();
+  const err = await new Response(stderr).text();
+  expect(err).not.toContain("error");
+  expect(stdout).toBeDefined();
+  const out = await new Response(stdout).text();
+  // `cowthink` command prints bubble with ( parens ) rather than cowsay default of < angles >
+  expect(out.trim()).toContain("( moo )");
+  expect(await exited).toBe(0);
 });

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -15,6 +15,24 @@ afterEach(async () => {
   await rm(x_dir, { force: true, recursive: true });
 });
 
+it("should invoke default package bin", async () => {
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "x", "cowsay", "hello"],
+    cwd: x_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr).toBeDefined();
+  const err = await new Response(stderr).text();
+  expect(err).not.toContain("error");
+  expect(stdout).toBeDefined();
+  const out = await new Response(stdout).text();
+  expect(out.trim()).toContain("< hello >");
+  expect(await exited).toBe(0);
+});
+
 it("should choose the tagged versions instead of the PATH versions when a tag is specified", async () => {
   const processes = Array.from({ length: 3 }, (_, i) => {
     return spawn({

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -307,3 +307,22 @@ it("with --package, arguments after -- should be passed to package", async () =>
   expect(out.trim()).not.toContain("bun");
   expect(await exited).toBe(0);
 });
+
+it("should exit if --package specified without --", async () => {
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "x", "--package", "cowsay", "hello"],
+    cwd: x_dir,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  expect(stderr).toBeDefined();
+  const err = await new Response(stderr).text();
+  expect(err).toContain("Perhaps you meant the following?");
+  expect(stdout).toBeDefined();
+  const out = await new Response(stdout).text();
+  expect(out).toHaveLength(0);
+  expect(await exited).toBe(1);
+});


### PR DESCRIPTION
### What does this PR do?
This PR adds a `--package` flag to `bunx`. I've tried to keep both the syntax and semantics of `--package` as close to NPM's implementation as possible.

Relevant docs:
 - https://docs.npmjs.com/cli/v10/commands/npm-exec
 - https://docs.npmjs.com/cli/v10/commands/npx

**Note for reviewers**

In earlier versions of this code, no distinction was drawn between the package being run and the binary being invoked. The binary name was derived directly from the package. This PR separates those two concepts.

While reviewing, it's helpful to think of there being two separate modes of operation: implicit package and explicit package. In implicit package mode, the package name is assumed to be the same as the first command argument. In explicit mode, the package name is specified via the `--package` flag. 

Tests that are currently failing appear to be doing so because I moved argument parsing to within `bunx_command.zig`. This is causing `bun x` to capture flags like `--help` that were previously passed along directly to the invoked command. I believe this new behavior is actually more consistent with how `node-exec` behaves, with that caveat that I haven't been able to test the difference between `bunx` and `bun x` because I'm not quite sure how to make dev builds of the former yet. Note that this is a breaking change which is probably avoidable. I'm not sure what Bun's stance on breaking changes is. 

**TL;DR:**
`bun x cowsay --help` previously passed `--help` to `cowsay` command, but now passes `--help` to `bun` command. I need input from the bun team regarding the preferred approach here.

For more discussion, see [npx docs](https://docs.npmjs.com/cli/v10/commands/npx#npx-vs-npm-exec).

**TODO**

 - [ ] `.ReplCommand` relies on `.BunxCommand`. Should I be testing anything specific?
 - [ ] test `--bun`. (Currently it looks like the incorrect bin is used with this flag.)
 - [ ] test `bun x tsc main.ts`

**To test**
 - [x] `bun x cowsay hello # this is existing shortcut behavior` [here](https://github.com/oven-sh/bun/pull/7369/files#diff-8223dcf25255bd59c8022233507cdc78a6cef9a6d9d985f7ee3172ab469289f4R32)
 - [ ] `bun x -- cowsay hello`
 - [x] `bun x --package=cowsay -- cowsay hello` [here](https://github.com/oven-sh/bun/pull/7369/files#diff-8223dcf25255bd59c8022233507cdc78a6cef9a6d9d985f7ee3172ab469289f4R251)
 - [x] `bun x --package=cowsay -- cowthink hello` [here](https://github.com/oven-sh/bun/pull/7369/files#diff-8223dcf25255bd59c8022233507cdc78a6cef9a6d9d985f7ee3172ab469289f4R270)
 - [x] `bun x --package=cowsay -- cowthink --version` [here](https://github.com/oven-sh/bun/pull/7369/files#diff-8223dcf25255bd59c8022233507cdc78a6cef9a6d9d985f7ee3172ab469289f4R288)
 - [x] `bun x --package=cowsay hello` errors [here](https://github.com/oven-sh/bun/pull/7369/files#diff-8223dcf25255bd59c8022233507cdc78a6cef9a6d9d985f7ee3172ab469289f4R311)
 - [ ] Test that everything behaves as expected with `bunx` command, too


Closes https://github.com/oven-sh/bun/issues/7034.
