### PR TITLE
cli: resolve TODO filing upstream issue

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1852,8 +1852,6 @@ pub const Command = struct {
         ReservedCommand,
 
         pub fn params(comptime cmd: Tag) []const Arguments.ParamType {
-            // TODO: report zig compiler bug
-            //       moving the "&" before "comptime" causes compiler error.
             return comptime &switch (cmd) {
                 .AutoCommand => Arguments.auto_params,
                 .RunCommand, .RunAsNodeCommand => Arguments.run_params,


### PR DESCRIPTION
filed the issue here https://github.com/ziglang/zig/issues/18397

however this is not a blocker for us because moving the `&` to the left would make the result a pointer to stack memory instead of comptime memory and introduce a bug