### PR TITLE
fix: Resolve specifiers passed to `mock.module`

### DIFF
--- a/src/bun.js/bindings/BunPlugin.h
+++ b/src/bun.js/bindings/BunPlugin.h
@@ -70,9 +70,14 @@ public:
         }
 
         VirtualModuleMap* virtualModules = nullptr;
+        bool mustDoExpensiveRelativeLookup = false;
         JSC::EncodedJSValue run(JSC::JSGlobalObject* globalObject, BunString* namespaceString, BunString* path);
 
+        bool hasVirtualModules() const { return virtualModules != nullptr; }
+
         void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock);
+
+        std::optional<String> resolveVirtualModule(const String& path, const String& from);
 
         ~OnLoad()
         {

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -4127,15 +4127,6 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
     ErrorableString res;
     res.success = false;
 
-    if (key.isString()) {
-        if (auto* virtualModules = globalObject->onLoadPlugins.virtualModules) {
-            auto keyString = key.toWTFString(globalObject);
-            if (virtualModules->contains(keyString)) {
-                return JSC::Identifier::fromString(globalObject->vm(), keyString);
-            }
-        }
-    }
-
     BunString keyZ;
     if (key.isString()) {
         auto moduleName = jsCast<JSString*>(key)->value(globalObject);
@@ -4149,10 +4140,20 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
         } else {
             keyZ = Bun::toStringRef(moduleName);
         }
+
     } else {
         keyZ = Bun::toStringRef(globalObject, key);
     }
     BunString referrerZ = referrer && !referrer.isUndefinedOrNull() && referrer.isString() ? Bun::toStringRef(globalObject, referrer) : BunStringEmpty;
+
+    if (globalObject->onLoadPlugins.hasVirtualModules()) {
+        if (auto resolvedString = globalObject->onLoadPlugins.resolveVirtualModule(keyZ.toWTFString(), referrerZ.toWTFString())) {
+            return Identifier::fromString(globalObject->vm(), resolvedString.value());
+        }
+    } else {
+        ASSERT(!globalObject->onLoadPlugins.mustDoExpensiveRelativeLookup);
+    }
+
     ZigString queryString = { 0, 0 };
     Zig__GlobalObject__resolve(&res, globalObject, &keyZ, &referrerZ, &queryString);
     keyZ.deref();
@@ -4184,10 +4185,10 @@ JSC::JSInternalPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* j
     auto* promise = JSC::JSInternalPromise::create(vm, globalObject->internalPromiseStructure());
     RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
 
-    if (auto* virtualModules = globalObject->onLoadPlugins.virtualModules) {
+    if (globalObject->onLoadPlugins.hasVirtualModules()) {
         auto keyString = moduleNameValue->value(globalObject);
-        if (virtualModules->contains(keyString)) {
-            auto resolvedIdentifier = JSC::Identifier::fromString(vm, keyString);
+        if (auto resolution = globalObject->onLoadPlugins.resolveVirtualModule(keyString, sourceOrigin.url().protocolIsFile() ? sourceOrigin.url().fileSystemPath() : String())) {
+            auto resolvedIdentifier = JSC::Identifier::fromString(vm, resolution.value());
 
             auto result = JSC::importModule(globalObject, resolvedIdentifier,
                 JSC::jsUndefined(), parameters, JSC::jsUndefined());

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -25,7 +25,7 @@ export default function (
     if (protocol.includes("ws")) {
       Bun.write(Bun.stderr, `Inspect in browser:\n  ${link(`https://debug.bun.sh/#${host}${pathname}`)}\n`);
     }
-    Bun.write(Bun.stderr, dim("--------------------- Bun Inspector ---------------------")+ reset() + "\n");
+    Bun.write(Bun.stderr, dim("--------------------- Bun Inspector ---------------------") + reset() + "\n");
   }
 
   const unix = process.env["BUN_INSPECT_NOTIFY"];

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -43,6 +43,24 @@ test("mocking a module that points to a file which does not resolve successfully
   expect(bar).toBe(42);
 });
 
+test("mocking a non-existant relative file", async () => {
+  // @ts-expect-error
+  expect(() => require.resolve("./hey-hey-you-you.ts")).toThrow();
+  mock.module("./hey-hey-you-you.ts", () => {
+    return {
+      bar: 42,
+    };
+  });
+
+  // @ts-expect-error
+  const { bar } = await import("./hey-hey-you-you.ts");
+  expect(bar).toBe(42);
+
+  expect(require("./hey-hey-you-you.ts").bar).toBe(42);
+  expect(require.resolve("./hey-hey-you-you.ts")).toBe(import.meta.resolveSync("./hey-hey-you-you.ts"));
+  expect(require.resolve("./hey-hey-you-you.ts")).toBe(await import.meta.resolve("./hey-hey-you-you.ts"));
+});
+
 test("mocking a local file", async () => {
   expect(fn()).toEqual(42);
   expect(variable).toEqual(7);

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -43,8 +43,24 @@ test("mocking a module that points to a file which does not resolve successfully
   expect(bar).toBe(42);
 });
 
-test("mocking a non-existant relative file", async () => {
+test("mocking a non-existant relative file with a file URL", async () => {
+  expect(() => require.resolve("./hey-hey-you-you2.ts")).toThrow();
+  mock.module("file:./hey-hey-you-you2.ts", () => {
+    return {
+      bar: 42,
+    };
+  });
+
   // @ts-expect-error
+  const { bar } = await import("./hey-hey-you-you2.ts");
+  expect(bar).toBe(42);
+
+  expect(require("./hey-hey-you-you2.ts").bar).toBe(42);
+  expect(require.resolve("./hey-hey-you-you2.ts")).toBe(import.meta.resolveSync("./hey-hey-you-you2.ts"));
+  expect(require.resolve("./hey-hey-you-you2.ts")).toBe(await import.meta.resolve("./hey-hey-you-you2.ts"));
+});
+
+test("mocking a non-existant relative file", async () => {
   expect(() => require.resolve("./hey-hey-you-you.ts")).toThrow();
   mock.module("./hey-hey-you-you.ts", () => {
     return {
@@ -77,7 +93,6 @@ test("mocking a local file", async () => {
   });
   expect(fn()).toEqual(1);
   expect(variable).toEqual(8);
-  // @ts-expect-error
   // expect(defaultValue).toEqual(42);
   expect(rexported).toEqual(43);
   expect(rexportedAs).toEqual(43);


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/7189
Fixes #7677 

Previously, mock.module would assume the specifier was already resolved.

For example: `mock.module("./foo", () => ({ bar: 42 }))` would only load successfully if `foo` lived in the path `./dir/foo` (i.e. it did not automatically infer the file extension or otherwise go through module resolution).

This was very confusing because, if you happened to mock a module before it was ever imported, then it would behave as expected because module resolution for mocks happens before the rest of the module resolution code.

### How did you verify your code works?

Updated tests which newly failed