### PR TITLE
 feat(server): add server backlog parameter 

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1877,6 +1877,14 @@ declare module "bun" {
     maxRequestBodySize?: number;
 
     /**
+     * The backlog argument defines the maximum length to which the queue of pending connections for server.
+     * If a connection request arrives when the queue is full, the client may receive an error with an indication of ECONNREFUSED or,
+     * if the underlying protocol supports retransmission, the request may be ignored so that a later reattempt at connection succeeds.
+     * @default 512
+     */
+    backlog?: number;
+
+    /**
      * Render contextual errors? This enables bun's error page
      * @default process.env.NODE_ENV !== 'production'
      */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1880,7 +1880,7 @@ declare module "bun" {
      * The backlog argument defines the maximum length to which the queue of pending connections for server.
      * If a connection request arrives when the queue is full, the client may receive an error with an indication of ECONNREFUSED or,
      * if the underlying protocol supports retransmission, the request may be ignored so that a later reattempt at connection succeeds.
-     * @default 512
+     * @default 511
      */
     backlog?: number;
 

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -457,6 +457,7 @@ inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd
     LIBUS_SOCKET_DESCRIPTOR listenFd,
     struct addrinfo *listenAddr,
     int port,
+    int backlog,
     int options
 ) {
 
@@ -488,7 +489,7 @@ inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd
     setsockopt(listenFd, IPPROTO_IPV6, IPV6_V6ONLY, (void *) &disabled, sizeof(disabled));
 #endif
 
-    if (bind(listenFd, listenAddr->ai_addr, (socklen_t) listenAddr->ai_addrlen) || listen(listenFd, 512)) {
+    if (bind(listenFd, listenAddr->ai_addr, (socklen_t) listenAddr->ai_addrlen) || listen(listenFd, backlog)) {
         return LIBUS_SOCKET_ERROR;
     }
 
@@ -497,7 +498,7 @@ inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd
 
 // return LIBUS_SOCKET_ERROR or the fd that represents listen socket
 // listen both on ipv6 and ipv4
-LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int options) {
+LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int backlog, int options) {
     struct addrinfo hints, *result;
     memset(&hints, 0, sizeof(struct addrinfo));
 
@@ -522,7 +523,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
             }
 
             listenAddr = a;
-            if (bsd_bind_listen_fd(listenFd, listenAddr, port, options) != LIBUS_SOCKET_ERROR) {
+            if (bsd_bind_listen_fd(listenFd, listenAddr, port, backlog, options) != LIBUS_SOCKET_ERROR) {
                 freeaddrinfo(result);
                 return listenFd;
             }
@@ -539,7 +540,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
             }
 
             listenAddr = a;
-            if (bsd_bind_listen_fd(listenFd, listenAddr, port, options) != LIBUS_SOCKET_ERROR) {
+            if (bsd_bind_listen_fd(listenFd, listenAddr, port, backlog, options) != LIBUS_SOCKET_ERROR) {
                 freeaddrinfo(result);
                 return listenFd;
             }
@@ -560,7 +561,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
 #endif
 #include <sys/stat.h>
 #include <stddef.h>
-LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket_unix(const char *path, int options) {
+LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket_unix(const char *path, int backlog, int options) {
 
     LIBUS_SOCKET_DESCRIPTOR listenFd = LIBUS_SOCKET_ERROR;
 
@@ -588,7 +589,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket_unix(const char *path, int opti
     unlink(path);
 #endif
 
-    if (bind(listenFd, (struct sockaddr *)&server_address, size) || listen(listenFd, 512)) {
+    if (bind(listenFd, (struct sockaddr *)&server_address, size) || listen(listenFd, backlog)) {
         bsd_close_socket(listenFd);
         return LIBUS_SOCKET_ERROR;
     }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -299,14 +299,14 @@ void us_socket_context_free(int ssl, struct us_socket_context_t *context) {
     us_free(context);
 }
 
-struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_context_t *context, const char *host, int port, int options, int socket_ext_size) {
+struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_context_t *context, const char *host, int port, int backlog, int options, int socket_ext_size) {
 #ifndef LIBUS_NO_SSL
     if (ssl) {
-        return us_internal_ssl_socket_context_listen((struct us_internal_ssl_socket_context_t *) context, host, port, options, socket_ext_size);
+        return us_internal_ssl_socket_context_listen((struct us_internal_ssl_socket_context_t *) context, host, port, backlog, options, socket_ext_size);
     }
 #endif
 
-    LIBUS_SOCKET_DESCRIPTOR listen_socket_fd = bsd_create_listen_socket(host, port, options);
+    LIBUS_SOCKET_DESCRIPTOR listen_socket_fd = bsd_create_listen_socket(host, port, backlog, options);
 
     if (listen_socket_fd == LIBUS_SOCKET_ERROR) {
         return 0;
@@ -330,14 +330,14 @@ struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_co
     return ls;
 }
 
-struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_socket_context_t *context, const char *path, int options, int socket_ext_size) {
+struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_socket_context_t *context, const char *path, int backlog, int options, int socket_ext_size) {
 #ifndef LIBUS_NO_SSL
     if (ssl) {
-        return us_internal_ssl_socket_context_listen_unix((struct us_internal_ssl_socket_context_t *) context, path, options, socket_ext_size);
+        return us_internal_ssl_socket_context_listen_unix((struct us_internal_ssl_socket_context_t *) context, path, backlog, options, socket_ext_size);
     }
 #endif
 
-    LIBUS_SOCKET_DESCRIPTOR listen_socket_fd = bsd_create_listen_socket_unix(path, options);
+    LIBUS_SOCKET_DESCRIPTOR listen_socket_fd = bsd_create_listen_socket_unix(path, backlog, options);
 
     if (listen_socket_fd == LIBUS_SOCKET_ERROR) {
         return 0;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1430,8 +1430,8 @@ void us_internal_ssl_socket_context_free(
 
 struct us_listen_socket_t *us_internal_ssl_socket_context_listen(
     struct us_internal_ssl_socket_context_t *context, const char *host,
-    int port, int options, int socket_ext_size) {
-  return us_socket_context_listen(0, &context->sc, host, port, options,
+    int port, int backlog, int options, int socket_ext_size) {
+  return us_socket_context_listen(0, &context->sc, host, port, backlog, options,
                                   sizeof(struct us_internal_ssl_socket_t) -
                                       sizeof(struct us_socket_t) +
                                       socket_ext_size);
@@ -1439,8 +1439,8 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen(
 
 struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(
     struct us_internal_ssl_socket_context_t *context, const char *path,
-    int options, int socket_ext_size) {
-  return us_socket_context_listen_unix(0, &context->sc, path, options,
+    int backlog, int options, int socket_ext_size) {
+  return us_socket_context_listen_unix(0, &context->sc, path, backlog, options,
                                        sizeof(struct us_internal_ssl_socket_t) -
                                            sizeof(struct us_socket_t) +
                                            socket_ext_size);

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -285,11 +285,11 @@ void us_internal_ssl_socket_context_on_connect_error(
 
 struct us_listen_socket_t *us_internal_ssl_socket_context_listen(
     struct us_internal_ssl_socket_context_t *context, const char *host,
-    int port, int options, int socket_ext_size);
+    int port, int backlog, int options, int socket_ext_size);
 
 struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(
     struct us_internal_ssl_socket_context_t *context, const char *path,
-    int options, int socket_ext_size);
+    int backlog, int options, int socket_ext_size);
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(
     struct us_internal_ssl_socket_context_t *context, const char *host,

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -95,9 +95,9 @@ int bsd_would_block();
 
 // return LIBUS_SOCKET_ERROR or the fd that represents listen socket
 // listen both on ipv6 and ipv4
-LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int options);
+LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int backlog, int options);
 
-LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket_unix(const char *path, int options);
+LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket_unix(const char *path, int backlog, int options);
 
 /* Creates an UDP socket bound to the hostname and port */
 LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port);

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -245,10 +245,10 @@ void us_socket_context_close(int ssl, struct us_socket_context_t *context);
 
 /* Listen for connections. Acts as the main driving cog in a server. Will call set async callbacks. */
 struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_context_t *context,
-    const char *host, int port, int options, int socket_ext_size);
+    const char *host, int port, int backlog, int options, int socket_ext_size);
 
 struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_socket_context_t *context,
-    const char *path, int options, int socket_ext_size);
+    const char *path, int backlog, int options, int socket_ext_size);
 
 /* listen_socket.c/.h */
 void us_listen_socket_close(int ssl, struct us_listen_socket_t *ls);

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -542,45 +542,45 @@ public:
         return std::move(*this);
     }
 
-    /* Host, port, callback */
-    TemplatedApp &&listen(std::string host, int port, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
+    /* Host, port, backlog, callback */
+    TemplatedApp &&listen(std::string host, int port, int backlog, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
         if (!host.length()) {
-            return listen(port, std::move(handler));
+            return listen(port, backlog, std::move(handler));
         }
-        handler(httpContext ? httpContext->listen(host.c_str(), port, 0) : nullptr);
+        handler(httpContext ? httpContext->listen(host.c_str(), port, backlog, 0) : nullptr);
         return std::move(*this);
     }
 
-    /* Host, port, options, callback */
-    TemplatedApp &&listen(std::string host, int port, int options, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
+    /* Host, port, backlog, options, callback */
+    TemplatedApp &&listen(std::string host, int port, int backlog, int options, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
         if (!host.length()) {
-            return listen(port, options, std::move(handler));
+            return listen(port, backlog, options, std::move(handler));
         }
-        handler(httpContext ? httpContext->listen(host.c_str(), port, options) : nullptr);
+        handler(httpContext ? httpContext->listen(host.c_str(), port, backlog, options) : nullptr);
         return std::move(*this);
     }
 
-    /* Port, callback */
-    TemplatedApp &&listen(int port, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
-        handler(httpContext ? httpContext->listen(nullptr, port, 0) : nullptr);
+    /* Port, backlog, callback */
+    TemplatedApp &&listen(int port, int backlog, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
+        handler(httpContext ? httpContext->listen(nullptr, port, backlog, 0) : nullptr);
         return std::move(*this);
     }
 
-    /* Port, options, callback */
-    TemplatedApp &&listen(int port, int options, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
-        handler(httpContext ? httpContext->listen(nullptr, port, options) : nullptr);
+    /* Port, backlog, options, callback */
+    TemplatedApp &&listen(int port, int backlog, int options, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
+        handler(httpContext ? httpContext->listen(nullptr, port, backlog, options) : nullptr);
         return std::move(*this);
     }
 
     /* options, callback, path to unix domain socket */
-    TemplatedApp &&listen(int options, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler, std::string path) {
-        handler(httpContext ? httpContext->listen(path.c_str(), options) : nullptr);
+    TemplatedApp &&listen(int backlog, int options, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler, std::string path) {
+        handler(httpContext ? httpContext->listen(path.c_str(), backlog, options) : nullptr);
         return std::move(*this);
     }
 
     /* callback, path to unix domain socket */
-    TemplatedApp &&listen(MoveOnlyFunction<void(us_listen_socket_t *)> &&handler, std::string path) {
-        handler(httpContext ? httpContext->listen(path.c_str(), 0) : nullptr);
+    TemplatedApp &&listen(int backlog, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler, std::string path) {
+        handler(httpContext ? httpContext->listen(path.c_str(), backlog, 0) : nullptr);
         return std::move(*this);
     }
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -491,13 +491,13 @@ public:
     }
 
     /* Listen to port using this HttpContext */
-    us_listen_socket_t *listen(const char *host, int port, int options) {
-        return us_socket_context_listen(SSL, getSocketContext(), host, port, options, sizeof(HttpResponseData<SSL>));
+    us_listen_socket_t *listen(const char *host, int port, int backlog, int options) {
+        return us_socket_context_listen(SSL, getSocketContext(), host, port, backlog, options, sizeof(HttpResponseData<SSL>));
     }
 
     /* Listen to unix domain socket using this HttpContext */
-    us_listen_socket_t *listen(const char *path, int options) {
-        return us_socket_context_listen_unix(SSL, getSocketContext(), path, options, sizeof(HttpResponseData<SSL>));
+    us_listen_socket_t *listen(const char *path, int backlog, int options) {
+        return us_socket_context_listen_unix(SSL, getSocketContext(), path, backlog, options, sizeof(HttpResponseData<SSL>));
     }
 };
 

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -341,7 +341,7 @@ pub const SocketConfig = struct {
     handlers: Handlers,
     default_data: JSC.JSValue = .zero,
     exclusive: bool = false,
-    backlog: i32 = 512,
+    backlog: i32 = 511,
 
     pub fn fromJS(
         opts: JSC.JSValue,
@@ -351,7 +351,7 @@ pub const SocketConfig = struct {
         var hostname_or_unix: JSC.ZigString.Slice = JSC.ZigString.Slice.empty;
         var port: ?u16 = null;
         var exclusive = false;
-        var backlog: i32 = 512;
+        var backlog: i32 = 511;
 
         var ssl: ?JSC.API.ServerConfig.SSLConfig = null;
         var default_data = JSValue.zero;

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -341,6 +341,7 @@ pub const SocketConfig = struct {
     handlers: Handlers,
     default_data: JSC.JSValue = .zero,
     exclusive: bool = false,
+    backlog: i32 = 512,
 
     pub fn fromJS(
         opts: JSC.JSValue,
@@ -350,6 +351,7 @@ pub const SocketConfig = struct {
         var hostname_or_unix: JSC.ZigString.Slice = JSC.ZigString.Slice.empty;
         var port: ?u16 = null;
         var exclusive = false;
+        var backlog: i32 = 512;
 
         var ssl: ?JSC.API.ServerConfig.SSLConfig = null;
         var default_data = JSValue.zero;
@@ -365,6 +367,12 @@ pub const SocketConfig = struct {
                 } else if (exception.* != null) {
                     return null;
                 }
+            }
+        }
+
+        if (opts.getTruthy(globalObject, "backlog")) |backlog_| {
+            if (backlog_.isNumber()) {
+                backlog = @as(i32, @intCast(backlog_.coerce(i32, globalObject)));
             }
         }
 
@@ -451,6 +459,7 @@ pub const SocketConfig = struct {
             .handlers = handlers,
             .default_data = default_data,
             .exclusive = exclusive,
+            .backlog = backlog,
         };
     }
 };
@@ -578,6 +587,7 @@ pub const Listener = struct {
 
         var hostname_or_unix = socket_config.hostname_or_unix;
         const port = socket_config.port;
+        const backlog = socket_config.backlog;
         var ssl = socket_config.ssl;
         var handlers = socket_config.handlers;
         var protos: ?[]const u8 = null;
@@ -674,6 +684,7 @@ pub const Listener = struct {
                         socket_context,
                         normalizeListeningHost(host),
                         c.port,
+                        backlog,
                         socket_flags,
                         8,
                     );
@@ -686,7 +697,7 @@ pub const Listener = struct {
                 .unix => |u| {
                     const host = bun.default_allocator.dupeZ(u8, u) catch unreachable;
                     defer bun.default_allocator.free(host);
-                    break :brk uws.us_socket_context_listen_unix(@intFromBool(ssl_enabled), socket_context, host, socket_flags, 8);
+                    break :brk uws.us_socket_context_listen_unix(@intFromBool(ssl_enabled), socket_context, host, backlog, socket_flags, 8);
                 },
             }
         } orelse {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -149,6 +149,7 @@ pub const ServerConfig = struct {
 
     ssl_config: ?SSLConfig = null,
     max_request_body_size: usize = 1024 * 1024 * 128,
+    backlog: i32 = 512,
     development: bool = false,
 
     onError: JSC.JSValue = JSC.JSValue.zero,
@@ -894,6 +895,12 @@ pub const ServerConfig = struct {
             if (arg.getTruthy(global, "maxRequestBodySize")) |max_request_body_size| {
                 if (max_request_body_size.isNumber()) {
                     args.max_request_body_size = @as(u64, @intCast(@max(0, max_request_body_size.toInt64())));
+                }
+            }
+
+            if (arg.getTruthy(global, "backlog")) |backlog| {
+                if (backlog.isNumber()) {
+                    args.backlog = @as(i32, @intCast(backlog.coerce(i32, global)));
                 }
             }
 
@@ -5984,6 +5991,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                     this.app.listenWithConfig(*ThisServer, this, onListen, .{
                         .port = tcp.port,
                         .host = host,
+                        .backlog = this.config.backlog,
                         .options = if (this.config.reuse_port) 0 else 1,
                     });
                 },
@@ -5994,6 +6002,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                         this,
                         onListen,
                         unix,
+                        this.config.backlog,
                         if (this.config.reuse_port) 0 else 1,
                     );
                 },

--- a/src/deps/_libusockets.h
+++ b/src/deps/_libusockets.h
@@ -67,6 +67,7 @@ typedef struct {
   int port;
   const char *host;
   int options;
+  int backlog;
 } uws_app_listen_config_t;
 
 struct uws_app_s;
@@ -123,8 +124,8 @@ typedef struct {
 
 typedef void (*uws_listen_handler)(struct us_listen_socket_t *listen_socket,
                                    void *user_data);
-typedef void (*uws_listen_domain_handler)(struct us_listen_socket_t *listen_socket, 
-                                          const char* domain, int options, 
+typedef void (*uws_listen_domain_handler)(struct us_listen_socket_t *listen_socket,
+                                          const char* domain, int options,
                                           void *user_data);
 
 typedef void (*uws_method_handler)(uws_res_t *response, uws_req_t *request,
@@ -132,10 +133,10 @@ typedef void (*uws_method_handler)(uws_res_t *response, uws_req_t *request,
 typedef void (*uws_filter_handler)(uws_res_t *response, int, void *user_data);
 typedef void (*uws_missing_server_handler)(const char *hostname,
                                            void *user_data);
-typedef void (*uws_get_headers_server_handler)(const char *header_name, 
-                                               size_t header_name_size, 
-                                               const char *header_value, 
-                                               size_t header_value_size, 
+typedef void (*uws_get_headers_server_handler)(const char *header_name,
+                                               size_t header_name_size,
+                                               const char *header_value,
+                                               size_t header_value_size,
                                                void *user_data);
 
 // Basic HTTP
@@ -165,16 +166,16 @@ void uws_app_any(int ssl, uws_app_t *app, const char *pattern,
 
 void uws_app_run(int ssl, uws_app_t *);
 
-void uws_app_listen(int ssl, uws_app_t *app, int port,
+void uws_app_listen(int ssl, uws_app_t *app, int port, int backlog,
                     uws_listen_handler handler, void *user_data);
 void uws_app_listen_with_config(int ssl, uws_app_t *app, const char *host,
-                                uint16_t port, int32_t options,
+                                uint16_t port, int32_t backlog, int32_t options,
                                 uws_listen_handler handler, void *user_data);
-void uws_app_listen_domain(int ssl, uws_app_t *app, const char *domain, 
+void uws_app_listen_domain(int ssl, uws_app_t *app, const char *domain, int backlog,
                            uws_listen_domain_handler handler, void *user_data);
 
 void uws_app_listen_domain_with_options(int ssl, uws_app_t *app, const char *domain,
-                                        int options, uws_listen_domain_handler handler,
+                                        int backlog, int options, uws_listen_domain_handler handler,
                                         void *user_data);
 void uws_app_domain(int ssl, uws_app_t *app, const char *server_name);
 

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -312,7 +312,7 @@ extern "C"
     }
   }
 
-  void uws_app_listen(int ssl, uws_app_t *app, int port,
+  void uws_app_listen(int ssl, uws_app_t *app, int port, int backlog,
                       uws_listen_handler handler, void *user_data)
   {
     uws_app_listen_config_t config;
@@ -323,7 +323,7 @@ extern "C"
     if (ssl)
     {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->listen(port, [handler, config,
+      uwsApp->listen(port, backlog, [handler, config,
                             user_data](struct us_listen_socket_t *listen_socket)
                      { handler((struct us_listen_socket_t *)listen_socket, user_data); });
     }
@@ -331,14 +331,14 @@ extern "C"
     {
       uWS::App *uwsApp = (uWS::App *)app;
 
-      uwsApp->listen(port, [handler, config,
+      uwsApp->listen(port, backlog, [handler, config,
                             user_data](struct us_listen_socket_t *listen_socket)
                      { handler((struct us_listen_socket_t *)listen_socket, user_data); });
     }
   }
 
   void uws_app_listen_with_config(int ssl, uws_app_t *app, const char *host,
-                                  uint16_t port, int32_t options,
+                                  uint16_t port, int32_t backlog, int32_t options,
                                   uws_listen_handler handler, void *user_data)
   {
     std::string hostname = host && host[0] ? std::string(host, strlen(host)) : "";
@@ -346,7 +346,7 @@ extern "C"
     {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
       uwsApp->listen(
-          hostname, port, options,
+          hostname, port, backlog, options,
           [handler, user_data](struct us_listen_socket_t *listen_socket)
           {
             handler((struct us_listen_socket_t *)listen_socket, user_data);
@@ -356,7 +356,7 @@ extern "C"
     {
       uWS::App *uwsApp = (uWS::App *)app;
       uwsApp->listen(
-          hostname, port, options,
+          hostname, port, backlog, options,
           [handler, user_data](struct us_listen_socket_t *listen_socket)
           {
             handler((struct us_listen_socket_t *)listen_socket, user_data);
@@ -365,32 +365,32 @@ extern "C"
   }
 
   /* callback, path to unix domain socket */
-  void uws_app_listen_domain(int ssl, uws_app_t *app, const char *domain, uws_listen_domain_handler handler, void *user_data)
+  void uws_app_listen_domain(int ssl, uws_app_t *app, const char *domain, int backlog, uws_listen_domain_handler handler, void *user_data)
   {
     if (ssl)
     {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->listen([handler, domain, user_data](struct us_listen_socket_t *listen_socket)
+      uwsApp->listen(backlog, [handler, domain, user_data](struct us_listen_socket_t *listen_socket)
                      { handler((struct us_listen_socket_t *)listen_socket, domain, 0, user_data); },
                      domain);
     }
     else
     {
       uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->listen([handler, domain, user_data](struct us_listen_socket_t *listen_socket)
+      uwsApp->listen(backlog, [handler, domain, user_data](struct us_listen_socket_t *listen_socket)
                      { handler((struct us_listen_socket_t *)listen_socket, domain, 0, user_data); },
                      domain);
     }
   }
 
   /* callback, path to unix domain socket */
-  void uws_app_listen_domain_with_options(int ssl, uws_app_t *app, const char *domain, int options, uws_listen_domain_handler handler, void *user_data)
+  void uws_app_listen_domain_with_options(int ssl, uws_app_t *app, const char *domain, int backlog, int options, uws_listen_domain_handler handler, void *user_data)
   {
     if (ssl)
     {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
       uwsApp->listen(
-          options, [handler, domain, options, user_data](struct us_listen_socket_t *listen_socket)
+          backlog, options, [handler, domain, options, user_data](struct us_listen_socket_t *listen_socket)
           { handler((struct us_listen_socket_t *)listen_socket, domain, options, user_data); },
           domain);
     }
@@ -398,7 +398,7 @@ extern "C"
     {
       uWS::App *uwsApp = (uWS::App *)app;
       uwsApp->listen(
-          options, [handler, domain, options, user_data](struct us_listen_socket_t *listen_socket)
+          backlog, options, [handler, domain, options, user_data](struct us_listen_socket_t *listen_socket)
           { handler((struct us_listen_socket_t *)listen_socket, domain, options, user_data); },
           domain);
     }

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1106,8 +1106,8 @@ extern fn us_socket_context_on_connect_error(ssl: i32, context: ?*SocketContext,
 extern fn us_socket_context_on_end(ssl: i32, context: ?*SocketContext, on_end: *const fn (*Socket) callconv(.C) ?*Socket) void;
 extern fn us_socket_context_ext(ssl: i32, context: ?*SocketContext) ?*anyopaque;
 
-pub extern fn us_socket_context_listen(ssl: i32, context: ?*SocketContext, host: ?[*:0]const u8, port: i32, options: i32, socket_ext_size: i32) ?*ListenSocket;
-pub extern fn us_socket_context_listen_unix(ssl: i32, context: ?*SocketContext, path: [*c]const u8, options: i32, socket_ext_size: i32) ?*ListenSocket;
+pub extern fn us_socket_context_listen(ssl: i32, context: ?*SocketContext, host: ?[*:0]const u8, port: i32, backlog: i32, options: i32, socket_ext_size: i32) ?*ListenSocket;
+pub extern fn us_socket_context_listen_unix(ssl: i32, context: ?*SocketContext, path: [*c]const u8, backlog: i32, options: i32, socket_ext_size: i32) ?*ListenSocket;
 pub extern fn us_socket_context_connect(ssl: i32, context: ?*SocketContext, host: ?[*:0]const u8, port: i32, source_host: [*c]const u8, options: i32, socket_ext_size: i32) ?*Socket;
 pub extern fn us_socket_context_connect_unix(ssl: i32, context: ?*SocketContext, path: [*c]const u8, options: i32, socket_ext_size: i32) ?*Socket;
 pub extern fn us_socket_is_established(ssl: i32, s: ?*Socket) i32;
@@ -1736,6 +1736,7 @@ pub fn NewApp(comptime ssl: bool) type {
         pub fn listen(
             app: *ThisApp,
             port: i32,
+            backlog: i32,
             comptime UserData: type,
             user_data: UserData,
             comptime handler: fn (UserData, ?*ThisApp.ListenSocket, uws_app_listen_config_t) void,
@@ -1756,7 +1757,7 @@ pub fn NewApp(comptime ssl: bool) type {
                     }
                 }
             };
-            return uws_app_listen(ssl_flag, @as(*uws_app_t, @ptrCast(app)), port, Wrapper.handle, user_data);
+            return uws_app_listen(ssl_flag, @as(*uws_app_t, @ptrCast(app)), port, backlog, Wrapper.handle, user_data);
         }
 
         pub fn listenWithConfig(
@@ -1778,7 +1779,7 @@ pub fn NewApp(comptime ssl: bool) type {
                     }
                 }
             };
-            return uws_app_listen_with_config(ssl_flag, @as(*uws_app_t, @ptrCast(app)), config.host, @as(u16, @intCast(config.port)), config.options, Wrapper.handle, user_data);
+            return uws_app_listen_with_config(ssl_flag, @as(*uws_app_t, @ptrCast(app)), config.host, @as(u16, @intCast(config.port)), config.backlog, config.options, Wrapper.handle, user_data);
         }
 
         pub fn listenOnUnixSocket(
@@ -1787,6 +1788,7 @@ pub fn NewApp(comptime ssl: bool) type {
             user_data: UserData,
             comptime handler: fn (UserData, ?*ThisApp.ListenSocket) void,
             domain: [*:0]const u8,
+            backlog: i32,
             flags: i32,
         ) void {
             const Wrapper = struct {
@@ -1805,6 +1807,7 @@ pub fn NewApp(comptime ssl: bool) type {
                 ssl_flag,
                 @as(*uws_app_t, @ptrCast(app)),
                 domain,
+                backlog,
                 flags,
                 Wrapper.handle,
                 user_data,
@@ -2242,6 +2245,7 @@ extern fn uws_app_listen_with_config(
     app: *uws_app_t,
     host: [*c]const u8,
     port: u16,
+    backlog: i32,
     options: i32,
     handler: uws_listen_handler,
     user_data: ?*anyopaque,
@@ -2376,6 +2380,7 @@ pub const uws_app_listen_config_t = extern struct {
     port: i32,
     host: [*c]const u8 = null,
     options: i32,
+    backlog: i32,
 };
 
 extern fn us_socket_mark_needs_more_not_ssl(socket: ?*uws_res) void;
@@ -2418,7 +2423,8 @@ extern fn uws_app_listen_domain_with_options(
     ssl_flag: c_int,
     app: *uws_app_t,
     domain: [*:0]const u8,
-    i32,
+    backlog: i32,
+    options: i32,
     *const (fn (*ListenSocket, domain: [*:0]const u8, i32, *anyopaque) callconv(.C) void),
     ?*anyopaque,
 ) void;

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -476,6 +476,7 @@ Server.prototype.listen = function (port, host, backlog, onListen) {
       this.close();
     });
 
+    backlog = port?.backlog;
     host = port?.host;
     port = port?.port;
 
@@ -500,6 +501,7 @@ Server.prototype.listen = function (port, host, backlog, onListen) {
       port,
       hostname: host,
       unix: socketPath,
+      backlog: backlog,
       // Bindings to be used for WS Server
       websocket: {
         open(ws) {

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -467,6 +467,10 @@ Server.prototype.listen = function (port, host, backlog, onListen) {
   if (typeof host === "function") {
     onListen = host;
     host = undefined;
+  } else if (Number.isSafeInteger(host) && host > 0) {
+    onListen = backlog;
+    backlog = host;
+    host = undefined;
   }
 
   if (typeof port === "function") {

--- a/src/js/node/net.js
+++ b/src/js/node/net.js
@@ -798,10 +798,14 @@ class Server extends EventEmitter {
     return this;
   }
 
-  listen(port, hostname, onListen) {
-    let backlog;
+  listen(port, hostname, backlog, onListen) {
     let path;
     let exclusive = false;
+
+    if (typeof backlog === "function") {
+      onListen = backlog;
+    }
+
     //port is actually path
     if (typeof port === "string") {
       if (Number.isSafeInteger(hostname)) {
@@ -834,6 +838,7 @@ class Server extends EventEmitter {
         exclusive = options.exclusive === true;
         const path = options.path;
         port = options.port;
+        backlog = options.backlog;
 
         if (!Number.isSafeInteger(port) || port < 0) {
           if (path) {
@@ -891,6 +896,7 @@ class Server extends EventEmitter {
           ? {
               exclusive,
               unix: path,
+              backlog: backlog,
               tls,
               socket: SocketClass[bunSocketServerHandlers],
             }
@@ -898,6 +904,7 @@ class Server extends EventEmitter {
               exclusive,
               port,
               hostname,
+              backlog: backlog,
               tls,
               socket: SocketClass[bunSocketServerHandlers],
             },

--- a/src/js/node/net.js
+++ b/src/js/node/net.js
@@ -804,6 +804,7 @@ class Server extends EventEmitter {
 
     if (typeof backlog === "function") {
       onListen = backlog;
+      backlog = undefined;
     }
 
     //port is actually path

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -990,7 +990,7 @@ describe("node:http", () => {
           .find(line => line.includes(`:${port}`));
         expect(line).toBeDefined();
         const columns = line.split(/\s+/);
-        expect(columns[3]).toBe("512");
+        expect(columns[3]).toBe("511");
         done();
       } catch (err) {
         done(err);

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -979,6 +979,24 @@ describe("node:http", () => {
     });
   });
 
+  test("should listen if we pass a backlog", done => {
+    const server = createServer((req, res) => {
+      res.end();
+    });
+    server.listen(0, "127.0.0.1", 1024, async (_err, host, port) => {
+      try {
+        await fetch(`http://${host}:${port}`).then(res => {
+          expect(res.status).toBe(200);
+          done();
+        });
+      } catch (err) {
+        done(err);
+      } finally {
+        server.close();
+      }
+    });
+  });
+
   test("error event not fired, issue#4651", done => {
     const server = createServer((req, res) => {
       res.end();

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -72,6 +72,35 @@ describe("net.createServer listen", () => {
     );
   });
 
+  it("should listen if we passed backlog", done => {
+    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+
+    const server: Server = createServer();
+
+    let timeout: Timer;
+    const closeAndFail = () => {
+      clearTimeout(timeout);
+      server.close();
+      mustNotCall()();
+    };
+    server.on("error", closeAndFail);
+    timeout = setTimeout(closeAndFail, 100);
+
+    server.listen(
+      0,
+      "0.0.0.0",
+      1024,
+      mustCall(() => {
+        const address = server.address() as AddressInfo;
+        expect(address.address).toStrictEqual("0.0.0.0");
+        expect(address.port).toBeGreaterThan(100);
+        expect(address.family).toStrictEqual("IPv4");
+        server.close();
+        done();
+      }),
+    );
+  });
+
   it("should call listening", done => {
     const { mustCall, mustNotCall } = createCallCheckCtx(done);
 

--- a/test/regression/issue/07740.test.ts
+++ b/test/regression/issue/07740.test.ts
@@ -5,10 +5,10 @@ import { tempDirWithFiles } from "harness";
 it("duplicate dependencies should warn instead of error", () => {
   const package_json = JSON.stringify({
     devDependencies: {
-      "empty-package-for-bun-test-runner": "1.0.0"
+      "empty-package-for-bun-test-runner": "1.0.0",
     },
     dependencies: {
-      "empty-package-for-bun-test-runner": "1.0.0"
+      "empty-package-for-bun-test-runner": "1.0.0",
     },
   });
 


### PR DESCRIPTION
### What does this PR do?

This pull request adds the `backlog` parameter to both `Bun.listen` and `Bun.serve`. Additionally, it addresses the issue where the `backlog` parameter of the` server.listen` function on the Node.js side was not taking effect. The default value is `512`.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

passed existing tests. And manually tested.


##### `Bun.serve`


```JavaScript
Bun.serve({
  hostname: "127.0.0.1",
  port: 8080,
  backlog: 1024,
  fetch(request) {
    console.log(request.url);
  },
});
```

##### `Bun.listen`

```JavaScript
Bun.listen({
  hostname: "127.0.0.1",
  port: 8080,
  backlog: 1024,
  socket: {
    data(socket, data) { },
  },
});
```

##### `http.createServer`

```JavaScript
const http = require("http");

const server = http.createServer((req, res) => {});
server.listen(8080, "127.0.0.1", 1024, () => {
  console.log("opened server on", server.address());
});

```

##### `net.createServer`

```JavaScript
const net = require("net");
const server = net.createServer();

server.listen(8080, "127.0.0.1", 1024, () => {
  console.log("opened server on", server.address());
});
```

Run the above code and see `send-q` via `ss` command

```
>> ss -tuln | grep 8080
tcp   LISTEN 0      2048       127.0.0.1:8080       0.0.0.0:*
```

Ref

https://www.linuxjournal.com/files/linuxjournal.com/linuxjournal/articles/023/2333/2333s2.html
