### PR TITLE
doc: improve Bun.Glob api docs

### DIFF
--- a/docs/api/glob.md
+++ b/docs/api/glob.md
@@ -9,6 +9,7 @@ import { Glob } from "bun";
 
 const glob = new Glob("*.ts");
 
+// Scans the root '.' and each of its sub-directories recursively
 for await (const file of glob.scan(".")) {
   console.log(file); // => "index.ts"
 }
@@ -82,7 +83,15 @@ interface ScanOptions {
 
 Bun supports the following glob patterns:
 
-### `*` - Match any number of characters except `/`
+### `?` - Match any single character
+
+```ts
+const glob = new Glob("???.ts");
+glob.match("foo.ts"); // => true
+glob.match("foobar.ts"); // => false
+```
+
+### `*` - Matches zero or more characters, except for path separators (`/` or `\`)
 
 ```ts
 const glob = new Glob("*.ts");
@@ -99,6 +108,26 @@ glob.match("src/index.ts"); // => true
 glob.match("src/index.js"); // => false
 ```
 
+### `[ab]` - Matches one of the characters contained in the brackets, as well as character ranges
+
+```ts
+const glob = new Glob("ba[rz].ts");
+glob.match("bar.ts"); // => true
+glob.match("baz.ts"); // => true
+glob.match("bat.ts"); // => false
+```
+
+You can use character ranges (e.g `[0-9]`, `[a-z]`) as well as the negation operators `^` or `!` to match anything _except_ the characters contained within the braces (e.g `[^ab]`, `[!a-z]`)
+
+```ts
+const glob = new Glob("ba[a-z][0-9][^4-9].ts");
+glob.match("bar01.ts"); // => true
+glob.match("baz83.ts"); // => true
+glob.match("bat22.ts"); // => true
+glob.match("bat24.ts"); // => false
+glob.match("ba0a8.ts"); // => false
+```
+
 ### `{a,b,c}` - Match any of the given patterns
 
 ```ts
@@ -107,4 +136,22 @@ glob.match("a.ts"); // => true
 glob.match("b.ts"); // => true
 glob.match("c.ts"); // => true
 glob.match("d.ts"); // => false
+```
+
+These match patterns can be deeply nested (up to 10 levels), and contain any of the wildcards from above.
+
+### `!` - Negates the result at the start of a pattern
+
+```ts
+const glob = new Glob("!index.ts");
+glob.match("index.ts"); // => false
+glob.match("foo.ts"); // => true
+```
+
+### `\` - Escapes any of the special characters above
+
+```ts
+const glob = new Glob("\\!index.ts");
+glob.match("!index.ts"); // => true
+glob.match("index.ts"); // => false
 ```

--- a/docs/api/glob.md
+++ b/docs/api/glob.md
@@ -9,7 +9,7 @@ import { Glob } from "bun";
 
 const glob = new Glob("*.ts");
 
-// Scans the root '.' and each of its sub-directories recursively
+// Scans the current working directory and each of its sub-directories recursively
 for await (const file of glob.scan(".")) {
   console.log(file); // => "index.ts"
 }

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4527,7 +4527,9 @@ declare module "bun" {
     constructor(pattern: string);
 
     /**
-     * Scan for files that match this glob pattern. Returns an async iterator.
+     * Scan a root directory recursively for files that match this glob pattern. Returns an async iterator.
+     *
+     * @throws {ENOTDIR} Given root cwd path must be a directory
      *
      * @example
      * ```js
@@ -4548,7 +4550,9 @@ declare module "bun" {
     ): AsyncIterableIterator<string>;
 
     /**
-     * Scan for files that match this glob pattern. Returns an iterator.
+     * Synchronously scan a root directory recursively for files that match this glob pattern. Returns an iterator.
+     *
+     * @throws {ENOTDIR} Given root cwd path must be a directory
      *
      * @example
      * ```js


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- Improves the Bun.Glob docs with more examples and shows that it actually supports generally "full" glob syntax
- Specifies that the cwd parameter of Glob.scan must be a directory, and adds an `@throws` annotation

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

N/A

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
