### PR TITLE
5% - 10% faster `new Headers(object)` & `new URLSearchParams(object)`

### DIFF
--- a/bench/snippets/urlsearchparams.mjs
+++ b/bench/snippets/urlsearchparams.mjs
@@ -1,40 +1,22 @@
-import { bench, run } from "../node_modules/mitata/src/cli.mjs";
+import { bench, run } from "./runner.mjs";
 
-// pure JS implementation will optimze this out
-bench("new Headers", function () {
-  return new Headers();
-});
+// bench("new URLSearchParams({})", () => {
+//   return new URLSearchParams({});
+// });
 
-var big = new Headers({
-  "Content-Type": "text/plain",
-  "Content-Length": "123",
-  hello: "there",
-  "X-Custom-Header": "Hello World",
-  "X-Another-Custom-Header": "Hello World",
-  "X-Yet-Another-Custom-ader": "Hello World",
-  "X-Yet-Another-Custom-Heder": "Hello World",
-  "X-Yet-Another-Custom-Heade": "Hello World",
-  "X-Yet-Another-Custom-Headz": "Hello Worlda",
-});
-
-bench("new Headers([])", () => {
-  return new Headers([]);
-});
-
-bench("new Headers({})", () => {
-  return new Headers({});
-});
-
-bench("new Headers(object)", () => {
-  return new Headers({
+bench("new URLSearchParams(obj)", () => {
+  return new URLSearchParams({
     "Content-Type": "text/plain",
     "Content-Length": "123",
     "User-Agent": "node-fetch/1.0",
+    "Accept-Encoding": "gzip,deflate",
+    "Content-Length": "0",
+    "Content-Range": "bytes 0-9/10",
   });
 });
 
-bench("new Headers(hugeObject)", () => {
-  return new Headers({
+bench("new URLSearchParams(absurdlyHugeObject)", () => {
+  return new URLSearchParams({
     "Accept": "123",
     "Accept-Charset": "123",
     "Accept-Language": "123",
@@ -126,31 +108,6 @@ bench("new Headers(hugeObject)", () => {
     "X-XSS-Protection": "123",
     "X-Temp-Tablet": "123",
   });
-});
-
-bench("Header.get", function () {
-  return big.get("Content-Type");
-});
-
-bench("Header.set (standard)", function () {
-  return big.set("Content-Type", "text/html");
-});
-
-bench("Header.set (non-standard)", function () {
-  return big.set("X-My-Custom", "text/html123");
-});
-
-if (big.toJSON)
-  bench("Headers.toJSON", function () {
-    return big.toJSON();
-  });
-
-bench("Object.fromEntries(headers.entries())", function () {
-  return Object.fromEntries(big.entries());
-});
-
-bench("Object.fromEntries(headers)", function () {
-  return Object.fromEntries(big);
 });
 
 await run();

--- a/src/bun.js/bindings/webcore/JSDOMConvertRecord.h
+++ b/src/bun.js/bindings/webcore/JSDOMConvertRecord.h
@@ -98,6 +98,71 @@ private:
         ReturnType result;
         HashMap<KeyType, size_t> resultMap;
 
+        bool canUseFastPath = false;
+        JSC::Structure* structure = nullptr;
+
+        switch (object->type()) {
+        case ObjectType:
+        case FinalObjectType: {
+            structure = object->structure();
+            canUseFastPath = structure->canPerformFastPropertyEnumeration() && !structure->hasNonReifiedStaticProperties();
+
+            if (canUseFastPath) {
+                JSValue prototype = object->getPrototypeDirect();
+
+                if (!(prototype == lexicalGlobalObject.objectPrototype() || prototype.structureOrNull() == lexicalGlobalObject.nullPrototypeObjectStructure())) {
+                    canUseFastPath = false;
+                }
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+        }
+
+        if (canUseFastPath) {
+            structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
+                if ((entry.attributes() & (PropertyAttribute::DontEnum))) {
+                    return true;
+                }
+
+                // 1. Let typedKey be key converted to an IDL value of type K.
+                auto typedKey = Detail::IdentifierConverter<K>::convert(lexicalGlobalObject, Identifier::fromUid(vm, entry.key()));
+                RETURN_IF_EXCEPTION(scope, false);
+
+                // 2. Let value be ? Get(O, key).
+                JSC::JSValue value = object->getDirect(entry.offset());
+                scope.assertNoException();
+
+                // 3. Let typedValue be value converted to an IDL value of type V.
+                auto typedValue = Converter<V>::convert(lexicalGlobalObject, value, args...);
+                RETURN_IF_EXCEPTION(scope, false);
+
+                // 4. Set result[typedKey] to typedValue.
+                // Note: It's possible that typedKey is already in result if K is USVString and key contains unpaired surrogates.
+                if constexpr (std::is_same_v<K, IDLUSVString>) {
+                    if (!typedKey.is8Bit()) {
+                        auto addResult = resultMap.add(typedKey, result.size());
+                        if (!addResult.isNewEntry) {
+                            ASSERT(result[addResult.iterator->value].key == typedKey);
+                            result[addResult.iterator->value].value = WTFMove(typedValue);
+                            return true;
+                        }
+                    }
+                } else
+                    UNUSED_VARIABLE(resultMap);
+
+                // 5. Otherwise, append to result a mapping (typedKey, typedValue).
+                result.append({ WTFMove(typedKey), WTFMove(typedValue) });
+                return true;
+            });
+
+            RETURN_IF_EXCEPTION(scope, {});
+
+            return result;
+        }
+
         // 4. Let keys be ? O.[[OwnPropertyKeys]]().
         JSC::PropertyNameArray keys(vm, JSC::PropertyNameMode::StringsAndSymbols, JSC::PrivateSymbolMode::Exclude);
         object->methodTable()->getOwnPropertyNames(object, &lexicalGlobalObject, keys, JSC::DontEnumPropertiesMode::Include);

--- a/src/bun.js/bindings/webcore/JSDOMConvertRecord.h
+++ b/src/bun.js/bindings/webcore/JSDOMConvertRecord.h
@@ -123,7 +123,7 @@ private:
 
         if (canUseFastPath) {
             structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
-                if ((entry.attributes() & (PropertyAttribute::DontEnum))) {
+                if (entry.attributes() & PropertyAttribute::DontEnum) {
                     return true;
                 }
 

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -23,6 +23,19 @@ describe("Headers", () => {
       });
       expect(headers.get("content-type")).toBe("text/plain");
     });
+
+    test("deleted key in header constructor is not kept", () => {
+      const record = {
+        "content-type": "text/plain",
+        "user-agent": "bun",
+      };
+      // @ts-expect-error
+      delete record["content-type"];
+
+      const headers = new Headers(record);
+      expect(headers.get("content-type")).toBeNull();
+      expect(headers.get("user-agent")).toBe("bun");
+    });
     test("can create headers from object with duplicates", () => {
       const headers = new Headers({
         "accept": "*/*",


### PR DESCRIPTION
### What does this PR do?

This makes JDOMConvertRecord faster by using `structure()->forEachProperty`. `structure()->forEachProperty` can only be used when it's a regular object that cannot observe getters or has property.

This makes `new Headers` & `new URLSearchParams` faster when the input is an object. It does nothing for arrays and very little for empty objects.

![image](https://github.com/oven-sh/bun/assets/709451/05b656bb-b9f4-4e23-8941-ad30311301db)


### How did you verify your code works?

Existing tests + added one which was probably unnecessary