### PR TITLE
fix(resolver): wildcard tsconfig path not including suffix

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -70,6 +70,7 @@ const bufs = struct {
     pub threadlocal var extension_path: [512]u8 = undefined;
     pub threadlocal var tsconfig_match_full_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
     pub threadlocal var tsconfig_match_full_buf2: [bun.MAX_PATH_BYTES]u8 = undefined;
+    pub threadlocal var tsconfig_match_full_buf3: [bun.MAX_PATH_BYTES]u8 = undefined;
 
     pub threadlocal var esm_subpath: [512]u8 = undefined;
     pub threadlocal var esm_absolute_package_path: [bun.MAX_PATH_BYTES]u8 = undefined;
@@ -2847,10 +2848,13 @@ pub const Resolver = struct {
                 var prefix_parts = [_]string{ abs_base_url, original_path[0 .. total_length orelse original_path.len] };
 
                 // Concatenate the matched text with the suffix from the wildcard path
-                const suffix = std.mem.trimLeft(u8, original_path[total_length orelse original_path.len ..], "*");
-                var matched_text_with_suffix = r.allocator.alloc(u8, matched_text.len + suffix.len) catch unreachable;
-                defer r.allocator.free(matched_text_with_suffix);
-                bun.concat(u8, matched_text_with_suffix, &.{ matched_text, suffix });
+                var matched_text_with_suffix = bufs(.tsconfig_match_full_buf3);
+                var matched_text_with_suffix_len: usize = 0;
+                if (total_length != null) {
+                    const suffix = std.mem.trimLeft(u8, original_path[total_length orelse original_path.len ..], "*");
+                    matched_text_with_suffix_len = matched_text.len + suffix.len;
+                    bun.concat(u8, matched_text_with_suffix, &.{ matched_text, suffix });
+                }
 
                 // 1. Normalize the base path
                 // so that "/Users/foo/project/", "../components/*" => "/Users/foo/components/""
@@ -2860,7 +2864,7 @@ pub const Resolver = struct {
                 // so that "/Users/foo/components/", "/foo/bar" => /Users/foo/components/foo/bar
                 var parts = [_]string{
                     prefix,
-                    if (total_length != null) std.mem.trimLeft(u8, matched_text_with_suffix, "/") else "",
+                    if (matched_text_with_suffix_len > 0) std.mem.trimLeft(u8, matched_text_with_suffix[0..matched_text_with_suffix_len], "/") else "",
                     std.mem.trimLeft(u8, longest_match.suffix, "/"),
                 };
                 var absolute_original_path = r.fs.absBuf(

--- a/test/js/bun/resolve/bar/src/index.js
+++ b/test/js/bun/resolve/bar/src/index.js
@@ -1,0 +1,2 @@
+// this file is used in resolve.test.js
+export default {};

--- a/test/js/bun/resolve/resolve-test.js
+++ b/test/js/bun/resolve/resolve-test.js
@@ -69,6 +69,7 @@ it("import.meta.resolve", async () => {
   // works with tsconfig.json "paths"
   expect(await import.meta.resolve("foo/bar")).toBe(join(import.meta.path, "../baz.js"));
   expect(await import.meta.resolve("@faasjs/baz")).toBe(join(import.meta.path, "../baz.js"));
+  expect(await import.meta.resolve("@faasjs/bar")).toBe(join(import.meta.path, "../bar/src/index.js"));
 
   // works with package.json "exports"
   expect(await import.meta.resolve("package-json-exports/baz")).toBe(

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -26,7 +26,7 @@
       "node-harness": ["js/node/harness.ts"],
       "deno:harness": ["js/deno/harness.ts"],
       "foo/bar": ["js/bun/resolve/baz.js"],
-      "@faasjs/*": ["js/bun/resolve/*.js"]
+      "@faasjs/*": ["js/bun/resolve/*.js", "js/bun/resolve/*/src/index.js"]
     }
   },
 


### PR DESCRIPTION
### What does this PR do?

- Fixes bug where wildcard tsconfig paths would fail to resolve due to the suffix not being added.

The error thrown that it fixes:

```
error: Cannot find module "@faasjs/bar" from ".../test/js/bun/resolve/resolve-test.js"
```

Feel free to make changes to this branch if there is something you want to modify :)

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

If JavaScript/TypeScript modules or builtins changed:

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
