### PR TITLE
fs.readFile & fs.writeFile encoding + simplify string handling + fix memory leak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 cmake_policy(SET CMP0091 NEW)
 cmake_policy(SET CMP0067 NEW)
 
-set(Bun_VERSION "1.0.19")
+set(Bun_VERSION "1.0.20")
 set(WEBKIT_TAG b4de09f41b83e9e5c0e43ef414f1aee5968b6f7c)
 
 set(BUN_WORKDIR "${CMAKE_CURRENT_BINARY_DIR}")

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4144,8 +4144,12 @@ declare module "bun" {
 
     /**
      * Get the resource usage information of the process (max RSS, CPU time, etc)
+     *
+     * Only available after the process has exited
+     *
+     * If the process hasn't exited yet, this will return `undefined`
      */
-    stats(): ResourceUsage;
+    resourceUsage(): ResourceUsage | undefined;
   }
 
   /**
@@ -4163,6 +4167,10 @@ declare module "bun" {
     stderr: SpawnOptions.ReadableToSyncIO<Err>;
     exitCode: number;
     success: boolean;
+    /**
+     * Get the resource usage information of the process (max RSS, CPU time, etc)
+     */
+    resourceUsage: ResourceUsage;
   }
 
   /**

--- a/packages/bun-types/html-rewriter.d.ts
+++ b/packages/bun-types/html-rewriter.d.ts
@@ -117,5 +117,15 @@ declare class HTMLRewriter {
    * @param input - The HTML to transform
    * @returns A new {@link Response} with the transformed HTML
    */
-  transform(input: Response): Response;
+  transform(input: Response | Blob | Bun.BufferSource): Response;
+  /**
+   * @param input - The HTML string to transform
+   * @returns A new {@link String} containing the transformed HTML
+   */
+  transform(input: string): string;
+  /**
+   * @param input - The HTML to transform as a {@link ArrayBuffer}
+   * @returns A new {@link ArrayBuffer} with the transformed HTML
+   */
+  transform(input: ArrayBuffer): ArrayBuffer;
 }

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -827,14 +827,9 @@ pub const JSBundler = struct {
                     return;
                 }
             } else {
-                const buffer_or_string: JSC.Node.SliceOrBuffer = JSC.Node.SliceOrBuffer.fromJS(completion.globalThis, bun.default_allocator, source_code_value) orelse
-                    @panic("expected buffer or string");
-
-                const source_code = switch (buffer_or_string) {
-                    .buffer => |arraybuffer| bun.default_allocator.dupe(u8, arraybuffer.slice()) catch @panic("Out of memory in onLoad callback"),
-                    .string => |slice| (slice.cloneIfNeeded(bun.default_allocator) catch @panic("Out of memory in onLoad callback")).slice(),
-                };
-
+                const source_code = JSC.Node.StringOrBuffer.fromJSToOwnedSlice(completion.globalThis, source_code_value, bun.default_allocator) catch
+                // TODO:
+                    @panic("Unexpected: source_code is not a string");
                 this.value = .{
                     .success = .{
                         .loader = @as(options.Loader, @enumFromInt(@as(u8, @intCast(loader_as_int.to(i32))))),

--- a/src/bun.js/api/bun.classes.ts
+++ b/src/bun.js/api/bun.classes.ts
@@ -83,8 +83,8 @@ export default [
         fn: "doUnref",
         length: 0,
       },
-      stats: {
-        fn: "stats",
+      resourceUsage: {
+        fn: "resourceUsage",
         length: 0,
       },
       send: {

--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -956,8 +956,13 @@ fn getImportedStyles(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) callc
     return JSValue.createStringArray(globalObject, styles.ptr, styles.len, true);
 }
 
+extern fn dump_zone_malloc_stats() void;
+
 pub fn dump_mimalloc(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) callconv(.C) JSC.JSValue {
     globalObject.bunVM().arena.dumpStats();
+    if (comptime bun.is_heap_breakdown_enabled) {
+        dump_zone_malloc_stats();
+    }
     return .undefined;
 }
 

--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -1743,23 +1743,18 @@ pub const Crypto = struct {
                     return JSC.JSValue.undefined;
             }
 
-            var string_or_buffer = JSC.Node.SliceOrBuffer.fromJS(globalObject, bun.default_allocator, arguments[0]) orelse {
+            const password_to_hash = JSC.Node.StringOrBuffer.fromJSToOwnedSlice(globalObject, arguments[0], bun.default_allocator) catch {
                 globalObject.throwInvalidArgumentType("hash", "password", "string or TypedArray");
                 return JSC.JSValue.undefined;
             };
 
-            if (string_or_buffer.slice().len == 0) {
+            if (password_to_hash.len == 0) {
                 globalObject.throwInvalidArguments("password must not be empty", .{});
-                string_or_buffer.deinit();
+                bun.default_allocator.free(password_to_hash);
                 return JSC.JSValue.undefined;
             }
 
-            string_or_buffer.ensureCloned(bun.default_allocator) catch {
-                globalObject.throwOutOfMemory();
-                return JSC.JSValue.undefined;
-            };
-
-            return hash(globalObject, string_or_buffer.slice(), algorithm, false);
+            return hash(globalObject, password_to_hash, algorithm, false);
         }
 
         // Once we have bindings generator, this should be replaced with a generated function
@@ -1782,7 +1777,7 @@ pub const Crypto = struct {
                     return JSC.JSValue.undefined;
             }
 
-            var string_or_buffer = JSC.Node.SliceOrBuffer.fromJS(globalObject, bun.default_allocator, arguments[0]) orelse {
+            var string_or_buffer = JSC.Node.StringOrBuffer.fromJS(globalObject, bun.default_allocator, arguments[0]) orelse {
                 globalObject.throwInvalidArgumentType("hash", "password", "string or TypedArray");
                 return JSC.JSValue.undefined;
             };
@@ -1793,10 +1788,6 @@ pub const Crypto = struct {
                 return JSC.JSValue.undefined;
             }
 
-            string_or_buffer.ensureCloned(bun.default_allocator) catch {
-                globalObject.throwOutOfMemory();
-                return JSC.JSValue.undefined;
-            };
             defer string_or_buffer.deinit();
 
             return hash(globalObject, string_or_buffer.slice(), algorithm, true);
@@ -1920,40 +1911,28 @@ pub const Crypto = struct {
                 };
             }
 
-            var password = JSC.Node.SliceOrBuffer.fromJS(globalObject, bun.default_allocator, arguments[0]) orelse {
-                globalObject.throwInvalidArgumentType("verify", "password", "string or TypedArray");
+            const owned_password = JSC.Node.StringOrBuffer.fromJSToOwnedSlice(globalObject, arguments[0], bun.default_allocator) catch |err| {
+                if (err != error.JSError) globalObject.throwInvalidArgumentType("verify", "password", "string or TypedArray");
                 return JSC.JSValue.undefined;
             };
 
-            var hash_ = JSC.Node.SliceOrBuffer.fromJS(globalObject, bun.default_allocator, arguments[1]) orelse {
-                password.deinit();
-                globalObject.throwInvalidArgumentType("verify", "hash", "string or TypedArray");
+            const owned_hash = JSC.Node.StringOrBuffer.fromJSToOwnedSlice(globalObject, arguments[1], bun.default_allocator) catch |err| {
+                bun.default_allocator.free(owned_password);
+                if (err != error.JSError) globalObject.throwInvalidArgumentType("verify", "hash", "string or TypedArray");
                 return JSC.JSValue.undefined;
             };
 
-            if (hash_.slice().len == 0) {
-                password.deinit();
+            if (owned_hash.len == 0) {
+                bun.default_allocator.free(owned_password);
                 return JSC.JSPromise.resolvedPromiseValue(globalObject, JSC.JSValue.jsBoolean(false));
             }
 
-            if (password.slice().len == 0) {
-                hash_.deinit();
+            if (owned_password.len == 0) {
+                bun.default_allocator.free(owned_hash);
                 return JSC.JSPromise.resolvedPromiseValue(globalObject, JSC.JSValue.jsBoolean(false));
             }
 
-            password.ensureCloned(bun.default_allocator) catch {
-                hash_.deinit();
-                globalObject.throwOutOfMemory();
-                return JSC.JSValue.undefined;
-            };
-
-            hash_.ensureCloned(bun.default_allocator) catch {
-                password.deinit();
-                globalObject.throwOutOfMemory();
-                return JSC.JSValue.undefined;
-            };
-
-            return verify(globalObject, password.slice(), hash_.slice(), algorithm, false);
+            return verify(globalObject, owned_password, owned_hash, algorithm, false);
         }
 
         // Once we have bindings generator, this should be replaced with a generated function
@@ -1985,12 +1964,12 @@ pub const Crypto = struct {
                 };
             }
 
-            var password = JSC.Node.SliceOrBuffer.fromJS(globalObject, bun.default_allocator, arguments[0]) orelse {
+            var password = JSC.Node.StringOrBuffer.fromJS(globalObject, bun.default_allocator, arguments[0]) orelse {
                 globalObject.throwInvalidArgumentType("verify", "password", "string or TypedArray");
                 return JSC.JSValue.undefined;
             };
 
-            var hash_ = JSC.Node.SliceOrBuffer.fromJS(globalObject, bun.default_allocator, arguments[1]) orelse {
+            var hash_ = JSC.Node.StringOrBuffer.fromJS(globalObject, bun.default_allocator, arguments[1]) orelse {
                 password.deinit();
                 globalObject.throwInvalidArgumentType("verify", "hash", "string or TypedArray");
                 return JSC.JSValue.undefined;
@@ -2046,7 +2025,7 @@ pub const Crypto = struct {
         fn hashToEncoding(
             globalThis: *JSGlobalObject,
             evp: *EVP,
-            input: JSC.Node.SliceOrBuffer,
+            input: JSC.Node.StringOrBuffer,
             encoding: JSC.Node.Encoding,
         ) JSC.JSValue {
             var output_digest_buf: Digest = undefined;
@@ -2065,7 +2044,7 @@ pub const Crypto = struct {
         fn hashToBytes(
             globalThis: *JSGlobalObject,
             evp: *EVP,
-            input: JSC.Node.SliceOrBuffer,
+            input: JSC.Node.StringOrBuffer,
             output: ?JSC.ArrayBuffer,
         ) JSC.JSValue {
             var output_digest_buf: Digest = undefined;
@@ -2100,7 +2079,7 @@ pub const Crypto = struct {
         pub fn hash_(
             globalThis: *JSGlobalObject,
             algorithm: ZigString,
-            input: JSC.Node.SliceOrBuffer,
+            input: JSC.Node.StringOrBuffer,
             output: ?JSC.Node.StringOrBuffer,
         ) JSC.JSValue {
             var evp = EVP.byName(algorithm, globalThis) orelse {
@@ -2112,7 +2091,8 @@ pub const Crypto = struct {
             if (output) |string_or_buffer| {
                 switch (string_or_buffer) {
                     .string => |str| {
-                        const encoding = JSC.Node.Encoding.from(str) orelse {
+                        defer str.deinit();
+                        const encoding = JSC.Node.Encoding.from(str.slice()) orelse {
                             globalThis.throwInvalidArguments("Unknown encoding: {s}", .{str});
                             return JSC.JSValue.zero;
                         };
@@ -2169,7 +2149,7 @@ pub const Crypto = struct {
             const arguments = callframe.arguments(2);
             const input = arguments.ptr[0];
             const encoding = arguments.ptr[1];
-            const buffer = JSC.Node.SliceOrBuffer.fromJSWithEncoding(globalThis, globalThis.bunVM().allocator, input, encoding) orelse {
+            const buffer = JSC.Node.StringOrBuffer.fromJSWithEncodingValue(globalThis, globalThis.bunVM().allocator, input, encoding) orelse {
                 globalThis.throwInvalidArguments("expected string or buffer", .{});
                 return JSC.JSValue.zero;
             };
@@ -2201,7 +2181,7 @@ pub const Crypto = struct {
         pub fn digest_(
             this: *@This(),
             globalThis: *JSGlobalObject,
-            output: ?JSC.Node.SliceOrBuffer,
+            output: ?JSC.Node.StringOrBuffer,
         ) JSC.JSValue {
             if (output) |string_or_buffer| {
                 switch (string_or_buffer) {
@@ -2348,7 +2328,8 @@ pub const Crypto = struct {
                 if (output) |string_or_buffer| {
                     switch (string_or_buffer) {
                         .string => |str| {
-                            const encoding = JSC.Node.Encoding.from(str) orelse {
+                            defer str.deinit();
+                            const encoding = JSC.Node.Encoding.from(str.slice()) orelse {
                                 globalThis.throwInvalidArguments("Unknown encoding: {s}", .{str});
                                 return JSC.JSValue.zero;
                             };
@@ -2381,7 +2362,7 @@ pub const Crypto = struct {
             pub fn update(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) JSC.JSValue {
                 const thisValue = callframe.this();
                 const input = callframe.argument(0);
-                const buffer = JSC.Node.SliceOrBuffer.fromJS(globalThis, globalThis.bunVM().allocator, input) orelse {
+                const buffer = JSC.Node.StringOrBuffer.fromJS(globalThis, globalThis.bunVM().allocator, input) orelse {
                     globalThis.throwInvalidArguments("expected string or buffer", .{});
                     return JSC.JSValue.zero;
                 };
@@ -2393,7 +2374,7 @@ pub const Crypto = struct {
             pub fn digest_(
                 this: *@This(),
                 globalThis: *JSGlobalObject,
-                output: ?JSC.Node.SliceOrBuffer,
+                output: ?JSC.Node.StringOrBuffer,
             ) JSC.JSValue {
                 if (output) |string_or_buffer| {
                     switch (string_or_buffer) {

--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -2090,10 +2090,10 @@ pub const Crypto = struct {
 
             if (output) |string_or_buffer| {
                 switch (string_or_buffer) {
-                    .string => |str| {
+                    inline else => |*str| {
                         defer str.deinit();
                         const encoding = JSC.Node.Encoding.from(str.slice()) orelse {
-                            globalThis.throwInvalidArguments("Unknown encoding: {s}", .{str});
+                            globalThis.throwInvalidArguments("Unknown encoding: {s}", .{str.slice()});
                             return JSC.JSValue.zero;
                         };
 
@@ -2185,10 +2185,10 @@ pub const Crypto = struct {
         ) JSC.JSValue {
             if (output) |string_or_buffer| {
                 switch (string_or_buffer) {
-                    .string => |str| {
+                    inline else => |*str| {
                         defer str.deinit();
                         const encoding = JSC.Node.Encoding.from(str.slice()) orelse {
-                            globalThis.throwInvalidArguments("Unknown encoding: {}", .{str});
+                            globalThis.throwInvalidArguments("Unknown encoding: {}", .{str.*});
                             return JSC.JSValue.zero;
                         };
 
@@ -2327,10 +2327,10 @@ pub const Crypto = struct {
             ) JSC.JSValue {
                 if (output) |string_or_buffer| {
                     switch (string_or_buffer) {
-                        .string => |str| {
+                        inline else => |*str| {
                             defer str.deinit();
                             const encoding = JSC.Node.Encoding.from(str.slice()) orelse {
-                                globalThis.throwInvalidArguments("Unknown encoding: {s}", .{str});
+                                globalThis.throwInvalidArguments("Unknown encoding: {s}", .{str.slice()});
                                 return JSC.JSValue.zero;
                             };
 
@@ -2378,7 +2378,7 @@ pub const Crypto = struct {
             ) JSC.JSValue {
                 if (output) |string_or_buffer| {
                     switch (string_or_buffer) {
-                        .string => |str| {
+                        inline else => |str| {
                             const encoding = JSC.Node.Encoding.from(str.slice()) orelse {
                                 globalThis.throwInvalidArguments("Unknown encoding: \"{s}\"", .{str.slice()});
                                 return JSC.JSValue.zero;

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -2073,7 +2073,8 @@ fn NewSocket(comptime ssl: bool) type {
 
             var exception_ref = [_]JSC.C.JSValueRef{null};
             const exception: JSC.C.ExceptionRef = &exception_ref;
-            if (JSC.Node.StringOrBuffer.fromJS(globalObject, arena.allocator(), session_arg, exception)) |sb| {
+            if (JSC.Node.StringOrBuffer.fromJS(globalObject, arena.allocator(), session_arg)) |sb| {
+                defer sb.deinit();
                 const session_slice = sb.slice();
                 const ssl_ptr = this.socket.ssl();
                 var tmp = @as([*c]const u8, @ptrCast(session_slice.ptr));
@@ -2205,7 +2206,8 @@ fn NewSocket(comptime ssl: bool) type {
 
                 var exception_ref = [_]JSC.C.JSValueRef{null};
                 const exception: JSC.C.ExceptionRef = &exception_ref;
-                if (JSC.Node.StringOrBuffer.fromJS(globalObject, arena.allocator(), context_arg, exception)) |sb| {
+                if (JSC.Node.StringOrBuffer.fromJS(globalObject, arena.allocator(), context_arg)) |sb| {
+                    defer sb.deinit();
                     const context_slice = sb.slice();
 
                     const buffer_size = @as(usize, @intCast(length));

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -359,7 +359,8 @@ pub const ServerConfig = struct {
                         var valid_count: u32 = 0;
                         while (i < count) : (i += 1) {
                             const item = js_obj.getIndex(global, i);
-                            if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), item, exception)) |sb| {
+                            if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), item)) |sb| {
+                                defer sb.deinit();
                                 const sliced = sb.slice();
                                 if (sliced.len > 0) {
                                     native_array[valid_count] = bun.default_allocator.dupeZ(u8, sliced) catch unreachable;
@@ -407,7 +408,8 @@ pub const ServerConfig = struct {
                     }
                 } else {
                     const native_array = bun.default_allocator.alloc([*c]const u8, 1) catch unreachable;
-                    if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), js_obj, exception)) |sb| {
+                    if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), js_obj)) |sb| {
+                        defer sb.deinit();
                         const sliced = sb.slice();
                         if (sliced.len > 0) {
                             native_array[0] = bun.default_allocator.dupeZ(u8, sliced) catch unreachable;
@@ -442,7 +444,8 @@ pub const ServerConfig = struct {
             }
 
             if (obj.getTruthy(global, "ALPNProtocols")) |protocols| {
-                if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), protocols, exception)) |sb| {
+                if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), protocols)) |sb| {
+                    defer sb.deinit();
                     const sliced = sb.slice();
                     if (sliced.len > 0) {
                         result.protos = bun.default_allocator.dupeZ(u8, sliced) catch unreachable;
@@ -468,7 +471,8 @@ pub const ServerConfig = struct {
 
                         while (i < count) : (i += 1) {
                             const item = js_obj.getIndex(global, i);
-                            if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), item, exception)) |sb| {
+                            if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), item)) |sb| {
+                                defer sb.deinit();
                                 const sliced = sb.slice();
                                 if (sliced.len > 0) {
                                     native_array[valid_count] = bun.default_allocator.dupeZ(u8, sliced) catch unreachable;
@@ -516,7 +520,8 @@ pub const ServerConfig = struct {
                     }
                 } else {
                     const native_array = bun.default_allocator.alloc([*c]const u8, 1) catch unreachable;
-                    if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), js_obj, exception)) |sb| {
+                    if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), js_obj)) |sb| {
+                        defer sb.deinit();
                         const sliced = sb.slice();
                         if (sliced.len > 0) {
                             native_array[0] = bun.default_allocator.dupeZ(u8, sliced) catch unreachable;
@@ -574,7 +579,8 @@ pub const ServerConfig = struct {
 
                         while (i < count) : (i += 1) {
                             const item = js_obj.getIndex(global, i);
-                            if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), item, exception)) |sb| {
+                            if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), item)) |sb| {
+                                defer sb.deinit();
                                 const sliced = sb.slice();
                                 if (sliced.len > 0) {
                                     native_array[valid_count] = bun.default_allocator.dupeZ(u8, sliced) catch unreachable;
@@ -622,7 +628,8 @@ pub const ServerConfig = struct {
                     }
                 } else {
                     const native_array = bun.default_allocator.alloc([*c]const u8, 1) catch unreachable;
-                    if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), js_obj, exception)) |sb| {
+                    if (JSC.Node.StringOrBuffer.fromJS(global, arena.allocator(), js_obj)) |sb| {
+                        defer sb.deinit();
                         const sliced = sb.slice();
                         if (sliced.len > 0) {
                             native_array[0] = bun.default_allocator.dupeZ(u8, sliced) catch unreachable;

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -27,213 +27,77 @@ const TaggedPointerUnion = TaggedPointerTypes.TaggedPointerUnion;
 pub const ExceptionValueRef = [*c]js.JSValueRef;
 pub const JSValueRef = js.JSValueRef;
 
-fn ObjectPtrType(comptime Type: type) type {
-    if (Type == void) return Type;
-    return *Type;
-}
-
-const Internal = struct {
-    pub fn toJSWithType(globalThis: *JSC.JSGlobalObject, comptime Type: type, value: Type, exception: JSC.C.ExceptionRef) JSValue {
-        // TODO: refactor withType to use this instead of the other way around
-        return JSC.JSValue.c(To.JS.withType(Type, value, globalThis, exception));
-    }
-
-    pub fn toJS(globalThis: *JSC.JSGlobalObject, value: anytype, exception: JSC.C.ExceptionRef) JSValue {
-        return toJSWithType(globalThis, @TypeOf(value), value, exception);
-    }
+pub const Lifetime = enum {
+    allocated,
+    temporary,
 };
-
-pub usingnamespace Internal;
-
-pub const To = struct {
-    pub const Cpp = struct {
-        pub fn PropertyGetter(
-            comptime Type: type,
-        ) type {
-            return comptime fn (
-                this: ObjectPtrType(Type),
-                globalThis: *JSC.JSGlobalObject,
-            ) callconv(.C) JSC.JSValue;
+pub fn toJS(globalObject: *JSC.JSGlobalObject, comptime ValueType: type, value: ValueType, comptime lifetime: Lifetime) JSC.JSValue {
+    const Type = comptime brk: {
+        var CurrentType = ValueType;
+        if (@typeInfo(ValueType) == .Optional) {
+            CurrentType = @typeInfo(ValueType).Optional.child;
         }
-
-        const toJS = Internal.toJSWithType;
-
-        pub fn GetterFn(comptime Type: type, comptime decl: std.meta.DeclEnum(Type)) PropertyGetter(Type) {
-            return struct {
-                pub fn getter(
-                    this: ObjectPtrType(Type),
-                    globalThis: *JSC.JSGlobalObject,
-                ) callconv(.C) JSC.JSValue {
-                    var exception_ref = [_]JSC.C.JSValueRef{null};
-                    const exception: JSC.C.ExceptionRef = &exception_ref;
-                    const result = toJS(globalThis, @call(.auto, @field(Type, @tagName(decl)), .{this}), exception);
-                    if (exception.* != null) {
-                        globalThis.throwValue(JSC.JSValue.c(exception.*));
-                        return .zero;
-                    }
-
-                    return result;
-                }
-            }.getter;
-        }
+        break :brk if (@typeInfo(CurrentType) == .Pointer and @typeInfo(CurrentType).Pointer.size == .One)
+            @typeInfo(CurrentType).Pointer.child
+        else
+            CurrentType;
     };
-    pub const JS = struct {
-        pub fn withType(comptime Type: type, value: Type, context: JSC.C.JSContextRef, exception: JSC.C.ExceptionRef) JSC.C.JSValueRef {
-            return withTypeClone(Type, value, context, exception, false);
-        }
 
-        pub fn withTypeClone(comptime Type: type, value: Type, context: JSC.C.JSContextRef, exception: JSC.C.ExceptionRef, clone: bool) JSC.C.JSValueRef {
-            if (comptime bun.trait.isNumber(Type)) {
-                return JSC.JSValue.jsNumberWithType(Type, value).asRef();
+    if (comptime bun.trait.isNumber(Type)) {
+        return JSC.JSValue.jsNumberWithType(Type, if (comptime Type != ValueType) value.* else value);
+    }
+
+    switch (comptime Type) {
+        void => return .undefined,
+        bool => return JSC.JSValue.jsBoolean(if (comptime Type != ValueType) value.* else value),
+        *JSC.JSGlobalObject => return value.toJSValue(),
+        []const u8, [:0]const u8, [*:0]const u8, []u8, [:0]u8, [*:0]u8 => {
+            const str = bun.String.create(value);
+            defer str.deref();
+            return str.toJS(globalObject);
+        },
+        []const bun.String => {
+            defer {
+                for (value) |out| {
+                    out.deref();
+                }
+                bun.default_allocator.free(value);
+            }
+            return bun.String.toJSArray(globalObject, value);
+        },
+        JSC.JSValue => return if (Type != ValueType) value.* else value,
+
+        else => {
+
+            // Recursion can stack overflow here
+            if (bun.trait.isSlice(Type)) {
+                const Child = comptime std.meta.Child(Type);
+
+                var array = JSC.JSValue.createEmptyArray(globalObject, value.len);
+                for (value, 0..) |*item, i| {
+                    const res = toJS(globalObject, *Child, item, lifetime);
+                    if (res == .zero) return .zero;
+                    array.putIndex(
+                        globalObject,
+                        @truncate(i),
+                        res,
+                    );
+                }
+                return array;
             }
 
-            var zig_str: JSC.ZigString = undefined;
+            if (comptime @hasDecl(Type, "toJSNewlyCreated") and @typeInfo(@TypeOf(@field(Type, "toJSNewlyCreated"))).Fn.params.len == 2) {
+                return value.toJSNewlyCreated(globalObject);
+            }
 
-            return switch (comptime Type) {
-                void => JSC.C.JSValueMakeUndefined(context),
-                bool => JSC.C.JSValueMakeBoolean(context, value),
-                []const u8, [:0]const u8, [*:0]const u8, []u8, [:0]u8, [*:0]u8 => brk: {
-                    zig_str = ZigString.init(value);
-                    const val = zig_str.toValueAuto(context.ptr());
+            if (comptime @hasDecl(Type, "toJS") and @typeInfo(@TypeOf(@field(Type, "toJS"))).Fn.params.len == 2) {
+                return value.toJS(globalObject);
+            }
 
-                    break :brk val.asObjectRef();
-                },
-                []const JSC.ZigString => {
-                    const array = JSC.JSValue.createStringArray(context.ptr(), value.ptr, value.len, clone).asObjectRef();
-                    const values: []const JSC.ZigString = value;
-                    defer bun.default_allocator.free(values);
-                    if (clone) {
-                        for (values) |out| {
-                            if (out.isGloballyAllocated()) {
-                                out.deinitGlobal();
-                            }
-                        }
-                    }
-
-                    return array;
-                },
-                []const bun.String => {
-                    defer {
-                        for (value) |out| {
-                            out.deref();
-                        }
-                        bun.default_allocator.free(value);
-                    }
-                    return bun.String.toJSArray(context, value).asObjectRef();
-                },
-                []const PathString, []const []const u8, []const []u8, [][]const u8, [][:0]const u8, [][:0]u8 => {
-                    if (value.len == 0)
-                        return JSC.C.JSObjectMakeArray(context, 0, null, exception);
-
-                    var stack_fallback = std.heap.stackFallback(512, bun.default_allocator);
-                    var allocator = stack_fallback.get();
-
-                    var zig_strings = allocator.alloc(ZigString, value.len) catch unreachable;
-                    defer if (stack_fallback.fixed_buffer_allocator.end_index >= 511) allocator.free(zig_strings);
-
-                    for (value, 0..) |path_string, i| {
-                        if (comptime Type == []const PathString) {
-                            zig_strings[i] = ZigString.init(path_string.slice());
-                        } else {
-                            zig_strings[i] = ZigString.init(path_string);
-                        }
-                    }
-                    // there is a possible C ABI bug or something here when the ptr is null
-                    // it should not be segfaulting but it is
-                    // that's why we check at the top of this function
-                    const array = JSC.JSValue.createStringArray(context.ptr(), zig_strings.ptr, zig_strings.len, clone).asObjectRef();
-
-                    if (clone and value.len > 0) {
-                        for (value) |path_string| {
-                            if (comptime Type == []const PathString) {
-                                bun.default_allocator.free(path_string.slice());
-                            } else {
-                                bun.default_allocator.free(path_string);
-                            }
-                        }
-                        bun.default_allocator.free(value);
-                    }
-
-                    return array;
-                },
-
-                JSC.C.JSValueRef => value,
-
-                else => {
-                    const Info: std.builtin.Type = @typeInfo(Type);
-                    if (Info == .Enum) {
-                        const Enum: std.builtin.Type.Enum = Info.Enum;
-                        if (!bun.trait.isNumber(Enum.tag_type)) {
-                            @compileError("im curious if this ever gets hit. this feels like dead code");
-                            // zig_str = JSC.ZigString.init(@tagName(value));
-                            // return zig_str.toValue(context.ptr()).asObjectRef();
-                        }
-                    }
-
-                    // Recursion can stack overflow here
-                    if (bun.trait.isSlice(Type)) {
-                        const Child = comptime std.meta.Child(Type);
-
-                        var array = JSC.JSValue.createEmptyArray(context, value.len);
-                        for (value, 0..) |item, i| {
-                            array.putIndex(
-                                context,
-                                @truncate(i),
-                                JSC.JSValue.c(To.JS.withType(Child, item, context, exception)),
-                            );
-
-                            if (exception.* != null) {
-                                return null;
-                            }
-                        }
-                        return array.asObjectRef();
-                    }
-
-                    if (comptime bun.trait.isZigString(Type)) {
-                        zig_str = JSC.ZigString.init(value);
-                        return zig_str.toValue(context.ptr()).asObjectRef();
-                    }
-
-                    if (comptime Info == .Pointer) {
-                        const Child = std.meta.Child(Type);
-                        if (bun.trait.isContainer(Child) and @hasDecl(Child, "Class") and @hasDecl(Child.Class, "isJavaScriptCoreClass")) {
-                            return Child.Class.make(context, value);
-                        }
-                    }
-
-                    if (comptime Info == .Struct) {
-                        if (comptime @hasDecl(Type, "Class") and @hasDecl(Type.Class, "isJavaScriptCoreClass")) {
-                            if (comptime !@hasDecl(Type, "finalize")) {
-                                @compileError(std.fmt.comptimePrint("JSC class {s} must implement finalize to prevent memory leaks", .{Type.Class.name}));
-                            }
-
-                            if (comptime !@hasDecl(Type, "toJS")) {
-                                return Type.Class.make(context, bun.new(Type, value));
-                            }
-                        }
-                    }
-
-                    if (comptime @hasDecl(Type, "toJSNewlyCreated") and @typeInfo(@TypeOf(@field(Type, "toJSNewlyCreated"))).Fn.params.len == 2) {
-                        return value.toJSNewlyCreated(context).asObjectRef();
-                    }
-
-                    if (comptime @hasDecl(Type, "toJS") and @typeInfo(@TypeOf(@field(Type, "toJS"))).Fn.params.len == 2) {
-                        return value.toJS(context).asObjectRef();
-                    }
-
-                    const res = value.toJS(context, exception);
-
-                    if (@TypeOf(res) == JSC.C.JSValueRef) {
-                        return res;
-                    } else if (@TypeOf(res) == JSC.JSValue) {
-                        return res.asObjectRef();
-                    }
-                    @compileError("dont know how to convert " ++ @typeName(@TypeOf(res)) ++ " to JS");
-                },
-            };
-        }
-    };
-};
+            @compileError("dont know how to convert " ++ @typeName(ValueType) ++ " to JS");
+        },
+    }
+}
 
 pub const Properties = struct {
     pub const UTF8 = struct {
@@ -791,7 +655,18 @@ pub const MarkedArrayBuffer = struct {
         );
     }
 
-    pub const toJS = toJSObjectRef;
+    // TODO: refactor this
+    pub fn toJS(this: *MarkedArrayBuffer, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
+        var exception = [_]JSC.C.JSValueRef{null};
+        const obj = this.toJSObjectRef(globalObject, &exception);
+
+        if (exception[0] != null) {
+            globalObject.throwValue(JSC.JSValue.c(exception[0]));
+            return .zero;
+        }
+
+        return JSC.JSValue.c(obj);
+    }
 };
 
 // expensive heap reference-counted string type

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -694,7 +694,7 @@ pub const ArrayBuffer = extern struct {
 };
 
 pub const MarkedArrayBuffer = struct {
-    buffer: ArrayBuffer,
+    buffer: ArrayBuffer = .{},
     allocator: ?std.mem.Allocator = null,
 
     pub const Stream = ArrayBuffer.Stream;
@@ -758,8 +758,8 @@ pub const MarkedArrayBuffer = struct {
         return container;
     }
 
-    pub fn toNodeBuffer(this: MarkedArrayBuffer, ctx: js.JSContextRef) js.JSObjectRef {
-        return JSValue.createBufferWithCtx(ctx, this.buffer.byteSlice(), this.buffer.ptr, MarkedArrayBuffer_deallocator).asObjectRef();
+    pub fn toNodeBuffer(this: MarkedArrayBuffer, ctx: js.JSContextRef) JSC.JSValue {
+        return JSValue.createBufferWithCtx(ctx, this.buffer.byteSlice(), this.buffer.ptr, MarkedArrayBuffer_deallocator);
     }
 
     pub fn toJSObjectRef(this: MarkedArrayBuffer, ctx: js.JSContextRef, exception: js.ExceptionRef) js.JSObjectRef {
@@ -1348,7 +1348,7 @@ pub fn wrapInstanceMethod(
                             iter.deinit();
                             return JSC.JSValue.zero;
                         };
-                        args[i] = JSC.Node.StringOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg, null) orelse {
+                        args[i] = JSC.Node.StringOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg) orelse {
                             globalThis.throwInvalidArguments("expected string or buffer", .{});
                             iter.deinit();
                             return JSC.JSValue.zero;
@@ -1357,22 +1357,7 @@ pub fn wrapInstanceMethod(
                     ?JSC.Node.StringOrBuffer => {
                         if (iter.nextEat()) |arg| {
                             if (!arg.isEmptyOrUndefinedOrNull()) {
-                                args[i] = JSC.Node.StringOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg, null) orelse {
-                                    globalThis.throwInvalidArguments("expected string or buffer", .{});
-                                    iter.deinit();
-                                    return JSC.JSValue.zero;
-                                };
-                            } else {
-                                args[i] = null;
-                            }
-                        } else {
-                            args[i] = null;
-                        }
-                    },
-                    ?JSC.Node.SliceOrBuffer => {
-                        if (iter.nextEat()) |arg| {
-                            if (!arg.isEmptyOrUndefinedOrNull()) {
-                                args[i] = JSC.Node.SliceOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg) orelse {
+                                args[i] = JSC.Node.StringOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg) orelse {
                                     globalThis.throwInvalidArguments("expected string or buffer", .{});
                                     iter.deinit();
                                     return JSC.JSValue.zero;
@@ -1520,7 +1505,7 @@ pub fn wrapStaticMethod(
                             iter.deinit();
                             return JSC.JSValue.zero;
                         };
-                        args[i] = JSC.Node.StringOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg, null) orelse {
+                        args[i] = JSC.Node.StringOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg) orelse {
                             globalThis.throwInvalidArguments("expected string or buffer", .{});
                             iter.deinit();
                             return JSC.JSValue.zero;
@@ -1528,30 +1513,7 @@ pub fn wrapStaticMethod(
                     },
                     ?JSC.Node.StringOrBuffer => {
                         if (iter.nextEat()) |arg| {
-                            args[i] = JSC.Node.StringOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg, null) orelse {
-                                globalThis.throwInvalidArguments("expected string or buffer", .{});
-                                iter.deinit();
-                                return JSC.JSValue.zero;
-                            };
-                        } else {
-                            args[i] = null;
-                        }
-                    },
-                    JSC.Node.SliceOrBuffer => {
-                        const arg = iter.nextEat() orelse {
-                            globalThis.throwInvalidArguments("expected string or buffer", .{});
-                            iter.deinit();
-                            return JSC.JSValue.zero;
-                        };
-                        args[i] = JSC.Node.SliceOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg) orelse {
-                            globalThis.throwInvalidArguments("expected string or buffer", .{});
-                            iter.deinit();
-                            return JSC.JSValue.zero;
-                        };
-                    },
-                    ?JSC.Node.SliceOrBuffer => {
-                        if (iter.nextEat()) |arg| {
-                            args[i] = JSC.Node.SliceOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg) orelse {
+                            args[i] = JSC.Node.StringOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg) orelse {
                                 globalThis.throwInvalidArguments("expected string or buffer", .{});
                                 iter.deinit();
                                 return JSC.JSValue.zero;

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -213,8 +213,12 @@ pub const To = struct {
                         }
                     }
 
+                    if (comptime @hasDecl(Type, "toJSNewlyCreated") and @typeInfo(@TypeOf(@field(Type, "toJSNewlyCreated"))).Fn.params.len == 2) {
+                        return value.toJSNewlyCreated(context).asObjectRef();
+                    }
+
                     if (comptime @hasDecl(Type, "toJS") and @typeInfo(@TypeOf(@field(Type, "toJS"))).Fn.params.len == 2) {
-                        return bun.new(Type, value).toJS(context).asObjectRef();
+                        return value.toJS(context).asObjectRef();
                     }
 
                     const res = value.toJS(context, exception);

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -2251,14 +2251,14 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage,
     //    arrayBuffers: 9386
     // }
 
-    result->putDirectOffset(vm, 0, JSC::jsNumber(current_rss));
-    result->putDirectOffset(vm, 1, JSC::jsNumber(vm.heap.blockBytesAllocated()));
+    result->putDirectOffset(vm, 0, JSC::jsDoubleNumber(current_rss));
+    result->putDirectOffset(vm, 1, JSC::jsDoubleNumber(vm.heap.blockBytesAllocated()));
 
     // heap.size() loops through every cell...
     // TODO: add a binding for heap.sizeAfterLastCollection()
-    result->putDirectOffset(vm, 2, JSC::jsNumber(vm.heap.sizeAfterLastEdenCollection()));
+    result->putDirectOffset(vm, 2, JSC::jsDoubleNumber(vm.heap.sizeAfterLastEdenCollection()));
 
-    result->putDirectOffset(vm, 3, JSC::jsNumber(vm.heap.externalMemorySize()));
+    result->putDirectOffset(vm, 3, JSC::jsDoubleNumber(vm.heap.extraMemorySize() + vm.heap.externalMemorySize()));
 
     // We report 0 for this because m_arrayBuffers in JSC::Heap is private and we need to add a binding
     // If we use objectTypeCounts(), it's hideously slow because it loops through every single object in the heap

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -28,6 +28,8 @@
 #include <wtf/text/AtomString.h>
 #include <wtf/text/WTFString.h>
 
+extern "C" void mi_free(void* ptr);
+
 using namespace JSC;
 extern "C" BunString BunString__fromBytes(const char* bytes, size_t length);
 
@@ -507,4 +509,26 @@ WTF::String BunString::toWTFString(ZeroCopyTag) const
     }
 
     return WTF::String();
+}
+
+extern "C" BunString BunString__createExternalGloballyAllocatedLatin1(
+    const LChar* bytes,
+    size_t length)
+{
+    ASSERT(length > 0);
+    Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create(bytes, length, nullptr, [](void*, void* ptr, size_t) {
+        mi_free(ptr);
+    });
+    return { BunStringTag::WTFStringImpl, { .wtf = &impl.leakRef() } };
+}
+
+extern "C" BunString BunString__createExternalGloballyAllocatedUTF16(
+    const UChar* bytes,
+    size_t length)
+{
+    ASSERT(length > 0);
+    Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create(bytes, length, nullptr, [](void*, void* ptr, size_t) {
+        mi_free(ptr);
+    });
+    return { BunStringTag::WTFStringImpl, { .wtf = &impl.leakRef() } };
 }

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -133,7 +133,7 @@ pub const ZigString = extern struct {
         }
     }
 
-    pub fn toJS(this: ZigString, ctx: *JSC.JSGlobalObject, _: JSC.C.ExceptionRef) JSValue {
+    pub fn toJS(this: ZigString, ctx: *JSC.JSGlobalObject) JSValue {
         if (this.isGloballyAllocated()) {
             return this.toExternalValue(ctx);
         }
@@ -2546,7 +2546,7 @@ pub const JSGlobalObject = extern struct {
         return JSGlobalObject__setTimeZone(this, timeZone);
     }
 
-    pub inline fn toJS(globalThis: *JSGlobalObject) JSValue {
+    pub inline fn toJSValue(globalThis: *JSGlobalObject) JSValue {
         return @enumFromInt(@as(JSValue.Type, @bitCast(@intFromPtr(globalThis))));
     }
 
@@ -2572,6 +2572,10 @@ pub const JSGlobalObject = extern struct {
             ZigString.static("ERR_INVALID_ARG_TYPE"),
             this,
         );
+    }
+
+    pub fn toJS(this: *JSC.JSGlobalObject, value: anytype, comptime lifetime: JSC.Lifetime) JSC.JSValue {
+        return JSC.toJS(this, @TypeOf(value), value, lifetime);
     }
 
     pub fn throwInvalidArgumentType(
@@ -3536,7 +3540,7 @@ pub const JSValue = enum(JSValueReprInt) {
         return JSC.C.JSObjectCallAsFunctionReturnValue(
             globalThis,
             this,
-            globalThis.toJS(),
+            globalThis.toJSValue(),
             args.len,
             @as(?[*]const JSC.C.JSValueRef, @ptrCast(args.ptr)),
         );
@@ -4275,7 +4279,7 @@ pub const JSValue = enum(JSValueReprInt) {
     pub fn bigIntSum(globalObject: *JSGlobalObject, a: JSValue, b: JSValue) JSValue {
         return cppFn("bigIntSum", .{ globalObject, a, b });
     }
-    
+
     pub fn toUInt64NoTruncate(this: JSValue) u64 {
         return cppFn("toUInt64NoTruncate", .{
             this,

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -403,6 +403,15 @@ pub const ZigString = extern struct {
         ptr: [*]const u8 = undefined,
         len: u32 = 0,
 
+        pub fn reportExtraMemory(this: *const Slice, vm: *JSC.VM) void {
+            if (this.allocator.get()) |allocator| {
+                // Don't report it if the memory is actually owned by JSC.
+                if (!bun.String.isWTFAllocator(allocator)) {
+                    vm.reportExtraMemory(this.len);
+                }
+            }
+        }
+
         pub fn init(allocator: std.mem.Allocator, input: []const u8) Slice {
             return .{
                 .ptr = input.ptr,

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -102,15 +102,14 @@ pub fn WorkTask(comptime Context: type) type {
         ref: Async.KeepAlive = .{},
 
         pub fn createOnJSThread(allocator: std.mem.Allocator, globalThis: *JSGlobalObject, value: *Context) !*This {
-            var this = try allocator.create(This);
             var vm = globalThis.bunVM();
-            this.* = .{
+            var this = bun.new(This, .{
                 .event_loop = vm.eventLoop(),
                 .ctx = value,
                 .allocator = allocator,
                 .globalThis = globalThis,
                 .async_task_tracker = JSC.AsyncTaskTracker.init(vm),
-            };
+            });
             this.ref.ref(this.event_loop.virtual_machine);
 
             return this;

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -42,13 +42,12 @@ pub fn ConcurrentPromiseTask(comptime Context: type) type {
         ref: Async.KeepAlive = .{},
 
         pub fn createOnJSThread(allocator: std.mem.Allocator, globalThis: *JSGlobalObject, value: *Context) !*This {
-            var this = try allocator.create(This);
-            this.* = .{
+            var this = bun.new(This, .{
                 .event_loop = VirtualMachine.get().event_loop,
                 .ctx = value,
                 .allocator = allocator,
                 .globalThis = globalThis,
-            };
+            });
             var promise = JSC.JSPromise.create(globalThis);
             this.promise.strong.set(globalThis, promise.asValue(globalThis));
             this.ref.ref(this.event_loop.virtual_machine);
@@ -80,7 +79,7 @@ pub fn ConcurrentPromiseTask(comptime Context: type) type {
         }
 
         pub fn deinit(this: *This) void {
-            this.allocator.destroy(this);
+            bun.destroy(this);
         }
     };
 }
@@ -145,10 +144,9 @@ pub fn WorkTask(comptime Context: type) type {
         }
 
         pub fn deinit(this: *This) void {
-            var allocator = this.allocator;
             this.ref.unref(this.event_loop.virtual_machine);
 
-            allocator.destroy(this);
+            bun.destroyWithAlloc(this.allocator, this);
         }
     };
 }

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -2386,7 +2386,7 @@ pub const Arguments = struct {
 
             if (exception.* != null) return null;
 
-            const buffer = StringOrBuffer.fromJS(ctx.ptr(), bun.default_allocator, arguments.nextEat() orelse {
+            const buffer = StringOrBuffer.fromJS(ctx.ptr(), bun.default_allocator, arguments.next() orelse {
                 if (exception.* == null) {
                     JSC.throwInvalidArguments(
                         "data is required",
@@ -2753,11 +2753,13 @@ pub const Arguments = struct {
                 return null;
             };
 
-            arguments.eat();
-
             var encoding = Encoding.buffer;
             var flag = FileSystemFlags.w;
             var mode: Mode = default_permission;
+
+            if (data_value.isString()) {
+                encoding = Encoding.utf8;
+            }
 
             if (arguments.next()) |arg| {
                 arguments.eat();

--- a/src/bun.js/node/node_fs_binding.zig
+++ b/src/bun.js/node/node_fs_binding.zig
@@ -26,6 +26,7 @@ fn callSync(comptime FunctionEnum: NodeFSFunctionEnum) NodeFSFunction {
     const Arguments = comptime function.params[1].type.?;
     const FormattedName = comptime [1]u8{std.ascii.toUpper(@tagName(FunctionEnum)[0])} ++ @tagName(FunctionEnum)[1..];
     const Result = comptime JSC.Maybe(@field(JSC.Node.NodeFS.ReturnType, FormattedName));
+    _ = Result;
 
     const NodeBindingClosure = struct {
         pub fn bind(
@@ -59,34 +60,18 @@ fn callSync(comptime FunctionEnum: NodeFSFunctionEnum) NodeFSFunction {
                 globalObject.throwValue(exception1);
                 return .zero;
             }
-
-            switch (Function(
+            var result = Function(
                 &this.node_fs,
                 args,
                 comptime Flavor.sync,
-            )) {
+            );
+            switch (result) {
                 .err => |err| {
                     globalObject.throwValue(JSC.JSValue.c(err.toJS(globalObject)));
                     return .zero;
                 },
-                .result => |res| {
-                    if (comptime Result.ReturnType != void) {
-                        const out = if (comptime Result.ReturnType == JSC.Node.StringOrBuffer) brk: {
-                            var res_ = res;
-                            break :brk res_.toJS(globalObject);
-                        } else JSC.JSValue.c(JSC.To.JS.withType(Result.ReturnType, res, globalObject, &exceptionref));
-                        const exception = JSC.JSValue.c(exceptionref);
-                        if (exception != .zero) {
-                            globalObject.throwValue(exception);
-                            return .zero;
-                        }
-
-                        return out;
-                    } else {
-                        return JSC.JSValue.jsUndefined();
-                    }
-
-                    unreachable;
+                .result => |*res| {
+                    return globalObject.toJS(res, .temporary);
                 },
             }
         }

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -25,9 +25,9 @@ const log = bun.Output.scoped(.StatWatcher, false);
 
 fn statToJSStats(globalThis: *JSC.JSGlobalObject, stats: bun.Stat, bigint: bool) JSC.JSValue {
     if (bigint) {
-        return StatsBig.initWithAllocator(globalThis.allocator(), stats).toJS(globalThis);
+        return bun.new(StatsBig, StatsBig.init(stats)).toJS(globalThis);
     } else {
-        return StatsSmall.initWithAllocator(globalThis.allocator(), stats).toJS(globalThis);
+        return bun.new(StatsSmall, StatsSmall.init(stats)).toJS(globalThis);
     }
 }
 

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1454,7 +1454,7 @@ pub fn StatType(comptime Big: bool) type {
         // TODO: BigIntStats includes a `_checkModeProperty` but I dont think anyone actually uses it.
 
         pub fn finalize(this: *This) callconv(.C) void {
-            bun.default_allocator.destroy(this);
+            bun.destroy(this);
         }
 
         pub fn init(stat_: bun.Stat) This {
@@ -1559,14 +1559,17 @@ pub const Stats = union(enum) {
     }
 
     pub fn toJSNewlyCreated(this: *const Stats, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
-        return bun.new(Stats, this.*).toJS(globalObject);
+        return switch (this.*) {
+            .big => bun.new(StatsBig, this.big).toJS(globalObject),
+            .small => bun.new(StatsSmall, this.small).toJS(globalObject),
+        };
     }
 
     pub inline fn toJS(this: *Stats, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
-        return switch (this.*) {
-            .big => this.big.toJS(globalObject),
-            .small => this.small.toJS(globalObject),
-        };
+        _ = this;
+        _ = globalObject;
+
+        @compileError("Only use Stats.toJSNewlyCreated() or Stats.toJS() directly on a StatsBig or StatsSmall");
     }
 };
 
@@ -1663,7 +1666,7 @@ pub const Dirent = struct {
 
     pub fn finalize(this: *Dirent) callconv(.C) void {
         this.name.deref();
-        bun.default_allocator.destroy(this);
+        bun.destroy(this);
     }
 };
 

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1502,16 +1502,12 @@ pub fn StatType(comptime Big: bool) type {
             // dev, mode, nlink, uid, gid, rdev, blksize, ino, size, blocks, atimeMs, mtimeMs, ctimeMs, birthtimeMs
             var args = callFrame.argumentsPtr()[0..@min(callFrame.argumentsCount(), 14)];
 
-            const this = globalThis.allocator().create(This) catch {
-                globalThis.throwOutOfMemory();
-                return null;
-            };
-
             const atime_ms: f64 = if (args.len > 10 and args[10].isNumber()) args[10].asNumber() else 0;
             const mtime_ms: f64 = if (args.len > 11 and args[11].isNumber()) args[11].asNumber() else 0;
             const ctime_ms: f64 = if (args.len > 12 and args[12].isNumber()) args[12].asNumber() else 0;
             const birthtime_ms: f64 = if (args.len > 13 and args[13].isNumber()) args[13].asNumber() else 0;
-            this.* = .{
+
+            const this = bun.new(This, .{
                 .dev = if (args.len > 0 and args[0].isNumber()) @intCast(args[0].toInt32()) else 0,
                 .mode = if (args.len > 1 and args[1].isNumber()) args[1].toInt32() else 0,
                 .nlink = if (args.len > 2 and args[2].isNumber()) args[2].toInt32() else 0,
@@ -1526,7 +1522,8 @@ pub fn StatType(comptime Big: bool) type {
                 .mtime_ms = mtime_ms,
                 .ctime_ms = ctime_ms,
                 .birthtime_ms = birthtime_ms,
-            };
+            });
+
             return this;
         }
 

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -2031,13 +2031,16 @@ pub const Blob = struct {
                 const buf = this.buffer.items;
 
                 defer store.deref();
-                defer bun.destroy(this);
-                if (this.system_error) |err| {
+                const total_size = this.size;
+                const system_error = this.system_error;
+                bun.destroy(this);
+
+                if (system_error) |err| {
                     cb(cb_ctx, ResultType{ .err = err });
                     return;
                 }
 
-                cb(cb_ctx, .{ .result = .{ .buf = buf, .total_size = this.size, .is_temporary = true } });
+                cb(cb_ctx, .{ .result = .{ .buf = buf, .total_size = total_size, .is_temporary = true } });
             }
 
             pub fn run(this: *ReadFile, task: *ReadFileTask) void {

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -299,7 +299,7 @@ pub const Blob = struct {
         comptime Reader: type,
         reader: Reader,
     ) !JSValue {
-        const allocator = globalThis.allocator();
+        const allocator = bun.default_allocator;
 
         const version = try reader.readInt(u8, .little);
         _ = version;
@@ -320,8 +320,7 @@ pub const Blob = struct {
                 const bytes = try readSlice(reader, bytes_len, allocator);
 
                 const blob = Blob.init(bytes, allocator, globalThis);
-                const blob_ = try allocator.create(Blob);
-                blob_.* = blob;
+                const blob_ = bun.new(Blob, blob);
 
                 break :brk blob_;
             },
@@ -332,13 +331,12 @@ pub const Blob = struct {
                     .fd => {
                         const fd = try reader.readInt(bun.FileDescriptor, .little);
 
-                        const blob = try allocator.create(Blob);
-                        blob.* = Blob.findOrCreateFileFromPath(
+                        const blob = bun.new(Blob, Blob.findOrCreateFileFromPath(
                             JSC.Node.PathOrFileDescriptor{
                                 .fd = fd,
                             },
                             globalThis,
-                        );
+                        ));
 
                         break :brk blob;
                     },
@@ -347,15 +345,14 @@ pub const Blob = struct {
 
                         const path = try readSlice(reader, path_len, default_allocator);
 
-                        const blob = try allocator.create(Blob);
-                        blob.* = Blob.findOrCreateFileFromPath(
+                        const blob = bun.new(Blob, Blob.findOrCreateFileFromPath(
                             JSC.Node.PathOrFileDescriptor{
                                 .path = .{
                                     .string = bun.PathString.init(path),
                                 },
                             },
                             globalThis,
-                        );
+                        ));
 
                         break :brk blob;
                     },
@@ -364,9 +361,7 @@ pub const Blob = struct {
                 return .zero;
             },
             .empty => brk: {
-                const blob = try allocator.create(Blob);
-                blob.* = Blob.initEmpty(globalThis);
-                break :brk blob;
+                break :brk bun.new(Blob, Blob.initEmpty(globalThis));
             },
         };
         blob.allocator = allocator;
@@ -500,8 +495,7 @@ pub const Blob = struct {
 
     export fn Blob__dupe(ptr: *anyopaque) *Blob {
         var this = bun.cast(*Blob, ptr);
-        var new = bun.default_allocator.create(Blob) catch unreachable;
-        new.* = this.dupeWithContentType(true);
+        var new = bun.new(Blob, this.dupeWithContentType(true));
         new.allocator = bun.default_allocator;
         return new;
     }
@@ -619,7 +613,7 @@ pub const Blob = struct {
         pub fn run(handler: *@This(), blob_: Store.CopyFile.ResultType) void {
             var promise = handler.promise;
             const globalThis = handler.globalThis;
-            bun.default_allocator.destroy(handler);
+            bun.destroy(handler);
             const blob = blob_ catch |err| {
                 var error_string = ZigString.init(
                     std.fmt.allocPrint(bun.default_allocator, "Failed to write file \"{s}\"", .{bun.asByteSlice(@errorName(err))}) catch unreachable,
@@ -629,8 +623,7 @@ pub const Blob = struct {
                 promise.reject(globalThis, error_string.toErrorInstance(globalThis));
                 return;
             };
-            var _blob = bun.default_allocator.create(Blob) catch unreachable;
-            _blob.* = blob;
+            var _blob = bun.new(Blob, blob);
             _blob.allocator = bun.default_allocator;
             promise.resolve(
                 globalThis,
@@ -692,14 +685,14 @@ pub const Blob = struct {
                     file_blob.detach();
                     _ = value.use();
                     this.promise.strong.deinit();
-                    bun.default_allocator.destroy(this);
+                    bun.destroy(this);
                     promise.reject(globalThis, err);
                 },
                 .Used => {
                     file_blob.detach();
                     _ = value.use();
                     this.promise.strong.deinit();
-                    bun.default_allocator.destroy(this);
+                    bun.destroy(this);
                     promise.reject(globalThis, ZigString.init("Body was used after it was consumed").toErrorInstance(globalThis));
                 },
                 .WTFStringImpl,
@@ -730,7 +723,7 @@ pub const Blob = struct {
 
                     file_blob.detach();
                     this.promise.strong.deinit();
-                    bun.default_allocator.destroy(this);
+                    bun.destroy(this);
                 },
                 .Locked => {
                     value.Locked.onReceiveValue = thenWrap;
@@ -757,10 +750,9 @@ pub const Blob = struct {
         const source_type = std.meta.activeTag(source_blob.store.?.data);
 
         if (destination_type == .file and source_type == .bytes) {
-            var write_file_promise = bun.default_allocator.create(WriteFilePromise) catch unreachable;
-            write_file_promise.* = .{
-                .globalThis = ctx.ptr(),
-            };
+            var write_file_promise = bun.new(WriteFilePromise, .{
+                .globalThis = ctx,
+            });
 
             const file_copier = Store.WriteFile.create(
                 bun.default_allocator,
@@ -801,8 +793,8 @@ pub const Blob = struct {
             // eventually, this could be like Buffer.concat
             var clone = source_blob.dupe();
             clone.allocator = bun.default_allocator;
-            var cloned = bun.default_allocator.create(Blob) catch unreachable;
-            cloned.* = clone;
+            const cloned = bun.new(Blob, clone);
+            cloned.allocator = bun.default_allocator;
             return JSPromise.resolvedPromiseValue(ctx.ptr(), cloned.toJS(ctx));
         } else if (destination_type == .bytes and source_type == .file) {
             var fake_call_frame: [8]JSC.JSValue = undefined;
@@ -1016,13 +1008,12 @@ pub const Blob = struct {
                         return JSC.JSPromise.rejectedPromiseValue(globalThis, err);
                     },
                     .Locked => {
-                        var task = bun.default_allocator.create(WriteFileWaitFromLockedValueTask) catch unreachable;
-                        task.* = WriteFileWaitFromLockedValueTask{
+                        var task = bun.new(WriteFileWaitFromLockedValueTask, .{
                             .globalThis = globalThis,
                             .file_blob = destination_blob,
                             .promise = JSC.JSPromise.Strong.init(globalThis),
                             .mkdirp_if_not_exists = mkdirp_if_not_exists orelse true,
-                        };
+                        });
 
                         response.body.value.Locked.task = task;
                         response.body.value.Locked.onReceiveValue = WriteFileWaitFromLockedValueTask.thenWrap;
@@ -1050,13 +1041,12 @@ pub const Blob = struct {
                         return JSC.JSPromise.rejectedPromiseValue(globalThis, err);
                     },
                     .Locked => {
-                        var task = bun.default_allocator.create(WriteFileWaitFromLockedValueTask) catch unreachable;
-                        task.* = WriteFileWaitFromLockedValueTask{
+                        var task = bun.new(WriteFileWaitFromLockedValueTask, .{
                             .globalThis = globalThis,
                             .file_blob = destination_blob,
                             .promise = JSC.JSPromise.Strong.init(globalThis),
                             .mkdirp_if_not_exists = mkdirp_if_not_exists orelse true,
-                        };
+                        });
 
                         request.body.value.Locked.task = task;
                         request.body.value.Locked.onReceiveValue = WriteFileWaitFromLockedValueTask.thenWrap;
@@ -1342,8 +1332,7 @@ pub const Blob = struct {
             blob.content_type_was_set = false;
         }
 
-        var blob_ = allocator.create(Blob) catch unreachable;
-        blob_.* = blob;
+        var blob_ = bun.new(Blob, blob);
         blob_.allocator = allocator;
         blob_.is_jsdom_file = true;
         return blob_;
@@ -1438,8 +1427,7 @@ pub const Blob = struct {
             }
         }
 
-        var ptr = bun.default_allocator.create(Blob) catch unreachable;
-        ptr.* = blob;
+        var ptr = bun.new(Blob, blob);
         ptr.allocator = bun.default_allocator;
         return ptr.toJS(globalObject);
     }
@@ -1525,8 +1513,7 @@ pub const Blob = struct {
         }
 
         pub fn initFile(pathlike: JSC.Node.PathOrFileDescriptor, mime_type: ?http.MimeType, allocator: std.mem.Allocator) !*Store {
-            const store = try allocator.create(Blob.Store);
-            store.* = .{
+            const store = bun.newWithAlloc(allocator, Blob.Store, .{
                 .data = .{
                     .file = FileStore.init(
                         pathlike,
@@ -1548,17 +1535,18 @@ pub const Blob = struct {
                 },
                 .allocator = allocator,
                 .ref_count = 1,
-            };
+            });
             return store;
         }
 
         pub fn init(bytes: []u8, allocator: std.mem.Allocator) !*Store {
-            const store = try allocator.create(Blob.Store);
-            store.* = .{
-                .data = .{ .bytes = ByteStore.init(bytes, allocator) },
+            const store = bun.newWithAlloc(allocator, Store, .{
+                .data = .{
+                    .bytes = ByteStore.init(bytes, allocator),
+                },
                 .allocator = allocator,
                 .ref_count = 1,
-            };
+            });
             return store;
         }
 
@@ -1591,7 +1579,7 @@ pub const Blob = struct {
                 },
             }
 
-            allocator.destroy(this);
+            bun.destroyWithAlloc(allocator, this);
         }
 
         const SerializeTag = enum(u8) {
@@ -1858,7 +1846,7 @@ pub const Blob = struct {
             }
 
             pub fn createWithCtx(
-                allocator: std.mem.Allocator,
+                _: std.mem.Allocator,
                 store: *Store,
                 onReadFileContext: *anyopaque,
                 onCompleteCallback: OnReadFileCallback,
@@ -1868,15 +1856,14 @@ pub const Blob = struct {
                 if (Environment.isWindows)
                     @compileError("dont call this function on windows");
 
-                const read_file = try allocator.create(ReadFile);
-                read_file.* = ReadFile{
+                const read_file = bun.new(ReadFile, ReadFile{
                     .file_store = store.data.file,
                     .offset = off,
                     .max_length = max_len,
                     .store = store,
                     .onCompleteCtx = onReadFileContext,
                     .onCompleteCallback = onCompleteCallback,
-                };
+                });
                 store.ref();
                 return read_file;
             }
@@ -2024,11 +2011,11 @@ pub const Blob = struct {
 
                 if (this.store == null and this.system_error != null) {
                     const system_error = this.system_error.?;
-                    bun.default_allocator.destroy(this);
+                    bun.destroy(this);
                     cb(cb_ctx, ResultType{ .err = system_error });
                     return;
                 } else if (this.store == null) {
-                    bun.default_allocator.destroy(this);
+                    bun.destroy(this);
                     if (Environment.isDebug) @panic("assertion failure - store should not be null");
                     cb(cb_ctx, ResultType{
                         .err = SystemError{
@@ -2044,7 +2031,7 @@ pub const Blob = struct {
                 const buf = this.buffer.items;
 
                 defer store.deref();
-                defer bun.default_allocator.destroy(this);
+                defer bun.destroy(this);
                 if (this.system_error) |err| {
                     cb(cb_ctx, ResultType{ .err = err });
                     return;
@@ -2340,7 +2327,7 @@ pub const Blob = struct {
             pub fn finalize(this: *ReadFileUV) void {
                 defer {
                     this.store.deref();
-                    bun.default_allocator.destroy(this);
+                    bun.destroy(this);
                 }
 
                 const cb = this.on_complete_fn;
@@ -2608,18 +2595,18 @@ pub const Blob = struct {
                 onCompleteCallback: OnWriteFileCallback,
                 mkdirp_if_not_exists: bool,
             ) !*WriteFile {
-                const read_file = try allocator.create(WriteFile);
-                read_file.* = WriteFile{
+                _ = allocator;
+                const write_file = bun.new(WriteFile, WriteFile{
                     .file_blob = file_blob,
                     .bytes_blob = bytes_blob,
                     .onCompleteCtx = onWriteFileContext,
                     .onCompleteCallback = onCompleteCallback,
                     .task = .{ .callback = &doWriteLoopTask },
                     .mkdirp_if_not_exists = mkdirp_if_not_exists,
-                };
+                });
                 file_blob.store.?.ref();
                 bytes_blob.store.?.ref();
-                return read_file;
+                return write_file;
             }
 
             pub fn create(
@@ -2704,7 +2691,7 @@ pub const Blob = struct {
                 this.file_blob.store.?.deref();
 
                 if (this.system_error) |err| {
-                    bun.default_allocator.destroy(this);
+                    bun.destroy(this);
                     cb(cb_ctx, .{
                         .err = err,
                     });
@@ -2712,7 +2699,7 @@ pub const Blob = struct {
                 }
 
                 const wrote = this.total_written;
-                bun.default_allocator.destroy(this);
+                bun.destroy(this);
                 cb(cb_ctx, .{ .result = @as(SizeType, @truncate(wrote)) });
             }
             pub fn run(this: *WriteFile, task: *WriteFileTask) void {
@@ -2919,8 +2906,7 @@ pub const Blob = struct {
                 globalThis: *JSC.JSGlobalObject,
                 mkdirp_if_not_exists: bool,
             ) !*CopyFilePromiseTask {
-                const read_file = try allocator.create(CopyFile);
-                read_file.* = CopyFile{
+                const read_file = bun.new(CopyFile, CopyFile{
                     .store = store,
                     .source_store = source_store,
                     .offset = off,
@@ -2929,7 +2915,7 @@ pub const Blob = struct {
                     .destination_file_store = store.data.file,
                     .source_file_store = source_store.data.file,
                     .mkdirp_if_not_exists = mkdirp_if_not_exists,
-                };
+                });
                 store.ref();
                 source_store.ref();
                 return try CopyFilePromiseTask.createOnJSThread(allocator, globalThis, read_file);
@@ -2946,7 +2932,7 @@ pub const Blob = struct {
                 }
                 this.store.?.deref();
 
-                bun.default_allocator.destroy(this);
+                bun.destroy(this);
             }
 
             pub fn reject(this: *CopyFile, promise: *JSC.JSPromise) void {
@@ -3722,16 +3708,13 @@ pub const Blob = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) callconv(.C) JSC.JSValue {
-        var allocator = globalThis.allocator();
+        var allocator = bun.default_allocator;
         var arguments_ = callframe.arguments(3);
         var args = arguments_.ptr[0..arguments_.len];
 
         if (this.size == 0) {
             const empty = Blob.initEmpty(globalThis);
-            var ptr = allocator.create(Blob) catch {
-                return JSC.JSValue.jsUndefined();
-            };
-            ptr.* = empty;
+            var ptr = bun.new(Blob, empty);
             ptr.allocator = allocator;
             return ptr.toJS(globalThis);
         }
@@ -3823,8 +3806,7 @@ pub const Blob = struct {
         blob.content_type_allocated = content_type_was_allocated;
         blob.content_type_was_set = this.content_type_was_set or content_type_was_allocated;
 
-        var blob_ = allocator.create(Blob) catch unreachable;
-        blob_.* = blob;
+        var blob_ = bun.new(Blob, blob);
         blob_.allocator = allocator;
         return blob_.toJS(globalThis);
     }
@@ -4031,7 +4013,7 @@ pub const Blob = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) callconv(.C) ?*Blob {
-        var allocator = globalThis.allocator();
+        var allocator = bun.default_allocator;
         var blob: Blob = undefined;
         var arguments = callframe.arguments(2);
         const args = arguments.ptr[0..arguments.len];
@@ -4089,8 +4071,7 @@ pub const Blob = struct {
             },
         }
 
-        var blob_ = allocator.create(Blob) catch unreachable;
-        blob_.* = blob;
+        var blob_ = bun.new(Blob, blob);
         blob_.allocator = allocator;
         return blob_;
     }
@@ -4222,7 +4203,7 @@ pub const Blob = struct {
 
         if (this.allocator) |alloc| {
             this.allocator = null;
-            alloc.destroy(this);
+            bun.destroyWithAlloc(alloc, this);
         }
     }
 
@@ -4259,7 +4240,7 @@ pub const Blob = struct {
                 var blob = handler.context;
                 blob.allocator = null;
                 const globalThis = handler.globalThis;
-                bun.default_allocator.destroy(handler);
+                bun.destroy(handler);
                 switch (maybe_bytes) {
                     .result => |result| {
                         const bytes = result.buf;
@@ -4288,7 +4269,7 @@ pub const Blob = struct {
         pub fn run(handler: *@This(), count: Blob.Store.WriteFile.ResultType) void {
             var promise = handler.promise.swap();
             const globalThis = handler.globalThis;
-            bun.default_allocator.destroy(handler);
+            bun.destroy(handler);
             const value = promise.asValue(globalThis);
             value.ensureStillAlive();
             switch (count) {

--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -649,8 +649,7 @@ pub const Body = struct {
                             async_form_data.toJS(global, blob.slice(), promise);
                         },
                         else => {
-                            var ptr = bun.default_allocator.create(Blob) catch unreachable;
-                            ptr.* = new.use();
+                            var ptr = bun.new(Blob, new.use());
                             ptr.allocator = bun.default_allocator;
                             promise.resolve(global, ptr.toJS(global));
                         },
@@ -1107,8 +1106,7 @@ pub fn BodyMixin(comptime Type: type) type {
             }
 
             var blob = value.use();
-            var ptr = getAllocator(globalObject).create(Blob) catch unreachable;
-            ptr.* = blob;
+            var ptr = bun.new(Blob, blob);
             blob.allocator = getAllocator(globalObject);
 
             if (blob.content_type.len == 0 and blob.store != null) {

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -1280,7 +1280,7 @@ pub const Encoder = struct {
             },
             // string is already encoded, just need to copy the data
             .ucs2, .utf16le => {
-                var to = std.mem.sliceAsBytes(allocator.alloc(u16, len * 2) catch return &[_]u8{});
+                var to = std.mem.sliceAsBytes(allocator.alloc(u16, len) catch return &[_]u8{});
                 const bytes = std.mem.sliceAsBytes(input[0..len]);
                 @memcpy(to[0..bytes.len], bytes);
                 return to;

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -880,6 +880,81 @@ pub const Encoder = struct {
         };
     }
 
+    pub fn toBunStringFromOwnedSlice(input: []u8, encoding: JSC.Node.Encoding) bun.String {
+        if (input.len == 0)
+            return bun.String.empty;
+
+        switch (encoding) {
+            .ascii => {
+                if (strings.isAllASCII(input)) {
+                    return bun.String.createExternalGloballyAllocated(.latin1, input);
+                }
+
+                defer bun.default_allocator.free(input);
+                const str, const chars = bun.String.createUninitialized(.latin1, input.len);
+                strings.copyLatin1IntoASCII(chars, input);
+                return str;
+            },
+            .latin1 => {
+                return bun.String.createExternalGloballyAllocated(.latin1, input);
+            },
+            .buffer, .utf8 => {
+                const converted = strings.toUTF16Alloc(bun.default_allocator, input, false) catch return bun.String.dead;
+                if (converted) |utf16| {
+                    defer bun.default_allocator.free(input);
+                    return bun.String.createExternalGloballyAllocated(.utf16, utf16);
+                }
+
+                // If we get here, it means we can safely assume the string is 100% ASCII characters
+                return bun.String.createExternalGloballyAllocated(.latin1, input);
+            },
+            .ucs2, .utf16le => {
+                // Avoid incomplete characters
+                if (input.len / 2 == 0) {
+                    bun.default_allocator.free(input);
+                    return bun.String.empty;
+                }
+
+                const as_u16 = std.mem.bytesAsSlice(u16, input);
+
+                return bun.String.createExternalGloballyAllocated(.utf16, @alignCast(as_u16));
+            },
+
+            .hex => {
+                defer bun.default_allocator.free(input);
+                const str, const chars = bun.String.createUninitialized(.latin1, input.len * 2);
+
+                const wrote = strings.encodeBytesToHex(chars, input);
+
+                // Return an empty string in this case, just like node.
+                if (wrote < chars.len) {
+                    str.deref();
+                    return bun.String.empty;
+                }
+
+                return str;
+            },
+
+            // TODO: this is not right. There is an issue here. But it needs to
+            // be addressed separately because constructFromU8's base64url also
+            // appears inconsistent with Node.js.
+            .base64url => {
+                defer bun.default_allocator.free(input);
+                const out, const chars = bun.String.createUninitialized(.latin1, bun.base64.urlSafeEncodeLen(input));
+                _ = bun.base64.encodeURLSafe(chars, input);
+                return out;
+            },
+
+            .base64 => {
+                defer bun.default_allocator.free(input);
+                const to_len = bun.base64.encodeLen(input);
+                var to = bun.default_allocator.alloc(u8, to_len) catch return bun.String.dead;
+                const wrote = bun.base64.encode(to, input);
+                return bun.String.createExternalGloballyAllocated(.latin1, to[0..wrote]);
+            },
+        }
+    }
+
     pub fn toString(input_ptr: [*]const u8, len: usize, global: *JSGlobalObject, comptime encoding: JSC.Node.Encoding) JSValue {
         if (len == 0)
             return ZigString.Empty.toValue(global);

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -1215,7 +1215,7 @@ pub const Encoder = struct {
     pub fn constructFromU8(input: [*]const u8, len: usize, comptime encoding: JSC.Node.Encoding) []u8 {
         if (len == 0) return &[_]u8{};
 
-        const allocator = VirtualMachine.get().allocator;
+        const allocator = bun.default_allocator;
 
         switch (comptime encoding) {
             .buffer => {
@@ -1267,7 +1267,7 @@ pub const Encoder = struct {
     pub fn constructFromU16(input: [*]const u16, len: usize, comptime encoding: JSC.Node.Encoding) []u8 {
         if (len == 0) return &[_]u8{};
 
-        const allocator = VirtualMachine.get().allocator;
+        const allocator = bun.default_allocator;
 
         switch (comptime encoding) {
             .utf8 => {

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -59,7 +59,6 @@ pub const Response = struct {
     const ResponseMixin = BodyMixin(@This());
     pub usingnamespace JSC.Codegen.JSResponse;
 
-    allocator: std.mem.Allocator,
     body: Body,
     init: Init,
     url: bun.String = bun.String.empty,
@@ -81,7 +80,7 @@ pub const Response = struct {
         var content_type_slice: ZigString.Slice = this.getContentType() orelse return null;
         defer content_type_slice.deinit();
         const encoding = bun.FormData.Encoding.get(content_type_slice.slice()) orelse return null;
-        return bun.FormData.AsyncFormData.init(this.allocator, encoding) catch unreachable;
+        return bun.FormData.AsyncFormData.init(bun.default_allocator, encoding) catch unreachable;
     }
 
     pub fn estimatedSize(this: *Response) callconv(.C) usize {
@@ -251,7 +250,7 @@ pub const Response = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) callconv(.C) JSValue {
-        const cloned = this.clone(getAllocator(globalThis), globalThis);
+        const cloned = this.clone(globalThis);
         return Response.makeMaybePooled(globalThis, cloned);
     }
 
@@ -259,14 +258,11 @@ pub const Response = struct {
         return ptr.toJS(globalObject);
     }
 
-    pub fn cloneInto(
+    pub fn cloneValue(
         this: *Response,
-        new_response: *Response,
-        allocator: std.mem.Allocator,
         globalThis: *JSGlobalObject,
-    ) void {
-        new_response.* = Response{
-            .allocator = allocator,
+    ) Response {
+        return Response{
             .body = this.body.clone(globalThis),
             .init = this.init.clone(globalThis),
             .url = this.url.clone(),
@@ -274,10 +270,8 @@ pub const Response = struct {
         };
     }
 
-    pub fn clone(this: *Response, allocator: std.mem.Allocator, globalThis: *JSGlobalObject) *Response {
-        const new_response = allocator.create(Response) catch unreachable;
-        this.cloneInto(new_response, allocator, globalThis);
-        return new_response;
+    pub fn clone(this: *Response, globalThis: *JSGlobalObject) *Response {
+        return bun.new(Response, this.cloneValue(globalThis));
     }
 
     pub fn getStatus(
@@ -291,13 +285,11 @@ pub const Response = struct {
     pub fn finalize(
         this: *Response,
     ) callconv(.C) void {
-        var allocator = this.allocator;
-
-        this.init.deinit(allocator);
-        this.body.deinit(allocator);
+        this.init.deinit(bun.default_allocator);
+        this.body.deinit(bun.default_allocator);
         this.url.deref();
 
-        allocator.destroy(this);
+        bun.destroy(this);
     }
 
     pub fn getContentType(
@@ -333,7 +325,6 @@ pub const Response = struct {
             .init = Response.Init{
                 .status_code = 200,
             },
-            .allocator = getAllocator(globalThis),
             .url = bun.String.empty,
         };
 
@@ -374,10 +365,7 @@ pub const Response = struct {
 
         var headers_ref = response.getOrCreateHeaders(globalThis);
         headers_ref.putDefault("content-type", MimeType.json.value, globalThis);
-        var ptr = response.allocator.create(Response) catch unreachable;
-        ptr.* = response;
-
-        return ptr.toJS(globalThis);
+        return bun.new(Response, response).toJS(globalThis);
     }
     pub fn constructRedirect(
         globalThis: *JSC.JSGlobalObject,
@@ -395,7 +383,6 @@ pub const Response = struct {
             .body = Body{
                 .value = .{ .Empty = {} },
             },
-            .allocator = getAllocator(globalThis),
             .url = bun.String.empty,
         };
 
@@ -422,8 +409,7 @@ pub const Response = struct {
         response.init.headers = response.getOrCreateHeaders(globalThis);
         var headers_ref = response.init.headers.?;
         headers_ref.put("location", url_string_slice.slice(), globalThis);
-        var ptr = response.allocator.create(Response) catch unreachable;
-        ptr.* = response;
+        const ptr = bun.new(Response, response);
 
         return ptr.toJS(globalThis);
     }
@@ -431,16 +417,17 @@ pub const Response = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) callconv(.C) JSValue {
-        var response = getAllocator(globalThis).create(Response) catch unreachable;
-        response.* = Response{
-            .init = Response.Init{
-                .status_code = 0,
+        const response = bun.new(
+            Response,
+            Response{
+                .init = Response.Init{
+                    .status_code = 0,
+                },
+                .body = Body{
+                    .value = .{ .Empty = {} },
+                },
             },
-            .body = Body{
-                .value = .{ .Empty = {} },
-            },
-            .allocator = getAllocator(globalThis),
-        };
+        );
 
         return response.toJS(globalThis);
     }
@@ -449,8 +436,6 @@ pub const Response = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) callconv(.C) ?*Response {
-        var allocator = getAllocator(globalThis);
-
         const args_list = brk: {
             var args = callframe.arguments(2);
             if (args.len > 1 and args.ptr[1].isEmptyOrUndefinedOrNull()) {
@@ -477,7 +462,7 @@ pub const Response = struct {
                 },
                 else => {
                     if (arguments[1].isObject()) {
-                        break :brk Init.init(allocator, globalThis, arguments[1]) catch null;
+                        break :brk Init.init(bun.default_allocator, globalThis, arguments[1]) catch null;
                     }
 
                     std.debug.assert(!arguments[1].isEmptyOrUndefinedOrNull());
@@ -504,13 +489,10 @@ pub const Response = struct {
             unreachable;
         } orelse return null;
 
-        var response = allocator.create(Response) catch unreachable;
-
-        response.* = Response{
+        var response = bun.new(Response, Response{
             .body = body,
             .init = init,
-            .allocator = getAllocator(globalThis),
-        };
+        });
 
         if (response.body.value == .Blob and
             response.init.headers != null and
@@ -620,21 +602,15 @@ pub const Response = struct {
         return emptyWithStatus(globalThis, 200);
     }
 
-    inline fn emptyWithStatus(globalThis: *JSC.JSGlobalObject, status: u16) Response {
-        var allocator = getAllocator(globalThis);
-        const response = allocator.create(Response) catch unreachable;
-
-        response.* = Response{
+    inline fn emptyWithStatus(_: *JSC.JSGlobalObject, status: u16) Response {
+        return bun.new(Response, .{
             .body = Body{
                 .value = Body.Value{ .Null = {} },
             },
             .init = Init{
                 .status_code = status,
             },
-            .allocator = getAllocator(globalThis),
-        };
-
-        return response;
+        });
     }
 };
 
@@ -1408,7 +1384,7 @@ pub const Fetch = struct {
             return response;
         }
 
-        fn toResponse(this: *FetchTasklet, allocator: std.mem.Allocator) Response {
+        fn toResponse(this: *FetchTasklet) Response {
             log("toResponse", .{});
             std.debug.assert(this.metadata != null);
             // at this point we always should have metadata
@@ -1416,7 +1392,6 @@ pub const Fetch = struct {
             const http_response = metadata.response;
             this.is_waiting_body = this.result.has_more;
             return Response{
-                .allocator = allocator,
                 .url = bun.String.createAtomIfPossible(metadata.url),
                 .redirected = this.result.redirected,
                 .init = .{
@@ -1432,9 +1407,7 @@ pub const Fetch = struct {
 
         pub fn onResolve(this: *FetchTasklet) JSValue {
             log("onResolve", .{});
-            const allocator = bun.default_allocator;
-            const response = allocator.create(Response) catch unreachable;
-            response.* = this.toResponse(allocator);
+            const response = bun.new(Response, this.toResponse());
             const response_js = Response.makeMaybePooled(@as(js.JSContextRef, this.global_this), response);
             response_js.ensureStillAlive();
             this.response = JSC.Strong.create(response_js, this.global_this);
@@ -1664,21 +1637,21 @@ pub const Fetch = struct {
             blob.content_type_allocated = true;
         }
 
-        var response = allocator.create(Response) catch @panic("out of memory");
-
-        response.* = Response{
-            .body = Body{
-                .value = .{
-                    .Blob = blob,
+        var response = bun.new(
+            Response,
+            Response{
+                .body = Body{
+                    .value = .{
+                        .Blob = blob,
+                    },
                 },
+                .init = Response.Init{
+                    .status_code = 200,
+                    .status_text = bun.String.createAtomASCII("OK"),
+                },
+                .url = data_url.url.dupeRef(),
             },
-            .init = Response.Init{
-                .status_code = 200,
-                .status_text = bun.String.createAtomASCII("OK"),
-            },
-            .allocator = allocator,
-            .url = data_url.url.dupeRef(),
-        };
+        );
 
         return JSPromise.resolvedPromiseValue(globalThis, response.toJS(globalThis));
     }
@@ -2185,18 +2158,15 @@ pub const Fetch = struct {
                 globalThis,
             );
 
-            var response = bun.default_allocator.create(Response) catch @panic("out of memory");
-
-            response.* = Response{
+            const response = bun.new(Response, Response{
                 .body = Body{
                     .value = .{ .Blob = bun_file },
                 },
                 .init = Response.Init{
                     .status_code = 200,
                 },
-                .allocator = bun.default_allocator,
                 .url = file_url_string.clone(),
-            };
+            });
 
             return JSPromise.resolvedPromiseValue(globalThis, response.toJS(globalThis));
         }

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -316,7 +316,6 @@ pub const Response = struct {
         const args_list = callframe.arguments(2);
         // https://github.com/remix-run/remix/blob/db2c31f64affb2095e4286b91306b96435967969/packages/remix-server-runtime/responses.ts#L4
         var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), args_list.ptr[0..args_list.len]);
-        // var response = getAllocator(globalThis).create(Response) catch unreachable;
 
         var response = Response{
             .body = Body{
@@ -374,7 +373,6 @@ pub const Response = struct {
         var args_list = callframe.arguments(4);
         // https://github.com/remix-run/remix/blob/db2c31f64affb2095e4286b91306b96435967969/packages/remix-server-runtime/responses.ts#L4
         var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), args_list.ptr[0..args_list.len]);
-        // var response = getAllocator(globalThis).create(Response) catch unreachable;
 
         var response = Response{
             .init = Response.Init{

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2804,6 +2804,13 @@ pub const is_heap_breakdown_enabled = Environment.allow_assert and Environment.i
 
 const HeapBreakdown = if (is_heap_breakdown_enabled) @import("./heap_breakdown.zig") else struct {};
 
+/// Globally-allocate a value on the heap.
+///
+/// When used, yuo must call `bun.destroy` to free the memory.
+/// default_allocator.destroy should not be used.
+///
+/// On macOS, you can use `Bun.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_mimalloc_dump()`
+/// to dump the heap.
 pub inline fn new(comptime T: type, t: T) *T {
     if (comptime is_heap_breakdown_enabled) {
         const ptr = HeapBreakdown.allocator(T).create(T) catch outOfMemory();
@@ -2816,6 +2823,10 @@ pub inline fn new(comptime T: type, t: T) *T {
     return ptr;
 }
 
+/// Free a globally-allocated a value
+///
+/// On macOS, you can use `Bun.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_mimalloc_dump()`
+/// to dump the heap.
 pub inline fn destroyWithAlloc(allocator: std.mem.Allocator, t: anytype) void {
     if (comptime is_heap_breakdown_enabled) {
         if (allocator.vtable == default_allocator.vtable) {
@@ -2851,6 +2862,12 @@ pub fn New(comptime T: type) type {
     };
 }
 
+/// Free a globally-allocated a value.
+///
+/// Must have used `new` to allocate the value.
+///
+/// On macOS, you can use `Bun.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_mimalloc_dump()`
+/// to dump the heap.
 pub inline fn destroy(t: anytype) void {
     if (comptime is_heap_breakdown_enabled) {
         HeapBreakdown.allocator(std.meta.Child(@TypeOf(t))).destroy(t);

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2800,17 +2800,48 @@ pub noinline fn outOfMemory() noreturn {
     @panic("Bun ran out of memory!");
 }
 
+pub const is_heap_breakdown_enabled = Environment.allow_assert and Environment.isMac;
+
+const HeapBreakdown = if (is_heap_breakdown_enabled) @import("./heap_breakdown.zig") else struct {};
+
 pub inline fn new(comptime T: type, t: T) *T {
+    if (comptime is_heap_breakdown_enabled) {
+        const ptr = HeapBreakdown.allocator(T).create(T) catch outOfMemory();
+        ptr.* = t;
+        return ptr;
+    }
+
     const ptr = default_allocator.create(T) catch outOfMemory();
     ptr.* = t;
     return ptr;
 }
 
+pub inline fn destroyWithAlloc(allocator: std.mem.Allocator, t: anytype) void {
+    if (comptime is_heap_breakdown_enabled) {
+        if (allocator.vtable == default_allocator.vtable) {
+            destroy(t);
+            return;
+        }
+    }
+
+    allocator.destroy(t);
+}
+
 pub inline fn destroy(t: anytype) void {
-    default_allocator.destroy(@TypeOf(t));
+    if (comptime is_heap_breakdown_enabled) {
+        HeapBreakdown.allocator(std.meta.Child(@TypeOf(t))).destroy(t);
+    } else {
+        default_allocator.destroy(t);
+    }
 }
 
 pub inline fn newWithAlloc(allocator: std.mem.Allocator, comptime T: type, t: T) *T {
+    if (comptime is_heap_breakdown_enabled) {
+        if (allocator.vtable == default_allocator.vtable) {
+            return new(T, t);
+        }
+    }
+
     const ptr = allocator.create(T) catch outOfMemory();
     ptr.* = t;
     return ptr;

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2827,6 +2827,30 @@ pub inline fn destroyWithAlloc(allocator: std.mem.Allocator, t: anytype) void {
     allocator.destroy(t);
 }
 
+pub fn New(comptime T: type) type {
+    return struct {
+        pub inline fn destroy(self: *T) void {
+            if (comptime is_heap_breakdown_enabled) {
+                HeapBreakdown.allocator(T).destroy(self);
+            } else {
+                default_allocator.destroy(self);
+            }
+        }
+
+        pub inline fn new(t: T) *T {
+            if (comptime is_heap_breakdown_enabled) {
+                const ptr = HeapBreakdown.allocator(T).create(T) catch outOfMemory();
+                ptr.* = t;
+                return ptr;
+            }
+
+            const ptr = default_allocator.create(T) catch outOfMemory();
+            ptr.* = t;
+            return ptr;
+        }
+    };
+}
+
 pub inline fn destroy(t: anytype) void {
     if (comptime is_heap_breakdown_enabled) {
         HeapBreakdown.allocator(std.meta.Child(@TypeOf(t))).destroy(t);

--- a/src/deps/lol-html.zig
+++ b/src/deps/lol-html.zig
@@ -88,6 +88,11 @@ pub const HTMLRewriter = opaque {
             strict: bool,
         ) ?*HTMLRewriter;
 
+        pub fn deinit(this: *HTMLRewriter.Builder) void {
+            auto_disable();
+            this.lol_html_rewriter_builder_free();
+        }
+
         extern fn lol_html_rewriter_builder_add_document_content_handlers(
             builder: *HTMLRewriter.Builder,
             doctype_handler: ?DirectiveFunctionType(DocType),

--- a/src/fd.zig
+++ b/src/fd.zig
@@ -281,7 +281,7 @@ pub const FDImpl = packed struct {
     }
 
     /// After calling, the input file descriptor is no longer valid and must not be used
-    pub fn toJS(value: FDImpl, _: *JSC.JSGlobalObject, _: JSC.C.ExceptionRef) JSValue {
+    pub fn toJS(value: FDImpl, _: *JSC.JSGlobalObject) JSValue {
         return JSValue.jsNumberFromInt32(value.makeLibUVOwned().uv());
     }
 

--- a/src/heap_breakdown.zig
+++ b/src/heap_breakdown.zig
@@ -1,0 +1,96 @@
+const bun = @import("root").bun;
+const std = @import("std");
+const HeapBreakdown = @This();
+
+pub fn allocator(comptime T: type) std.mem.Allocator {
+    const Holder = struct {
+        pub var allocator: ?std.mem.Allocator = null;
+    };
+    if (Holder.allocator == null) {
+        Holder.allocator = malloc_zone_t.create(T);
+    }
+
+    return Holder.allocator.?;
+}
+
+const malloc_zone_t = opaque {
+    const Allocator = std.mem.Allocator;
+    const vm_size_t = usize;
+
+    pub extern fn malloc_default_zone() *malloc_zone_t;
+    pub extern fn malloc_create_zone(start_size: vm_size_t, flags: c_uint) *malloc_zone_t;
+    pub extern fn malloc_destroy_zone(zone: *malloc_zone_t) void;
+    pub extern fn malloc_zone_malloc(zone: *malloc_zone_t, size: usize) ?*anyopaque;
+    pub extern fn malloc_zone_calloc(zone: *malloc_zone_t, num_items: usize, size: usize) ?*anyopaque;
+    pub extern fn malloc_zone_valloc(zone: *malloc_zone_t, size: usize) ?*anyopaque;
+    pub extern fn malloc_zone_free(zone: *malloc_zone_t, ptr: ?*anyopaque) void;
+    pub extern fn malloc_zone_realloc(zone: *malloc_zone_t, ptr: ?*anyopaque, size: usize) ?*anyopaque;
+    pub extern fn malloc_zone_from_ptr(ptr: ?*const anyopaque) *malloc_zone_t;
+    pub extern fn malloc_zone_memalign(zone: *malloc_zone_t, alignment: usize, size: usize) ?*anyopaque;
+    pub extern fn malloc_zone_batch_malloc(zone: *malloc_zone_t, size: usize, results: [*]?*anyopaque, num_requested: c_uint) c_uint;
+    pub extern fn malloc_zone_batch_free(zone: *malloc_zone_t, to_be_freed: [*]?*anyopaque, num: c_uint) void;
+    pub extern fn malloc_default_purgeable_zone() *malloc_zone_t;
+    pub extern fn malloc_make_purgeable(ptr: ?*anyopaque) void;
+    pub extern fn malloc_make_nonpurgeable(ptr: ?*anyopaque) c_int;
+    pub extern fn malloc_zone_register(zone: *malloc_zone_t) void;
+    pub extern fn malloc_zone_unregister(zone: *malloc_zone_t) void;
+    pub extern fn malloc_set_zone_name(zone: *malloc_zone_t, name: ?[*:0]const u8) void;
+    pub extern fn malloc_get_zone_name(zone: *malloc_zone_t) ?[*:0]const u8;
+    pub extern fn malloc_zone_pressure_relief(zone: *malloc_zone_t, goal: usize) usize;
+
+    fn alignedAlloc(zone: *malloc_zone_t, len: usize, alignment: usize) ?[*]u8 {
+        // The posix_memalign only accepts alignment values that are a
+        // multiple of the pointer size
+        const eff_alignment = @max(alignment, @sizeOf(usize));
+
+        const ptr = malloc_zone_memalign(zone, eff_alignment, len);
+        return @as(?[*]u8, @ptrCast(ptr));
+    }
+
+    fn alignedAllocSize(ptr: [*]u8) usize {
+        return std.c.malloc_size(ptr);
+    }
+
+    fn alloc(ptr: *anyopaque, len: usize, log2_align: u8, _: usize) ?[*]u8 {
+        const alignment = @as(usize, 1) << @as(Allocator.Log2Align, @intCast(log2_align));
+        return alignedAlloc(@ptrCast(ptr), len, alignment);
+    }
+
+    fn resize(_: *anyopaque, buf: []u8, _: u8, new_len: usize, _: usize) bool {
+        if (new_len <= buf.len) {
+            return true;
+        }
+
+        const full_len = alignedAllocSize(buf.ptr);
+        if (new_len <= full_len) {
+            return true;
+        }
+
+        return false;
+    }
+
+    fn free(ptr: *anyopaque, buf: [*]u8, _: u8, _: usize) void {
+        malloc_zone_free(@ptrCast(ptr), @ptrCast(buf));
+    }
+
+    pub const VTable = std.mem.Allocator.VTable{
+        .alloc = @ptrCast(&alloc),
+        .resize = @ptrCast(&resize),
+        .free = @ptrCast(&free),
+    };
+
+    pub fn create(comptime T: type) std.mem.Allocator {
+        const zone = malloc_create_zone(0, 0);
+        const title = struct {
+            const base_name = if (@hasDecl(T, "heap_label")) T.heap_label else bun.meta.typeBaseName(@typeName(T));
+            pub const title_: []const u8 = "Bun__" ++ base_name ++ .{0};
+            pub const title: [:0]const u8 = title_[0 .. title_.len - 1 :0];
+        }.title;
+        malloc_set_zone_name(zone, title.ptr);
+
+        return std.mem.Allocator{
+            .vtable = &VTable,
+            .ptr = @ptrCast(zone),
+        };
+    }
+};

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1645,7 +1645,7 @@ pub fn saveToDisk(this: *Lockfile, filename: stringZ) void {
                     .fd = bun.toFD(file.handle),
                 },
                 .dirfd = if (!Environment.isWindows) bun.invalid_fd else @panic("TODO"),
-                .data = .{ .string = bytes.items },
+                .data = .{ .string = .{ .utf8 = bun.JSC.ZigString.Slice.from(bytes.items, bun.default_allocator) } },
             },
             .sync,
         )) {

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -92,6 +92,14 @@ class Response extends WebResponse {
     return await super.json();
   }
 
+  // This is a deprecated function in node-fetch
+  // but is still used by some libraries and frameworks (like Astro)
+  async buffer() {
+    // load the getter
+    this.body;
+    return new $Buffer(await super.arrayBuffer());
+  }
+
   async text() {
     // load the getter
     this.body;

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -771,7 +771,7 @@ pub fn pwritev(fd: bun.FileDescriptor, buffers: []const std.os.iovec_const, posi
 pub fn readv(fd: bun.FileDescriptor, buffers: []std.os.iovec) Maybe(usize) {
     if (comptime Environment.allow_assert) {
         if (buffers.len == 0) {
-            @panic("readv() called with 0 length buffer");
+            bun.Output.debugWarn("readv() called with 0 length buffer", .{});
         }
     }
 
@@ -805,7 +805,7 @@ pub fn readv(fd: bun.FileDescriptor, buffers: []std.os.iovec) Maybe(usize) {
 pub fn preadv(fd: bun.FileDescriptor, buffers: []std.os.iovec, position: isize) Maybe(usize) {
     if (comptime Environment.allow_assert) {
         if (buffers.len == 0) {
-            @panic("preadv() called with 0 length buffer");
+            bun.Output.debugWarn("preadv() called with 0 length buffer", .{});
         }
     }
 
@@ -878,7 +878,7 @@ pub fn pread(fd: bun.FileDescriptor, buf: []u8, offset: i64) Maybe(usize) {
 
     if (comptime Environment.allow_assert) {
         if (adjusted_len == 0) {
-            @panic("pread() called with 0 length buffer");
+            bun.Output.debugWarn("pread() called with 0 length buffer", .{});
         }
     }
 
@@ -902,7 +902,7 @@ else
 pub fn pwrite(fd: bun.FileDescriptor, bytes: []const u8, offset: i64) Maybe(usize) {
     if (comptime Environment.allow_assert) {
         if (bytes.len == 0) {
-            @panic("pwrite() called with 0 length buffer");
+            bun.Output.debugWarn("pwrite() called with 0 length buffer", .{});
         }
     }
 
@@ -925,7 +925,7 @@ pub fn pwrite(fd: bun.FileDescriptor, bytes: []const u8, offset: i64) Maybe(usiz
 pub fn read(fd: bun.FileDescriptor, buf: []u8) Maybe(usize) {
     if (comptime Environment.allow_assert) {
         if (buf.len == 0) {
-            @panic("read() called with 0 length buffer");
+            bun.Output.debugWarn("read() called with 0 length buffer", .{});
         }
     }
     const debug_timer = bun.Output.DebugTimer.start();
@@ -963,7 +963,7 @@ pub fn recv(fd: bun.FileDescriptor, buf: []u8, flag: u32) Maybe(usize) {
     const adjusted_len = @min(buf.len, max_count);
     if (comptime Environment.allow_assert) {
         if (adjusted_len == 0) {
-            @panic("recv() called with 0 length buffer");
+            bun.Output.debugWarn("recv() called with 0 length buffer", .{});
         }
     }
 

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -5,16 +5,16 @@ import { bunEnv, bunExe } from "harness";
 let cwd: string;
 
 describe("bun", () => {
-    test("should error with missing script", () => {
-      const { exitCode, stdout, stderr } = spawnSync({
-        cwd,
-        cmd: [bunExe(), "run", "dev"],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      expect(stdout.toString()).toBeEmpty();
-      expect(stderr.toString()).toMatch(/Script not found/);
-      expect(exitCode).toBe(1);
+  test("should error with missing script", () => {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd,
+      cmd: [bunExe(), "run", "dev"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
     });
-})
+    expect(stdout.toString()).toBeEmpty();
+    expect(stderr.toString()).toMatch(/Script not found/);
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -11,11 +11,8 @@ import { tmpdir } from "os";
 let renderToReadableStream: any = null;
 let app_jsx: any = null;
 
-console.log("started");
-
 type Handler = (req: Request) => Response;
 afterEach(() => {
-  console.log("afterEach");
   gc(true);
 });
 
@@ -23,8 +20,6 @@ const count = 200;
 let server: Server | undefined;
 
 async function runTest({ port, ...serverOptions }: Serve<any>, test: (server: Server) => Promise<void> | void) {
-  console.trace("runTest");
-  console.log("server:", server);
   if (server) {
     server.reload({ ...serverOptions, port: 0 });
   } else {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -299,7 +299,7 @@ it("Bun.write(Bun.stderr, 'new TextEncoder().encode(Bun.write STDERR TEST'))", a
 
 // FLAKY TEST
 // Since Bun.file is resolved lazily, this needs to specifically be checked
-it.skip("Bun.write('output.html', HTMLRewriter.transform(Bun.file)))", async done => {
+it("Bun.write('output.html', HTMLRewriter.transform(Bun.file)))", async done => {
   var rewriter = new HTMLRewriter();
 
   rewriter.on("div", {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -343,6 +343,7 @@ it("promises.readFile", async () => {
   }
 });
 
+describe("promises.readFile", async () => {
   const nodeOutput = [
     {
       "encoding": "utf8",

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -527,7 +527,7 @@ describe("promises.readFile", async () => {
     },
   ];
 
-  it("encodes", async () => {
+  it("& fs.promises.writefile encodes & decodes", async () => {
     const results = [];
     for (let encoding of [
       "utf8",
@@ -561,7 +561,12 @@ describe("promises.readFile", async () => {
         }
 
         expect(fs.readFileSync(outfile, encoding)).toEqual(out);
-        fs.rm(outfile, { force: true }, () => {});
+        await promises.rm(outfile, { force: true });
+
+        expect(await promises.writeFile(outfile, text, encoding)).toBeUndefined();
+        expect(await promises.readFile(outfile, encoding)).toEqual(out);
+        promises.rm(outfile, { force: true });
+
         results.push({
           encoding,
           text,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { dirname, resolve, relative } from "node:path";
 import { promisify } from "node:util";
 import { bunEnv, bunExe, gc } from "harness";
+import { isAscii } from "node:buffer";
 import fs, {
   closeSync,
   existsSync,
@@ -340,6 +341,237 @@ it("promises.readFile", async () => {
       expect(e.path).toBe("/i-dont-exist");
     }
   }
+});
+
+  const nodeOutput = [
+    {
+      "encoding": "utf8",
+      "text": "ascii",
+      "correct": {
+        "type": "Buffer",
+        "data": [97, 115, 99, 105, 105],
+      },
+      "out": "ascii",
+    },
+    {
+      "encoding": "utf8",
+      "text": "utf16 🍇 🍈 🍉 🍊 🍋",
+      "correct": {
+        "type": "Buffer",
+        "data": [
+          117, 116, 102, 49, 54, 32, 240, 159, 141, 135, 32, 240, 159, 141, 136, 32, 240, 159, 141, 137, 32, 240, 159,
+          141, 138, 32, 240, 159, 141, 139,
+        ],
+      },
+      "out": "utf16 🍇 🍈 🍉 🍊 🍋",
+    },
+    {
+      "encoding": "utf8",
+      "text": "👍",
+      "correct": {
+        "type": "Buffer",
+        "data": [240, 159, 145, 141],
+      },
+      "out": "👍",
+    },
+    {
+      "encoding": "utf-8",
+      "text": "ascii",
+      "correct": {
+        "type": "Buffer",
+        "data": [97, 115, 99, 105, 105],
+      },
+      "out": "ascii",
+    },
+    {
+      "encoding": "utf-8",
+      "text": "utf16 🍇 🍈 🍉 🍊 🍋",
+      "correct": {
+        "type": "Buffer",
+        "data": [
+          117, 116, 102, 49, 54, 32, 240, 159, 141, 135, 32, 240, 159, 141, 136, 32, 240, 159, 141, 137, 32, 240, 159,
+          141, 138, 32, 240, 159, 141, 139,
+        ],
+      },
+      "out": "utf16 🍇 🍈 🍉 🍊 🍋",
+    },
+    {
+      "encoding": "utf-8",
+      "text": "👍",
+      "correct": {
+        "type": "Buffer",
+        "data": [240, 159, 145, 141],
+      },
+      "out": "👍",
+    },
+    {
+      "encoding": "utf16le",
+      "text": "ascii",
+      "correct": {
+        "type": "Buffer",
+        "data": [97, 0, 115, 0, 99, 0, 105, 0, 105, 0],
+      },
+      "out": "ascii",
+    },
+    {
+      "encoding": "utf16le",
+      "text": "utf16 🍇 🍈 🍉 🍊 🍋",
+      "correct": {
+        "type": "Buffer",
+        "data": [
+          117, 0, 116, 0, 102, 0, 49, 0, 54, 0, 32, 0, 60, 216, 71, 223, 32, 0, 60, 216, 72, 223, 32, 0, 60, 216, 73,
+          223, 32, 0, 60, 216, 74, 223, 32, 0, 60, 216, 75, 223,
+        ],
+      },
+      "out": "utf16 🍇 🍈 🍉 🍊 🍋",
+    },
+    {
+      "encoding": "utf16le",
+      "text": "👍",
+      "correct": {
+        "type": "Buffer",
+        "data": [61, 216, 77, 220],
+      },
+      "out": "👍",
+    },
+    {
+      "encoding": "latin1",
+      "text": "ascii",
+      "correct": {
+        "type": "Buffer",
+        "data": [97, 115, 99, 105, 105],
+      },
+      "out": "ascii",
+    },
+    {
+      "encoding": "latin1",
+      "text": "utf16 🍇 🍈 🍉 🍊 🍋",
+      "correct": {
+        "type": "Buffer",
+        "data": [117, 116, 102, 49, 54, 32, 60, 71, 32, 60, 72, 32, 60, 73, 32, 60, 74, 32, 60, 75],
+      },
+      "out": "utf16 <G <H <I <J <K",
+    },
+    {
+      "encoding": "latin1",
+      "text": "👍",
+      "correct": {
+        "type": "Buffer",
+        "data": [61, 77],
+      },
+      "out": "=M",
+    },
+    {
+      "encoding": "binary",
+      "text": "ascii",
+      "correct": {
+        "type": "Buffer",
+        "data": [97, 115, 99, 105, 105],
+      },
+      "out": "ascii",
+    },
+    {
+      "encoding": "binary",
+      "text": "utf16 🍇 🍈 🍉 🍊 🍋",
+      "correct": {
+        "type": "Buffer",
+        "data": [117, 116, 102, 49, 54, 32, 60, 71, 32, 60, 72, 32, 60, 73, 32, 60, 74, 32, 60, 75],
+      },
+      "out": "utf16 <G <H <I <J <K",
+    },
+    {
+      "encoding": "binary",
+      "text": "👍",
+      "correct": {
+        "type": "Buffer",
+        "data": [61, 77],
+      },
+      "out": "=M",
+    },
+    {
+      "encoding": "base64",
+      "text": "ascii",
+      "correct": {
+        "type": "Buffer",
+        "data": [106, 199, 34],
+      },
+      "out": "asci",
+    },
+    {
+      "encoding": "hex",
+      "text": "ascii",
+      "correct": {
+        "type": "Buffer",
+        "data": [],
+      },
+      "out": "",
+    },
+    {
+      "encoding": "hex",
+      "text": "utf16 🍇 🍈 🍉 🍊 🍋",
+      "correct": {
+        "type": "Buffer",
+        "data": [],
+      },
+      "out": "",
+    },
+    {
+      "encoding": "hex",
+      "text": "👍",
+      "correct": {
+        "type": "Buffer",
+        "data": [],
+      },
+      "out": "",
+    },
+  ];
+
+  it("encodes", async () => {
+    const results = [];
+    for (let encoding of [
+      "utf8",
+      "utf-8",
+      "utf16le",
+      "latin1",
+      "binary",
+      "base64",
+      /* TODO: "base64url", */ "hex",
+    ] as const) {
+      for (let text of ["ascii", "utf16 🍇 🍈 🍉 🍊 🍋", "👍"]) {
+        if (encoding === "base64" && !isAscii(Buffer.from(text)))
+          // TODO: output does not match Node.js, and it's not a problem with readFile specifically.
+          continue;
+        const correct = Buffer.from(text, encoding);
+        const outfile = join(
+          tmpdir(),
+          "promises.readFile-" + Date.now() + "-" + Math.random().toString(32) + "-" + encoding + ".txt",
+        );
+        writeFileSync(outfile, correct);
+        const out = await fs.promises.readFile(outfile, encoding);
+        {
+          const { promise, resolve, reject } = Promise.withResolvers();
+
+          fs.readFile(outfile, encoding, (err, data) => {
+            if (err) reject(err);
+            else resolve(data);
+          });
+
+          expect(await promise).toEqual(out);
+        }
+
+        expect(fs.readFileSync(outfile, encoding)).toEqual(out);
+        fs.rm(outfile, { force: true }, () => {});
+        results.push({
+          encoding,
+          text,
+          correct,
+          out,
+        });
+      }
+    }
+
+    expect(JSON.parse(JSON.stringify(results, null, 2))).toEqual(nodeOutput);
+  });
 });
 
 it("promises.readFile - UTF16 file path", async () => {

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -300,6 +300,6 @@ it("setTimeout CPU usage #7790", async () => {
   });
   const code = await process.exited;
   expect(code).toBe(0);
-  const stats = process.stats();
+  const stats = process.resourceUsage();
   expect(stats.cpuTime.user / BigInt(1e6)).toBeLessThan(1);
 });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -539,11 +539,9 @@ afterAll(() => {
 const request_types = ["/", "/gzip", "/chunked/gzip", "/chunked", "/file", "/file/gzip"];
 ["http", "https"].forEach(protocol => {
   request_types.forEach(url => {
-    //TODO: change this when Bun.file supports https
-    const test = url.indexOf("file") !== -1 && protocol === "https" ? it.todo : it;
-    test(`works with ${protocol} fetch using ${url}`, async () => {
+    it(`works with ${protocol} fetch using ${url}`, async () => {
       const server = protocol === "http" ? http_server : https_server;
-      const server_url = `${protocol}://${server?.hostname}:${server?.port}`;
+      const server_url = server.url;
       const res = await fetch(`${server_url}${url}`, { tls: { rejectUnauthorized: false } });
       let calls = 0;
       const rw = new HTMLRewriter();

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -77,19 +77,17 @@ describe("HTMLRewriter", () => {
     });
   }
 
-  for (let input of [new Response(Bun.file("/tmp/html-rewriter.txt.js"))]) {
-    it("(from file) supports element handlers with input: " + input.constructor.name, async () => {
-      var rewriter = new HTMLRewriter();
-      rewriter.on("div", {
-        element(element) {
-          element.setInnerContent("<blink>it worked!</blink>", { html: true });
-        },
-      });
-      await Bun.write("/tmp/html-rewriter.txt.js", "<div>hello</div>");
-      var output = rewriter.transform(input);
-      expect(await output.text()).toBe("<div><blink>it worked!</blink></div>");
+  it("(from file) supports element handlers", async () => {
+    var rewriter = new HTMLRewriter();
+    rewriter.on("div", {
+      element(element) {
+        element.setInnerContent("<blink>it worked!</blink>", { html: true });
+      },
     });
-  }
+    await Bun.write("/tmp/html-rewriter.txt.js", "<div>hello</div>");
+    var output = rewriter.transform(new Response(Bun.file("/tmp/html-rewriter.txt.js")));
+    expect(await output.text()).toBe("<div><blink>it worked!</blink></div>");
+  });
 
   it("supports attribute iterator", async () => {
     var rewriter = new HTMLRewriter();

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -78,7 +78,7 @@ describe("HTMLRewriter", () => {
     });
   }
 
-  for (let input of [new Response(Bun.file("/tmp/html-rewriter.txt.js")), Bun.file("/tmp/html-rewriter.txt.js")]) {
+  for (let input of [new Response(Bun.file("/tmp/html-rewriter.txt.js"))]) {
     it("(from file) supports element handlers with input: " + input.constructor.name, async () => {
       var rewriter = new HTMLRewriter();
       rewriter.on("div", {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -72,9 +72,8 @@ describe("HTMLRewriter", () => {
           element.setInnerContent("<blink>it worked!</blink>", { html: true });
         },
       });
-      var input = new Response("<div>hello</div>");
       var output = rewriter.transform(input);
-      expect(await output.text()).toBe("<div><blink>it worked!</blink></div>");
+      expect(typeof input === "string" ? output : await output.text()).toBe("<div><blink>it worked!</blink></div>");
     });
   }
 


### PR DESCRIPTION
### What does this PR do?

This replaces the following structs with `StringOrBuffer`:
- `SliceOrBuffer`
- `SliceWithUnderlyingStringOrBuffer`
- `StringOrNodeBuffer`
- `StringOrBunStringOrBuffer`

By making it simpler, hopefully we make fewer mistakes going forward.

This also:

- Fixes a memory leak in fs.writeFile
- Fixes a memory leak in fs.readlink
- Fixes a memory leak in fs.stat
- Fixes a memory leak in HTMLRewriter
- Fixes #6569 
- Fixes #4845 
- Fixes #7165 
- Fixes #2325
 
We are still not streamingly converting to base64/hex which I do not like, but it is better than the status quo which is not doing that at all in readFile or writeFile. 

### How did you verify your code works?

There are tests.

This manual test needs to become an automated test:
```js
import { writeFile } from "fs/promises";
const concurrency = 100;

let remaining = 10_000;
const array = new Array(concurrency);
const sample = "y oy oy oy oyoyoyoy yo".repeat(9024);

while (remaining > 0) {
  for (let i = 0; i < array.length; i++) {
    array[i] = writeFile("/tmp/out.txt", sample + i);
  }

  await Promise.all(array);
  remaining -= concurrency;
}
array.length = 0;
Bun.gc(true);

console.log("RSS:", (process.memoryUsage().rss / 1024 / 1024) | 0, "MB");
```

One thing I am a little worried about is the memory usage does double for this microbenchmark:
```js
import { readlink, writeFile } from "fs/promises";
const concurrency = 100;

let remaining = 10_00000;
const array = new Array(concurrency);

while (remaining > 0) {
  for (let i = 0; i < array.length; i++) {
    array[i] = readlink(("apaokdspoakdaspodk" + process.argv.at(-1)).slice(18), "utf8");
  }

  await Promise.all(array);
  remaining -= concurrency;
}
array.length = 0;
Bun.gc(true);

console.log("RSS:", (process.memoryUsage().rss / 1024 / 1024) | 0, "MB");
```