### PR TITLE
feat: add `toBeObject`

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1270,6 +1270,15 @@ declare module "bun:test" {
      */
     toBeInteger(): void;
     /**
+     * Asserts that a value is an `object`.
+     *
+     * @example
+     * expect({}).toBeObject();
+     * expect("notAnObject").not.toBeObject();
+     * expect(NaN).not.toBeObject();
+     */
+    toBeObject(): void;
+    /**
      * Asserts that a value is a `number`, and is not `NaN` or `Infinity`.
      *
      * @example

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -2690,12 +2690,12 @@ pub const Expect = struct {
         const received = value.toFmt(globalThis, &formatter);
 
         if (not) {
-            const fmt = comptime getSignature("toBeObject", "", true) ++ "\n\n" ++ "Received: <red>{any}<r>\n";
+            const fmt = comptime getSignature("toBeObject", "", true) ++ "\n\nExpected value <b>not<r> to be an object" ++ "\n\nReceived: <red>{any}<r>\n";
             globalThis.throwPretty(fmt, .{received});
             return .zero;
         }
 
-        const fmt = comptime getSignature("toBeObject", "", false) ++ "\n\n" ++ "Received: <red>{any}<r>\n";
+        const fmt = comptime getSignature("toBeObject", "", false) ++ "\n\nExpected value to be an object" ++ "\n\nReceived: <red>{any}<r>\n";
         globalThis.throwPretty(fmt, .{received});
         return .zero;
     }

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -2679,7 +2679,7 @@ pub const Expect = struct {
         const thisValue = callFrame.this();
         const value: JSValue = this.getValue(globalThis, thisValue, "toBeObject", "") orelse return .zero;
 
-        active_test_expectation_counter.actual += 1;
+        incrementExpectCallCounter();
 
         const not = this.flags.not;
         const pass = value.isObject() != not;

--- a/src/bun.js/test/jest.classes.ts
+++ b/src/bun.js/test/jest.classes.ts
@@ -483,6 +483,10 @@ export default [
         fn: "toBeInteger",
         length: 0,
       },
+      toBeObject: {
+        fn: "toBeObject",
+        length: 0,
+      },
       toBeFinite: {
         fn: "toBeFinite",
         length: 0,

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3285,6 +3285,11 @@ describe("expect()", () => {
 
   test("toBeObject()", () => {
     expect({}).toBeObject();
+    expect(class A {}).toBeObject();
+    expect([]).toBeObject();
+    expect(new Set()).toBeObject();
+    expect(new Map()).toBeObject();
+    expect(new Array(0)).toBeObject();
     expect({e: 1, e2: 2}).toBeObject();
     expect("notAnObject").not.toBeObject();
     expect(1).not.toBeObject();

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3290,7 +3290,7 @@ describe("expect()", () => {
     expect(new Set()).toBeObject();
     expect(new Map()).toBeObject();
     expect(new Array(0)).toBeObject();
-    expect({e: 1, e2: 2}).toBeObject();
+    expect({ e: 1, e2: 2 }).toBeObject();
     expect("notAnObject").not.toBeObject();
     expect(1).not.toBeObject();
     expect(NaN).not.toBeObject();

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3283,6 +3283,15 @@ describe("expect()", () => {
     expect({}).not.toBeInteger();
   });
 
+  test("toBeObject()", () => {
+    expect({}).toBeObject();
+    expect({e: 1, e2: 2}).toBeObject();
+    expect("notAnObject").not.toBeObject();
+    expect(1).not.toBeObject();
+    expect(NaN).not.toBeObject();
+    expect(undefined).not.toBeObject();
+  });
+
   test("toBeFinite()", () => {
     expect(0).toBeFinite();
     expect(1).toBeFinite();


### PR DESCRIPTION
### What does this PR do?

Add `toBeObject` from https://github.com/oven-sh/bun/issues/1825


- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
 I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->


- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
