### PR TITLE
Unconditionally reset stack on deepEqual exit

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -76,6 +76,7 @@
 #include "JSDOMWrapperCache.h"
 
 #include "wtf/text/AtomString.h"
+#include "wtf/Scope.h"
 #include "HTTPHeaderNames.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JavaScriptCore/TestRunnerUtils.h"
@@ -498,6 +499,7 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     if (addToStack) {
         stack.append({ v1, v2 });
     }
+    auto removeFromStack = WTF::makeScopeExit([&] { if (addToStack) { stack.remove(originalLength); } });
 
     JSCell* c1 = v1.asCell();
     JSCell* c2 = v2.asCell();
@@ -901,10 +903,6 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             RETURN_IF_EXCEPTION(*scope, false);
         }
 
-        if (addToStack) {
-            stack.remove(originalLength);
-        }
-
         RETURN_IF_EXCEPTION(*scope, false);
 
         return true;
@@ -1021,10 +1019,6 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                 }
             }
 
-            if (addToStack) {
-                stack.remove(originalLength);
-            }
-
             return result;
         }
     }
@@ -1071,10 +1065,6 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         }
 
         RETURN_IF_EXCEPTION(*scope, false);
-    }
-
-    if (addToStack) {
-        stack.remove(originalLength);
     }
 
     return true;

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3885,7 +3885,7 @@ describe("expect()", () => {
 
     test("Array of dates", async () => {
       const obj = new Date("2020-01-01T00:00:00.001Z");
-      const parsed = JSON.parse(JSON.stringify([obj, obj])).map(a => (new Date(a)));
+      const parsed = JSON.parse(JSON.stringify([obj, obj])).map(a => new Date(a));
       expect(parsed).toEqual([obj, obj]);
     });
   });

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3882,5 +3882,11 @@ describe("expect()", () => {
         },
       });
     });
+
+    test("Array of dates", async () => {
+      const obj = new Date("2020-01-01T00:00:00.001Z");
+      const parsed = JSON.parse(JSON.stringify([obj, obj])).map(a => (new Date(a)));
+      expect(parsed).toEqual([obj, obj]);
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

deepEqual maintains a stack for cycle checking. The bug was that while checking an array, the prior array elements would not be removed from the stack before checking later array elements.

Fix by unconditionally resetting the stack on deepEqual exit.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

Added a test to expect.tests that reproduces the issue. The [obj,obj] array thought that there was a self reference between the "first" array element and the "zeroth" array element.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
