### PR TITLE
Handle holey arrays console log edge case

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -2348,19 +2348,18 @@ pub const ZigConsoleClient = struct {
                             }
 
                             if (empty_start) |empty| {
+                                if (empty > 0) {
+                                    this.printComma(Writer, writer_, enable_ansi_colors) catch unreachable;
+                                    if (this.ordered_properties or this.goodTimeForANewLine()) {
+                                        was_good_time = true;
+                                        writer.writeAll("\n");
+                                        this.writeIndent(Writer, writer_) catch unreachable;
+                                    } else {
+                                        writer.space();
+                                    }
+                                }
                                 const empty_count = i - empty;
                                 if (empty_count == 1) {
-                                    if (i > 1) {
-                                        this.printComma(Writer, writer_, enable_ansi_colors) catch unreachable;
-                                        if (this.ordered_properties or this.goodTimeForANewLine()) {
-                                            was_good_time = true;
-                                            writer.writeAll("\n");
-                                            this.writeIndent(Writer, writer_) catch unreachable;
-                                        } else {
-                                            writer.space();
-                                        }
-                                    }
-
                                     writer.pretty("<r><d>empty item<r>", enable_ansi_colors, .{});
                                 } else {
                                     this.estimated_line_length += bun.fmt.fastDigitCount(empty_count);

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -145,6 +145,7 @@ myCustomName {
 [ 1, 2, empty item ]
 [ 1, 2, 3 ]
 [ 2 x empty items, 3 ]
+[ 1, 2 x empty items ]
 [
   1, 2, empty item, 4, 38 x empty items
 ]

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -124,6 +124,7 @@ console.log(hole([1, 2, 3], 1));
 console.log(hole([1, 2, 3], 0, 1));
 console.log(hole([1, 2, 3], 0, 1, 2));
 console.log(hole([1, 2, 3], 2));
+console.log(hole([1, 2, 3], 0));
 
 {
   const overriddenArray = [1, 2, 3, 4];


### PR DESCRIPTION
Closes #7567

", " was only being written when appropriate before "empty item", and not "N x empty items".

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

This fixes the aforementioned bug, and adds a line to the corresponding JS test.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
