### PR TITLE
fix: add ws properties to BunWebSocketMocked prototype

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1139,6 +1139,26 @@ Object.defineProperty(BunWebSocket.prototype, "CLOSED", {
   value: readyStates.indexOf("CLOSED"),
 });
 
+Object.defineProperty(BunWebSocketMocked.prototype, "CONNECTING", {
+  enumerable: true,
+  value: readyStates.indexOf("CONNECTING"),
+});
+
+Object.defineProperty(BunWebSocketMocked.prototype, "OPEN", {
+  enumerable: true,
+  value: readyStates.indexOf("OPEN"),
+});
+
+Object.defineProperty(BunWebSocketMocked.prototype, "CLOSING", {
+  enumerable: true,
+  value: readyStates.indexOf("CLOSING"),
+});
+
+Object.defineProperty(BunWebSocketMocked.prototype, "CLOSED", {
+  enumerable: true,
+  value: readyStates.indexOf("CLOSED"),
+});
+
 class Sender {
   constructor() {
     throw new Error("Not supported yet in Bun");

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -253,10 +253,10 @@ describe("WebSocket", () => {
 });
 
 describe("WebSocketServer", () => {
-  it("sets websocket prototype properties correctly", (done) => {
+  it("sets websocket prototype properties correctly", done => {
     const wss = new WebSocketServer({ port: 0 });
 
-    wss.on("connection", (ws) => {
+    wss.on("connection", ws => {
       try {
         expect(ws.CLOSED).toBeDefined();
         expect(ws.CLOSING).toBeDefined();
@@ -276,10 +276,10 @@ describe("WebSocketServer", () => {
 });
 
 describe("Server", () => {
-  it("sets websocket prototype properties correctly", (done) => {
+  it("sets websocket prototype properties correctly", done => {
     const wss = new Server({ port: 0 });
 
-    wss.on("connection", (ws) => {
+    wss.on("connection", ws => {
       try {
         expect(ws.CLOSED).toBeDefined();
         expect(ws.CLOSING).toBeDefined();

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { bunEnv, bunExe, nodeExe } from "harness";
-import { WebSocket, WebSocketServer } from "ws";
+import { Server, WebSocket, WebSocketServer } from "ws";
 
 const strings = [
   {
@@ -255,6 +255,29 @@ describe("WebSocket", () => {
 describe("WebSocketServer", () => {
   it("sets websocket prototype properties correctly", (done) => {
     const wss = new WebSocketServer({ port: 0 });
+
+    wss.on("connection", (ws) => {
+      try {
+        expect(ws.CLOSED).toBeDefined();
+        expect(ws.CLOSING).toBeDefined();
+        expect(ws.CONNECTING).toBeDefined();
+        expect(ws.OPEN).toBeDefined();
+        return done();
+      } catch (err) {
+        done(err);
+      } finally {
+        wss.close();
+        ws.close();
+      }
+    });
+
+    new WebSocket("ws://localhost:" + wss.address().port);
+  });
+});
+
+describe("Server", () => {
+  it("sets websocket prototype properties correctly", (done) => {
+    const wss = new Server({ port: 0 });
 
     wss.on("connection", (ws) => {
       try {

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -237,6 +237,42 @@ describe("WebSocket", () => {
       done();
     });
   });
+  test("prototype properties are set correctly", (ws, done) => {
+    expect(ws.CLOSED).toBeDefined();
+    expect(ws.CLOSING).toBeDefined();
+    expect(ws.CONNECTING).toBeDefined();
+    expect(ws.OPEN).toBeDefined();
+    done();
+  });
+  it("sets static properties correctly", () => {
+    expect(WebSocket.CLOSED).toBeDefined();
+    expect(WebSocket.CLOSING).toBeDefined();
+    expect(WebSocket.CONNECTING).toBeDefined();
+    expect(WebSocket.OPEN).toBeDefined();
+  });
+});
+
+describe("WebSocketServer", () => {
+  it("sets websocket prototype properties correctly", (done) => {
+    const wss = new WebSocketServer({ port: 0 });
+
+    wss.on("connection", (ws) => {
+      try {
+        expect(ws.CLOSED).toBeDefined();
+        expect(ws.CLOSING).toBeDefined();
+        expect(ws.CONNECTING).toBeDefined();
+        expect(ws.OPEN).toBeDefined();
+        return done();
+      } catch (err) {
+        done(err);
+      } finally {
+        wss.close();
+        ws.close();
+      }
+    });
+
+    new WebSocket("ws://localhost:" + wss.address().port);
+  });
 });
 
 it("isBinary", done => {


### PR DESCRIPTION
### What does this PR do?

Injects some properties to the `BunWebSocketMocked` prototype. Currently, these values are injected, [as in the original ws module](https://github.com/websockets/ws/blob/d343a0cf7bba29a4e14217cb010446bec8fdf444/lib/websocket.js#L499-L569), only for the `BunWebSocket` class, and not for the WebSocket instances from `WebSocketServer` or `Server`.

I'm only adding the properties to the prototype because the class is not exposed.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

Closes https://github.com/oven-sh/bun/issues/7892
