### PR TITLE
fix(standalone): runtime dynamic imports now transpile correctly.

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1231,7 +1231,7 @@ pub const VirtualMachine = struct {
 
     pub const Options = struct {
         allocator: std.mem.Allocator,
-        args: Api.TransformOptions = std.mem.zeroes(Api.TransformOptions),
+        args: Api.TransformOptions,
         log: ?*logger.Log = null,
         env_loader: ?*DotEnv.Loader = null,
         store_fd: bool = false,

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -62,6 +62,7 @@ pub const Run = struct {
             .vm = try VirtualMachine.initWithModuleGraph(.{
                 .allocator = arena.allocator(),
                 .log = ctx.log,
+                .args = ctx.args,
                 .graph = graph_ptr,
             }),
             .arena = arena,

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -555,6 +555,18 @@ pub const Resolver = struct {
     }
 
     pub inline fn usePackageManager(self: *const ThisResolver) bool {
+        // TODO(@paperdave): make this configurable. the rationale for disabling
+        // auto-install in standalone mode is that such executable must either:
+        //
+        // - bundle the dependency itself. dynamic `require`/`import` should be
+        //   able to bundle possible dependencies specified in package.json
+        //
+        // - try to load the user's node_modules.
+        //
+        // auto install, as of writing, is also quite buggy and untested, it always
+        // installs the latest version regardless of a user's package.json or specifier.
+        if (self.standalone_module_graph) |_| return false;
+
         return self.opts.global_cache.isEnabled();
     }
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -558,13 +558,16 @@ pub const Resolver = struct {
         // TODO(@paperdave): make this configurable. the rationale for disabling
         // auto-install in standalone mode is that such executable must either:
         //
-        // - bundle the dependency itself. dynamic `require`/`import` should be
-        //   able to bundle possible dependencies specified in package.json
+        // - bundle the dependency itself. dynamic `require`/`import` could be
+        //   changed to bundle potential dependencies specified in package.json
         //
-        // - try to load the user's node_modules.
+        // - want to load the user's node_modules, which is what currently happens.
         //
         // auto install, as of writing, is also quite buggy and untested, it always
         // installs the latest version regardless of a user's package.json or specifier.
+        // in addition to being not fully stable, it is completely unexpected to invoke
+        // a package manager after bundling an executable. if enough people run into
+        // this, we could implement point 1
         if (self.standalone_module_graph) |_| return false;
 
         return self.opts.global_cache.isEnabled();

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -86,4 +86,70 @@ describe("bundler", () => {
     },
     compile: true,
   });
+  itBundled("compile/DynamicRequire", {
+    files: {
+      "/entry.tsx": /* tsx */ `
+        const req = (x) => require(x);
+        const y = req('commonjs');
+        const z = req('esm').default;
+        console.log(JSON.stringify([w, x, y, z]));
+        module.exports = null;
+      `,
+      "/node_modules/commonjs/index.js": "throw new Error('Must be runtime import.')",
+      "/node_modules/esm/index.js": "throw new Error('Must be runtime import.')",
+      "/node_modules/other/index.js": "throw new Error('Must be runtime import.')",
+      "/node_modules/other-esm/index.js": "throw new Error('Must be runtime import.')",
+    },
+    runtimeFiles: {
+      "/node_modules/commonjs/index.js": "module.exports = 2; require('other');",
+      "/node_modules/esm/index.js": "import 'other-esm'; export default 3;",
+      "/node_modules/other/index.js": "globalThis.x = 1;",
+      "/node_modules/other-esm/index.js": "globalThis.w = 0;"
+    },
+    run: {
+      stdout: "[0,1,2,3]",
+      setCwd: true
+    },
+    compile: true,
+  });
+  itBundled("compile/DynamicImport", {
+    files: {
+      "/entry.tsx": /* tsx */ `
+        import 'static';
+        const imp = (x) => import(x).then(x => x.default);
+        const y = await imp('commonjs');
+        const z = await imp('esm');
+        console.log(JSON.stringify([w, x, y, z]));
+      `,
+      "/node_modules/static/index.js": "'use strict';",
+      "/node_modules/commonjs/index.js": "throw new Error('Must be runtime import.')",
+      "/node_modules/esm/index.js": "throw new Error('Must be runtime import.')",
+      "/node_modules/other/index.js": "throw new Error('Must be runtime import.')",
+      "/node_modules/other-esm/index.js": "throw new Error('Must be runtime import.')",
+    },
+    runtimeFiles: {
+      "/node_modules/commonjs/index.js": "module.exports = 2; require('other');",
+      "/node_modules/esm/index.js": "import 'other-esm'; export default 3;",
+      "/node_modules/other/index.js": "globalThis.x = 1;",
+      "/node_modules/other-esm/index.js": "globalThis.w = 0;"
+    },
+    run: {
+      stdout: "[0,1,2,3]",
+      setCwd: true
+    },
+    compile: true,
+  });
+  // see comment in `usePackageManager` for why this is a test
+  itBundled("compile/NoAutoInstall", {
+    files: {
+      "/entry.tsx": /* tsx */ `
+        const req = (x) => require(x);
+        req('express');
+      `,
+    },
+    run: {
+      error: 'Cannot find package "express"'
+    },
+    compile: true,
+  });
 });

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -104,11 +104,11 @@ describe("bundler", () => {
       "/node_modules/commonjs/index.js": "module.exports = 2; require('other');",
       "/node_modules/esm/index.js": "import 'other-esm'; export default 3;",
       "/node_modules/other/index.js": "globalThis.x = 1;",
-      "/node_modules/other-esm/index.js": "globalThis.w = 0;"
+      "/node_modules/other-esm/index.js": "globalThis.w = 0;",
     },
     run: {
       stdout: "[0,1,2,3]",
-      setCwd: true
+      setCwd: true,
     },
     compile: true,
   });
@@ -131,11 +131,11 @@ describe("bundler", () => {
       "/node_modules/commonjs/index.js": "module.exports = 2; require('other');",
       "/node_modules/esm/index.js": "import 'other-esm'; export default 3;",
       "/node_modules/other/index.js": "globalThis.x = 1;",
-      "/node_modules/other-esm/index.js": "globalThis.w = 0;"
+      "/node_modules/other-esm/index.js": "globalThis.w = 0;",
     },
     run: {
       stdout: "[0,1,2,3]",
-      setCwd: true
+      setCwd: true,
     },
     compile: true,
   });
@@ -148,7 +148,7 @@ describe("bundler", () => {
       `,
     },
     run: {
-      error: 'Cannot find package "express"'
+      error: 'Cannot find package "express"',
     },
     compile: true,
   });

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -269,6 +269,8 @@ export interface BundlerTestRunOptions {
   errorLineMatch?: RegExp;
 
   runtime?: "bun" | "node";
+
+  setCwd?: boolean;
 }
 
 /** given when you do itBundled('id', (this object) => BundlerTestInput) */
@@ -1218,6 +1220,7 @@ for (const [key, blob] of build.outputs) {
             IS_TEST_RUNNER: "1",
           },
           stdio: ["ignore", "pipe", "pipe"],
+          cwd: run.setCwd ? root : undefined
         });
 
         if (run.error) {

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1220,7 +1220,7 @@ for (const [key, blob] of build.outputs) {
             IS_TEST_RUNNER: "1",
           },
           stdio: ["ignore", "pipe", "pipe"],
-          cwd: run.setCwd ? root : undefined
+          cwd: run.setCwd ? root : undefined,
         });
 
         if (run.error) {


### PR DESCRIPTION
### What does this PR do?

if you run `bun build --compile` on code like

```
let x = (x) => require(x);

x("express");
```

This dynamic require will not load the dependency at build time, **which is still the case**. **For standalone executables this pattern is discouraged**, as it will search the filesystem for node_modules and load the files.

In the case this happens, this branch makes it so CommonJS files properly transpile, as we did not pass the correct transpilation flags in standalone mode.

Also, this disables auto-installs when using standalone mode. I have written a comment about it in the code

>  TODO: make this configurable. the rationale for disabling auto-install in standalone mode is that such executable must either:
>
> - bundle the dependency itself. dynamic `require`/`import` should be able to bundle possible dependencies specified in package.json
>
> - try to load the user's node_modules.
>
> auto install, as of writing, is also quite buggy and untested, it always installs the latest version regardless of a user's package.json or specifier

Closes #5561