### PR TITLE
Fix `Location` header not being cloned from `Response.redirect()`

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -1456,7 +1456,7 @@ void WebCore__FetchHeaders__put_(WebCore__FetchHeaders* headers, const ZigString
 {
     auto throwScope = DECLARE_THROW_SCOPE(global->vm());
     WebCore::propagateException(*global, throwScope,
-        headers->set(Zig::toString(*arg1), Zig::toString(*arg2)));
+        headers->set(Zig::toString(*arg1), Zig::toStringCopy(*arg2)));
 }
 void WebCore__FetchHeaders__remove(WebCore__FetchHeaders* headers, const ZigString* arg1, JSC__JSGlobalObject* global)
 {

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -408,7 +408,6 @@ pub const Response = struct {
             url_string = url_string_value.getZigString(globalThis.ptr());
         }
         var url_string_slice = url_string.toSlice(getAllocator(globalThis));
-        defer url_string_slice.deinit();
 
         if (args.nextEat()) |init| {
             if (init.isUndefinedOrNull()) {} else if (init.isNumber()) {

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -408,6 +408,7 @@ pub const Response = struct {
             url_string = url_string_value.getZigString(globalThis.ptr());
         }
         var url_string_slice = url_string.toSlice(getAllocator(globalThis));
+        defer url_string_slice.deinit();
 
         if (args.nextEat()) |init| {
             if (init.isUndefinedOrNull()) {} else if (init.isNumber()) {

--- a/test/regression/issue/07397.test.ts
+++ b/test/regression/issue/07397.test.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "bun:test";
+
+test("Response.redirect clones string from Location header", () => {
+  const url = new URL("http://example.com");
+  url.hostname = "example1.com";
+  const { href } = url;
+  expect(href).toBe("http://example1.com/");
+  const response = Response.redirect(href);
+  expect(response.headers.get("Location")).toBe(href);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #7397

The value from `Response.redirect` was being cloned, but then `deinit`'d. The problem was  the slice was also added to the headers, which meant the header value was garbage.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote a regression test.