### PR TITLE
Fixes #7740: Change "Duplicate dependency" to warn instead of error

### DIFF
--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -3499,7 +3499,7 @@ pub const Package = extern struct {
                         .location = logger.Location.initOrNull(&source, source.rangeOfString(entry.value_ptr.*)),
                     };
 
-                    try log.addRangeErrorFmtWithNotes(
+                    try log.addRangeWarningFmtWithNotes(
                         &source,
                         source.rangeOfString(key_loc),
                         lockfile.allocator,

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -1115,6 +1115,16 @@ pub const Log = struct {
         });
     }
 
+    pub fn addRangeWarningFmtWithNotes(log: *Log, source: ?*const Source, r: Range, allocator: std.mem.Allocator, notes: []Data, comptime fmt: string, args: anytype) !void {
+        @setCold(true);
+        log.errors += 1;
+        try log.addMsg(.{
+            .kind = .warn,
+            .data = try rangeData(source, r, allocPrint(allocator, fmt, args) catch unreachable).cloneLineText(log.clone_line_text, log.msgs.allocator),
+            .notes = notes,
+        });
+    }
+
     pub fn addRangeErrorFmtWithNote(
         log: *Log,
         source: ?*const Source,

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -1117,7 +1117,7 @@ pub const Log = struct {
 
     pub fn addRangeWarningFmtWithNotes(log: *Log, source: ?*const Source, r: Range, allocator: std.mem.Allocator, notes: []Data, comptime fmt: string, args: anytype) !void {
         @setCold(true);
-        log.errors += 1;
+        log.warnings += 1;
         try log.addMsg(.{
             .kind = .warn,
             .data = try rangeData(source, r, allocPrint(allocator, fmt, args) catch unreachable).cloneLineText(log.clone_line_text, log.msgs.allocator),

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -7123,7 +7123,7 @@ it("should not override npm dependency by workspace with mismatched version", as
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
   expect(err).not.toContain("Saved lockfile");
-  expect(err).toContain('error: Duplicate dependency: "bar" specified in package.json');
+  expect(err).toContain('warn: Duplicate dependency: "bar" specified in package.json');
   expect(stdout).toBeDefined();
   expect(await new Response(stdout).text()).toBeEmpty();
   expect(await exited).toBe(1);

--- a/test/regression/issue/07740.test.ts
+++ b/test/regression/issue/07740.test.ts
@@ -9,8 +9,8 @@ it("duplicate dependencies should warn instead of error", () => {
     },
     dependencies: {
       "empty-package-for-bun-test-runner": "1.0.0"
-    }
-  })
+    },
+  });
 
   const dir = tempDirWithFiles("07740", {
     "package.json": package_json,

--- a/test/regression/issue/07740.test.ts
+++ b/test/regression/issue/07740.test.ts
@@ -1,0 +1,35 @@
+import { stderr } from "bun";
+import { bunEnv } from "harness";
+import { bunExe } from "harness";
+import { bun, bunRunAsScript, tempDirWithFiles } from "harness"
+
+it("duplicate dependencies should warn instead of error", () => {
+    const package_json = JSON.stringify({
+        devDependencies: {
+            vuex: "3.6.2"
+        },
+        dependencies: {
+            vuex: "3.6.2"
+        }
+    })
+
+    const dir = tempDirWithFiles('07740', {
+        'package.json': package_json,
+    });
+
+    const proc = Bun.spawnSync([bunExe(), 'install'], {
+        env: bunEnv,
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+
+    const [stdout, stderr] = [
+        proc.stdout.toString('utf-8').trim(),
+        proc.stderr.toString('utf-8').trim()
+    ]
+
+    expect(stderr).not.toContain("error: Duplicate dependency:");
+    expect(stderr).toContain("warn: Duplicate dependency");
+    expect(stdout).toEqual("");
+})

--- a/test/regression/issue/07740.test.ts
+++ b/test/regression/issue/07740.test.ts
@@ -5,12 +5,12 @@ import { tempDirWithFiles } from "harness";
 it("duplicate dependencies should warn instead of error", () => {
   const package_json = JSON.stringify({
     devDependencies: {
-      vuex: "3.6.2",
+      "empty-package-for-bun-test-runner": "1.0.0"
     },
     dependencies: {
-      vuex: "3.6.2",
-    },
-  });
+      "empty-package-for-bun-test-runner": "1.0.0"
+    }
+  })
 
   const dir = tempDirWithFiles("07740", {
     "package.json": package_json,

--- a/test/regression/issue/07740.test.ts
+++ b/test/regression/issue/07740.test.ts
@@ -1,29 +1,29 @@
 import { bunEnv } from "harness";
 import { bunExe } from "harness";
-import { tempDirWithFiles } from "harness"
+import { tempDirWithFiles } from "harness";
 
 it("duplicate dependencies should warn instead of error", () => {
-    const package_json = JSON.stringify({
-        devDependencies: {
-            vuex: "3.6.2"
-        },
-        dependencies: {
-            vuex: "3.6.2"
-        }
-    })
+  const package_json = JSON.stringify({
+    devDependencies: {
+      vuex: "3.6.2",
+    },
+    dependencies: {
+      vuex: "3.6.2",
+    },
+  });
 
-    const dir = tempDirWithFiles('07740', {
-        'package.json': package_json,
-    });
+  const dir = tempDirWithFiles("07740", {
+    "package.json": package_json,
+  });
 
-    const proc = Bun.spawnSync([bunExe(), 'install'], {
-        env: bunEnv,
-        cwd: dir,
-        stderr: "pipe",
-    });
+  const proc = Bun.spawnSync([bunExe(), "install"], {
+    env: bunEnv,
+    cwd: dir,
+    stderr: "pipe",
+  });
 
-    const stderr = proc.stderr.toString('utf-8').trim();
+  const stderr = proc.stderr.toString("utf-8").trim();
 
-    expect(stderr).not.toContain("error: Duplicate dependency:");
-    expect(stderr).toContain("warn: Duplicate dependency");
-})
+  expect(stderr).not.toContain("error: Duplicate dependency:");
+  expect(stderr).toContain("warn: Duplicate dependency");
+});

--- a/test/regression/issue/07740.test.ts
+++ b/test/regression/issue/07740.test.ts
@@ -1,7 +1,6 @@
-import { stderr } from "bun";
 import { bunEnv } from "harness";
 import { bunExe } from "harness";
-import { bun, bunRunAsScript, tempDirWithFiles } from "harness"
+import { tempDirWithFiles } from "harness"
 
 it("duplicate dependencies should warn instead of error", () => {
     const package_json = JSON.stringify({
@@ -20,16 +19,11 @@ it("duplicate dependencies should warn instead of error", () => {
     const proc = Bun.spawnSync([bunExe(), 'install'], {
         env: bunEnv,
         cwd: dir,
-        stdout: "pipe",
         stderr: "pipe",
     });
 
-    const [stdout, stderr] = [
-        proc.stdout.toString('utf-8').trim(),
-        proc.stderr.toString('utf-8').trim()
-    ]
+    const stderr = proc.stderr.toString('utf-8').trim();
 
     expect(stderr).not.toContain("error: Duplicate dependency:");
     expect(stderr).toContain("warn: Duplicate dependency");
-    expect(stdout).toEqual("");
 })


### PR DESCRIPTION
### What does this PR do?

- Fixes #7740 
- Add `addRangeWarningFmtWithNotes()` to `src/logger.zig`

### How did you verify your code works?

- Added a regression test covering this behaviour (`test/regression/issue/07740.test.ts`)
- Ran all regression tests to identify potential conflicts (none spotted)

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I included a test for the new code, or an existing test covers it
- [X] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [X] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)