### PR TITLE
Fix `BunWebSocketMocked` onmessage callback to match expected return type

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -687,8 +687,9 @@ class BunWebSocketMocked extends EventEmitter {
     if (this.#onmessage) {
       this.removeListener("message", this.#onmessage);
     }
-    this.on("message", cb);
-    this.#onmessage = cb;
+    const l = data => cb({ data });
+    this.on("message", l);
+    this.#onmessage = l;
   }
 
   set onopen(cb) {

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -263,6 +263,21 @@ it("isBinary", done => {
   });
 });
 
+it("onmessage", done => {
+  const wss = new WebSocketServer({ port: 0 });
+  wss.on("connection", ws => {
+    ws.onmessage = e => {
+      expect(e.data).toEqual(Buffer.from("hello"));
+      done();
+    };
+  });
+
+  const ws = new WebSocket("ws://localhost:" + wss.address().port);
+  ws.onopen = () => {
+    ws.send("hello");
+  };
+});
+
 function test(label: string, fn: (ws: WebSocket, done: (err?: unknown) => void) => void, timeout?: number) {
   it(
     label,


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fixes #7525. See issue for description of bug

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

* I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

I wrote a test, and ran it against bun latest:
```
> bun --revision
1.0.15+b3bdf22eb
> bun test test/js/first_party/ws/ws.test.ts
bun test v1.0.15 (b3bdf22e)

...

Timeout: test "onmessage" timed out after 5000ms
✗ onmessage [9999.32ms]

1 tests failed:
✗ onmessage [9999.32ms]

 30 pass
 1 fail
 51 expect() calls
Ran 31 tests across 1 files. [11.73s]
```

I then built bun locally and ran the test again against my local built:
```
> bun-debug --revision
1.0.16-debug+653e2934f
> bun-debug test test/js/first_party/ws/ws.test.ts

...

 31 pass
 0 fail
 51 expect() calls
Ran 31 tests across 1 files. [1.99s]
```


<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
