### PR TITLE
fix(install) make sure node-gyp is available during lifecycle scripts

### DIFF
--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -265,6 +265,7 @@ pub const BunxCommand = struct {
             &ORIGINAL_PATH,
             root_dir_info.abs_path,
             force_using_bun,
+            false,
         );
 
         var PATH = this_bundler.env.map.get("PATH").?;

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -265,7 +265,6 @@ pub const BunxCommand = struct {
             &ORIGINAL_PATH,
             root_dir_info.abs_path,
             force_using_bun,
-            false,
         );
 
         var PATH = this_bundler.env.map.get("PATH").?;

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -507,11 +507,11 @@ pub const RunCommand = struct {
             }
         }
 
-        if (PATH.items.len > 0) {
-            try PATH.append(':');
+        if (PATH.items.len > 0 and PATH.items[PATH.items.len - 1] != std.fs.path.delimiter) {
+            try PATH.append(std.fs.path.delimiter);
         }
 
-        try PATH.appendSlice(bun_node_dir ++ ":");
+        try PATH.appendSlice(bun_node_dir ++ &[_]u8{std.fs.path.delimiter});
     }
 
     pub const Filter = enum { script, bin, all, bun_js, all_plus_bun_js, script_and_descriptions, script_exclude };

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -511,7 +511,7 @@ pub const RunCommand = struct {
             try PATH.append(std.fs.path.delimiter);
         }
 
-        try PATH.appendSlice(bun_node_dir ++ &[_]u8{std.fs.path.delimiter});
+        try PATH.appendSlice(bun_node_dir);
     }
 
     pub const Filter = enum { script, bin, all, bun_js, all_plus_bun_js, script_and_descriptions, script_exclude };

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1105,6 +1105,7 @@ pub const RunCommand = struct {
         ORIGINAL_PATH: ?*string,
         cwd: string,
         force_using_bun: bool,
+        add_temp_node_gyp: bool,
     ) !void {
         var package_json_dir: string = "";
 
@@ -1180,11 +1181,13 @@ pub const RunCommand = struct {
             }
 
             try new_path.appendSlice(PATH);
-            try new_path.append(std.fs.path.delimiter);
 
-            try new_path.appendSlice(PackageManager.instance.temp_dir_name);
-            try new_path.append(std.fs.path.sep);
-            try new_path.appendSlice(PackageManager.instance.node_gyp_tempdir_name);
+            if (add_temp_node_gyp) {
+                try new_path.append(std.fs.path.delimiter);
+                try new_path.appendSlice(PackageManager.instance.temp_dir_name);
+                try new_path.append(std.fs.path.sep);
+                try new_path.appendSlice(PackageManager.instance.node_gyp_tempdir_name);
+            }
         }
 
         this_bundler.env.map.put("PATH", new_path.items) catch unreachable;
@@ -1598,7 +1601,7 @@ pub const RunCommand = struct {
         var ORIGINAL_PATH: string = "";
         var this_bundler: bundler.Bundler = undefined;
         var root_dir_info = try configureEnvForRun(ctx, &this_bundler, null, log_errors);
-        try configurePathForRun(ctx, root_dir_info, &this_bundler, &ORIGINAL_PATH, root_dir_info.abs_path, force_using_bun);
+        try configurePathForRun(ctx, root_dir_info, &this_bundler, &ORIGINAL_PATH, root_dir_info.abs_path, force_using_bun, false);
         this_bundler.env.map.put("npm_lifecycle_event", script_name_to_search) catch unreachable;
         if (root_dir_info.enclosing_package_json) |package_json| {
             if (package_json.scripts) |scripts| {

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1180,6 +1180,11 @@ pub const RunCommand = struct {
             }
 
             try new_path.appendSlice(PATH);
+            try new_path.append(std.fs.path.delimiter);
+
+            try new_path.appendSlice(PackageManager.instance.temp_dir_name);
+            try new_path.append(std.fs.path.sep);
+            try new_path.appendSlice(PackageManager.instance.node_gyp_tempdir_name);
         }
 
         this_bundler.env.map.put("PATH", new_path.items) catch unreachable;

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -194,6 +194,7 @@ pub const Loader = struct {
         if (ccache_path.len > 0) {
             var cxx_gop = try this.map.getOrPutWithoutValue("CMAKE_CXX_COMPILER_LAUNCHER");
             if (!cxx_gop.found_existing) {
+                cxx_gop.key_ptr.* = try this.allocator.dupe(u8, cxx_gop.key_ptr.*);
                 cxx_gop.value_ptr.* = .{
                     .value = try this.allocator.dupe(u8, ccache_path),
                     .conditional = false,
@@ -201,6 +202,7 @@ pub const Loader = struct {
             }
             var c_gop = try this.map.getOrPutWithoutValue("CMAKE_C_COMPILER_LAUNCHER");
             if (!c_gop.found_existing) {
+                c_gop.key_ptr.* = try this.allocator.dupe(u8, c_gop.key_ptr.*);
                 c_gop.value_ptr.* = .{
                     .value = try this.allocator.dupe(u8, ccache_path),
                     .conditional = false,

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -168,6 +168,47 @@ pub const Loader = struct {
         }
         return http_proxy;
     }
+
+    var did_load_ccache_path: bool = false;
+
+    pub fn loadCCachePath(this: *Loader, fs: *Fs.FileSystem) void {
+        if (did_load_ccache_path) {
+            return;
+        }
+        did_load_ccache_path = true;
+        loadCCachePathImpl(this, fs) catch {};
+    }
+
+    fn loadCCachePathImpl(this: *Loader, fs: *Fs.FileSystem) !void {
+
+        // if they have ccache installed, put it in env variable `CMAKE_CXX_COMPILER_LAUNCHER` so
+        // cmake can use it to hopefully speed things up
+        var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+        const ccache_path = bun.which(
+            &buf,
+            this.map.get("PATH") orelse return,
+            fs.top_level_dir,
+            "ccache",
+        ) orelse "";
+
+        if (ccache_path.len > 0) {
+            var cxx_gop = try this.map.getOrPutWithoutValue("CMAKE_CXX_COMPILER_LAUNCHER");
+            if (!cxx_gop.found_existing) {
+                cxx_gop.value_ptr.* = .{
+                    .value = try this.allocator.dupe(u8, ccache_path),
+                    .conditional = false,
+                };
+            }
+            var c_gop = try this.map.getOrPutWithoutValue("CMAKE_C_COMPILER_LAUNCHER");
+            if (!c_gop.found_existing) {
+                c_gop.value_ptr.* = .{
+                    .value = try this.allocator.dupe(u8, ccache_path),
+                    .conditional = false,
+                };
+            }
+        }
+    }
+
     var node_path_to_use_set_once: []const u8 = "";
     pub fn loadNodeJSConfig(this: *Loader, fs: *Fs.FileSystem, override_node: []const u8) !bool {
         var buf: Fs.PathBuffer = undefined;
@@ -179,9 +220,9 @@ pub const Loader = struct {
             } else {
                 var node = this.getNodePath(fs, &buf) orelse return false;
                 node_path_to_use = try fs.dirname_store.append([]const u8, bun.asByteSlice(node));
-                node_path_to_use_set_once = node_path_to_use;
             }
         }
+        node_path_to_use_set_once = node_path_to_use;
         try this.map.put("NODE", node_path_to_use);
         try this.map.put("npm_node_execpath", node_path_to_use);
         return true;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2485,8 +2485,8 @@ pub const PackageManager = struct {
         var existing_path = this.env.get("PATH") orelse "";
         var PATH = try std.ArrayList(u8).initCapacity(bun.default_allocator, existing_path.len + 1 + node_gyp_tempdir_name.len);
         try PATH.appendSlice(existing_path);
-        if (existing_path.len > 0 and existing_path[existing_path.len - 1] != ':')
-            try PATH.append(':');
+        if (existing_path.len > 0 and existing_path[existing_path.len - 1] != std.fs.path.delimiter)
+            try PATH.append(std.fs.path.delimiter);
         try PATH.appendSlice(node_gyp_tempdir_name);
         try this.env.map.put("PATH", PATH.items);
     }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2422,6 +2422,10 @@ pub const PackageManager = struct {
     }
 
     pub fn ensureTempNodeGypScript(this: *PackageManager) !void {
+        if (comptime Environment.isWindows) {
+            @panic("TODO: command prompt version of temp node-gyp script");
+        }
+
         if (this.node_gyp_tempdir_name.len > 0) return;
 
         const tempdir = this.getTemporaryDirectory();

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2487,6 +2487,8 @@ pub const PackageManager = struct {
         try PATH.appendSlice(existing_path);
         if (existing_path.len > 0 and existing_path[existing_path.len - 1] != std.fs.path.delimiter)
             try PATH.append(std.fs.path.delimiter);
+        try PATH.appendSlice(this.temp_dir_name);
+        try PATH.append(std.fs.path.sep);
         try PATH.appendSlice(node_gyp_tempdir_name);
         try this.env.map.put("PATH", PATH.items);
     }
@@ -9376,22 +9378,20 @@ pub const PackageManager = struct {
 
         var PATH = try std.ArrayList(u8).initCapacity(bun.default_allocator, original_path.len + 1 + "node_modules/.bin".len + cwd.len + 1);
         var current_dir: ?*DirInfo = this_bundler.resolver.readDirInfo(cwd) catch null;
-        var last_dir_with_node_modules: ?*DirInfo = null;
+        std.debug.assert(current_dir != null);
         while (current_dir) |dir| {
-            if (dir.hasNodeModules()) {
-                last_dir_with_node_modules = dir;
-                if (PATH.items.len > 0 and PATH.items[PATH.items.len - 1] != ':') {
-                    try PATH.appendSlice(":");
-                }
-                try PATH.appendSlice(strings.withoutTrailingSlash(dir.abs_path));
-                try PATH.appendSlice(this.options.bin_path);
+            if (PATH.items.len > 0 and PATH.items[PATH.items.len - 1] != std.fs.path.delimiter) {
+                try PATH.append(std.fs.path.delimiter);
             }
+            try PATH.appendSlice(strings.withoutTrailingSlash(dir.abs_path));
+            try PATH.append(std.fs.path.sep);
+            try PATH.appendSlice(this.options.bin_path);
             current_dir = dir.getParent();
         }
 
         if (original_path.len > 0) {
-            if (PATH.items.len > 0 and PATH.items[PATH.items.len - 1] != ':') {
-                try PATH.append(':');
+            if (PATH.items.len > 0 and PATH.items[PATH.items.len - 1] != std.fs.path.delimiter) {
+                try PATH.append(std.fs.path.delimiter);
             }
 
             try PATH.appendSlice(original_path);

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -2527,6 +2527,36 @@ for (const forceWaiterThread of [false, true]) {
       ]);
       expect(await exited).toBe(0);
     });
+    test("node-gyp should always be available for lifecycle scripts", async () => {
+      await writeFile(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          scripts: {
+            install: "node-gyp --version",
+          },
+        }),
+      );
+
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: null,
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+
+      const err = await new Response(stderr).text();
+      expect(err).not.toContain("Saved lockfile");
+      expect(err).not.toContain("not found");
+      expect(err).not.toContain("error:");
+      const out = await new Response(stdout).text();
+
+      // if node-gyp isn't available, it would return a non-zero exit code
+      expect(await exited).toBe(0);
+    });
   });
 }
 


### PR DESCRIPTION
### What does this PR do?
Adds a temporary node-gyp script when node-gyp is used in a lifecycle script. This is needed when node-gyp is not a dependency of any packages and not installed globally.
fixes #7598 
fixes #7606 
fixes #7599 
fixes #7643
fixes #7629


<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
