### PR TITLE
fix toMatchSnapshot signature

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1145,6 +1145,14 @@ declare module "bun:test" {
      * Asserts that a value matches the most recent snapshot.
      *
      * @example
+     * expect([1, 2, 3]).toMatchSnapshot('hint message');
+     * @param hint Hint used to identify the snapshot in the snapshot file.
+     */
+    toMatchSnapshot(hint?: string): void;
+    /**
+     * Asserts that a value matches the most recent snapshot.
+     *
+     * @example
      * expect([1, 2, 3]).toMatchSnapshot();
      * expect({ a: 1, b: 2 }).toMatchSnapshot({ a: 1 });
      * expect({ c: new Date() }).toMatchSnapshot({ c: expect.any(Date) });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

closes https://github.com/oven-sh/bun/issues/7786

For reference, this is the def in jest https://github.com/jestjs/jest/blob/6604b37930d734d6ca9f69cc764785c3e862d63c/packages/jest-snapshot/src/types.ts#L39-L52

and this is the zig code https://github.com/oven-sh/bun/blob/c195926c190dd7b424e17da4b783b8475d95b347/src/bun.js/test/expect.zig#L2192-L2217

so that it supports signature with only hint message but ts defs doesn't reflect that

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

Just eyeball it.

I can add some tests if you can let me know which file to add it.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
