### PR TITLE
perf: More efficient `setTimeout` and `setInterval`

### DIFF
--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -3427,8 +3427,8 @@ pub const Timer = struct {
                 var timeout = Timeout{
                     .callback = JSC.Strong.create(callback, globalThis),
                     .globalThis = globalThis,
-                    .timer = uws.Timer.create(
-                        vm.uwsLoop(),
+                    .timer = Timeout.TimerReference.create(
+                        vm.eventLoop(),
                         id,
                     ),
                 };
@@ -3450,12 +3450,7 @@ pub const Timer = struct {
 
                 map.put(vm.allocator, this.id, timeout) catch unreachable;
 
-                timeout.timer.set(
-                    id,
-                    Timeout.run,
-                    this.interval,
-                    @as(i32, @intFromBool(this.kind == .setInterval)) * this.interval,
-                );
+                timeout.timer.?.schedule(this.interval);
                 return this_value;
             }
             return JSValue.jsUndefined();
@@ -3503,11 +3498,106 @@ pub const Timer = struct {
     pub const Timeout = struct {
         callback: JSC.Strong = .{},
         globalThis: *JSC.JSGlobalObject,
-        timer: *uws.Timer,
+        timer: ?*TimerReference = null,
         did_unref_timer: bool = false,
         poll_ref: Async.KeepAlive = Async.KeepAlive.init(),
         arguments: JSC.Strong = .{},
         has_scheduled_job: bool = false,
+
+        pub const TimerReference = struct {
+            id: ID = .{ .id = 0 },
+            cancelled: bool = false,
+
+            event_loop: *JSC.EventLoop,
+            timer: bun.io.Timer = .{
+                .tag = .TimerReference,
+                .next = std.mem.zeroes(std.os.timespec),
+            },
+            request: bun.io.Request = .{
+                .callback = &onRequest,
+            },
+            interval: i32 = -1,
+
+            fn onRequest(req: *bun.io.Request) bun.io.Action {
+                var this: *TimerReference = @fieldParentPtr(TimerReference, "request", req);
+                if (this.timer.state == .CANCELLED) {
+                    this.deinit();
+                    return bun.io.Action{
+                        .timer_cancelled = {},
+                    };
+                }
+                return bun.io.Action{
+                    .timer = &this.timer,
+                };
+            }
+
+            pub fn callback(this: *TimerReference) bun.io.Timer.Arm {
+                this.event_loop.enqueueTaskConcurrent(JSC.ConcurrentTask.create(JSC.Task.init(this)));
+
+                // TODO:
+                return .{ .disarm = {} };
+            }
+
+            pub fn runFromJSThread(this: *TimerReference) void {
+                const timer_id = this.id;
+                const vm = this.event_loop.virtual_machine;
+
+                if (this.cancelled) {
+                    this.deinit();
+                    return;
+                }
+                if (Timeout.runFromConcurrentTask(timer_id, vm) and !this.cancelled) {
+                    this.request = .{
+                        .callback = &onRequest,
+                    };
+                    this.schedule(null);
+                } else {
+                    this.deinit();
+                }
+            }
+
+            pub fn deinit(this: *TimerReference) void {
+                bun.default_allocator.destroy(this);
+            }
+
+            pub fn create(event_loop: *JSC.EventLoop, id: ID) *TimerReference {
+                const timer = bun.default_allocator.create(TimerReference) catch unreachable;
+                timer.* = .{
+                    .id = id,
+                    .event_loop = event_loop,
+                };
+                return timer;
+            }
+
+            pub fn schedule(this: *TimerReference, interval: ?i32) void {
+                std.debug.assert(!this.cancelled);
+                this.timer.state = .PENDING;
+                this.timer.next = msToTimespec(@intCast(@max(interval orelse this.interval, 1)));
+                bun.io.Loop.get().schedule(&this.request);
+            }
+
+            fn msToTimespec(ms: usize) std.os.timespec {
+                var now: std.os.timespec = undefined;
+                // std.time.Instant.now uses a different clock on macOS than monotonic
+                bun.io.Loop.updateTimespec(&now);
+
+                var increment = std.os.timespec{
+                    // nanosecond from ms milliseconds
+                    .tv_nsec = @intCast((ms % std.time.ms_per_s) *| std.time.ns_per_ms),
+                    .tv_sec = @intCast(ms / std.time.ms_per_s),
+                };
+
+                increment.tv_nsec +|= now.tv_nsec;
+                increment.tv_sec +|= now.tv_sec;
+
+                if (increment.tv_nsec >= std.time.ns_per_s) {
+                    increment.tv_nsec -= std.time.ns_per_s;
+                    increment.tv_sec +|= 1;
+                }
+
+                return increment;
+            }
+        };
 
         pub const Kind = enum(u32) {
             setTimeout,
@@ -3535,8 +3625,99 @@ pub const Timer = struct {
 
             // use the threadlocal despite being slow on macOS
             // to handle the timeout being cancelled after already enqueued
-            var vm = JSC.VirtualMachine.get();
+            const vm = JSC.VirtualMachine.get();
 
+            runWithIDAndVM(timer_id, vm);
+        }
+
+        pub fn runFromConcurrentTask(timer_id: ID, vm: *JSC.VirtualMachine) bool {
+            const repeats = timer_id.repeats();
+
+            var map = vm.timer.maps.get(timer_id.kind);
+
+            const this_: ?Timeout = map.get(
+                timer_id.id,
+            ) orelse return false;
+            var this = this_ orelse
+                return false;
+
+            const globalThis = this.globalThis;
+
+            // Disable thundering herd of setInterval() calls
+            // Skip setInterval() calls when the previous one has not been run yet.
+            if (repeats and this.has_scheduled_job) {
+                return false;
+            }
+
+            const cb: CallbackJob = .{
+                .callback = if (repeats)
+                    JSC.Strong.create(
+                        this.callback.get() orelse {
+                            // if the callback was freed, that's an error
+                            if (comptime Environment.allow_assert)
+                                unreachable;
+
+                            this.deinit();
+                            _ = map.swapRemove(timer_id.id);
+                            return false;
+                        },
+                        globalThis,
+                    )
+                else
+                    this.callback,
+                .arguments = if (repeats and this.arguments.has())
+                    JSC.Strong.create(
+                        this.arguments.get() orelse {
+                            // if the arguments freed, that's an error
+                            if (comptime Environment.allow_assert)
+                                unreachable;
+
+                            this.deinit();
+                            _ = map.swapRemove(timer_id.id);
+                            return false;
+                        },
+                        globalThis,
+                    )
+                else
+                    this.arguments,
+                .globalThis = globalThis,
+                .id = timer_id.id,
+                .kind = timer_id.kind,
+            };
+
+            var reschedule = false;
+            // This allows us to:
+            //  - free the memory before the job is run
+            //  - reuse the JSC.Strong
+            if (!repeats) {
+                this.callback = .{};
+                this.arguments = .{};
+                map.put(vm.allocator, timer_id.id, null) catch unreachable;
+                this.deinit();
+            } else {
+                this.has_scheduled_job = true;
+                map.put(vm.allocator, timer_id.id, this) catch {};
+                reschedule = true;
+            }
+
+            // TODO: remove this memory allocation!
+            var job = vm.allocator.create(CallbackJob) catch @panic(
+                "Out of memory while allocating Timeout",
+            );
+            job.* = cb;
+            job.task = CallbackJob.Task.init(job);
+            job.ref.ref(vm);
+
+            if (vm.isInspectorEnabled()) {
+                Debugger.didScheduleAsyncCall(globalThis, .DOMTimer, timer_id.asyncID(), !repeats);
+            }
+
+            job.perform();
+
+            return reschedule;
+        }
+
+        pub fn runWithIDAndVM(timer_id: ID, vm: *JSC.VirtualMachine) void {
             const repeats = timer_id.repeats();
 
             var map = vm.timer.maps.get(timer_id.kind);
@@ -3625,7 +3806,9 @@ pub const Timer = struct {
 
             this.poll_ref.unref(vm);
 
-            this.timer.deinit(false);
+            if (this.timer) |timer| {
+                timer.cancelled = true;
+            }
 
             if (comptime Environment.isPosix)
                 // balance double unreffing in doUnref
@@ -3683,8 +3866,8 @@ pub const Timer = struct {
         var timeout = Timeout{
             .callback = JSC.Strong.create(callback, globalThis),
             .globalThis = globalThis,
-            .timer = uws.Timer.create(
-                vm.uwsLoop(),
+            .timer = Timeout.TimerReference.create(
+                vm.eventLoop(),
                 Timeout.ID{
                     .id = id,
                     .kind = kind,
@@ -3703,15 +3886,7 @@ pub const Timer = struct {
             Debugger.didScheduleAsyncCall(globalThis, .DOMTimer, Timeout.ID.asyncID(.{ .id = id, .kind = kind }), !repeat);
         }
 
-        timeout.timer.set(
-            Timeout.ID{
-                .id = id,
-                .kind = kind,
-            },
-            Timeout.run,
-            interval,
-            @as(i32, @intFromBool(kind == .setInterval)) * interval,
-        );
+        timeout.timer.?.schedule(interval);
     }
 
     pub fn setImmediate(

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -272,8 +272,7 @@ JSC_DEFINE_HOST_FUNCTION(functionBunSleepThenCallback,
 {
     JSC::VM& vm = globalObject->vm();
 
-    RELEASE_ASSERT(callFrame->argumentCount() == 1);
-    JSPromise* promise = jsCast<JSC::JSPromise*>(callFrame->argument(0));
+    JSPromise* promise = jsDynamicCast<JSC::JSPromise*>(callFrame->argument(0));
     RELEASE_ASSERT(promise);
 
     promise->resolve(globalObject, JSC::jsUndefined());

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -339,6 +339,7 @@ const Lchmod = JSC.Node.Async.lchmod;
 const Lchown = JSC.Node.Async.lchown;
 const Unlink = JSC.Node.Async.unlink;
 const WaitPidResultTask = JSC.Subprocess.WaiterThread.WaitPidResultTask;
+const TimerReference = JSC.BunTimer.Timeout.TimerReference;
 // Task.get(ReadFileTask) -> ?ReadFileTask
 pub const Task = TaggedPointerUnion(.{
     FetchTasklet,
@@ -398,6 +399,7 @@ pub const Task = TaggedPointerUnion(.{
     Lchown,
     Unlink,
     WaitPidResultTask,
+    TimerReference,
 });
 const UnboundedQueue = @import("./unbounded_queue.zig").UnboundedQueue;
 pub const ConcurrentTask = struct {
@@ -919,6 +921,11 @@ pub const EventLoop = struct {
                     var any: *WaitPidResultTask = task.get(WaitPidResultTask).?;
                     any.runFromJSThread();
                 },
+                @field(Task.Tag, typeBaseName(@typeName(TimerReference))) => {
+                    var any: *TimerReference = task.get(TimerReference).?;
+                    any.runFromJSThread();
+                },
+
                 else => if (Environment.allow_assert) {
                     bun.Output.prettyln("\nUnexpected tag: {s}\n", .{@tagName(task.tag())});
                 } else {

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -92,6 +92,8 @@ pub const Loop = struct {
             @compileError("Epoll is Linux-Only");
         }
 
+        this.updateNow();
+
         while (true) {
 
             // Process pending requests
@@ -127,22 +129,12 @@ pub const Loop = struct {
                             this.active -= 1;
                             close.onDone(close.ctx);
                         },
+                        .timer_cancelled => {},
                         .timer => |timer| {
                             while (true) {
                                 switch (timer.state) {
                                     .PENDING => {
                                         timer.state = .ACTIVE;
-                                        if (Timer.less({}, timer, &.{ .next = this.cached_now })) {
-                                            if (timer.fire() == .rearm) {
-                                                if (timer.reset) |reset| {
-                                                    timer.next = reset;
-                                                    timer.reset = null;
-                                                    continue;
-                                                }
-                                            }
-
-                                            break;
-                                        }
                                         this.timers.insert(timer);
                                     },
                                     .ACTIVE => {
@@ -174,7 +166,9 @@ pub const Loop = struct {
                     @as(u64, @intCast(this.cached_now.tv_nsec)) / std.time.ns_per_ms;
                 const ms_next = @as(u64, @intCast(t.next.tv_sec)) * std.time.ms_per_s +
                     @as(u64, @intCast(t.next.tv_nsec)) / std.time.ns_per_ms;
-                break :timeout @as(i32, @intCast(ms_next -| ms_now));
+                const out = @as(i32, @intCast(ms_next -| ms_now));
+
+                break :timeout @max(out, 0);
             };
 
             var events: [256]EventType = undefined;
@@ -230,6 +224,8 @@ pub const Loop = struct {
             @compileError("Kqueue is MacOS-Only");
         }
 
+        this.updateNow();
+
         while (true) {
             var stack_fallback = std.heap.stackFallback(@sizeOf([256]EventType), bun.default_allocator);
             var events_list: std.ArrayList(EventType) = std.ArrayList(EventType).initCapacity(stack_fallback.get(), 256) catch unreachable;
@@ -270,6 +266,7 @@ pub const Loop = struct {
                                 &events_list.items.ptr[i],
                             );
                         },
+
                         .close => |close| {
                             if (close.poll.flags.contains(.poll_readable) or close.poll.flags.contains(.poll_writable)) {
                                 const i = events_list.items.len;
@@ -285,22 +282,12 @@ pub const Loop = struct {
                             }
                             close.onDone(close.ctx);
                         },
+                        .timer_cancelled => {},
                         .timer => |timer| {
                             while (true) {
                                 switch (timer.state) {
                                     .PENDING => {
                                         timer.state = .ACTIVE;
-                                        if (Timer.less({}, timer, &.{ .next = this.cached_now })) {
-                                            if (timer.fire() == .rearm) {
-                                                if (timer.reset) |reset| {
-                                                    timer.next = reset;
-                                                    timer.reset = null;
-                                                    continue;
-                                                }
-                                            }
-
-                                            break;
-                                        }
                                         this.timers.insert(timer);
                                     },
                                     .ACTIVE => {
@@ -330,6 +317,15 @@ pub const Loop = struct {
                 var out: std.os.timespec = undefined;
                 out.tv_sec = t.next.tv_sec -| this.cached_now.tv_sec;
                 out.tv_nsec = t.next.tv_nsec -| this.cached_now.tv_nsec;
+
+                if (out.tv_nsec < 0) {
+                    out.tv_sec -= 1;
+                    out.tv_nsec += std.time.ns_per_s;
+                }
+
+                if (out.tv_sec < 0) {
+                    break :timeout null;
+                }
 
                 break :timeout out;
             };
@@ -390,11 +386,15 @@ pub const Loop = struct {
     }
 
     fn updateNow(this: *Loop) void {
+        updateTimespec(&this.cached_now);
+    }
+
+    pub fn updateTimespec(timespec: *os.timespec) void {
         if (comptime Environment.isLinux) {
-            const rc = linux.clock_gettime(linux.CLOCK.MONOTONIC, &this.cached_now);
+            const rc = linux.clock_gettime(linux.CLOCK.MONOTONIC, timespec);
             assert(rc == 0);
         } else if (comptime Environment.isMac) {
-            std.os.clock_gettime(std.os.CLOCK.MONOTONIC, &this.cached_now) catch {};
+            std.os.clock_gettime(std.os.CLOCK.MONOTONIC, timespec) catch {};
         } else {
             @compileError("TODO: implement poll for this platform");
         }
@@ -416,6 +416,7 @@ pub const Action = union(enum) {
     writable: FileAction,
     close: CloseAction,
     timer: *Timer,
+    timer_cancelled: void,
 
     pub const FileAction = struct {
         fd: bun.FileDescriptor,
@@ -482,6 +483,8 @@ const Pollable = struct {
     }
 };
 
+const TimerReference = bun.JSC.BunTimer.Timeout.TimerReference;
+
 pub const Timer = struct {
     /// The absolute time to fire this timer next.
     next: os.timespec,
@@ -501,10 +504,12 @@ pub const Timer = struct {
 
     pub const Tag = enum {
         TimerCallback,
+        TimerReference,
 
         pub fn Type(comptime T: Tag) type {
             return switch (T) {
                 .TimerCallback => TimerCallback,
+                .TimerReference => TimerReference,
             };
         }
     };
@@ -557,9 +562,25 @@ pub const Timer = struct {
     };
 
     pub fn fire(this: *Timer) Arm {
+        if (comptime Environment.allow_assert) {
+            if (comptime Environment.isPosix) {
+                const timer = std.time.Instant{ .timestamp = this.next };
+                var now = std.time.Instant{ .timestamp = undefined };
+                Loop.updateTimespec(&now.timestamp);
+
+                if (timer.order(now) != .lt) {
+                    bun.Output.panic("Timer fired {} too early", .{bun.fmt.fmtDuration(timer.since(now))});
+                }
+            }
+        }
+
         switch (this.tag) {
             inline else => |t| {
                 var container: *t.Type() = @fieldParentPtr(t.Type(), "timer", this);
+                if (comptime @hasDecl(t.Type(), "callback")) {
+                    return container.callback();
+                }
+
                 return container.callback(container);
             },
         }

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -498,20 +498,19 @@ for (let [gcTick, label] of [
 if (!process.env.BUN_FEATURE_FLAG_FORCE_WAITER_THREAD) {
   it("with BUN_FEATURE_FLAG_FORCE_WAITER_THREAD", async () => {
     const result = spawnSync({
-      cmd: [bunExe(), "test", import.meta.path],
+      cmd: [bunExe(), "test", path.resolve(import.meta.path)],
       env: {
         ...bunEnv,
         // Both flags are necessary to force this condition
         "BUN_FEATURE_FLAG_FORCE_WAITER_THREAD": "1",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "1",
       },
+      stderr: "inherit",
+      stdout: "inherit",
+      stdin: "inherit",
     });
-    if (result.exitCode !== 0) {
-      console.error(result.stderr.toString());
-      console.log(result.stdout.toString());
-    }
     expect(result.exitCode).toBe(0);
-  }, 60_000);
+  }, 128_000);
 }
 
 describe("spawn unref and kill should not hang", () => {


### PR DESCRIPTION
### What does this PR do?

This makes timers much more efficient by using a timer heap instead of a timerfd

On Linux, this is about an 8x improvement on the below benchmark which schedules 20,000 timers simultaneously. On macOS, it's 5.6x.

<img width="416" alt="image" src="https://github.com/oven-sh/bun/assets/709451/d6557d03-2605-41a5-b340-214614aae24a">

We are not yet faster than Node on this. I think there is 1 more kind of coalescing to do. 

Benchmark:
```js
const maxPerBatch = 1024 * 20;
const total = 1_000_000;

var ran = 0;
const noop = function () {
  ran++;

  if (ran > maxPerBatch - 1 && ran % maxPerBatch === 0) {
    if (ran >= total) {
      console.log(`Executed ${ran} timers in`, performance.now(), "ms");
      return;
    }

    for (let i = 0; i < maxPerBatch; i++) {
      setTimeout(noop, 0);
    }
  }
};

for (let j = 0; j < maxPerBatch; j++) {
  setTimeout(noop, 0);
}
```

### How did you verify your code works?

Existing tests