### PR TITLE
Don't call read() with an empty buffer

### DIFF
--- a/src/sys.zig
+++ b/src/sys.zig
@@ -747,6 +747,13 @@ pub fn pwritev(fd_: bun.FileDescriptor, buffers: []std.os.iovec, position: isize
 
 pub fn readv(fd_: bun.FileDescriptor, buffers: []std.os.iovec) Maybe(usize) {
     const fd = bun.fdcast(fd_);
+
+    if (comptime Environment.allow_assert) {
+        if (buffers.len == 0) {
+            @panic("readv() called with 0 length buffer");
+        }
+    }
+
     if (comptime Environment.isMac) {
         const rc = readv_sym(fd, buffers.ptr, @as(i32, @intCast(buffers.len)));
         if (comptime Environment.allow_assert)
@@ -776,6 +783,12 @@ pub fn readv(fd_: bun.FileDescriptor, buffers: []std.os.iovec) Maybe(usize) {
 
 pub fn preadv(fd_: bun.FileDescriptor, buffers: []std.os.iovec, position: isize) Maybe(usize) {
     const fd = bun.fdcast(fd_);
+    if (comptime Environment.allow_assert) {
+        if (buffers.len == 0) {
+            @panic("preadv() called with 0 length buffer");
+        }
+    }
+
     if (comptime Environment.isMac) {
         const rc = preadv_sym(fd, buffers.ptr, @as(i32, @intCast(buffers.len)), position);
         if (comptime Environment.allow_assert)
@@ -844,6 +857,12 @@ pub fn pread(fd_: bun.FileDescriptor, buf: []u8, offset: i64) Maybe(usize) {
     const fd = bun.fdcast(fd_);
     const adjusted_len = @min(buf.len, max_count);
 
+    if (comptime Environment.allow_assert) {
+        if (adjusted_len == 0) {
+            @panic("pread() called with 0 length buffer");
+        }
+    }
+
     const ioffset = @as(i64, @bitCast(offset)); // the OS treats this as unsigned
     while (true) {
         const rc = pread_sym(fd, buf.ptr, adjusted_len, ioffset);
@@ -862,6 +881,12 @@ else
     sys.pwrite;
 
 pub fn pwrite(fd_: bun.FileDescriptor, bytes: []const u8, offset: i64) Maybe(usize) {
+    if (comptime Environment.allow_assert) {
+        if (bytes.len == 0) {
+            @panic("pwrite() called with 0 length buffer");
+        }
+    }
+
     const fd = bun.fdcast(fd_);
     const adjusted_len = @min(bytes.len, max_count);
 
@@ -880,6 +905,11 @@ pub fn pwrite(fd_: bun.FileDescriptor, bytes: []const u8, offset: i64) Maybe(usi
 }
 
 pub fn read(fd_: bun.FileDescriptor, buf: []u8) Maybe(usize) {
+    if (comptime Environment.allow_assert) {
+        if (buf.len == 0) {
+            @panic("read() called with 0 length buffer");
+        }
+    }
     const fd = bun.fdcast(fd_);
     const debug_timer = bun.Output.DebugTimer.start();
     const adjusted_len = @min(buf.len, max_count);
@@ -910,6 +940,11 @@ pub fn read(fd_: bun.FileDescriptor, buf: []u8) Maybe(usize) {
 pub fn recv(fd_: bun.FileDescriptor, buf: []u8, flag: u32) Maybe(usize) {
     const fd = bun.fdcast(fd_);
     const adjusted_len = @min(buf.len, max_count);
+    if (comptime Environment.allow_assert) {
+        if (adjusted_len == 0) {
+            @panic("recv() called with 0 length buffer");
+        }
+    }
 
     if (comptime Environment.isMac) {
         const rc = system.@"recvfrom$NOCANCEL"(fd, buf.ptr, adjusted_len, flag, null, null);


### PR DESCRIPTION
### What does this PR do?

In the perf trace output of #7503, one thing that stands out a little
> pid  4115] read(13, "Hello, World!", 13) = 13
> [pid  4115] read(13, "", 0)             = 0

Why is it reading into an empty buffer? The pointer is assumed to be non-null, so what happens if it is null (due to being empty)? 

This might fix #7503, but I'm not sure. 

### How did you verify your code works?

Manually