### PR TITLE
Fix for building lambda runtime zip files

### DIFF
--- a/packages/bun-lambda/scripts/build-layer.ts
+++ b/packages/bun-lambda/scripts/build-layer.ts
@@ -2,7 +2,7 @@
 process.stdout.getWindowSize = () => [80, 80];
 process.stderr.getWindowSize = () => [80, 80];
 
-import { createReadStream, createWriteStream } from "node:fs";
+import { createReadStream, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { Command, Flags } from "@oclif/core";
 import JSZip from "jszip";
@@ -85,15 +85,15 @@ export class BuildCommand extends Command {
       archive.file(filename, createReadStream(path));
     }
     this.log("Saving...", output);
-    archive
-      .generateNodeStream({
-        streamFiles: true,
+    const archiveBuffer = await archive
+      .generateAsync({
+        type: 'blob',
         compression: "DEFLATE",
         compressionOptions: {
           level: 9,
         },
-      })
-      .pipe(createWriteStream(output));
+      }).then(blob => blob.arrayBuffer());
+    writeFileSync(output, archiveBuffer);
     this.log("Saved");
   }
 }


### PR DESCRIPTION
### What does this PR do?

Resolves https://github.com/oven-sh/bun/issues/7028

Building the zip file required by the lambda runtime was broken and result in a corrupted file that could not be opened. This prevented the publish script from working. It's not clear what broke but it may have exposed a bug in bun.

- [ ] ~~Documentation or TypeScript types (it's okay to leave the rest blank in this case)~~
- [x] Code changes

### How did you verify your code works?

Verified I could build and deploy new Bun-based lambda runtimes.
