### PR TITLE
Compare error name and message on `Bun.deepEquals` and `assert.deepStrictEqual`

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -830,6 +830,24 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
 
         return false;
     }
+    case ErrorInstanceType: {
+        if (c2Type != ErrorInstanceType) {
+            return false;
+        }
+
+        if (JSC::ErrorInstance* left = jsDynamicCast<JSC::ErrorInstance*>(v1)) {
+            JSC::ErrorInstance* right = jsDynamicCast<JSC::ErrorInstance*>(v2);
+
+            if (UNLIKELY(!right)) {
+                return false;
+            }
+
+            return (
+                left->sanitizedNameString(globalObject) == right->sanitizedNameString(globalObject) &&
+                left->sanitizedMessageString(globalObject) == right->sanitizedMessageString(globalObject)
+            );
+        }
+    }
     case Int8ArrayType:
     case Uint8ArrayType:
     case Uint8ClampedArrayType:

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -161,6 +161,10 @@ test("testing Bun.deepEquals() using isEqual()", () => {
   expect(Infinity).toEqual(1 / 0);
   expect(-Infinity).toEqual(-Infinity);
   expect(-Infinity).toEqual(-1 / 0);
+
+  expect(Error("foo")).toEqual(Error("foo"));
+  expect(Error("foo")).not.toEqual(Error("bar"));
+  expect(Error("foo")).not.toEqual("foo");
 });
 
 try {

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -165,6 +165,10 @@ test("testing Bun.deepEquals() using isEqual()", () => {
   expect(Error("foo")).toEqual(Error("foo"));
   expect(Error("foo")).not.toEqual(Error("bar"));
   expect(Error("foo")).not.toEqual("foo");
+
+  class CustomError extends Error { constructor(message) { super(message); } };
+  expect(new CustomError("foo")).not.toEqual(new CustomError("bar"));
+  expect(new CustomError("foo")).toEqual(new CustomError("foo"));
 });
 
 try {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Currently, Bun doesn't handle comparisons among error instances, it only checks if the types are different.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

If C++* files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

### Sanity check
| `Bun.deepEquals` | Bun's `assert.deepStrictEqual` |
| --- | --- |
|![image](https://github.com/oven-sh/bun/assets/11046907/98fd84d1-d13e-451a-922f-6967d8a66135)|![image](https://github.com/oven-sh/bun/assets/11046907/ccbb8d1f-326f-4942-bd1f-0c8163f11647)|

#### Node for comparison
![image](https://github.com/oven-sh/bun/assets/11046907/7dd31664-ddc4-410c-83b7-4f3905e7530e)

Closes https://github.com/oven-sh/bun/issues/7239