### PR TITLE
Switch to `std.sort.pdq` from `std.sort.block`

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -5878,7 +5878,7 @@ const LinkerContext = struct {
             // of hash calculation.
             if (chunk_meta.dynamic_imports.count() > 0) {
                 var dynamic_chunk_indices = chunk_meta.dynamic_imports.keys();
-                std.sort.block(Index.Int, dynamic_chunk_indices, {}, std.sort.asc(Index.Int));
+                std.sort.pdq(Index.Int, dynamic_chunk_indices, {}, std.sort.asc(Index.Int));
 
                 var imports = chunk.cross_chunk_imports.listManaged(c.allocator);
                 defer chunk.cross_chunk_imports.update(imports);
@@ -6137,7 +6137,7 @@ const LinkerContext = struct {
                 }
             }
 
-            std.sort.block(StableRef, list.items, {}, StableRef.isLessThan);
+            std.sort.pdq(StableRef, list.items, {}, StableRef.isLessThan);
             break :brk list;
         };
         defer sorted_imports_from_other_chunks.deinit();
@@ -6209,7 +6209,7 @@ const LinkerContext = struct {
                     }
                 }
 
-                std.sort.block(renamer.StableSymbolCount, top_level_symbols.items, {}, StableSymbolCount.lessThan);
+                std.sort.pdq(renamer.StableSymbolCount, top_level_symbols.items, {}, StableSymbolCount.lessThan);
                 capacity += top_level_symbols.items.len;
                 top_level_symbols_all.appendSlice(top_level_symbols.items) catch unreachable;
             }
@@ -8806,8 +8806,8 @@ const LinkerContext = struct {
                     return strings.order(a, b) == .lt;
                 }
             };
-            std.sort.block(u32, sorted_client_component_ids.items, Sorter{ .sources = all_sources }, Sorter.isLessThan);
-            std.sort.block(u32, sorted_server_component_ids.items, Sorter{ .sources = all_sources }, Sorter.isLessThan);
+            std.sort.pdq(u32, sorted_client_component_ids.items, Sorter{ .sources = all_sources }, Sorter.isLessThan);
+            std.sort.pdq(u32, sorted_server_component_ids.items, Sorter{ .sources = all_sources }, Sorter.isLessThan);
 
             inline for (.{
                 sorted_client_component_ids.items,
@@ -9440,7 +9440,7 @@ const LinkerContext = struct {
                 .ref = export_ref,
             };
         }
-        std.sort.block(StableRef, result.items, {}, StableRef.isLessThan);
+        std.sort.pdq(StableRef, result.items, {}, StableRef.isLessThan);
     }
 
     pub fn markFileReachableForCodeSplitting(
@@ -10759,7 +10759,7 @@ pub const Chunk = struct {
         /// equidistant to an entry point, then break the tie by sorting on the
         /// stable source index derived from the DFS over all entry points.
         pub fn sort(a: []Order) void {
-            std.sort.block(Order, a, Order{}, lessThan);
+            std.sort.pdq(Order, a, Order{}, lessThan);
         }
     };
 
@@ -11202,7 +11202,7 @@ pub const CrossChunkImport = struct {
                 item.export_alias = exports_to_other_chunks.get(item.ref).?;
                 std.debug.assert(item.export_alias.len > 0);
             }
-            std.sort.block(CrossChunkImport.Item, import_items.slice(), {}, CrossChunkImport.Item.lessThan);
+            std.sort.pdq(CrossChunkImport.Item, import_items.slice(), {}, CrossChunkImport.Item.lessThan);
 
             result.append(CrossChunkImport{
                 .chunk_index = chunk_index,
@@ -11210,7 +11210,7 @@ pub const CrossChunkImport = struct {
             }) catch unreachable;
         }
 
-        std.sort.block(CrossChunkImport, result.items, {}, CrossChunkImport.lessThan);
+        std.sort.pdq(CrossChunkImport, result.items, {}, CrossChunkImport.lessThan);
     }
 };
 

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -243,7 +243,7 @@ pub const PackageManagerCommand = struct {
                 for (sorted_dependencies, 0..) |*dep, i| {
                     dep.* = @as(DependencyID, @truncate(root_deps.off + i));
                 }
-                std.sort.block(DependencyID, sorted_dependencies, ByName{
+                std.sort.pdq(DependencyID, sorted_dependencies, ByName{
                     .dependencies = dependencies,
                     .buf = string_bytes,
                 }, ByName.isLessThan);
@@ -368,7 +368,7 @@ fn printNodeModulesFolderStructure(
     const sorted_dependencies = try allocator.alloc(DependencyID, directory.dependencies.len);
     defer allocator.free(sorted_dependencies);
     bun.copy(DependencyID, sorted_dependencies, directory.dependencies);
-    std.sort.block(DependencyID, sorted_dependencies, ByName{
+    std.sort.pdq(DependencyID, sorted_dependencies, ByName{
         .dependencies = dependencies,
         .buf = string_bytes,
     }, ByName.isLessThan);

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -284,7 +284,7 @@ pub const CommandLineReporter = struct {
             return;
         }
 
-        std.sort.block(bun.sourcemap.ByteRangeMapping, byte_ranges.items, void{}, bun.sourcemap.ByteRangeMapping.isLessThan);
+        std.sort.pdq(bun.sourcemap.ByteRangeMapping, byte_ranges.items, void{}, bun.sourcemap.ByteRangeMapping.isLessThan);
 
         iter = map.valueIterator();
         var writer = Output.errorWriter();

--- a/src/comptime_string_map.zig
+++ b/src/comptime_string_map.zig
@@ -42,7 +42,7 @@ pub fn ComptimeStringMapWithKeyType(comptime KeyType: type, comptime V: type, co
         } else {
             @compileError("Not implemented for this key type");
         }
-        std.sort.block(KV, &sorted_kvs, {}, lenAsc);
+        std.sort.pdq(KV, &sorted_kvs, {}, lenAsc);
         const min_len = sorted_kvs[0].key.len;
         const max_len = sorted_kvs[sorted_kvs.len - 1].key.len;
         var len_indexes: [max_len + 1]usize = undefined;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2547,7 +2547,7 @@ pub const PackageManager = struct {
         };
 
         // TODO: make this fewer passes
-        std.sort.block(
+        std.sort.pdq(
             Semver.Version,
             installed_versions.items,
             @as([]const u8, tags_buf.items),

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1376,7 +1376,7 @@ pub const Printer = struct {
                 }
             }
 
-            std.sort.block(
+            std.sort.pdq(
                 PackageID,
                 alphabetized_names,
                 Lockfile.Package.Alphabetizer{
@@ -4264,7 +4264,7 @@ pub const Package = extern struct {
             }
         }
 
-        std.sort.block(
+        std.sort.pdq(
             Dependency,
             package_dependencies[0..total_dependencies_count],
             lockfile.buffers.string_bytes.items,
@@ -5172,7 +5172,7 @@ pub fn generateMetaHash(this: *Lockfile, print_name_version_string: bool) !MetaH
         string_builder.count(scripts_end);
     }
 
-    std.sort.block(
+    std.sort.pdq(
         PackageID,
         alphabetized_names,
         Lockfile.Package.Alphabetizer{

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -571,7 +571,7 @@ pub const PackageManifest = struct {
                 }
             };
             var trash: i32 = undefined; // workaround for stage1 compiler bug
-            std.sort.block(Data, &data, &trash, Sort.lessThan);
+            std.sort.pdq(Data, &data, &trash, Sort.lessThan);
             var sizes_bytes: [fields.len]usize = undefined;
             var names: [fields.len][]const u8 = undefined;
             for (data, 0..) |elem, i| {
@@ -1657,7 +1657,7 @@ pub const PackageManifest = struct {
                         .all_versions = semver_versions_,
                         .all_versioned_packages = versioned_packages_,
                     };
-                    std.sort.block(Int, indices, sorter, ExternVersionSorter.isLessThan);
+                    std.sort.pdq(Int, indices, sorter, ExternVersionSorter.isLessThan);
 
                     for (indices, versioned_packages_, semver_versions_) |i, *pkg, *version| {
                         pkg.* = cloned_packages[i];

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -671,7 +671,7 @@ pub const CharFreq = struct {
             break :brk _array;
         };
 
-        std.sort.block(CharAndCount, &array, {}, CharAndCount.lessThan);
+        std.sort.pdq(CharAndCount, &array, {}, CharAndCount.lessThan);
 
         var minifier = NameMinifier.init(allocator);
         minifier.head.ensureTotalCapacityPrecise(NameMinifier.default_head.len) catch unreachable;
@@ -2071,11 +2071,11 @@ pub const E = struct {
         }
 
         pub fn alphabetizeProperties(this: *Object) void {
-            std.sort.block(G.Property, this.properties.slice(), {}, Sorter.isLessThan);
+            std.sort.pdq(G.Property, this.properties.slice(), {}, Sorter.isLessThan);
         }
 
         pub fn packageJSONSort(this: *Object) void {
-            std.sort.block(G.Property, this.properties.slice(), {}, PackageJSONSort.Fields.isLessThan);
+            std.sort.pdq(G.Property, this.properties.slice(), {}, PackageJSONSort.Fields.isLessThan);
         }
 
         const PackageJSONSort = struct {

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -3977,7 +3977,7 @@ pub const Parser = struct {
                 i += 1;
             }
 
-            std.sort.block(
+            std.sort.pdq(
                 u8,
                 runtime_imports[0..i],
                 {},

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -5828,7 +5828,7 @@ pub fn printAst(
             }
         }
 
-        std.sort.block(rename.StableSymbolCount, top_level_symbols.items, {}, rename.StableSymbolCount.lessThan);
+        std.sort.pdq(rename.StableSymbolCount, top_level_symbols.items, {}, rename.StableSymbolCount.lessThan);
 
         try minify_renamer.allocateTopLevelSymbolSlots(top_level_symbols);
         var minifier = tree.char_freq.?.compile(allocator);

--- a/src/renamer.zig
+++ b/src/renamer.zig
@@ -297,7 +297,7 @@ pub const MinifyRenamer = struct {
                     .count = slot.count,
                 };
             }
-            std.sort.block(SlotAndCount, sorted.items, {}, SlotAndCount.lessThan);
+            std.sort.pdq(SlotAndCount, sorted.items, {}, SlotAndCount.lessThan);
 
             var next_name: isize = 0;
 
@@ -395,7 +395,7 @@ pub fn assignNestedScopeSlotsHelper(sorted_members: *std.ArrayList(u32), scope: 
             sorted_members_buf[i] = member.ref.innerIndex();
             i += 1;
         }
-        std.sort.block(u32, sorted_members_buf, {}, std.sort.asc(u32));
+        std.sort.pdq(u32, sorted_members_buf, {}, std.sort.asc(u32));
 
         // Assign slots for this scope's symbols. Only do this if the slot is
         // not already assigned. Nested scopes have copies of symbols from parent
@@ -593,7 +593,7 @@ pub const NumberRenamer = struct {
                 remaining = remaining[1..];
             }
             std.debug.assert(remaining.len == 0);
-            std.sort.block(u32, sorted.items, {}, std.sort.asc(u32));
+            std.sort.pdq(u32, sorted.items, {}, std.sort.asc(u32));
 
             for (sorted.items) |inner_index| {
                 r.assignName(s, Ref.init(@as(Ref.Int, @intCast(inner_index)), source_index, false));

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -1153,7 +1153,7 @@ pub const ExportsMap = struct {
                     // PATTERN_KEY_COMPARE which orders in descending order of specificity.
                     const GlobLengthSorter: type = strings.NewGlobLengthSorter(Entry.Data.Map.MapEntry, "key");
                     var sorter = GlobLengthSorter{};
-                    std.sort.block(Entry.Data.Map.MapEntry, expansion_keys, sorter, GlobLengthSorter.lessThan);
+                    std.sort.pdq(Entry.Data.Map.MapEntry, expansion_keys, sorter, GlobLengthSorter.lessThan);
 
                     return Entry{
                         .data = .{

--- a/src/router.zig
+++ b/src/router.zig
@@ -356,7 +356,7 @@ const RouteLoader = struct {
             .allocator = allocator,
         };
 
-        std.sort.block(*Route, this.all_routes.items, Route.Sorter{}, Route.Sorter.sortByName);
+        std.sort.pdq(*Route, this.all_routes.items, Route.Sorter{}, Route.Sorter.sortByName);
 
         var route_list = RouteIndex.List{};
         route_list.setCapacity(allocator, this.all_routes.items.len) catch unreachable;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -445,7 +445,7 @@ pub const Runtime = struct {
                     return std.mem.order(u8, a, b) == .lt;
                 }
             };
-            std.sort.block(string, &list, {}, Sorter.compare);
+            std.sort.pdq(string, &list, {}, Sorter.compare);
             break :brk list;
         };
 

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -4605,12 +4605,12 @@ const sort_desc = std.sort.desc(u8);
 
 pub fn sortAsc(in: []string) void {
     // TODO: experiment with simd to see if it's faster
-    std.sort.block([]const u8, in, {}, cmpStringsAsc);
+    std.sort.pdq([]const u8, in, {}, cmpStringsAsc);
 }
 
 pub fn sortDesc(in: []string) void {
     // TODO: experiment with simd to see if it's faster
-    std.sort.block([]const u8, in, {}, cmpStringsDesc);
+    std.sort.pdq([]const u8, in, {}, cmpStringsDesc);
 }
 
 pub const StringArrayByIndexSorter = struct {

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -500,7 +500,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
             // swapRemove messes up the order
             // But, it only messes up the order if any elements in the list appear after the item being removed
             // So if we just sort the list by the biggest index first, that should be fine
-            std.sort.block(
+            std.sort.pdq(
                 WatchItemIndex,
                 evict_list[0..evict_list_i],
                 {},
@@ -646,7 +646,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
                         }
 
                         var all_events = watchevents[0..watch_event_id];
-                        std.sort.block(WatchEvent, all_events, {}, WatchEvent.sortByIndex);
+                        std.sort.pdq(WatchEvent, all_events, {}, WatchEvent.sortByIndex);
 
                         var last_event_index: usize = 0;
                         var last_event_id: INotify.EventListIndex = std.math.maxInt(INotify.EventListIndex);


### PR DESCRIPTION
### What does this PR do?

Switch from `std.sort.block` to `std.sort.pdq`, which is an unstable sorting algorithm. The implementation of block sort did not support values being equal, so I don't think there will be a behavior difference other than the workaround for bun install

See https://github.com/ziglang/zig/issues/18252

### How did you verify your code works?

Existing tests should have interesting things to say if this causes other bugs