### PR TITLE
Allow custom glob patterns for bun test

### DIFF
--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -27,17 +27,37 @@ test("2 + 2", () => {
 });
 ```
 
-The runner recursively searches the working directory for files that match the following patterns:
+The runner recursively searches the working directory for files that match the following glob patterns:
 
-- `*.test.{js|jsx|ts|tsx}`
-- `*_test.{js|jsx|ts|tsx}`
-- `*.spec.{js|jsx|ts|tsx}`
-- `*_spec.{js|jsx|ts|tsx}`
+- `**/*.test.{js,jsx,ts,tsx}`
+- `**/*_test.{js,jsx,ts,tsx}`
+- `**/*.spec.{js,jsx,ts,tsx}`
+- `**/*_spec.{js,jsx,ts,tsx}`
 
-You can filter the set of _test files_ to run by passing additional positional arguments to `bun test`. Any test file with a path that matches one of the filters will run. Commonly, these filters will be file or directory names; glob patterns are not yet supported.
+You can change the glob pattern to use with the `--include` flag:
+
+```bash
+$ bun test --include "tests/**/*.ts"
+```
+
+The above example only runs Typescript files inside `tests/` or one of its subdirectories.
+
+{% callout %}
+Note that if you are running `bun test` from a shell, escaping the pattern with double quotes is necessary to prevent the shell from performing glob expansion itself.
+{% /callout %}
+
+This is also configurable through the [`test.include`](/docs/runtime/bunfig#test-include) property in the `bunfig.toml`.
+
+You can also filter the set of _test files_ to run by passing additional positional arguments to `bun test`. Any test file with a path that includes one of the filters will run. Commonly, these filters will be file or directory names.
 
 ```bash
 $ bun test <filter> <filter> ...
+```
+
+For example, this will run all tests with `foo` or `bar` in the filename:
+
+```bash
+$ bun test foo bar
 ```
 
 To filter by _test name_, use the `-t`/`--test-name-pattern` flag.

--- a/docs/runtime/bunfig.md
+++ b/docs/runtime/bunfig.md
@@ -126,6 +126,17 @@ The root directory to run tests from. Default `.`.
 root = "./__tests__"
 ```
 
+### `test.include`
+
+Specify a glob pattern to select which tests files to run.
+
+Defaults to: `**/*.{test,_test,spec,_spec}.{js,jsx,ts,tsx}`
+
+```toml
+[test]
+include = "tests/**/*.{js,jsx,ts,tsx}"
+```
+
 ### `test.preload`
 
 Same as the top-level `preload` field, but only applies to `bun test`.

--- a/src/bun.js/api/glob.zig
+++ b/src/bun.js/api/glob.zig
@@ -268,6 +268,7 @@ pub const WalkTask = struct {
 
     fn deinit(this: *WalkTask) void {
         this.walker.deinit(true);
+        this.alloc.destroy(this.walker);
         this.alloc.destroy(this);
     }
 };
@@ -306,7 +307,9 @@ fn makeGlobWalker(
             return null;
         };
 
-        globWalker.* = .{};
+        globWalker.* = .{
+            .allocator = alloc,
+        };
 
         switch (globWalker.initWithCwd(
             arena,
@@ -334,7 +337,9 @@ fn makeGlobWalker(
         return null;
     };
 
-    globWalker.* = .{};
+    globWalker.* = .{
+        .allocator = alloc,
+    };
     switch (globWalker.init(
         arena,
         this.pattern,
@@ -463,6 +468,7 @@ pub fn __scanSync(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.Call
         arena.deinit();
         return .undefined;
     };
+    defer alloc.destroy(globWalker);
     defer globWalker.deinit(true);
 
     switch (globWalker.walk() catch {

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -237,6 +237,11 @@ pub const Bunfig = struct {
                         this.ctx.debug.test_directory = root.asString(this.allocator) orelse "";
                     }
 
+                    if (test_.get("include")) |expr| {
+                        try this.expect(expr, .e_string);
+                        this.ctx.test_options.include = expr.data.e_string.data;
+                    }
+
                     if (test_.get("preload")) |expr| {
                         try this.loadPreload(allocator, expr);
                     }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -239,6 +239,7 @@ pub const Arguments = struct {
         clap.parseParam("--coverage                       Generate a coverage profile") catch unreachable,
         clap.parseParam("--bail <NUMBER>?                 Exit the test suite after <NUMBER> failures. If you do not specify a number, it defaults to 1.") catch unreachable,
         clap.parseParam("-t, --test-name-pattern <STR>    Run only tests with a name that matches the given regex.") catch unreachable,
+        clap.parseParam("--include <STR>                  Use glob patterns to select which tests to run, works in conjunction with positional arguments.") catch unreachable,
     };
     pub const test_params = test_only_params ++ runtime_params_ ++ transpiler_params_ ++ base_params_;
 
@@ -466,6 +467,9 @@ pub const Arguments = struct {
                     Global.exit(1);
                 };
                 ctx.test_options.test_filter_regex = regex;
+            }
+            if (args.option("--include")) |include_pattern| {
+                ctx.test_options.include = include_pattern;
             }
             ctx.test_options.update_snapshots = args.flag("--update-snapshots");
             ctx.test_options.run_todo = args.flag("--todo");
@@ -1051,6 +1055,9 @@ pub const Command = struct {
         bail: u32 = 0,
         coverage: TestCommand.CodeCoverageOptions = .{},
         test_filter_regex: ?*RegularExpression = null,
+        /// A glob pattern to scan for files to test
+        /// This is applied _before_ the positional "filter" argument.
+        include: ?[]const u8 = null,
     };
 
     pub const Debugger = union(enum) {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -6,7 +6,7 @@ import { describe, test, expect } from "bun:test";
 import { bunExe, bunEnv } from "harness";
 
 describe("bun test", () => {
-  test("FUCK", () => {
+  test("glob include", () => {
     const cwd = createTest([
       {
         filename: "hello.lol.js",

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -6,7 +6,7 @@ import { describe, test, expect } from "bun:test";
 import { bunExe, bunEnv } from "harness";
 
 describe("bun test", () => {
-  test("glob include", () => {
+  test("bun test include", () => {
     const cwd = createTest([
       {
         filename: "hello.lol.js",

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -6,6 +6,53 @@ import { describe, test, expect } from "bun:test";
 import { bunExe, bunEnv } from "harness";
 
 describe("bun test", () => {
+  test("FUCK", () => {
+    const cwd = createTest([
+      {
+        filename: "hello.lol.js",
+        contents: /* typescript */ `
+        import { test, expect } from "bun:test"
+        test("test #1", () => {
+          expect(true).toBe(true);
+        });
+        `,
+      },
+      {
+        filename: "nice.lol.ts",
+        contents: /* typescript */ `
+        import { test, expect } from "bun:test"
+        test("test #2", () => {
+          expect(true).toBe(true);
+        });
+        `,
+      },
+      {
+        filename: "index.js",
+        contents: /* typescript */ `
+        import { test, expect } from "bun:test"
+        test("test #3", () => {
+          expect(true).toBe(true);
+        });
+        `,
+      },
+      {
+        filename: "index.lol.ts",
+        contents: /* typescript */ `
+        import { test, expect } from "bun:test"
+        test("test #4", () => {
+          expect(true).toBe(true);
+        });
+        `,
+      },
+    ]);
+    const stderr = runTest({
+      args: ["--include", "**/*.lol.{ts,js}"],
+      cwd,
+    });
+    expect(stderr).toContain("test #1");
+    expect(stderr).toContain("test #2");
+    expect(stderr).toContain("test #4");
+  });
   test("can provide no arguments", () => {
     const stderr = runTest({
       args: [],


### PR DESCRIPTION
### What does this PR do?

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

This allows specifying a custom glob pattern to configure which files to scan for tests by adding the `--include` flag and the `test.include` property in bunfig.toml

Since we use the word "filter" to refer to the positional argument, I named this option "include" to avoid confusion and it is also what Vitest uses so it will be familiar to users of that

This feature works in conjunction with positional arguments. For example:
```bash
bun test --include "tests/**/*.ts" foo bar
```
Which will only run tests in .ts files inside `test/` or one of its subdirectories, and only if the filenames include `foo` or `bar` in the name

### How did you verify your code works?

I wrote automated tests

Zig files changed:
- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
