### PR TITLE
feat: Make using `await` inside a non-async function have a helpful error message

### DIFF
--- a/src/bun.js/BuildMessage.zig
+++ b/src/bun.js/BuildMessage.zig
@@ -27,6 +27,24 @@ pub const BuildMessage = struct {
         return null;
     }
 
+    pub fn getNotes(this: *BuildMessage, globalThis: *JSC.JSGlobalObject) callconv(.C) JSC.JSValue {
+        const notes: []const logger.Data = this.msg.notes orelse &[_]logger.Data{};
+        const array = JSC.JSValue.createEmptyArray(globalThis, notes.len);
+        for (notes, 0..) |note, i| {
+            const cloned = note.clone(bun.default_allocator) catch {
+                globalThis.throwOutOfMemory();
+                return .zero;
+            };
+            array.putIndex(
+                globalThis,
+                @intCast(i),
+                BuildMessage.create(globalThis, bun.default_allocator, logger.Msg{ .data = cloned, .kind = .note }),
+            );
+        }
+
+        return array;
+    }
+
     pub fn toStringFn(this: *BuildMessage, globalThis: *JSC.JSGlobalObject) JSC.JSValue {
         var text = std.fmt.allocPrint(default_allocator, "BuildMessage: {s}", .{this.msg.data.text}) catch {
             globalThis.throwOutOfMemory();

--- a/src/bun.js/resolve_message.classes.ts
+++ b/src/bun.js/resolve_message.classes.ts
@@ -78,6 +78,12 @@ export default [
         getter: "getPosition",
         cache: true,
       },
+
+      notes: {
+        getter: "getNotes",
+        cache: true,
+      },
+
       ["@@toPrimitive"]: {
         fn: "toPrimitive",
         length: 1,

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -517,7 +517,10 @@ pub const Msg = struct {
             for (notes) |*note| {
                 note.deinit(allocator);
             }
+
+            allocator.free(notes);
         }
+
         msg.notes = null;
     }
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2086,7 +2086,7 @@ describe("utimesSync", () => {
     expect(finalStats.atime).toEqual(prevAccessTime);
   });
 
-  it.only("works after 2038", () => {
+  it("works after 2038", () => {
     const tmp = join(tmpdir(), "utimesSync-test-file-" + Math.random().toString(36).slice(2));
     writeFileSync(tmp, "test");
     const prevStats = fs.statSync(tmp);


### PR DESCRIPTION
### What does this PR do?

Comparison:

<img width="455" alt="image" src="https://github.com/oven-sh/bun/assets/709451/0f91ece7-a587-4e22-a039-c0bef04dacd6">

Also:
- Adds `notes` as a getter on`BuildMessage`
- Frees the `notes` slice in `deinit`


### How did you verify your code works?

There are tests. Most of the parser changes were based on what esbuild does.