### PR TITLE
fix: params in help menu for commands update and install

### DIFF
--- a/docs/cli/link.md
+++ b/docs/cli/link.md
@@ -36,11 +36,3 @@ In addition, the `--save` flag can be used to add `cool-pkg` to the `dependencie
     }
   }
 ```
-
-To _unregister_ a local package, navigate to the package's root directory and run `bun unlink`.
-
-```bash
-$ cd /path/to/cool-pkg
-$ bun unlink
-bun unlink v1.x (7416672e)
-```

--- a/docs/cli/unlink.md
+++ b/docs/cli/unlink.md
@@ -1,0 +1,7 @@
+Use `bun unlink` in the root directory to unregister a local package.
+
+```bash
+$ cd /path/to/cool-pkg
+$ bun unlink
+bun unlink v1.x (7416672e)
+```

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -6872,7 +6872,7 @@ pub const PackageManager = struct {
                     Output.flush();
                     Output.pretty("\n\n<b>Flags:<r>", .{});
                     Output.flush();
-                    clap.simpleHelp(&PackageManager.add_params);
+                    clap.simpleHelp(&PackageManager.install_params);
                     Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
                     Output.flush();
                 },
@@ -6893,7 +6893,7 @@ pub const PackageManager = struct {
                     Output.flush();
                     Output.pretty("\n<b>Flags:<r>", .{});
                     Output.flush();
-                    clap.simpleHelp(&PackageManager.add_params);
+                    clap.simpleHelp(&PackageManager.update_params);
                     Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
                     Output.flush();
                 },
@@ -6976,15 +6976,22 @@ pub const PackageManager = struct {
                 Subcommand.unlink => {
                     const intro_text =
                         \\<b>Usage<r>: <b><green>bun unlink<r> <cyan>[flags]<r>
-                        \\
+                    ;
+
+                    const outro_text =
                         \\<b>Examples:<r>
                         \\  <d>Unregister the current directory as a linkable package.<r>
                         \\  <b><green>bun unlink<r>
                         \\
-                        \\Full documentation is available at <magenta>https://bun.sh/docs/cli/link<r>
+                        \\Full documentation is available at <magenta>https://bun.sh/docs/cli/unlink<r>
                     ;
 
                     Output.pretty("\n" ++ intro_text ++ "\n", .{});
+                    Output.flush();
+                    Output.pretty("\n<b>Flags:<r>", .{});
+                    Output.flush();
+                    clap.simpleHelp(&PackageManager.unlink_params);
+                    Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
                     Output.flush();
                 },
             }


### PR DESCRIPTION
### What does this PR do?

- Fix the params for the update and install command
- Add specific documentation for unlink and more details in help menu

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Manually

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
