### PR TITLE
vscode: set zig path to local one

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "zig.zls.enableInlayHints": false,
+  "zig.path": "${workspaceFolder}/.cache/zig/zig",
   "git.ignoreSubmodules": true,
   "[jsx]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
this will ensure that the zig extension uses the one installed locally by the setup scripts and build system