### PR TITLE
Fixes #5178

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1713,7 +1713,7 @@ pub const VirtualMachine = struct {
                     source_to_use,
                     normalized_specifier,
                     if (is_esm) .stmt else .require,
-                    .read_only,
+                    if (jsc_vm.standalone_module_graph == null) .read_only else .disable,
                 )) {
                     .success => |r| r,
                     .failure => |e| e,
@@ -2091,7 +2091,7 @@ pub const VirtualMachine = struct {
                 this.bundler.fs.top_level_dir,
                 normalizeSource(preload),
                 .stmt,
-                .read_only,
+                if (this.standalone_module_graph == null) .read_only else .disable,
             )) {
                 .success => |r| r,
                 .failure => |e| {

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -109,8 +109,8 @@ pub const BuildCommand = struct {
 
             // We never want to hit the filesystem for these files
             // This "compiled" protocol is specially handled by the module resolver.
-            this_bundler.options.public_path = "compiled://root/";
-            this_bundler.resolver.opts.public_path = "compiled://root/";
+            this_bundler.options.public_path = "/$bunfs/root/";
+            this_bundler.resolver.opts.public_path = "/$bunfs/root/";
 
             if (outfile.len == 0) {
                 outfile = std.fs.path.basename(this_bundler.options.entry_points[0]);

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -108,7 +108,12 @@ pub const BuildCommand = struct {
             }
 
             // We never want to hit the filesystem for these files
-            // This "compiled" protocol is specially handled by the module resolver.
+            // We use the `/$bunfs/` prefix to indicate that it's a virtual path
+            // It is `/$bunfs/` because:
+            //
+            // - `$` makes it unlikely to collide with a real path
+            // - `/$bunfs/` is 8 characters which is fast to compare for 64-bit CPUs
+            //
             this_bundler.options.public_path = "/$bunfs/root/";
             this_bundler.resolver.opts.public_path = "/$bunfs/root/";
 

--- a/src/standalone_bun.zig
+++ b/src/standalone_bun.zig
@@ -19,7 +19,7 @@ pub const StandaloneModuleGraph = struct {
     }
 
     pub fn find(this: *const StandaloneModuleGraph, name: []const u8) ?*File {
-        if (!bun.strings.hasPrefixComptime(name, "compiled://root/")) {
+        if (!bun.strings.isBunStandaloneFilePath(name)) {
             return null;
         }
 

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -955,6 +955,10 @@ pub fn hasPrefixComptime(self: string, comptime alt: anytype) bool {
     return self.len >= alt.len and eqlComptimeCheckLenWithType(u8, self[0..alt.len], alt, false);
 }
 
+pub fn isBunStandaloneFilePath(self: string) bool {
+    return hasPrefixComptime(self, "/$bunfs/");
+}
+
 pub fn hasPrefixComptimeUTF16(self: []const u16, comptime alt: []const u8) bool {
     return self.len >= alt.len and eqlComptimeCheckLenWithType(u16, self[0..alt.len], comptime toUTF16Literal(alt), false);
 }

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -13,6 +13,18 @@ describe("bundler", () => {
     },
     run: { stdout: "Hello, world!" },
   });
+  itBundled("compile/pathToFileURLWorks", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import {pathToFileURL, fileURLToPath} from 'bun';
+        console.log(pathToFileURL(import.meta.path).href + " " + fileURLToPath(import.meta.url));
+        if (fileURLToPath(import.meta.url) !== import.meta.path) throw "fail";
+        if (pathToFileURL(import.meta.path).href !== import.meta.url) throw "fail";
+      `,
+    },
+    run: { stdout: `file:///$bunfs/root/out /$bunfs/root/out`, setCwd: true },
+  });
   itBundled("compile/VariousBunAPIs", {
     compile: true,
     files: {
@@ -144,11 +156,25 @@ describe("bundler", () => {
     files: {
       "/entry.tsx": /* tsx */ `
         const req = (x) => require(x);
-        req('express');
+        console.log(req('express'));
       `,
     },
     run: {
       error: 'Cannot find package "express"',
+      setCwd: true,
+    },
+    compile: true,
+  });
+  itBundled("compile/CanRequireLocalPackages", {
+    files: {
+      "/entry.tsx": /* tsx */ `
+        const req = (x) => require(x);
+        console.log(req('react/package.json').version);
+      `,
+    },
+    run: {
+      stdout: require("react/package.json").version,
+      setCwd: false,
     },
     compile: true,
   });


### PR DESCRIPTION
### What does this PR do?

Fixes #5178

This changes the internally-generated path to files compiled with `bun build --compile` from `compiled://root/` to `/$bunfs/root`. This does effectively ban importing files in `/$bunfs/`, but that seems like a better tradeoff than expecting all software that use `file:` URLs to also check for `compiled:`. The `$` in `$bunfs` makes it less likely to conflict in practice  because it's not valid on Windows (iirc) and if you type that in a terminal, it will think its an environment variable. 

### How did you verify your code works?

Tests