### PR TITLE
Fix crash in WebSocket client when handshaking fails or when the HTTP response is invalid

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -547,7 +547,7 @@ ssl_on_writable(struct us_internal_ssl_socket_t *s) {
 
   // Do not call on_writable if the socket is closed.
   // on close means the socket data is no longer accessible
-  if (us_socket_is_closed(0, &s->s)) {
+  if (!s || us_socket_is_closed(0, &s->s)) {
     return 0;
   }
 

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -499,7 +499,7 @@ restart:
     s = (struct us_internal_ssl_socket_t *)context->sc.on_writable(
         &s->s); // cast here!
     // if we are closed here, then exit
-    if (us_socket_is_closed(0, &s->s)) {
+    if (!s || us_socket_is_closed(0, &s->s)) {
       return s;
     }
   }
@@ -544,8 +544,13 @@ ssl_on_writable(struct us_internal_ssl_socket_t *s) {
                                                                0); // cast here!
   }
 
-  // should this one come before we have read? should it come always? spurious
-  // on_writable is okay
+
+  // Do not call on_writable if the socket is closed.
+  // on close means the socket data is no longer accessible
+  if (us_socket_is_closed(0, &s->s)) {
+    return 0;
+  }
+
   s = context->on_writable(s);
 
   return s;

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -207,8 +207,8 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
     #endif
             }
             cb->cb(cb->cb_expects_the_loop ? (struct us_internal_callback_t *) cb->loop : (struct us_internal_callback_t *) &cb->p);
+            break;
         }
-        break;
     case POLL_TYPE_SEMI_SOCKET: {
             /* Both connect and listen sockets are semi-sockets
              * but they poll for different events */
@@ -220,6 +220,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
                     /* Emit error, close without emitting on_close */
                     s->context->on_connect_error(s, 0);
                     us_socket_close_connecting(0, s);
+                    s = NULL;
                 } else {
                     /* All sockets poll for readable */
                     us_poll_change(p, s->context->loop, LIBUS_SOCKET_READABLE);
@@ -274,8 +275,8 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
                     } while ((client_fd = bsd_accept_socket(us_poll_fd(p), &addr)) != LIBUS_SOCKET_ERROR);
                 }
             }
-        }
         break;
+    }
     case POLL_TYPE_SOCKET_SHUT_DOWN:
     case POLL_TYPE_SOCKET: {
             /* We should only use s, no p after this point */
@@ -288,7 +289,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
 
                 s = s->context->on_writable(s);
 
-                if (us_socket_is_closed(0, s)) {
+                if (!s || us_socket_is_closed(0, s)) {
                     return;
                 }
 
@@ -351,8 +352,8 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
                 s = us_socket_close(0, s, 0, NULL);
                 return;
             }
+            break;
         }
-        break;
     }
 }
 

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -346,7 +346,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
             }
 
             /* Such as epollerr epollhup */
-            if (error) {
+            if (error && s) {
                 /* Todo: decide what code we give here */
                 s = us_socket_close(0, s, 0, NULL);
                 return;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3651,6 +3651,7 @@ pub const ServerWebSocket = struct {
     opened: bool = false,
 
     pub usingnamespace JSC.Codegen.JSServerWebSocket;
+    pub usingnamespace bun.New(ServerWebSocket);
 
     const log = Output.scoped(.WebSocketServer, false);
 
@@ -3958,7 +3959,7 @@ pub const ServerWebSocket = struct {
 
     pub fn finalize(this: *ServerWebSocket) callconv(.C) void {
         log("finalize", .{});
-        bun.default_allocator.destroy(this);
+        this.destroy();
     }
 
     pub fn publish(
@@ -5077,11 +5078,12 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
 
             resp.clearAborted();
 
-            const ws = this.vm.allocator.create(ServerWebSocket) catch return .zero;
-            ws.* = .{
+            data_value.ensureStillAlive();
+            const ws = ServerWebSocket.new(.{
                 .handler = &this.config.websocket.?.handler,
                 .this_value = data_value,
-            };
+            });
+            data_value.ensureStillAlive();
 
             var sec_websocket_protocol_str = sec_websocket_protocol.toSlice(bun.default_allocator);
             defer sec_websocket_protocol_str.deinit();

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -764,6 +764,24 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             @field(holder, socket_field_name) = adopted;
             return holder;
         }
+
+        pub fn adoptPtr(
+            socket: *Socket,
+            socket_ctx: *SocketContext,
+            comptime Context: type,
+            comptime socket_field_name: []const u8,
+            ctx: *Context,
+        ) bool {
+            var adopted = ThisSocket{ .socket = us_socket_context_adopt_socket(comptime ssl_int, socket_ctx, socket, @sizeOf(*Context)) orelse return false };
+            const holder = adopted.ext(*anyopaque) orelse {
+                if (comptime bun.Environment.allow_assert) unreachable;
+                _ = us_socket_close(comptime ssl_int, socket, 0, null);
+                return false;
+            };
+            holder.* = ctx;
+            @field(ctx, socket_field_name) = adopted;
+            return true;
+        }
     };
 }
 

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -262,7 +262,6 @@ describe("WebSocket", () => {
     const server = Bun.serve({
       port: 0,
       fetch(req, server) {
-        done();
         server.stop();
         return new Response();
       },
@@ -271,9 +270,17 @@ describe("WebSocket", () => {
         message(ws) {
           ws.close();
         },
+        close() {},
       },
     });
-    new WebSocket(`http://${server.hostname}:${server.port}`, {});
+    var ws = new WebSocket(`http://${server.hostname}:${server.port}`, {});
+    ws.onopen = () => {
+      ws.send("Hello World!");
+    };
+
+    ws.onclose = () => {
+      done();
+    };
   });
   describe("nodebuffer", () => {
     it("should support 'nodebuffer' binaryType", done => {


### PR DESCRIPTION
### What does this PR do?

This fixes a crash that sometimes happened when either:
- TLS handshaking fails
- The HTTP response was invalid (due to example, sending "200 OK" instead of "101 Switching Protocols")

The problem was:
- `on_writable` in usockets was called after the socket was already closed. This is effectively a use-after-free.
- `.terminate` could cause a crash if the socket was not fully connected yet because it would free the socket and then check  if the socket was still available

### How did you verify your code works?

Updated tests. Hopefully now the `ws` test is no longer flaky. 

