### PR TITLE
fix(console): console format use whatwg standard

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2130,7 +2130,7 @@ pub const ZigConsoleClient = struct {
                     }
                 },
                 .Integer => {
-                    if (value.isSymbol()) {
+                    if (value.isSymbol() or value.isUndefined()) {
                         this.addForNewLine("NaN".len);
                         writer.print(comptime Output.prettyFmt("<r><yellow>NaN<r>", enable_ansi_colors), .{});
                         return;
@@ -2160,7 +2160,7 @@ pub const ZigConsoleClient = struct {
                     writer.print(comptime Output.prettyFmt("<r><yellow>{s}n<r>", enable_ansi_colors), .{out_str});
                 },
                 .Double => {
-                    if (value.isSymbol()) {
+                    if (value.isSymbol() or value.isUndefined()) {
                         this.addForNewLine("NaN".len);
                         writer.print(comptime Output.prettyFmt("<r><yellow>NaN<r>", enable_ansi_colors), .{});
                         return;

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2166,30 +2166,6 @@ pub const ZigConsoleClient = struct {
                         return;
                     }
 
-                    // if (value.isCell()) {
-                    //     var number_name = ZigString.Empty;
-                    //     value.getClassName(this.globalThis, &number_name);
-
-                    //     var number_value = ZigString.Empty;
-                    //     value.toZigString(&number_value, this.globalThis);
-
-                    //     if (!strings.eqlComptime(number_name.slice(), "Number")) {
-                    //         this.addForNewLine(number_name.len + number_value.len + "[Number ():]".len);
-                    //         writer.print(comptime Output.prettyFmt("<r><yellow>[Number ({s}): {s}]<r>", enable_ansi_colors), .{
-                    //             number_name,
-                    //             number_value,
-                    //         });
-                    //         return;
-                    //     }
-
-                    //     this.addForNewLine(number_name.len + number_value.len + 4);
-                    //     writer.print(comptime Output.prettyFmt("<r><yellow>[{s}: {s}]<r>", enable_ansi_colors), .{
-                    //         number_name,
-                    //         number_value,
-                    //     });
-                    //     return;
-                    // }
-
                     const num = value.coerce(f64, this.globalThis);
 
                     if (std.math.isPositiveInf(num)) {

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2130,6 +2130,12 @@ pub const ZigConsoleClient = struct {
                     }
                 },
                 .Integer => {
+                    if (value.isSymbol()) {
+                        this.addForNewLine("NaN".len);
+                        writer.print(comptime Output.prettyFmt("<r><yellow>NaN<r>", enable_ansi_colors), .{});
+                        return;
+                    }
+
                     const int = value.coerce(i64, this.globalThis);
                     if (int < std.math.maxInt(u32)) {
                         var i = int;
@@ -2154,6 +2160,12 @@ pub const ZigConsoleClient = struct {
                     writer.print(comptime Output.prettyFmt("<r><yellow>{s}n<r>", enable_ansi_colors), .{out_str});
                 },
                 .Double => {
+                    if (value.isSymbol()) {
+                        this.addForNewLine("NaN".len);
+                        writer.print(comptime Output.prettyFmt("<r><yellow>NaN<r>", enable_ansi_colors), .{});
+                        return;
+                    }
+
                     if (value.isCell()) {
                         var number_name = ZigString.Empty;
                         value.getClassName(this.globalThis, &number_name);

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2166,31 +2166,31 @@ pub const ZigConsoleClient = struct {
                         return;
                     }
 
-                    if (value.isCell()) {
-                        var number_name = ZigString.Empty;
-                        value.getClassName(this.globalThis, &number_name);
+                    // if (value.isCell()) {
+                    //     var number_name = ZigString.Empty;
+                    //     value.getClassName(this.globalThis, &number_name);
 
-                        var number_value = ZigString.Empty;
-                        value.toZigString(&number_value, this.globalThis);
+                    //     var number_value = ZigString.Empty;
+                    //     value.toZigString(&number_value, this.globalThis);
 
-                        if (!strings.eqlComptime(number_name.slice(), "Number")) {
-                            this.addForNewLine(number_name.len + number_value.len + "[Number ():]".len);
-                            writer.print(comptime Output.prettyFmt("<r><yellow>[Number ({s}): {s}]<r>", enable_ansi_colors), .{
-                                number_name,
-                                number_value,
-                            });
-                            return;
-                        }
+                    //     if (!strings.eqlComptime(number_name.slice(), "Number")) {
+                    //         this.addForNewLine(number_name.len + number_value.len + "[Number ():]".len);
+                    //         writer.print(comptime Output.prettyFmt("<r><yellow>[Number ({s}): {s}]<r>", enable_ansi_colors), .{
+                    //             number_name,
+                    //             number_value,
+                    //         });
+                    //         return;
+                    //     }
 
-                        this.addForNewLine(number_name.len + number_value.len + 4);
-                        writer.print(comptime Output.prettyFmt("<r><yellow>[{s}: {s}]<r>", enable_ansi_colors), .{
-                            number_name,
-                            number_value,
-                        });
-                        return;
-                    }
+                    //     this.addForNewLine(number_name.len + number_value.len + 4);
+                    //     writer.print(comptime Output.prettyFmt("<r><yellow>[{s}: {s}]<r>", enable_ansi_colors), .{
+                    //         number_name,
+                    //         number_value,
+                    //     });
+                    //     return;
+                    // }
 
-                    const num = value.asNumber();
+                    const num = value.coerce(f64, this.globalThis);
 
                     if (std.math.isPositiveInf(num)) {
                         this.addForNewLine("Infinity".len);

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -88,30 +88,3 @@ test("console._stderr", () => {
     configurable: true,
   });
 });
-
-describe("console formatter", () => {
-  test("format float", async () => {
-    const [stream, value] = writable();
-    const c = new Console({ stdout: stream, stderr: stream, colorMode: true });
-    c.log("%f", 0.5);
-    c.log("%f", {
-      [Symbol.toPrimitive]() {
-        return 0.9;
-      },
-    });
-    c.log("%f", Symbol(0.1));
-    stream.end();
-    expect(await value()).toBe("0.5\n0.9\nNaN\n");
-  });
-
-  test("format number", async () => {
-    const [stream, value] = writable();
-    const c = new Console({ stdout: stream, stderr: stream, colorMode: true });
-    c.log("%d", 1);
-    c.log("%d", Symbol(1));
-    c.log("%i", 1);
-    c.log("%i", Symbol(1));
-    stream.end();
-    expect(await value()).toBe("1\nNaN\n1\nNaN\n");
-  });
-});

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -88,3 +88,30 @@ test("console._stderr", () => {
     configurable: true,
   });
 });
+
+describe("console formatter", () => {
+  test("format float", async () => {
+    const [stream, value] = writable();
+    const c = new Console({ stdout: stream, stderr: stream, colorMode: true });
+    c.log("%f", 0.5);
+    c.log("%f", {
+      [Symbol.toPrimitive]() {
+        return 0.9;
+      },
+    });
+    c.log("%f", Symbol(0.1));
+    stream.end();
+    expect(await value()).toBe("0.5\n0.9\nNaN\n");
+  });
+
+  test("format number", async () => {
+    const [stream, value] = writable();
+    const c = new Console({ stdout: stream, stderr: stream, colorMode: true });
+    c.log("%d", 1);
+    c.log("%d", Symbol(1));
+    c.log("%i", 1);
+    c.log("%i", Symbol(1));
+    stream.end();
+    expect(await value()).toBe("1\nNaN\n1\nNaN\n");
+  });
+});

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -255,3 +255,7 @@ NaN
 1
 1
 0
+undefined
+NaN
+NaN
+NaN

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -240,3 +240,11 @@ myCustomName {
   "1": 42,
   length: 1,
 }
+0.5
+0.9
+NaN
+NaN
+1
+NaN
+1
+NaN

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -244,7 +244,14 @@ myCustomName {
 0.9
 NaN
 NaN
-1
+NaN
 NaN
 1
+1
+1
+0
 NaN
+1
+1
+1
+0

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -170,3 +170,21 @@ console.log(hole([1, 2, 3], 2));
 
 // TODO: handle DerivedArray
 // It appears to not be set and I don't know why.
+
+console.log("%f", 0.5);
+console.log("%f", {
+  [Symbol.toPrimitive]() {
+    return 0.9;
+  },
+});
+console.log("%f", {
+  [Symbol.toPrimitive]() {
+    return "abc";
+  },
+});
+console.log("%f", Symbol(0.1));
+
+console.log("%d", 1);
+console.log("%d", Symbol(1));
+console.log("%i", 1);
+console.log("%i", Symbol(1));

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -182,9 +182,21 @@ console.log("%f", {
     return "abc";
   },
 });
+console.log("%f", {
+  [Symbol.toPrimitive]() {
+    throw 1;
+  },
+});
 console.log("%f", Symbol(0.1));
 
-console.log("%d", 1);
 console.log("%d", Symbol(1));
-console.log("%i", 1);
+console.log("%d", 1);
+console.log("%d", new Number(1));
+console.log("%d", "1");
+console.log("%d", 0.5);
+
 console.log("%i", Symbol(1));
+console.log("%i", 1);
+console.log("%i", new Number(1));
+console.log("%i", "1");
+console.log("%i", 0.5);

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -200,3 +200,8 @@ console.log("%i", 1);
 console.log("%i", new Number(1));
 console.log("%i", "1");
 console.log("%i", 0.5);
+
+console.log("%s", undefined);
+console.log("%f", undefined);
+console.log("%d", undefined);
+console.log("%i", undefined);


### PR DESCRIPTION
### What does this PR do?

Standard link: https://console.spec.whatwg.org/#formatter

Resolves #7401

1. Print NaN when value is a Symbol.
2. Not print the class name when format is float

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [x] add test