### PR TITLE
tidy: bun.zig: remove switch on literal

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -657,16 +657,10 @@ pub const fmt = struct {
             }
 
             const mags_si = " KMGTPEZY";
-            const mags_iec = " KMGTPEZY";
-
             const log2 = math.log2(value);
             const magnitude = @min(log2 / comptime math.log2(1000), mags_si.len - 1);
             const new_value = math.lossyCast(f64, value) / math.pow(f64, 1000, math.lossyCast(f64, magnitude));
-            const suffix = switch (1000) {
-                1000 => mags_si[magnitude],
-                1024 => mags_iec[magnitude],
-                else => unreachable,
-            };
+            const suffix = mags_si[magnitude];
 
             if (suffix == ' ') {
                 try fmt.formatFloatDecimal(new_value / 1000.0, .{ .precision = 2 }, writer);
@@ -674,13 +668,7 @@ pub const fmt = struct {
             } else {
                 try fmt.formatFloatDecimal(new_value, .{ .precision = if (std.math.approxEqAbs(f64, new_value, @trunc(new_value), 0.100)) @as(usize, 1) else @as(usize, 2) }, writer);
             }
-
-            const buf = switch (1000) {
-                1000 => &[_]u8{ ' ', suffix, 'B' },
-                1024 => &[_]u8{ ' ', suffix, 'i', 'B' },
-                else => unreachable,
-            };
-            return writer.writeAll(buf);
+            return writer.writeAll(&[_]u8{ ' ', suffix, 'B' });
         }
     };
 


### PR DESCRIPTION
this code was previously copied from elsewhere but then never cleaned up when the flag was removed