### PR TITLE
chore(build): include `src/*/*/*.zig`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -717,6 +717,7 @@ endif()
 file(GLOB ZIG_FILES
     "${BUN_SRC}/*.zig"
     "${BUN_SRC}/*/*.zig"
+    "${BUN_SRC}/*/*/*.zig"
     "${BUN_SRC}/*/*/*/*.zig"
     "${BUN_SRC}/*/*/*/*/*.zig"
 )


### PR DESCRIPTION
### What does this PR do?

When running `bun run build`, `src/bun.js/test/expect.zig` is not included in the compilation.



### How did you verify your code works?

local test

