### PR TITLE
Make large stdio in Bun.spawnSync efficient on Linux

### DIFF
--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -402,6 +402,48 @@ pub const ArrayBuffer = extern struct {
 
     extern fn JSBuffer__fromMmap(*JSC.JSGlobalObject, addr: *anyopaque, len: usize) JSC.JSValue;
 
+    // 4 MB or so is pretty good for mmap()
+    const mmap_threshold = 1024 * 1024 * 4;
+
+    /// Only use this when reading from the file descriptor is _very_ cheap. Like, for example, an in-memory file descriptor.
+    /// Do not use this for pipes, however tempting it may seem.
+    pub fn toJSBufferFromFd(fd: bun.FileDescriptor, size: usize, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
+        const buffer_value = Bun__createUint8ArrayForCopy(globalObject, null, size, true);
+        if (buffer_value == .zero) {
+            return .zero;
+        }
+
+        var array_buffer = buffer_value.asArrayBuffer(globalObject) orelse @panic("Unexpected");
+        var bytes = array_buffer.byteSlice();
+
+        buffer_value.ensureStillAlive();
+
+        var read: isize = 0;
+        while (bytes.len > 0) {
+            switch (bun.sys.pread(fd, bytes, read)) {
+                .result => |amount| {
+                    bytes = bytes[amount..];
+                    read += @intCast(amount);
+
+                    if (amount == 0) {
+                        if (bytes.len > 0) {
+                            @memset(bytes, 0);
+                        }
+                        break;
+                    }
+                },
+                .err => |err| {
+                    globalObject.throwValue(err.toJSC(globalObject));
+                    return .zero;
+                },
+            }
+        }
+
+        buffer_value.ensureStillAlive();
+
+        return buffer_value;
+    }
+
     pub fn toJSBufferFromMemfd(fd: bun.FileDescriptor, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
         const stat = switch (bun.sys.fstat(fd)) {
             .err => |err| {
@@ -417,6 +459,16 @@ pub const ArrayBuffer = extern struct {
         if (size == 0) {
             _ = bun.sys.close(fd);
             return createBuffer(globalObject, "");
+        }
+
+        // mmap() is kind of expensive to do
+        // It creates a new memory mapping.
+        // If there is a lot of repetitive memory allocations in a tight loop, it performs poorly.
+        // So we clone it when it's small.
+        if (size < mmap_threshold) {
+            const result = toJSBufferFromFd(fd, @intCast(size), globalObject);
+            _ = bun.sys.close(fd);
+            return result;
         }
 
         const result = bun.sys.mmap(null, @intCast(@max(size, 0)), std.os.PROT.READ | std.os.PROT.WRITE, std.os.MAP.SHARED | 0, fd, 0);

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -1660,14 +1660,14 @@ extern "C" JSC::EncodedJSValue JSBuffer__fromMmap(Zig::GlobalObject* globalObjec
         munmap(p, length);
     }));
 
-    auto* buffer = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, WTFMove(buffer), 0, length);
+    auto* view = JSC::JSUint8Array::create(globalObject, structure, WTFMove(buffer), 0, length);
 
-    if (UNLIKELY(!buffer)) {
+    if (UNLIKELY(!view)) {
         throwOutOfMemoryError(globalObject, scope);
         return JSC::JSValue::encode(jsUndefined());
     }
 
-    return JSC::JSValue::encode(buffer);
+    return JSC::JSValue::encode(view);
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsBufferConstructorFunction_alloc, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1494,7 +1494,7 @@ extern "C" JSC__JSValue Bun__createUint8ArrayForCopy(JSC::JSGlobalObject* global
         return JSC::JSValue::encode(JSC::JSValue {});
     }
 
-    if (len > 0)
+    if (len > 0 && ptr != nullptr)
         memcpy(array->vector(), ptr, len);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(array));

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1231,7 +1231,7 @@ pub fn getFdPath(fd: bun.FileDescriptor, out_buffer: *[MAX_PATH_BYTES]u8) Maybe(
 /// Use of a mapped region can result in these signals:
 /// * SIGSEGV - Attempted write into a region mapped as read-only.
 /// * SIGBUS - Attempted  access to a portion of the buffer that does not correspond to the file
-fn mmap(
+pub fn mmap(
     ptr: ?[*]align(mem.page_size) u8,
     length: usize,
     prot: u32,


### PR DESCRIPTION
### What does this PR do?

This makes spawnSync efficient on Linux when the output or input is large amounts of data. It leverages an in-memory file descriptor to avoid cloning and buffering via pipes

<img width="623" alt="image" src="https://github.com/oven-sh/bun/assets/709451/4478140c-0e61-4711-a282-a286410bfda1">

Microbenchmark:
```js
const { spawnSync } = require("node:child_process");
const runs = 5;

console.time("cat 1 GB file x " + runs);
for (let i = 0; i < runs; i++) {
  const { stdout } = spawnSync("cat", ["1gig.file"], {
    maxBuffer: Infinity,
    stdout: "pipe",
    encoding: "buffer",
  });
  // access the file somehow
  if (stdout.byteLength < 1024 * 1024 * 1024) {
    throw new Error("Expected huge file");
  }

}
console.timeEnd("cat 1 GB file x " + runs);
console.log("RSS", (process.memoryUsage.rss() / 1024 / 1024) | 0, "MB");
```


Write a 1 gigabyte file:
```js
const buffer = Buffer.allocUnsafe(1024 * 1024 * 1024);

for (let i= 0; i < 256; i++) {
    buffer[i] = i;
}

// fill the buffer with values from 0-255 
for (let i = 0; i < buffer.length; i+= 255) {
    buffer.copyWithin(i, 0, 255);
}

await Bun.write("./2mb.file", buffer);

```

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
