### PR TITLE
fix: properly transform http method to uppercase

### DIFF
--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -154,6 +154,10 @@ static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JS
                 methodString = "FETCH"_s;
                 break;
             }
+            if (methodView == std::string_view("purge", 6)) {
+                methodString = "PURGE"_s;
+                break;
+            }
 
             break;
         }
@@ -161,10 +165,6 @@ static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JS
         case 6: {
             if (methodView == std::string_view("delete", 6)) {
                 methodString = "DELETE"_s;
-                break;
-            }
-            if (methodView == std::string_view("purge", 6)) {
-                methodString = "PURGE"_s;
                 break;
             }
 
@@ -176,12 +176,7 @@ static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JS
                 methodString = "CONNECT"_s;
                 break;
             }
-
-            break;
-        }
-
-        case 8: {
-            if (methodView == std::string_view("options", 8)) {
+            if (methodView == std::string_view("options", 7)) {
                 methodString = "OPTIONS"_s;
                 break;
             }

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -154,7 +154,7 @@ static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JS
                 methodString = "FETCH"_s;
                 break;
             }
-            if (methodView == std::string_view("purge", 6)) {
+            if (methodView == std::string_view("purge", 5)) {
                 methodString = "PURGE"_s;
                 break;
             }

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -136,6 +136,23 @@ describe("node:http", () => {
       expect(listenResponse).toBe(server);
       listenResponse.close();
     });
+
+    it("option method should be uppercase (#7250)", async () => {
+      try {
+        var server = createServer((req, res) => {
+          expect(req.method).toBe("OPTIONS");
+          res.writeHead(204, {});
+          res.end();
+        });
+        const url = await listen(server);
+        const res = await fetch(url, {
+          method: "OPTIONS",
+        });
+        expect(res.status).toBe(204);
+      } finally {
+        server.close();
+      }
+    });
   });
 
   describe("response", () => {


### PR DESCRIPTION
### What does this PR do?

Transforming HTTP method names to uppercase inside `assignHeadersFromUWebSockets` uses wrong HTTP Method length which causes `PURGE` / `OPTIONS` methods in lowercase.

I assume this will fix #7250

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test/js/node/http/node-http.test.ts`)

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
