### PR TITLE
Fix typos

### DIFF
--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -51,7 +51,7 @@ function __bun_last_cmd --argument-names n
 end
 
 set -l bun_install_boolean_flags yarn production optional development no-save dry-run force no-cache silent verbose global
-set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't install devDependencies" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependenices" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
+set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't install devDependencies" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
 
 set -l bun_builtin_cmds dev create help bun upgrade discord run install remove add init link unlink pm x
 set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add init pm x

--- a/completions/spec.yaml
+++ b/completions/spec.yaml
@@ -121,7 +121,7 @@ subcommands:
       - frozen-lockfile -- "Disallow changes to lockfile"
       - no-save --
       - dry-run -- "Don't install anything"
-      - force -- "Always request the latest versions from the registry & reinstall all dependenices"
+      - force -- "Always request the latest versions from the registry & reinstall all dependencies"
       - name: cache-dir
         type: string
         summary: "Store & load cached data from a specific directory path"
@@ -156,7 +156,7 @@ subcommands:
       - frozen-lockfile -- "Disallow changes to lockfile"
       - no-save --
       - dry-run -- "Don't install anything"
-      - force -- "Always request the latest versions from the registry & reinstall all dependenices"
+      - force -- "Always request the latest versions from the registry & reinstall all dependencies"
       - no-cache -- "Ignore manifest cache entirely"
       - silent -- "Don't output anything"
       - verbose -- "Excessively verbose logging"
@@ -194,7 +194,7 @@ subcommands:
       - frozen-lockfile -- "Disallow changes to lockfile"
       - no-save --
       - dry-run -- "Don't install anything"
-      - force -- "Always request the latest versions from the registry & reinstall all dependenices"
+      - force -- "Always request the latest versions from the registry & reinstall all dependencies"
       - name: cache-dir
         type: string
         summary: "Store & load cached data from a specific directory path"

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -568,9 +568,9 @@ pub fn maybeCloneFilteringRootPackages(
     features: Features,
     exact_versions: bool,
 ) !*Lockfile {
-    const old_root_dependenices_list = old.packages.items(.dependencies)[0];
+    const old_root_dependencies_list = old.packages.items(.dependencies)[0];
     var old_root_resolutions = old.packages.items(.resolutions)[0];
-    const root_dependencies = old_root_dependenices_list.get(old.buffers.dependencies.items);
+    const root_dependencies = old_root_dependencies_list.get(old.buffers.dependencies.items);
     var resolutions = old_root_resolutions.mut(old.buffers.resolutions.items);
     var any_changes = false;
     const end = @as(PackageID, @truncate(old.packages.len));


### PR DESCRIPTION
### What does this PR do?

bun's fish shell-completion code has a typo

- NG: dependen **ice** s
- OK: dependen **cie** s

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

I don't think there will be any impact as it is just a typo correction in variable names and comments.