### PR TITLE
docs: add missing comma in examples

### DIFF
--- a/docs/api/file-system-router.md
+++ b/docs/api/file-system-router.md
@@ -46,7 +46,7 @@ router.match("/settings?foo=bar");
   kind: "dynamic",
   name: "/settings",
   pathname: "/settings?foo=bar",
-  src: "https://mydomain.com/_next/static/pages/settings.tsx"
+  src: "https://mydomain.com/_next/static/pages/settings.tsx",
   query: {
     foo: "bar"
   }
@@ -64,7 +64,7 @@ router.match("/blog/my-cool-post");
   kind: "dynamic",
   name: "/blog/[slug]",
   pathname: "/blog/my-cool-post",
-  src: "https://mydomain.com/_next/static/pages/blog/[slug].tsx"
+  src: "https://mydomain.com/_next/static/pages/blog/[slug].tsx",
   params: {
     slug: "my-cool-post"
   }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
The documentation for FileSystemRouter was missing a comma `,` in few places. This PR fixes the examples.
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
This PR does not modify the code.
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
