### PR TITLE
fix: renaming `strings. endsWithChar` to be more consistant + fix crash in `bun init`

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -811,7 +811,7 @@ pub const RunCommand = struct {
                                 if (!has_copied) {
                                     bun.copy(u8, &path_buf, value.dir);
                                     dir_slice = path_buf[0..value.dir.len];
-                                    if (!strings.endsWithChar(value.dir, std.fs.path.sep)) {
+                                    if (!strings.endsWithCharOrIsZeroLength(value.dir, std.fs.path.sep)) {
                                         dir_slice = path_buf[0 .. value.dir.len + 1];
                                     }
                                     has_copied = true;

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -1753,7 +1753,7 @@ pub const ESModule = struct {
                         log.addNoteFmt("Substituted \"{s}\" for \"*\" in \".{s}\" to get \".{s}\" ", .{ subpath, resolved_target, result });
                     }
 
-                    const status: Status = if (strings.endsWithChar(result, '*') and strings.indexOfChar(result, '*').? == result.len - 1)
+                    const status: Status = if (strings.endsWithCharOrIsZeroLength(result, '*') and strings.indexOfChar(result, '*').? == result.len - 1)
                         .ExactEndsWithStar
                     else
                         .Exact;
@@ -1937,7 +1937,7 @@ pub const ESModule = struct {
         if (match_obj.data != .map) return null;
         const map = match_obj.data.map;
 
-        if (!strings.endsWithChar(query, "*")) {
+        if (!strings.endsWithCharOrIsZeroLength(query, "*")) {
             var slices = map.list.slice();
             const keys = slices.items(.key);
             const values = slices.items(.value);
@@ -1949,7 +1949,7 @@ pub const ESModule = struct {
         }
 
         for (map.expansion_keys) |expansion| {
-            if (strings.endsWithChar(expansion.key, '*')) {
+            if (strings.endsWithCharOrIsZeroLength(expansion.key, '*')) {
                 if (r.resolveTargetReverse(query, expansion.key, expansion.value, .pattern)) |result| {
                     return result;
                 }

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -713,6 +713,10 @@ pub inline fn startsWithChar(self: string, char: u8) bool {
 }
 
 pub inline fn endsWithChar(self: string, char: u8) bool {
+    return self.len > 0 and self[self.len - 1] == char;
+}
+
+pub inline fn endsWithCharOrIsZeroLength(self: string, char: u8) bool {
     return self.len == 0 or self[self.len - 1] == char;
 }
 

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -6,12 +6,51 @@ import { bunExe, bunEnv } from "harness";
 test("bun init works", () => {
   const temp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bun-init-X")));
 
-  Bun.spawnSync({
+  const out = Bun.spawnSync({
     cmd: [bunExe(), "init", "-y"],
     cwd: temp,
     stdio: ["ignore", "inherit", "inherit"],
     env: bunEnv,
   });
+
+  expect(out.signal).toBe(undefined);
+  expect(out.exitCode).toBe(0);
+
+  const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
+  expect(pkg).toEqual({
+    "name": path.basename(temp).toLowerCase(),
+    "module": "index.ts",
+    "type": "module",
+    "devDependencies": {
+      "bun-types": "latest",
+    },
+    "peerDependencies": {
+      "typescript": "^5.0.0",
+    },
+  });
+  const readme = fs.readFileSync(path.join(temp, "README.md"), "utf8");
+  expect(readme).toStartWith("# " + path.basename(temp).toLowerCase() + "\n");
+  expect(readme).toInclude("v" + Bun.version.replaceAll("-debug", ""));
+  expect(readme).toInclude("index.ts");
+
+  expect(fs.existsSync(path.join(temp, "index.ts"))).toBe(true);
+  expect(fs.existsSync(path.join(temp, ".gitignore"))).toBe(true);
+  expect(fs.existsSync(path.join(temp, "node_modules"))).toBe(true);
+  expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+}, 30_000);
+
+test("bun init with piped cli", () => {
+  const temp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bun-init-X")));
+
+  const out = Bun.spawnSync({
+    cmd: [bunExe(), "init"],
+    cwd: temp,
+    stdio: [new Blob(["\n\n\n\n\n\n\n\n\n\n\n\n"]), "inherit", "inherit"],
+    env: bunEnv,
+  });
+
+  expect(out.signal).toBe(undefined);
+  expect(out.exitCode).toBe(0);
 
   const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
   expect(pkg).toEqual({


### PR DESCRIPTION
### What does this PR do?

I have totally written some more incorrect code assuming this `endsWithChar` does not include an empty string. imo this is a useless function as startsWith doesnt work this way, JS spec startsWith/endsWith doesnt work like this, and even *webkit's WTF::String* does not work like this.

![image](https://github.com/oven-sh/bun/assets/24465214/5c501067-bcce-4594-b924-5b6f06d04536)

i rename this to a more annoying function name:

<img width="656" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/e326f6bc-14ab-4718-b56f-04c962157204">

i dont know if we need it, but to retain compatibility i have moved most usages of the old function to this new name


<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

i wrote a test using `bun init` on piped \n\n\n\n\n\n input. it will segfault on canary due to unchecked access on invalid memory.
