### PR TITLE
Improve bun-types handling of JSON types & some extras

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -207,10 +207,10 @@ declare module "bun" {
      *
      * @param {string} command The name of the executable or script
      * @param {string} options.PATH Overrides the PATH environment variable
-     * @param {string} options.cwd Limits the search to a particular directory in which to searc
+     * @param {string} options.cwd Limits the search to a particular directory in which to search
      *
      */
-    parse(input: string): object;
+    parse(input: string): Record<string, unknown>;
   }
   export const TOML: TOML;
 
@@ -494,7 +494,7 @@ declare module "bun" {
    * @param stream The stream to consume.
    * @returns A promise that resolves with the concatenated chunks as a {@link String}.
    */
-  export function readableStreamToJSON(stream: ReadableStream): Promise<any>;
+  export function readableStreamToJSON(stream: ReadableStream): Promise<string>;
 
   /**
    * Consume all data from a {@link ReadableStream} until it closes or errors.
@@ -776,7 +776,7 @@ declare module "bun" {
     unref(): void;
   }
 
-  export interface FileBlob extends BunFile {}
+  export interface FileBlob extends BunFile { }
   /**
    * [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) powered by the fastest system calls available for operating on files.
    *
@@ -2211,13 +2211,13 @@ declare module "bun" {
 
   export interface TLSWebSocketServeOptions<WebSocketDataType = undefined>
     extends WebSocketServeOptions<WebSocketDataType>,
-      TLSOptions {
+    TLSOptions {
     unix?: never;
     tls?: TLSOptions;
   }
   export interface UnixTLSWebSocketServeOptions<WebSocketDataType = undefined>
     extends UnixWebSocketServeOptions<WebSocketDataType>,
-      TLSOptions {
+    TLSOptions {
     /**
      * If set, the HTTP server will listen on a unix socket instead of a port.
      * (Cannot be used with hostname+port)
@@ -3714,8 +3714,8 @@ declare module "bun" {
     readonly unix: string;
   }
 
-  interface TCPSocket extends Socket {}
-  interface TLSSocket extends Socket {}
+  interface TCPSocket extends Socket { }
+  interface TLSSocket extends Socket { }
 
   type BinaryTypeList = {
     arraybuffer: ArrayBuffer;

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -3567,7 +3567,7 @@ interface CallSite {
 }
 
 interface ArrayBufferConstructor {
-  new(byteLength: number, options: { maxByteLength?: number }): ArrayBuffer;
+  new (byteLength: number, options: { maxByteLength?: number }): ArrayBuffer;
 }
 
 interface ArrayBuffer {
@@ -3888,7 +3888,7 @@ interface JSON {
    * @param reviver A function that transforms the results. This function is called for each member of the object.
    * If a member contains nested objects, the nested objects are transformed before the parent object is.
   */
-  parse(text: string, reviver?: (this: void, key: string, value: any) => any): unknown;
+  parse(text: string, reviver?: (this: any, key: string, value: any) => any): unknown;
 }
 
 // Allow `<Array>.filter(Boolean)` to properly reflect

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -239,7 +239,7 @@ declare namespace NodeJS {
     main: NodeModule | undefined;
   }
 
-  interface ProcessEnv {}
+  interface ProcessEnv { }
   type Signals =
     | "SIGABRT"
     | "SIGALRM"
@@ -789,7 +789,7 @@ declare module "node:process" {
 interface BlobInterface {
   text(): Promise<string>;
   arrayBuffer(): Promise<ArrayBuffer>;
-  json<TJSONReturnType = any>(): Promise<TJSONReturnType>;
+  json(): Promise<unknown>;
   formData(): Promise<FormData>;
 }
 
@@ -984,7 +984,7 @@ declare interface Blob {
    * This first decodes the data from UTF-8, then parses it as JSON.
    *
    */
-  json<TJSONReturnType = any>(): Promise<TJSONReturnType>;
+  json(): Promise<unknown>;
 
   /**
    * Read the data from the blob as a {@link FormData} object.
@@ -1173,7 +1173,7 @@ declare class Response implements BlobInterface {
    * This first decodes the data from UTF-8, then parses it as JSON.
    *
    */
-  json<TJSONReturnType = any>(): Promise<TJSONReturnType>;
+  json(): Promise<unknown>;
 
   /**
    * Read the data from the Response as a Blob.
@@ -1442,7 +1442,7 @@ declare class Request implements BlobInterface {
    * This first decodes the data from UTF-8, then parses it as JSON.
    *
    */
-  json<TJSONReturnType = any>(): Promise<TJSONReturnType>;
+  json(): Promise<unknown>;
 
   /**
    * Consume the [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) body as a `Blob`.
@@ -2888,7 +2888,7 @@ declare var WritableStreamDefaultWriter: {
   new <W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>;
 };
 
-interface ReadWriteStream extends ReadableStream, WritableStream {}
+interface ReadWriteStream extends ReadableStream, WritableStream { }
 
 interface TransformerFlushCallback<O> {
   (controller: TransformStreamDefaultController<O>): void | PromiseLike<void>;
@@ -3567,7 +3567,7 @@ interface CallSite {
 }
 
 interface ArrayBufferConstructor {
-  new (byteLength: number, options: { maxByteLength?: number }): ArrayBuffer;
+  new(byteLength: number, options: { maxByteLength?: number }): ArrayBuffer;
 }
 
 interface ArrayBuffer {
@@ -3595,7 +3595,7 @@ interface SharedArrayBuffer {
 }
 
 declare namespace WebAssembly {
-  interface CompileError extends Error {}
+  interface CompileError extends Error { }
 
   var CompileError: {
     prototype: CompileError;
@@ -3622,7 +3622,7 @@ declare namespace WebAssembly {
     new (module: Module, importObject?: Imports): Instance;
   };
 
-  interface LinkError extends Error {}
+  interface LinkError extends Error { }
 
   var LinkError: {
     prototype: LinkError;
@@ -3640,7 +3640,7 @@ declare namespace WebAssembly {
     new (descriptor: MemoryDescriptor): Memory;
   };
 
-  interface Module {}
+  interface Module { }
 
   var Module: {
     prototype: Module;
@@ -3650,7 +3650,7 @@ declare namespace WebAssembly {
     imports(moduleObject: Module): ModuleImportDescriptor[];
   };
 
-  interface RuntimeError extends Error {}
+  interface RuntimeError extends Error { }
 
   var RuntimeError: {
     prototype: RuntimeError;
@@ -3876,3 +3876,30 @@ interface Navigator {
 }
 
 declare var navigator: Navigator;
+
+// -----------------------
+// -----------------------
+// --- ts builtins (lib.es5)
+
+interface JSON {
+  /**
+   * Converts a JavaScript Object Notation (JSON) string into an object.
+   * @param text A valid JSON string.
+   * @param reviver A function that transforms the results. This function is called for each member of the object.
+   * If a member contains nested objects, the nested objects are transformed before the parent object is.
+  */
+  parse(text: string, reviver?: (this: void, key: string, value: any) => any): unknown;
+}
+
+// Allow `<Array>.filter(Boolean)` to properly reflect
+interface Array<T> {
+  filter(predicate: BooleanConstructor, thisArg?: any): T[];
+}
+
+interface ReadonlyArray<T> {
+  filter(predicate: BooleanConstructor, thisArg?: any): T[];
+}
+
+interface ArrayConstructor {
+  isArray(arg: any): arg is unknown[];
+}


### PR DESCRIPTION
Auto formatter had some fun with braces

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### Notes

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

This has "breaking" changes.
We should not blindly follow the bad practices of node and should instead enforce better types on JSON like we do for other interfaces.

I decided to also apply this to `Array.isArray` as well for the same reason.

On the other hand i also decided to fix the issue where `Array.filter(Boolean)` doesnt properly reflect the types in typescript (this is just a QoL improvement and could be removed from this pr)