### PR TITLE
Add Scoop installation reference for Windows

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,13 +41,13 @@ $ proto install bun
 
 Bun provides a _limited, experimental_ native build for Windows. It is recommended to use Bun within [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install) and follow the above instructions. To help catch bugs, the experimental build enables many debugging assertions, which will make the binary slower than what the stable version will be.
 
-To install, paste this into your terminal:
+To install, paste this into a terminal:
 
 {% codetabs %}
 
-```powershell#PowerShell/CMD
+```powershell#PowerShell/cmd.exe
 # WARNING: No stability is guaranteed on the experimental Windows builds
-powershell -c "iwr bun.sh/install.ps1 | iex"
+powershell -c "irm bun.sh/install.ps1|iex"
 ```
 
 ```powershell#Scoop

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,12 +41,22 @@ $ proto install bun
 
 Bun provides a _limited, experimental_ native build for Windows. It is recommended to use Bun within [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install) and follow the above instructions. To help catch bugs, the experimental build enables many debugging assertions, which will make the binary slower than what the stable version will be.
 
-To install, paste this into your terminal (Powershell or `cmd.exe`):
+To install, paste this into your terminal:
 
-```powershell
+{% codetabs %}
+
+```powershell#PowerShell
 # WARNING: No stability is guaranteed on the experimental Windows builds
-powershell -c "iwr bun.sh/install.ps1|iex"
+iwr bun.sh/install.ps1 | iex
 ```
+
+```powershell#Scoop
+# WARNING: No stability is guaranteed on the experimental Windows builds
+scoop bucket add versions
+scoop install bun-canary
+```
+
+{% /codetabs %}
 
 For support and discussion, please join the [#windows channel on our Discord](http://bun.sh/discord).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,9 +45,9 @@ To install, paste this into your terminal:
 
 {% codetabs %}
 
-```powershell#PowerShell
+```powershell#PowerShell/CMD
 # WARNING: No stability is guaranteed on the experimental Windows builds
-iwr bun.sh/install.ps1 | iex
+powershell -c "iwr bun.sh/install.ps1 | iex"
 ```
 
 ```powershell#Scoop


### PR DESCRIPTION
[`bun-canary`](https://scoop.sh/#/apps?q=bun-canary&id=94a4ad4b189dee5b4f62aaf863fd2178827f3791) is now available on Scoop via the Versions bucket.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
