### PR TITLE
Fix `bun create` help script

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1982,7 +1982,7 @@ pub const Command = struct {
                         \\
                         \\<b>Environment variables:<r>
                         \\  <cyan>GITHUB_ACCESS_TOKEN<r>      <d>Supply a token to download code from GitHub with a higher rate limit<r>
-                        \\  <cyan>GITHUB_API_DOMAIN<r>        <d>Configure custom/enterprise GitHub domain. Default "api.github.comx".<r>
+                        \\  <cyan>GITHUB_API_DOMAIN<r>        <d>Configure custom/enterprise GitHub domain. Default "api.github.com".<r>
                         \\  <cyan>NPM_CLIENT<r>               <d>Absolute path to the npm client executable<r>
                     ;
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1980,9 +1980,9 @@ pub const Command = struct {
                         \\  <b><green>bun create<r> <blue>\<template\><r> <cyan>[...flags]<r> <blue>[dest]<r>
                         \\  <b><green>bun create<r> <blue>\<username/repo\><r> <cyan>[...flags]<r> <blue>[dest]<r>
                         \\
-                        \\<b>Environment variables:
+                        \\<b>Environment variables:<r>
                         \\  <cyan>GITHUB_ACCESS_TOKEN<r>      <d>Supply a token to download code from GitHub with a higher rate limit<r>
-                        \\  <cyan>GITHUB_API_DOMAIN<r>        <d>Configure custom/enterprise GitHub domain. Default \"api.github.com\".<r>
+                        \\  <cyan>GITHUB_API_DOMAIN<r>        <d>Configure custom/enterprise GitHub domain. Default "api.github.comx".<r>
                         \\  <cyan>NPM_CLIENT<r>               <d>Absolute path to the npm client executable<r>
                     ;
 


### PR DESCRIPTION
### What does this PR do?

I looked at the [zig docs for multiline string](https://ziglang.org/documentation/0.10.1/#Multiline-String-Literals) and saw unnecessary escape character for quotation marks in `"api.github.com"`

There was also the bold from the "Environment variables" title leaking into the first env var, so I added the style reset syntax on the end of title.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I assume based on other usages.
