### PR TITLE
fix: convert http.Server to a function-style class

### DIFF
--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1615,7 +1615,7 @@ it("#6892", () => {
   }
 });
 
-it("#4415.1", () => {
+it("#4415.1 ServerResponse es6", () => {
   class Response extends ServerResponse {
     constructor(req) {
       super(req);
@@ -1626,7 +1626,7 @@ it("#4415.1", () => {
   expect(res.req).toBe(req);
 });
 
-it("#4415.2", () => {
+it("#4415.2 ServerResponse es5", () => {
   function Response(req) {
     ServerResponse.call(this, req);
   }
@@ -1634,4 +1634,27 @@ it("#4415.2", () => {
   const req = {};
   const res = new Response(req);
   expect(res.req).toBe(req);
+});
+
+it("#4415.3 Server es5", done => {
+  const server = Server((req, res) => {
+    res.end();
+  });
+  server.listen(0, async (_err, host, port) => {
+    try {
+      const res = await fetch(`http://localhost:${port}`);
+      expect(res.status).toBe(200);
+      done();
+    } catch (err) {
+      done(err);
+    } finally {
+      server.close();
+    }
+  });
+});
+
+it("#4415.4 IncomingMessage es5", () => {
+  const im = Object.create(IncomingMessage.prototype);
+  IncomingMessage.call(im, { url: "/foo" });
+  expect(im.url).toBe("/foo");
 });


### PR DESCRIPTION
### What does this PR do?

convert http.Server and http.IncomingMessage to es5 class

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

-->
- [X] I included a test for the new code, or existing tests cover it
- [X] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)


<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
