### PR TITLE
ci: build with debug mode

### DIFF
--- a/.github/workflows/bun-linux-build.yml
+++ b/.github/workflows/bun-linux-build.yml
@@ -50,6 +50,7 @@ jobs:
             assertions: "OFF"
             zig_optimize: "ReleaseFast"
             target: "artifact"
+            build-type: "Release"
           - cpu: nehalem
             tag: linux-x64-baseline
             arch: x86_64
@@ -58,6 +59,17 @@ jobs:
             build_machine_arch: x86_64
             assertions: "OFF"
             zig_optimize: "ReleaseFast"
+            target: "artifact"
+            build-type: "Release"
+          - cpu: haswell
+            tag: linux-x64
+            arch: x86_64
+            build_arch: amd64
+            runner: big-ubuntu
+            build_machine_arch: x86_64
+            build-type: "Debug"
+            assertions: "ON"
+            zig_optimize: "ReleaseSafe"
             target: "artifact"
           # - cpu: haswell
           #   tag: linux-x64-assertions
@@ -114,6 +126,7 @@ jobs:
             GIT_SHA=${{github.sha}}
             ASSERTIONS=${{matrix.assertions}}
             ZIG_OPTIMIZE=${{matrix.zig_optimize}}
+            CMAKE_BUILD_TYPE${{matrix.build-type}}
             SCCACHE_BUCKET=bun
             SCCACHE_REGION=auto
             SCCACHE_S3_USE_SSL=true

--- a/.github/workflows/bun-mac-aarch64.yml
+++ b/.github/workflows/bun-mac-aarch64.yml
@@ -43,6 +43,9 @@ jobs:
           - cpu: native
             arch: aarch64
             tag: bun-obj-darwin-aarch64
+          - cpu: native
+            arch: aarch64
+            tag: bun-obj-darwin-aarch64-debug
     steps:
       - uses: actions/checkout@v4
       # - name: Checkout submodules
@@ -96,10 +99,7 @@ jobs:
       matrix:
         include:
           - cpu: native
-            arch: aarch64
             tag: bun-darwin-aarch64
-            obj: bun-obj-darwin-aarch64
-            artifact: bun-obj-darwin-aarch64
             runner: macos-arm64
     steps:
       - uses: actions/checkout@v4
@@ -172,9 +172,13 @@ jobs:
           - cpu: native
             arch: aarch64
             tag: bun-darwin-aarch64
-            obj: bun-obj-darwin-aarch64
-            artifact: bun-obj-darwin-aarch64
             runner: macos-arm64
+            build-type: Release
+          - cpu: native
+            arch: aarch64
+            tag: bun-darwin-aarch64-debug
+            runner: macos-arm64
+            build-type: Debug
     steps:
       - uses: actions/checkout@v4
       - name: Checkout submodules
@@ -238,7 +242,12 @@ jobs:
             tag: bun-darwin-aarch64
             obj: bun-obj-darwin-aarch64
             package: bun-darwin-aarch64
-            artifact: bun-obj-darwin-aarch64
+            runner: macos-arm64
+          - cpu: native
+            arch: aarch64
+            tag: bun-darwin-aarch64-debug
+            obj: bun-obj-darwin-aarch64-debug
+            package: bun-darwin-aarch64-debug
             runner: macos-arm64
     steps:
       - uses: actions/checkout@v4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -219,5 +219,6 @@
   },
   "C_Cpp.errorSquiggles": "enabled",
   "eslint.workingDirectories": ["packages/bun-types"],
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "cmake.configureOnOpen": false
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ endif()
 
 set(CI OFF)
 
-if(DEFINED ENV{CI} OR DEFINED ENV{GITHUB_ACTIONS})
+if(DEFINED ENV{CI} OR DEFINED ENV{GITHUB_ACTION})
     set(CI ON)
 endif()
 
@@ -230,6 +230,12 @@ if(UNIX AND NOT APPLE)
     endif()
 endif()
 
+
+set(_DEFAULT_USE_DYNAMIC_LOADED_JS OFF)
+if((CMAKE_BUILD_TYPE STREQUAL "Debug") AND NOT CI)
+    set(_DEFAULT_USE_DYNAMIC_LOADED_JS ON)
+endif()
+
 # -- Build Flags --
 option(USE_STATIC_SQLITE "Statically link SQLite?" ${DEFAULT_ON_UNLESS_APPLE})
 option(USE_CUSTOM_ZLIB "Use Bun's recommended version of zlib" ON)
@@ -243,6 +249,8 @@ option(USE_CUSTOM_LOLHTML "Use Bun's recommended version of lolhtml" ON)
 option(USE_CUSTOM_TINYCC "Use Bun's recommended version of tinycc" ON)
 option(USE_CUSTOM_LIBUV "Use Bun's recommended version of libuv (Windows only)" ON)
 option(USE_CUSTOM_LSHPACK "Use Bun's recommended version of ls-hpack" ON)
+
+option(USE_DYNAMIC_LOADED_JS "Do not bundle JS into the binary, load from system" ${_DEFAULT_USE_DYNAMIC_LOADED_JS})
 option(USE_BASELINE_BUILD "Build Bun for baseline (older) CPUs" OFF)
 
 option(ZIG_OPTIMIZE "Optimization level for Zig" ${DEFAULT_ZIG_OPTIMIZE})
@@ -391,7 +399,6 @@ if(NOT WEBKIT_DIR)
     set(ASSERT_ENABLED "0")
 
     if(USE_DEBUG_JSC)
-        add_compile_definitions("BUN_DEBUG=1")
         set(BUN_WEBKIT_PACKAGE_NAME_SUFFIX "-debug")
         set(ASSERT_ENABLED "1")
     elseif(NOT DEBUG AND NOT WIN32)
@@ -447,7 +454,6 @@ else()
         set(WEBKIT_LIB_DIR "${WEBKIT_DIR}/lib")
 
         if(USE_DEBUG_JSC)
-            add_compile_definitions("BUN_DEBUG=1")
             set(ASSERT_ENABLED "1")
         endif()
     else()
@@ -652,7 +658,7 @@ if(NOT NO_CODEGEN)
         "${BUN_WORKDIR}/codegen/NativeModuleImpl.h"
         "${BUN_WORKDIR}/codegen/ResolvedSourceTag.zig"
         "${BUN_WORKDIR}/codegen/SyntheticModuleType.h"
-        COMMAND ${BUN_EXECUTABLE} "${BUN_SRC}/codegen/bundle-modules.ts" "--debug=${DEBUG}" "${BUN_WORKDIR}"
+        COMMAND ${BUN_EXECUTABLE} "${BUN_SRC}/codegen/bundle-modules.ts" "--debug=${DEBUG}" "--dynamic-loading=${USE_DYNAMIC_LOADED_JS}" "${BUN_WORKDIR}"
         DEPENDS ${BUN_TS_MODULES} ${CODEGEN_FILES}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMENT "Bundling JS modules"
@@ -667,7 +673,7 @@ WEBKIT_ADD_SOURCE_DEPENDENCIES(
 add_custom_command(
     OUTPUT "${BUN_WORKDIR}/codegen/WebCoreJSBuiltins.cpp"
     "${BUN_WORKDIR}/codegen/WebCoreJSBuiltins.h"
-    COMMAND ${BUN_EXECUTABLE} "${BUN_SRC}/codegen/bundle-functions.ts" "--debug=${DEBUG}" "${BUN_WORKDIR}"
+    COMMAND ${BUN_EXECUTABLE} "${BUN_SRC}/codegen/bundle-functions.ts" "--debug=${DEBUG}" "--dynamic-loading=${USE_DYNAMIC_LOADED_JS}" "${BUN_WORKDIR}"
     DEPENDS ${BUN_TS_FUNCTIONS} ${CODEGEN_FILES}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Bundling JS builtin functions"
@@ -908,6 +914,10 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
         target_compile_options(${bun} PUBLIC /O2 -flto=full)
         target_link_options(${bun} PUBLIC /LTCG)
     endif()
+endif()
+
+if(USE_DYNAMIC_LOADED_JS)
+    add_compile_definitions("BUN_USE_DEBUG_MODULE_REGISTRY=1")
 endif()
 
 if(NOT CI AND NOT WIN32)

--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -11,7 +11,9 @@ console.log("Bundling Bun builtin functions...");
 const PARALLEL = false;
 const KEEP_TMP = true;
 
+// one day we'll use these variables
 const debug = process.argv[2] === "--debug=ON";
+const dynamicLoading = process.argv[3] === "--dynamic-loading=ON";
 const CMAKE_BUILD_ROOT = process.argv[3];
 
 if (!CMAKE_BUILD_ROOT) {

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -11,7 +11,8 @@ import { createInternalModuleRegistry } from "./internal-module-registry-scanner
 
 const BASE = path.join(import.meta.dir, "../js");
 const debug = process.argv[2] === "--debug=ON";
-const CMAKE_BUILD_ROOT = process.argv[3];
+const dynamicLoading = process.argv[2] === "--dynamic-loading=ON";
+const CMAKE_BUILD_ROOT = process.argv[4];
 
 if (!CMAKE_BUILD_ROOT) {
   console.error("Usage: bun bundle-modules.ts <CMAKE_WORK_DIR>");
@@ -189,21 +190,6 @@ if (out.exitCode !== 0) {
   process.exit(out.exitCode);
 }
 
-// const config = ({ debug }: { debug?: boolean }) =>
-//   ({
-//     entrypoints: bundledEntryPoints,
-//     // Whitespace and identifiers are not minified to give better error messages when an error happens in our builtins
-//     minify: { syntax: !debug, whitespace: false },
-//     root: TMP_DIR,
-//     target: "bun",
-//     external: builtinModules,
-//     define: {
-//       ...define,
-//       IS_BUN_DEVELOPMENT: String(!!debug),
-//       __intrinsic__debug: debug ? "$debug_log_enabled" : "false",
-//     },
-//   } satisfies BuildConfig);
-
 mark("Bundle modules");
 
 const outputs = new Map();
@@ -327,7 +313,7 @@ JSValue InternalModuleRegistry::createInternalModuleById(JSGlobalObject* globalO
 //
 // We cannot use ASCIILiteral's `_s` operator for the module source code because for long
 // strings it fails a constexpr assert. Instead, we do that assert in JS before we format the string
-if (!debug) {
+if (!dynamicLoading) {
   writeIfNotChanged(
     path.join(CODEGEN_DIR, "InternalModuleRegistryConstants.h"),
     `// clang-format off

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -372,6 +372,12 @@ pub fn openDirAtWindows(
         log("NtCreateFile({d}, {}) = {d} (dir)", .{ dirFd, bun.strings.fmtUTF16(path), rc });
     }
 
+    if (Environment.isDebug) {
+        if (rc == std.os.windows.NTSTATUS.OBJECT_PATH_SYNTAX_BAD) {
+            @breakpoint();
+        }
+    }
+
     switch (windows.Win32Error.fromNTStatus(rc)) {
         .SUCCESS => {
             return JSC.Maybe(bun.FileDescriptor){


### PR DESCRIPTION
### What does this PR do?

new cmake flag `USE_DYNAMIC_LOADED_JS`. it defaults to `ON` in non-ci debug builds.

added ci builds

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

i let ci build and see :)