### PR TITLE
fix(node): always use .RunCommand when binary is named `node`

### DIFF
--- a/src/bun.js/ResolveMessage.zig
+++ b/src/bun.js/ResolveMessage.zig
@@ -51,6 +51,9 @@ pub const ResolveMessage = struct {
     pub fn fmt(allocator: std.mem.Allocator, specifier: string, referrer: string, err: anyerror) !string {
         switch (err) {
             error.ModuleNotFound => {
+                if (strings.eqlComptime(referrer, "bun:main")) {
+                    return try std.fmt.allocPrint(allocator, "Module not found \"{s}\"", .{specifier});
+                }
                 if (Resolver.isPackagePath(specifier) and !strings.containsChar(specifier, '/')) {
                     return try std.fmt.allocPrint(allocator, "Cannot find package \"{s}\" from \"{s}\"", .{ specifier, referrer });
                 } else {

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -306,7 +306,7 @@ pub const BunxCommand = struct {
         const bunx_cache_dir = PATH[0 .. bun.fs.FileSystem.RealFS.PLATFORM_TMP_DIR.len + "/--bunx".len + package_fmt.len];
 
         var absolute_in_cache_dir_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-        var absolute_in_cache_dir = std.fmt.bufPrint(&absolute_in_cache_dir_buf, "/{s}/node_modules/.bin/{s}", .{ bunx_cache_dir, initial_bin_name }) catch unreachable;
+        var absolute_in_cache_dir = std.fmt.bufPrint(&absolute_in_cache_dir_buf, "{s}/node_modules/.bin/{s}", .{ bunx_cache_dir, initial_bin_name }) catch unreachable;
 
         const passthrough = passthrough_list.items;
 

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -15,10 +15,11 @@ const JSC = bun.JSC;
 const WaiterThread = JSC.Subprocess.WaiterThread;
 
 const lex = bun.js_lexer;
-const logger = @import("root").bun.logger;
-const clap = @import("root").bun.clap;
-const cli = @import("../cli.zig");
-const Arguments = cli.Arguments;
+const logger = bun.logger;
+const clap = bun.clap;
+const CLI = bun.CLI;
+const Arguments = CLI.Arguments;
+const Command = CLI.Command;
 
 const options = @import("../options.zig");
 const js_parser = bun.js_parser;
@@ -31,7 +32,6 @@ const sync = @import("../sync.zig");
 const Api = @import("../api/schema.zig").Api;
 const resolve_path = @import("../resolver/resolve_path.zig");
 const configureTransformOptionsForBun = @import("../bun.js/config.zig").configureTransformOptionsForBun;
-const Command = cli.Command;
 const bundler = bun.bundler;
 
 const DotEnv = @import("../env_loader.zig");
@@ -1534,7 +1534,7 @@ pub const RunCommand = struct {
                         // once we know it's a file, check if they have any preloads
                         if (ext.len > 0 and !has_loader) {
                             if (!ctx.debug.loaded_bunfig) {
-                                try bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand);
+                                try CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", &ctx, .RunCommand);
                             }
 
                             if (ctx.preloads.len == 0)
@@ -1734,7 +1734,7 @@ pub const RunCommand = struct {
     }
 
     pub fn execAsIfNode(ctx: Command.Context) !void {
-        std.debug.assert(cli.pretend_to_be_node);
+        std.debug.assert(CLI.pretend_to_be_node);
 
         if (ctx.positionals.len == 0) {
             Output.errGeneric("Missing script to execute. Bun's provided 'node' cli wrapper does not support a repl.", .{});

--- a/src/output.zig
+++ b/src/output.zig
@@ -757,14 +757,15 @@ pub inline fn err(error_name: anytype, comptime fmt: []const u8, args: anytype) 
         // error unions
         if (info == .ErrorSet) {
             if (info.ErrorSet) |errors| {
+                if (errors.len == 0) {
+                    @compileError("Output.err was given an empty error set");
+                }
 
                 // TODO: convert zig errors to errno for better searchability?
                 if (errors.len == 1) break :display_name .{ comptime @errorName(errors[0]), true };
-
-                break :display_name .{ @errorName(error_name), false };
-            } else {
-                @compileLog("Output.err was given an empty error set");
             }
+
+            break :display_name .{ @errorName(error_name), false };
         }
 
         // enum literals

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from "bun:test";
+import { fakeNodeRun, tempDirWithFiles } from "../../harness";
+import { join } from "path";
+
+describe("fake node cli", () => {
+  test("the node cli actually works", () => {
+    const temp = tempDirWithFiles("fake-node", {
+      "index.ts": "console.log(Bun.version)",
+    });
+    expect(fakeNodeRun(temp, join(temp, "index.ts")).stdout).toBe(Bun.version);
+  });
+  test("doesnt resolve bins", () => {
+    const temp = tempDirWithFiles("fake-node", {
+      "vite.js": "console.log('pass')",
+      "node_modules/.bin/vite": "#!/usr/bin/sh\necho fail && exit 1",
+    });
+    expect(fakeNodeRun(temp, "vite").stdout).toBe("pass");
+  });
+  test("doesnt resolve scripts", () => {
+    const temp = tempDirWithFiles("fake-node", {
+      "vite.js": "console.log('pass')",
+      "package.json": '{"scripts":{"vite":"echo fail && exit 1"}}',
+    });
+    expect(fakeNodeRun(temp, "vite").stdout).toBe("pass");
+  });
+  test("can run a script named run.js", () => {
+    const temp = tempDirWithFiles("fake-node", {
+      "run.js": "console.log('pass')",
+      "run/index.js": "console.log('fail')",
+      "node_modules/run/index.js": "console.log('fail')",
+    });
+    expect(fakeNodeRun(temp, "run").stdout).toBe("pass");
+  });
+  describe("entrypoint file extension picking", () => {
+    // Bun supports JSX and TS, and node doesnt, so our behavior here differs a bit
+    // Hopefully these priorization rules will not break any node apps.
+    test("picks tsx over any other ext", () => {
+      const temp = tempDirWithFiles("fake-node", {
+        "build.js": "console.log('fail (build.js)')",
+        "build.jsx": "console.log('fail (build.jsx)')",
+        "build.cjs": "console.log('fail (build.cjs)')",
+        "build.mjs": "console.log('fail (build.mjs)')",
+        "build.ts": "console.log('fail (build.ts)')",
+        "build.cts": "console.log('fail (build.cts)')",
+        "build.mts": "console.log('fail (build.mts)')",
+        "build.tsx": "console.log('pass')",
+      });
+      expect(fakeNodeRun(temp, "build").stdout).toBe("pass");
+    });
+    test("picks jsx over ts", () => {
+      const temp = tempDirWithFiles("fake-node", {
+        "build.js": "console.log('fail (build.js)')",
+        "build.jsx": "console.log('pass')",
+        "build.cjs": "console.log('fail (build.cjs)')",
+        "build.mjs": "console.log('fail (build.mjs)')",
+        "build.ts": "console.log('fail (build.ts)')",
+        "build.cts": "console.log('fail (build.cts)')",
+        "build.mts": "console.log('fail (build.mts)')",
+      });
+      expect(fakeNodeRun(temp, "build").stdout).toBe("pass");
+    });
+    test("picks mts over ts", () => {
+      const temp = tempDirWithFiles("fake-node", {
+        "build.js": "console.log('fail (build.js)')",
+        "build.cjs": "console.log('fail (build.cjs)')",
+        "build.mjs": "console.log('fail (build.mjs)')",
+        "build.ts": "console.log('fail (build.ts)')",
+        "build.cts": "console.log('fail (build.cts)')",
+        "build.mts": "console.log('pass')",
+      });
+      expect(fakeNodeRun(temp, "build").stdout).toBe("pass");
+    });
+    test("picks ts over js/cjs/etc", () => {
+      const temp = tempDirWithFiles("fake-node", {
+        "build.js": "console.log('fail (build.js)')",
+        "build.cjs": "console.log('fail (build.cjs)')",
+        "build.mjs": "console.log('fail (build.mjs)')",
+        "build.ts": "console.log('pass')",
+        "build.cts": "console.log('fail (build.cts)')",
+      });
+      expect(fakeNodeRun(temp, "build").stdout).toBe("pass");
+    });
+  });
+});

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -81,4 +81,9 @@ describe("fake node cli", () => {
       expect(fakeNodeRun(temp, "build").stdout).toBe("pass");
     });
   });
+
+  test("node -e ", () => {
+    const temp = tempDirWithFiles("fake-node", {});
+    expect(fakeNodeRun(temp, ["-e", "console.log('pass')"]).stdout).toBe("pass");
+  });
 });

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { fakeNodeRun, tempDirWithFiles } from "../../harness";
+import { bunExe, fakeNodeRun, tempDirWithFiles } from "../../harness";
 import { join } from "path";
 
 describe("fake node cli", () => {
@@ -85,5 +85,20 @@ describe("fake node cli", () => {
   test("node -e ", () => {
     const temp = tempDirWithFiles("fake-node", {});
     expect(fakeNodeRun(temp, ["-e", "console.log('pass')"]).stdout).toBe("pass");
+  });
+
+  test("process args work", () => {
+    const temp = tempDirWithFiles("fake-node", {
+      "index.js": "console.log(JSON.stringify(process.argv))",
+    });
+    expect(fakeNodeRun(temp, ["index", "a", "b", "c"]).stdout).toBe(
+      // note: no extension here is INTENTIONAL
+      JSON.stringify([bunExe(), join(temp, "index"), "a", "b", "c"]),
+    );
+  });
+
+  test("no args is exit code zero for now", () => {
+    const temp = tempDirWithFiles("fake-node", {});
+    expect(() => fakeNodeRun(temp, [])).toThrow();
   });
 });

--- a/test/cli/run/if-present.test.ts
+++ b/test/cli/run/if-present.test.ts
@@ -26,7 +26,7 @@ describe("bun", () => {
       stderr: "pipe",
     });
     expect(stdout.toString()).toBeEmpty();
-    expect(stderr.toString()).toMatch(/script not found/);
+    expect(stderr.toString()).toMatch(/Script not found/);
     expect(exitCode).toBe(1);
   });
   test("should error with missing module", () => {
@@ -38,7 +38,7 @@ describe("bun", () => {
       stderr: "pipe",
     });
     expect(stdout.toString()).toBeEmpty();
-    expect(stderr.toString()).toMatch(/module not found/);
+    expect(stderr.toString()).toMatch(/Module not found/);
     expect(exitCode).toBe(1);
   });
   test("should error with missing file", () => {
@@ -50,7 +50,7 @@ describe("bun", () => {
       stderr: "pipe",
     });
     expect(stdout.toString()).toBeEmpty();
-    expect(stderr.toString()).toMatch(/file not found/);
+    expect(stderr.toString()).toMatch(/File not found/);
     expect(exitCode).toBe(1);
   });
 });

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -157,9 +157,9 @@ export function bunRunAsScript(dir: string, script: string, env?: Record<string,
   };
 }
 
-export function fakeNodeRun(dir: string, file: string, env?: Record<string, string>) {
+export function fakeNodeRun(dir: string, file: string | string[], env?: Record<string, string>) {
   var path = require("path");
-  const result = Bun.spawnSync([bunExe(), "--bun", "node", file], {
+  const result = Bun.spawnSync([bunExe(), "--bun", "node", ...(Array.isArray(file) ? file : [file])], {
     cwd: dir ?? path.dirname(file),
     env: {
       ...bunEnv,

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -156,3 +156,20 @@ export function bunRunAsScript(dir: string, script: string, env?: Record<string,
     stderr: result.stderr.toString("utf8").trim(),
   };
 }
+
+export function fakeNodeRun(dir: string, file: string, env?: Record<string, string>) {
+  var path = require("path");
+  const result = Bun.spawnSync([bunExe(), "--bun", "node", file], {
+    cwd: dir ?? path.dirname(file),
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+      ...env,
+    },
+  });
+  if (!result.success) throw new Error(result.stderr.toString("utf8"));
+  return {
+    stdout: result.stdout.toString("utf8").trim(),
+    stderr: result.stderr.toString("utf8").trim(),
+  };
+}


### PR DESCRIPTION
### What does this PR do?

This makes `bun --bun node` always use the run command. Fixes #7610.

<img width="708" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/fc615253-4153-44e5-a052-451f97176918">

Related issue #7605, but this just fixes the underlying case that prompted wanted having a feature to disable a single script. I think its fine to keep that open as there are legitimate reasons to disallow a single script, and that probably can come with a more robust `trustedDependencies` field.

Also, this tweaks some error messages to be more consistent with each other.

![image](https://github.com/oven-sh/bun/assets/24465214/46b37db5-2c11-4044-9fb6-b81da3d50150)

also addresses #7504 by using `/tmp/bun-node-<git sha>` however this is not fully closing the issue as it does not actually fix the issue it describes, but simply makes it harder to hit.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

I wrote tests 
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

