### PR TITLE
Fix crash with latin1 supplemental characters in bun:sqlite query

### DIFF
--- a/bench/sqlite/bun.js
+++ b/bench/sqlite/bun.js
@@ -1,7 +1,8 @@
 import { run, bench } from "mitata";
 import { Database } from "bun:sqlite";
+import { join } from "path";
 
-const db = Database.open("./src/northwind.sqlite");
+const db = Database.open(join(import.meta.dir, "src", "northwind.sqlite"));
 
 {
   const sql = db.prepare(`SELECT * FROM "Order"`);

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -25,6 +25,7 @@
 #include "DOMJITIDLTypeFilter.h"
 #include "DOMJITHelpers.h"
 #include <JavaScriptCore/DFGAbstractHeap.h>
+#include "simdutf.h"
 
 /* ******************************************************************************** */
 // Lazy Load SQLite on macOS
@@ -46,6 +47,42 @@ static inline int lazyLoadSQLite()
 
 #endif
 /* ******************************************************************************** */
+
+#if !USE(SYSTEM_MALLOC)
+#include <bmalloc/BPlatform.h>
+#define ENABLE_SQLITE_FAST_MALLOC (BENABLE(MALLOC_SIZE) && BENABLE(MALLOC_GOOD_SIZE))
+#endif
+
+static void enableFastMallocForSQLite()
+{
+#if ENABLE(SQLITE_FAST_MALLOC)
+    int returnCode = sqlite3_config(SQLITE_CONFIG_LOOKASIDE, 0, 0);
+    ASSERT_WITH_MESSAGE(returnCode == SQLITE_OK, "Unable to reduce lookaside buffer size");
+
+    static sqlite3_mem_methods fastMallocMethods = {
+        [](int n) { return fastMalloc(n); },
+        fastFree,
+        [](void* p, int n) { return fastRealloc(p, n); },
+        [](void* p) { return static_cast<int>(fastMallocSize(p)); },
+        [](int n) { return static_cast<int>(fastMallocGoodSize(n)); },
+        [](void*) { return SQLITE_OK; },
+        [](void*) {},
+        nullptr
+    };
+
+    returnCode = sqlite3_config(SQLITE_CONFIG_MALLOC, &fastMallocMethods);
+    ASSERT_WITH_MESSAGE(returnCode == SQLITE_OK, "Unable to replace SQLite malloc");
+
+#endif
+}
+
+static void initializeSQLite()
+{
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        enableFastMallocForSQLite();
+    });
+}
 
 static WTF::String sqliteString(const char* str)
 {
@@ -522,7 +559,10 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementSetCustomSQLite, (JSC::JSGlobalObject * l
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, msg));
         return JSValue::encode(JSC::jsUndefined());
     }
+
 #endif
+
+    initializeSQLite();
 
     RELEASE_AND_RETURN(scope, JSValue::encode(JSC::jsBoolean(true)));
 }
@@ -569,6 +609,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementDeserialize, (JSC::JSGlobalObject * lexic
         return JSValue::encode(JSC::jsUndefined());
     }
 #endif
+    initializeSQLite();
 
     size_t byteLength = array->byteLength();
     void* ptr = array->vector();
@@ -766,10 +807,14 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
     sqlite3_stmt* statement = nullptr;
 
     int rc = SQLITE_OK;
-    if (sqlString.is8Bit()) {
+    if (
+        // fast path: ascii latin1 string is utf8
+        sqlString.is8Bit() && simdutf::validate_ascii(reinterpret_cast<const char*>(sqlString.characters8()), sqlString.length())) {
         rc = sqlite3_prepare_v3(db, reinterpret_cast<const char*>(sqlString.characters8()), sqlString.length(), 0, &statement, nullptr);
     } else {
-        rc = sqlite3_prepare16_v3(db, sqlString.characters16(), sqlString.length() * 2, 0, &statement, nullptr);
+        // slow path: utf16 or utf8 string
+        CString utf8 = sqlString.utf8();
+        rc = sqlite3_prepare_v3(db, utf8.data(), utf8.length(), 0, &statement, nullptr);
     }
 
     if (UNLIKELY(rc != SQLITE_OK || statement == nullptr)) {
@@ -905,10 +950,14 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementPrepareStatementFunction, (JSC::JSGlobalO
     sqlite3_stmt* statement = nullptr;
 
     int rc = SQLITE_OK;
-    if (sqlString.is8Bit()) {
-        rc = sqlite3_prepare_v3(db, reinterpret_cast<const char*>(sqlString.characters8()), sqlString.length(), flags, &statement, nullptr);
+    if (
+        // fast path: ascii latin1 string is utf8
+        sqlString.is8Bit() && simdutf::validate_ascii(reinterpret_cast<const char*>(sqlString.characters8()), sqlString.length())) {
+        rc = sqlite3_prepare_v3(db, reinterpret_cast<const char*>(sqlString.characters8()), sqlString.length(), 0, &statement, nullptr);
     } else {
-        rc = sqlite3_prepare16_v3(db, sqlString.characters16(), sqlString.length() * 2, flags, &statement, nullptr);
+        // slow path: utf16 or utf8 string
+        CString utf8 = sqlString.utf8();
+        rc = sqlite3_prepare_v3(db, utf8.data(), utf8.length(), 0, &statement, nullptr);
     }
 
     if (rc != SQLITE_OK) {
@@ -966,6 +1015,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementOpenStatementFunction, (JSC::JSGlobalObje
         return JSValue::encode(JSC::jsUndefined());
     }
 #endif
+    initializeSQLite();
 
     auto catchScope = DECLARE_CATCH_SCOPE(vm);
     String path = pathValue.toWTFString(lexicalGlobalObject);

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -812,7 +812,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
         sqlString.is8Bit() && simdutf::validate_ascii(reinterpret_cast<const char*>(sqlString.characters8()), sqlString.length())) {
         rc = sqlite3_prepare_v3(db, reinterpret_cast<const char*>(sqlString.characters8()), sqlString.length(), 0, &statement, nullptr);
     } else {
-        // slow path: utf16 or utf8 string
+        // slow path: utf16 or latin1 string with supplemental characters
         CString utf8 = sqlString.utf8();
         rc = sqlite3_prepare_v3(db, utf8.data(), utf8.length(), 0, &statement, nullptr);
     }
@@ -955,7 +955,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementPrepareStatementFunction, (JSC::JSGlobalO
         sqlString.is8Bit() && simdutf::validate_ascii(reinterpret_cast<const char*>(sqlString.characters8()), sqlString.length())) {
         rc = sqlite3_prepare_v3(db, reinterpret_cast<const char*>(sqlString.characters8()), sqlString.length(), 0, &statement, nullptr);
     } else {
-        // slow path: utf16 or utf8 string
+        // slow path: utf16 or latin1 string with supplemental characters
         CString utf8 = sqlString.utf8();
         rc = sqlite3_prepare_v3(db, utf8.data(), utf8.length(), 0, &statement, nullptr);
     }

--- a/src/bun.js/bindings/sqlite/lazy_sqlite3.h
+++ b/src/bun.js/bindings/sqlite/lazy_sqlite3.h
@@ -4,7 +4,7 @@
 
 #if !OS(WINDOWS)
 #include <dlfcn.h>
-#else 
+#else
 #include <windows.h>
 #endif
 
@@ -37,6 +37,8 @@ typedef char* (*lazy_sqlite3_expanded_sql_type)(sqlite3_stmt* pStmt);
 typedef int (*lazy_sqlite3_finalize_type)(sqlite3_stmt* pStmt);
 typedef void (*lazy_sqlite3_free_type)(void*);
 typedef int (*lazy_sqlite3_get_autocommit_type)(sqlite3*);
+typedef int (*lazy_sqlite3_get_autocommit_type)(sqlite3*);
+typedef int (*lazy_sqlite3_config_type)(int, ...);
 typedef int (*lazy_sqlite3_open_v2_type)(const char* filename, /* Database filename (UTF-8) */ sqlite3** ppDb, /* OUT: SQLite db handle */ int flags, /* Flags */ const char* zVfs /* Name of VFS module to use */);
 typedef int (*lazy_sqlite3_prepare_v3_type)(sqlite3* db, /* Database handle */
     const char* zSql, /* SQL statement, UTF-8 encoded */
@@ -79,7 +81,7 @@ typedef int (*lazy_sqlite3_deserialize_type)(
 );
 
 typedef int (*lazy_sqlite3_stmt_readonly_type)(sqlite3_stmt* pStmt);
-typedef int (*lazy_sqlite3_compileoption_used_type)(const char *zOptName);
+typedef int (*lazy_sqlite3_compileoption_used_type)(const char* zOptName);
 
 static lazy_sqlite3_bind_blob_type lazy_sqlite3_bind_blob;
 static lazy_sqlite3_bind_double_type lazy_sqlite3_bind_double;
@@ -122,6 +124,7 @@ static lazy_sqlite3_serialize_type lazy_sqlite3_serialize;
 static lazy_sqlite3_deserialize_type lazy_sqlite3_deserialize;
 static lazy_sqlite3_stmt_readonly_type lazy_sqlite3_stmt_readonly;
 static lazy_sqlite3_compileoption_used_type lazy_sqlite3_compileoption_used;
+static lazy_sqlite3_config_type lazy_sqlite3_config;
 
 #define sqlite3_bind_blob lazy_sqlite3_bind_blob
 #define sqlite3_bind_double lazy_sqlite3_bind_double
@@ -163,11 +166,15 @@ static lazy_sqlite3_compileoption_used_type lazy_sqlite3_compileoption_used;
 #define sqlite3_stmt_readonly lazy_sqlite3_stmt_readonly
 #define sqlite3_column_int64 lazy_sqlite3_column_int64
 #define sqlite3_compileoption_used lazy_sqlite3_compileoption_used
+#define sqlite3_config lazy_sqlite3_config
 
 #if !OS(WINDOWS)
 #define HMODULE void*
 #else
-static const char* dlerror() { return "Unknown error while loading sqlite"; }
+static const char* dlerror()
+{
+    return "Unknown error while loading sqlite";
+}
 #define dlsym GetProcAddress
 #endif
 
@@ -234,6 +241,7 @@ static int lazyLoadSQLite()
     lazy_sqlite3_malloc64 = (lazy_sqlite3_malloc64_type)dlsym(sqlite3_handle, "sqlite3_malloc64");
     lazy_sqlite3_stmt_readonly = (lazy_sqlite3_stmt_readonly_type)dlsym(sqlite3_handle, "sqlite3_stmt_readonly");
     lazy_sqlite3_compileoption_used = (lazy_sqlite3_compileoption_used_type)dlsym(sqlite3_handle, "sqlite3_compileoption_used");
+    lazy_sqlite3_config = (lazy_sqlite3_config_type)dlsym(sqlite3_handle, "sqlite3_config");
 
     return 0;
 }

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -607,3 +607,18 @@ it("#5872", () => {
   const result = query.all({ $greeting: "sup" });
   expect(result).toEqual([]);
 });
+
+it("latin1 sqlite3 column name", () => {
+  const db = new Database(":memory:");
+
+  db.run("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, copyright© TEXT)");
+
+  db.run("INSERT INTO foo (id, copyright©) VALUES (?, ?)", [1, "© 2021 The Authors. All rights reserved."]);
+
+  expect(db.query("SELECT * FROM foo").all()).toEqual([
+    {
+      id: 1,
+      "copyright©": "© 2021 The Authors. All rights reserved.",
+    },
+  ]);
+});

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -166,7 +166,11 @@ test("testing Bun.deepEquals() using isEqual()", () => {
   expect(Error("foo")).not.toEqual(Error("bar"));
   expect(Error("foo")).not.toEqual("foo");
 
-  class CustomError extends Error { constructor(message) { super(message); } };
+  class CustomError extends Error {
+    constructor(message) {
+      super(message);
+    }
+  }
   expect(new CustomError("foo")).not.toEqual(new CustomError("bar"));
   expect(new CustomError("foo")).toEqual(new CustomError("foo"));
 });


### PR DESCRIPTION
### What does this PR do?

This does three things:

1. We were missing a check for non-ascii latin1 supplemental characters in `bun:sqlite`, which can lead to a crash. I have not seen a GitHub issue for this yet, and it should be relatively uncommon. In most cases, non-ascii characters become UTF-16.
2. We stop using the utf16 methods from sqlite3 because the code for those convert it to UTF8 and their conversion code is almost certainly slower than ours/WebKit's.
3. This makes sqlite use WebKit's memory allocator instead of libc malloc, and removes their memory pooling code (lookaside buffer). This aligns with what WebKit did for WebSQL : https://github.com/oven-sh/WebKit/blob/b4de09f41b83e9e5c0e43ef414f1aee5968b6f7c/Source/WebCore/platform/sql/SQLiteDatabase.cpp#L85-L106. Should theoretically use less memory, but haven't seen it change much in benchmarks.


### How did you verify your code works?

Tests