### PR TITLE
Try to make fs.watch tests less flaky

### DIFF
--- a/src/js/node/fs.js
+++ b/src/js/node/fs.js
@@ -56,7 +56,14 @@ class FSWatcher extends EventEmitter {
   }
 
   #onEvent(eventType, filenameOrError) {
-    if (eventType === "error" || eventType === "close") {
+    if (eventType === "close") {
+      // close on next microtask tick to avoid long-running function calls when
+      // we're trying to detach the watcher
+      queueMicrotask(() => {
+        this.emit("close", filenameOrError);
+      });
+      return;
+    } else if (eventType === "error") {
       this.emit(eventType, filenameOrError);
     } else {
       this.emit("change", eventType, filenameOrError);


### PR DESCRIPTION
### What does this PR do?

- This makes `task_count` an `atomic.Value` to be extra careful when getting/setting the value
- Makes `close` happen in a microtask so that the watcher is already detached by the time the `close` event actually fires
- uses `bun.new` to more easily track allocations

This probably doesn't make the tests less flaky, but its worth an attempt



### How did you verify your code works?

Ran the existing tests for this locally