### PR TITLE
fix: do not inline `process.env` during `bun run` and `bun test`

### DIFF
--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -509,9 +509,7 @@ WTF::String BunString::toWTFString(ZeroCopyTag) const
     }
 
     if (this->tag == BunStringTag::WTFStringImpl) {
-#if BUN_DEBUG
-        RELEASE_ASSERT(this->impl.wtf->refCount() > 0);
-#endif
+        ASSERT(this->impl.wtf->refCount() > 0);
         return WTF::String(this->impl.wtf);
     }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -79,7 +79,7 @@ pub const LoaderColonList = ColonListType(Api.Loader, Arguments.loader_resolver)
 pub const DefineColonList = ColonListType(string, Arguments.noop_resolver);
 fn invalidTarget(diag: *clap.Diagnostic, _target: []const u8) noreturn {
     @setCold(true);
-    diag.name.long = "--target";
+    diag.name.long = "target";
     diag.arg = _target;
     diag.report(Output.errorWriter(), error.InvalidTarget) catch {};
     std.process.exit(1);

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -569,6 +569,7 @@ pub const TestCommand = struct {
         var env_loader = brk: {
             var map = try ctx.allocator.create(DotEnv.Map);
             map.* = DotEnv.Map.init(ctx.allocator);
+            try map.put("NODE_ENV", "test");
 
             var loader = try ctx.allocator.create(DotEnv.Loader);
             loader.* = DotEnv.Loader.init(map, ctx.allocator);
@@ -637,6 +638,7 @@ pub const TestCommand = struct {
         vm.argv = ctx.passthrough;
         vm.preload = ctx.preloads;
         vm.bundler.options.rewrite_jest_for_tests = true;
+        vm.bundler.options.env.behavior = .load_all_without_inlining;
 
         try vm.bundler.configureDefines();
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -569,7 +569,6 @@ pub const TestCommand = struct {
         var env_loader = brk: {
             var map = try ctx.allocator.create(DotEnv.Map);
             map.* = DotEnv.Map.init(ctx.allocator);
-            try map.put("NODE_ENV", "test");
 
             var loader = try ctx.allocator.create(DotEnv.Loader);
             loader.* = DotEnv.Loader.init(map, ctx.allocator);
@@ -639,6 +638,14 @@ pub const TestCommand = struct {
         vm.preload = ctx.preloads;
         vm.bundler.options.rewrite_jest_for_tests = true;
         vm.bundler.options.env.behavior = .load_all_without_inlining;
+
+        const node_env_entry = try env_loader.map.getOrPutWithoutValue("NODE_ENV");
+        if (!node_env_entry.found_existing) {
+            node_env_entry.value_ptr.* = .{
+                .value = try env_loader.allocator.dupe(u8, "test"),
+                .conditional = false,
+            };
+        }
 
         try vm.bundler.configureDefines();
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -641,7 +641,7 @@ pub const TestCommand = struct {
 
         const node_env_entry = try env_loader.map.getOrPutWithoutValue("NODE_ENV");
         if (!node_env_entry.found_existing) {
-            node_env_entry.key_ptr = try env_loader.allocator.dupe(u8, node_env_entry.key_ptr);
+            node_env_entry.key_ptr.* = try env_loader.allocator.dupe(u8, node_env_entry.key_ptr.*);
             node_env_entry.value_ptr.* = .{
                 .value = try env_loader.allocator.dupe(u8, "test"),
                 .conditional = false,

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -641,6 +641,7 @@ pub const TestCommand = struct {
 
         const node_env_entry = try env_loader.map.getOrPutWithoutValue("NODE_ENV");
         if (!node_env_entry.found_existing) {
+            node_env_entry.key_ptr = try env_loader.allocator.dupe(u8, node_env_entry.key_ptr);
             node_env_entry.value_ptr.* = .{
                 .value = try env_loader.allocator.dupe(u8, "test"),
                 .conditional = false,

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -218,7 +218,7 @@ pub const Loader = struct {
         behavior: Api.DotEnvBehavior,
         prefix: string,
         allocator: std.mem.Allocator,
-    ) ![]u8 {
+    ) !void {
         var iter = this.map.iter();
         var key_count: usize = 0;
         var string_map_hashes = try allocator.alloc(u64, framework_defaults.keys.len);
@@ -361,8 +361,6 @@ pub const Loader = struct {
                 _ = try to_json.getOrPutValue(key, value);
             }
         }
-
-        return key_buf;
     }
 
     pub fn init(map: *Map, allocator: std.mem.Allocator) Loader {

--- a/src/options.zig
+++ b/src/options.zig
@@ -1122,13 +1122,11 @@ pub fn definesFromTransformOptions(
     allocator: std.mem.Allocator,
     log: *logger.Log,
     maybe_input_define: ?Api.StringMap,
-    hmr: bool,
     target: Target,
     env_loader: ?*DotEnv.Loader,
     framework_env: ?*const Env,
     NODE_ENV: ?string,
 ) !*defines.Define {
-    _ = hmr;
     var input_user_define = maybe_input_define orelse std.mem.zeroes(Api.StringMap);
 
     var user_defines = try stringHashMapFromArrays(

--- a/src/options.zig
+++ b/src/options.zig
@@ -1129,16 +1129,14 @@ pub const DefaultUserDefines = struct {
 pub fn definesFromTransformOptions(
     allocator: std.mem.Allocator,
     log: *logger.Log,
-    _input_define: ?Api.StringMap,
+    maybe_input_define: ?Api.StringMap,
     hmr: bool,
     target: Target,
-    loader: ?*DotEnv.Loader,
+    env_loader: ?*DotEnv.Loader,
     framework_env: ?*const Env,
     NODE_ENV: ?string,
-    debugger: bool,
 ) !*defines.Define {
-    _ = debugger;
-    var input_user_define = _input_define orelse std.mem.zeroes(Api.StringMap);
+    var input_user_define = maybe_input_define orelse std.mem.zeroes(Api.StringMap);
 
     var user_defines = try stringHashMapFromArrays(
         defines.RawDefines,
@@ -1150,73 +1148,75 @@ pub fn definesFromTransformOptions(
     var environment_defines = defines.UserDefinesArray.init(allocator);
     defer environment_defines.deinit();
 
-    if (loader) |_loader| {
-        if (framework_env) |framework| {
-            _ = try _loader.copyForDefine(
-                defines.RawDefines,
-                &user_defines,
-                defines.UserDefinesArray,
-                &environment_defines,
-                framework.toAPI().defaults,
-                framework.behavior,
-                framework.prefix,
-                allocator,
-            );
-        } else {
-            _ = try _loader.copyForDefine(
-                defines.RawDefines,
-                &user_defines,
-                defines.UserDefinesArray,
-                &environment_defines,
-                std.mem.zeroes(Api.StringMap),
-                Api.DotEnvBehavior.disable,
-                "",
-                allocator,
-            );
+    var behavior: Api.DotEnvBehavior = .disable;
+
+    load_env: {
+        const env = env_loader orelse break :load_env;
+        const framework = framework_env orelse break :load_env;
+
+        if (Environment.allow_assert) {
+            std.debug.assert(framework.behavior != ._none);
         }
+
+        behavior = framework.behavior;
+        if (behavior == .load_all_without_inlining or behavior == .disable)
+            break :load_env;
+
+        try env.copyForDefine(
+            defines.RawDefines,
+            &user_defines,
+            defines.UserDefinesArray,
+            &environment_defines,
+            framework.toAPI().defaults,
+            framework.behavior,
+            framework.prefix,
+            allocator,
+        );
     }
 
-    var quoted_node_env: string = brk: {
-        if (NODE_ENV) |node_env| {
-            if (node_env.len > 0) {
-                if ((strings.startsWithChar(node_env, '"') and strings.endsWithChar(node_env, '"')) or
-                    (strings.startsWithChar(node_env, '\'') and strings.endsWithChar(node_env, '\'')))
-                {
-                    break :brk node_env;
-                }
+    if (behavior != .load_all_without_inlining) {
+        var quoted_node_env: string = brk: {
+            if (NODE_ENV) |node_env| {
+                if (node_env.len > 0) {
+                    if ((strings.startsWithChar(node_env, '"') and strings.endsWithChar(node_env, '"')) or
+                        (strings.startsWithChar(node_env, '\'') and strings.endsWithChar(node_env, '\'')))
+                    {
+                        break :brk node_env;
+                    }
 
-                // avoid allocating if we can
-                if (strings.eqlComptime(node_env, "production")) {
-                    break :brk "\"production\"";
-                } else if (strings.eqlComptime(node_env, "development")) {
-                    break :brk "\"development\"";
-                } else if (strings.eqlComptime(node_env, "test")) {
-                    break :brk "\"test\"";
-                } else {
-                    break :brk try std.fmt.allocPrint(allocator, "\"{s}\"", .{node_env});
+                    // avoid allocating if we can
+                    if (strings.eqlComptime(node_env, "production")) {
+                        break :brk "\"production\"";
+                    } else if (strings.eqlComptime(node_env, "development")) {
+                        break :brk "\"development\"";
+                    } else if (strings.eqlComptime(node_env, "test")) {
+                        break :brk "\"test\"";
+                    } else {
+                        break :brk try std.fmt.allocPrint(allocator, "\"{s}\"", .{node_env});
+                    }
                 }
             }
+            break :brk "\"development\"";
+        };
+
+        _ = try user_defines.getOrPutValue(
+            "process.env.NODE_ENV",
+            quoted_node_env,
+        );
+        _ = try user_defines.getOrPutValue(
+            "process.env.BUN_ENV",
+            quoted_node_env,
+        );
+
+        if (hmr) {
+            try user_defines.put(DefaultUserDefines.HotModuleReloading.Key, DefaultUserDefines.HotModuleReloading.Value);
         }
-        break :brk "\"development\"";
-    };
 
-    _ = try user_defines.getOrPutValue(
-        "process.env.NODE_ENV",
-        quoted_node_env,
-    );
-    _ = try user_defines.getOrPutValue(
-        "process.env.BUN_ENV",
-        quoted_node_env,
-    );
-
-    if (hmr) {
-        try user_defines.put(DefaultUserDefines.HotModuleReloading.Key, DefaultUserDefines.HotModuleReloading.Value);
-    }
-
-    // Automatically set `process.browser` to `true` for browsers and false for node+js
-    // This enables some extra dead code elimination
-    if (target.processBrowserDefineValue()) |value| {
-        _ = try user_defines.getOrPutValue(DefaultUserDefines.ProcessBrowserDefine.Key, value);
+        // Automatically set `process.browser` to `true` for browsers and false for node+js
+        // This enables some extra dead code elimination
+        if (target.processBrowserDefineValue()) |value| {
+            _ = try user_defines.getOrPutValue(DefaultUserDefines.ProcessBrowserDefine.Key, value);
+        }
     }
 
     if (target.isBun()) {
@@ -1543,7 +1543,6 @@ pub const BundleOptions = struct {
 
                 break :node_env "\"development\"";
             },
-            this.debugger,
         );
         this.defines_loaded = true;
     }

--- a/src/options.zig
+++ b/src/options.zig
@@ -1107,14 +1107,6 @@ pub const Timings = struct {
 };
 
 pub const DefaultUserDefines = struct {
-    pub const HotModuleReloading = struct {
-        pub const Key = "process.env.BUN_HMR_ENABLED";
-        pub const Value = "true";
-    };
-    pub const HotModuleReloadingVerbose = struct {
-        pub const Key = "process.env.BUN_HMR_VERBOSE";
-        pub const Value = "true";
-    };
     // This must be globally scoped so it doesn't disappear
     pub const NodeEnv = struct {
         pub const Key = "process.env.NODE_ENV";
@@ -1136,6 +1128,7 @@ pub fn definesFromTransformOptions(
     framework_env: ?*const Env,
     NODE_ENV: ?string,
 ) !*defines.Define {
+    _ = hmr;
     var input_user_define = maybe_input_define orelse std.mem.zeroes(Api.StringMap);
 
     var user_defines = try stringHashMapFromArrays(
@@ -1207,10 +1200,6 @@ pub fn definesFromTransformOptions(
             "process.env.BUN_ENV",
             quoted_node_env,
         );
-
-        if (hmr) {
-            try user_defines.put(DefaultUserDefines.HotModuleReloading.Key, DefaultUserDefines.HotModuleReloading.Value);
-        }
 
         // Automatically set `process.browser` to `true` for browsers and false for node+js
         // This enables some extra dead code elimination
@@ -1525,7 +1514,6 @@ pub const BundleOptions = struct {
             allocator,
             this.log,
             this.transform_options.define,
-            this.transform_options.serve orelse false,
             this.target,
             loader_,
             env,

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { expect, it } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { bunExe, bunEnv, tempDirWithFiles, bunRun, bunRunAsScript } from "harness";
 import { readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -105,7 +105,7 @@ export function tempDirWithFiles(basename: string, files: Record<string, string 
   return dir;
 }
 
-export function bunRun(file: string, env?: Record<string, string>) {
+export function bunRun(file: string, env?: Record<string, string | undefined>) {
   var path = require("path");
   const result = Bun.spawnSync([bunExe(), file], {
     cwd: path.dirname(file),

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -105,9 +105,9 @@ export function tempDirWithFiles(basename: string, files: Record<string, string 
   return dir;
 }
 
-export function bunRun(file: string, env?: Record<string, string | undefined>, execArgv: string[] = []) {
+export function bunRun(file: string, env?: Record<string, string>) {
   var path = require("path");
-  const result = Bun.spawnSync([bunExe(), ...execArgv, file], {
+  const result = Bun.spawnSync([bunExe(), file], {
     cwd: path.dirname(file),
     env: {
       ...bunEnv,

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -105,9 +105,9 @@ export function tempDirWithFiles(basename: string, files: Record<string, string 
   return dir;
 }
 
-export function bunRun(file: string, env?: Record<string, string | undefined>) {
+export function bunRun(file: string, env?: Record<string, string | undefined>, execArgv: string[] = []) {
   var path = require("path");
-  const result = Bun.spawnSync([bunExe(), file], {
+  const result = Bun.spawnSync([bunExe(), ...execArgv, file], {
     cwd: path.dirname(file),
     env: {
       ...bunEnv,


### PR DESCRIPTION
### What does this PR do?

No longer inline env vars in bun run and bun test. this fixes #7609.

In bun test, explicitly setting NODE_ENV applies.

In bun test, dynamically reading NODE_ENV reads test if an explicit node_env is set

Removes check for adding `BUN_HMR_ENABLED` as this variable is not documented anywhere and never was functional due to a typo.
```
console.log(process.env.BUN_HMR_ENABLED);process.exit(0)
```

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

many new tests for different configs. bundler is tested by existing 
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
