### PR TITLE
Update file-io.md: BunFile.stream() doesn't return promise

### DIFF
--- a/docs/api/file-io.md
+++ b/docs/api/file-io.md
@@ -300,7 +300,7 @@ interface BunFile {
   readonly type: string;
 
   text(): Promise<string>;
-  stream(): Promise<ReadableStream>;
+  stream(): ReadableStream;
   arrayBuffer(): Promise<ArrayBuffer>;
   json(): Promise<any>;
   writer(params: { highWaterMark?: number }): FileSink;


### PR DESCRIPTION
Based on testing, `.stream()` returns a `ReadableStream` directly instead of a `Promise`.

### What does this PR do?

Fixes the type signature reference for `BunFile` in the docs.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

