### PR TITLE
Remove "not production ready" from WebSocket

### DIFF
--- a/docs/runtime/web-apis.md
+++ b/docs/runtime/web-apis.md
@@ -32,7 +32,7 @@ The following Web APIs are partially or completely supported.
 ---
 
 - WebSockets
-- [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) (_not production ready_)
+- [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

This removes the "not production ready" text from the Web APIs page, as the WebSocket API was marked as stable as of Bun v1.0.15.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

Only changed docs.