### PR TITLE
Allow `expect.extend` in preload, remove "expect must be called in a test" error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 cmake_policy(SET CMP0091 NEW)
 cmake_policy(SET CMP0067 NEW)
 
-set(Bun_VERSION "1.0.15")
+set(Bun_VERSION "1.0.16")
 set(WEBKIT_TAG 0aa1f6dfc9b48be1e89b8f709fd44e3c88feaf33)
 
 set(BUN_WORKDIR "${CMAKE_CURRENT_BINARY_DIR}")

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -57,10 +57,26 @@ pub fn getMatcherFlags(comptime T: type, value: JSValue) Expect.Flags {
 // To support async tests, we need to track the test ID
 pub const Expect = struct {
     pub usingnamespace JSC.Codegen.JSExpect;
-
-    test_id: TestRunner.Test.ID,
-    scope: *DescribeScope,
     flags: Flags = .{},
+    parent: ParentScope = .{ .global = {} },
+
+    pub const TestScope = struct {
+        test_id: TestRunner.Test.ID,
+        describe: *DescribeScope,
+    };
+
+    pub const ParentScope = union(enum) {
+        global: void,
+        TestScope: TestScope,
+    };
+
+    pub fn testScope(this: *const Expect) ?*const TestScope {
+        if (this.parent == .TestScope) {
+            return &this.parent.TestScope;
+        }
+
+        return null;
+    }
 
     pub const Flags = packed struct {
         // note: keep this struct in sync with C++ implementation (at bindings.cpp)
@@ -145,11 +161,6 @@ pub const Expect = struct {
     }
 
     pub fn getValue(this: *Expect, globalThis: *JSGlobalObject, thisValue: JSValue, matcher_name: string, comptime matcher_params_fmt: string) ?JSValue {
-        if (this.scope.tests.items.len <= this.test_id) {
-            globalThis.throw("{s}() must be called in a test", .{matcher_name});
-            return null;
-        }
-
         const value = Expect.capturedValueGetCached(thisValue) orelse {
             globalThis.throw("Internal error: the expect(value) was garbage collected but it should not have been!", .{});
             return null;
@@ -173,12 +184,12 @@ pub const Expect = struct {
                     promise.setHandled(vm);
 
                     const now = std.time.Instant.now() catch unreachable;
-                    const pending_test = Jest.runner.?.pending_test.?;
-                    const elapsed = @divFloor(now.since(pending_test.started_at), std.time.ns_per_ms);
+                    const elapsed = if (Jest.runner.?.pending_test) |pending_test| @divFloor(now.since(pending_test.started_at), std.time.ns_per_ms) else 0;
                     const remaining = @as(u32, @truncate(Jest.runner.?.last_test_timeout_timer_duration -| elapsed));
 
                     if (!globalThis.bunVM().waitForPromiseWithTimeout(promise, remaining)) {
-                        pending_test.timeout();
+                        if (Jest.runner.?.pending_test) |pending_test|
+                            pending_test.timeout();
                         return null;
                     }
 
@@ -263,10 +274,12 @@ pub const Expect = struct {
     }
 
     pub fn getSnapshotName(this: *Expect, allocator: std.mem.Allocator, hint: string) ![]const u8 {
-        const test_name = this.scope.tests.items[this.test_id].label;
+        var parent = this.testScope() orelse return error.NoTest;
+
+        const test_name = parent.describe.tests.items[parent.test_id].label;
 
         var length: usize = 0;
-        var curr_scope: ?*DescribeScope = this.scope;
+        var curr_scope: ?*DescribeScope = parent.describe;
         while (curr_scope) |scope| {
             if (scope.label.len > 0) {
                 length += scope.label.len + 1;
@@ -292,7 +305,7 @@ pub const Expect = struct {
             bun.copy(u8, buf[index..], test_name);
         }
         // copy describe scopes in reverse order
-        curr_scope = this.scope;
+        curr_scope = parent.describe;
         while (curr_scope) |scope| {
             if (scope.label.len > 0) {
                 index -= scope.label.len + 1;
@@ -320,16 +333,14 @@ pub const Expect = struct {
             return .zero;
         };
 
-        if (Jest.runner.?.pending_test == null) {
-            const err = globalObject.createErrorInstance("expect() must be called in a test", .{});
-            err.put(globalObject, ZigString.static("name"), ZigString.init("TestNotRunningError").toValueGC(globalObject));
-            globalObject.throwValue(err);
-            return .zero;
-        }
-
         expect.* = .{
-            .scope = Jest.runner.?.pending_test.?.describe,
-            .test_id = Jest.runner.?.pending_test.?.test_id,
+            .parent = if (Jest.runner.?.pending_test) |pending|
+                Expect.ParentScope{ .TestScope = Expect.TestScope{
+                    .describe = pending.describe,
+                    .test_id = pending.test_id,
+                } }
+            else
+                Expect.ParentScope{ .global = {} },
         };
         const expect_js_value = expect.toJS(globalObject);
         expect_js_value.ensureStillAlive();
@@ -375,7 +386,7 @@ pub const Expect = struct {
             _msg = ZigString.fromBytes("passes by .pass() assertion");
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = true;
@@ -428,7 +439,7 @@ pub const Expect = struct {
             _msg = ZigString.fromBytes("fails by .fail() assertion");
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = false;
@@ -465,7 +476,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
         const right = arguments[0];
         right.ensureStillAlive();
         const left = this.getValue(globalObject, thisValue, "toBe", "<green>expected<r>") orelse return .zero;
@@ -549,7 +560,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const expected: JSValue = arguments[0];
         const value: JSValue = this.getValue(globalObject, thisValue, "toHaveLength", "<green>expected<r>") orelse return .zero;
@@ -635,7 +646,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const expected = arguments[0];
         expected.ensureStillAlive();
@@ -697,7 +708,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalObject, thisValue, "toBeTruthy", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = false;
@@ -739,7 +750,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalObject, thisValue, "toBeUndefined", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = false;
@@ -780,7 +791,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalObject, thisValue, "toBeNaN", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = false;
@@ -824,7 +835,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalObject, thisValue, "toBeNull", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = value.isNull();
@@ -863,7 +874,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalObject, thisValue, "toBeDefined", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = !value.isUndefined();
@@ -903,7 +914,7 @@ pub const Expect = struct {
 
         const value: JSValue = this.getValue(globalObject, thisValue, "toBeFalsy", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = false;
@@ -952,7 +963,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const expected = arguments[0];
         const value: JSValue = this.getValue(globalObject, thisValue, "toEqual", "<green>expected<r>") orelse return .zero;
@@ -996,7 +1007,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const expected = arguments[0];
         const value: JSValue = this.getValue(globalObject, thisValue, "toStrictEqual", "<green>expected<r>") orelse return .zero;
@@ -1043,7 +1054,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const expected_property_path = arguments[0];
         expected_property_path.ensureStillAlive();
@@ -1166,7 +1177,7 @@ pub const Expect = struct {
 
         const value: JSValue = this.getValue(globalObject, thisValue, "toBeEven", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = false;
@@ -1235,7 +1246,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const other_value = arguments[0];
         other_value.ensureStillAlive();
@@ -1309,7 +1320,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const other_value = arguments[0];
         other_value.ensureStillAlive();
@@ -1380,7 +1391,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const other_value = arguments[0];
         other_value.ensureStillAlive();
@@ -1451,7 +1462,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const other_value = arguments[0];
         other_value.ensureStillAlive();
@@ -1611,7 +1622,7 @@ pub const Expect = struct {
 
         const value: JSValue = this.getValue(globalObject, thisValue, "toBeOdd", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = false;
@@ -1673,7 +1684,7 @@ pub const Expect = struct {
         const _arguments = callFrame.arguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const expected_value: JSValue = if (arguments.len > 0) brk: {
             const value = arguments[0];
@@ -2037,13 +2048,20 @@ pub const Expect = struct {
         const _arguments = callFrame.arguments(2);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         if (not) {
             const signature = comptime getSignature("toMatchSnapshot", "", true);
             const fmt = signature ++ "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n";
             globalObject.throwPretty(fmt, .{});
+        }
+
+        if (this.testScope() == null) {
+            const signature = comptime getSignature("toMatchSnapshot", "", true);
+            const fmt = signature ++ "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n";
+            globalObject.throwPretty(fmt, .{});
+            return .zero;
         }
 
         var hint_string: ZigString = ZigString.Empty;
@@ -2102,7 +2120,7 @@ pub const Expect = struct {
 
         const result = Jest.runner.?.snapshots.getOrPut(this, value, hint.slice(), globalObject) catch |err| {
             var formatter = JSC.ZigConsoleClient.Formatter{ .globalThis = globalObject };
-            const test_file_path = Jest.runner.?.files.get(this.scope.file_id).source.path.text;
+            const test_file_path = Jest.runner.?.files.get(this.testScope().?.describe.file_id).source.path.text;
             switch (err) {
                 error.FailedToOpenSnapshotFile => globalObject.throw("Failed to open snapshot file for test file: {s}", .{test_file_path}),
                 error.FailedToMakeSnapshotDirectory => globalObject.throw("Failed to make snapshot directory for test file: {s}", .{test_file_path}),
@@ -2149,7 +2167,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalObject, thisValue, "toBeEmpty", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = false;
@@ -2227,7 +2245,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeNil", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = value.isUndefinedOrNull() != not;
@@ -2254,12 +2272,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeArray", "") orelse return .zero;
 
-        if (this.scope.tests.items.len <= this.test_id) {
-            globalThis.throw("toBeArray() must be called in a test", .{});
-            return .zero;
-        }
-
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = value.jsType().isArray() != not;
@@ -2294,11 +2307,6 @@ pub const Expect = struct {
 
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeArrayOfSize", "") orelse return .zero;
 
-        if (this.scope.tests.items.len <= this.test_id) {
-            globalThis.throw("toBeArrayOfSize() must be called in a test", .{});
-            return .zero;
-        }
-
         const size = arguments[0];
         size.ensureStillAlive();
 
@@ -2307,7 +2315,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         var pass = value.jsType().isArray() and @as(i32, @intCast(value.getLength(globalThis))) == size.toInt32();
@@ -2335,7 +2343,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeBoolean", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = value.isBoolean() != not;
@@ -2368,18 +2376,13 @@ pub const Expect = struct {
             return .zero;
         }
 
-        if (this.scope.tests.items.len <= this.test_id) {
-            globalThis.throw("toBeTypeOf() must be called in a test", .{});
-            return .zero;
-        }
-
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeTypeOf", "") orelse return .zero;
 
         const expected = arguments[0];
         expected.ensureStillAlive();
 
         const expectedAsStr = expected.toString(globalThis).toSlice(globalThis, default_allocator).slice();
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         if (!expected.isString()) {
             globalThis.throwInvalidArguments("toBeTypeOf() requires a string argument", .{});
@@ -2443,7 +2446,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeTrue", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = (value.isBoolean() and value.toBoolean()) != not;
@@ -2470,7 +2473,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeFalse", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = (value.isBoolean() and !value.toBoolean()) != not;
@@ -2497,7 +2500,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeNumber", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = value.isNumber() != not;
@@ -2524,7 +2527,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeInteger", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = value.isAnyInt() != not;
@@ -2551,7 +2554,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeFinite", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         var pass = value.isNumber();
         if (pass) {
@@ -2584,7 +2587,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBePositive", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         var pass = value.isNumber();
         if (pass) {
@@ -2617,7 +2620,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeNegative", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         var pass = value.isNumber();
         if (pass) {
@@ -2674,7 +2677,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         var pass = value.isNumber();
         if (pass) {
@@ -2719,7 +2722,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const expected = arguments[0];
         const value: JSValue = this.getValue(globalThis, thisValue, "toEqualIgnoringWhitespace", "<green>expected<r>") orelse return .zero;
@@ -2790,7 +2793,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeSymbol", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = value.isSymbol() != not;
@@ -2817,7 +2820,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeFunction", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = value.isCallable(globalThis.vm()) != not;
@@ -2844,7 +2847,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeDate", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = value.isDate() != not;
@@ -2871,7 +2874,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeString", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = value.isString() != not;
@@ -2914,7 +2917,7 @@ pub const Expect = struct {
 
         const value: JSValue = this.getValue(globalThis, thisValue, "toInclude", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         var pass = value.isString();
         if (pass) {
@@ -2959,12 +2962,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        if (this.scope.tests.items.len <= this.test_id) {
-            globalThis.throw("toIncludeRepeated() must be called in a test", .{});
-            return .zero;
-        }
-
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const substring = arguments[0];
         substring.ensureStillAlive();
@@ -3075,12 +3073,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        if (this.scope.tests.items.len <= this.test_id) {
-            globalThis.throw("toSatisfy() must be called in a test", .{});
-            return .zero;
-        }
-
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const predicate = arguments[0];
         predicate.ensureStillAlive();
@@ -3169,7 +3162,7 @@ pub const Expect = struct {
 
         const value: JSValue = this.getValue(globalThis, thisValue, "toStartWith", "<green>expected<r>") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         var pass = value.isString();
         if (pass) {
@@ -3224,7 +3217,7 @@ pub const Expect = struct {
 
         const value: JSValue = this.getValue(globalThis, thisValue, "toEndWith", "<green>expected<r>") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         var pass = value.isString();
         if (pass) {
@@ -3269,7 +3262,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
         var formatter = JSC.ZigConsoleClient.Formatter{ .globalThis = globalObject, .quote_strings = true };
 
         const expected_value = arguments[0];
@@ -3323,7 +3316,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         var formatter = JSC.ZigConsoleClient.Formatter{ .globalThis = globalObject, .quote_strings = true };
 
@@ -3381,7 +3374,7 @@ pub const Expect = struct {
         const value: JSValue = this.getValue(globalObject, thisValue, "toHaveBeenCalled", "") orelse return .zero;
 
         const calls = JSMockFunction__getCalls(value);
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         if (calls == .zero or !calls.jsType().isArray()) {
             globalObject.throw("Expected value must be a mock function: {}", .{value});
@@ -3417,7 +3410,7 @@ pub const Expect = struct {
         defer this.postMatch(globalObject);
         const value: JSValue = this.getValue(globalObject, thisValue, "toHaveBeenCalledTimes", "<green>expected<r>") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const calls = JSMockFunction__getCalls(value);
 
@@ -3460,7 +3453,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const args = callFrame.arguments(1).slice();
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
 
@@ -3528,7 +3521,7 @@ pub const Expect = struct {
         defer this.postMatch(globalObject);
         const value: JSValue = this.getValue(globalObject, thisValue, "toHaveBeenCalledWith", "<green>expected<r>") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const calls = JSMockFunction__getCalls(value);
 
@@ -3594,7 +3587,7 @@ pub const Expect = struct {
         defer this.postMatch(globalObject);
         const value: JSValue = this.getValue(globalObject, thisValue, "toHaveBeenLastCalledWith", "<green>expected<r>") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const calls = JSMockFunction__getCalls(value);
 
@@ -3659,7 +3652,7 @@ pub const Expect = struct {
         defer this.postMatch(globalObject);
         const value: JSValue = this.getValue(globalObject, thisValue, "toHaveBeenNthCalledWith", "<green>expected<r>") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const calls = JSMockFunction__getCalls(value);
 
@@ -3911,12 +3904,12 @@ pub const Expect = struct {
             promise.setHandled(vm);
 
             const now = std.time.Instant.now() catch unreachable;
-            const pending_test = Jest.runner.?.pending_test.?;
-            const elapsed = @divFloor(now.since(pending_test.started_at), std.time.ns_per_ms);
+            const elapsed = if (Jest.runner.?.pending_test) |pending_test| @divFloor(now.since(pending_test.started_at), std.time.ns_per_ms) else 0;
             const remaining = @as(u32, @truncate(Jest.runner.?.last_test_timeout_timer_duration -| elapsed));
 
             if (!globalObject.bunVM().waitForPromiseWithTimeout(promise, remaining)) {
-                pending_test.timeout();
+                if (Jest.runner.?.pending_test) |pending_test|
+                    pending_test.timeout();
                 globalObject.throw("Timed out while awaiting the promise returned by matcher \"{s}\"", .{matcher_name});
                 return false;
             }
@@ -4022,11 +4015,6 @@ pub const Expect = struct {
         // retrieve the matcher name
         const matcher_name = matcher_fn.getName(globalObject);
 
-        if (expect.scope.tests.items.len <= expect.test_id) {
-            globalObject.throw("expect.{s}() must be called in a test", .{matcher_name});
-            return .zero;
-        }
-
         const matcher_params = CustomMatcherParamsFormatter{
             .colors = Output.enable_ansi_colors,
             .globalObject = globalObject,
@@ -4041,7 +4029,7 @@ pub const Expect = struct {
         value = Expect.processPromise(expect.flags, globalObject, value, matcher_name, matcher_params, false) orelse return .zero;
         value.ensureStillAlive();
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         // prepare the args array
         const args_ptr = callFrame.argumentsPtr();
@@ -4221,13 +4209,6 @@ pub const ExpectAnything = struct {
     }
 
     pub fn call(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) callconv(.C) JSValue {
-        if (Jest.runner.?.pending_test == null) {
-            const err = globalObject.createErrorInstance("expect.anything() must be called in a test", .{});
-            err.put(globalObject, ZigString.static("name"), ZigString.init("TestNotRunningError").toValueGC(globalObject));
-            globalObject.throwValue(err);
-            return .zero;
-        }
-
         const anything = globalObject.bunVM().allocator.create(ExpectAnything) catch {
             globalObject.throwOutOfMemory();
             return .zero;
@@ -4265,13 +4246,6 @@ pub const ExpectStringMatching = struct {
         }
 
         const test_value = args[0];
-
-        if (Jest.runner.?.pending_test == null) {
-            const err = globalObject.createErrorInstance("expect.stringContaining() must be called in a test", .{});
-            err.put(globalObject, ZigString.static("name"), ZigString.init("TestNotRunningError").toValueGC(globalObject));
-            globalObject.throwValue(err);
-            return .zero;
-        }
 
         const string_matching = globalObject.bunVM().allocator.create(ExpectStringMatching) catch {
             globalObject.throwOutOfMemory();
@@ -4317,13 +4291,6 @@ pub const ExpectCloseTo = struct {
             return .zero;
         }
 
-        if (Jest.runner.?.pending_test == null) {
-            const err = globalObject.createErrorInstance("expect.closeTo() must be called in a test", .{});
-            err.put(globalObject, ZigString.static("name"), ZigString.init("TestNotRunningError").toValueGC(globalObject));
-            globalObject.throwValue(err);
-            return .zero;
-        }
-
         const instance = globalObject.bunVM().allocator.create(ExpectCloseTo) catch {
             globalObject.throwOutOfMemory();
             return .zero;
@@ -4364,13 +4331,6 @@ pub const ExpectObjectContaining = struct {
 
         const object_value = args[0];
 
-        if (Jest.runner.?.pending_test == null) {
-            const err = globalObject.createErrorInstance("expect.objectContaining() must be called in a test", .{});
-            err.put(globalObject, ZigString.static("name"), ZigString.init("TestNotRunningError").toValueGC(globalObject));
-            globalObject.throwValue(err);
-            return .zero;
-        }
-
         const instance = globalObject.bunVM().allocator.create(ExpectObjectContaining) catch {
             globalObject.throwOutOfMemory();
             return .zero;
@@ -4407,13 +4367,6 @@ pub const ExpectStringContaining = struct {
         }
 
         const string_value = args[0];
-
-        if (Jest.runner.?.pending_test == null) {
-            const err = globalObject.createErrorInstance("expect.stringContaining() must be called in a test", .{});
-            err.put(globalObject, ZigString.static("name"), ZigString.init("TestNotRunningError").toValueGC(globalObject));
-            globalObject.throwValue(err);
-            return .zero;
-        }
 
         const string_containing = globalObject.bunVM().allocator.create(ExpectStringContaining) catch {
             globalObject.throwOutOfMemory();
@@ -4458,13 +4411,6 @@ pub const ExpectAny = struct {
             return .zero;
         }
 
-        if (Jest.runner.?.pending_test == null) {
-            const err = globalObject.createErrorInstance("expect.any() must be called in a test", .{});
-            err.put(globalObject, ZigString.static("name"), ZigString.init("TestNotRunningError").toValueGC(globalObject));
-            globalObject.throwValue(err);
-            return .zero;
-        }
-
         var any = globalObject.bunVM().allocator.create(ExpectAny) catch {
             globalObject.throwOutOfMemory();
             return .zero;
@@ -4504,13 +4450,6 @@ pub const ExpectArrayContaining = struct {
         }
 
         const array_value = args[0];
-
-        if (Jest.runner.?.pending_test == null) {
-            const err = globalObject.createErrorInstance("expect.arrayContaining() must be called in a test", .{});
-            err.put(globalObject, ZigString.static("name"), ZigString.init("TestNotRunningError").toValueGC(globalObject));
-            globalObject.throwValue(err);
-            return .zero;
-        }
 
         const array_containing = globalObject.bunVM().allocator.create(ExpectArrayContaining) catch {
             globalObject.throwOutOfMemory();
@@ -4891,4 +4830,8 @@ comptime {
     @export(ExpectMatcherUtils.createSingleton, .{ .name = "ExpectMatcherUtils_createSigleton" });
     @export(Expect.readFlagsAndProcessPromise, .{ .name = "Expect_readFlagsAndProcessPromise" });
     @export(ExpectCustomAsymmetricMatcher.execute, .{ .name = "ExpectCustomAsymmetricMatcher__execute" });
+}
+
+fn incrementExpectCallCounter() void {
+    active_test_expectation_counter.actual += 1;
 }

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -495,6 +495,11 @@ pub const Jest = struct {
 
         module.put(globalObject, ZigString.static("jest"), jest);
         module.put(globalObject, ZigString.static("spyOn"), spyOn);
+        module.put(
+            globalObject,
+            ZigString.static("expect"),
+            Expect.getConstructor(globalObject),
+        );
 
         const vi = JSValue.createEmptyObject(globalObject, 3);
         vi.put(globalObject, ZigString.static("fn"), mockFn);

--- a/src/bun.js/test/snapshot.zig
+++ b/src/bun.js/test/snapshot.zig
@@ -38,7 +38,7 @@ pub const Snapshots = struct {
     };
 
     pub fn getOrPut(this: *Snapshots, expect: *Expect, value: JSValue, hint: string, globalObject: *JSC.JSGlobalObject) !?string {
-        switch (try this.getSnapshotFile(expect.scope.file_id)) {
+        switch (try this.getSnapshotFile(expect.testScope().?.describe.file_id)) {
             .result => {},
             .err => |err| {
                 return switch (err.syscall) {

--- a/test/js/bun/test/custom-matcher-preload-test-fixture-1.ts
+++ b/test/js/bun/test/custom-matcher-preload-test-fixture-1.ts
@@ -1,0 +1,10 @@
+import { expect } from "bun:test";
+
+expect.extend({
+  toBeGoat(actual, expected, message) {
+    return {
+      pass: actual === "goat",
+      message: () => `expected ${actual} to be goat`,
+    };
+  },
+});

--- a/test/js/bun/test/custom-matcher-preload-test-fixture-2.ts
+++ b/test/js/bun/test/custom-matcher-preload-test-fixture-2.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "bun:test";
+
+test("custom matcher", () => {
+  // @ts-expect-error
+  expect("goat").toBeGoat();
+  console.log("custom matcher test passed");
+});

--- a/test/js/bun/test/expect-extend-preload.test.ts
+++ b/test/js/bun/test/expect-extend-preload.test.ts
@@ -1,0 +1,33 @@
+import { file } from "bun";
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+test("custom matcher runs", async () => {
+  const dir = tempDirWithFiles("custom-matcher-preload-test-fixture", {
+    "preload.ts": await file(join(import.meta.dir, "custom-matcher-preload-test-fixture-1.ts")).text(),
+    "expect-extend.test.ts": await file(join(import.meta.dir, "custom-matcher-preload-test-fixture-2.ts")).text(),
+    "bunfig.toml": `
+[test]
+preload = "./preload.ts"
+        `,
+    "package.json": JSON.stringify(
+      {
+        name: "custom-matcher-preload-test-fixture",
+        version: "1.0.0",
+      },
+      null,
+      2,
+    ),
+  });
+  const { stdout, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "test", "expect-extend.test.ts"],
+    cwd: dir,
+    env: bunEnv,
+    stderr: "inherit",
+    stdout: "pipe",
+    stdin: "inherit",
+  });
+  expect(stdout.toString().trim()).toContain("custom matcher test passed");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

- Allow `expect.extend` to be used in preload
- Remove "expect must be called in a test" error

Fixes https://github.com/oven-sh/bun/issues/7423

### How did you verify your code works?

There is a test