### PR TITLE
fix(worker): fix SIGSEGV when terminating a Worker

### DIFF
--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -10,7 +10,7 @@ const Async = bun.Async;
 pub const WebWorker = struct {
     /// null when haven't started yet
     vm: ?*JSC.VirtualMachine = null,
-    status: Status = .start,
+    status: std.atomic.Atomic(Status) = std.atomic.Atomic(Status).init(.start),
     /// To prevent UAF, the `spin` function (aka the worker's event loop) will call deinit once this is set and properly exit the loop.
     requested_terminate: bool = false,
     execution_context_id: u32 = 0,
@@ -31,7 +31,7 @@ pub const WebWorker = struct {
     worker_event_loop_running: bool = true,
     parent_poll_ref: Async.KeepAlive = .{},
 
-    pub const Status = enum {
+    pub const Status = enum(u8) {
         start,
         starting,
         running,
@@ -141,7 +141,7 @@ pub const WebWorker = struct {
             return;
         }
 
-        std.debug.assert(this.status == .start);
+        std.debug.assert(this.status.load(.Acquire) == .start);
         std.debug.assert(this.vm == null);
         this.arena = try bun.MimallocArena.init();
         var vm = try JSC.VirtualMachine.initWorker(this, .{
@@ -230,7 +230,8 @@ pub const WebWorker = struct {
 
     fn setStatus(this: *WebWorker, status: Status) void {
         log("[{d}] status: {s}", .{ this.execution_context_id, @tagName(status) });
-        this.status = status;
+
+        this.status.store(status, .Release);
     }
 
     fn unhandledError(this: *WebWorker, _: anyerror) void {
@@ -239,7 +240,7 @@ pub const WebWorker = struct {
 
     fn spin(this: *WebWorker) void {
         var vm = this.vm.?;
-        std.debug.assert(this.status == .start);
+        std.debug.assert(this.status.load(.Acquire) == .start);
         this.setStatus(.starting);
 
         var promise = vm.loadEntryPointForWebWorker(this.specifier) catch {
@@ -307,6 +308,9 @@ pub const WebWorker = struct {
     /// Request a terminate (Called from main thread from worker.terminate(), or inside worker in process.exit())
     /// The termination will actually happen after the next tick of the worker's loop.
     pub fn requestTerminate(this: *WebWorker) callconv(.C) void {
+        if (this.status.load(.Acquire) == .terminated) {
+            return;
+        }
         if (this.requested_terminate) {
             return;
         }
@@ -324,6 +328,8 @@ pub const WebWorker = struct {
     /// Otherwise, call `requestTerminate` to cause the event loop to safely terminate after the next tick.
     pub fn exitAndDeinit(this: *WebWorker) noreturn {
         JSC.markBinding(@src());
+        this.setStatus(.terminated);
+
         log("[{d}] exitAndDeinit", .{this.execution_context_id});
         var cpp_worker = this.cpp_worker;
         var exit_code: i32 = 0;


### PR DESCRIPTION
### What does this PR do?

Close: #7209


```
(lldb) bt
* thread #1, name = 'bun-profile', stop reason = signal SIGSEGV
  * frame #0: 0x00005591bb1e71ba bun-profile`JSC__VM__notifyNeedTermination + 10
    frame #1: 0x00005591ba0b86f0 bun-profile`WebWorker__requestTerminate at shimmer.zig:186:41
    frame #2: 0x00005591ba0b86eb bun-profile`WebWorker__requestTerminate [inlined] src.bun.js.bindings.bindings.VM.notifyNeedTermination(vm=<unavailable>) at bindings.zig:5131:14
    frame #3: 0x00005591ba0b86eb bun-profile`WebWorker__requestTerminate(this=<unavailable>) at web_worker.zig:317:41
    frame #4: 0x00005591bb27da39 bun-profile`WebCore::jsWorkerPrototypeFunction_terminate(JSC::JSGlobalObject*, JSC::CallFrame*) + 233
    frame #5: 0x00007f5b02ecc1b8
    frame #6: 0x00005591bb00fa71 bun-profile`js_trampoline_op_call_ignore_result + 23
    frame #7: 0x00005591bb00ec97 bun-profile`llint_op_call + 176
    frame #8: 0x00005591bb00ec97 bun-profile`llint_op_call + 176
    frame #9: 0x00005591bb00fa31 bun-profile`llint_op_call_ignore_result + 176
    frame #10: 0x00005591baff15f0 bun-profile`vmEntryToJavaScript + 213
    frame #11: 0x00005591bbed2129 bun-profile`JSC::Interpreter::executeCall(JSC::JSObject*, JSC::CallData const&, JSC::JSValue, JSC::ArgList const&) + 1961
    frame #12: 0x00005591bc1c7584 bun-profile`JSC::profiledCall(JSC::JSGlobalObject*, JSC::ProfilingReason, JSC::JSValue, JSC::CallData const&, JSC::JSValue, JSC::ArgList const&) + 212
    frame #13: 0x00005591bc36f35b bun-profile`JSC::runJSMicrotask(JSC::JSGlobalObject*, WTF::ObjectIdentifierGeneric<JSC::MicrotaskIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>, JSC::JSValue, JSC::JSValue, JSC::JSValue, JSC::JSValue, JSC::JSValue) + 379
    frame #14: 0x00005591bc59396d bun-profile`JSC::VM::drainMicrotasks() + 285
    frame #15: 0x00005591ba4089d2 bun-profile`src.bun.js.event_loop.EventLoop.tickQueueWithCount__anon_341774 [inlined] src.bun.js.event_loop.EventLoop.drainMicrotasksWithGlobal(this=0x00000392760f0180, globalObject=0x00007f5b014c4068) at event_loop.zig:649:45
    frame #16: 0x00005591ba4089ca bun-profile`src.bun.js.event_loop.EventLoop.tickQueueWithCount__anon_341774(this=0x00000392760f0180) at event_loop.zig:939:43
    frame #17: 0x00005591b9ffe8f7 bun-profile`src.bun.js.event_loop.EventLoop.tick [inlined] src.bun.js.event_loop.EventLoop.tickWithCount(this=0x00000392760f0180) at event_loop.zig:947:39
    frame #18: 0x00005591b9ffe8ef bun-profile`src.bun.js.event_loop.EventLoop.tick(this=0x00000392760f0180) at event_loop.zig:1163:38
    frame #19: 0x00005591b9f3b7e5 bun-profile`src.bun.js.javascript.OpaqueWrap__anon_46705__struct_261737.callback [inlined] src.bun.js.javascript.VirtualMachine.tick(this=<unavailable>) at javascript.zig:1057:30
    frame #20: 0x00005591b9f3b7d7 bun-profile`src.bun.js.javascript.OpaqueWrap__anon_46705__struct_261737.callback at bun_js.zig:365:28
    frame #21: 0x00005591b9f3ab61 bun-profile`src.bun.js.javascript.OpaqueWrap__anon_46705__struct_261737.callback(ctx=0x00005591bcfbd1d8) at javascript.zig:105:13
    frame #22: 0x00005591bb1e7114 bun-profile`JSC__VM__holdAPILock + 52
    frame #23: 0x00005591b9f0af62 bun-profile`src.bun_js.Run.boot at shimmer.zig:186:41
    frame #24: 0x00005591b9f0af4c bun-profile`src.bun_js.Run.boot [inlined] src.bun.js.bindings.bindings.VM.holdAPILock(this=<unavailable>, ctx=<unavailable>, callback=<unavailable>) at bindings.zig:5055:14
    frame #25: 0x00005591b9f0af4c bun-profile`src.bun_js.Run.boot(ctx_=<unavailable>, entry_path=<unavailable>) at bun_js.zig:241:35
    frame #26: 0x00005591b9f0be28 bun-profile`src.cli.run_command.RunCommand.exec__anon_249570(ctx_=<unavailable>) at run_command.zig:1060:29
    frame #27: 0x00005591b9c7afa6 bun-profile`src.cli.Cli.start__anon_5044 at cli.zig:1602:44
    frame #28: 0x00005591b9c7a0a8 bun-profile`src.cli.Cli.start__anon_5044(allocator=<unavailable>, (null)=<unavailable>, (null)=<unavailable>) at cli.zig:58:22
    frame #29: 0x00005591b9c79c4d bun-profile`main at main.zig:46:22
    frame #30: 0x00005591b9c79a00 bun-profile`main [inlined] start.callMain at start.zig:575:22
    frame #31: 0x00005591b9c79a00 bun-profile`main [inlined] start.initEventLoopAndCallMain at start.zig:519:5
    frame #32: 0x00005591b9c79a00 bun-profile`main at start.zig:469:36
    frame #33: 0x00005591b9c799bc bun-profile`main(c_argc=<unavailable>, c_argv=<unavailable>, c_envp=<unavailable>) at start.zig:484:101
    frame #34: 0x00007f5b4d82bcd0 libc.so.6`___lldb_unnamed_symbol3187 + 128
    frame #35: 0x00007f5b4d82bd8a libc.so.6`__libc_start_main + 138
    frame #36: 0x00005591b9c79825 bun-profile`_start + 37
(lldb) f 0
frame #0: 0x00005591bb1e71ba bun-profile`JSC__VM__notifyNeedTermination + 10
bun-profile`JSC__VM__notifyNeedTermination:
->  0x5591bb1e71ba <+10>: movq   0x10(%rdi), %rax
    0x5591bb1e71be <+14>: cmpb   $0x0, 0x6(%rax)
    0x5591bb1e71c2 <+18>: je     0x3e391e5                 ; <+53>
    0x5591bb1e71c4 <+20>: movq   0x8(%rax), %r14
```

the value if `rdi` is invalid, thread panic at `bool didEnter = vm.currentThreadIsHoldingAPILock()`. This is a UAF problem, worker has exited before main thread called `worker.terminate()`

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

`bun run build:release` and test this repo https://github.com/sukka-reproductions/bun-crash-repro 