### PR TITLE
adding purescript and spago to default-trusted-dependencies.txt

### DIFF
--- a/src/install/default-trusted-dependencies.txt
+++ b/src/install/default-trusted-dependencies.txt
@@ -384,6 +384,7 @@ prisma
 protoc
 protoc-gen-grpc-web
 puppeteer
+purescript
 quick-mongo-super
 re2
 react-intl-universal
@@ -425,6 +426,7 @@ snyk
 sockopt
 sodium-native
 sonar-scanner
+spago
 spectaql
 spectron
 spellchecker


### PR DESCRIPTION
### What does this PR do?

This adds two packages to default-trusted-dependencies.txt. These are two important packages for purescript development, `purescript` is the language (including a binary file that must be installed), and `spago` is the purescript package manager (also including a binary file that must be installed). 

Took a very loooong time for me to realize that trusted dependencies were the problem due to lack of obvious error feedback in the bun install process, so hoping to save some people time with this. 
