### PR TITLE
Try larger runners

### DIFF
--- a/.github/workflows/bun-mac-aarch64.yml
+++ b/.github/workflows/bun-mac-aarch64.yml
@@ -114,7 +114,7 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          brew install sccache ccache rust llvm@$LLVM_VERSION pkg-config coreutils libtool cmake libiconv automake openssl@1.1 ninja gnu-sed pkg-config --force
+          brew install go sccache ccache rust llvm@$LLVM_VERSION pkg-config coreutils libtool cmake libiconv automake openssl@1.1 ninja gnu-sed pkg-config --force
           echo "$(brew --prefix ccache)/bin" >> $GITHUB_PATH
           # echo "$(brew --prefix sccache)/bin" >> $GITHUB_PATH
           echo "$(brew --prefix coreutils)/libexec/gnubin" >> $GITHUB_PATH
@@ -188,7 +188,7 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          brew install sccache ccache rust llvm@$LLVM_VERSION pkg-config coreutils libtool cmake libiconv automake openssl@1.1 ninja gnu-sed pkg-config --force
+          brew install go sccache ccache rust llvm@$LLVM_VERSION pkg-config coreutils libtool cmake libiconv automake openssl@1.1 ninja gnu-sed pkg-config --force
           echo "$(brew --prefix ccache)/bin" >> $GITHUB_PATH
           # echo "$(brew --prefix sccache)/bin" >> $GITHUB_PATH
           echo "$(brew --prefix coreutils)/libexec/gnubin" >> $GITHUB_PATH

--- a/.github/workflows/bun-mac-aarch64.yml
+++ b/.github/workflows/bun-mac-aarch64.yml
@@ -176,7 +176,7 @@ jobs:
             tag: bun-darwin-aarch64
             obj: bun-obj-darwin-aarch64
             artifact: bun-obj-darwin-aarch64
-            runner: macos-arm64
+            runner: macos-13-xlarge
     steps:
       - uses: actions/checkout@v4
       - name: Checkout submodules
@@ -241,7 +241,7 @@ jobs:
             obj: bun-obj-darwin-aarch64
             package: bun-darwin-aarch64
             artifact: bun-obj-darwin-aarch64
-            runner: macos-arm64
+            runner: macos-13-xlarge
     steps:
       - uses: actions/checkout@v4
         with:
@@ -376,7 +376,7 @@ jobs:
       matrix:
         include:
           - tag: bun-darwin-aarch64
-            runner: macos-arm64
+            runner: macos-13-xlarge
     steps:
       - id: checkout
         name: Checkout

--- a/.github/workflows/bun-mac-aarch64.yml
+++ b/.github/workflows/bun-mac-aarch64.yml
@@ -102,7 +102,7 @@ jobs:
             tag: bun-darwin-aarch64
             obj: bun-obj-darwin-aarch64
             artifact: bun-obj-darwin-aarch64
-            runner: macos-arm64
+            runner: macos-13-xlarge
     steps:
       - uses: actions/checkout@v4
       - name: Checkout submodules

--- a/.github/workflows/bun-mac-aarch64.yml
+++ b/.github/workflows/bun-mac-aarch64.yml
@@ -121,6 +121,13 @@ jobs:
           echo "$(brew --prefix llvm@$LLVM_VERSION)/bin" >> $GITHUB_PATH
           brew link --overwrite llvm@$LLVM_VERSION
 
+          curl -LO "$BUN_DOWNLOAD_URL_BASE/bun-darwin-aarch64.zip"
+          unzip bun-darwin-aarch64.zip
+          mkdir -p ${{ runner.temp }}/.bun/bin
+          mv bun-darwin-aarch64/bun ${{ runner.temp }}/.bun/bin/bun
+          chmod +x ${{ runner.temp }}/.bun/bin/bun
+          echo "${{ runner.temp }}/.bun/bin" >> $GITHUB_PATH
+
       - name: Hash submodule versions
         run: |
           print_data() {
@@ -194,6 +201,13 @@ jobs:
           echo "$(brew --prefix coreutils)/libexec/gnubin" >> $GITHUB_PATH
           echo "$(brew --prefix llvm@$LLVM_VERSION)/bin" >> $GITHUB_PATH
           brew link --overwrite llvm@$LLVM_VERSION
+
+          curl -LO "$BUN_DOWNLOAD_URL_BASE/bun-darwin-aarch64.zip"
+          unzip bun-darwin-aarch64.zip
+          mkdir -p ${{ runner.temp }}/.bun/bin
+          mv bun-darwin-aarch64/bun ${{ runner.temp }}/.bun/bin/bun
+          chmod +x ${{ runner.temp }}/.bun/bin/bun
+          echo "${{ runner.temp }}/.bun/bin" >> $GITHUB_PATH
 
       # TODO: replace with sccache
       - name: ccache

--- a/.github/workflows/bun-mac-x64-baseline.yml
+++ b/.github/workflows/bun-mac-x64-baseline.yml
@@ -113,7 +113,7 @@ jobs:
             arch: x86_64
             tag: bun-darwin-x64-baseline
             obj: bun-obj-darwin-x64-baseline
-            runner: macos-12
+            runner: macos-12-large
             artifact: bun-obj-darwin-x64-baseline
     steps:
       - uses: actions/checkout@v4
@@ -187,7 +187,7 @@ jobs:
             arch: x86_64
             tag: bun-darwin-x64-baseline
             obj: bun-obj-darwin-x64-baseline
-            runner: macos-12
+            runner: macos-12-large
             artifact: bun-obj-darwin-x64-baseline
     steps:
       - uses: actions/checkout@v4
@@ -259,7 +259,7 @@ jobs:
             tag: bun-darwin-x64-baseline
             obj: bun-obj-darwin-x64-baseline
             package: bun-darwin-x64
-            runner: macos-12
+            runner: macos-12-large
             artifact: bun-obj-darwin-x64-baseline
     steps:
       - uses: actions/checkout@v3
@@ -391,7 +391,7 @@ jobs:
       matrix:
         include:
           - tag: bun-darwin-x64-baseline
-            runner: macos-12
+            runner: macos-12-large
     steps:
       - id: checkout
         name: Checkout

--- a/.github/workflows/bun-mac-x64.yml
+++ b/.github/workflows/bun-mac-x64.yml
@@ -111,7 +111,7 @@ jobs:
             arch: x86_64
             tag: bun-darwin-x64
             obj: bun-obj-darwin-x64
-            runner: macos-12
+            runner: macos-12-large
             artifact: bun-obj-darwin-x64
     steps:
       - uses: actions/checkout@v4
@@ -185,7 +185,7 @@ jobs:
             arch: x86_64
             tag: bun-darwin-x64
             obj: bun-obj-darwin-x64
-            runner: macos-12
+            runner: macos-12-large
             artifact: bun-obj-darwin-x64
     steps:
       - uses: actions/checkout@v4
@@ -257,7 +257,7 @@ jobs:
             tag: bun-darwin-x64
             obj: bun-obj-darwin-x64
             package: bun-darwin-x64
-            runner: macos-12
+            runner: macos-12-large
             artifact: bun-obj-darwin-x64
     steps:
       - uses: actions/checkout@v3
@@ -389,7 +389,7 @@ jobs:
       matrix:
         include:
           - tag: bun-darwin-x64
-            runner: macos-12
+            runner: macos-12-large
     steps:
       - id: checkout
         name: Checkout

--- a/src/bun.js/bindings/webcore/AbortSignal.cpp
+++ b/src/bun.js/bindings/webcore/AbortSignal.cpp
@@ -102,8 +102,6 @@ void AbortSignal::signalAbort(JSC::JSValue reason)
     // 2. Set signal’s aborted flag.
     m_aborted = true;
 
-    // FIXME: This code is wrong: we should emit a write-barrier. Otherwise, GC can collect it.
-    // https://bugs.webkit.org/show_bug.cgi?id=236353
     ASSERT(reason);
     auto& vm = scriptExecutionContext()->vm();
     m_reason.set(vm, reason);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
