### PR TITLE
Add `nuxt` to trusted dependencies whitelist

### DIFF
--- a/src/install/default-trusted-dependencies.txt
+++ b/src/install/default-trusted-dependencies.txt
@@ -355,6 +355,7 @@ node-zopfli-es
 nodegit
 nodejieba
 nodent-runtime
+nuxt
 nuxt-edge
 nx
 odiff-bin


### PR DESCRIPTION

[Nuxt](https://nuxt.com) is a popular open source web development framework, which supports `bun` as a default package manager.

Nuxt requires running of a `postinstall` task to generate initial types, during installation and after upgrades, if this doesn't get run after an upgrade of existing projects, things can appear broken.

https://www.npmjs.com/package/nuxt