### PR TITLE
increase default thread stack size

### DIFF
--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -51,7 +51,7 @@ pub const WebWorker = struct {
         worker.cpp_worker = ptr;
 
         var thread = std.Thread.spawn(
-            .{ .stack_size = bun.default_stack_size },
+            .{ .stack_size = bun.default_thread_stack_size },
             startWithErrorHandling,
             .{worker},
         ) catch {

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1198,7 +1198,7 @@ pub const AsyncIO = @import("async_io");
 
 pub const logger = @import("./logger.zig");
 pub const ThreadPool = @import("./thread_pool.zig");
-pub const default_stack_size = ThreadPool.default_stack_size;
+pub const default_thread_stack_size = ThreadPool.default_thread_stack_size;
 pub const picohttp = @import("./deps/picohttp.zig");
 pub const uws = @import("./deps/uws.zig");
 pub const BoringSSL = @import("./boringssl.zig");

--- a/src/http.zig
+++ b/src/http.zig
@@ -710,7 +710,7 @@ pub const HTTPThread = struct {
 
         const thread = try std.Thread.spawn(
             .{
-                .stack_size = bun.default_stack_size,
+                .stack_size = bun.default_thread_stack_size,
             },
             comptime onStart,
             .{

--- a/src/network_thread.zig
+++ b/src/network_thread.zig
@@ -191,7 +191,7 @@ pub fn init() !void {
         global.waker = try AsyncIO.Waker.init(@import("root").bun.default_allocator);
     }
 
-    global.thread = try std.Thread.spawn(.{ .stack_size = bun.default_stack_size }, onStartIOThread, .{
+    global.thread = try std.Thread.spawn(.{ .stack_size = bun.default_thread_stack_size }, onStartIOThread, .{
         global.waker,
     });
     global.thread.detach();

--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -52,7 +52,7 @@ const Sync = packed struct {
 /// Configuration options for the thread pool.
 /// TODO: add CPU core affinity?
 pub const Config = struct {
-    stack_size: u32 = default_stack_size,
+    stack_size: u32 = default_thread_stack_size,
     max_threads: u32,
 };
 
@@ -440,9 +440,9 @@ inline fn notify(self: *ThreadPool, is_waking: bool) void {
     return self.notifySlow(is_waking);
 }
 
-pub const default_stack_size = brk: {
-    // 2mb
-    const default = 2 * 1024 * 1024;
+pub const default_thread_stack_size = brk: {
+    // 4mb
+    const default = 4 * 1024 * 1024;
 
     if (!Environment.isMac) break :brk default;
 
@@ -473,7 +473,7 @@ pub fn warm(self: *ThreadPool, count: u14) void {
             .Release,
             .Monotonic,
         ) orelse break));
-        const spawn_config = std.Thread.SpawnConfig{ .stack_size = default_stack_size };
+        const spawn_config = std.Thread.SpawnConfig{ .stack_size = default_thread_stack_size };
         const thread = std.Thread.spawn(spawn_config, Thread.run, .{self}) catch return self.unregister(null);
         thread.detach();
     }
@@ -515,7 +515,7 @@ noinline fn notifySlow(self: *ThreadPool, is_waking: bool) void {
 
             // We signaled to spawn a new thread
             if (can_wake and sync.spawned < self.max_threads) {
-                const spawn_config = std.Thread.SpawnConfig{ .stack_size = default_stack_size };
+                const spawn_config = std.Thread.SpawnConfig{ .stack_size = default_thread_stack_size };
                 const thread = std.Thread.spawn(spawn_config, Thread.run, .{self}) catch return self.unregister(null);
                 // if (self.name.len > 0) thread.setName(self.name) catch {};
                 return thread.detach();

--- a/src/work_pool.zig
+++ b/src/work_pool.zig
@@ -14,7 +14,7 @@ pub fn NewWorkPool(comptime max_threads: ?usize) type {
 
             pool = ThreadPool.init(.{
                 .max_threads = max_threads orelse @max(@as(u32, @truncate(std.Thread.getCpuCount() catch 0)), 2),
-                .stack_size = ThreadPool.default_stack_size,
+                .stack_size = ThreadPool.default_thread_stack_size,
             });
             return &pool;
         }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
