### PR TITLE
feat(test): support promise rejection in `expect().rejects.toThrow`

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1702,14 +1702,18 @@ pub const Expect = struct {
 
         const value: JSValue = this.getValue(globalObject, thisValue, "toThrow", "<green>expected<r>") orelse return .zero;
 
-        if (!value.jsType().isFunction()) {
-            globalObject.throw("Expected value must be a function", .{});
-            return .zero;
-        }
-
         const not = this.flags.not;
 
         const result_: ?JSValue = brk: {
+            if (!value.jsType().isFunction()) {
+                if (this.flags.promise != .none) {
+                    break :brk value;
+                }
+
+                globalObject.throw("Expected value must be a function", .{});
+                return .zero;
+            }
+
             var vm = globalObject.bunVM();
             var return_value: JSValue = .zero;
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -52,7 +52,7 @@ describe("expect()", () => {
     await expect(Promise.reject({ a: 1, b: 2 })).rejects.toMatchObject({ a: 1 });
     await expect(Promise.reject({ a: 1, b: 2 })).rejects.not.toMatchObject({ c: 1 });
     await expect(Promise.reject(new Error("rejectMessage"))).rejects.toMatchObject({ message: "rejectMessage" });
-    //await expect(Promise.reject(new Error())).rejects.toThrow(); // FIXME
+    await expect(Promise.reject(new Error())).rejects.toThrow();
 
     // not receiving a rejected promise -> should throw
     if (isBun) {
@@ -82,6 +82,7 @@ describe("expect()", () => {
         throw new Error();
       }),
     ).resolves.toThrow();
+    await expect(Promise.resolve(new Error())).resolves.toThrow();
 
     // not receiving a resolved promise -> should throw
     if (isBun) {


### PR DESCRIPTION
### What does this PR do?

Fixes #7631
