### PR TITLE
Tweaks to lifecycle script enqueue

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2797,7 +2797,9 @@ pub const PackageManager = struct {
 
     pub fn getInstalledVersionsFromDiskCache(this: *PackageManager, tags_buf: *std.ArrayList(u8), package_name: []const u8, allocator: std.mem.Allocator) !std.ArrayList(Semver.Version) {
         var list = std.ArrayList(Semver.Version).init(allocator);
-        var dir = this.getCacheDirectory().openDir(package_name, .{}) catch |err| switch (err) {
+        var dir = this.getCacheDirectory().openDir(package_name, .{
+            .iterate = true,
+        }) catch |err| switch (err) {
             error.FileNotFound, error.NotDir, error.AccessDenied, error.DeviceBusy => return list,
             else => return err,
         };
@@ -7598,7 +7600,7 @@ pub const PackageManager = struct {
                         }
                     }
                 } else |err| {
-                    if (err != error.FileNotFound) {
+                    if (err != error.ENOENT) {
                         Output.err(err, "while reading node_modules/.bin", .{});
                         Global.crash();
                     }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8235,19 +8235,12 @@ pub const PackageManager = struct {
                     break :brk Syscall.exists(binding_dot_gyp_path);
                 } else false;
 
-                const path_str = brk: {
-                    var base = Path.joinAbsStringBuf(
-                        node_modules_path,
-                        &path_buf_to_use,
-                        &[_]string{destination_dir_subpath},
-                        .posix,
-                    );
-
-                    base = strings.withoutTrailingSlash(base);
-                    path_buf_to_use[base.len] = std.fs.path.sep;
-                    path_buf_to_use[base.len + 1] = 0;
-                    break :brk path_buf_to_use[0 .. base.len + 1 :0];
-                };
+                const path_str = Path.joinAbsStringBufZTrailingSlash(
+                    node_modules_path,
+                    &path_buf_to_use,
+                    &[_]string{destination_dir_subpath},
+                    .posix,
+                );
 
                 if (scripts.enqueue(
                     this.lockfile,

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2432,6 +2432,7 @@ pub const Package = extern struct {
                 inline for (install_scripts) |hook| {
                     const script = @field(this, hook);
                     if (!script.isEmpty()) {
+                        debug("enqueue({s}, {s}) in {s}", .{ hook, package_name, _cwd });
                         const entry: Lockfile.Scripts.Entry = .{
                             .cwd = cwd orelse brk: {
                                 cwd = lockfile.allocator.dupe(u8, _cwd) catch unreachable;
@@ -2460,6 +2461,7 @@ pub const Package = extern struct {
                     inline for (prepare_scripts) |hook| {
                         const script = @field(this, hook);
                         if (!script.isEmpty()) {
+                            debug("enqueue({s}, {s}) in {s}", .{ hook, package_name, _cwd });
                             const entry: Lockfile.Scripts.Entry = .{
                                 .cwd = cwd orelse brk: {
                                     cwd = lockfile.allocator.dupe(u8, _cwd) catch unreachable;
@@ -2479,6 +2481,8 @@ pub const Package = extern struct {
                 .workspace => {
                     script_index += 1;
                     if (!this.prepare.isEmpty()) {
+                        debug("enqueue({s}, {s}) in {s}", .{ "prepare", package_name, _cwd });
+
                         const entry: Lockfile.Scripts.Entry = .{
                             .cwd = cwd orelse brk: {
                                 cwd = lockfile.allocator.dupe(u8, _cwd) catch unreachable;
@@ -2545,32 +2549,40 @@ pub const Package = extern struct {
             name: string,
             resolution: *const Resolution,
         ) !?Package.Scripts.List {
-            var path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+            var node_modules_path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+            const node_modules_path = try bun.getFdPath(bun.toFD(node_modules.fd), &node_modules_path_buf);
 
-            const cwd = Path.joinAbsString(
-                bun.getFdPath(bun.toFD(node_modules.fd), &path_buf) catch unreachable,
+            var path_buf2: [bun.MAX_PATH_BYTES]u8 = undefined;
+
+            const cwd = Path.joinAbsStringBufZTrailingSlash(
+                node_modules_path,
+                &path_buf2,
                 &[_]string{subpath},
                 .auto,
             );
 
-            const json_file_fd = try bun.sys.openat(
-                bun.toFD(node_modules.fd),
-                bun.path.joinZ([_]string{ subpath, "package.json" }, .auto),
-                std.os.O.RDONLY,
-                0,
-            ).unwrap();
-            const json_file = std.fs.File{ .handle = bun.fdcast(json_file_fd) };
-            defer json_file.close();
-            const json_stat_size = try json_file.getEndPos();
-            const json_buf = try lockfile.allocator.alloc(u8, json_stat_size + 64);
-            const json_len = try json_file.preadAll(json_buf, 0);
-            const json_src = logger.Source.initPathString(cwd, json_buf[0..json_len]);
-            initializeStore();
-            const json = try json_parser.ParseJSONUTF8(
-                &json_src,
-                log,
-                lockfile.allocator,
-            );
+            const json = brk: {
+                const json_path = bun.path.joinZ([_]string{ subpath, "package.json" }, .auto);
+                const json_file_fd = try bun.sys.openat(
+                    bun.toFD(node_modules.fd),
+                    json_path,
+                    std.os.O.RDONLY,
+                    0,
+                ).unwrap();
+                const json_file = std.fs.File{ .handle = bun.fdcast(json_file_fd) };
+                defer json_file.close();
+                const json_stat_size = try json_file.getEndPos();
+                const json_buf = try lockfile.allocator.alloc(u8, json_stat_size + 64);
+                errdefer lockfile.allocator.free(json_buf);
+                const json_len = try json_file.preadAll(json_buf, 0);
+                const json_src = logger.Source.initPathString(json_path, json_buf[0..json_len]);
+                initializeStore();
+                break :brk try json_parser.ParseJSONUTF8(
+                    &json_src,
+                    log,
+                    lockfile.allocator,
+                );
+            };
 
             var tmp: Lockfile = undefined;
             try tmp.initEmpty(lockfile.allocator);
@@ -2579,8 +2591,6 @@ pub const Package = extern struct {
             Lockfile.Package.Scripts.parseCount(lockfile.allocator, &builder, json);
             try builder.allocate();
             this.parseAlloc(lockfile.allocator, &builder, json);
-
-            const node_modules_path = bun.getFdPath(bun.toFD(node_modules.fd), &path_buf) catch unreachable;
 
             const add_node_gyp_rebuild_script = if (lockfile.hasTrustedDependency(name) and
                 this.install.isEmpty() and

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -1021,6 +1021,17 @@ pub fn joinAbsStringBufZ(cwd: []const u8, buf: []u8, _parts: anytype, comptime _
     return _joinAbsStringBuf(true, [:0]const u8, cwd, buf, _parts, _platform);
 }
 
+pub fn joinAbsStringBufZTrailingSlash(cwd: []const u8, buf: []u8, _parts: anytype, comptime _platform: Platform) [:0]const u8 {
+    const out = _joinAbsStringBuf(true, [:0]const u8, cwd, buf, _parts, _platform);
+    if (out.len + 2 < buf.len and out.len > 0 and out[out.len - 1] != _platform.separator()) {
+        buf[out.len] = _platform.separator();
+        buf[out.len + 1] = 0;
+        return buf[0 .. out.len + 1 :0];
+    }
+
+    return out;
+}
+
 fn _joinAbsStringBuf(comptime is_sentinel: bool, comptime ReturnType: type, _cwd: []const u8, buf: []u8, _parts: anytype, comptime _platform: Platform) ReturnType {
     if (_platform.resolve() == .windows) return _joinAbsStringBufWindows(is_sentinel, ReturnType, _cwd, buf, _parts);
 


### PR DESCRIPTION
### What does this PR do?

This hopefully helps with #8010, but I'm doubtful it fixes the issue

This makes it so that the current working directory passed to `readDirInfo` has a trailing slash, which is necessary. 

This also:
- Removes an extra call to `try bun.getFdPath`
- Adds more logging for lifecycle scripts in debug builds
- Gives us a way to force the usage of the /proc/ workaround in debug builds
- Closes the json file descriptor sooner

### How did you verify your code works?

Manually