### PR TITLE
Fix memory leaks  in errors from node:fs & Bun.write. Fix memory leak in Bun.file(path) and Bun.write(pathString, dest) 

### DIFF
--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -1610,6 +1610,13 @@ pub const SystemError = extern struct {
     pub const namespace = "";
 
     pub fn toErrorInstance(this: *const SystemError, global: *JSGlobalObject) JSValue {
+        defer {
+            this.path.deref();
+            this.code.deref();
+            this.message.deref();
+            this.syscall.deref();
+        }
+
         return shim.cppFn("toErrorInstance", .{ this, global });
     }
 

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -617,13 +617,6 @@ pub const PathLike = union(enum) {
         return sliceZWithForceCopy(this, buf, false);
     }
 
-    pub inline fn sliceZAssume(
-        this: PathLike,
-    ) [:0]const u8 {
-        var sliced = this.slice();
-        return sliced.ptr[0..sliced.len :0];
-    }
-
     pub fn toJS(this: *const PathLike, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
         return switch (this.*) {
             .string => this.string.toJS(globalObject, null),

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -50,7 +50,7 @@ const PathOrBlob = union(enum) {
     blob: Blob,
 
     pub fn fromJSNoCopy(ctx: js.JSContextRef, args: *JSC.Node.ArgumentsSlice, exception: js.ExceptionRef) ?PathOrBlob {
-        if (JSC.Node.PathOrFileDescriptor.fromJS(ctx, args, args.arena.allocator(), exception)) |path| {
+        if (JSC.Node.PathOrFileDescriptor.fromJS(ctx, args, bun.default_allocator, exception)) |path| {
             return PathOrBlob{
                 .path = path,
             };
@@ -331,10 +331,11 @@ pub const Blob = struct {
                     .fd => {
                         const fd = try reader.readInt(bun.FileDescriptor, .little);
 
+                        var path_or_fd = JSC.Node.PathOrFileDescriptor{
+                            .fd = fd,
+                        };
                         const blob = bun.new(Blob, Blob.findOrCreateFileFromPath(
-                            JSC.Node.PathOrFileDescriptor{
-                                .fd = fd,
-                            },
+                            &path_or_fd,
                             globalThis,
                         ));
 
@@ -344,13 +345,13 @@ pub const Blob = struct {
                         const path_len = try reader.readInt(u32, .little);
 
                         const path = try readSlice(reader, path_len, default_allocator);
-
-                        const blob = bun.new(Blob, Blob.findOrCreateFileFromPath(
-                            JSC.Node.PathOrFileDescriptor{
-                                .path = .{
-                                    .string = bun.PathString.init(path),
-                                },
+                        var dest = JSC.Node.PathOrFileDescriptor{
+                            .path = .{
+                                .string = bun.PathString.init(path),
                             },
+                        };
+                        const blob = bun.new(Blob, Blob.findOrCreateFileFromPath(
+                            &dest,
                             globalThis,
                         ));
 
@@ -830,6 +831,11 @@ pub const Blob = struct {
             }
             return .zero;
         };
+        defer {
+            if (path_or_blob == .path) {
+                path_or_blob.path.deinit();
+            }
+        }
 
         var data = args.nextEat() orelse {
             globalThis.throwInvalidArguments("Bun.write(pathOrFdOrBlob, blob) expects a Blob-y thing to write", .{});
@@ -902,8 +908,6 @@ pub const Blob = struct {
             bun.isRegularFile(path_or_blob.blob.store.?.data.file.mode))))
         {
             if (data.isString()) {
-                defer if (!needs_async and path_or_blob == .path) path_or_blob.path.deinit();
-
                 const len = data.getLength(globalThis);
 
                 if (len < 256 * 1024) {
@@ -939,8 +943,6 @@ pub const Blob = struct {
                     }
                 }
             } else if (data.asArrayBuffer(globalThis)) |buffer_view| {
-                defer if (!needs_async and path_or_blob == .path) path_or_blob.path.deinit();
-
                 if (buffer_view.byte_len < 256 * 1024) {
                     const pathlike: JSC.Node.PathOrFileDescriptor = if (path_or_blob == .path)
                         path_or_blob.path
@@ -977,10 +979,9 @@ pub const Blob = struct {
         }
 
         // if path_or_blob is a path, convert it into a file blob
-        var destination_blob: Blob = if (path_or_blob == .path)
-            Blob.findOrCreateFileFromPath(path_or_blob.path, globalThis)
-        else
-            path_or_blob.blob.dupe();
+        var destination_blob: Blob = if (path_or_blob == .path) brk: {
+            break :brk Blob.findOrCreateFileFromPath(&path_or_blob.path, globalThis);
+        } else path_or_blob.blob.dupe();
 
         if (destination_blob.store == null) {
             globalThis.throwInvalidArguments("Writing to an empty blob is not implemented yet", .{});
@@ -1384,7 +1385,7 @@ pub const Blob = struct {
         var exception_ = [1]JSC.JSValueRef{null};
         const exception = &exception_;
 
-        const path = JSC.Node.PathOrFileDescriptor.fromJS(globalObject, &args, args.arena.allocator(), exception) orelse {
+        var path = JSC.Node.PathOrFileDescriptor.fromJS(globalObject, &args, bun.default_allocator, exception) orelse {
             if (exception_[0] == null) {
                 globalObject.throwInvalidArguments("Expected file path string or file descriptor", .{});
             } else {
@@ -1393,8 +1394,9 @@ pub const Blob = struct {
 
             return .undefined;
         };
+        defer path.deinitAndUnprotect();
 
-        var blob = Blob.findOrCreateFileFromPath(path, globalObject);
+        var blob = Blob.findOrCreateFileFromPath(&path, globalObject);
 
         if (arguments.len >= 2) {
             const opts = arguments[1];
@@ -1432,28 +1434,32 @@ pub const Blob = struct {
         return ptr.toJS(globalObject);
     }
 
-    pub fn findOrCreateFileFromPath(path_: JSC.Node.PathOrFileDescriptor, globalThis: *JSGlobalObject) Blob {
+    pub fn findOrCreateFileFromPath(path_: *JSC.Node.PathOrFileDescriptor, globalThis: *JSGlobalObject) Blob {
         var vm = globalThis.bunVM();
-        const allocator = vm.allocator;
+        const allocator = bun.default_allocator;
 
         const path: JSC.Node.PathOrFileDescriptor = brk: {
-            switch (path_) {
+            switch (path_.*) {
                 .path => {
                     const slice = path_.path.slice();
 
                     if (vm.standalone_module_graph) |graph| {
                         if (graph.find(slice)) |file| {
+                            defer {
+                                if (path_.path != .string) {
+                                    path_.deinit();
+                                    path_.* = .{ .path = .{ .string = bun.PathString.empty } };
+                                }
+                            }
+
                             return file.blob(globalThis).dupe();
                         }
                     }
 
-                    const cloned = (allocator.dupeZ(u8, slice) catch unreachable)[0..slice.len];
-
-                    break :brk .{
-                        .path = .{
-                            .string = bun.PathString.init(cloned),
-                        },
-                    };
+                    path_.toThreadSafe();
+                    const copy = path_.*;
+                    path_.* = .{ .path = .{ .string = bun.PathString.empty } };
+                    break :brk copy;
                 },
                 .fd => {
                     switch (bun.FDTag.get(path_.fd)) {
@@ -1471,7 +1477,7 @@ pub const Blob = struct {
                         ),
                         else => {},
                     }
-                    break :brk path_;
+                    break :brk path_.*;
                 },
             }
         };
@@ -1574,7 +1580,11 @@ pub const Blob = struct {
                 },
                 .file => |file| {
                     if (file.pathlike == .path) {
-                        allocator.free(@constCast(file.pathlike.path.slice()));
+                        if (file.pathlike.path == .string) {
+                            allocator.free(@constCast(file.pathlike.path.slice()));
+                        } else {
+                            file.pathlike.path.deinit();
+                        }
                     }
                 },
             }
@@ -3006,11 +3016,12 @@ pub const Blob = struct {
             const open_source_flags = O.CLOEXEC | O.RDONLY;
 
             pub fn doOpenFile(this: *CopyFile, comptime which: IOWhich) !void {
+                var path_buf1: [bun.MAX_PATH_BYTES]u8 = undefined;
                 // open source file first
                 // if it fails, we don't want the extra destination file hanging out
                 if (which == .both or which == .source) {
                     this.source_fd = switch (bun.sys.open(
-                        this.source_file_store.pathlike.path.sliceZAssume(),
+                        this.source_file_store.pathlike.path.sliceZ(&path_buf1),
                         open_source_flags,
                         0,
                     )) {
@@ -3024,7 +3035,7 @@ pub const Blob = struct {
 
                 if (which == .both or which == .destination) {
                     while (true) {
-                        const dest = this.destination_file_store.pathlike.path.sliceZAssume();
+                        const dest = this.destination_file_store.pathlike.path.sliceZ(&path_buf1);
                         this.destination_fd = switch (bun.sys.open(
                             dest,
                             open_destination_flags,
@@ -3255,10 +3266,11 @@ pub const Blob = struct {
                     if (comptime Environment.isMac) {
                         if (this.offset == 0 and this.source_file_store.pathlike == .path and this.destination_file_store.pathlike == .path) {
                             do_clonefile: {
+                                var path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
 
                                 // stat the output file, make sure it:
                                 // 1. Exists
-                                switch (bun.sys.stat(this.source_file_store.pathlike.path.sliceZAssume())) {
+                                switch (bun.sys.stat(this.source_file_store.pathlike.path.sliceZ(&path_buf))) {
                                     .result => |result| {
                                         stat_ = result;
 
@@ -3281,7 +3293,7 @@ pub const Blob = struct {
                                     if (this.max_length != Blob.max_size and this.max_length < @as(SizeType, @intCast(stat_.?.size))) {
                                         // If this fails...well, there's not much we can do about it.
                                         _ = bun.C.truncate(
-                                            this.destination_file_store.pathlike.path.sliceZAssume(),
+                                            this.destination_file_store.pathlike.path.sliceZ(&path_buf),
                                             @as(std.os.off_t, @intCast(this.max_length)),
                                         );
                                         this.read_len = @as(SizeType, @intCast(this.max_length));

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -2145,14 +2145,17 @@ pub const Fetch = struct {
             var file_url_string = JSC.URL.fileURLFromString(bun.String.fromUTF8(temp_file_path));
             defer file_url_string.deref();
 
-            const bun_file = Blob.findOrCreateFileFromPath(
-                .{
-                    .path = .{
-                        .string = bun.PathString.init(
-                            temp_file_path,
-                        ),
-                    },
+            var pathlike: JSC.Node.PathOrFileDescriptor = .{
+                .path = .{
+                    .encoded_slice = ZigString.Slice.init(bun.default_allocator, bun.default_allocator.dupe(u8, temp_file_path) catch {
+                        globalThis.throwOutOfMemory();
+                        return .zero;
+                    }),
                 },
+            };
+
+            const bun_file = Blob.findOrCreateFileFromPath(
+                &pathlike,
                 globalThis,
             );
 


### PR DESCRIPTION
### What does this PR do?

Fixes #7868

- `SystemError` leaked the `path` string when ceated via `bun.String` (dynamically allocated). This impacts `node:fs`, `Bun.write` and more.
- `Bun.file(path)` leaked the `path` string

### How did you verify your code works?

Comparing memory usage for a few different snippets. We really need a simpler way to measure memory growth. Like a `expect(fn).toNotLeakMemory()`

To compare `SystemError`:

```js
const superduperlongstring = "/tmp/bad-dir/not-found.txt";
Bun.gc(true);

const buffer = new Uint8Array(1);
const mkdirp = { createPath: false };
const src = Bun.file(superduperlongstring);
const out = new Blob([new Uint8Array(1024 * 257)]);
const count = 100000;
const promises = new Array(count);
for (let i = 0; i < count; i++)
  promises[i] = Bun.write(src, out, mkdirp).catch(() => {});
console.log("there");
await Promise.allSettled(promises);
promises.length = 0;
Bun.gc(true);
console.log("RSS:", (process.memoryUsage().rss / 1024 / 1024) | 0, "MB");
```

To compare Bun.file(path):
```js
const superduperlongstring =
  "/tmp/bad-dir/apsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdkapsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdkapsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdkapsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdkapsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdkapsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdkapsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdkapsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdkapsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdkapsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdkapsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdkapsodkpasodkpaosdkpoasdkaspodkaposdkpaoksdpoaskdpoasdkpoasdkpoasdk";
Bun.gc(true);

for (let i = 0; i < 100_000_0; i++) Bun.file(superduperlongstring + i);
console.log("RSS:", (process.memoryUsage().rss / 1024 / 1024) | 0, "MB");
```