### PR TITLE
bun-types: add recursive option to readdir/Sync

### DIFF
--- a/packages/bun-types/fs.d.ts
+++ b/packages/bun-types/fs.d.ts
@@ -1721,6 +1721,7 @@ declare module "fs" {
       | {
           encoding: BufferEncoding | null;
           withFileTypes?: false | undefined;
+          recursive?: boolean | undefined;
         }
       | BufferEncoding
       | undefined
@@ -1738,6 +1739,7 @@ declare module "fs" {
       | {
           encoding: "buffer";
           withFileTypes?: false | undefined;
+          recursive?: boolean | undefined;
         }
       | "buffer",
     callback: (err: SystemError | null, files: Buffer[]) => void,
@@ -1752,6 +1754,7 @@ declare module "fs" {
     options:
       | (ObjectEncodingOptions & {
           withFileTypes?: false | undefined;
+          recursive?: boolean | undefined;
         })
       | BufferEncoding
       | undefined
@@ -1775,6 +1778,7 @@ declare module "fs" {
     path: PathLike,
     options: ObjectEncodingOptions & {
       withFileTypes: true;
+      recursive?: boolean | undefined;
     },
     callback: (err: SystemError | null, files: Dirent[]) => void,
   ): void;
@@ -1790,6 +1794,7 @@ declare module "fs" {
   //       | {
   //           encoding: BufferEncoding | null;
   //           withFileTypes?: false | undefined;
+  //           recursive?: boolean | undefined;
   //         }
   //       | BufferEncoding
   //       | null
@@ -1806,6 +1811,7 @@ declare module "fs" {
   //       | {
   //           encoding: "buffer";
   //           withFileTypes?: false | undefined;
+  //           recursive?: boolean | undefined;
   //         }
   //   ): Promise<Buffer[]>;
   //   /**
@@ -1818,6 +1824,7 @@ declare module "fs" {
   //     options?:
   //       | (ObjectEncodingOptions & {
   //           withFileTypes?: false | undefined;
+  //           recursive?: boolean | undefined;
   //         })
   //       | BufferEncoding
   //       | null
@@ -1831,6 +1838,7 @@ declare module "fs" {
   //     path: PathLike,
   //     options: ObjectEncodingOptions & {
   //       withFileTypes: true;
+  //       recursive?: boolean | undefined;
   //     }
   //   ): Promise<Dirent[]>;
   // }
@@ -1853,6 +1861,7 @@ declare module "fs" {
       | {
           encoding: BufferEncoding | null;
           withFileTypes?: false | undefined;
+          recursive?: boolean | undefined;
         }
       | BufferEncoding
       | null,
@@ -1868,6 +1877,7 @@ declare module "fs" {
       | {
           encoding: "buffer";
           withFileTypes?: false | undefined;
+          recursive?: boolean | undefined;
         }
       | "buffer",
   ): Buffer[];
@@ -1881,6 +1891,7 @@ declare module "fs" {
     options?:
       | (ObjectEncodingOptions & {
           withFileTypes?: false | undefined;
+          recursive?: boolean | undefined;
         })
       | BufferEncoding
       | null,
@@ -1894,6 +1905,7 @@ declare module "fs" {
     path: PathLike,
     options: ObjectEncodingOptions & {
       withFileTypes: true;
+      recursive?: boolean | undefined;
     },
   ): Dirent[];
   /**

--- a/packages/bun-types/fs/promises.d.ts
+++ b/packages/bun-types/fs/promises.d.ts
@@ -226,6 +226,7 @@ declare module "fs/promises" {
     options?:
       | (ObjectEncodingOptions & {
           withFileTypes?: false | undefined;
+          recursive?: boolean | undefined;
         })
       | BufferEncoding
       | undefined
@@ -242,6 +243,7 @@ declare module "fs/promises" {
       | {
           encoding: "buffer";
           withFileTypes?: false | undefined;
+          recursive?: boolean | undefined;
         }
       | "buffer",
   ): Promise<Buffer[]>;
@@ -255,6 +257,7 @@ declare module "fs/promises" {
     options?:
       | (ObjectEncodingOptions & {
           withFileTypes?: false | undefined;
+          recursive?: boolean | undefined;
         })
       | BufferEncoding
       | null,
@@ -268,6 +271,7 @@ declare module "fs/promises" {
     path: PathLike,
     options: ObjectEncodingOptions & {
       withFileTypes: true;
+      recursive?: boolean | undefined;
     },
   ): Promise<Dirent[]>;
   /**


### PR DESCRIPTION
### What does this PR do?

This corrects the type definitions for `fs.readdir`, `fs.readdirSync`, and `fs.promises.readdir` to include the `recursive` option, which support was added for in #7296 (1.0.15).

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

I basically just made this consistent with https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/fs.d.ts since that appears to have been the model for these type definitions.

### How did you verify your code works?

I built the `bun-types` package and imported it into my other project which uses `recursive`; verifying that the LSP was no longer complaining about the invalid type signature.
