### PR TITLE
Don't print the cd part of the create command's get started comment if the destination for create was `.`

### DIFF
--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1530,18 +1530,31 @@ pub const CreateCommand = struct {
             , .{create_react_app_entry_point_path});
         }
 
-        Output.pretty(
-            \\
-            \\<d>#<r><b> To get started, run:<r>
-            \\
-            \\  <b><cyan>cd {s}<r>
-            \\  <b><cyan>{s}<r>
-            \\
-            \\
-        , .{
-            filesystem.relativeTo(destination),
-            start_command,
-        });
+        if (destination != ".") {
+            Output.pretty(
+                \\
+                \\<d>#<r><b> To get started, run:<r>
+                \\
+                \\  <b><cyan>cd {s}<r>
+                \\  <b><cyan>{s}<r>
+                \\
+                \\
+            , .{
+                filesystem.relativeTo(destination),
+                start_command,
+            });
+        } else {
+            Output.pretty(
+                \\
+                \\<d>#<r><b> To get started, run:<r>
+                \\
+                \\  <b><cyan>{s}<r>
+                \\
+                \\
+            , .{
+                start_command,
+            });
+        }
 
         Output.flush();
 


### PR DESCRIPTION

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

The current message for getting started always includes a `cd` part, even when the directory you made the project into is `.`. It feels like it might make more sense not to show it in that case?

This is what I mean:

<img width="183" alt="image" src="https://github.com/oven-sh/bun/assets/722505/af6ae53f-2522-46b1-8021-b3917d88c208">

- [x] Code changes

### How did you verify your code works?

I did not write automated tests. I apologise. I was thinking about it and didn't know what to call the command with, maybe a minimal local template, made just for the test?