### PR TITLE
Remove line truncation in logger

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -353,7 +353,9 @@ pub const fmt = struct {
                             var i: usize = 1;
                             for (remain[i..]) |c| {
                                 if (c == char) {
-                                    i += 1;
+                                    if (i < remain.len) {
+                                        i += 1;
+                                    }
                                     break;
                                 } else if (c == '\\') {
                                     i += 1;
@@ -361,7 +363,9 @@ pub const fmt = struct {
                                         i += 1;
                                     }
                                 } else {
-                                    i += 1;
+                                    if (i < remain.len) {
+                                        i += 1;
+                                    }
                                 }
                             }
 

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -106,7 +106,7 @@ pub const Location = struct {
     pub fn count(this: Location, builder: *StringBuilder) void {
         builder.count(this.file);
         builder.count(this.namespace);
-        if (this.line_text) |text| builder.count(text[0..@min(text.len, 690)]);
+        if (this.line_text) |text| builder.count(text);
         if (this.suggestion) |text| builder.count(text);
     }
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
