### PR TITLE
fix(jest): fix segfault when passing jest.fn into another jest.fn

### DIFF
--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -280,6 +280,8 @@ public:
             if (lengthJSValue.isNumber()) {
                 this->putDirect(vm, vm.propertyNames->length, (lengthJSValue), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly);
             }
+        } else if (auto* fn = jsDynamicCast<JSMockFunction*>(value)) {
+            nameToUse = fn->get(global, vm.propertyNames->name).toWTFString(global);
         } else if (auto* fn = jsDynamicCast<InternalFunction*>(value)) {
             nameToUse = fn->name();
         } else {

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -620,6 +620,21 @@ describe("mock()", () => {
     expect(fn).toHaveBeenNthCalledWith(5, 1, undefined);
     expect(fn).not.toHaveBeenNthCalledWith(5, 1);
   });
+
+  it("no segmentation fault when passing jest.fn into another jest.fn, issue#5900", () => {
+    function foo() {
+      return true;
+    }
+
+    function bar(fn = jest.fn(foo)) {
+      expect(fn.getMockName()).toBe("foo");
+      let newFn = jest.fn(fn);
+      expect(newFn.getMockName()).toBe("foo");
+      return newFn;
+    }
+
+    expect(bar()()).toBe(true);
+  });
 });
 
 describe("spyOn", () => {


### PR DESCRIPTION

### What does this PR do?

Close: #5900


coredump stack

```
(lldb) bt
* thread #1, name = 'bun-debug', stop reason = signal SIGABRT
  * frame #0: 0x00007f7dd171783c libc.so.6`___lldb_unnamed_symbol3601 + 268
    frame #1: 0x00007f7dd16c7668 libc.so.6`raise + 24
    frame #2: 0x00007f7dd16af542 libc.so.6`abort + 353
    frame #3: 0x000055d3784e18fb bun-debug`WTFCrashWithInfo((null)=121, (null)="", (null)="", (null)=337) at Assertions.h:778:5
    frame #4: 0x000055d37af3499a bun-debug`JSC::WriteBarrierBase<JSC::JSString, WTF::RawPtrTraits<JSC::JSString>>::operator->(this=0x00007f7dc702fa98) const at WriteBarrier.h:121:9
    frame #5: 0x000055d37af27028 bun-debug`JSC::InternalFunction::name(this=0x00007f7dc702fa78) at InternalFunction.cpp:82:26
    frame #6: 0x000055d378608b40 bun-debug`Bun::JSMockFunction::copyNameAndLength(this=0x00007f7dc702c638, vm=0x00007f7d85000000, global=0x00007f7d85459868, value=JSValue @ scalar) at JSMockFunction.cpp:284:29
    frame #7: 0x000055d378602ef6 bun-debug`JSMock__jsMockFn(lexicalGlobalObject=0x00007f7d85459868, callframe=<unavailable>) at JSMockFunction.cpp:1060:25
    frame #8: 0x00007f7d86d501b8
    frame #9: 0x000055d37964a9cc bun-debug`js_trampoline_op_call + 23
    frame #10: 0x000055d37964a9cc bun-debug`js_trampoline_op_call + 23
    frame #11: 0x000055d37962611f bun-debug`vmEntryToJavaScript + 286
    frame #12: 0x000055d37aa1129f bun-debug`JSC::Interpreter::executeCallImpl(this=0x00007f7d85012888, vm=0x00007f7d85000000, function=0x00007f7d8546cd60, callData=0x00007ffe71339b30, thisValue=JSValue @ 0x00007ffe71339820, args=0x00007ffe71339b58) at Interpreter.cpp:1166:32
    frame #13: 0x000055d37aa05f50 bun-debug`JSC::Interpreter::executeCall(this=0x00007f7d85012888, function=0x00007f7d8546cd60, callData=0x00007ffe71339b30, thisValue=JSValue @ 0x00007ffe713398b0, args=0x00007ffe71339b58) at Interpreter.cpp:1175:16
    frame #14: 0x000055d37ae0ea8d bun-debug`JSC::call(globalObject=0x00007f7d85459868, functionObject=JSValue @ 0x00007ffe71339910, callData=0x00007ffe71339b30, thisValue=JSValue @ 0x00007ffe71339908, args=0x00007ffe71339b58) at CallData.cpp:57:27
    frame #15: 0x000055d37ae0eb5c bun-debug`JSC::call(globalObject=0x00007f7d85459868, functionObject=JSValue @ 0x00007ffe71339a30, callData=0x00007ffe71339b30, thisValue=JSValue @ 0x00007ffe71339a28, args=0x00007ffe71339b58, returnedException=0x00007ffe71339b28) at CallData.cpp:64:22
    frame #16: 0x000055d37ae0ee50 bun-debug`JSC::profiledCall(globalObject=0x00007f7d85459868, reason=API, functionObject=JSValue @ 0x00007ffe71339ad0, callData=0x00007ffe71339b30, thisValue=JSValue @ 0x00007ffe71339ac8, args=0x00007ffe71339b58, returnedException=0x00007ffe71339b28) at CallData.cpp:85:12
    frame #17: 0x000055d3786d04bc bun-debug`JSObjectCallAsFunctionReturnValue(ctx=0x00007f7d85459868, object=<unavailable>, thisObject=<unavailable>, argumentCount=<unavailable>, arguments=<unavailable>) at bindings.cpp:2053:19
    frame #18: 0x000055d376b1acb4 bun-debug`src.bun.js.bindings.bindings.JSValue.callWithThis(this=140177083649376, globalThis=0x00007f7d85459868, thisValue=undefined, args=[]src.bun.js.bindings.bindings.JSValue @ 0x00007ffe71339c50) at bindings.zig:3523:55
    frame #19: 0x000055d376fc1e1b bun-debug`src.bun.js.bindings.bindings.JSValue.call(this=140177083649376, globalThis=0x00007f7d85459868, args=[]src.bun.js.bindings.bindings.JSValue @ 0x00007ffe71339c80) at bindings.zig:3507:28
    frame #20: 0x000055d377a75d4b bun-debug`src.bun.js.test.jest.callJSFunctionForTestRunner(vm=0x0000020000140000, globalObject=0x00007f7d85459868, function=140177083649376, args=[]src.bun.js.bindings.bindings.JSValue @ 0x00007ffe71339d08) at jest.zig:2085:33
    frame #21: 0x000055d377e0431b bun-debug`src.bun.js.test.jest.TestScope.run(this=0x00007ffe7133a350, task=0x00000200001e36b0) at jest.zig:683:52
    frame #22: 0x000055d377a75a13 bun-debug`src.bun.js.test.jest.TestRunnerTask.run(this=0x00000200001e36b0) at jest.zig:1354:37
    frame #23: 0x000055d37765d690 bun-debug`src.bun.js.test.jest.TestRunner.drain(this=0x0000020000130000) at jest.zig:158:26
    frame #24: 0x000055d37765be02 bun-debug`src.cli.test_command.TestCommand.run(reporter=0x0000020000130000, vm=0x0000020000140000, file_name=(ptr = "/home/kumiko/zig/bun/test/segfault.test.ts", len = 42), (null)=<unavailable>, is_last=true) at test_command.zig:1035:49
    frame #25: 0x000055d3772137d8 bun-debug`src.cli.test_command.TestCommand.runAllTests.Context.begin(this=0x00007ffe7133bf60) at test_command.zig:931:32
    frame #26: 0x000055d376d5533c bun-debug`src.bun.js.javascript.OpaqueWrap__anon_93830__struct_123897.callback(ctx=0x00007ffe7133bf60) at javascript.zig:105:13
    frame #27: 0x000055d3786dc844 bun-debug`JSC__VM__holdAPILock(arg0=<unavailable>, ctx=0x00007ffe7133bf60, callback=(bun-debug`src.bun.js.javascript.OpaqueWrap__anon_93830__struct_123897.callback at javascript.zig:103)) at bindings.cpp:4354:5
    frame #28: 0x000055d37627dfd6 bun-debug`src.bun.js.bindings.bindings.VM.holdAPILock at shimmer.zig:186:41
    frame #29: 0x000055d37627dfc0 bun-debug`src.bun.js.bindings.bindings.VM.holdAPILock(this=0x00007f7d85000000, ctx=0x00007ffe7133bf60, callback=0x000055d376d552d0) at bindings.zig:5118:14
    frame #30: 0x000055d376603c6c bun-debug`src.cli.test_command.TestCommand.runAllTests at javascript.zig:2319:37
    frame #31: 0x000055d376603c2b bun-debug`src.cli.test_command.TestCommand.runAllTests(reporter_=0x0000020000130000, vm_=0x0000020000140000, files_=[]src.string_types.PathString @ 0x00007ffe7133bdd8, allocator_=mem.Allocator @ 0x00007ffe713492a0) at test_command.zig:940:27
    frame #32: 0x000055d37660027b bun-debug`src.cli.test_command.TestCommand.exec(ctx=src.cli.Command.Context @ 0x00007ffe71348f90) at test_command.zig:721:24
    frame #33: 0x000055d37663f6ca bun-debug`src.cli.Command.start(allocator=mem.Allocator @ 0x000055d37c1b3120, log=0x000055d37cf00260) at cli.zig:1402:37
    frame #34: 0x000055d3761b58f3 bun-debug`src.cli.Cli.start__anon_5085(allocator=mem.Allocator @ 0x000055d37c1b3120, (null)=<unavailable>, (null)=<unavailable>) at cli.zig:58:22
    frame #35: 0x000055d3761b380b bun-debug`src.main.main at main.zig:46:22
    frame #36: 0x000055d3761b3255 bun-debug`main [inlined] start.callMain at start.zig:575:22
    frame #37: 0x000055d3761b3250 bun-debug`main [inlined] start.initEventLoopAndCallMain at start.zig:519:5
    frame #38: 0x000055d3761b3250 bun-debug`main at start.zig:469:36
    frame #39: 0x000055d3761b31f3 bun-debug`main(c_argc=3, c_argv=0x00007ffe71351918, c_envp=0x00007ffe71351938) at start.zig:484:101
    frame #40: 0x00007f7dd16b0cd0 libc.so.6`___lldb_unnamed_symbol3187 + 128
    frame #41: 0x00007f7dd16b0d8a libc.so.6`__libc_start_main + 138
    frame #42: 0x000055d3761b2e25 bun-debug`_start + 37

```


- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests