### PR TITLE
Update init template & TS documentation

### DIFF
--- a/docs/guides/runtime/typescript.md
+++ b/docs/guides/runtime/typescript.md
@@ -2,31 +2,10 @@
 name: Install TypeScript declarations for Bun
 ---
 
-To install TypeScript definitions for Bun's built-in APIs in your project, install `bun-types`.
+To install TypeScript definitions for Bun's built-in APIs in your project, install `@types/bun`.
 
 ```sh
-$ bun add -d bun-types # dev dependency
-```
-
----
-
-Then include `"bun-types"` in the `compilerOptions.types` in your `tsconfig.json`:
-
-```json-diff
-  {
-    "compilerOptions": {
-+     "types": ["bun-types"]
-    }
-  }
-```
-
----
-
-Unfortunately, setting a value for `"types"` means that TypeScript will ignore other global type definitions, including `lib: ["dom"]`. If you need to add DOM types into your project, add the following [triple-slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html) at the top of any TypeScript file in your project.
-
-```ts
-/// <reference lib="dom" />
-/// <reference lib="dom.iterable" />
+$ bun add -d @types/bun # dev dependency
 ```
 
 ---
@@ -36,30 +15,30 @@ Below is the full set of recommended `compilerOptions` for a Bun project. With t
 ```jsonc
 {
   "compilerOptions": {
-    // add Bun type definitions
-    "types": ["bun-types"],
-
     // enable latest features
-    "lib": ["esnext"],
-    "module": "esnext",
-    "target": "esnext",
-
-    // if TS 5.x+
-    "moduleResolution": "bundler",
-    "noEmit": true,
-    "allowImportingTsExtensions": true,
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
     "moduleDetection": "force",
-    // if TS 4.x or earlier
-    // "moduleResolution": "nodenext",
-
     "jsx": "react-jsx", // support JSX
     "allowJs": true, // allow importing `.js` from `.ts`
-    "esModuleInterop": true, // allow default imports for CommonJS modules
 
-    // best practices
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
     "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Some stricter flags
+    "useUnknownInCatchVariables": true,
+    "noPropertyAccessFromIndexSignature": true
   }
 }
 ```

--- a/packages/bun-inspector-frontend/package.json
+++ b/packages/bun-inspector-frontend/package.json
@@ -3,7 +3,7 @@
   "module": "index.ts",
   "type": "module",
   "devDependencies": {
-    "bun-types": "latest"
+    "@types/bun": "latest"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/bun-vscode/example/package.json
+++ b/packages/bun-vscode/example/package.json
@@ -17,7 +17,7 @@
     "mime"
   ],
   "devDependencies": {
-    "bun-types": "latest"
+    "@types/bun": "latest"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -317,7 +317,7 @@ pub const InitCommand = struct {
 
             if (needs_dev_dependencies) {
                 var dev_dependencies = fields.object.get("devDependencies") orelse js_ast.Expr.init(js_ast.E.Object, js_ast.E.Object{}, logger.Loc.Empty);
-                try dev_dependencies.data.e_object.putString(alloc, "bun-types", "latest");
+                try dev_dependencies.data.e_object.putString(alloc, "@types/bun", "latest");
                 try fields.object.put(alloc, "devDependencies", dev_dependencies);
             }
 

--- a/src/cli/tsconfig-for-init.json
+++ b/src/cli/tsconfig-for-init.json
@@ -1,22 +1,25 @@
 {
   "compilerOptions": {
     "lib": ["ESNext"],
-    "module": "esnext",
-    "target": "esnext",
-    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "module": "ESNext",
     "moduleDetection": "force",
-    "allowImportingTsExtensions": true,
-    "noEmit": true,
-    "composite": true,
-    "strict": true,
-    "downlevelIteration": true,
-    "skipLibCheck": true,
     "jsx": "react-jsx",
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true,
     "allowJs": true,
-    "types": [
-      "bun-types" // add Bun global
-    ]
-  }
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    /* Linting */
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
 }

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -22,7 +22,7 @@ test("bun init works", () => {
     "module": "index.ts",
     "type": "module",
     "devDependencies": {
-      "bun-types": "latest",
+      "@types/bun": "latest",
     },
     "peerDependencies": {
       "typescript": "^5.0.0",
@@ -58,7 +58,7 @@ test("bun init with piped cli", () => {
     "module": "index.ts",
     "type": "module",
     "devDependencies": {
-      "bun-types": "latest",
+      "@types/bun": "latest",
     },
     "peerDependencies": {
       "typescript": "^5.0.0",

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -5,16 +5,16 @@ import { bunEnv, bunExe } from "harness";
 let cwd: string;
 
 describe("bun", () => {
-    test("should error with missing script", () => {
-      const { exitCode, stdout, stderr } = spawnSync({
-        cwd,
-        cmd: [bunExe(), "run", "dev"],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      expect(stdout.toString()).toBeEmpty();
-      expect(stderr.toString()).toMatch(/Script not found/);
-      expect(exitCode).toBe(1);
+  test("should error with missing script", () => {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd,
+      cmd: [bunExe(), "run", "dev"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
     });
-})
+    expect(stdout.toString()).toBeEmpty();
+    expect(stderr.toString()).toMatch(/Script not found/);
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/integration/sharp/package.json
+++ b/test/integration/sharp/package.json
@@ -3,7 +3,7 @@
   "module": "index.ts",
   "type": "module",
   "devDependencies": {
-    "bun-types": "latest"
+    "@types/bun": "latest"
   },
   "peerDependencies": {
     "typescript": "5.3.2"

--- a/test/js/third_party/es-module-lexer/package.json
+++ b/test/js/third_party/es-module-lexer/package.json
@@ -3,7 +3,7 @@
   "module": "index.ts",
   "type": "module",
   "devDependencies": {
-    "bun-types": "latest"
+    "@types/bun": "latest"
   },
   "dependencies": {
     "es-module-lexer": "1.3.0"


### PR DESCRIPTION
Fixes #7803

I've done a similar update to the TSConfig close to one I've done for Vite:
- Remove flags enabled by default (`forceConsistentCasingInFileNames`, `allowSyntheticDefaultImports` with `bundler` mode)
- Remove `composite` because this not needed for one file
- Remove `downlevelIteration` as the compilation is done by Bun
- Group flags by topic so this is easier to read
- Use the case of the TS doc (`esnext` -> `ESNext`)

Then the things that are up to decide by the core team:
- Enable `verbatimModuleSyntax` flag which allows to warn when some things are imported as type only which avoid transpiler bug like https://twitter.com/jarredsumner/status/1728790622536962448 (even if catches less things than the TS-ESLint lint rule) 
- Enable `noUnusedLocals`, `noUnusedParameters` & `noFallthroughCasesInSwitch` which for me is always good
- Enable `useUnknownInCatchVariables`, which is also enabled in Vite templates
- Enable `noPropertyAccessFromIndexSignature`, which is a stronger one I discovered recently and really important to make you aware when you're dealing with a loosely typed object. I did not enable in Vite because people are used to `styles.button` instead of `styles["button"]` for CSS Modules. I've personnaly working with it and it's nice when writing code outside of quick scripting. 
