### PR TITLE
Handle `EXDEV` when saving lockfile

### DIFF
--- a/src/c.zig
+++ b/src/c.zig
@@ -160,6 +160,10 @@ pub fn moveFileZSlow(from_dir: std.os.fd_t, filename: [:0]const u8, to_dir: std.
 pub fn copyFileZSlowWithHandle(in_handle: std.os.fd_t, to_dir: std.os.fd_t, destination: [:0]const u8) !void {
     const stat_ = if (comptime Environment.isPosix) try std.os.fstat(in_handle) else void{};
 
+    // Attempt to delete incase it already existed.
+    // This fixes ETXTBUSY on Linux
+    _ = bun.sys.unlinkat(to_dir, destination);
+
     const out_handle = try bun.sys.openat(
         to_dir,
         destination,

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -641,13 +641,14 @@ pub const FileSystem = struct {
                 if (this.fd != bun.invalid_fd) _ = bun.sys.close(this.fd);
             }
 
-            pub fn create(this: *TmpfilePosix, rfs: *RealFS, name: [:0]const u8) !void {
-                var tmpdir_ = try rfs.openTmpDir();
+            pub fn create(this: *TmpfilePosix, _: *RealFS, name: [:0]const u8) !void {
+                // We originally used
+                const dir_fd = std.fs.cwd().fd;
 
                 const flags = std.os.O.CREAT | std.os.O.RDWR | std.os.O.CLOEXEC;
-                this.dir_fd = bun.toFD(tmpdir_.fd);
+                this.dir_fd = bun.toFD(dir_fd);
 
-                const result = try bun.sys.openat(tmpdir_.fd, name, flags, std.os.S.IRWXU).unwrap();
+                const result = try bun.sys.openat(dir_fd, name, flags, std.os.S.IRWXU).unwrap();
                 this.fd = bun.toFD(result);
             }
 

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -642,7 +642,7 @@ pub const FileSystem = struct {
             }
 
             pub fn create(this: *TmpfilePosix, _: *RealFS, name: [:0]const u8) !void {
-                // We originally used
+                // We originally used a temporary directory, but it caused EXDEV.
                 const dir_fd = std.fs.cwd().fd;
 
                 const flags = std.os.O.CREAT | std.os.O.RDWR | std.os.O.CLOEXEC;


### PR DESCRIPTION
### What does this PR do?

Closes #7420

This makes us save the lockfile in the cwd instead of in a temporary directory, so that `EXDEV` cannot happen

Before:
```js
root@archlinux-latest-64-minimal ~/bun (jarred/werror) [1]# bun-debug add prettier
[SYS] openat(-100, /root/.bunfig.toml) = 18446744073709551614
[SYS] openat(-100, /root/bun/bunfig.toml) = 8
[SYS] openat(-100, /root/bun/) = 8
bun add v1.0.15 (5795718c)
[OverrideMap] parsed 0 overrides
  🔒 Saving lockfile... [SYS] openat(-100, /tmp) = 6
[SYS] openat(6, bunlock-5967babc751fe34c3c68739ba232e2a1) = 10
[SYS] write(10, 72152) = 72152
[SYS] openat(-100, bun.lockb) = 11

DEBUG: copy_file_range is supported
[SYS] close(11)
error: failed to save lockfile: EXDEV
```

After:
```js
[SYS] openat(-100, /root/.bunfig.toml) = 18446744073709551614
[SYS] openat(-100, /root/bun/bunfig.toml) = 8
[SYS] openat(-100, /root/bun/) = 8
bun add v1.0.15 (5795718c)
[OverrideMap] parsed 0 overrides
  🔒 Saving lockfile... [SYS] openat(-100, .bunlockbbbfddbb7de05472cd406feec92051eae) = 6
[SYS] write(6, 72152) = 72152
[SYS] close(6)

 installed prettier@3.1.0 with binaries:
  - prettier

[8.00ms] done
```

### How did you verify your code works?

Manually