### PR TITLE
remove zig assert in bun setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -32,7 +32,6 @@ for type in CC CXX; do
   ) || fail "LLVM ${LLVM_VERSION} is required. Detected $type as '$compiler'"
 done
 
-has_exec "zig" || fail "'zig' is missing"
 has_exec "bun" || fail "you need an existing copy of 'bun' in your path to build bun"
 has_exec "cmake" || fail "'cmake' is missing"
 has_exec "ninja" || fail "'ninja' is missing"


### PR DESCRIPTION
### What does this PR do?

zig will be installed automatically later, so there is no need to block the script if the user does not have it installed.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I ran Bun setup without Zig installed

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
