### PR TITLE
feat(build): adjust arch linux auto detect to include manjaro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ endif()
 if(UNIX AND NOT APPLE)
     execute_process(COMMAND cat /etc/os-release COMMAND head -n1 OUTPUT_VARIABLE LINUX_DISTRO)
 
-    if(${LINUX_DISTRO} STREQUAL "NAME=\"Arch Linux\"\n")
+    if(${LINUX_DISTRO} MATCHES "NAME=\"(Arch|Manjaro) Linux\"\n")
         set(DEFAULT_USE_STATIC_LIBATOMIC OFF)
     endif()
 endif()


### PR DESCRIPTION
### What does this PR do?

Following on progress from issue #2664 and corresponding PR #6835, I noticed `bun setup` / `bun run build` were failing on a Manjaro machine for the same reason that Manjaro uses the same suffix as Arch for `libatomic`.

Currently, `CMakeLists.txt` looks for a `NAME` property in `/etc/os-release` matching `"Arch Linux"`. 

This PR introduces changes to the code to include matches for `"(Arch|Manjaro) Linux"`.
 
- [X] Code changes

### How did you verify your code works?

Re-built on Arch & Manjaro, read code in `CMakeLists.txt`.