### PR TITLE
Fix variable name at typedarray-to-string.md docs

### DIFF
--- a/docs/guides/binary/typedarray-to-string.md
+++ b/docs/guides/binary/typedarray-to-string.md
@@ -7,7 +7,7 @@ Bun implements the Web-standard [`TextDecoder`](https://developer.mozilla.org/en
 ```ts
 const arr = new Uint8Array([104, 101, 108, 108, 111]);
 const decoder = new TextDecoder();
-const str = decoder.decode(buf);
+const str = decoder.decode(arr);
 // => "hello"
 ```
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes #7454 a variable name in the docs. There is no `buf` variable initialized.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
