### PR TITLE
all: make bun.FileDescriptor a unique type

### DIFF
--- a/src/async/windows_event_loop.zig
+++ b/src/async/windows_event_loop.zig
@@ -205,7 +205,7 @@ pub const FilePoll = struct {
 
     pub fn unregister(this: *FilePoll, loop: *Loop) bool {
         _ = loop;
-        uv.uv_unref(@ptrFromInt(this.fd));
+        uv.uv_unref(@ptrFromInt(this.fd.int()));
         return true;
     }
 

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -147,7 +147,7 @@ pub const TransformTask = struct {
         const parse_options = Bundler.Bundler.ParseOptions{
             .allocator = allocator,
             .macro_remappings = this.macro_map,
-            .dirname_fd = 0,
+            .dirname_fd = .zero,
             .file_descriptor = null,
             .loader = this.loader,
             .jsx = jsx,
@@ -868,7 +868,7 @@ fn getParseResult(this: *Transpiler, allocator: std.mem.Allocator, code: []const
     const parse_options = Bundler.Bundler.ParseOptions{
         .allocator = allocator,
         .macro_remappings = this.transpiler_options.macro_map,
-        .dirname_fd = 0,
+        .dirname_fd = .zero,
         .file_descriptor = null,
         .loader = loader orelse this.transpiler_options.default_loader,
         .jsx = jsx,

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -120,13 +120,13 @@ const LibInfo = struct {
             return promise_value;
         }
         std.debug.assert(request.backend.libinfo.machport != null);
-        request.backend.libinfo.file_poll = bun.Async.FilePoll.init(this.vm, std.math.maxInt(i32) - 1, .{}, GetAddrInfoRequest, request);
+        request.backend.libinfo.file_poll = bun.Async.FilePoll.init(this.vm, bun.toFD(std.math.maxInt(i32) - 1), .{}, GetAddrInfoRequest, request);
         std.debug.assert(
             request.backend.libinfo.file_poll.?.registerWithFd(
                 this.vm.event_loop_handle.?,
                 .machport,
                 true,
-                @intFromPtr(request.backend.libinfo.machport),
+                bun.toFD(@intFromPtr(request.backend.libinfo.machport)),
             ) == .result,
         );
 
@@ -1938,13 +1938,13 @@ pub const DNSResolver = struct {
         defer vm.drainMicrotasks();
 
         var channel = this.channel orelse {
-            _ = this.polls.orderedRemove(@as(i32, @intCast(poll.fd)));
+            _ = this.polls.orderedRemove(poll.fd.int());
             poll.deinit();
             return;
         };
 
         channel.process(
-            @as(i32, @intCast(poll.fd)),
+            poll.fd.int(),
             poll.isReadable(),
             poll.isWritable(),
         );

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -951,13 +951,7 @@ pub const Listener = struct {
         const connection: Listener.UnixOrHost = blk: {
             if (opts.getTruthy(globalObject, "fd")) |fd_| {
                 if (fd_.isNumber()) {
-                    if (Environment.isWindows) {
-                        // SOCKET is actually a u32 but we are casting to a *anyopaque, so we are conservative here
-                        const socket: bun.FDImpl.System = @ptrFromInt(fd_.to(u64));
-                        const fd: bun.FileDescriptor = bun.toFD(socket);
-                        break :blk .{ .fd = fd };
-                    }
-                    const fd: bun.FileDescriptor = bun.toFD(fd_.to(i32));
+                    const fd = fd_.asFileDescriptor();
                     break :blk .{ .fd = fd };
                 }
             }

--- a/src/bun.js/api/bun/spawn.zig
+++ b/src/bun.js/api/bun/spawn.zig
@@ -234,13 +234,13 @@ pub const PosixSpawn = struct {
             self.* = undefined;
         }
 
-        pub fn open(self: *PosixSpawnActions, fd: fd_t, path: []const u8, flags: u32, mode: mode_t) !void {
+        pub fn open(self: *PosixSpawnActions, fd: bun.FileDescriptor, path: []const u8, flags: u32, mode: mode_t) !void {
             const posix_path = try toPosixPath(path);
             return self.openZ(fd, &posix_path, flags, mode);
         }
 
-        pub fn openZ(self: *PosixSpawnActions, fd: fd_t, path: [*:0]const u8, flags: u32, mode: mode_t) !void {
-            switch (errno(system.posix_spawn_file_actions_addopen(&self.actions, fd, path, @as(c_int, @bitCast(flags)), mode))) {
+        pub fn openZ(self: *PosixSpawnActions, fd: bun.FileDescriptor, path: [*:0]const u8, flags: u32, mode: mode_t) !void {
+            switch (errno(system.posix_spawn_file_actions_addopen(&self.actions, fd.cast(), path, @as(c_int, @bitCast(flags)), mode))) {
                 .SUCCESS => return,
                 .BADF => return error.InvalidFileDescriptor,
                 .NOMEM => return error.SystemResources,
@@ -250,8 +250,8 @@ pub const PosixSpawn = struct {
             }
         }
 
-        pub fn close(self: *PosixSpawnActions, fd: fd_t) !void {
-            switch (errno(system.posix_spawn_file_actions_addclose(&self.actions, fd))) {
+        pub fn close(self: *PosixSpawnActions, fd: bun.FileDescriptor) !void {
+            switch (errno(system.posix_spawn_file_actions_addclose(&self.actions, fd.cast()))) {
                 .SUCCESS => return,
                 .BADF => return error.InvalidFileDescriptor,
                 .NOMEM => return error.SystemResources,
@@ -261,8 +261,8 @@ pub const PosixSpawn = struct {
             }
         }
 
-        pub fn dup2(self: *PosixSpawnActions, fd: fd_t, newfd: fd_t) !void {
-            switch (errno(system.posix_spawn_file_actions_adddup2(&self.actions, fd, newfd))) {
+        pub fn dup2(self: *PosixSpawnActions, fd: bun.FileDescriptor, newfd: bun.FileDescriptor) !void {
+            switch (errno(system.posix_spawn_file_actions_adddup2(&self.actions, fd.cast(), newfd.cast()))) {
                 .SUCCESS => return,
                 .BADF => return error.InvalidFileDescriptor,
                 .NOMEM => return error.SystemResources,
@@ -272,8 +272,8 @@ pub const PosixSpawn = struct {
             }
         }
 
-        pub fn inherit(self: *PosixSpawnActions, fd: fd_t) !void {
-            switch (errno(system.posix_spawn_file_actions_addinherit_np(&self.actions, fd))) {
+        pub fn inherit(self: *PosixSpawnActions, fd: bun.FileDescriptor) !void {
+            switch (errno(system.posix_spawn_file_actions_addinherit_np(&self.actions, fd.cast()))) {
                 .SUCCESS => return,
                 .BADF => return error.InvalidFileDescriptor,
                 .NOMEM => return error.SystemResources,

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1813,6 +1813,7 @@ pub const Subprocess = struct {
             }
         }
 
+        // TODO: move pipe2 to bun.sys so it can return [2]bun.FileDesriptor
         const stdin_pipe = if (stdio[0].isPiped()) os.pipe2(0) catch |err| {
             globalThis.throw("failed to create stdin pipe: {s}", .{@errorName(err)});
             return .zero;

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -2658,12 +2658,11 @@ pub const Subprocess = struct {
 
             return true;
         } else if (value.isNumber()) {
-            const fd_ = value.toInt64();
-            if (fd_ < 0) {
+            const fd = value.asFileDescriptor();
+            if (fd.int() < 0) {
                 globalThis.throwInvalidArguments("file descriptor must be a positive integer", .{});
                 return false;
             }
-            const fd = bun.toFD(fd_);
 
             switch (bun.FDTag.get(fd)) {
                 .stdin => {

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1575,12 +1575,12 @@ pub const Subprocess = struct {
                     }
 
                     if (args.get(globalThis, "stderr")) |value| {
-                        if (!extractStdio(globalThis, 1, value, &stdio[1]))
+                        if (!extractStdio(globalThis, 2, value, &stdio[2]))
                             return .zero;
                     }
 
                     if (args.get(globalThis, "stdout")) |value| {
-                        if (!extractStdio(globalThis, 2, value, &stdio[2]))
+                        if (!extractStdio(globalThis, 1, value, &stdio[1]))
                             return .zero;
                     }
                 }

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -424,23 +424,23 @@ pub const Subprocess = struct {
             }
         };
 
-        pub fn init(stdio: Stdio, fd: i32, allocator: std.mem.Allocator, max_size: u32) Readable {
+        pub fn init(stdio: Stdio, fd: bun.FileDescriptor, allocator: std.mem.Allocator, max_size: u32) Readable {
             return switch (stdio) {
                 .inherit => Readable{ .inherit = {} },
                 .ignore => Readable{ .ignore = {} },
                 .pipe => brk: {
                     break :brk .{
                         .pipe = .{
-                            .buffer = BufferedOutput.initWithAllocator(allocator, bun.toFD(fd), max_size),
+                            .buffer = BufferedOutput.initWithAllocator(allocator, fd, max_size),
                         },
                     };
                 },
                 .path => Readable{ .ignore = {} },
-                .blob, .fd => Readable{ .fd = bun.toFD(fd) },
+                .blob, .fd => Readable{ .fd = fd },
                 .memfd => Readable{ .memfd = stdio.memfd },
                 .array_buffer => Readable{
                     .pipe = .{
-                        .buffer = BufferedOutput.initWithSlice(bun.toFD(fd), stdio.array_buffer.slice()),
+                        .buffer = BufferedOutput.initWithSlice(fd, stdio.array_buffer.slice()),
                     },
                 },
             };
@@ -1153,7 +1153,7 @@ pub const Subprocess = struct {
         pub fn onReady(_: *Writable, _: ?JSC.WebCore.Blob.SizeType, _: ?JSC.WebCore.Blob.SizeType) void {}
         pub fn onStart(_: *Writable) void {}
 
-        pub fn init(stdio: Stdio, fd: i32, globalThis: *JSC.JSGlobalObject) !Writable {
+        pub fn init(stdio: Stdio, fd: bun.FileDescriptor, globalThis: *JSC.JSGlobalObject) !Writable {
             switch (stdio) {
                 .pipe => |maybe_readable| {
                     if (Environment.isWindows) @panic("TODO");
@@ -1570,17 +1570,17 @@ pub const Subprocess = struct {
                     }
                 } else {
                     if (args.get(globalThis, "stdin")) |value| {
-                        if (!extractStdio(globalThis, bun.posix.STDIN_FD, value, &stdio[bun.posix.STDIN_FD]))
+                        if (!extractStdio(globalThis, 0, value, &stdio[0]))
                             return .zero;
                     }
 
                     if (args.get(globalThis, "stderr")) |value| {
-                        if (!extractStdio(globalThis, bun.posix.STDERR_FD, value, &stdio[bun.posix.STDERR_FD]))
+                        if (!extractStdio(globalThis, 1, value, &stdio[1]))
                             return .zero;
                     }
 
                     if (args.get(globalThis, "stdout")) |value| {
-                        if (!extractStdio(globalThis, bun.posix.STDOUT_FD, value, &stdio[bun.posix.STDOUT_FD]))
+                        if (!extractStdio(globalThis, 2, value, &stdio[2]))
                             return .zero;
                     }
                 }
@@ -1848,6 +1848,7 @@ pub const Subprocess = struct {
 
         for (stdio_pipes.items) |*item| {
             const maybe = blk: {
+                // TODO: move this to bun.sys so it can return [2]bun.FileDesriptor
                 var fds: [2]c_int = undefined;
                 const socket_type = os.SOCK.STREAM;
                 const rc = std.os.system.socketpair(os.AF.UNIX, socket_type, 0, &fds);
@@ -1861,8 +1862,8 @@ pub const Subprocess = struct {
                     .PROTONOSUPPORT => break :blk error.ProtocolNotSupported,
                     else => |err| break :blk std.os.unexpectedErrno(err),
                 }
-                actions.dup2(fds[1], item.fileno) catch |err| break :blk err;
-                actions.close(fds[1]) catch |err| break :blk err;
+                actions.dup2(bun.toFD(fds[1]), bun.toFD(item.fileno)) catch |err| break :blk err;
+                actions.close(bun.toFD(fds[1])) catch |err| break :blk err;
                 item.fd = fds[0];
                 // enable non-block
                 const before = std.c.fcntl(fds[0], os.F.GETFL);
@@ -1913,7 +1914,7 @@ pub const Subprocess = struct {
                 });
                 return .zero;
             };
-            actions.dup2(fds[1], 3) catch |err| return globalThis.handleError(err, "in posix_spawn");
+            actions.dup2(bun.toFD(fds[1]), bun.toFD(3)) catch |err| return globalThis.handleError(err, "in posix_spawn");
         }
 
         env_array.append(allocator, null) catch {
@@ -1925,16 +1926,16 @@ pub const Subprocess = struct {
         const pid = brk: {
             defer {
                 if (stdio[0].isPiped()) {
-                    _ = bun.sys.close(stdin_pipe[0]);
+                    _ = bun.sys.close(bun.toFD(stdin_pipe[0]));
                 }
                 if (stdio[1].isPiped()) {
-                    _ = bun.sys.close(stdout_pipe[1]);
+                    _ = bun.sys.close(bun.toFD(stdout_pipe[1]));
                 }
                 if (stdio[2].isPiped()) {
-                    _ = bun.sys.close(stderr_pipe[1]);
+                    _ = bun.sys.close(bun.toFD(stderr_pipe[1]));
                 }
                 for (stdio_pipes.items) |item| {
-                    _ = bun.sys.close(item.fd + 1);
+                    _ = bun.sys.close(bun.toFD(item.fd + 1));
                 }
             }
 
@@ -2010,14 +2011,14 @@ pub const Subprocess = struct {
             .globalThis = globalThis,
             .pid = pid,
             .pid_rusage = if (has_rusage) rusage_result else null,
-            .pidfd = if (WaiterThread.shouldUseWaiterThread()) @truncate(bun.invalid_fd) else @truncate(pidfd),
-            .stdin = Writable.init(stdio[bun.STDIN_FD], stdin_pipe[1], globalThis) catch {
+            .pidfd = if (WaiterThread.shouldUseWaiterThread()) @truncate(bun.invalid_fd.int()) else @truncate(pidfd),
+            .stdin = Writable.init(stdio[0], bun.toFD(stdin_pipe[1]), globalThis) catch {
                 globalThis.throwOutOfMemory();
                 return .zero;
             },
             // stdout and stderr only uses allocator and default_max_buffer_size if they are pipes and not a array buffer
-            .stdout = Readable.init(stdio[bun.STDOUT_FD], stdout_pipe[0], jsc_vm.allocator, default_max_buffer_size),
-            .stderr = Readable.init(stdio[bun.STDERR_FD], stderr_pipe[0], jsc_vm.allocator, default_max_buffer_size),
+            .stdout = Readable.init(stdio[1], bun.toFD(stdout_pipe[0]), jsc_vm.allocator, default_max_buffer_size),
+            .stderr = Readable.init(stdio[2], bun.toFD(stderr_pipe[0]), jsc_vm.allocator, default_max_buffer_size),
             .stdio_pipes = stdio_pipes,
             .on_exit_callback = if (on_exit_callback != .zero) JSC.Strong.create(on_exit_callback, globalThis) else .{},
             .ipc_mode = ipc_mode,
@@ -2049,7 +2050,7 @@ pub const Subprocess = struct {
 
         if (comptime !is_sync) {
             if (!WaiterThread.shouldUseWaiterThread()) {
-                const poll = Async.FilePoll.init(jsc_vm, watchfd, .{}, Subprocess, subprocess);
+                const poll = Async.FilePoll.init(jsc_vm, bun.toFD(watchfd), .{}, Subprocess, subprocess);
                 subprocess.poll = .{ .poll_ref = poll };
                 switch (subprocess.poll.poll_ref.?.register(
                     jsc_vm.event_loop_handle.?,
@@ -2115,7 +2116,7 @@ pub const Subprocess = struct {
         subprocess.closeIO(.stdin);
 
         if (!WaiterThread.shouldUseWaiterThread()) {
-            const poll = Async.FilePoll.init(jsc_vm, watchfd, .{}, Subprocess, subprocess);
+            const poll = Async.FilePoll.init(jsc_vm, bun.toFD(watchfd), .{}, Subprocess, subprocess);
             subprocess.poll = .{ .poll_ref = poll };
             switch (subprocess.poll.poll_ref.?.register(
                 jsc_vm.event_loop_handle.?,
@@ -2509,15 +2510,15 @@ pub const Subprocess = struct {
             stdio: @This(),
             actions: *PosixSpawn.Actions,
             pipe_fd: [2]i32,
-            std_fileno: i32,
+            std_fileno: bun.FileDescriptor,
         ) !void {
             switch (stdio) {
                 .array_buffer, .blob, .pipe => {
                     std.debug.assert(!(stdio == .blob and stdio.blob.needsToReadFile()));
-                    const idx: usize = if (std_fileno == 0) 0 else 1;
+                    const idx: usize = if (std_fileno == bun.STDIN_FD) 0 else 1;
 
-                    try actions.dup2(pipe_fd[idx], std_fileno);
-                    try actions.close(pipe_fd[1 - idx]);
+                    try actions.dup2(bun.toFD(pipe_fd[idx]), std_fileno);
+                    try actions.close(bun.toFD(pipe_fd[1 - idx]));
                 },
                 .fd => |fd| {
                     try actions.dup2(fd, std_fileno);
@@ -2662,18 +2663,18 @@ pub const Subprocess = struct {
                 return false;
             }
 
-            const fd = @as(bun.FileDescriptor, @intCast(fd_));
+            const fd = bun.toFD(fd_);
 
             switch (bun.FDTag.get(fd)) {
                 .stdin => {
-                    if (i == bun.STDERR_FD or i == bun.STDOUT_FD) {
+                    if (i == 1 or i == 2) {
                         globalThis.throwInvalidArguments("stdin cannot be used for stdout or stderr", .{});
                         return false;
                     }
                 },
 
                 .stdout, .stderr => {
-                    if (i == bun.STDIN_FD) {
+                    if (i == 0) {
                         globalThis.throwInvalidArguments("stdout and stderr cannot be used for stdin", .{});
                         return false;
                     }
@@ -2694,7 +2695,7 @@ pub const Subprocess = struct {
             return extractStdioBlob(globalThis, req.getBodyValue().useAsAnyBlob(), i, out_stdio);
         } else if (JSC.WebCore.ReadableStream.fromJS(value, globalThis)) |req_const| {
             var req = req_const;
-            if (i == bun.STDIN_FD) {
+            if (i == 0) {
                 if (req.toAnyBlob(globalThis)) |blob| {
                     return extractStdioBlob(globalThis, blob, i, out_stdio);
                 }
@@ -2911,7 +2912,7 @@ pub const Subprocess = struct {
                 var process = queue[i];
 
                 // this case shouldn't really happen
-                if (process.pid == bun.invalid_fd) {
+                if (process.pid == bun.invalid_fd.int()) {
                     _ = this.queue.orderedRemove(i);
                     _ = process.poll.wait_thread.ref_count.fetchSub(1, .Monotonic);
                     queue = this.queue.items;
@@ -2960,7 +2961,7 @@ pub const Subprocess = struct {
             while (queue.len > 0 and i < queue.len) {
                 var lifecycle_script_subprocess = queue[i];
 
-                if (lifecycle_script_subprocess.pid == bun.invalid_fd) {
+                if (lifecycle_script_subprocess.pid == bun.invalid_fd.int()) {
                     _ = this.lifecycle_script_queue.orderedRemove(i);
                     queue = this.lifecycle_script_queue.items;
                 }

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1750,7 +1750,7 @@ pub const Subprocess = struct {
             const resource_usage = subprocess.createResourceUsageObject(globalThis);
             subprocess.finalizeSync();
 
-            const sync_value = JSC.JSValue.createEmptyObject(globalThis, 4);
+            const sync_value = JSC.JSValue.createEmptyObject(globalThis, 5);
             sync_value.put(globalThis, JSC.ZigString.static("exitCode"), JSValue.jsNumber(@as(i32, @intCast(exitCode))));
             sync_value.put(globalThis, JSC.ZigString.static("stdout"), stdout);
             sync_value.put(globalThis, JSC.ZigString.static("stderr"), stderr);

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1898,9 +1898,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 var sbytes: std.os.off_t = adjusted_count;
                 const signed_offset = @as(i64, @bitCast(@as(u64, this.sendfile.offset)));
                 const errcode = std.c.getErrno(std.c.sendfile(
-                    this.sendfile.fd,
+                    this.sendfile.fd.cast(),
                     this.sendfile.socket_fd,
-
                     signed_offset,
                     &sbytes,
                     null,
@@ -5476,7 +5475,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             this.unref();
 
             if (!ssl_enabled_)
-                this.vm.removeListeningSocketForWatchMode(@intCast(listener.socket().fd()));
+                this.vm.removeListeningSocketForWatchMode(listener.socket().fd());
 
             if (!abrupt) {
                 listener.close();
@@ -5661,7 +5660,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             this.listener = socket;
             this.vm.event_loop_handle = Async.Loop.get();
             if (!ssl_enabled_)
-                this.vm.addListeningSocketForWatchMode(@intCast(socket.?.socket().fd()));
+                this.vm.addListeningSocketForWatchMode(socket.?.socket().fd());
         }
 
         pub fn ref(this: *ThisServer) void {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1879,7 +1879,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 const start = this.sendfile.offset;
                 const val =
                     // this does the syscall directly, without libc
-                    linux.sendfile(this.sendfile.socket_fd, this.sendfile.fd, &signed_offset, this.sendfile.remain);
+                    linux.sendfile(this.sendfile.socket_fd, this.sendfile.fd.cast(), &signed_offset, this.sendfile.remain);
                 this.sendfile.offset = @as(Blob.SizeType, @intCast(signed_offset));
 
                 const errcode = linux.getErrno(val);

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1876,9 +1876,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             if (Environment.isLinux) {
                 var signed_offset = @as(i64, @intCast(this.sendfile.offset));
                 const start = this.sendfile.offset;
-                const val =
-                    // this does the syscall directly, without libc
-                    linux.sendfile(this.sendfile.socket_fd, this.sendfile.fd.cast(), &signed_offset, this.sendfile.remain);
+                const val = linux.sendfile(this.sendfile.socket_fd.cast(), this.sendfile.fd.cast(), &signed_offset, this.sendfile.remain);
                 this.sendfile.offset = @as(Blob.SizeType, @intCast(signed_offset));
 
                 const errcode = linux.getErrno(val);
@@ -1893,7 +1891,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     this.cleanupAndFinalizeAfterSendfile();
                     return errcode != .SUCCESS;
                 }
-            } else if(Environment.isWindows) {
+            } else if (Environment.isWindows) {
                 const win = std.os.windows;
                 const uv = bun.windows.libuv;
                 const socket = bun.socketcast(this.sendfile.socket_fd);
@@ -1906,7 +1904,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 const signed_offset = @as(i64, @bitCast(@as(u64, this.sendfile.offset)));
                 const errcode = std.c.getErrno(std.c.sendfile(
                     this.sendfile.fd.cast(),
-                    this.sendfile.socket_fd,
+                    this.sendfile.socket_fd.cast(),
                     signed_offset,
                     &sbytes,
                     null,

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -4861,7 +4861,7 @@ pub const JSValue = enum(JSValueReprInt) {
 
     pub fn asFileDescriptor(this: JSValue) bun.FileDescriptor {
         std.debug.assert(this.isNumber());
-        return bun.FDImpl.fromUV(this.asInt32()).encode();
+        return bun.FDImpl.fromUV(this.toInt32()).encode();
     }
 
     pub inline fn toU16(this: JSValue) u16 {

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -1604,7 +1604,7 @@ pub const SystemError = extern struct {
     message: String = String.empty,
     path: String = String.empty,
     syscall: String = String.empty,
-    fd: i32 = -1,
+    fd: bun.FileDescriptor = bun.toFD(-1),
 
     pub fn Maybe(comptime Result: type) type {
         return union(enum) {
@@ -3873,6 +3873,9 @@ pub const JSValue = enum(JSValueReprInt) {
                 if (comptime Number == std.os.fd_t) {
                     return jsNumber(bun.toFD(number));
                 }
+                if (Number == bun.FileDescriptor) {
+                    return jsNumber(number.int());
+                }
 
                 @compileError("Type transformation missing for number of type: " ++ @typeName(Number));
             },
@@ -4854,6 +4857,11 @@ pub const JSValue = enum(JSValueReprInt) {
 
     pub fn asInt32(this: JSValue) i32 {
         return FFI.JSVALUE_TO_INT32(.{ .asJSValue = this });
+    }
+
+    pub fn asFileDescriptor(this: JSValue) bun.FileDescriptor {
+        std.debug.assert(this.isNumber());
+        return bun.FDImpl.fromUV(this.asInt32()).encode();
     }
 
     pub inline fn toU16(this: JSValue) u16 {

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -382,7 +382,7 @@ pub const RuntimeTranspilerStore = struct {
                 .hot, .watch => {
                     if (vm.bun_watcher.indexOf(hash)) |index| {
                         const _fd = vm.bun_watcher.watchlist().items(.fd)[index];
-                        fd = if (_fd > 0) _fd else null;
+                        fd = if (_fd.int() > 0) _fd else null;
                         package_json = vm.bun_watcher.watchlist().items(.package_json)[index];
                     }
                 },
@@ -406,12 +406,12 @@ pub const RuntimeTranspilerStore = struct {
             //
             var should_close_input_file_fd = fd == null;
 
-            var input_file_fd: StoredFileDescriptorType = 0;
+            var input_file_fd: StoredFileDescriptorType = .zero;
             var parse_options = Bundler.ParseOptions{
                 .allocator = allocator,
                 .path = path,
                 .loader = loader,
-                .dirname_fd = 0,
+                .dirname_fd = .zero,
                 .file_descriptor = fd,
                 .file_fd_ptr = &input_file_fd,
                 .file_hash = hash,
@@ -430,9 +430,9 @@ pub const RuntimeTranspilerStore = struct {
             };
 
             defer {
-                if (should_close_input_file_fd and input_file_fd != 0) {
+                if (should_close_input_file_fd and input_file_fd != .zero) {
                     _ = bun.sys.close(input_file_fd);
-                    input_file_fd = 0;
+                    input_file_fd = .zero;
                 }
             }
 
@@ -451,7 +451,7 @@ pub const RuntimeTranspilerStore = struct {
                 false,
             ) orelse {
                 if (vm.isWatcherEnabled()) {
-                    if (input_file_fd != 0) {
+                    if (input_file_fd != .zero) {
                         if (!is_node_override and std.fs.path.isAbsolute(path.text) and !strings.contains(path.text, "node_modules")) {
                             should_close_input_file_fd = false;
                             vm.bun_watcher.addFile(
@@ -459,7 +459,7 @@ pub const RuntimeTranspilerStore = struct {
                                 path.text,
                                 hash,
                                 loader,
-                                0,
+                                .zero,
                                 package_json,
                                 true,
                             ) catch {};
@@ -472,7 +472,7 @@ pub const RuntimeTranspilerStore = struct {
             };
 
             if (vm.isWatcherEnabled()) {
-                if (input_file_fd != 0) {
+                if (input_file_fd != .zero) {
                     if (!is_node_override and
                         std.fs.path.isAbsolute(path.text) and !strings.contains(path.text, "node_modules"))
                     {
@@ -482,7 +482,7 @@ pub const RuntimeTranspilerStore = struct {
                             path.text,
                             hash,
                             loader,
-                            0,
+                            .zero,
                             package_json,
                             true,
                         ) catch {};
@@ -1326,7 +1326,7 @@ pub const ModuleLoader = struct {
                             path.text,
                             this.hash,
                             options.Loader.fromAPI(this.loader),
-                            0,
+                            .zero,
                             this.package_json,
                             true,
                         ) catch {};
@@ -1467,7 +1467,7 @@ pub const ModuleLoader = struct {
 
                 if (jsc_vm.bun_watcher.indexOf(hash)) |index| {
                     const _fd = jsc_vm.bun_watcher.watchlist().items(.fd)[index];
-                    fd = if (_fd > 0) _fd else null;
+                    fd = if (_fd.int() > 0) _fd else null;
                     package_json = jsc_vm.bun_watcher.watchlist().items(.package_json)[index];
                 }
 
@@ -1555,7 +1555,7 @@ pub const ModuleLoader = struct {
                         ) orelse {
                             if (comptime !disable_transpilying) {
                                 if (jsc_vm.isWatcherEnabled()) {
-                                    if (input_file_fd != 0) {
+                                    if (input_file_fd != .zero) {
                                         if (!is_node_override and std.fs.path.isAbsolute(path.text) and !strings.contains(path.text, "node_modules")) {
                                             should_close_input_file_fd = false;
                                             jsc_vm.bun_watcher.addFile(
@@ -1563,7 +1563,7 @@ pub const ModuleLoader = struct {
                                                 path.text,
                                                 hash,
                                                 loader,
-                                                0,
+                                                .zero,
                                                 package_json,
                                                 true,
                                             ) catch {};
@@ -1598,7 +1598,7 @@ pub const ModuleLoader = struct {
 
                 if (comptime !disable_transpilying) {
                     if (jsc_vm.isWatcherEnabled()) {
-                        if (input_file_fd != 0) {
+                        if (input_file_fd != .zero) {
                             if (!is_node_override and std.fs.path.isAbsolute(path.text) and !strings.contains(path.text, "node_modules")) {
                                 should_close_input_file_fd = false;
                                 jsc_vm.bun_watcher.addFile(
@@ -1606,7 +1606,7 @@ pub const ModuleLoader = struct {
                                     path.text,
                                     hash,
                                     loader,
-                                    0,
+                                    .zero,
                                     package_json,
                                     true,
                                 ) catch {};

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -3972,16 +3972,16 @@ pub const NodeFS = struct {
                     _ = bun.sys.unlink(dest);
                     return err;
                 }
-                _ = C.fchmod(dest_fd, stat_.mode);
+                _ = C.fchmod(dest_fd.cast(), stat_.mode);
                 _ = Syscall.close(dest_fd);
                 return ret.success;
             }
 
             // If we know it's a regular file and ioctl_ficlone is available, attempt to use it.
             if (os.S.ISREG(stat_.mode) and bun.can_use_ioctl_ficlone()) {
-                const rc = bun.C.linux.ioctl_ficlone(@intCast(dest_fd), @intCast(src_fd));
+                const rc = bun.C.linux.ioctl_ficlone(dest_fd, src_fd);
                 if (rc == 0) {
-                    _ = C.fchmod(dest_fd, stat_.mode);
+                    _ = C.fchmod(dest_fd.cast(), stat_.mode);
                     _ = Syscall.close(dest_fd);
                     return ret.success;
                 }
@@ -3992,8 +3992,8 @@ pub const NodeFS = struct {
             }
 
             defer {
-                _ = linux.ftruncate(dest_fd, @as(i64, @intCast(@as(u63, @truncate(wrote)))));
-                _ = linux.fchmod(dest_fd, stat_.mode);
+                _ = linux.ftruncate(dest_fd.cast(), @as(i64, @intCast(@as(u63, @truncate(wrote)))));
+                _ = linux.fchmod(dest_fd.cast(), stat_.mode);
                 _ = Syscall.close(dest_fd);
             }
 
@@ -4009,7 +4009,7 @@ pub const NodeFS = struct {
                 while (true) {
                     // Linux Kernel 5.3 or later
                     // Not supported in gVisor
-                    const written = linux.copy_file_range(src_fd, &off_in_copy, dest_fd, &off_out_copy, std.mem.page_size, 0);
+                    const written = linux.copy_file_range(src_fd.cast(), &off_in_copy, dest_fd.cast(), &off_out_copy, std.mem.page_size, 0);
                     if (ret.errnoSysP(written, .copy_file_range, dest)) |err| {
                         return switch (err.getErrno()) {
                             inline .XDEV, .NOSYS => |errno| brk: {
@@ -4029,7 +4029,7 @@ pub const NodeFS = struct {
                 while (size > 0) {
                     // Linux Kernel 5.3 or later
                     // Not supported in gVisor
-                    const written = linux.copy_file_range(src_fd, &off_in_copy, dest_fd, &off_out_copy, size, 0);
+                    const written = linux.copy_file_range(src_fd.cast(), &off_in_copy, dest_fd.cast(), &off_out_copy, size, 0);
                     if (ret.errnoSysP(written, .copy_file_range, dest)) |err| {
                         return switch (err.getErrno()) {
                             inline .XDEV, .NOSYS => |errno| brk: {
@@ -5277,7 +5277,7 @@ pub const NodeFS = struct {
                     else brk: {
                         // on linux, it's absolutely positioned
                         const pos = bun.sys.system.lseek(
-                            fd,
+                            fd.cast(),
                             @as(std.os.off_t, @intCast(0)),
                             std.os.linux.SEEK.CUR,
                         );
@@ -5289,7 +5289,7 @@ pub const NodeFS = struct {
                     };
 
                     bun.C.preallocate_file(
-                        fd,
+                        fd.cast(),
                         @as(std.os.off_t, @intCast(offset)),
                         @as(std.os.off_t, @intCast(buf.len)),
                     ) catch {};
@@ -6269,9 +6269,9 @@ pub const NodeFS = struct {
             var size: usize = @intCast(@max(stat_.size, 0));
 
             if (os.S.ISREG(stat_.mode) and bun.can_use_ioctl_ficlone()) {
-                const rc = bun.C.linux.ioctl_ficlone(@intCast(dest_fd), @intCast(src_fd));
+                const rc = bun.C.linux.ioctl_ficlone(dest_fd, src_fd);
                 if (rc == 0) {
-                    _ = C.fchmod(dest_fd, stat_.mode);
+                    _ = C.fchmod(dest_fd.cast(), stat_.mode);
                     _ = Syscall.close(dest_fd);
                     return ret.success;
                 }
@@ -6280,8 +6280,8 @@ pub const NodeFS = struct {
             }
 
             defer {
-                _ = linux.ftruncate(dest_fd, @as(i64, @intCast(@as(u63, @truncate(wrote)))));
-                _ = linux.fchmod(dest_fd, stat_.mode);
+                _ = linux.ftruncate(dest_fd.cast(), @as(i64, @intCast(@as(u63, @truncate(wrote)))));
+                _ = linux.fchmod(dest_fd.cast(), stat_.mode);
                 _ = Syscall.close(dest_fd);
             }
 
@@ -6297,7 +6297,7 @@ pub const NodeFS = struct {
                 while (true) {
                     // Linux Kernel 5.3 or later
                     // Not supported in gVisor
-                    const written = linux.copy_file_range(src_fd, &off_in_copy, dest_fd, &off_out_copy, std.mem.page_size, 0);
+                    const written = linux.copy_file_range(src_fd.cast(), &off_in_copy, dest_fd.cast(), &off_out_copy, std.mem.page_size, 0);
                     if (ret.errnoSysP(written, .copy_file_range, dest)) |err| {
                         return switch (err.getErrno()) {
                             inline .XDEV, .NOSYS => |errno| brk: {
@@ -6317,7 +6317,7 @@ pub const NodeFS = struct {
                 while (size > 0) {
                     // Linux Kernel 5.3 or later
                     // Not supported in gVisor
-                    const written = linux.copy_file_range(src_fd, &off_in_copy, dest_fd, &off_out_copy, size, 0);
+                    const written = linux.copy_file_range(src_fd.cast(), &off_in_copy, dest_fd.cast(), &off_out_copy, size, 0);
                     if (ret.errnoSysP(written, .copy_file_range, dest)) |err| {
                         return switch (err.getErrno()) {
                             inline .XDEV, .NOSYS => |errno| brk: {

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -3908,8 +3908,8 @@ pub const NodeFS = struct {
                         .err => |err| return Maybe(Return.CopyFile){ .err = err.withPath(args.dest.slice()) },
                     };
                     defer {
-                        _ = std.c.ftruncate(dest_fd, @as(std.c.off_t, @intCast(@as(u63, @truncate(wrote)))));
-                        _ = C.fchmod(dest_fd, stat_.mode);
+                        _ = std.c.ftruncate(dest_fd.int(), @as(std.c.off_t, @intCast(@as(u63, @truncate(wrote)))));
+                        _ = C.fchmod(dest_fd.int(), stat_.mode);
                         _ = Syscall.close(dest_fd);
                     }
 
@@ -4126,14 +4126,14 @@ pub const NodeFS = struct {
             return Syscall.fchown(args.fd, args.uid, args.gid);
         }
 
-        return Maybe(Return.Fchown).errnoSys(C.fchown(args.fd, args.uid, args.gid), .fchown) orelse
+        return Maybe(Return.Fchown).errnoSys(C.fchown(args.fd.int(), args.uid, args.gid), .fchown) orelse
             Maybe(Return.Fchown).success;
     }
     pub fn fdatasync(_: *NodeFS, args: Arguments.FdataSync, comptime _: Flavor) Maybe(Return.Fdatasync) {
         if (Environment.isWindows) {
             return Syscall.fdatasync(args.fd);
         }
-        return Maybe(Return.Fdatasync).errnoSys(system.fdatasync(args.fd), .fdatasync) orelse
+        return Maybe(Return.Fdatasync).errnoSys(system.fdatasync(args.fd.int()), .fdatasync) orelse
             Maybe(Return.Fdatasync).success;
     }
     pub fn fstat(_: *NodeFS, args: Arguments.Fstat, comptime _: Flavor) Maybe(Return.Fstat) {
@@ -4147,7 +4147,7 @@ pub const NodeFS = struct {
         if (Environment.isWindows) {
             return Syscall.fsync(args.fd);
         }
-        return Maybe(Return.Fsync).errnoSys(system.fsync(args.fd), .fsync) orelse
+        return Maybe(Return.Fsync).errnoSys(system.fsync(args.fd.int()), .fsync) orelse
             Maybe(Return.Fsync).success;
     }
 
@@ -4175,7 +4175,7 @@ pub const NodeFS = struct {
             args.atime,
         };
 
-        return if (Maybe(Return.Futimes).errnoSys(system.futimens(args.fd, &times), .futimens)) |err|
+        return if (Maybe(Return.Futimes).errnoSys(system.futimens(args.fd.int(), &times), .futimens)) |err|
             err
         else
             Maybe(Return.Futimes).success;
@@ -4627,7 +4627,7 @@ pub const NodeFS = struct {
         comptime ExpectedType: type,
         entries: *std.ArrayList(ExpectedType),
     ) Maybe(void) {
-        const dir = std.fs.Dir{ .fd = bun.fdcast(fd) };
+        const dir = fd.asDir();
         var iterator = DirIterator.iterate(dir);
         var entry = iterator.next();
 
@@ -4724,7 +4724,7 @@ pub const NodeFS = struct {
             }
         }
 
-        var iterator = DirIterator.iterate(.{ .fd = bun.fdcast(fd) });
+        var iterator = DirIterator.iterate(fd.asDir());
         var entry = iterator.next();
 
         while (switch (entry) {
@@ -4867,7 +4867,7 @@ pub const NodeFS = struct {
                 }
             }
 
-            var iterator = DirIterator.iterate(.{ .fd = bun.fdcast(fd) });
+            var iterator = DirIterator.iterate(fd.asDir());
             var entry = iterator.next();
 
             while (switch (entry) {
@@ -6007,7 +6007,7 @@ pub const NodeFS = struct {
         }
 
         var iterator = iterator: {
-            const dir = std.fs.Dir{ .fd = bun.fdcast(fd) };
+            const dir = fd.asDir();
             if (Environment.isWindows) {
                 // iterate directly over [:0]const u16 instead of converting to utf8
                 break :iterator DirIterator.IteratorW{
@@ -6176,8 +6176,8 @@ pub const NodeFS = struct {
                         }
                     };
                     defer {
-                        _ = std.c.ftruncate(dest_fd, @as(std.c.off_t, @intCast(@as(u63, @truncate(wrote)))));
-                        _ = C.fchmod(dest_fd, stat_.mode);
+                        _ = std.c.ftruncate(dest_fd.int(), @as(std.c.off_t, @intCast(@as(u63, @truncate(wrote)))));
+                        _ = C.fchmod(dest_fd.int(), stat_.mode);
                         _ = Syscall.close(dest_fd);
                     }
 
@@ -6463,7 +6463,7 @@ pub const NodeFS = struct {
             .result => {},
         }
 
-        const dir = std.fs.Dir{ .fd = fd };
+        const dir = std.fs.Dir{ .fd = fd.int() };
         var iterator = DirIterator.iterate(dir);
         var entry = iterator.next();
         while (switch (entry) {

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -6463,7 +6463,7 @@ pub const NodeFS = struct {
             .result => {},
         }
 
-        const dir = std.fs.Dir{ .fd = fd.int() };
+        const dir = fd.asDir();
         var iterator = DirIterator.iterate(dir);
         var entry = iterator.next();
         while (switch (entry) {

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -38,7 +38,7 @@ pub const PathWatcherManager = struct {
     has_pending_tasks: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     mutex: Mutex,
     const PathInfo = struct {
-        fd: StoredFileDescriptorType = 0,
+        fd: StoredFileDescriptorType = .zero,
         is_file: bool = true,
         path: [:0]const u8,
         dirname: string,
@@ -92,7 +92,7 @@ pub const PathWatcherManager = struct {
             .iterate = true,
         })) |iterable_dir| {
             const result = PathInfo{
-                .fd = iterable_dir.fd,
+                .fd = bun.toFD(iterable_dir.fd),
                 .is_file = false,
                 .path = cloned_path,
                 .dirname = cloned_path,
@@ -105,7 +105,7 @@ pub const PathWatcherManager = struct {
             if (err == error.NotDir) {
                 const file = try std.fs.openFileAbsoluteZ(cloned_path, .{ .mode = .read_only });
                 const result = PathInfo{
-                    .fd = file.handle,
+                    .fd = bun.toFD(file.handle),
                     .is_file = true,
                     .path = cloned_path,
                     // if is really a file we need to get the dirname
@@ -436,7 +436,7 @@ pub const PathWatcherManager = struct {
             const manager = this.manager;
             const path = this.path;
             const fd = path.fd;
-            var iter = (std.fs.Dir{ .fd = fd }).iterate();
+            var iter = fd.asDir().iterate();
 
             // now we iterate over all files and directories
             while (try iter.next()) |entry| {
@@ -463,7 +463,7 @@ pub const PathWatcherManager = struct {
 
                 // we need to call this unlocked
                 if (child_path.is_file) {
-                    try manager.main_watcher.addFile(child_path.fd, child_path.path, child_path.hash, options.Loader.file, 0, null, false);
+                    try manager.main_watcher.addFile(child_path.fd, child_path.path, child_path.hash, options.Loader.file, .zero, null, false);
                 } else {
                     if (watcher.recursive and !watcher.isClosed()) {
                         // this may trigger another thread with is desired when available to watch long trees
@@ -531,7 +531,7 @@ pub const PathWatcherManager = struct {
 
         const path = watcher.path;
         if (path.is_file) {
-            try this.main_watcher.addFile(path.fd, path.path, path.hash, options.Loader.file, 0, null, false);
+            try this.main_watcher.addFile(path.fd, path.path, path.hash, options.Loader.file, .zero, null, false);
         } else {
             if (comptime Environment.isMac) {
                 if (watcher.fsevents_watcher != null) {
@@ -707,7 +707,7 @@ pub const PathWatcher = struct {
         if (comptime Environment.isMac) {
             if (!path.is_file) {
                 var buffer: [bun.MAX_PATH_BYTES]u8 = undefined;
-                const resolved_path_temp = std.os.getFdPath(path.fd, &buffer) catch |err| {
+                const resolved_path_temp = std.os.getFdPath(path.fd.int(), &buffer) catch |err| {
                     bun.default_allocator.destroy(this);
                     return err;
                 };

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -707,7 +707,7 @@ pub const PathWatcher = struct {
         if (comptime Environment.isMac) {
             if (!path.is_file) {
                 var buffer: [bun.MAX_PATH_BYTES]u8 = undefined;
-                const resolved_path_temp = std.os.getFdPath(path.fd.int(), &buffer) catch |err| {
+                const resolved_path_temp = std.os.getFdPath(path.fd.cast(), &buffer) catch |err| {
                     bun.default_allocator.destroy(this);
                     return err;
                 };

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -144,7 +144,7 @@ pub fn Maybe(comptime ResultType: type) type {
                     .err = .{
                         .errno = @truncate(@intFromEnum(err)),
                         .syscall = syscall,
-                        .fd = @intCast(bun.toFD(fd)),
+                        .fd = bun.toFD(fd),
                     },
                 },
             };

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -136,7 +136,7 @@ pub fn Maybe(comptime ResultType: type) type {
             };
         }
 
-        pub inline fn errnoSysFd(rc: anytype, syscall: Syscall.Tag, fd: anytype) ?@This() {
+        pub inline fn errnoSysFd(rc: anytype, syscall: Syscall.Tag, fd: bun.FileDescriptor) ?@This() {
             return switch (Syscall.getErrno(rc)) {
                 .SUCCESS => null,
                 else => |err| @This(){
@@ -144,7 +144,7 @@ pub fn Maybe(comptime ResultType: type) type {
                     .err = .{
                         .errno = @truncate(@intFromEnum(err)),
                         .syscall = syscall,
-                        .fd = bun.toFD(fd),
+                        .fd = fd,
                     },
                 },
             };

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -2809,7 +2809,7 @@ pub const Blob = struct {
                     // seemed to have zero performance impact in
                     // microbenchmarks.
                     if (!this.could_block and this.bytes_blob.sharedView().len > 1024) {
-                        bun.C.preallocate_file(fd, 0, @intCast(this.bytes_blob.sharedView().len)) catch {}; // we don't care if it fails.
+                        bun.C.preallocate_file(fd.cast(), 0, @intCast(this.bytes_blob.sharedView().len)) catch {}; // we don't care if it fails.
                     }
                 }
 
@@ -3121,7 +3121,7 @@ pub const Blob = struct {
                             return bun.errnoToZigErr(err.errno);
                         },
                         .result => {
-                            _ = linux.ftruncate(dest_fd, @as(std.os.off_t, @intCast(total_written)));
+                            _ = linux.ftruncate(dest_fd.cast(), @as(std.os.off_t, @intCast(total_written)));
                             return;
                         },
                     }
@@ -3129,9 +3129,9 @@ pub const Blob = struct {
 
                 while (true) {
                     const written = switch (comptime use) {
-                        .copy_file_range => linux.copy_file_range(src_fd, null, dest_fd, null, remain, 0),
-                        .sendfile => linux.sendfile(dest_fd, src_fd, null, remain),
-                        .splice => bun.C.splice(src_fd, null, dest_fd, null, remain, 0),
+                        .copy_file_range => linux.copy_file_range(src_fd.cast(), null, dest_fd.cast(), null, remain, 0),
+                        .sendfile => linux.sendfile(dest_fd.cast(), src_fd.cast(), null, remain),
+                        .splice => bun.C.splice(src_fd.cast(), null, dest_fd.cast(), null, remain, 0),
                     };
 
                     switch (linux.getErrno(written)) {
@@ -3144,7 +3144,7 @@ pub const Blob = struct {
                                     return bun.errnoToZigErr(err.errno);
                                 },
                                 .result => {
-                                    _ = linux.ftruncate(dest_fd, @as(std.os.off_t, @intCast(total_written)));
+                                    _ = linux.ftruncate(dest_fd.cast(), @as(std.os.off_t, @intCast(total_written)));
                                     return;
                                 },
                             }
@@ -3157,9 +3157,9 @@ pub const Blob = struct {
                                     // make() can set STDOUT / STDERR to O_APPEND
                                     // this messes up sendfile()
                                     has_unset_append = true;
-                                    const flags = linux.fcntl(dest_fd, linux.F.GETFL, 0);
+                                    const flags = linux.fcntl(dest_fd.cast(), linux.F.GETFL, 0);
                                     if ((flags & O.APPEND) != 0) {
-                                        _ = linux.fcntl(dest_fd, linux.F.SETFL, flags ^ O.APPEND);
+                                        _ = linux.fcntl(dest_fd.cast(), linux.F.SETFL, flags ^ O.APPEND);
                                         continue;
                                     }
                                 }
@@ -3176,7 +3176,7 @@ pub const Blob = struct {
                                         return bun.errnoToZigErr(err.errno);
                                     },
                                     .result => {
-                                        _ = linux.ftruncate(dest_fd, @as(std.os.off_t, @intCast(total_written)));
+                                        _ = linux.ftruncate(dest_fd.cast(), @as(std.os.off_t, @intCast(total_written)));
                                         return;
                                     },
                                 }
@@ -4574,7 +4574,7 @@ pub const Blob = struct {
                                     const byteLength = buf.len;
 
                                     const result = JSC.ArrayBuffer.toArrayBufferFromSharedMemfd(
-                                        @intCast(allocator.fd),
+                                        allocator.fd.cast(),
                                         global,
                                         byteOffset,
                                         byteLength,

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -3367,7 +3367,7 @@ pub const Blob = struct {
                         this.max_length > bun.C.preallocate_length and
                         this.max_length != Blob.max_size)
                     {
-                        bun.C.preallocate_file(this.destination_fd.int(), 0, this.max_length) catch {};
+                        bun.C.preallocate_file(this.destination_fd.cast(), 0, this.max_length) catch {};
                     }
                 }
 
@@ -3420,7 +3420,7 @@ pub const Blob = struct {
                         return;
                     };
                     if (stat.size != 0 and @as(SizeType, @intCast(stat.size)) > this.max_length) {
-                        _ = darwin.ftruncate(this.destination_fd.int(), @as(std.os.off_t, @intCast(this.max_length)));
+                        _ = darwin.ftruncate(this.destination_fd.cast(), @as(std.os.off_t, @intCast(this.max_length)));
                     }
 
                     this.doClose();

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -3852,7 +3852,7 @@ pub const FIFO = struct {
 
     pub fn getAvailableToReadOnLinux(this: *FIFO) u32 {
         var len: c_int = 0;
-        const rc: c_int = std.c.ioctl(this.fd, std.os.linux.T.FIONREAD, @as(*c_int, &len));
+        const rc: c_int = std.c.ioctl(this.fd.cast(), std.os.linux.T.FIONREAD, @as(*c_int, &len));
         if (rc != 0) {
             len = 0;
         }

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -3900,7 +3900,7 @@ pub const FIFO = struct {
             if (!is_readable and (this.close_on_empty_read or poll.isHUP())) {
                 // it might be readable actually
                 this.close_on_empty_read = true;
-                switch (bun.isReadable(@intCast(poll.fd))) {
+                switch (bun.isReadable(poll.fd)) {
                     .ready => {
                         this.close_on_empty_read = false;
                         return null;
@@ -3923,7 +3923,7 @@ pub const FIFO = struct {
 
                 // this happens if we've registered a watcher but we haven't
                 // ticked the event loop since registering it
-                switch (bun.isReadable(@intCast(poll.fd))) {
+                switch (bun.isReadable(poll.fd)) {
                     .ready => {
                         poll.flags.insert(.readable);
                         return null;
@@ -4236,9 +4236,9 @@ pub const File = struct {
         };
 
         if (comptime Environment.isPosix) {
-            if ((file.is_atty orelse false) or (fd < 3 and std.os.isatty(fd))) {
+            if ((file.is_atty orelse false) or (fd.int() < 3 and std.os.isatty(fd.int()))) {
                 var termios = std.mem.zeroes(std.os.termios);
-                _ = std.c.tcgetattr(fd, &termios);
+                _ = std.c.tcgetattr(fd.int(), &termios);
                 bun.C.cfmakeraw(&termios);
                 file.is_atty = true;
             }
@@ -4257,7 +4257,7 @@ pub const File = struct {
                     // it is important for us to clone it so we don't cause Weird Things to happen
                     if ((flags & std.os.O.NONBLOCK) == 0) {
                         fd = switch (Syscall.fcntl(fd, std.os.F.DUPFD, 0)) {
-                            .result => |_fd| @as(@TypeOf(fd), @intCast(_fd)),
+                            .result => |_fd| bun.toFD(_fd),
                             .err => |err| return .{ .err = err },
                         };
 
@@ -4843,8 +4843,7 @@ pub fn NewReadyWatcher(
                 @panic("TODO on Windows");
             }
 
-            const fd = @as(c_int, @intCast(fd_));
-            std.debug.assert(@as(c_int, @intCast(this.poll_ref.?.fd)) == fd);
+            std.debug.assert(this.poll_ref.?.fd == fd_);
             std.debug.assert(
                 this.poll_ref.?.unregister(JSC.VirtualMachine.get().event_loop_handle.?, false) == .result,
             );
@@ -4872,11 +4871,10 @@ pub fn NewReadyWatcher(
             return false;
         }
 
-        pub fn watch(this: *Context, fd_: anytype) void {
+        pub fn watch(this: *Context, fd: bun.FileDescriptor) void {
             if (comptime Environment.isWindows) {
                 @panic("Do not call watch() on windows");
             }
-            const fd = @as(bun.FileDescriptor, @intCast(fd_));
             var poll_ref: *Async.FilePoll = this.poll_ref orelse brk: {
                 this.poll_ref = Async.FilePoll.init(
                     JSC.VirtualMachine.get(),

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -4236,9 +4236,9 @@ pub const File = struct {
         };
 
         if (comptime Environment.isPosix) {
-            if ((file.is_atty orelse false) or (fd.int() < 3 and std.os.isatty(fd.int()))) {
+            if ((file.is_atty orelse false) or (fd.int() < 3 and std.os.isatty(fd.cast()))) {
                 var termios = std.mem.zeroes(std.os.termios);
-                _ = std.c.tcgetattr(fd.int(), &termios);
+                _ = std.c.tcgetattr(fd.cast(), &termios);
                 bun.C.cfmakeraw(&termios);
                 file.is_atty = true;
             }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -866,6 +866,12 @@ pub const FileDescriptor = enum(FileDescriptorInt) {
     pub inline fn asFile(fd: FileDescriptor) std.fs.File {
         return std.fs.File{ .handle = fdcast(fd) };
     }
+
+    pub fn format(fd: FileDescriptor, comptime fmt_: string, options_: std.fmt.FormatOptions, writer: anytype) !void {
+        _ = fmt_;
+        _ = options_;
+        try writer.print("{d}", .{@intFromEnum(fd)});
+    }
 };
 
 pub const FDImpl = @import("./fd.zig").FDImpl;

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2581,7 +2581,7 @@ pub inline fn socketcast(fd: anytype) std.os.socket_t {
     if (Environment.isWindows) {
         return @ptrCast(FDImpl.decode(fd).system());
     } else {
-        return fd;
+        return fd.cast();
     }
 }
 

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -829,7 +829,8 @@ pub const fmt = struct {
 pub const Output = @import("./output.zig");
 pub const Global = @import("./__global.zig");
 
-pub const FileDescriptor = if (Environment.isBrowser)
+// make this non-pub after https://github.com/ziglang/zig/issues/18462 is resolved
+pub const FileDescriptorInt = if (Environment.isBrowser)
     u0
 else if (Environment.isWindows)
     // On windows, this is a bitcast "bun.FDImpl" struct
@@ -837,6 +838,35 @@ else if (Environment.isWindows)
     u64
 else
     std.os.fd_t;
+
+pub const FileDescriptor = enum(FileDescriptorInt) {
+    zero,
+    _,
+
+    pub inline fn int(fd: FileDescriptor) FileDescriptorInt {
+        return @intFromEnum(fd);
+    }
+
+    pub inline fn writeTo(fd: FileDescriptor, writer: anytype, endian: std.builtin.Endian) !void {
+        try writer.writeInt(FileDescriptorInt, fd.int(), endian);
+    }
+
+    pub inline fn readFrom(reader: anytype, endian: std.builtin.Endian) !FileDescriptor {
+        return @enumFromInt(try reader.readInt(FileDescriptorInt, endian));
+    }
+
+    pub inline fn cast(fd: FileDescriptor) std.os.fd_t {
+        return fdcast(fd);
+    }
+
+    pub inline fn asDir(fd: FileDescriptor) std.fs.Dir {
+        return std.fs.Dir{ .fd = fdcast(fd) };
+    }
+
+    pub inline fn asFile(fd: FileDescriptor) std.fs.File {
+        return std.fs.File{ .handle = fdcast(fd) };
+    }
+};
 
 pub const FDImpl = @import("./fd.zig").FDImpl;
 
@@ -1200,7 +1230,7 @@ pub fn isReadable(fd: FileDescriptor) PollFlag {
 
     var polls = [_]std.os.pollfd{
         .{
-            .fd = fd,
+            .fd = fd.cast(),
             .events = std.os.POLL.IN | std.os.POLL.ERR,
             .revents = 0,
         },
@@ -1224,7 +1254,7 @@ pub fn isWritable(fd: FileDescriptor) PollFlag {
 
     var polls = [_]std.os.pollfd{
         .{
-            .fd = fd,
+            .fd = fd.cast(),
             .events = std.os.POLL.OUT,
             .revents = 0,
         },
@@ -1362,8 +1392,8 @@ pub fn openDir(dir: std.fs.Dir, path_: [:0]const u8) !std.fs.Dir {
         const res = try sys.openDirAtWindowsA(toFD(dir.fd), path_, true, false).unwrap();
         return std.fs.Dir{ .fd = fdcast(res) };
     } else {
-        const fd = try sys.openat(dir.fd, path_, std.os.O.DIRECTORY | std.os.O.CLOEXEC | std.os.O.RDONLY, 0).unwrap();
-        return std.fs.Dir{ .fd = fd };
+        const fd = try sys.openat(toFD(dir.fd), path_, std.os.O.DIRECTORY | std.os.O.CLOEXEC | std.os.O.RDONLY, 0).unwrap();
+        return fd.asDir();
     }
 }
 
@@ -1372,8 +1402,8 @@ pub fn openDirA(dir: std.fs.Dir, path_: []const u8) !std.fs.Dir {
         const res = try sys.openDirAtWindowsA(toFD(dir.fd), path_, true, false).unwrap();
         return std.fs.Dir{ .fd = fdcast(res) };
     } else {
-        const fd = try sys.openatA(dir.fd, path_, std.os.O.DIRECTORY | std.os.O.CLOEXEC | std.os.O.RDONLY, 0).unwrap();
-        return std.fs.Dir{ .fd = fd };
+        const fd = try sys.openatA(toFD(dir.fd), path_, std.os.O.DIRECTORY | std.os.O.CLOEXEC | std.os.O.RDONLY, 0).unwrap();
+        return fd.asDir();
     }
 }
 
@@ -1383,7 +1413,7 @@ pub fn openDirAbsolute(path_: []const u8) !std.fs.Dir {
         return std.fs.Dir{ .fd = fdcast(res) };
     } else {
         const fd = try sys.openA(path_, std.os.O.DIRECTORY | std.os.O.CLOEXEC | std.os.O.RDONLY, 0).unwrap();
-        return std.fs.Dir{ .fd = fd };
+        return fd.asDir();
     }
 }
 pub const MimallocArena = @import("./mimalloc_arena.zig").Arena;
@@ -1418,7 +1448,8 @@ pub const FDHashMapContext = struct {
         // a file descriptor is i32 on linux, u64 on windows
         // the goal here is to do zero work and widen the 32 bit type to 64
         // this should compile error if FileDescriptor somehow is larger than 64 bits.
-        return @as(std.meta.Int(.unsigned, @bitSizeOf(FileDescriptor)), @bitCast(fd));
+        if (@bitSizeOf(FileDescriptorInt) > 64) @compileError("no bueno");
+        return @intCast(fd.int());
     }
     pub fn eql(_: @This(), a: FileDescriptor, b: FileDescriptor) bool {
         return a == b;
@@ -2175,9 +2206,9 @@ pub fn reloadProcess(
     // macOS doesn't have CLOEXEC, so we must go through posix_spawn
     if (comptime Environment.isMac) {
         var actions = PosixSpawn.Actions.init() catch unreachable;
-        actions.inherit(0) catch unreachable;
-        actions.inherit(1) catch unreachable;
-        actions.inherit(2) catch unreachable;
+        actions.inherit(posix.STDIN_FD) catch unreachable;
+        actions.inherit(posix.STDOUT_FD) catch unreachable;
+        actions.inherit(posix.STDERR_FD) catch unreachable;
         var attrs = PosixSpawn.Attr.init() catch unreachable;
         attrs.set(
             C.POSIX_SPAWN_CLOEXEC_DEFAULT |
@@ -2456,7 +2487,7 @@ pub inline fn todo(src: std.builtin.SourceLocation, value: anytype) @TypeOf(valu
 ///
 /// This may be needed in places where a FileDescriptor is given to `std` or `kernel32` apis
 pub inline fn fdcast(fd: FileDescriptor) std.os.fd_t {
-    if (!Environment.isWindows) return fd;
+    if (!Environment.isWindows) return fd.int();
     // if not having this check, the cast may crash zig compiler?
     if (@inComptime() and fd == invalid_fd) return FDImpl.invalid.system();
     return FDImpl.decode(fd).system();
@@ -2480,7 +2511,12 @@ pub inline fn toFD(fd: anytype) FileDescriptor {
     } else {
         // TODO: remove intCast. we should not be casting u32 -> i32
         // even though file descriptors are always positive, linux/mac repesents them as signed integers
-        return @intCast(fd);
+        return switch (T) {
+            FileDescriptor => fd, // TODO: remove the toFD call from these places and make this a @compileError
+            c_int, i32, u32, comptime_int => @enumFromInt(fd),
+            usize, i64 => @enumFromInt(@as(i32, @intCast(fd))),
+            else => @compileError("bun.toFD() not implemented for: " ++ @typeName(T)),
+        };
     }
 }
 
@@ -2500,7 +2536,7 @@ pub inline fn toLibUVOwnedFD(fd: anytype) FileDescriptor {
             else => @compileError("toLibUVOwnedFD() does not support type \"" ++ @typeName(T) ++ "\""),
         }).encode();
     } else {
-        return @intCast(fd);
+        return toFD(fd);
     }
 }
 
@@ -2590,9 +2626,9 @@ pub const Stat = if (Environment.isWindows) windows.libuv.uv_stat_t else std.os.
 
 pub const posix = struct {
     // we use these on windows for crt/uv stuff, and std.os does not define them, hence the if
-    pub const STDIN_FD = if (Environment.isPosix) std.os.STDIN_FILENO else 0;
-    pub const STDOUT_FD = if (Environment.isPosix) std.os.STDOUT_FILENO else 1;
-    pub const STDERR_FD = if (Environment.isPosix) std.os.STDERR_FILENO else 2;
+    pub const STDIN_FD = toFD(if (Environment.isPosix) std.os.STDIN_FILENO else 0);
+    pub const STDOUT_FD = toFD(if (Environment.isPosix) std.os.STDOUT_FILENO else 1);
+    pub const STDERR_FD = toFD(if (Environment.isPosix) std.os.STDERR_FILENO else 2);
 
     pub inline fn argv() [][*:0]u8 {
         return std.os.argv;
@@ -2603,9 +2639,9 @@ pub const posix = struct {
 
     pub fn stdio(i: anytype) FileDescriptor {
         return switch (i) {
-            STDOUT_FD => STDOUT_FD,
-            STDERR_FD => STDERR_FD,
-            STDIN_FD => STDIN_FD,
+            1 => STDOUT_FD,
+            2 => STDERR_FD,
+            0 => STDIN_FD,
             else => @panic("Invalid stdio fd"),
         };
     }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2505,7 +2505,7 @@ pub inline fn toFD(fd: anytype) FileDescriptor {
             FDImpl.UV => FDImpl.fromUV(fd),
             FileDescriptor => FDImpl.decode(fd),
             // TODO: remove u32
-            u32, i32 => FDImpl.fromUV(@as(FDImpl.UV, @intCast(fd))),
+            u32, i32, comptime_int, usize, i64 => FDImpl.fromUV(@as(FDImpl.UV, @intCast(fd))),
             else => @compileError("toFD() does not support type \"" ++ @typeName(T) ++ "\""),
         }).encode();
     } else {

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -1027,7 +1027,7 @@ pub const Bundler = struct {
 
                     if (bundler.fs.fs.needToCloseFiles()) {
                         file.close();
-                        file_op.fd = 0;
+                        file_op.fd = .zero;
                     }
                 }
 
@@ -1038,7 +1038,7 @@ pub const Bundler = struct {
                 var pathname = try bundler.allocator.alloc(u8, hashed_name.len + file_path.name.ext.len);
                 bun.copy(u8, pathname, hashed_name);
                 bun.copy(u8, pathname[hashed_name.len..], file_path.name.ext);
-                const dir = if (bundler.options.output_dir_handle) |output_handle| bun.toFD(output_handle.fd) else 0;
+                const dir = if (bundler.options.output_dir_handle) |output_handle| bun.toFD(output_handle.fd) else .zero;
 
                 output_file.value = .{
                     .copy = options.OutputFile.FileOperation{

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1474,8 +1474,8 @@ pub const BundleV2 = struct {
                             // unknown at this point:
                             .contents_or_fd = .{
                                 .fd = .{
-                                    .dir = 0,
-                                    .file = 0,
+                                    .dir = .zero,
+                                    .file = .zero,
                                 },
                             },
                             .side_effects = _resolver.SideEffects.has_side_effects,
@@ -2083,7 +2083,7 @@ pub const BundleV2 = struct {
                 }
 
                 if (this.bun_watcher != null) {
-                    if (empty_result.watcher_data.fd > 0 and empty_result.watcher_data.fd != bun.invalid_fd) {
+                    if (empty_result.watcher_data.fd.int() > 0 and empty_result.watcher_data.fd != bun.invalid_fd) {
                         this.bun_watcher.?.addFile(
                             empty_result.watcher_data.fd,
                             input_files.items(.source)[empty_result.source_index.get()].path.text,
@@ -2102,7 +2102,7 @@ pub const BundleV2 = struct {
                 {
                     // to minimize contention, we add watcher here
                     if (this.bun_watcher != null) {
-                        if (result.watcher_data.fd > 0 and result.watcher_data.fd != bun.invalid_fd) {
+                        if (result.watcher_data.fd.int() > 0 and result.watcher_data.fd != bun.invalid_fd) {
                             this.bun_watcher.?.addFile(
                                 result.watcher_data.fd,
                                 result.source.path.text,
@@ -2344,8 +2344,8 @@ pub const ParseTask = struct {
         },
 
         const WatcherData = struct {
-            fd: bun.StoredFileDescriptorType = 0,
-            dir_fd: bun.StoredFileDescriptorType = 0,
+            fd: bun.StoredFileDescriptorType = .zero,
+            dir_fd: bun.StoredFileDescriptorType = .zero,
             package_json: ?*PackageJSON = null,
         };
 
@@ -2500,7 +2500,7 @@ pub const ParseTask = struct {
                                 allocator,
                                 bundler.fs,
                                 override_pathZ,
-                                0,
+                                .zero,
                                 false,
                                 null,
                             );
@@ -2523,7 +2523,7 @@ pub const ParseTask = struct {
                     file_path.text,
                     task.contents_or_fd.fd.dir,
                     false,
-                    if (task.contents_or_fd.fd.file > 0)
+                    if (task.contents_or_fd.fd.file.int() > 0)
                         task.contents_or_fd.fd.file
                     else
                         null,
@@ -2554,18 +2554,18 @@ pub const ParseTask = struct {
             },
             .contents => |contents| CacheEntry{
                 .contents = contents,
-                .fd = 0,
+                .fd = .zero,
             },
         };
 
         errdefer if (task.contents_or_fd == .fd) entry.deinit(allocator);
 
-        const will_close_file_descriptor = task.contents_or_fd == .fd and entry.fd > 2 and this.ctx.bun_watcher == null;
+        const will_close_file_descriptor = task.contents_or_fd == .fd and entry.fd.int() > 2 and this.ctx.bun_watcher == null;
         if (will_close_file_descriptor) {
             _ = entry.closeFD();
         }
 
-        if (!will_close_file_descriptor and entry.fd > 2) task.contents_or_fd = .{
+        if (!will_close_file_descriptor and entry.fd.int() > 2) task.contents_or_fd = .{
             .fd = .{
                 .file = entry.fd,
                 .dir = bun.invalid_fd,
@@ -2664,8 +2664,8 @@ pub const ParseTask = struct {
                 0,
 
             .watcher_data = .{
-                .fd = if (task.contents_or_fd == .fd and !will_close_file_descriptor) task.contents_or_fd.fd.file else 0,
-                .dir_fd = if (task.contents_or_fd == .fd) task.contents_or_fd.fd.dir else 0,
+                .fd = if (task.contents_or_fd == .fd and !will_close_file_descriptor) task.contents_or_fd.fd.file else .zero,
+                .dir_fd = if (task.contents_or_fd == .fd) task.contents_or_fd.fd.dir else .zero,
             },
         };
     }
@@ -2698,8 +2698,8 @@ pub const ParseTask = struct {
                             .empty = .{
                                 .source_index = this.source_index,
                                 .watcher_data = .{
-                                    .fd = if (this.contents_or_fd == .fd) this.contents_or_fd.fd.file else 0,
-                                    .dir_fd = if (this.contents_or_fd == .fd) this.contents_or_fd.fd.dir else 0,
+                                    .fd = if (this.contents_or_fd == .fd) this.contents_or_fd.fd.file else .zero,
+                                    .dir_fd = if (this.contents_or_fd == .fd) this.contents_or_fd.fd.dir else .zero,
                                 },
                             },
                         };
@@ -2711,8 +2711,8 @@ pub const ParseTask = struct {
                             .empty = .{
                                 .source_index = this.source_index,
                                 .watcher_data = .{
-                                    .fd = if (this.contents_or_fd == .fd) this.contents_or_fd.fd.file else 0,
-                                    .dir_fd = if (this.contents_or_fd == .fd) this.contents_or_fd.fd.dir else 0,
+                                    .fd = if (this.contents_or_fd == .fd) this.contents_or_fd.fd.file else .zero,
+                                    .dir_fd = if (this.contents_or_fd == .fd) this.contents_or_fd.fd.dir else .zero,
                                 },
                             },
                         };

--- a/src/c.zig
+++ b/src/c.zig
@@ -175,7 +175,7 @@ pub fn copyFileZSlowWithHandle(in_handle: bun.FileDescriptor, to_dir: bun.FileDe
     defer _ = bun.sys.close(out_handle);
 
     if (comptime Environment.isLinux) {
-        _ = std.os.linux.fallocate(out_handle, 0, 0, @intCast(stat_.size));
+        _ = std.os.linux.fallocate(out_handle.cast(), 0, 0, @intCast(stat_.size));
     }
 
     try bun.copyFile(bun.fdcast(in_handle), bun.fdcast(out_handle));

--- a/src/c.zig
+++ b/src/c.zig
@@ -127,9 +127,8 @@ pub fn moveFileZ(from_dir: std.os.fd_t, filename: [:0]const u8, to_dir: std.os.f
     }
 }
 
-// TODO: change types to use `bun.FileDescriptor`
-pub fn moveFileZWithHandle(from_handle: std.os.fd_t, from_dir: std.os.fd_t, filename: [:0]const u8, to_dir: std.os.fd_t, destination: [:0]const u8) !void {
-    switch (bun.sys.renameat(bun.toFD(from_dir), filename, bun.toFD(to_dir), destination)) {
+pub fn moveFileZWithHandle(from_handle: bun.FileDescriptor, from_dir: bun.FileDescriptor, filename: [:0]const u8, to_dir: bun.FileDescriptor, destination: [:0]const u8) !void {
+    switch (bun.sys.renameat(from_dir, filename, to_dir, destination)) {
         .err => |err| {
             // allow over-writing an empty directory
             if (err.getErrno() == .ISDIR) {
@@ -161,7 +160,7 @@ pub fn moveFileZSlow(from_dir: std.os.fd_t, filename: [:0]const u8, to_dir: std.
 }
 
 pub fn copyFileZSlowWithHandle(in_handle: bun.FileDescriptor, to_dir: bun.FileDescriptor, destination: [:0]const u8) !void {
-    const stat_ = if (comptime Environment.isPosix) try std.os.fstat(in_handle) else void{};
+    const stat_ = if (comptime Environment.isPosix) try std.os.fstat(in_handle.cast()) else void{};
 
     // Attempt to delete incase it already existed.
     // This fixes ETXTBUSY on Linux
@@ -182,8 +181,8 @@ pub fn copyFileZSlowWithHandle(in_handle: bun.FileDescriptor, to_dir: bun.FileDe
     try bun.copyFile(bun.fdcast(in_handle), bun.fdcast(out_handle));
 
     if (comptime Environment.isPosix) {
-        _ = fchmod(out_handle, stat_.mode);
-        _ = fchown(out_handle, stat_.uid, stat_.gid);
+        _ = fchmod(out_handle.cast(), stat_.mode);
+        _ = fchown(out_handle.cast(), stat_.uid, stat_.gid);
     }
 }
 

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -166,11 +166,11 @@ pub const Fs = struct {
     ) !Entry {
         var rfs = _fs.fs;
 
-        var file_handle: std.fs.File = if (_file_handle) |__file| std.fs.File{ .handle = bun.fdcast(__file) } else undefined;
+        var file_handle: std.fs.File = if (_file_handle) |__file| __file.asFile() else undefined;
 
         if (_file_handle == null) {
-            if (FeatureFlags.store_file_descriptors and dirname_fd != bun.invalid_fd and dirname_fd > 0) {
-                file_handle = std.fs.Dir.openFile(std.fs.Dir{ .fd = dirname_fd }, std.fs.path.basename(path), .{ .mode = .read_only }) catch |err| brk: {
+            if (FeatureFlags.store_file_descriptors and dirname_fd != bun.invalid_fd and dirname_fd.int() > 0) {
+                file_handle = std.fs.Dir.openFile(dirname_fd.asDir(), std.fs.path.basename(path), .{ .mode = .read_only }) catch |err| brk: {
                     switch (err) {
                         error.FileNotFound => {
                             const handle = try std.fs.openFileAbsolute(path, .{ .mode = .read_only });
@@ -215,7 +215,7 @@ pub const Fs = struct {
 
         return Entry{
             .contents = file.contents,
-            .fd = if (FeatureFlags.store_file_descriptors and !will_close) file_handle.handle else bun.invalid_fd,
+            .fd = if (FeatureFlags.store_file_descriptors and !will_close) bun.toFD(file_handle.handle) else bun.invalid_fd,
         };
     }
 };

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -433,7 +433,7 @@ pub const CreateCommand = struct {
                 if (!create_options.skip_package_json) {
                     const plucker = pluckers[0];
 
-                    if (plucker.found and plucker.fd != 0) {
+                    if (plucker.found and plucker.fd != .zero) {
                         node.name = "Updating package.json";
                         progress.refresh();
 

--- a/src/copy_file.zig
+++ b/src/copy_file.zig
@@ -39,7 +39,7 @@ pub fn copyFile(fd_in: os.fd_t, fd_out: os.fd_t) CopyFileError!void {
         if (can_use_ioctl_ficlone()) {
             // We only check once if the ioctl is supported, and cache the result.
             // EXT4 does not support FICLONE.
-            const rc = bun.C.linux.ioctl_ficlone(@intCast(fd_out), @intCast(fd_in));
+            const rc = bun.C.linux.ioctl_ficlone(bun.toFD(fd_out), bun.toFD(fd_in));
             switch (std.os.linux.getErrno(rc)) {
                 .SUCCESS => return,
                 .FBIG => return error.FileTooBig,

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -214,7 +214,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 @compileError("SSL sockets do not have a file descriptor accessible this way");
             }
 
-            return bun.toFD(@intFromPtr(us_socket_get_native_handle(0, this.socket)));
+            return bun.toFD(Poll.us_poll_fd(@ptrCast(this.socket)));
         }
 
         pub fn markNeedsMoreForSendfile(this: ThisSocket) void {
@@ -1198,7 +1198,7 @@ pub const Poll = opaque {
     }
 
     pub fn fd(self: *Poll) std.os.fd_t {
-        return @intCast(us_poll_fd(self));
+        return us_poll_fd(self);
     }
 
     pub fn start(self: *Poll, loop: *Loop, flags: Flags) void {
@@ -1239,7 +1239,7 @@ pub const Poll = opaque {
     extern fn us_poll_stop(p: ?*Poll, loop: ?*Loop) void;
     extern fn us_poll_events(p: ?*Poll) i32;
     extern fn us_poll_ext(p: ?*Poll) ?*anyopaque;
-    extern fn us_poll_fd(p: ?*Poll) i32;
+    extern fn us_poll_fd(p: ?*Poll) std.os.fd_t;
     extern fn us_poll_resize(p: ?*Poll, loop: ?*Loop, ext_size: c_uint) ?*Poll;
 };
 

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -209,12 +209,12 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             return @as(*NativeSocketHandleType(is_ssl), @ptrCast(us_socket_get_native_handle(comptime ssl_int, this.socket).?));
         }
 
-        pub inline fn fd(this: ThisSocket) i32 {
+        pub inline fn fd(this: ThisSocket) bun.FileDescriptor {
             if (comptime is_ssl) {
                 @compileError("SSL sockets do not have a file descriptor accessible this way");
             }
 
-            return @as(i32, @intCast(@intFromPtr(us_socket_get_native_handle(0, this.socket))));
+            return bun.toFD(@intFromPtr(us_socket_get_native_handle(0, this.socket)));
         }
 
         pub fn markNeedsMoreForSendfile(this: ThisSocket) void {

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1197,8 +1197,8 @@ pub const Poll = opaque {
         return us_poll_ext(self).?;
     }
 
-    pub fn fd(self: *Poll) @import("std").os.fd_t {
-        return @as(@import("std").os.fd_t, @intCast(us_poll_fd(self)));
+    pub fn fd(self: *Poll) std.os.fd_t {
+        return @intCast(us_poll_fd(self));
     }
 
     pub fn start(self: *Poll, loop: *Loop, flags: Flags) void {
@@ -2366,7 +2366,7 @@ pub const LIBUS_RECV_BUFFER_LENGTH = 524288;
 pub const LIBUS_TIMEOUT_GRANULARITY = @as(i32, 4);
 pub const LIBUS_RECV_BUFFER_PADDING = @as(i32, 32);
 pub const LIBUS_EXT_ALIGNMENT = @as(i32, 16);
-pub const LIBUS_SOCKET_DESCRIPTOR = if (Environment.isWindows) std.os.socket_t else i32;
+pub const LIBUS_SOCKET_DESCRIPTOR = std.os.socket_t;
 
 pub const _COMPRESSOR_MASK: i32 = 255;
 pub const _DECOMPRESSOR_MASK: i32 = 3840;

--- a/src/fd.zig
+++ b/src/fd.zig
@@ -139,11 +139,12 @@ pub const FDImpl = packed struct {
 
     /// Convert to bun.FileDescriptor
     pub fn encode(this: FDImpl) bun.FileDescriptor {
-        return @bitCast(this);
+        // https://github.com/ziglang/zig/issues/18462
+        return @enumFromInt(@as(bun.FileDescriptorInt, @bitCast(this)));
     }
 
     pub fn decode(fd: bun.FileDescriptor) FDImpl {
-        return @bitCast(fd);
+        return @bitCast(fd.int());
     }
 
     /// When calling this function, you should consider the FD struct to now be invalid.
@@ -207,10 +208,10 @@ pub const FDImpl = packed struct {
                 };
             },
             .mac => result: {
-                const fd = this.system();
+                const fd = this.encode();
                 std.debug.assert(fd != bun.invalid_fd);
-                std.debug.assert(fd > -1);
-                break :result switch (bun.sys.system.getErrno(bun.sys.system.@"close$NOCANCEL"(fd))) {
+                std.debug.assert(fd.cast() > -1);
+                break :result switch (bun.sys.system.getErrno(bun.sys.system.@"close$NOCANCEL"(fd.cast()))) {
                     .BADF => bun.sys.Error{ .errno = @intFromEnum(os.E.BADF), .syscall = .close, .fd = fd },
                     else => null,
                 };

--- a/src/fd.zig
+++ b/src/fd.zig
@@ -171,7 +171,7 @@ pub const FDImpl = packed struct {
         if (env.os != .windows or this.kind == .uv) {
             // This branch executes always on linux (uv() is no-op),
             // or on Windows when given a UV file descriptor.
-            const fd = this.uv();
+            const fd = bun.toFD(this.uv());
             if (fd == bun.STDOUT_FD or fd == bun.STDERR_FD) {
                 log("close({}) SKIPPED", .{this});
                 return null;

--- a/src/fd.zig
+++ b/src/fd.zig
@@ -199,10 +199,10 @@ pub const FDImpl = packed struct {
 
         const result: ?bun.sys.Error = switch (env.os) {
             .linux => result: {
-                const fd = this.system();
+                const fd = this.encode();
                 std.debug.assert(fd != bun.invalid_fd);
-                std.debug.assert(fd > -1);
-                break :result switch (linux.getErrno(linux.close(fd))) {
+                std.debug.assert(fd.cast() > -1);
+                break :result switch (linux.getErrno(linux.close(fd.cast()))) {
                     .BADF => bun.sys.Error{ .errno = @intFromEnum(os.E.BADF), .syscall = .close, .fd = fd },
                     else => null,
                 };

--- a/src/glob.zig
+++ b/src/glob.zig
@@ -183,7 +183,7 @@ pub fn GlobWalker_(
         pub const Iterator = struct {
             walker: *GlobWalker,
             iter_state: IterState = .get_next,
-            cwd_fd: bun.FileDescriptor = 0,
+            cwd_fd: bun.FileDescriptor = .zero,
             empty_dir_path: [0:0]u8 = [0:0]u8{},
             /// This is to make sure in debug/tests that we are closing file descriptors
             /// We should only have max 2 open at a time. One for the cwd, and one for the
@@ -238,7 +238,7 @@ pub fn GlobWalker_(
             }
 
             pub fn closeCwdFd(this: *Iterator) void {
-                if (this.cwd_fd == 0) return;
+                if (this.cwd_fd == .zero) return;
                 _ = Syscall.close(this.cwd_fd);
                 if (bun.Environment.allow_assert) this.fds_open -= 1;
             }
@@ -263,7 +263,7 @@ pub fn GlobWalker_(
                 comptime root: bool,
             ) !Maybe(void) {
                 this.iter_state = .{ .directory = .{
-                    .fd = 0,
+                    .fd = .zero,
                     .iter = undefined,
                     .path = undefined,
                     .dir_path = undefined,

--- a/src/http.zig
+++ b/src/http.zig
@@ -156,9 +156,8 @@ pub const Sendfile = struct {
             var sbytes: std.os.off_t = adjusted_count;
             const signed_offset = @as(i64, @bitCast(@as(u64, this.offset)));
             const errcode = std.c.getErrno(std.c.sendfile(
-                this.fd,
-                socket.fd(),
-
+                this.fd.cast(),
+                socket.fd().cast(),
                 signed_offset,
                 &sbytes,
                 null,

--- a/src/http.zig
+++ b/src/http.zig
@@ -138,7 +138,7 @@ pub const Sendfile = struct {
             const begin = this.offset;
             const val =
                 // this does the syscall directly, without libc
-                std.os.linux.sendfile(socket.fd(), this.fd, &signed_offset, this.remain);
+                std.os.linux.sendfile(socket.fd().cast(), this.fd.cast(), &signed_offset, this.remain);
             this.offset = @as(u64, @intCast(signed_offset));
 
             const errcode = std.os.linux.getErrno(val);

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1562,8 +1562,7 @@ const PackageInstall = struct {
             const rc = Syscall.system.open(path, @as(u32, std.os.O.PATH | 0), @as(u32, 0));
             switch (Syscall.getErrno(rc)) {
                 .SUCCESS => {
-                    const fd = @as(bun.FileDescriptor, @intCast(rc));
-                    _ = Syscall.system.close(fd);
+                    _ = Syscall.system.close(@intCast(rc));
                     return false;
                 },
                 else => return true,

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -3479,7 +3479,7 @@ pub const PackageManager = struct {
 
         if (comptime Environment.isPosix) {
             _ = C.fchmod(
-                tmpfile.fd,
+                tmpfile.fd.cast(),
                 // chmod 666,
                 0o0000040 | 0o0000004 | 0o0000002 | 0o0000400 | 0o0000200 | 0o0000020,
             );
@@ -6558,12 +6558,12 @@ pub const PackageManager = struct {
             if (package.bin.tag != .none) {
                 var bin_linker = Bin.Linker{
                     .bin = package.bin,
-                    .package_installed_node_modules = node_modules.fd,
+                    .package_installed_node_modules = bun.toFD(node_modules.fd),
                     .global_bin_path = manager.options.bin_path,
                     .global_bin_dir = manager.options.global_bin_dir,
 
                     // .destination_dir_subpath = destination_dir_subpath,
-                    .root_node_modules_folder = node_modules.fd,
+                    .root_node_modules_folder = bun.toFD(node_modules.fd),
                     .package_name = strings.StringOrTinyString.init(name),
                     .string_buf = lockfile.buffers.string_bytes.items,
                     .extern_string_buf = lockfile.buffers.extern_strings.items,
@@ -6701,12 +6701,12 @@ pub const PackageManager = struct {
             if (package.bin.tag != .none) {
                 var bin_linker = Bin.Linker{
                     .bin = package.bin,
-                    .package_installed_node_modules = node_modules.fd,
+                    .package_installed_node_modules = bun.toFD(node_modules.fd),
                     .global_bin_path = manager.options.bin_path,
                     .global_bin_dir = manager.options.global_bin_dir,
 
                     // .destination_dir_subpath = destination_dir_subpath,
-                    .root_node_modules_folder = node_modules.fd,
+                    .root_node_modules_folder = bun.toFD(node_modules.fd),
                     .package_name = strings.StringOrTinyString.init(name),
                     .string_buf = lockfile.buffers.string_bytes.items,
                     .extern_string_buf = lockfile.buffers.extern_strings.items,

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -57,7 +57,7 @@ pub const LifecycleScriptSubprocess = struct {
         );
 
         pub fn getFd(this: *OutputReader) bun.FileDescriptor {
-            return bun.toFD(this.poll.fd);
+            return this.poll.fd;
         }
 
         pub fn getBuffer(this: *OutputReader) *std.ArrayList(u8) {

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -217,8 +217,8 @@ pub const LifecycleScriptSubprocess = struct {
             try actions.openZ(bun.STDIN_FD, "/dev/null", std.os.O.RDONLY, 0o664);
 
             if (!this.manager.options.log_level.isVerbose()) {
-                try actions.dup2(fdsOut[1], bun.STDOUT_FD);
-                try actions.dup2(fdsErr[1], bun.STDERR_FD);
+                try actions.dup2(bun.toFD(fdsOut[1]), bun.STDOUT_FD);
+                try actions.dup2(bun.toFD(fdsErr[1]), bun.STDERR_FD);
             } else {
                 if (comptime Environment.isMac) {
                     try actions.inherit(bun.STDOUT_FD);
@@ -233,8 +233,8 @@ pub const LifecycleScriptSubprocess = struct {
 
             defer {
                 if (!this.manager.options.log_level.isVerbose()) {
-                    _ = bun.sys.close(fdsOut[1]);
-                    _ = bun.sys.close(fdsErr[1]);
+                    _ = bun.sys.close(bun.toFD(fdsOut[1]));
+                    _ = bun.sys.close(bun.toFD(fdsErr[1]));
                 }
             }
 
@@ -329,12 +329,12 @@ pub const LifecycleScriptSubprocess = struct {
         if (!this.manager.options.log_level.isVerbose()) {
             this.stdout = .{
                 .parent = this,
-                .poll = Async.FilePoll.initWithPackageManager(manager, fdsOut[0], .{}, &this.stdout),
+                .poll = Async.FilePoll.initWithPackageManager(manager, bun.toFD(fdsOut[0]), .{}, &this.stdout),
             };
 
             this.stderr = .{
                 .parent = this,
-                .poll = Async.FilePoll.initWithPackageManager(manager, fdsErr[0], .{}, &this.stderr),
+                .poll = Async.FilePoll.initWithPackageManager(manager, bun.toFD(fdsErr[0]), .{}, &this.stderr),
             };
             try this.stdout.start().unwrap();
             try this.stderr.start().unwrap();
@@ -345,7 +345,7 @@ pub const LifecycleScriptSubprocess = struct {
         } else {
             this.pid_poll = Async.FilePoll.initWithPackageManager(
                 manager,
-                pid_fd,
+                bun.toFD(pid_fd),
                 .{},
                 @as(*PidPollData, @ptrCast(this)),
             );

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1664,7 +1664,7 @@ pub fn saveToDisk(this: *Lockfile, filename: stringZ) void {
         @panic("TODO on Windows");
     } else {
         _ = C.fchmod(
-            tmpfile.fd,
+            tmpfile.fd.cast(),
             // chmod 777
             0o0000010 | 0o0000100 | 0o0000001 | 0o0001000 | 0o0000040 | 0o0000004 | 0o0000002 | 0o0000400 | 0o0000200 | 0o0000020,
         );
@@ -3829,7 +3829,7 @@ pub const Package = extern struct {
                         .auto,
                     );
 
-                    if (entry.cache.fd == 0) {
+                    if (entry.cache.fd == .zero) {
                         entry.cache.fd = bun.toFD(bun.sys.open(
                             entry_path,
                             std.os.O.DIRECTORY | std.os.O.CLOEXEC | std.os.O.NOCTTY | std.os.O.RDONLY,

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -16,7 +16,7 @@ const assert = std.debug.assert;
 pub const Loop = struct {
     pending: Request.Queue = .{},
     waker: bun.Async.Waker,
-    epoll_fd: if (Environment.isLinux) bun.FileDescriptor else u0 = 0,
+    epoll_fd: if (Environment.isLinux) bun.FileDescriptor else u0 = if (Environment.isLinux) .zero else 0,
 
     timers: TimerHeap = .{ .context = {} },
 
@@ -39,13 +39,13 @@ pub const Loop = struct {
                 .waker = bun.Async.Waker.init(bun.default_allocator) catch @panic("failed to initialize waker"),
             };
             if (comptime Environment.isLinux) {
-                loop.epoll_fd = std.os.epoll_create1(std.os.linux.EPOLL.CLOEXEC | 0) catch @panic("Failed to create epoll file descriptor");
+                loop.epoll_fd = bun.toFD(std.os.epoll_create1(std.os.linux.EPOLL.CLOEXEC | 0) catch @panic("Failed to create epoll file descriptor"));
 
                 {
                     var epoll = std.mem.zeroes(std.os.linux.epoll_event);
                     epoll.events = std.os.linux.EPOLL.IN | std.os.linux.EPOLL.ERR | std.os.linux.EPOLL.HUP;
                     epoll.data.ptr = @intFromPtr(&loop);
-                    const rc = std.os.linux.epoll_ctl(loop.epoll_fd, std.os.linux.EPOLL.CTL_ADD, loop.waker.getFd(), &epoll);
+                    const rc = std.os.linux.epoll_ctl(loop.epoll_fd.cast(), std.os.linux.EPOLL.CTL_ADD, loop.waker.getFd().cast(), &epoll);
 
                     switch (std.os.linux.getErrno(rc)) {
                         .SUCCESS => {},
@@ -105,7 +105,7 @@ pub const Loop = struct {
                     request.scheduled = false;
                     switch (request.callback(request)) {
                         .readable => |readable| {
-                            switch (readable.poll.registerForEpoll(readable.tag, this, .poll_readable, true, @intCast(readable.fd))) {
+                            switch (readable.poll.registerForEpoll(readable.tag, this, .poll_readable, true, readable.fd)) {
                                 .err => |err| {
                                     readable.onError(request, err);
                                 },
@@ -115,7 +115,7 @@ pub const Loop = struct {
                             }
                         },
                         .writable => |writable| {
-                            switch (writable.poll.registerForEpoll(writable.tag, this, .poll_writable, true, @intCast(writable.fd))) {
+                            switch (writable.poll.registerForEpoll(writable.tag, this, .poll_writable, true, writable.fd)) {
                                 .err => |err| {
                                     writable.onError(request, err);
                                 },
@@ -125,7 +125,7 @@ pub const Loop = struct {
                             }
                         },
                         .close => |close| {
-                            close.poll.unregisterWithFd(@intCast(this.pollfd()), @intCast(close.fd));
+                            close.poll.unregisterWithFd(this.pollfd(), close.fd);
                             this.active -= 1;
                             close.onDone(close.ctx);
                         },
@@ -176,7 +176,7 @@ pub const Loop = struct {
             var events: [256]EventType = undefined;
 
             const rc = linux.epoll_wait(
-                @intCast(this.pollfd()),
+                this.pollfd().cast(),
                 &events,
                 @intCast(events.len),
                 timeout,
@@ -209,15 +209,15 @@ pub const Loop = struct {
         }
     }
 
-    pub fn pollfd(this: *const Loop) std.os.fd_t {
+    pub fn pollfd(this: *const Loop) bun.FileDescriptor {
         if (comptime Environment.isLinux) {
-            return @intCast(this.epoll_fd);
+            return this.epoll_fd;
         }
 
         return this.waker.getFd();
     }
 
-    pub fn fd(this: *const Loop) std.os.fd_t {
+    pub fn fd(this: *const Loop) bun.FileDescriptor {
         return this.waker.getFd();
     }
 
@@ -335,7 +335,7 @@ pub const Loop = struct {
             };
 
             const rc = os.system.kevent64(
-                this.pollfd(),
+                this.pollfd().cast(),
                 events_list.items.ptr,
                 @intCast(change_count),
                 // The same array may be used for the changelist and eventlist.
@@ -810,11 +810,11 @@ pub const Poll = struct {
         }
     };
 
-    pub fn unregisterWithFd(this: *Poll, watcher_fd: u64, fd: u64) void {
+    pub fn unregisterWithFd(this: *Poll, watcher_fd: bun.FileDescriptor, fd: bun.FileDescriptor) void {
         _ = linux.epoll_ctl(
-            @intCast(watcher_fd),
+            watcher_fd.cast(),
             linux.EPOLL.CTL_DEL,
-            @intCast(fd.int()),
+            fd.cast(),
             null,
         );
         this.flags.remove(.was_ever_registered);
@@ -870,7 +870,7 @@ pub const Poll = struct {
         }
     }
 
-    pub fn registerForEpoll(this: *Poll, tag: Pollable.Tag, loop: *Loop, comptime flag: Flags, one_shot: bool, fd: u64) JSC.Maybe(void) {
+    pub fn registerForEpoll(this: *Poll, tag: Pollable.Tag, loop: *Loop, comptime flag: Flags, one_shot: bool, fd: bun.FileDescriptor) JSC.Maybe(void) {
         const watcher_fd = loop.pollfd();
 
         log("register: {s} ({d})", .{ @tagName(flag), fd });
@@ -898,9 +898,9 @@ pub const Poll = struct {
             const op: u32 = if (this.flags.contains(.registered) or this.flags.contains(.needs_rearm)) linux.EPOLL.CTL_MOD else linux.EPOLL.CTL_ADD;
 
             const ctl = linux.epoll_ctl(
-                watcher_fd,
+                watcher_fd.cast(),
                 op,
-                @intCast(fd.int()),
+                fd.cast(),
                 &event,
             );
             this.flags.insert(.registered);

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -770,7 +770,7 @@ pub const Poll = struct {
 
             kqueue_event.* = switch (comptime action) {
                 .readable => .{
-                    .ident = @as(u64, @intCast(fd)),
+                    .ident = @as(u64, @intCast(fd.int())),
                     .filter = std.os.system.EVFILT_READ,
                     .data = 0,
                     .fflags = 0,
@@ -779,7 +779,7 @@ pub const Poll = struct {
                     .ext = .{ generation_number, 0 },
                 },
                 .writable => .{
-                    .ident = @as(u64, @intCast(fd)),
+                    .ident = @as(u64, @intCast(fd.int())),
                     .filter = std.os.system.EVFILT_WRITE,
                     .data = 0,
                     .fflags = 0,
@@ -788,7 +788,7 @@ pub const Poll = struct {
                     .ext = .{ generation_number, 0 },
                 },
                 .cancel => if (poll.flags.contains(.poll_readable)) .{
-                    .ident = @as(u64, @intCast(fd)),
+                    .ident = @as(u64, @intCast(fd.int())),
                     .filter = std.os.system.EVFILT_READ,
                     .data = 0,
                     .fflags = 0,
@@ -796,7 +796,7 @@ pub const Poll = struct {
                     .flags = std.c.EV_DELETE,
                     .ext = .{ poll.generation_number, 0 },
                 } else if (poll.flags.contains(.poll_writable)) .{
-                    .ident = @as(u64, @intCast(fd)),
+                    .ident = @as(u64, @intCast(fd.int())),
                     .filter = std.os.system.EVFILT_WRITE,
                     .data = 0,
                     .fflags = 0,
@@ -814,7 +814,7 @@ pub const Poll = struct {
         _ = linux.epoll_ctl(
             @intCast(watcher_fd),
             linux.EPOLL.CTL_DEL,
-            @intCast(fd),
+            @intCast(fd.int()),
             null,
         );
         this.flags.remove(.was_ever_registered);
@@ -900,7 +900,7 @@ pub const Poll = struct {
             const ctl = linux.epoll_ctl(
                 watcher_fd,
                 op,
-                @intCast(fd),
+                @intCast(fd.int()),
                 &event,
             );
             this.flags.insert(.registered);

--- a/src/io/io_darwin.zig
+++ b/src/io/io_darwin.zig
@@ -74,8 +74,8 @@ pub const Waker = struct {
         this.has_pending_wake = true;
     }
 
-    pub fn getFd(this: *const Waker) os.fd_t {
-        return this.kq;
+    pub fn getFd(this: *const Waker) bun.FileDescriptor {
+        return bun.toFD(this.kq);
     }
 
     pub fn wait(this: Waker) void {

--- a/src/io/io_linux.zig
+++ b/src/io/io_linux.zig
@@ -147,7 +147,7 @@ pub const Waker = struct {
     fd: bun.FileDescriptor,
 
     pub fn init(allocator: std.mem.Allocator) !Waker {
-        return initWithFileDescriptor(allocator, @intCast(try std.os.eventfd(0, 0)));
+        return initWithFileDescriptor(allocator, bun.toFD(try std.os.eventfd(0, 0)));
     }
 
     pub fn getFd(this: *const Waker) bun.FileDescriptor {
@@ -162,13 +162,13 @@ pub const Waker = struct {
 
     pub fn wait(this: Waker) void {
         var bytes: usize = 0;
-        _ = std.os.read(this.fd, @as(*[8]u8, @ptrCast(&bytes))) catch 0;
+        _ = std.os.read(this.fd.cast(), @as(*[8]u8, @ptrCast(&bytes))) catch 0;
     }
 
     pub fn wake(this: *const Waker) void {
         var bytes: usize = 1;
         _ = std.os.write(
-            this.fd,
+            this.fd.cast(),
             @as(*[8]u8, @ptrCast(&bytes)),
         ) catch 0;
     }

--- a/src/libarchive/libarchive.zig
+++ b/src/libarchive/libarchive.zig
@@ -375,12 +375,12 @@ pub const Archive = struct {
         contents: MutableString,
         filename_hash: u64 = 0,
         found: bool = false,
-        fd: FileDescriptorType = 0,
+        fd: FileDescriptorType = .zero,
         pub fn init(filepath: string, estimated_size: usize, allocator: std.mem.Allocator) !Plucker {
             return Plucker{
                 .contents = try MutableString.init(allocator, estimated_size),
                 .filename_hash = bun.hash(filepath),
-                .fd = 0,
+                .fd = .zero,
                 .found = false,
             };
         }

--- a/src/linux_c.zig
+++ b/src/linux_c.zig
@@ -591,5 +591,5 @@ pub const linux_fs = if (bun.Environment.isLinux) @cImport({
 ///
 /// Support for FICLONE is dependent on the filesystem driver.
 pub fn ioctl_ficlone(dest_fd: bun.FileDescriptor, srcfd: bun.FileDescriptor) usize {
-    return std.os.linux.ioctl(@intCast(dest_fd), linux_fs.FICLONE, @intCast(srcfd));
+    return std.os.linux.ioctl(dest_fd.cast(), linux_fs.FICLONE, @intCast(srcfd.int()));
 }

--- a/src/linux_memfd_allocator.zig
+++ b/src/linux_memfd_allocator.zig
@@ -18,7 +18,7 @@ const std = @import("std");
 /// the virtual memory. So we should only really use this for large blobs of
 /// data that we expect to be cloned multiple times. Such as Blob in FormData.
 pub const LinuxMemFdAllocator = struct {
-    fd: bun.FileDescriptor = 0,
+    fd: bun.FileDescriptor = .zero,
     ref_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
     size: usize = 0,
 

--- a/src/options.zig
+++ b/src/options.zig
@@ -2017,7 +2017,7 @@ pub const OutputFile = struct {
             .noop => JSC.JSValue.undefined,
             .copy => |copy| brk: {
                 const file_blob = JSC.WebCore.Blob.Store.initFile(
-                    if (copy.fd != 0)
+                    if (copy.fd.int() != 0)
                         JSC.Node.PathOrFileDescriptor{
                             .fd = copy.fd,
                         }
@@ -2453,7 +2453,7 @@ pub const RouteConfig = struct {
     static_dir_handle: ?std.fs.Dir = null,
     static_dir_enabled: bool = false,
     single_page_app_routing: bool = false,
-    single_page_app_fd: StoredFileDescriptorType = 0,
+    single_page_app_fd: StoredFileDescriptorType = .zero,
 
     pub fn toAPI(this: *const RouteConfig) Api.LoadedRouteConfig {
         return .{

--- a/src/resolver/dir_info.zig
+++ b/src/resolver/dir_info.zig
@@ -78,7 +78,7 @@ pub fn hasParentPackage(this: *const DirInfo) bool {
 
 pub fn getFileDescriptor(dirinfo: *const DirInfo) StoredFileDescriptorType {
     if (!FeatureFlags.store_file_descriptors) {
-        return 0;
+        return .zero;
     }
 
     if (dirinfo.getEntries(0)) |entries| {

--- a/src/resolver/dir_info.zig
+++ b/src/resolver/dir_info.zig
@@ -84,7 +84,7 @@ pub fn getFileDescriptor(dirinfo: *const DirInfo) StoredFileDescriptorType {
     if (dirinfo.getEntries(0)) |entries| {
         return entries.fd;
     } else {
-        return 0;
+        return .zero;
     }
 }
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3917,9 +3917,9 @@ pub const Resolver = struct {
             const entry = lookup.entry;
             if (entry.kind(rfs, r.store_fd) == .file) {
                 info.package_json = if (r.usePackageManager() and !info.hasNodeModules() and !info.isNodeModules())
-                    r.parsePackageJSON(path, if (FeatureFlags.store_file_descriptors) fd else 0, package_id, true) catch null
+                    r.parsePackageJSON(path, if (FeatureFlags.store_file_descriptors) fd else .zero, package_id, true) catch null
                 else
-                    r.parsePackageJSON(path, if (FeatureFlags.store_file_descriptors) fd else 0, null, false) catch null;
+                    r.parsePackageJSON(path, if (FeatureFlags.store_file_descriptors) fd else .zero, null, false) catch null;
 
                 if (info.package_json) |pkg| {
                     if (pkg.browser_map.count() > 0) {
@@ -3970,7 +3970,7 @@ pub const Resolver = struct {
             if (tsconfig_path) |tsconfigpath| {
                 info.tsconfig_json = r.parseTSConfig(
                     tsconfigpath,
-                    if (FeatureFlags.store_file_descriptors) fd else 0,
+                    if (FeatureFlags.store_file_descriptors) fd else .zero,
                 ) catch |err| brk: {
                     const pretty = r.prettyPath(Path.init(tsconfigpath));
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3812,7 +3812,7 @@ pub const Resolver = struct {
                             bin_folders = BinFolderArray.init(0) catch unreachable;
                         }
 
-                        const this_dir = std.fs.Dir{ .fd = bun.fdcast(fd) };
+                        const this_dir = fd.asDir();
                         var file = this_dir.openDirZ(bun.pathLiteral("node_modules/.bin"), .{ .iterate = true }) catch break :append_bin_dir;
                         defer file.close();
                         const bin_path = bun.getFdPath(file.fd, bufs(.node_bin_path)) catch break :append_bin_dir;

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -211,8 +211,8 @@ pub const Result = struct {
 
     debug_meta: ?DebugMeta = null,
 
-    dirname_fd: StoredFileDescriptorType = 0,
-    file_fd: StoredFileDescriptorType = 0,
+    dirname_fd: StoredFileDescriptorType = .zero,
+    file_fd: StoredFileDescriptorType = .zero,
     import_kind: ast.ImportKind = undefined,
 
     pub const Union = union(enum) {
@@ -317,7 +317,7 @@ pub const DirEntryResolveQueueItem = struct {
     result: allocators.Result,
     unsafe_path: string,
     safe_path: string = "",
-    fd: StoredFileDescriptorType = 0,
+    fd: StoredFileDescriptorType = .zero,
 };
 
 pub const DebugLogs = struct {
@@ -373,8 +373,8 @@ pub const DebugLogs = struct {
 
 pub const MatchResult = struct {
     path_pair: PathPair,
-    dirname_fd: StoredFileDescriptorType = 0,
-    file_fd: StoredFileDescriptorType = 0,
+    dirname_fd: StoredFileDescriptorType = .zero,
+    file_fd: StoredFileDescriptorType = .zero,
     is_node_module: bool = false,
     package_json: ?*PackageJSON = null,
     diff_case: ?Fs.FileSystem.Entry.Lookup.DifferentCase = null,
@@ -442,8 +442,8 @@ pub const PendingResolution = struct {
 pub const LoadResult = struct {
     path: string,
     diff_case: ?Fs.FileSystem.Entry.Lookup.DifferentCase,
-    dirname_fd: StoredFileDescriptorType = 0,
-    file_fd: StoredFileDescriptorType = 0,
+    dirname_fd: StoredFileDescriptorType = .zero,
+    file_fd: StoredFileDescriptorType = .zero,
     dir_info: ?*DirInfo = null,
 };
 
@@ -1033,7 +1033,7 @@ pub const Resolver = struct {
                     const symlink_path = query.entry.symlink(&r.fs.fs, r.store_fd);
                     if (symlink_path.len > 0) {
                         path.setRealpath(symlink_path);
-                        if (result.file_fd == 0) result.file_fd = query.entry.cache.fd;
+                        if (result.file_fd == .zero) result.file_fd = query.entry.cache.fd;
 
                         if (r.debug_logs) |*debug| {
                             debug.addNoteFmt("Resolved symlink \"{s}\" to \"{s}\"", .{ path.text, symlink_path });
@@ -1046,7 +1046,7 @@ pub const Resolver = struct {
 
                         const store_fd = r.store_fd;
 
-                        if (query.entry.cache.fd == 0) {
+                        if (query.entry.cache.fd == .zero) {
                             buf[out.len] = 0;
                             const span = buf[0..out.len :0];
                             var file = try if (store_fd)
@@ -1058,7 +1058,7 @@ pub const Resolver = struct {
                                 std.debug.assert(bun.FDTag.get(file.handle) == .none);
                                 out = try bun.getFdPath(file.handle, &buf);
                                 file.close();
-                                query.entry.cache.fd = 0;
+                                query.entry.cache.fd = .zero;
                             } else {
                                 query.entry.cache.fd = bun.toFD(file.handle);
                                 Fs.FileSystem.setMaxFd(file.handle);
@@ -1067,10 +1067,10 @@ pub const Resolver = struct {
 
                         defer {
                             if (r.fs.fs.needToCloseFiles()) {
-                                if (query.entry.cache.fd != 0) {
-                                    var file = std.fs.File{ .handle = bun.fdcast(query.entry.cache.fd) };
+                                if (query.entry.cache.fd != .zero) {
+                                    var file = query.entry.cache.fd.asFile();
                                     file.close();
-                                    query.entry.cache.fd = 0;
+                                    query.entry.cache.fd = .zero;
                                 }
                             }
                         }
@@ -1084,7 +1084,7 @@ pub const Resolver = struct {
                             debug.addNoteFmt("Resolved symlink \"{s}\" to \"{s}\"", .{ symlink, path.text });
                         }
                         query.entry.cache.symlink = PathString.init(symlink);
-                        if (result.file_fd == 0 and store_fd) result.file_fd = query.entry.cache.fd;
+                        if (result.file_fd == .zero and store_fd) result.file_fd = query.entry.cache.fd;
 
                         path.setRealpath(symlink);
                     }
@@ -1729,7 +1729,7 @@ pub const Resolver = struct {
                                         .success = .{
                                             .path_pair = .{ .primary = package_json.source.path },
                                             .dirname_fd = pkg_dir_info.getFileDescriptor(),
-                                            .file_fd = 0,
+                                            .file_fd = .zero,
                                             .is_node_module = package_json.source.path.isNodeModule(),
                                             .package_json = package_json,
                                             .dir_info = dir_info,
@@ -1993,7 +1993,7 @@ pub const Resolver = struct {
                                         .success = .{
                                             .path_pair = .{ .primary = package_json.source.path },
                                             .dirname_fd = pkg_dir_info.getFileDescriptor(),
-                                            .file_fd = 0,
+                                            .file_fd = .zero,
                                             .is_node_module = package_json.source.path.isNodeModule(),
                                             .package_json = package_json,
                                             .dir_info = dir_info,
@@ -2550,7 +2550,7 @@ pub const Resolver = struct {
             bufs(.dir_entry_paths_to_resolve)[@as(usize, @intCast(i))] = DirEntryResolveQueueItem{
                 .unsafe_path = top,
                 .result = result,
-                .fd = 0,
+                .fd = .zero,
             };
 
             if (rfs.entries.get(top)) |top_entry| {
@@ -2568,7 +2568,7 @@ pub const Resolver = struct {
                 bufs(.dir_entry_paths_to_resolve)[@as(usize, @intCast(i))] = DirEntryResolveQueueItem{
                     .unsafe_path = root_path,
                     .result = result,
-                    .fd = 0,
+                    .fd = .zero,
                 };
                 if (rfs.entries.get(top)) |top_entry| {
                     bufs(.dir_entry_paths_to_resolve)[@as(usize, @intCast(i))].safe_path = top_entry.entries.dir;
@@ -2615,7 +2615,7 @@ pub const Resolver = struct {
             defer top_parent = queue_top.result;
             queue_slice.len -= 1;
 
-            const open_dir = if (queue_top.fd != 0)
+            const open_dir = if (queue_top.fd != .zero)
                 std.fs.Dir{ .fd = bun.fdcast(queue_top.fd) }
             else open_dir: {
                 // This saves us N copies of .toPosixPath
@@ -2679,7 +2679,7 @@ pub const Resolver = struct {
                 };
             };
 
-            if (queue_top.fd == 0) {
+            if (queue_top.fd == .zero) {
                 Fs.FileSystem.setMaxFd(open_dir.fd);
                 // these objects mostly just wrap the file descriptor, so it's fine to keep it.
                 bufs(.open_dirs)[open_dir_count] = open_dir;
@@ -2746,7 +2746,7 @@ pub const Resolver = struct {
                 if (in_place) |existing| {
                     existing.data.clearAndFree(allocator);
                 }
-                new_entry.fd = if (r.store_fd) bun.toFD(open_dir.fd) else 0;
+                new_entry.fd = if (r.store_fd) bun.toFD(open_dir.fd) else .zero;
                 var dir_entries_ptr = in_place orelse allocator.create(Fs.FileSystem.DirEntry) catch unreachable;
                 dir_entries_ptr.* = new_entry;
                 dir_entries_option = try rfs.entries.put(&cached_dir_entry_result, .{
@@ -3883,7 +3883,7 @@ pub const Resolver = struct {
             if (!r.opts.preserve_symlinks) {
                 if (parent_.getEntries(r.generation)) |parent_entries| {
                     if (parent_entries.get(base)) |lookup| {
-                        if (entries.fd != 0 and lookup.entry.cache.fd == 0 and r.store_fd) lookup.entry.cache.fd = entries.fd;
+                        if (entries.fd != .zero and lookup.entry.cache.fd == .zero and r.store_fd) lookup.entry.cache.fd = entries.fd;
                         const entry = lookup.entry;
 
                         var symlink = entry.symlink(rfs, r.store_fd);
@@ -3989,7 +3989,7 @@ pub const Resolver = struct {
                         const ts_dir_name = Dirname.dirname(current.abs_path);
                         // not sure why this needs cwd but we'll just pass in the dir of the tsconfig...
                         const abs_path = ResolvePath.joinAbsStringBuf(ts_dir_name, bufs(.tsconfig_path_abs), &[_]string{ ts_dir_name, current.extends }, .auto);
-                        const parent_config_maybe = r.parseTSConfig(abs_path, 0) catch |err| {
+                        const parent_config_maybe = r.parseTSConfig(abs_path, bun.STDIN_FD) catch |err| {
                             r.log.addDebugFmt(null, logger.Loc.Empty, r.allocator, "{s} loading tsconfig.json extends {}", .{
                                 @errorName(err),
                                 strings.QuotedFormatter{

--- a/src/router.zig
+++ b/src/router.zig
@@ -38,7 +38,7 @@ pub const Param = struct {
     pub const List = std.MultiArrayList(Param);
 };
 
-dir: StoredFileDescriptorType = 0,
+dir: StoredFileDescriptorType = .zero,
 routes: Routes,
 loaded_routes: bool = false,
 allocator: std.mem.Allocator,
@@ -736,8 +736,8 @@ pub const Route = struct {
             var file: std.fs.File = undefined;
             var needs_close = false;
             defer if (needs_close) file.close();
-            if (entry.cache.fd != 0) {
-                file = std.fs.File{ .handle = bun.fdcast(entry.cache.fd) };
+            if (entry.cache.fd != .zero) {
+                file = entry.cache.fd.asFile();
             } else {
                 var parts = [_]string{ entry.dir, entry.base() };
                 abs_path_str = FileSystem.instance.absBuf(&parts, &route_file_buf);

--- a/src/standalone_bun.zig
+++ b/src/standalone_bun.zig
@@ -591,7 +591,7 @@ pub const StandaloneModuleGraph = struct {
 
         if (comptime Environment.isLinux) {
             if (std.fs.openFileAbsoluteZ("/proc/self/exe", flags)) |easymode| {
-                return easymode.handle;
+                return bun.toFD(easymode.handle);
             } else |_| {
                 if (bun.argv().len > 0) {
                     // The user doesn't have /proc/ mounted, so now we just guess and hope for the best.
@@ -602,7 +602,7 @@ pub const StandaloneModuleGraph = struct {
                         "",
                         bun.span(bun.argv()[0]),
                     )) |path| {
-                        return (try std.fs.cwd().openFileZ(path, flags)).handle;
+                        return bun.toFD((try std.fs.cwd().openFileZ(path, flags)).handle);
                     }
                 }
 

--- a/src/standalone_bun.zig
+++ b/src/standalone_bun.zig
@@ -233,7 +233,6 @@ pub const StandaloneModuleGraph = struct {
         var zname: [:0]const u8 = bun.span(bun.fs.FileSystem.instance.tmpname("bun-build", &buf, @as(u64, @bitCast(std.time.milliTimestamp()))) catch |err| {
             Output.prettyErrorln("<r><red>error<r><d>:<r> failed to get temporary file name: {s}", .{@errorName(err)});
             Global.exit(1);
-            return -1;
         });
 
         const cleanup = struct {
@@ -248,7 +247,6 @@ pub const StandaloneModuleGraph = struct {
             const self_exe = std.fs.selfExePath(&self_buf) catch |err| {
                 Output.prettyErrorln("<r><red>error<r><d>:<r> failed to get self executable path: {s}", .{@errorName(err)});
                 Global.exit(1);
-                return -1;
             };
             self_buf[self_exe.len] = 0;
             const self_exeZ = self_buf[0..self_exe.len :0];
@@ -360,6 +358,7 @@ pub const StandaloneModuleGraph = struct {
         //  file (but this does not change the size of the file).  If data is
         //  later written at this point, subsequent reads of the data in the
         //  gap (a "hole") return null bytes ('\0') until data is actually
+
         //  written into the gap.
         //
         switch (Syscall.setFileOffset(cloned_executable_fd, seek_position)) {
@@ -393,7 +392,7 @@ pub const StandaloneModuleGraph = struct {
         // the final 8 bytes in the file are the length of the module graph with padding, excluding the trailer and offsets
         _ = Syscall.write(cloned_executable_fd, std.mem.asBytes(&total_byte_count));
         if (comptime !Environment.isWindows) {
-            _ = bun.C.fchmod(cloned_executable_fd, 0o777);
+            _ = bun.C.fchmod(cloned_executable_fd.int(), 0o777);
         }
 
         return cloned_executable_fd;
@@ -404,12 +403,6 @@ pub const StandaloneModuleGraph = struct {
         if (bytes.len == 0) return;
 
         const fd = inject(bytes);
-        if (fd == -1) {
-            // TODO: remove this
-            Output.prettyErrorln("<r><red>error<r><d>:<r> failed to inject into file", .{});
-            Global.exit(1);
-        }
-
         var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
         const temp_location = bun.getFdPath(fd, &buf) catch |err| {
             Output.prettyErrorln("<r><red>error<r><d>:<r> failed to get path for fd: {s}", .{@errorName(err)});
@@ -446,9 +439,9 @@ pub const StandaloneModuleGraph = struct {
 
         bun.C.moveFileZWithHandle(
             fd,
-            std.fs.cwd().fd,
+            bun.toFD(std.fs.cwd().fd),
             bun.sliceTo(&(try std.os.toPosixPath(temp_location)), 0),
-            root_dir.fd,
+            bun.toFD(root_dir.fd),
             bun.sliceTo(&(try std.os.toPosixPath(std.fs.path.basename(outfile))), 0),
         ) catch |err| {
             if (err == error.IsDir) {
@@ -470,6 +463,7 @@ pub const StandaloneModuleGraph = struct {
 
         var trailer_bytes: [4096]u8 = undefined;
         std.os.lseek_END(bun.fdcast(self_exe), -4096) catch return null;
+
         var read_amount: usize = 0;
         while (read_amount < trailer_bytes.len) {
             switch (Syscall.read(self_exe, trailer_bytes[read_amount..])) {
@@ -625,7 +619,7 @@ pub const StandaloneModuleGraph = struct {
         const self_exe_path = try std.fs.selfExePath(&buf);
         buf[self_exe_path.len] = 0;
         const file = try std.fs.openFileAbsoluteZ(buf[0..self_exe_path.len :0].ptr, flags);
-        return file.handle;
+        return @enumFromInt(file.handle);
     }
 };
 

--- a/src/tmp.zig
+++ b/src/tmp.zig
@@ -78,6 +78,6 @@ pub const Tmpfile = struct {
             }
         }
 
-        try bun.C.moveFileZWithHandle(bun.fdcast(this.fd), this.destination_dir, this.tmpfilename, bun.fdcast(this.destination_dir), destname);
+        try bun.C.moveFileZWithHandle(this.fd, this.destination_dir, this.tmpfilename, this.destination_dir, destname);
     }
 };

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -395,7 +395,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
 
             watcher.* = Watcher{
                 .fs = fs,
-                .fd = 0,
+                .fd = .zero,
                 .allocator = allocator,
                 .watched_count = 0,
                 .ctx = ctx,
@@ -747,7 +747,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
                 event.fflags = std.c.NOTE_WRITE | std.c.NOTE_RENAME | std.c.NOTE_DELETE;
 
                 // id
-                event.ident = @as(usize, @intCast(fd));
+                event.ident = @intCast(fd.int());
 
                 // Store the hash for fast filtering later
                 event.udata = @as(usize, @intCast(watchlist_id));
@@ -796,7 +796,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
             comptime copy_file_path: bool,
         ) !WatchItemIndex {
             const fd = brk: {
-                if (stored_fd > 0) break :brk stored_fd;
+                if (stored_fd.int() > 0) break :brk stored_fd;
                 const dir = try std.fs.cwd().openDir(file_path, .{});
                 break :brk bun.toFD(dir.fd);
             };
@@ -828,7 +828,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
                 event.fflags = std.c.NOTE_WRITE | std.c.NOTE_RENAME | std.c.NOTE_DELETE;
 
                 // id
-                event.ident = @as(usize, @intCast(fd));
+                event.ident = @intCast(fd.int());
 
                 // Store the hash for fast filtering later
                 event.udata = @as(usize, @intCast(watchlist_id));
@@ -916,7 +916,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
             if (autowatch_parent_dir) {
                 var watchlist_slice = this.watchlist.slice();
 
-                if (dir_fd > 0) {
+                if (dir_fd.int() > 0) {
                     const fds = watchlist_slice.items(.fd);
                     if (std.mem.indexOfScalar(StoredFileDescriptorType, fds, dir_fd)) |i| {
                         parent_watch_item = @as(WatchItemIndex, @truncate(i));

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -207,7 +207,7 @@ pub const INotify = struct {
 
     pub fn stop() void {
         if (inotify_fd != 0) {
-            _ = bun.sys.close(inotify_fd);
+            _ = bun.sys.close(bun.toFD(inotify_fd));
             inotify_fd = 0;
         }
     }
@@ -705,7 +705,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
             if (this.indexOf(hash)) |index| {
                 if (comptime FeatureFlags.atomic_file_watcher) {
                     // On Linux, the file descriptor might be out of date.
-                    if (fd > 0) {
+                    if (fd.int() > 0) {
                         var fds = this.watchlist.items(.fd);
                         fds[index] = fd;
                     }


### PR DESCRIPTION
ensure better type safety by making `bun.FileDescriptor` a unique type. by being an enum we can not only ensure unintentional c_int's don't get passed as FD's while keeping the same abi size and behavior, but also add convenience methods for interacting with them.