### PR TITLE
Make file uploads use less memory on Linux

### DIFF
--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -312,6 +312,9 @@ pub const ArrayBuffer = extern struct {
         return buffer_value;
     }
 
+    extern fn ArrayBuffer__fromSharedMemfd(fd: i64, globalObject: *JSC.JSGlobalObject, byte_offset: usize, byte_length: usize, total_size: usize) JSC.JSValue;
+    const toArrayBufferFromSharedMemfd = ArrayBuffer__fromSharedMemfd;
+
     pub fn toJSBufferFromMemfd(fd: bun.FileDescriptor, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
         const stat = switch (bun.sys.fstat(fd)) {
             .err => |err| {

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -313,7 +313,7 @@ pub const ArrayBuffer = extern struct {
     }
 
     extern fn ArrayBuffer__fromSharedMemfd(fd: i64, globalObject: *JSC.JSGlobalObject, byte_offset: usize, byte_length: usize, total_size: usize) JSC.JSValue;
-    const toArrayBufferFromSharedMemfd = ArrayBuffer__fromSharedMemfd;
+    pub const toArrayBufferFromSharedMemfd = ArrayBuffer__fromSharedMemfd;
 
     pub fn toJSBufferFromMemfd(fd: bun.FileDescriptor, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
         const stat = switch (bun.sys.fstat(fd)) {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1255,6 +1255,8 @@ pub const VirtualMachine = struct {
         debugger: bun.CLI.Command.Debugger = .{ .unspecified = {} },
     };
 
+    pub var is_smol_mode = false;
+
     pub fn init(opts: Options) !*VirtualMachine {
         JSC.markBinding(@src());
         const allocator = opts.allocator;
@@ -1342,6 +1344,9 @@ pub const VirtualMachine = struct {
         vm.regular_event_loop.virtual_machine = vm;
         vm.jsc = vm.global.vm();
         vm.smol = opts.smol;
+
+        if (opts.smol)
+            is_smol_mode = opts.smol;
 
         if (source_code_printer == null) {
             const writer = try js_printer.BufferWriter.init(allocator);

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -4571,7 +4571,7 @@ pub const Blob = struct {
                                     defer allocator.deref();
 
                                     const byteOffset = @as(usize, @intFromPtr(buf.ptr)) -| @as(usize, @intFromPtr(allocated_slice.ptr));
-                                    const byteLength = allocated_slice.len;
+                                    const byteLength = buf.len;
 
                                     const result = JSC.ArrayBuffer.toArrayBufferFromSharedMemfd(
                                         @intCast(allocator.fd),

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -4562,10 +4562,10 @@ pub const Blob = struct {
             .clone => {
                 if (comptime Environment.isLinux) {
                     // If we can use a copy-on-write clone of the buffer, do so.
-                    if (bun.linux.memfd_allocator.shouldUse(buf)) {
-                        if (this.store) |store| {
+                    if (this.store) |store| {
+                        if (store.data == .bytes) {
                             const allocated_slice = store.data.bytes.allocatedSlice();
-                            if (store.data == .bytes and bun.isSliceInBuffer(buf, allocated_slice)) {
+                            if (bun.isSliceInBuffer(buf, allocated_slice)) {
                                 if (bun.linux.memfd_allocator.from(store.data.bytes.allocator)) |allocator| {
                                     allocator.ref();
                                     defer allocator.deref();

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1155,6 +1155,9 @@ pub fn assertDefined(val: anytype) void {
 }
 
 pub const LinearFifo = @import("./linear_fifo.zig").LinearFifo;
+pub const linux = struct {
+    pub const memfd_allocator = @import("./linux_memfd_allocator.zig").LinuxMemFdAllocator;
+};
 
 /// hash a string
 pub fn hash(content: []const u8) u64 {

--- a/src/linux_memfd_allocator.zig
+++ b/src/linux_memfd_allocator.zig
@@ -1,0 +1,195 @@
+const bun = @import("root").bun;
+const std = @import("std");
+
+/// When cloning large amounts of data potentially multiple times, we can
+/// leverage copy-on-write memory to avoid actually copying the data. To do that
+/// on Linux, we need to use a memfd, which is a Linux-specific feature.
+///
+/// The steps are roughly:
+///
+/// 1. Create a memfd
+/// 2. Write the data to the memfd
+/// 3. Map the memfd into memory
+///
+/// Then, to clone the data later, we can just call `mmap` again.
+///
+/// The big catch is that mmap(), memfd_create(), write() all have overhead. And
+/// often we will re-use virtual memory within the process. This does not reuse
+/// the virtual memory. So we should only really use this for large blobs of
+/// data that we expect to be cloned multiple times. Such as Blob in FormData.
+pub const LinuxMemFdAllocator = struct {
+    fd: bun.FileDescriptor = 0,
+    ref_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+    size: usize = 0,
+
+    var memfd_counter = std.atomic.Value(usize).init(0);
+
+    pub usingnamespace bun.New(LinuxMemFdAllocator);
+
+    pub fn ref(this: *LinuxMemFdAllocator) void {
+        this.ref_count.fetchAdd(1, .Monotonic);
+    }
+
+    pub fn deref(this: *LinuxMemFdAllocator) void {
+        if (this.ref_count.fetchSub(1, .Monotonic) == 1) {
+            _ = bun.sys.close(this.fd);
+            this.destroy();
+        }
+    }
+
+    pub fn allocator(this: *LinuxMemFdAllocator) std.mem.Allocator {
+        return .{
+            .ptr = this,
+            .vtable = AllocatorInterface.VTable,
+        };
+    }
+
+    pub fn asLinuxMemFdAllocator(allocator_: std.mem.Allocator) ?*LinuxMemFdAllocator {
+        if (allocator_.vtable == AllocatorInterface.VTable) {
+            return @alignCast(@ptrCast(allocator_.ptr));
+        }
+
+        return null;
+    }
+
+    const AllocatorInterface = struct {
+        fn alloc(_: *anyopaque, _: usize, _: u8, _: usize) ?[*]u8 {
+            // it should perform no allocations or resizes
+            return null;
+        }
+
+        fn resize(
+            _: *anyopaque,
+            _: []u8,
+            _: u29,
+            _: usize,
+            _: u29,
+            _: usize,
+        ) ?usize {
+            return null;
+        }
+
+        fn free(
+            ptr: *anyopaque,
+            buf: []u8,
+            _: u29,
+            _: usize,
+        ) void {
+            var this: *LinuxMemFdAllocator = @alignCast(@ptrCast(ptr));
+            defer this.deref();
+            bun.sys.munmap(@ptrCast(buf)).unwrap() catch |err| {
+                bun.Output.debugWarn("Failed to munmap memfd: {s}", .{@tagName(err.getErrno())});
+            };
+        }
+
+        pub const VTable = &std.mem.Allocator.VTable{
+            .alloc = &AllocatorInterface.alloc,
+            .resize = &resize,
+            .free = &free,
+        };
+    };
+
+    pub fn alloc(this: *LinuxMemFdAllocator, len: usize, offset: usize) bun.JSC.Maybe(bun.JSC.WebCore.Blob.ByteStore) {
+        var size = len;
+
+        // size rounded up to nearest page
+        size += (size + std.mem.page_size - 1) & std.mem.page_size;
+
+        switch (bun.sys.mmap(0, @min(size, this.size), std.os.PROT.READ | std.os.PROT.WRITE, std.os.MAP.PRIVATE | 0, this.fd, offset)) {
+            .result => |slice| {
+                return .{
+                    .result = bun.JSC.WebCore.Blob.ByteStore{
+                        .cap = @truncate(slice.len),
+                        .ptr = slice.ptr,
+                        .len = @truncate(len),
+                        .allocator = this.allocator(),
+                    },
+                };
+            },
+            else => |errno| {
+                return .{ .err = errno };
+            },
+        }
+    }
+
+    pub fn shouldUse(bytes: []const u8) bool {
+        if (comptime !bun.Environment.isLinux) {
+            return false;
+        }
+
+        return bytes.len > 1024 * 1024 * 2;
+    }
+
+    pub fn create(bytes: []const u8) bun.JSC.Maybe(bun.JSC.WebCore.Blob.ByteStore) {
+        if (comptime !bun.Environment.isLinux) {
+            unreachable;
+        }
+
+        const rc = brk: {
+            var label_buf: [128]u8 = undefined;
+            const label = std.fmt.bufPrintZ(&label_buf, "memfd-num-{d}", .{memfd_counter.fetchAdd(1)}) catch "";
+            const code = std.os.linux.memfd_create(label.ptr, std.os.linux.MFD.CLOEXEC | 0);
+            bun.sys.syslog("memfd_create({s}) = {d}", .{ label, code });
+            break :brk code;
+        };
+
+        switch (std.os.linux.getErrno(rc)) {
+            .SUCCESS => {},
+            else => |errno| {
+                bun.sys.syslog("Failed to create memfd: {s}", .{@tagName(errno)});
+                return .{ .err = bun.sys.Error.fromCode(errno, .open) };
+            },
+        }
+
+        const fd = bun.toFD(rc);
+
+        var remain = bytes;
+
+        if (remain.len > 0)
+            // Hint at the size of the file
+            _ = bun.sys.ftruncate(fd, @intCast(remain.len));
+
+        // Dump all the bytes in there
+        var written: isize = 0;
+        while (remain.len > 0) {
+            switch (bun.sys.pwrite(fd, remain, written)) {
+                .err => |err| {
+                    if (err.getErrno() == .AGAIN) {
+                        continue;
+                    }
+
+                    bun.Output.debugWarn("Failed to write to memfd: {s}", .{@tagName(err.getErrno())});
+                    _ = bun.sys.close(fd);
+                    return .{ .err = err };
+                },
+                .result => |result| {
+                    if (result == 0) {
+                        bun.Output.debugWarn("Failed to write to memfd: EOF", .{});
+                        _ = bun.sys.close(fd);
+                        return .{ .err = bun.sys.Error.fromCode(.NOMEM, .write) };
+                    }
+                    written += @intCast(result);
+                    remain = remain[result..];
+                },
+            }
+        }
+
+        var linux_memfd_allocator = LinuxMemFdAllocator.new(.{
+            .fd = fd,
+            .ref_count = std.atomic.Value(u32).init(1),
+            .size = bytes.len,
+        });
+
+        switch (linux_memfd_allocator.alloc(bytes.len, 0)) {
+            .result => |res| {
+                return .{ .result = res };
+            },
+            .err => |err| {
+                linux_memfd_allocator.deref();
+                return .{ .err = err };
+            },
+        }
+
+        unreachable;
+    }
+};

--- a/test/js/web/fetch/blob-cow.test.ts
+++ b/test/js/web/fetch/blob-cow.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "bun:test";
+
+test("Blob.arrayBuffer copy-on-write is not shared", async () => {
+  // 8 MB is the threshold for copy-on-write without --smol.
+  const bytes = new Uint8Array((1024 * 1024 * 8 * 1.5) | 0);
+  bytes.fill(42);
+  bytes[bytes.length - 100] = 43;
+  const blob = new Blob([bytes]);
+  bytes.fill(8);
+
+  const buf = new Uint8Array(await blob.arrayBuffer());
+  expect(buf.length).toBe(blob.size);
+  expect(buf[0]).toBe(42);
+  expect(buf[buf.length - 1]).toBe(42);
+
+  buf[0] = 0;
+
+  const buf2 = new Uint8Array(await blob.arrayBuffer());
+  expect(buf2[0]).toBe(42);
+  buf2[0] = 1;
+  expect(buf2[buf.length - 1]).toBe(42);
+
+  const buf3 = new Uint8Array(await blob.slice(0, 1).arrayBuffer());
+  expect(buf3[0]).toBe(42);
+  buf3[0] = 2;
+  expect(buf3.length).toBe(1);
+
+  const buf4 = new Uint8Array(await blob.slice(blob.size - 100).arrayBuffer());
+  expect(buf4[0]).toBe(43);
+  buf4[0] = 3;
+  expect(buf4.length).toBe(100);
+
+  expect(buf[0]).toBe(0);
+  expect(buf2[0]).toBe(1);
+  expect(buf3[0]).toBe(2);
+  expect(buf4[0]).toBe(3);
+});


### PR DESCRIPTION
### What does this PR do?

When receiving a large file upload (> 8 MB, or > 1 MB  with `--smol`) on Linux, Bun will now use copy-on-write memory for `.arrayBuffer()` instead of new memory. 

### How did you verify your code works?

We have existing tests, but I should add some more for copy-on-write specifically