### PR TITLE
script/setup.sh: don't hardcode search for pkg-config

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -43,7 +43,7 @@ $(
 ) || fail "Rust and Cargo version must be installed (minimum version 1.57)"
 has_exec "go" || fail "'go' is missing"
 
-has_exec "pkg-config" || fail "'pkg-config' is missing"
+has_exec "${PKG_CONFIG:-pkg-config}" || fail "'pkg-config' is missing"
 has_exec "automake" || fail "'automake' is missing"
 has_exec "perl" || fail "'perl' is missing"
 has_exec "ruby" || fail "'ruby' is missing"


### PR DESCRIPTION
documented [1] and [2] and [3] and necessary to use alternate implementations.

needed this for my environment setup.

[1]: https://linux.die.net/man/1/pkg-config
[2]: https://cmake.org/cmake/help/latest/module/FindPkgConfig.html
[3]: https://github.com/pkgconf/pkgconf
