### PR TITLE
fix: jsx key after spread

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1078,6 +1078,11 @@ declare module "bun" {
      * it in some cases. Do your own benchmarks!
      */
     inline?: boolean;
+
+    /**
+     * @default "warn"
+     */
+    logLevel?: "verbose" | "debug" | "info" | "warn" | "error";
   }
 
   /**

--- a/src/bun.js/RuntimeTranspilerCache.zig
+++ b/src/bun.js/RuntimeTranspilerCache.zig
@@ -1,5 +1,5 @@
 // ** Update the version number when any breaking changes are made to the cache format or to the JS parser **
-const expected_version = 1;
+const expected_version = 2;
 
 const bun = @import("root").bun;
 const std = @import("std");

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -248,6 +248,7 @@ pub const JavaScript = struct {
         source: *const logger.Source,
     ) anyerror!?js_ast.Result {
         var temp_log = logger.Log.init(allocator);
+        temp_log.level = log.level;
         var parser = js_parser.Parser.init(opts, &temp_log, source, defines, allocator) catch {
             temp_log.appendToMaybeRecycled(log, source) catch {};
             return null;

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -293,7 +293,7 @@ pub const LocRef = struct {
 
 pub const Flags = struct {
     pub const JSXElement = enum {
-        is_key_before_rest,
+        is_key_after_spread,
         has_any_dynamic,
         can_be_inlined,
         can_be_hoisted,

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -257,7 +257,7 @@ describe("Bun.build", () => {
     expect(x.success).toBe(true);
     expect(x.logs).toHaveLength(1);
     expect(x.logs[0].message).toBe(
-      '"key" prop before a {...spread} is deprecated in JSX. Falling back to classic runtime.',
+      '"key" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.',
     );
     expect(x.logs[0].name).toBe("BuildMessage");
     expect(x.logs[0].position).toBeTruthy();

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -12,7 +12,7 @@ describe("bun build", () => {
     });
     expect(exitCode).toBe(0);
     expect(stderr.toString("utf8")).toContain(
-      'warn: "key" prop before a {...spread} is deprecated in JSX. Falling back to classic runtime.',
+      'warn: "key" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.',
     );
   });
 

--- a/test/bundler/fixtures/jsx-warning/index.jsx
+++ b/test/bundler/fixtures/jsx-warning/index.jsx
@@ -1,1 +1,1 @@
-console.log(<div key={"123"} {...props} />);
+console.log(<div {...props} key={"123"} />);

--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -1253,6 +1253,24 @@ export default <>hi</>
       `console.log(jsxDEV("div", {}, undefined, false, undefined, this));
 `,
     );
+
+    // key after spread props
+    // https://github.com/oven-sh/bun/issues/7328
+    expect(bun.transformSync(`console.log(<div {...obj} key="after" />, <div key="before" {...obj} />);`)).toBe(
+      `console.log(createElement(\"div\", {\n  ...obj,\n  key: \"after\"\n}), jsxDEV(\"div\", {\n  ...obj\n}, \"before\", false, undefined, this));
+`,
+    );
+    expect(bun.transformSync(`console.log(<div {...obj} key="after" {...obj2} />);`)).toBe(
+      `console.log(createElement(\"div\", {\n  ...obj,\n  key: \"after\",\n  ...obj2\n}));
+`,
+    );
+    expect(
+      bun.transformSync(`// @jsx foo;
+console.log(<div {...obj} key="after" />);`),
+    ).toBe(
+      `console.log(createElement(\"div\", {\n  ...obj,\n  key: \"after\"\n}));
+`,
+    );
   });
 
   it.todo("JSX", () => {

--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -1198,6 +1198,7 @@ export default <>hi</>
       define: {
         "process.env.NODE_ENV": JSON.stringify("development"),
       },
+      logLevel: "error",
     });
 
     expect(bun.transformSync("console.log(<div key={() => {}} points={() => {}}></div>);")).toBe(


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix #7328.
Following the implementation of [TypeScript](https://www.typescriptlang.org/play?target=99&jsx=4#code/MYewdgziA2CmB00QHMAUAeAJgSwG4AIBveEkAIwCsBffAa1gE8BeAIgEMAzAF1gCcX8AegB8AGnxY8dRqzKwOIXrAHFSlGiICUQA), if jsx with key comes after spread props, it should fallback to `createElement`.

### Example:
`bun build --outdir=dist --external=react example.js`
```js
console.log(<div {...obj} key="after" />, <div key="before" {...obj} />)
```

**Before**
`warn: "key" prop before a {...spread} is deprecated in JSX. Falling back to classic runtime.`
```js
import {
jsxDEV
} from "react/jsx-dev-runtime";
console.log(jsxDEV("div", {
  ...obj
}, "after", false, undefined, this), React.createElement("div", {
  key: "before",
  ...obj
}));
```

**After**
```js
import {
jsxDEV
} from "react/jsx-dev-runtime";
import {
createElement
} from "react";
console.log(createElement("div", {
  ...obj,
  key: "after"
}), jsxDEV("div", {
  ...obj
}, "before", false, undefined, this));
```


<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Test included, [see](https://github.com/oven-sh/bun/pull/7464/files#diff-fa88bc0d245c46b2dbd67a0132a3646fdf248b6b9fd4beefbffcfc27ff56d74bR1259-R1264)


<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
