### PR TITLE
Added the command to run bun using pkgx installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,6 +31,10 @@ $ docker pull oven/bun
 $ docker run --rm --init --ulimit memlock=-1:-1 oven/bun
 ```
 
+```bash#pkgx
+$ pkgx install bun # or run directly `pkgx bun`
+```
+
 ```bash#Proto
 $ proto install bun
 ```
@@ -226,6 +230,10 @@ $ npm uninstall -g bun
 
 ```bash#Homebrew
 $ brew uninstall bun
+```
+
+```bash#pkgx
+$ rm -rf ~/.local/bin/bun # for macOS, Linux, and WSL
 ```
 
 ```bash#Proto


### PR DESCRIPTION
### What does this PR do?

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)

This PR adds the command to run and install bun via [pkgx](https://pkgx.sh) to the installation docs.