### PR TITLE
Make `PerformanceEntry` use 40% less memory

### DIFF
--- a/src/bun.js/bindings/webcore/JSDOMConvertSequences.h
+++ b/src/bun.js/bindings/webcore/JSDOMConvertSequences.h
@@ -380,6 +380,7 @@ template<typename T> struct JSConverter<IDLSequence<T>> {
         JSC::VM& vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
         JSC::MarkedArgumentBuffer list;
+        list.ensureCapacity(vector.size());
         for (auto& element : vector) {
             auto jsValue = toJS<T>(lexicalGlobalObject, globalObject, element);
             RETURN_IF_EXCEPTION(scope, {});
@@ -417,6 +418,7 @@ template<typename T> struct JSConverter<IDLFrozenArray<T>> {
         JSC::VM& vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
         JSC::MarkedArgumentBuffer list;
+        list.ensureCapacity(vector.size());
         for (auto& element : vector) {
             auto jsValue = toJS<T>(lexicalGlobalObject, globalObject, element);
             RETURN_IF_EXCEPTION(scope, {});

--- a/src/bun.js/bindings/webcore/JSPerformanceObserverCallback.cpp
+++ b/src/bun.js/bindings/webcore/JSPerformanceObserverCallback.cpp
@@ -30,7 +30,6 @@
 #include "ScriptExecutionContext.h"
 #include "ZigGlobalObject.h"
 
-
 namespace WebCore {
 using namespace JSC;
 
@@ -48,7 +47,7 @@ JSPerformanceObserverCallback::~JSPerformanceObserverCallback()
     if (!context || context->isContextThread())
         delete m_data;
     else
-        RELEASE_ASSERT_NOT_REACHED(); 
+        RELEASE_ASSERT_NOT_REACHED();
 #ifndef NDEBUG
     m_data = nullptr;
 #endif
@@ -69,7 +68,7 @@ CallbackResult<typename IDLUndefined::ImplementationType> JSPerformanceObserverC
     JSValue thisValue = toJS<IDLInterface<PerformanceObserver>>(lexicalGlobalObject, globalObject, thisObject);
     MarkedArgumentBuffer args;
     args.append(toJS<IDLInterface<PerformanceObserverEntryList>>(lexicalGlobalObject, globalObject, entries));
-    args.append(toJS<IDLInterface<PerformanceObserver>>(lexicalGlobalObject, globalObject, observer));
+    args.append(&observer == &thisObject ? thisValue : toJS<IDLInterface<PerformanceObserver>>(lexicalGlobalObject, globalObject, observer));
     ASSERT(!args.hasOverflowed());
 
     NakedPtr<JSC::Exception> returnedException;
@@ -78,9 +77,9 @@ CallbackResult<typename IDLUndefined::ImplementationType> JSPerformanceObserverC
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
         return CallbackResultType::ExceptionThrown;
-     }
+    }
 
-    return { };
+    return {};
 }
 
 void JSPerformanceObserverCallback::visitJSFunction(JSC::AbstractSlotVisitor& visitor)

--- a/src/bun.js/bindings/webcore/PerformanceEntry.h
+++ b/src/bun.js/bindings/webcore/PerformanceEntry.h
@@ -40,19 +40,20 @@ namespace WebCore {
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PerformanceEntry);
 class PerformanceEntry : public RefCounted<PerformanceEntry> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(PerformanceEntry);
+
 public:
     virtual ~PerformanceEntry();
 
     const String& name() const { return m_name; }
-    virtual double startTime() const { return m_startTime; }
-    virtual double duration() const { return m_duration; }
+    const double startTime() const { return m_startTime; }
+    const double duration() const { return m_duration; }
 
     enum class Type : uint8_t {
-        Navigation  = 1 << 0,
-        Mark        = 1 << 1,
-        Measure     = 1 << 2,
-        Resource    = 1 << 3,
-        Paint       = 1 << 4
+        Navigation = 1 << 0,
+        Mark = 1 << 1,
+        Measure = 1 << 2,
+        Resource = 1 << 3,
+        Paint = 1 << 4
     };
 
     virtual Type performanceEntryType() const = 0;

--- a/src/bun.js/bindings/webcore/PerformanceMark.h
+++ b/src/bun.js/bindings/webcore/PerformanceMark.h
@@ -45,13 +45,13 @@ public:
     JSC::JSValue detail(JSC::JSGlobalObject&);
 
 private:
-    PerformanceMark(const String& name, double startTime, Ref<SerializedScriptValue>&&);
+    PerformanceMark(const String& name, double startTime, RefPtr<SerializedScriptValue>&&);
     ~PerformanceMark();
 
     Type performanceEntryType() const final { return Type::Mark; }
     ASCIILiteral entryType() const final { return "mark"_s; }
 
-    Ref<SerializedScriptValue> m_serializedDetail;
+    RefPtr<SerializedScriptValue> m_serializedDetail;
 };
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcore/PerformanceMeasure.cpp
+++ b/src/bun.js/bindings/webcore/PerformanceMeasure.cpp
@@ -30,12 +30,12 @@
 
 namespace WebCore {
 
-ExceptionOr<Ref<PerformanceMeasure>> PerformanceMeasure::create(const String& name, double startTime, double endTime, Ref<SerializedScriptValue>&& serializedDetail)
+ExceptionOr<Ref<PerformanceMeasure>> PerformanceMeasure::create(const String& name, double startTime, double endTime, RefPtr<SerializedScriptValue>&& serializedDetail)
 {
     return adoptRef(*new PerformanceMeasure(name, startTime, endTime, WTFMove(serializedDetail)));
 }
 
-PerformanceMeasure::PerformanceMeasure(const String& name, double startTime, double endTime, Ref<SerializedScriptValue>&& serializedDetail)
+PerformanceMeasure::PerformanceMeasure(const String& name, double startTime, double endTime, RefPtr<SerializedScriptValue>&& serializedDetail)
     : PerformanceEntry(name, startTime, endTime)
     , m_serializedDetail(WTFMove(serializedDetail))
 {
@@ -45,8 +45,11 @@ PerformanceMeasure::~PerformanceMeasure() = default;
 
 JSC::JSValue PerformanceMeasure::detail(JSC::JSGlobalObject& globalObject)
 {
+    if (!m_serializedDetail) {
+        return JSC::jsNull();
+    }
+    
     return m_serializedDetail->deserialize(globalObject, &globalObject);
 }
 
 }
-

--- a/src/bun.js/bindings/webcore/PerformanceMeasure.h
+++ b/src/bun.js/bindings/webcore/PerformanceMeasure.h
@@ -40,18 +40,18 @@ class ScriptExecutionContext;
 
 class PerformanceMeasure final : public PerformanceEntry {
 public:
-    static ExceptionOr<Ref<PerformanceMeasure>> create(const String& name, double startTime, double endTime, Ref<SerializedScriptValue>&& detail);
+    static ExceptionOr<Ref<PerformanceMeasure>> create(const String& name, double startTime, double endTime, RefPtr<SerializedScriptValue>&& detail);
 
     JSC::JSValue detail(JSC::JSGlobalObject&);
 
 private:
-    PerformanceMeasure(const String& name, double startTime, double endTime, Ref<SerializedScriptValue>&& detail);
+    PerformanceMeasure(const String& name, double startTime, double endTime, RefPtr<SerializedScriptValue>&& detail);
     ~PerformanceMeasure();
 
     Type performanceEntryType() const final { return Type::Measure; }
     ASCIILiteral entryType() const final { return "measure"_s; }
 
-    Ref<SerializedScriptValue> m_serializedDetail;
+    RefPtr<SerializedScriptValue> m_serializedDetail;
 };
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcore/PerformanceUserTiming.h
+++ b/src/bun.js/bindings/webcore/PerformanceUserTiming.h
@@ -43,6 +43,7 @@ using PerformanceEntryMap = HashMap<String, Vector<RefPtr<PerformanceEntry>>>;
 
 class PerformanceUserTiming {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
     explicit PerformanceUserTiming(Performance&);
 
@@ -71,7 +72,9 @@ private:
 
     Performance& m_performance;
     PerformanceEntryMap m_marksMap;
+    int64_t m_markCounter { 0 };
     PerformanceEntryMap m_measuresMap;
+    int64_t m_measureCounter { 0 };
 };
 
 }


### PR DESCRIPTION
### What does this PR do?

<img width="438" alt="image" src="https://github.com/oven-sh/bun/assets/709451/2873badd-2b9f-459e-82a8-891d837a43e7">

```js
const count = Number(process.argv.at(-1));
for (let i = 0; i < count; i++) {
  performance.mark("count");
}


console.time("getEntries for " + count);
performance.getEntriesByName("count").length;
console.timeEnd("getEntries for " + count);
```

### How did you verify your code works?

Existing tests