### PR TITLE
Fix multiple partial consume from BufferList

### DIFF
--- a/src/bun.js/bindings/JSBufferList.cpp
+++ b/src/bun.js/bindings/JSBufferList.cpp
@@ -182,8 +182,9 @@ JSC::JSValue JSBufferList::_getBuffer(JSC::VM& vm, JSC::JSGlobalObject* lexicalG
     }
     if (n < len) {
         auto buffer = array->possiblySharedBuffer();
-        JSC::JSUint8Array* retArray = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, buffer, 0, n);
-        JSC::JSUint8Array* newArray = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, buffer, n, len - n);
+        auto off = array->byteOffset();
+        JSC::JSUint8Array* retArray = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, buffer, off, n);
+        JSC::JSUint8Array* newArray = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, buffer, off + n, len - n);
         m_deque.first().set(vm, this, newArray);
         RELEASE_AND_RETURN(throwScope, retArray);
     }
@@ -207,7 +208,8 @@ JSC::JSValue JSBufferList::_getBuffer(JSC::VM& vm, JSC::JSGlobalObject* lexicalG
                 return throwOutOfMemoryError(lexicalGlobalObject, throwScope);
             }
             auto buffer = array->possiblySharedBuffer();
-            JSC::JSUint8Array* newArray = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, buffer, n, len - n);
+            auto off = array->byteOffset();
+            JSC::JSUint8Array* newArray = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, buffer, off + n, len - n);
             element.set(vm, this, newArray);
             offset += n;
             break;

--- a/test/js/node/stream/bufferlist.test.ts
+++ b/test/js/node/stream/bufferlist.test.ts
@@ -194,6 +194,17 @@ it("should work with .unshift()", () => {
   expect(list.shift()).toBeUndefined();
 });
 
+it("should work with multiple partial .consume() from buffers", () => {
+  // @ts-ignore
+  const list = new Readable().readableBuffer;
+  expect(list.length).toBe(0);
+  expect(list.push(Buffer.from("f000baaa", "hex"))).toBeUndefined();
+  expect(list.length).toBe(1);
+  expect(list.consume(2, undefined)).toEqual(Buffer.from("f000", "hex"));
+  expect(list.consume(1, undefined)).toEqual(Buffer.from("ba", "hex"));
+  expect(list.length).toBe(1);
+});
+
 it("should work with partial .consume() followed by .first()", () => {
   // @ts-ignore
   const list = new Readable().readableBuffer;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

The JSUint8Array::possiblySharedBuffer() returns the backing array,
not taking into account the byteOffset that indicates the start of
the data in the backing array. This means that when creating an array
with the same backing array, the current byteOffset needs to be added
to the start of the new slice.

This led to consume() returning the same data when repeatedly consuming
small numbers of bytes from the BufferList.

This PR fixes the problem in https://github.com/oven-sh/bun/issues/7385
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
