### PR TITLE
Prevent shell-option changes leaking out of the bash-completion script

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -1,15 +1,17 @@
 #/usr/bin/env bash
 
 _file_arguments() {
-    shopt -s extglob globstar
-    local extensions="${1}";
+    local extensions="${1}"
+    local reset=$(shopt -p globstar)
+    shopt -s globstar
 
     if [[ -z "${cur_word}" ]]; then
         COMPREPLY=( $(compgen -fG -X "${extensions}" -- "${cur_word}") );
     else
         COMPREPLY=( $(compgen -f -X "${extensions}" -- "${cur_word}") );
     fi
-    shopt -u extglob globstar
+
+    $reset
 }
 
 _long_short_completion() {
@@ -43,9 +45,7 @@ _read_scripts_in_package_json() {
         local package_json_compreply;
         local matched="${BASH_REMATCH[@]:1}";
         local scripts="${matched%%\}*}";
-        shopt -s extglob;
         scripts="${scripts//@(\"|\')/}";
-        shopt -u extglob;
         readarray -td, scripts <<<"${scripts}";
         for completion in "${scripts[@]}"; do
             package_json_compreply+=( "${completion%:*}" );


### PR DESCRIPTION
### What does this PR do?

Fixes #7645

This PR prevents the bash-completion script leaking changes to shell options:

  - save and restore `globstar` rather than leaving it unset
  - don't change `extglob` as it's already required and [defined](https://github.com/scop/bash-completion/blob/52419c0736497d92e864d419b58a390af2da5c88/bash_completion#L41) by [bash-completion](https://github.com/scop/bash-completion)

### How did you verify your code works?

Manual tests (bash 5.2.21, Linux)
