### PR TITLE
fix replacing node:module._resolveFilename not passing the parent module

### DIFF
--- a/src/bun.js/bindings/CommonJSModuleRecord.cpp
+++ b/src/bun.js/bindings/CommonJSModuleRecord.cpp
@@ -66,7 +66,7 @@
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/HeapAnalyzer.h>
 
-extern "C" bool Bun__isBunMain(JSC::JSGlobalObject* global, const char* input_ptr, uint64_t input_len);
+extern "C" bool Bun__isBunMain(JSC::JSGlobalObject* global, const BunString*);
 
 namespace Bun {
 using namespace JSC;
@@ -321,8 +321,9 @@ JSC_DEFINE_CUSTOM_GETTER(getterParent, (JSC::JSGlobalObject * globalObject, JSC:
     // dont need `module.parent` and creating commonjs module records is done a ton.
     auto idValue = thisObject->m_id.get();
     if (idValue) {
-        auto id = idValue->value(globalObject).utf8();
-        if (Bun__isBunMain(globalObject, id.data(), id.length())) {
+        auto id = idValue->value(globalObject);
+        auto idStr = Bun::toString(id);
+        if (Bun__isBunMain(globalObject, &idStr)) {
             thisObject->m_parent.set(globalObject->vm(), thisObject, jsNull());
             return JSValue::encode(jsNull());
         }

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -304,8 +304,8 @@ pub export fn Bun__Process__send(
     }
 }
 
-pub export fn Bun__isBunMain(globalObject: *JSGlobalObject, input_ptr: [*]const u8, input_len: usize) bool {
-    return strings.eql(globalObject.bunVM().main, input_ptr[0..input_len]);
+pub export fn Bun__isBunMain(globalObject: *JSGlobalObject, str: *const bun.String) bool {
+    return str.eqlUTF8(globalObject.bunVM().main);
 }
 
 pub export fn Bun__Process__disconnect(

--- a/src/bun.js/modules/NodeModuleModule.h
+++ b/src/bun.js/modules/NodeModuleModule.h
@@ -188,18 +188,24 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeModuleCreateRequire,
   if (val.startsWith("file://"_s)) {
     WTF::URL url(val);
     if (!url.isValid()) {
-      throwTypeError(globalObject, scope, makeString("createRequire() was given an invalid URL '"_s, url.string(), "'"_s));;
+      throwTypeError(globalObject, scope,
+                     makeString("createRequire() was given an invalid URL '"_s,
+                                url.string(), "'"_s));
+      ;
       RELEASE_AND_RETURN(scope, JSValue::encode({}));
     }
     if (!url.protocolIsFile()) {
-      throwTypeError(globalObject, scope, "createRequire() does not support non-file URLs"_s);
+      throwTypeError(globalObject, scope,
+                     "createRequire() does not support non-file URLs"_s);
       RELEASE_AND_RETURN(scope, JSValue::encode({}));
     }
     val = url.fileSystemPath();
   }
 
   RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
-  RELEASE_AND_RETURN(scope, JSValue::encode(Bun::JSCommonJSModule::createBoundRequireFunction(vm, globalObject, val)));
+  RELEASE_AND_RETURN(
+      scope, JSValue::encode(Bun::JSCommonJSModule::createBoundRequireFunction(
+                 vm, globalObject, val)));
 }
 extern "C" JSC::EncodedJSValue Resolver__nodeModulePathsForJS(JSGlobalObject *,
                                                               CallFrame *);
@@ -246,6 +252,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
   }
   default: {
     JSC::JSValue moduleName = callFrame->argument(0);
+    JSC::JSValue fromValue = callFrame->argument(1);
 
     if (moduleName.isUndefinedOrNull()) {
       auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
@@ -255,9 +262,26 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
       return JSC::JSValue::encode(JSC::JSValue{});
     }
 
+    if (
+        // fast path: it's a real CommonJS module object.
+        auto *cjs = jsDynamicCast<Bun::JSCommonJSModule *>(fromValue)) {
+      fromValue = cjs->id();
+    } else if
+        // slow path: userland code did something weird. lets let them do that
+        // weird thing.
+        (fromValue.isObject()) {
+
+      if (auto idValue = fromValue.getObject()->getIfPropertyExists(
+              globalObject, Identifier::fromString(vm, "filename"_s))) {
+        if (idValue.isString()) {
+          fromValue = idValue;
+        }
+      }
+    }
+
     auto result =
         Bun__resolveSync(globalObject, JSC::JSValue::encode(moduleName),
-                         JSValue::encode(callFrame->argument(1)), false);
+                         JSValue::encode(fromValue), false);
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     if (!JSC::JSValue::decode(result).isString()) {

--- a/src/string.zig
+++ b/src/string.zig
@@ -1087,7 +1087,7 @@ pub const String = extern struct {
     }
 
     pub fn eqlUTF8(this: String, other: []const u8) bool {
-        return this.toZigString().eql(ZigString.initUTF8(other));
+        return this.toZigString().eql(ZigString.fromUTF8(other));
     }
 
     pub fn eql(this: String, other: String) bool {

--- a/test/js/node/module/resolveFilenameOverwrite.cjs
+++ b/test/js/node/module/resolveFilenameOverwrite.cjs
@@ -4,8 +4,9 @@ const path = require("path");
 const Module = require("module");
 
 const original = Module._resolveFilename;
-Module._resolveFilename = str => {
-  eql(str.endsWith("💔"), true);
+Module._resolveFilename = (specifier, parent, isMain) => {
+  eql(specifier.endsWith("💔"), true);
+  eql(parent.filename, path.join(__dirname, "./resolveFilenameOverwrite.cjs"));
   return path.join(__dirname, "./resolveFilenameOverwrite-fixture.cjs");
 };
 eql(require("overwriting _resolveFilename broke 💔"), "winner");


### PR DESCRIPTION
playwright depends on this behavior being correct and previously it was passing the filename string in the second argument rather than the whole parent module object