### PR TITLE
fix: `stream` on sliced `BunFile`

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -74,6 +74,7 @@ pub const Blob = struct {
 
     size: SizeType = 0,
     offset: SizeType = 0,
+    was_sliced: bool = false,
     /// When set, the blob will be freed on finalization callbacks
     /// If the blob is contained in Response or Request, this must be null
     allocator: ?std.mem.Allocator = null,
@@ -3260,6 +3261,7 @@ pub const Blob = struct {
         var blob = this.dupe();
         blob.offset = offset;
         blob.size = len;
+        blob.was_sliced = true;
 
         // infer the content type if it was not specified
         if (content_type.len == 0 and this.content_type.len > 0 and !this.content_type_allocated)

--- a/test/js/bun/io/bun-stream.test.ts
+++ b/test/js/bun/io/bun-stream.test.ts
@@ -1,0 +1,41 @@
+import { expect, it } from "bun:test";
+import { tmpdir } from "os";
+import fs from "fs";
+
+function create_file(filename, contents) {
+    try {
+        fs.writeFileSync(filename, contents);
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+it("stream a BunFile correctly", async () => {
+    const filename = tmpdir() + "bun-stream.test.txt";
+    create_file(filename, "12345");
+
+    const file = Bun.file(filename);
+    const content = await(new Response(file.stream())).text();
+    expect(content).toBe("12345");
+    expect(file.size).toBe(5);
+});
+
+it("stream on sliced BunFile correctly", async () => {
+    const filename = tmpdir() + "bun-stream.test.txt";
+    create_file(filename, "12345");
+
+    const file = Bun.file(filename).slice(0, 2);
+    const content = await(new Response(file.stream())).text();
+    expect(content).toBe("12");
+    expect(file.size).toBe(2);
+});
+
+it("stream on doubly sliced BunFile", async () => {
+    const filename = tmpdir() + "bun-stream.test.txt";
+    create_file(filename, "0123456789");
+
+    const file = Bun.file(filename).slice(5, 10).slice(0, 3);
+    const content = await(new Response(file.stream())).text();
+    expect(content).toBe("567");
+    expect(file.size).toBe(3);
+});


### PR DESCRIPTION
### What does this PR do?

Stores sliced offsets inside `FileReader` for `.stream()` to use. Fixes #7057 

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

- [X] I included a test for the new code, or an existing test covers it
- [X] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
