### PR TITLE
Add 'listening' boolean property to 'net:Server'

### DIFF
--- a/src/js/node/net.js
+++ b/src/js/node/net.js
@@ -706,7 +706,6 @@ class Server extends EventEmitter {
   [bunSocketServerConnections] = 0;
   [bunSocketServerOptions];
   maxConnections = 0;
-  listening = false;
 
   constructor(options, connectionListener) {
     super();
@@ -727,6 +726,10 @@ class Server extends EventEmitter {
     this[bunSocketServerOptions] = options;
   }
 
+  get listening() {
+    return !!this.#server;
+  }
+
   ref() {
     this.#server?.ref();
     return this;
@@ -743,7 +746,6 @@ class Server extends EventEmitter {
       this.#server = null;
       this[bunSocketServerConnections] = 0;
       this.emit("close");
-      this.listening = false;
       if (typeof callback === "function") {
         callback();
       }
@@ -940,7 +942,6 @@ function emitListeningNextTick(self, onListen) {
       self.emit("error", err);
     }
   }
-  self.listening = true;
   self.emit("listening");
 }
 

--- a/src/js/node/net.js
+++ b/src/js/node/net.js
@@ -706,6 +706,7 @@ class Server extends EventEmitter {
   [bunSocketServerConnections] = 0;
   [bunSocketServerOptions];
   maxConnections = 0;
+  listening = false;
 
   constructor(options, connectionListener) {
     super();
@@ -742,6 +743,7 @@ class Server extends EventEmitter {
       this.#server = null;
       this[bunSocketServerConnections] = 0;
       this.emit("close");
+      this.listening = false;
       if (typeof callback === "function") {
         callback();
       }
@@ -938,6 +940,7 @@ function emitListeningNextTick(self, onListen) {
       self.emit("error", err);
     }
   }
+  self.listening = true;
   self.emit("listening");
 }
 

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -98,6 +98,35 @@ describe("net.createServer listen", () => {
     server.listen(0, "0.0.0.0");
   });
 
+  it("should provide listening property", done => {
+    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+
+    const server: Server = createServer();
+    expect(server.listening).toBeFalse();
+
+    let timeout: Timer;
+    const closeAndFail = () => {
+      clearTimeout(timeout);
+      server.close();
+      mustNotCall()();
+    };
+
+    server.on("error", closeAndFail).on(
+      "listening",
+      mustCall(() => {
+        expect(server.listening).toBeTrue();
+        clearTimeout(timeout);
+        server.close();
+        expect(server.listening).toBeFalse();
+        done();
+      }),
+    );
+
+    timeout = setTimeout(closeAndFail, 100);
+
+    server.listen(0, "0.0.0.0");
+  });
+
   it("should listen on localhost", done => {
     const { mustCall, mustNotCall } = createCallCheckCtx(done);
 

--- a/test/regression/issue/07740.test.ts
+++ b/test/regression/issue/07740.test.ts
@@ -5,10 +5,10 @@ import { tempDirWithFiles } from "harness";
 it("duplicate dependencies should warn instead of error", () => {
   const package_json = JSON.stringify({
     devDependencies: {
-      "empty-package-for-bun-test-runner": "1.0.0"
+      "empty-package-for-bun-test-runner": "1.0.0",
     },
     dependencies: {
-      "empty-package-for-bun-test-runner": "1.0.0"
+      "empty-package-for-bun-test-runner": "1.0.0",
     },
   });
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Added `listening` flag to `net:Server`, see https://nodejs.org/api/net.html#serverlistening.

This fixes #7657.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

I added a test.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [x] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
