### PR TITLE
misc: use compileError instead of unreachable for comptime-known switches

### DIFF
--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -1638,7 +1638,7 @@ pub const ModuleLoader = struct {
                         .source_code = switch (comptime flags) {
                             .print_source_and_clone => bun.String.init(jsc_vm.allocator.dupe(u8, parse_result.source.contents) catch unreachable),
                             .print_source => bun.String.static(parse_result.source.contents),
-                            else => unreachable,
+                            else => @compileError("unreachable"),
                         },
                         .specifier = input_specifier,
                         .source_url = if (input_specifier.eqlUTF8(path.text)) input_specifier.dupeRef() else String.init(path.text),

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -479,11 +479,11 @@ pub const AsyncReaddirRecursiveTask = struct {
                 )) {
                     .err => |err| {
                         for (entries.items) |*item| {
-                            switch (comptime ResultType) {
+                            switch (ResultType) {
                                 bun.String => item.deref(),
                                 Dirent => item.name.deref(),
                                 Buffer => bun.default_allocator.free(item.buffer.byteSlice()),
-                                else => unreachable,
+                                else => @compileError("unreachable"),
                             }
                         }
 
@@ -516,11 +516,11 @@ pub const AsyncReaddirRecursiveTask = struct {
 
     pub fn writeResults(this: *AsyncReaddirRecursiveTask, comptime ResultType: type, result: *std.ArrayList(ResultType)) void {
         if (result.items.len > 0) {
-            const Field = comptime switch (ResultType) {
+            const Field = switch (ResultType) {
                 bun.String => .files,
                 Dirent => .with_file_types,
                 Buffer => .buffers,
-                else => unreachable,
+                else => @compileError("unreachable"),
             };
             const list = bun.default_allocator.create(ResultListEntry) catch bun.outOfMemory();
             errdefer {
@@ -4634,7 +4634,7 @@ pub const NodeFS = struct {
         while (switch (entry) {
             .err => |err| {
                 for (entries.items) |*item| {
-                    switch (comptime ExpectedType) {
+                    switch (ExpectedType) {
                         Dirent => {
                             item.name.deref();
                         },
@@ -4644,7 +4644,7 @@ pub const NodeFS = struct {
                         bun.String => {
                             item.deref();
                         },
-                        else => unreachable,
+                        else => @compileError("unreachable"),
                     }
                 }
 
@@ -4657,7 +4657,7 @@ pub const NodeFS = struct {
             .result => |ent| ent,
         }) |current| : (entry = iterator.next()) {
             const utf8_name = current.name.slice();
-            switch (comptime ExpectedType) {
+            switch (ExpectedType) {
                 Dirent => {
                     entries.append(.{
                         .name = bun.String.create(utf8_name),
@@ -4670,7 +4670,7 @@ pub const NodeFS = struct {
                 bun.String => {
                     entries.append(bun.String.create(utf8_name)) catch bun.outOfMemory();
                 },
-                else => unreachable,
+                else => @compileError("unreachable"),
             }
         }
 
@@ -4933,11 +4933,11 @@ pub const NodeFS = struct {
         comptime recursive: bool,
         comptime flavor: Flavor,
     ) Maybe(Return.Readdir) {
-        const file_type = comptime switch (ExpectedType) {
+        const file_type = switch (ExpectedType) {
             Dirent => "with_file_types",
             bun.String => "files",
             Buffer => "buffers",
-            else => unreachable,
+            else => @compileError("unreachable"),
         };
 
         const path = args.path.sliceZ(buf);
@@ -4949,7 +4949,7 @@ pub const NodeFS = struct {
             return switch (readdirWithEntriesRecursiveSync(&buf_to_pass, args, path, ExpectedType, &entries)) {
                 .err => |err| {
                     for (entries.items) |*result| {
-                        switch (comptime ExpectedType) {
+                        switch (ExpectedType) {
                             Dirent => {
                                 result.name.deref();
                             },
@@ -4959,7 +4959,7 @@ pub const NodeFS = struct {
                             bun.String => {
                                 result.deref();
                             },
-                            else => unreachable,
+                            else => @compileError("unreachable"),
                         }
                     }
 

--- a/src/crash_reporter.zig
+++ b/src/crash_reporter.zig
@@ -16,13 +16,13 @@ noinline fn sigaction_handler(sig: i32, info: *const std.os.siginfo_t, _: ?*cons
     // Prevent recursive calls
     setup_sigactions(null) catch unreachable;
 
-    const addr = switch (comptime builtin.target.os.tag) {
+    const addr = switch (builtin.target.os.tag) {
         .linux => @intFromPtr(info.fields.sigfault.addr),
         .macos, .freebsd => @intFromPtr(info.addr),
         .netbsd => @intFromPtr(info.info.reason.fault.addr),
         .openbsd => @intFromPtr(info.data.fault.addr),
         .solaris => @intFromPtr(info.reason.fault.addr),
-        else => unreachable,
+        else => @compileError("unreachable"),
     };
     if (on_error) |handle| handle(sig, addr);
 }

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -462,7 +462,7 @@ const Pollable = struct {
             return switch (T) {
                 .ReadFile => ReadFile,
                 .WriteFile => WriteFile,
-                .empty => unreachable,
+                .empty => @compileError("unreachable"),
             };
         }
     };
@@ -749,7 +749,7 @@ pub const Poll = struct {
                             unreachable;
                         }
                     },
-                    else => unreachable,
+                    else => @compileError("unreachable"),
                 }
 
                 if (comptime Environment.allow_assert and action != .cancel) {
@@ -882,7 +882,7 @@ pub const Poll = struct {
                 .poll_readable,
                 => linux.EPOLL.IN | linux.EPOLL.HUP | linux.EPOLL.ERR | one_shot_flag,
                 .poll_writable => linux.EPOLL.OUT | linux.EPOLL.HUP | linux.EPOLL.ERR | one_shot_flag,
-                else => unreachable,
+                else => @compileError("unreachable"),
             };
 
             var event = linux.epoll_event{ .events = flags, .data = .{ .u64 = @intFromPtr(Pollable.init(tag, this).ptr()) } };
@@ -908,7 +908,7 @@ pub const Poll = struct {
             .poll_readable => .poll_readable,
             .poll_process => if (comptime Environment.isLinux) .poll_readable else .poll_process,
             .poll_writable => .poll_writable,
-            else => unreachable,
+            else => @compileError("unreachable"),
         });
         this.flags.remove(.needs_rearm);
 

--- a/src/multi_array_list.zig
+++ b/src/multi_array_list.zig
@@ -86,7 +86,7 @@ pub fn MultiArrayList(comptime T: type) type {
                 const e = switch (@typeInfo(T)) {
                     .Struct => elem,
                     .Union => Elem.fromT(elem),
-                    else => unreachable,
+                    else => @compileError("unreachable"),
                 };
                 inline for (fields, 0..) |field_info, i| {
                     self.items(@as(Field, @enumFromInt(i)))[index] = @field(e, field_info.name);
@@ -101,7 +101,7 @@ pub fn MultiArrayList(comptime T: type) type {
                 return switch (@typeInfo(T)) {
                     .Struct => result,
                     .Union => Elem.toT(result.tags, result.data),
-                    else => unreachable,
+                    else => @compileError("unreachable"),
                 };
             }
 
@@ -293,7 +293,7 @@ pub fn MultiArrayList(comptime T: type) type {
             const entry = switch (@typeInfo(T)) {
                 .Struct => elem,
                 .Union => Elem.fromT(elem),
-                else => unreachable,
+                else => @compileError("unreachable"),
             };
             const slices = self.slice();
             inline for (fields, 0..) |field_info, field_index| {

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -494,7 +494,7 @@ pub const PackageJSON = struct {
                     }
                 }
             },
-            else => unreachable,
+            else => @compileError("unreachable"),
         }
 
         if (loadFrameworkExpression(pair.framework, framework_object.expr, allocator, read_defines)) {

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -449,7 +449,7 @@ pub fn dirname(str: []const u8, comptime platform: Platform) []const u8 {
             const separator = lastIndexOfSeparatorWindows(str) orelse return std.fs.path.diskDesignatorWindows(str);
             return str[0..separator];
         },
-        else => unreachable,
+        else => @compileError("unreachable"),
     }
 }
 
@@ -882,7 +882,7 @@ pub fn normalizeStringBuf(str: []const u8, buf: []u8, comptime allow_above_root:
     const platform = comptime _platform.resolve();
 
     switch (comptime platform) {
-        .auto => unreachable,
+        .auto => @compileError("unreachable"),
 
         .windows => {
             return normalizeStringWindows(

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -596,7 +596,7 @@ pub const RwLock = if (@import("builtin").os.tag != .windows and @import("builti
                         attr: i32 = 0,
                         __reserved: [36]u8 = [_]u8{0} ** 36,
                     },
-                    else => unreachable,
+                    else => @compileError("unreachable"),
                 },
                 else => extern struct {
                     size: [56]u8 align(@alignOf(usize)) = [_]u8{0} ** 56,
@@ -613,7 +613,7 @@ pub const RwLock = if (@import("builtin").os.tag != .windows and @import("builti
                 ptr_interlock: switch (@import("builtin").target.cpu.arch) {
                     .aarch64, .sparc, .x86_64 => u8,
                     .arm, .powerpc => c_int,
-                    else => unreachable,
+                    else => @compileError("unreachable"),
                 } = 0,
                 ptr_rblocked_first: ?*u8 = null,
                 ptr_rblocked_last: ?*u8 = null,


### PR DESCRIPTION
this ensures the value stays comptime-known and prevents any stray `unreachable` in these cases from reaching runtime by accident as the code changes