### PR TITLE
implemented assert.doesNotMatch

### DIFF
--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -6,7 +6,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:assert`](https://nodejs.org/api/assert.html)
 
-🟡 Missing `doesNotMatch`
+🟢 Fully implemented.
 
 ### [`node:async_hooks`](https://nodejs.org/api/async_hooks.html)
 

--- a/src/js/node/assert.js
+++ b/src/js/node/assert.js
@@ -998,6 +998,7 @@ var require_assert = __commonJS({
     };
     var internalMatch = function (actual, expected, message, fn) {
       if (arguments.length < 2) throw new ERR_MISSING_ARGS("actual", "expected");
+      if (typeof actual !== "string") throw new ERR_INVALID_ARG_TYPE("actual", "string", actual);
       if (!isRegExp(expected)) throw new ERR_INVALID_ARG_TYPE("expected", "RegExp", expected);
       var match = fn === assert.match;
       expected.test(actual) === match ||

--- a/src/js/node/assert.js
+++ b/src/js/node/assert.js
@@ -996,17 +996,24 @@ var require_assert = __commonJS({
           stackStartFn: notStrictEqual,
         });
     };
-    assert.match = function match(actual, expected, message) {
+    var internalMatch = function (actual, expected, message, fn) {
       if (arguments.length < 2) throw new ERR_MISSING_ARGS("actual", "expected");
       if (!isRegExp(expected)) throw new ERR_INVALID_ARG_TYPE("expected", "RegExp", expected);
-      expected.test(actual) ||
+      var match = fn === assert.match;
+      expected.test(actual) === match ||
         innerFail({
           actual,
           expected,
           message,
-          operator: "match",
-          stackStartFn: match,
+          operator: fn.name,
+          stackStartFn: fn,
         });
+    };
+    assert.doesNotMatch = function doesNotMatch(actual, expected, message) {
+      internalMatch(actual, expected, message, doesNotMatch);
+    };
+    assert.match = function match(actual, expected, message) {
+      internalMatch(actual, expected, message, match);
     };
     var Comparison = function Comparison2(obj, keys, actual) {
       var _this = this;

--- a/test/js/node/assert/assert-doesNotMatch.test.cjs
+++ b/test/js/node/assert/assert-doesNotMatch.test.cjs
@@ -1,0 +1,19 @@
+var assert = require("assert");
+
+test("doesNotMatch does not throw when not matching", () => {
+  assert.doesNotMatch('I will pass', /different/);
+});
+
+test("doesNotMatch throws when argument is not string", () => {
+  try {
+    assert.doesNotMatch(123, /pass/);
+    expect.unreachable();
+  } catch (e) {}
+});
+
+test("doesNotMatch throws when matching", () => {
+  try {
+    assert.doesNotMatch('I will fail', /fail/);
+    expect.unreachable();
+  } catch (e) {}
+});

--- a/test/js/node/assert/assert-doesNotMatch.test.cjs
+++ b/test/js/node/assert/assert-doesNotMatch.test.cjs
@@ -5,15 +5,9 @@ test("doesNotMatch does not throw when not matching", () => {
 });
 
 test("doesNotMatch throws when argument is not string", () => {
-  try {
-    assert.doesNotMatch(123, /pass/);
-    expect.unreachable();
-  } catch (e) {}
+  expect(() => assert.doesNotMatch(123, /pass/)).toThrow("The \"actual\" argument must be of type string. Received type number");
 });
 
 test("doesNotMatch throws when matching", () => {
-  try {
-    assert.doesNotMatch('I will fail', /fail/);
-    expect.unreachable();
-  } catch (e) {}
+  expect(() => assert.doesNotMatch('I will fail', /fail/, "doesNotMatch throws when matching")).toThrow("doesNotMatch throws when matching");
 });

--- a/test/js/node/assert/assert-match.test.cjs
+++ b/test/js/node/assert/assert-match.test.cjs
@@ -1,0 +1,19 @@
+var assert = require("assert");
+
+test("match does not throw when matching", () => {
+  assert.match('I will pass', /pass/);
+});
+
+test("match throws when argument is not string", () => {
+  try {
+    assert.match(123, /pass/);
+    expect.unreachable();
+  } catch (e) {}
+});
+
+test("match throws when not matching", () => {
+  try {
+    assert.match('I will fail', /pass/);
+    expect.unreachable();
+  } catch (e) {}
+});

--- a/test/js/node/assert/assert-match.test.cjs
+++ b/test/js/node/assert/assert-match.test.cjs
@@ -5,15 +5,9 @@ test("match does not throw when matching", () => {
 });
 
 test("match throws when argument is not string", () => {
-  try {
-    assert.match(123, /pass/);
-    expect.unreachable();
-  } catch (e) {}
+  expect(() => assert.match(123, /pass/)).toThrow("The \"actual\" argument must be of type string. Received type number");
 });
 
 test("match throws when not matching", () => {
-  try {
-    assert.match('I will fail', /pass/);
-    expect.unreachable();
-  } catch (e) {}
+  expect(() => assert.match('I will fail', /pass/, "match throws when not matching")).toThrow("match throws when not matching");
 });

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -27,27 +27,6 @@ import url from "url";
 const noop = () => {};
 const mustCallChecks = [];
 
-//? Bun does not have this function yet
-assert.doesNotMatch = (string, regexp, message) => {
-  try {
-    assert.match(string, regexp, message);
-    throw null;
-  } catch (e) {
-    if (e === null) {
-      const msg =
-        message || `The input was expected to not match the regular expression ${regexp}. Input:\n'${string}'`;
-      throw new assert.AssertionError({
-        message: msg,
-        actual: string,
-        expected: regexp,
-        operator: "doesNotMatch",
-        stackStartFn: assert.doesNotMatch,
-      });
-    }
-    // pass
-  }
-};
-
 test("no assertion failures", () => {
   assert.strictEqual(util.inspect(1), "1");
   assert.strictEqual(util.inspect(false), "false");


### PR DESCRIPTION
### What does this PR do?

It implements assert.doesNotMatch making node:assert fully implemented.

_The documentation and TypeScript definitions already exists, this just provides the missing implementation._

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests.

If JavaScript/TypeScript modules or builtins changed:

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

If new methods, getters, or setters were added to a publicly exposed class:

_The documentation and TypeScript definitions already exists, this just provides the missing implementation._

- [ ] I added TypeScript types for the new methods, getters, or setters
