### PR TITLE
Fixes #8010

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9248,7 +9248,13 @@ pub const PackageManager = struct {
                     };
                 }
                 if (!manager.options.global) {
-                    if (log_level != .silent) Output.prettyErrorln("No packages! Deleted empty lockfile", .{});
+                    if (log_level != .silent) {
+                        if (manager.to_remove.len > 0) {
+                            Output.prettyErrorln("\npackage.json has no dependencies! Deleted empty lockfile", .{});
+                        } else {
+                            Output.prettyErrorln("No packages! Deleted empty lockfile", .{});
+                        }
+                    }
                 }
 
                 break :save;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9184,9 +9184,6 @@ pub const PackageManager = struct {
 
         if (manager.log.hasErrors()) Global.crash();
 
-        const needs_clean_lockfile = had_any_diffs or needs_new_lockfile or manager.package_json_updates.len > 0;
-        var did_meta_hash_change = needs_clean_lockfile;
-
         // This operation doesn't perform any I/O, so it should be relatively cheap.
         manager.lockfile = try manager.lockfile.cleanWithLogger(
             manager.package_json_updates,
@@ -9208,7 +9205,7 @@ pub const PackageManager = struct {
             manager.lockfile.verifyResolutions(manager.options.local_package_features, manager.options.remote_package_features, log_level);
         }
 
-        did_meta_hash_change = try manager.lockfile.hasMetaHashChanged(
+        const did_meta_hash_change = try manager.lockfile.hasMetaHashChanged(
             PackageManager.verbose_install or manager.options.do.print_meta_hash_string,
         );
 

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -880,6 +880,7 @@ pub fn cleanWithLogger(
     }
     new.trusted_dependencies = old_trusted_dependencies;
     new.scripts = old_scripts;
+    new.meta_hash = old.meta_hash;
 
     return new;
 }

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1418,9 +1418,8 @@ it("should add dependency without duplication", async () => {
 
   expect(err2).not.toContain("error:");
 
-  // the meta hash did not change, the display name did not change, therefore
-  // the lockfile did not change and should not need to be saved.
-  expect(err2).not.toContain("Saved lockfile");
+  // The meta-hash didn't change, but we do save everytime you do "bun add <package>".
+  expect(err2).toContain("Saved lockfile");
 
   expect(out2.replace(/\s*\[[0-9\.]+m?s\] done\s*$/, "").split(/\r?\n/)).toEqual(["", " installed bar@0.0.2"]);
   expect(await exited2).toBe(0);
@@ -1533,8 +1532,8 @@ it("should add dependency without duplication (GitHub)", async () => {
   const err2 = await new Response(stderr2).text();
   expect(err2).not.toContain("error:");
 
-  // We didn't make any changes to the lockfile, so it should not be saved.
-  expect(err2).not.toContain("Saved lockfile");
+  // The meta-hash didn't change, but we do save everytime you do "bun add <package>".
+  expect(err2).toContain("Saved lockfile");
 
   expect(stdout2).toBeDefined();
   const out2 = await new Response(stdout2).text();

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -983,10 +983,11 @@ it("should install version tagged with `latest` by default", async () => {
   });
   expect(stderr1).toBeDefined();
   const err1 = await new Response(stderr1).text();
+  const out1 = await new Response(stdout1).text();
+
   expect(err1).not.toContain("error:");
   expect(err1).toContain("Saved lockfile");
   expect(stdout1).toBeDefined();
-  const out1 = await new Response(stdout1).text();
   expect(out1.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     "",
     " installed baz@0.0.3",
@@ -1410,11 +1411,17 @@ it("should add dependency without duplication", async () => {
     env,
   });
   expect(stderr2).toBeDefined();
-  const err2 = await new Response(stderr2).text();
-  expect(err2).not.toContain("error:");
-  expect(err2).toContain("Saved lockfile");
   expect(stdout2).toBeDefined();
+
+  const err2 = await new Response(stderr2).text();
   const out2 = await new Response(stdout2).text();
+
+  expect(err2).not.toContain("error:");
+
+  // the meta hash did not change, the display name did not change, therefore
+  // the lockfile did not change and should not need to be saved.
+  expect(err2).not.toContain("Saved lockfile");
+
   expect(out2.replace(/\s*\[[0-9\.]+m?s\] done\s*$/, "").split(/\r?\n/)).toEqual(["", " installed bar@0.0.2"]);
   expect(await exited2).toBe(0);
   expect(urls.sort()).toBeEmpty();
@@ -1525,7 +1532,10 @@ it("should add dependency without duplication (GitHub)", async () => {
   expect(stderr2).toBeDefined();
   const err2 = await new Response(stderr2).text();
   expect(err2).not.toContain("error:");
-  expect(err2).toContain("Saved lockfile");
+
+  // We didn't make any changes to the lockfile, so it should not be saved.
+  expect(err2).not.toContain("Saved lockfile");
+
   expect(stdout2).toBeDefined();
   const out2 = await new Response(stdout2).text();
   expect(out2.replace(/\s*\[[0-9\.]+m?s\] done\s*$/, "").split(/\r?\n/)).toEqual([

--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -99,6 +99,8 @@ it("should remove existing package", async () => {
   expect(await removeExited1).toBe(0);
   expect(stdout1).toBeDefined();
   const out1 = await new Response(stdout1).text();
+  const err1 = await new Response(stderr1).text();
+
   expect(out1.replace(/\s*\[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual([
     "",
     ` + pkg2@${pkg2_path}`,
@@ -108,7 +110,6 @@ it("should remove existing package", async () => {
     "",
   ]);
   expect(stderr1).toBeDefined();
-  const err1 = await new Response(stderr1).text();
   expect(err1.replace(/^(.*?) v[^\n]+/, "$1").split(/\r?\n/)).toEqual(["bun remove", " Saved lockfile", ""]);
   expect(await file(join(package_dir, "package.json")).text()).toEqual(
     JSON.stringify(
@@ -139,12 +140,14 @@ it("should remove existing package", async () => {
   expect(await removeExited2).toBe(0);
   expect(stdout2).toBeDefined();
   const out2 = await new Response(stdout2).text();
-  expect(out2.replace(/\s*\[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual([" done", ""]);
-  expect(stderr2).toBeDefined();
   const err2 = await new Response(stderr2).text();
+
+  expect(out2.replace(/\s*\[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual(["", " - pkg2", " 1 package removed", ""]);
+  expect(stderr2).toBeDefined();
   expect(err2.replace(/^(.*?) v[^\n]+/, "$1").split(/\r?\n/)).toEqual([
     "bun remove",
-    "No packages! Deleted empty lockfile",
+    "",
+    "package.json has no dependencies! Deleted empty lockfile",
     "",
   ]);
   expect(await file(join(package_dir, "package.json")).text()).toEqual(

--- a/test/cli/install/overrides.test.ts
+++ b/test/cli/install/overrides.test.ts
@@ -8,9 +8,9 @@ function install(cwd: string, args: string[]) {
   const exec = Bun.spawnSync({
     cmd: [bunExe(), ...args],
     cwd,
-    stdout: "ignore",
-    stdin: "ignore",
-    stderr: "ignore",
+    stdout: "inherit",
+    stdin: "inherit",
+    stderr: "inherit",
     env: bunEnv,
   });
   if (exec.exitCode !== 0) {
@@ -23,9 +23,9 @@ function installExpectFail(cwd: string, args: string[]) {
   const exec = Bun.spawnSync({
     cmd: [bunExe(), ...args],
     cwd,
-    stdout: "ignore",
-    stdin: "ignore",
-    stderr: "ignore",
+    stdout: "inherit",
+    stdin: "inherit",
+    stderr: "inherit",
     env: bunEnv,
   });
   if (exec.exitCode === 0) {
@@ -42,11 +42,12 @@ function versionOf(cwd: string, path: string) {
 
 function ensureLockfileDoesntChangeOnBunI(cwd: string) {
   install(cwd, ["install"]);
-  const lockb_hash = new Bun.CryptoHasher("sha256").update(readFileSync(join(cwd, "bun.lockb"))).digest();
+  const lockb1 = readFileSync(join(cwd, "bun.lockb"));
   install(cwd, ["install", "--frozen-lockfile"]);
   install(cwd, ["install", "--force"]);
-  const lockb_hash2 = new Bun.CryptoHasher("sha256").update(readFileSync(join(cwd, "bun.lockb"))).digest();
-  expect(lockb_hash).toEqual(lockb_hash2);
+  const lockb2 = readFileSync(join(cwd, "bun.lockb"));
+
+  expect(lockb1.toString("hex")).toEqual(lockb2.toString("hex"));
 }
 
 test("overrides affect your own packages", async () => {
@@ -62,7 +63,6 @@ test("overrides affect your own packages", async () => {
   );
   install(tmp, ["install", "lodash"]);
   expect(versionOf(tmp, "node_modules/lodash/package.json")).toBe("4.0.0");
-
   ensureLockfileDoesntChangeOnBunI(tmp);
 });
 


### PR DESCRIPTION
### What does this PR do?

Fixes #8010

This makes it so we always regenerate the lockfile whenever the meta hash changes. Previously, we would skip this work in certain cases, but that makes bun install less deterministic when we upgrade versions. 

In our site repo (~680 packages to install), it doesn't seem to have a meaningful performance impact. Maybe +1ms on an M1. 

I think this would have a slight perf impact in very large workspaces, but probably not more than a few milliseconds at most, which we can afford right now.

 

### How did you verify your code works?

Let's see if CI gets mad