### PR TITLE
Faster `Buffer.concat`, fixes #8034

### DIFF
--- a/bench/snippets/buffer-concat.mjs
+++ b/bench/snippets/buffer-concat.mjs
@@ -1,6 +1,6 @@
 import { bench, run } from "./runner.mjs";
 
-for (let size of [32, 2048, 1024 * 16, 1024 * 1024 * 2]) {
+for (let size of [32, 2048, 1024 * 16, 1024 * 1024 * 2, 1024 * 1024 * 16]) {
   const first = Buffer.allocUnsafe(size);
   const second = Buffer.allocUnsafe(size);
   const third = Buffer.allocUnsafe(size);

--- a/bench/snippets/buffer-concat.mjs
+++ b/bench/snippets/buffer-concat.mjs
@@ -1,6 +1,6 @@
 import { bench, run } from "./runner.mjs";
 
-for (let size of [32, 1837, 1024 * 6, 1024 * 1024 * 2 + 72, 1024 * 1024 * 16]) {
+for (let size of [32, 2048, 1024 * 16, 1024 * 1024 * 2]) {
   const first = Buffer.allocUnsafe(size);
   const second = Buffer.allocUnsafe(size);
   const third = Buffer.allocUnsafe(size);
@@ -43,5 +43,12 @@ for (let size of [32, 1837, 1024 * 6, 1024 * 1024 * 2 + 72, 1024 * 1024 * 16]) {
     },
   );
 }
+
+const chunk = Buffer.alloc(16);
+chunk.fill("3");
+const array = Array.from({ length: 100 }, () => chunk);
+bench("Buffer.concat 100 tiny chunks", () => {
+  return Buffer.concat(array);
+});
 
 await run();

--- a/bench/snippets/buffer-concat.mjs
+++ b/bench/snippets/buffer-concat.mjs
@@ -1,0 +1,47 @@
+import { bench, run } from "./runner.mjs";
+
+for (let size of [32, 1837, 1024 * 6, 1024 * 1024 * 2 + 72, 1024 * 1024 * 16]) {
+  const first = Buffer.allocUnsafe(size);
+  const second = Buffer.allocUnsafe(size);
+  const third = Buffer.allocUnsafe(size);
+  first.fill(1);
+  second.fill(2);
+  third.fill(3);
+
+  const check = true;
+
+  const buffers = [first, second, third];
+
+  const fmt =
+    size > 1024 * 1024
+      ? new Intl.NumberFormat(undefined, { unit: "megabyte", style: "unit" })
+      : size > 1024
+      ? new Intl.NumberFormat(undefined, { unit: "kilobyte", style: "unit" })
+      : new Intl.NumberFormat(undefined, { unit: "byte", style: "unit" });
+
+  bench(
+    `Buffer.concat(${fmt.format(
+      Number((size > 1024 * 1024 ? size / 1024 / 1024 : size > 1024 ? size / 1024 : size).toFixed(2)),
+    )} x 3)`,
+    () => {
+      const result = Buffer.concat(buffers);
+      if (check) {
+        if (result.byteLength != size * 3) throw new Error("Wrong length");
+        if (result[0] != 1) throw new Error("Wrong first byte");
+        if (result[size] != 2) throw new Error("Wrong second byte");
+        if (result[size * 2] != 3) throw new Error("Wrong third byte");
+
+        result[0] = 10;
+        if (first[0] != 1) throw new Error("First buffer was modified");
+
+        result[size] = 20;
+        if (second[0] != 2) throw new Error("Second buffer was modified");
+
+        result[size * 2] = 30;
+        if (third[0] != 3) throw new Error("Third buffer was modified");
+      }
+    },
+  );
+}
+
+await run();

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -1,6 +1,7 @@
+
 #include "root.h"
 #include "ZigGlobalObject.h"
-
+#include "JavaScriptCore/ArgList.h"
 #include "JSDOMURL.h"
 #include "helpers.h"
 #include "IDLTypes.h"
@@ -28,6 +29,7 @@
 #include "BunObject+exports.h"
 #include "JSDOMException.h"
 #include "JSDOMConvert.h"
+#include "wtf/Compiler.h"
 
 namespace Bun {
 
@@ -72,6 +74,15 @@ static inline JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBuffer(JSGlobalO
     bool any_buffer = false;
     bool any_typed = false;
 
+    // Use an argument buffer to avoid calling `getIndex` more than once per element.
+    // This is a small optimization
+    MarkedArgumentBuffer args;
+    args.ensureCapacity(arrayLength);
+    if (UNLIKELY(args.hasOverflowed())) {
+        throwOutOfMemoryError(lexicalGlobalObject, throwScope);
+        return JSValue::encode({});
+    }
+
     for (size_t i = 0; i < arrayLength; i++) {
         auto element = array->getIndex(lexicalGlobalObject, i);
         RETURN_IF_EXCEPTION(throwScope, {});
@@ -81,8 +92,13 @@ static inline JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBuffer(JSGlobalO
                 throwTypeError(lexicalGlobalObject, throwScope, "ArrayBufferView is detached"_s);
                 return JSValue::encode(jsUndefined());
             }
-            byteLength += typedArray->byteLength();
+            size_t current = typedArray->byteLength();
             any_typed = true;
+            byteLength += current;
+
+            if (current > 0) {
+                args.append(typedArray);
+            }
         } else if (auto* arrayBuffer = JSC::jsDynamicCast<JSC::JSArrayBuffer*>(element)) {
             auto* impl = arrayBuffer->impl();
             if (UNLIKELY(!impl)) {
@@ -90,8 +106,14 @@ static inline JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBuffer(JSGlobalO
                 return JSValue::encode(jsUndefined());
             }
 
-            byteLength += impl->byteLength();
+            size_t current = impl->byteLength();
             any_buffer = true;
+
+            if (current > 0) {
+                args.append(arrayBuffer);
+            }
+
+            byteLength += current;
         } else {
             throwTypeError(lexicalGlobalObject, throwScope, "Expected TypedArray"_s);
             return JSValue::encode(jsUndefined());
@@ -112,8 +134,8 @@ static inline JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBuffer(JSGlobalO
     auto* head = reinterpret_cast<char*>(buffer->data());
 
     if (!any_buffer) {
-        for (size_t i = 0; i < arrayLength && remain > 0; i++) {
-            auto element = array->getIndex(lexicalGlobalObject, i);
+        for (size_t i = 0; i < args.size(); i++) {
+            auto element = args.at(i);
             RETURN_IF_EXCEPTION(throwScope, {});
             auto* view = JSC::jsCast<JSC::JSArrayBufferView*>(element);
             size_t length = std::min(remain, view->byteLength());
@@ -122,8 +144,8 @@ static inline JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBuffer(JSGlobalO
             head += length;
         }
     } else if (!any_typed) {
-        for (size_t i = 0; i < arrayLength && remain > 0; i++) {
-            auto element = array->getIndex(lexicalGlobalObject, i);
+        for (size_t i = 0; i < args.size(); i++) {
+            auto element = args.at(i);
             RETURN_IF_EXCEPTION(throwScope, {});
             auto* view = JSC::jsCast<JSC::JSArrayBuffer*>(element);
             size_t length = std::min(remain, view->impl()->byteLength());
@@ -132,8 +154,8 @@ static inline JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBuffer(JSGlobalO
             head += length;
         }
     } else {
-        for (size_t i = 0; i < arrayLength && remain > 0; i++) {
-            auto element = array->getIndex(lexicalGlobalObject, i);
+        for (size_t i = 0; i < args.size(); i++) {
+            auto element = args.at(i);
             RETURN_IF_EXCEPTION(throwScope, {});
             size_t length = 0;
             if (auto* view = JSC::jsDynamicCast<JSC::JSArrayBuffer*>(element)) {

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -43,6 +43,7 @@
 #include <JavaScriptCore/BuiltinNames.h>
 
 #include "JSBufferEncodingType.h"
+#include "wtf/Assertions.h"
 #include <JavaScriptCore/JSBase.h>
 #if ENABLE(MEDIA_SOURCE)
 #include "BufferMediaSource.h"
@@ -852,11 +853,11 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JS
         auto* typedArray = JSC::jsCast<JSC::JSUint8Array*>(args.at(i));
         size_t length = std::min(remain, typedArray->length());
 
-        if (length > 0) {
-            auto* source = typedArray->typedVector();
-            ASSERT(source);
-            memcpy(head, source, length);
-        }
+        ASSERT_WITH_MESSAGE(length > 0, "length should be greater than 0. This should be checked before appending to the MarkedArgumentBuffer.");
+
+        auto* source = typedArray->typedVector();
+        ASSERT(source);
+        memcpy(head, source, length);
 
         remain -= length;
         head += length;

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -781,6 +781,8 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JS
 
     size_t byteLength = 0;
 
+    // Use an argument buffer to avoid calling `getIndex` more than once per element.
+    // This is a small optimization
     MarkedArgumentBuffer args;
     args.ensureCapacity(arrayLength);
     if (UNLIKELY(args.hasOverflowed())) {

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -779,6 +779,8 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JS
         RELEASE_AND_RETURN(throwScope, constructBufferEmpty(lexicalGlobalObject));
     }
 
+    JSValue totalLengthValue = callFrame->argument(1);
+
     size_t byteLength = 0;
 
     // Use an argument buffer to avoid calling `getIndex` more than once per element.
@@ -805,11 +807,14 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JS
             return JSValue::encode(jsUndefined());
         }
 
-        args.append(element);
-        byteLength += typedArray->length();
+        auto length = typedArray->length();
+
+        if (length > 0)
+            args.append(element);
+
+        byteLength += length;
     }
 
-    JSValue totalLengthValue = callFrame->argument(1);
     size_t availableLength = byteLength;
     if (!totalLengthValue.isUndefined()) {
         if (UNLIKELY(!totalLengthValue.isNumber())) {

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -1,5 +1,10 @@
+
 #include "root.h"
+
 #include "JSBuffer.h"
+
+#include "JavaScriptCore/ArgList.h"
+#include "JavaScriptCore/ExceptionScope.h"
 
 #include "ActiveDOMObject.h"
 #include "ExtendedDOMClientIsoSubspaces.h"
@@ -73,7 +78,6 @@ static JSC_DECLARE_HOST_FUNCTION(jsBufferConstructorFunction_concat);
 static JSC_DECLARE_HOST_FUNCTION(jsBufferConstructorFunction_from);
 static JSC_DECLARE_HOST_FUNCTION(jsBufferConstructorFunction_isBuffer);
 static JSC_DECLARE_HOST_FUNCTION(jsBufferConstructorFunction_isEncoding);
-static JSC_DECLARE_HOST_FUNCTION(jsBufferConstructorFunction_toBuffer);
 
 static JSC_DECLARE_HOST_FUNCTION(jsBufferPrototypeFunction_compare);
 static JSC_DECLARE_HOST_FUNCTION(jsBufferPrototypeFunction_copy);
@@ -90,35 +94,42 @@ static JSC_DECLARE_HOST_FUNCTION(jsBufferPrototypeFunction_write);
 
 static JSUint8Array* allocBuffer(JSC::JSGlobalObject* lexicalGlobalObject, size_t byteLength)
 {
+#if ASSERT_ENABLED
     JSC::VM& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+#endif
 
     auto* globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
     auto* subclassStructure = globalObject->JSBufferSubclassStructure();
 
     auto* uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, byteLength);
+#if ASSERT_ENABLED
     if (UNLIKELY(!uint8Array)) {
-        throwOutOfMemoryError(lexicalGlobalObject, throwScope);
-        return nullptr;
+        // it should have thrown an exception already
+        ASSERT(throwScope.exception());
     }
+#endif
 
     return uint8Array;
 }
 static JSUint8Array* allocBufferUnsafe(JSC::JSGlobalObject* lexicalGlobalObject, size_t byteLength)
 {
+
+#if ASSERT_ENABLED
     JSC::VM& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+#endif
 
-    auto* globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
-    auto* subclassStructure = globalObject->JSBufferSubclassStructure();
+    auto* result = createUninitializedBuffer(lexicalGlobalObject, byteLength);
 
-    auto* uint8Array = JSC::JSUint8Array::createUninitialized(lexicalGlobalObject, subclassStructure, byteLength);
-    if (UNLIKELY(!uint8Array)) {
-        throwOutOfMemoryError(lexicalGlobalObject, throwScope);
-        return nullptr;
+#if ASSERT_ENABLED
+    if (UNLIKELY(!result)) {
+        // it should have thrown an exception already
+        ASSERT(throwScope.exception());
     }
+#endif
 
-    return uint8Array;
+    return result;
 }
 
 // Normalize val to be an integer in the range of [1, -1] since
@@ -256,6 +267,44 @@ static inline JSC::EncodedJSValue writeToBuffer(JSC::JSGlobalObject* lexicalGlob
     return JSC::JSValue::encode(JSC::jsNumber(written));
 }
 
+JSC::JSUint8Array* createBuffer(JSC::JSGlobalObject* lexicalGlobalObject, const uint8_t* ptr, size_t length)
+{
+    auto* buffer = createUninitializedBuffer(lexicalGlobalObject, length);
+
+    if (LIKELY(ptr && length > 0 && buffer))
+        memcpy(buffer->typedVector(), ptr, length);
+
+    return buffer;
+}
+
+JSC::JSUint8Array* createBuffer(JSC::JSGlobalObject* lexicalGlobalObject, const std::span<const uint8_t> data)
+{
+    return createBuffer(lexicalGlobalObject, data.data(), data.size());
+}
+
+JSC::JSUint8Array* createBuffer(JSC::JSGlobalObject* lexicalGlobalObject, const char* ptr, size_t length)
+{
+    return createBuffer(lexicalGlobalObject, reinterpret_cast<const uint8_t*>(ptr), length);
+}
+
+JSC::JSUint8Array* createBuffer(JSC::JSGlobalObject* lexicalGlobalObject, const Vector<uint8_t>& data)
+{
+    return createBuffer(lexicalGlobalObject, data.data(), data.size());
+}
+
+JSC::JSUint8Array* createEmptyBuffer(JSC::JSGlobalObject* lexicalGlobalObject)
+{
+    return createUninitializedBuffer(lexicalGlobalObject, 0);
+}
+
+JSC::JSUint8Array* createUninitializedBuffer(JSC::JSGlobalObject* lexicalGlobalObject, size_t length)
+{
+    auto* globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
+    auto* subclassStructure = globalObject->JSBufferSubclassStructure();
+
+    return JSC::JSUint8Array::createUninitialized(lexicalGlobalObject, subclassStructure, length);
+}
+
 static inline JSC::JSUint8Array* JSBuffer__bufferFromLengthAsArray(JSC::JSGlobalObject* lexicalGlobalObject, int64_t length)
 {
     auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject->vm());
@@ -265,16 +314,9 @@ static inline JSC::JSUint8Array* JSBuffer__bufferFromLengthAsArray(JSC::JSGlobal
         return nullptr;
     }
 
-    JSC::JSUint8Array* uint8Array = nullptr;
-
     auto* globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
     auto* subclassStructure = globalObject->JSBufferSubclassStructure();
-
-    if (LIKELY(length > 0)) {
-        uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, length);
-    } else {
-        uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, 0);
-    }
+    JSC::JSUint8Array* uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, static_cast<size_t>(length));
 
     RELEASE_AND_RETURN(throwScope, uint8Array);
 }
@@ -294,27 +336,22 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_allocUnsafeBody(JS
     if (callFrame->argumentCount() < 1)
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
 
-    auto length = callFrame->uncheckedArgument(0).toInt32(lexicalGlobalObject);
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(allocBufferUnsafe(lexicalGlobalObject, length)));
-}
-
-EncodedJSValue JSBuffer__bufferFromPointerAndLength(JSC::JSGlobalObject* lexicalGlobalObject, const unsigned char* ptr, size_t length)
-{
-
-    JSC::JSUint8Array* uint8Array;
-
-    auto* globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
-    auto* subclassStructure = globalObject->JSBufferSubclassStructure();
-
-    if (LIKELY(length > 0)) {
-        auto buffer = ArrayBuffer::create(ptr, length);
-
-        uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, WTFMove(buffer), 0, length);
-    } else {
-        uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, 0);
+    JSValue lengthValue = callFrame->uncheckedArgument(0);
+    if (UNLIKELY(!lengthValue.isNumber())) {
+        throwTypeError(lexicalGlobalObject, throwScope, "size argument must be a number"_s);
+        return {};
     }
 
-    return JSC::JSValue::encode(uint8Array);
+    double lengthDouble = lengthValue.toIntegerWithTruncation(lexicalGlobalObject);
+
+    if (UNLIKELY(lengthDouble < 0 || lengthDouble > UINT_MAX)) {
+        throwRangeError(lexicalGlobalObject, throwScope, "Buffer size must be 0...4294967295"_s);
+        return {};
+    }
+
+    size_t length = static_cast<size_t>(lengthDouble);
+
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(allocBufferUnsafe(lexicalGlobalObject, length)));
 }
 
 // new Buffer()
@@ -350,7 +387,7 @@ static JSC::EncodedJSValue constructFromEncoding(JSGlobalObject* lexicalGlobalOb
         }
         case WebCore::BufferEncodingType::ascii: // ascii is a noop for latin1
         case WebCore::BufferEncodingType::latin1: { // The native encoding is latin1, so we don't need to do any conversion.
-            result = JSBuffer__bufferFromPointerAndLength(lexicalGlobalObject, view.characters8(), view.length());
+            result = JSValue::encode(createBuffer(lexicalGlobalObject, view.characters8(), view.length()));
             break;
         }
         default: {
@@ -372,7 +409,7 @@ static JSC::EncodedJSValue constructFromEncoding(JSGlobalObject* lexicalGlobalOb
         case WebCore::BufferEncodingType::utf16le: {
             // The native encoding is UTF-16
             // so we don't need to do any conversion.
-            result = JSBuffer__bufferFromPointerAndLength(lexicalGlobalObject, reinterpret_cast<const unsigned char*>(view.characters16()), view.length() * 2);
+            result = JSValue::encode(createBuffer(lexicalGlobalObject, reinterpret_cast<const unsigned char*>(view.characters16()), view.length() * 2));
             break;
         }
         default: {
@@ -428,23 +465,26 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_allocBody(JSC::JSG
 {
     VM& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto lengthArg = callFrame->uncheckedArgument(0);
-    if (UNLIKELY(!lengthArg.isNumber())) {
-        throwTypeError(lexicalGlobalObject, scope, "Expected number"_s);
-        return JSValue::encode(jsUndefined());
-    }
-    auto length = lengthArg.toInt32(lexicalGlobalObject);
-    if (length < 0) {
-        throwRangeError(lexicalGlobalObject, scope, "Invalid array length"_s);
-        return JSValue::encode(jsUndefined());
+    JSValue lengthValue = callFrame->uncheckedArgument(0);
+    if (UNLIKELY(!lengthValue.isNumber())) {
+        throwTypeError(lexicalGlobalObject, scope, "size argument must be a number"_s);
+        return {};
     }
 
-    auto* globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
-    auto* subclassStructure = globalObject->JSBufferSubclassStructure();
+    double lengthDouble = lengthValue.toIntegerWithTruncation(lexicalGlobalObject);
+
+    if (UNLIKELY(lengthDouble < 0 || lengthDouble > UINT_MAX)) {
+        throwRangeError(lexicalGlobalObject, scope, "Buffer size must be 0...4294967295"_s);
+        return {};
+    }
+
+    size_t length = static_cast<size_t>(lengthDouble);
 
     // fill argument
     if (UNLIKELY(callFrame->argumentCount() > 1)) {
-        auto* uint8Array = JSC::JSUint8Array::createUninitialized(lexicalGlobalObject, subclassStructure, length);
+        auto* uint8Array = createUninitializedBuffer(lexicalGlobalObject, length);
+        RETURN_IF_EXCEPTION(scope, {});
+
         auto value = callFrame->argument(1);
 
         if (value.isString()) {
@@ -511,13 +551,7 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_allocBody(JSC::JSG
 
         RELEASE_AND_RETURN(scope, JSC::JSValue::encode(uint8Array));
     } else {
-        auto* uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, length);
-        if (UNLIKELY(!uint8Array)) {
-            throwOutOfMemoryError(lexicalGlobalObject, scope);
-            return JSC::JSValue::encode(jsUndefined());
-        }
-
-        RELEASE_AND_RETURN(scope, JSC::JSValue::encode(uint8Array));
+        RELEASE_AND_RETURN(scope, JSValue::encode(allocBuffer(lexicalGlobalObject, length)));
     }
 }
 
@@ -747,7 +781,14 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JS
 
     size_t byteLength = 0;
 
-    for (size_t i = 0; i < arrayLength; i++) {
+    MarkedArgumentBuffer args;
+    args.ensureCapacity(arrayLength);
+    if (UNLIKELY(args.hasOverflowed())) {
+        throwOutOfMemoryError(lexicalGlobalObject, throwScope);
+        return JSValue::encode(jsUndefined());
+    }
+
+    for (unsigned i = 0; i < arrayLength; i++) {
         auto element = array->getIndex(lexicalGlobalObject, i);
         RETURN_IF_EXCEPTION(throwScope, {});
 
@@ -756,10 +797,18 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JS
             throwTypeError(lexicalGlobalObject, throwScope, "Buffer.concat expects Uint8Array"_s);
             return JSValue::encode(jsUndefined());
         }
+
+        if (UNLIKELY(typedArray->isDetached())) {
+            throwVMTypeError(lexicalGlobalObject, throwScope, "Uint8Array is detached"_s);
+            return JSValue::encode(jsUndefined());
+        }
+
+        args.append(element);
         byteLength += typedArray->length();
     }
 
     JSValue totalLengthValue = callFrame->argument(1);
+    size_t availableLength = byteLength;
     if (!totalLengthValue.isUndefined()) {
         if (UNLIKELY(!totalLengthValue.isNumber())) {
             throwTypeError(lexicalGlobalObject, throwScope, "totalLength must be a valid number"_s);
@@ -775,16 +824,33 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JS
         RELEASE_AND_RETURN(throwScope, constructBufferEmpty(lexicalGlobalObject));
     }
 
-    JSC::JSUint8Array* outBuffer = JSBuffer__bufferFromLengthAsArray(lexicalGlobalObject, byteLength);
+    JSC::JSUint8Array* outBuffer = byteLength <= availableLength
+        ?
+        // all pages will be copied in, so we can use uninitialized buffer
+        createUninitializedBuffer(lexicalGlobalObject, byteLength)
+        :
+        // there will be some data that needs to be zeroed out
+        // let's let the operating system do that for us
+        allocBuffer(lexicalGlobalObject, byteLength);
+
+    if (!outBuffer) {
+        ASSERT(throwScope.exception());
+        return JSValue::encode({});
+    }
+
     size_t remain = byteLength;
     auto* head = outBuffer->typedVector();
-
-    for (size_t i = 0; i < arrayLength && remain > 0; i++) {
-        auto element = array->getIndex(lexicalGlobalObject, i);
-        RETURN_IF_EXCEPTION(throwScope, {});
-        auto* typedArray = JSC::jsCast<JSC::JSUint8Array*>(element);
+    const int arrayLengthI = arrayLength;
+    for (int i = 0; i < arrayLengthI && remain > 0; i++) {
+        auto* typedArray = JSC::jsCast<JSC::JSUint8Array*>(args.at(i));
         size_t length = std::min(remain, typedArray->length());
-        memcpy(head, typedArray->typedVector(), length);
+
+        if (length > 0) {
+            auto* source = typedArray->typedVector();
+            ASSERT(source);
+            memcpy(head, source, length);
+        }
+
         remain -= length;
         head += length;
     }
@@ -801,31 +867,6 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_isEncodingBody(JSC
 
     std::optional<BufferEncodingType> encoded = parseEnumeration<BufferEncodingType>(*lexicalGlobalObject, encoding_);
     return JSValue::encode(jsBoolean(!!encoded));
-}
-
-static inline JSC::EncodedJSValue jsBufferConstructorFunction_toBufferBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
-{
-    auto& vm = JSC::getVM(lexicalGlobalObject);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(callFrame->argumentCount() < 1)) {
-        throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
-        return JSValue::encode(jsUndefined());
-    }
-
-    auto buffer = callFrame->uncheckedArgument(0);
-    if (!buffer.isCell() || !JSC::isTypedView(buffer.asCell()->type())) {
-        throwVMTypeError(lexicalGlobalObject, throwScope, "Expected Uint8Array"_s);
-        return JSValue::encode(jsUndefined());
-    }
-
-    JSC::JSUint8Array* view = JSC::jsDynamicCast<JSC::JSUint8Array*>(buffer);
-
-    if (!view) {
-        throwVMTypeError(lexicalGlobalObject, throwScope, "Expected Uint8Array"_s);
-        return JSValue::encode(jsUndefined());
-    }
-    toBuffer(lexicalGlobalObject, view);
-    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(view));
 }
 
 class JSBufferPrototype : public JSC::JSNonFinalObject {
@@ -1693,11 +1734,6 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferConstructorFunction_byteLength, (JSGlobalObject
     return jsBufferConstructorFunction_byteLengthBody(lexicalGlobalObject, callFrame);
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsBufferConstructorFunction_toBuffer, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
-{
-    return jsBufferConstructorFunction_toBufferBody(lexicalGlobalObject, callFrame);
-}
-
 class JSBufferConstructor final : public JSC::InternalFunction {
 public:
     using Base = JSC::InternalFunction;
@@ -2011,7 +2047,6 @@ static const JSC::DOMJIT::Signature DOMJITSignaturejsBufferConstructorAllocUnsaf
     concat          jsBufferConstructorFunction_concat             Function 2
     from            JSBuiltin                                      Builtin|Function 1
     isBuffer        JSBuiltin                                      Builtin|Function 1
-    toBuffer        jsBufferConstructorFunction_toBuffer           Function 1
     isEncoding      jsBufferConstructorFunction_isEncoding         Function 1
 @end
 */
@@ -2045,11 +2080,6 @@ JSC::JSObject* createBufferConstructor(JSC::VM& vm, JSC::JSGlobalObject* globalO
 }
 
 } // namespace WebCore
-
-// this is now a no-op
-void toBuffer(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSUint8Array* uint8Array)
-{
-}
 
 JSC_DEFINE_HOST_FUNCTION(constructJSBuffer, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
@@ -2097,10 +2127,9 @@ JSC_DEFINE_HOST_FUNCTION(constructJSBuffer, (JSC::JSGlobalObject * lexicalGlobal
                 return JSValue::encode({});
             }
 
-            auto* subclassStructure = globalObject->JSBufferSubclassStructure();
-            auto* uint8Array = JSC::JSUint8Array::createUninitialized(lexicalGlobalObject, subclassStructure, byteLength);
+            auto* uint8Array = createUninitializedBuffer(lexicalGlobalObject, byteLength);
             if (UNLIKELY(!uint8Array)) {
-                throwOutOfMemoryError(globalObject, throwScope);
+                ASSERT(throwScope.exception());
                 return JSValue::encode({});
             }
 
@@ -2126,16 +2155,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSBuffer, (JSC::JSGlobalObject * lexicalGlobal
                 return JSValue::encode({});
             }
 
-            auto* subclassStructure = globalObject->JSBufferSubclassStructure();
-            auto* uint8Array = JSC::JSUint8Array::createUninitialized(lexicalGlobalObject, subclassStructure, byteLength);
-            if (UNLIKELY(!uint8Array)) {
-                throwOutOfMemoryError(globalObject, throwScope);
-                return JSValue::encode({});
-            }
-
-            if (byteLength) {
-                memcpy(uint8Array->vector(), data, byteLength);
-            }
+            auto* uint8Array = createBuffer(lexicalGlobalObject, static_cast<uint8_t*>(data), byteLength);
 
             RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(uint8Array));
         }
@@ -2222,7 +2242,6 @@ JSC_DEFINE_HOST_FUNCTION(constructJSBuffer, (JSC::JSGlobalObject * lexicalGlobal
 bool JSBuffer__isBuffer(JSC::JSGlobalObject* lexicalGlobalObject, JSC::EncodedJSValue value)
 {
     JSC::VM& vm = lexicalGlobalObject->vm();
-    auto clientData = WebCore::clientData(vm);
 
     JSC::JSValue jsValue = JSC::JSValue::decode(value);
     if (!jsValue || !jsValue.isCell())

--- a/src/bun.js/bindings/JSBuffer.h
+++ b/src/bun.js/bindings/JSBuffer.h
@@ -35,11 +35,14 @@ extern "C" JSC::EncodedJSValue Bun__encoding__toStringUTF8(const uint8_t* input,
 extern "C" bool Bun__Buffer_fill(ZigString*, void*, size_t, WebCore::BufferEncodingType);
 extern "C" bool JSBuffer__isBuffer(JSC::JSGlobalObject*, JSC::EncodedJSValue);
 
-void toBuffer(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSUint8Array* uint8Array);
-JSC::JSValue makeBuffer(JSC::JSGlobalObject* lexicalGlobalObject, unsigned int byteLength);
-JSC::JSValue makeBufferUnsafe(JSC::JSGlobalObject* lexicalGlobalObject, unsigned int byteLength);
-
 namespace WebCore {
+
+JSC::JSUint8Array* createUninitializedBuffer(JSC::JSGlobalObject* lexicalGlobalObject, size_t length);
+JSC::JSUint8Array* createBuffer(JSC::JSGlobalObject* lexicalGlobalObject, const uint8_t* data, size_t length);
+JSC::JSUint8Array* createBuffer(JSC::JSGlobalObject* lexicalGlobalObject, const Vector<uint8_t>& data);
+JSC::JSUint8Array* createBuffer(JSC::JSGlobalObject* lexicalGlobalObject, const std::span<const uint8_t> data);
+JSC::JSUint8Array* createBuffer(JSC::JSGlobalObject* lexicalGlobalObject, const char* ptr, size_t length);
+JSC::JSUint8Array* createEmptyBuffer(JSC::JSGlobalObject* lexicalGlobalObject);
 
 JSC::EncodedJSValue constructSlowBuffer(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame);
 JSC::JSObject* createBufferPrototype(JSC::VM&, JSC::JSGlobalObject*);

--- a/src/bun.js/bindings/KeyObject.cpp
+++ b/src/bun.js/bindings/KeyObject.cpp
@@ -1369,11 +1369,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
             return JSC::JSValue::encode(JSC::JSValue {});
         }
         auto resultData = result.releaseReturnValue();
-        auto size = resultData.size();
-        auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-        if (size > 0)
-            memcpy(buffer->vector(), resultData.data(), size);
-
+        auto* buffer = createBuffer(globalObject, resultData);
         return JSC::JSValue::encode(buffer);
     }
     case CryptoKeyClass::OKP: {
@@ -1384,11 +1380,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
             return JSC::JSValue::encode(JSC::JSValue {});
         }
         auto resultData = result.releaseReturnValue();
-        auto size = resultData.size();
-        auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-        if (size > 0)
-            memcpy(buffer->vector(), resultData.data(), size);
-
+        auto* buffer = WebCore::createBuffer(globalObject, resultData);
         return JSC::JSValue::encode(buffer);
     }
     case CryptoKeyClass::EC: {
@@ -1424,11 +1416,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
             return JSC::JSValue::encode(JSC::JSValue {});
         }
         auto resultData = result.releaseReturnValue();
-        auto size = resultData.size();
-        auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-        if (size > 0)
-            memcpy(buffer->vector(), resultData.data(), size);
-
+        auto* buffer = WebCore::createBuffer(globalObject, resultData);
         return JSC::JSValue::encode(buffer);
     }
     case CryptoKeyClass::RSA: {
@@ -1447,10 +1435,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
                 return JSC::JSValue::encode(JSC::JSValue {});
             }
             auto resultData = result.releaseReturnValue();
-            auto size = resultData.size();
-            auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-            if (size > 0)
-                memcpy(buffer->vector(), resultData.data(), size);
+            auto* buffer = WebCore::createBuffer(globalObject, resultData);
 
             return JSC::JSValue::encode(buffer);
         }
@@ -1496,10 +1481,7 @@ JSC::EncodedJSValue KeyObject__Sign(JSC::JSGlobalObject* globalObject, JSC::Call
                 return JSC::JSValue::encode(JSC::JSValue {});
             }
             auto resultData = result.releaseReturnValue();
-            auto size = resultData.size();
-            auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-            if (size > 0)
-                memcpy(buffer->vector(), resultData.data(), size);
+            auto* buffer = WebCore::createBuffer(globalObject, resultData);
 
             return JSC::JSValue::encode(buffer);
         }
@@ -1776,10 +1758,7 @@ JSC::EncodedJSValue KeyObject__Exports(JSC::JSGlobalObject* globalObject, JSC::C
             const auto& hmac = downcast<WebCore::CryptoKeyHMAC>(wrapped);
             if (string == "buffer"_s) {
                 auto keyData = hmac.key();
-                auto size = keyData.size();
-                auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-                if (size > 0)
-                    memcpy(buffer->vector(), keyData.data(), size);
+                auto* buffer = createBuffer(globalObject, keyData);
 
                 return JSC::JSValue::encode(buffer);
             } else if (string == "jwk"_s) {
@@ -1793,10 +1772,7 @@ JSC::EncodedJSValue KeyObject__Exports(JSC::JSGlobalObject* globalObject, JSC::C
             const auto& aes = downcast<WebCore::CryptoKeyAES>(wrapped);
             if (string == "buffer"_s) {
                 auto keyData = aes.key();
-                auto size = keyData.size();
-                auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-                if (size > 0)
-                    memcpy(buffer->vector(), keyData.data(), size);
+                auto* buffer = createBuffer(globalObject, keyData);
 
                 return JSC::JSValue::encode(buffer);
             } else if (string == "jwk"_s) {
@@ -1976,7 +1952,7 @@ JSC::EncodedJSValue KeyObject__Exports(JSC::JSGlobalObject* globalObject, JSC::C
                     }
                 }
 
-                BUF_MEM* bptr;
+                BUF_MEM* bptr = nullptr;
                 BIO_get_mem_ptr(bio, &bptr);
                 auto length = bptr->length;
                 if (string == "pem"_s) {
@@ -1984,9 +1960,7 @@ JSC::EncodedJSValue KeyObject__Exports(JSC::JSGlobalObject* globalObject, JSC::C
                     return JSValue::encode(JSC::jsString(vm, str));
                 }
 
-                auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, length)));
-                if (length > 0)
-                    memcpy(buffer->vector(), bptr->data, length);
+                auto* buffer = createBuffer(globalObject, bptr->data, length);
 
                 BIO_free(bio);
                 return JSC::JSValue::encode(buffer);
@@ -2147,7 +2121,7 @@ JSC::EncodedJSValue KeyObject__Exports(JSC::JSGlobalObject* globalObject, JSC::C
                     }
                 }
 
-                BUF_MEM* bptr;
+                BUF_MEM* bptr = nullptr;
                 BIO_get_mem_ptr(bio, &bptr);
                 auto length = bptr->length;
                 if (string == "pem"_s) {
@@ -2155,9 +2129,7 @@ JSC::EncodedJSValue KeyObject__Exports(JSC::JSGlobalObject* globalObject, JSC::C
                     return JSValue::encode(JSC::jsString(vm, str));
                 }
 
-                auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, length)));
-                if (length > 0)
-                    memcpy(buffer->vector(), bptr->data, length);
+                auto* buffer = createBuffer(globalObject, bptr->data, length);
 
                 BIO_free(bio);
                 return JSC::JSValue::encode(buffer);
@@ -2320,7 +2292,7 @@ JSC::EncodedJSValue KeyObject__Exports(JSC::JSGlobalObject* globalObject, JSC::C
                     }
                 }
 
-                BUF_MEM* bptr;
+                BUF_MEM* bptr = nullptr;
                 BIO_get_mem_ptr(bio, &bptr);
                 auto length = bptr->length;
                 if (string == "pem"_s) {
@@ -2329,9 +2301,7 @@ JSC::EncodedJSValue KeyObject__Exports(JSC::JSGlobalObject* globalObject, JSC::C
                     return JSValue::encode(JSC::jsString(vm, str));
                 }
 
-                auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, length)));
-                if (length > 0)
-                    memcpy(buffer->vector(), bptr->data, length);
+                auto* buffer = WebCore::createBuffer(globalObject, { bptr->data, length });
 
                 BIO_free(bio);
                 EVP_PKEY_free(evpKey);
@@ -2342,12 +2312,7 @@ JSC::EncodedJSValue KeyObject__Exports(JSC::JSGlobalObject* globalObject, JSC::C
             const auto& raw = downcast<WebCore::CryptoKeyRaw>(wrapped);
             if (string == "buffer"_s) {
                 auto keyData = raw.key();
-                auto size = keyData.size();
-                auto* buffer = jsCast<JSUint8Array*>(JSValue::decode(JSBuffer__bufferFromLength(globalObject, size)));
-                if (size > 0)
-                    memcpy(buffer->vector(), keyData.data(), size);
-
-                return JSC::JSValue::encode(buffer);
+                return JSC::JSValue::encode(WebCore::createBuffer(globalObject, keyData));
             }
 
             JSC::throwTypeError(globalObject, scope, "format is expected to be 'buffer'"_s);

--- a/src/bun.js/bindings/webcore/WebSocket.h
+++ b/src/bun.js/bindings/webcore/WebSocket.h
@@ -131,7 +131,7 @@ public:
 
     void didReceiveMessage(String&& message);
     void didReceiveData(const char* data, size_t length);
-    void didReceiveBinaryData(const AtomString& eventName, Vector<uint8_t>&& binaryData);
+    void didReceiveBinaryData(const AtomString& eventName, const std::span<const uint8_t> binaryData);
 
     void updateHasPendingActivity();
     bool hasPendingActivity() const

--- a/test/js/node/buffer-concat.test.ts
+++ b/test/js/node/buffer-concat.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test";
+
+test("Buffer.concat throws OutOfMemoryError", () => {
+  const bufferToUse = Buffer.allocUnsafe(1024 * 1024 * 64);
+  const buffers = new Array(1024);
+  for (let i = 0; i < buffers.length; i++) {
+    buffers[i] = bufferToUse;
+  }
+
+  expect(() => Buffer.concat(buffers)).toThrow(/out of memory/i);
+});
+
+test("Bun.concatArrayBuffers throws OutOfMemoryError", () => {
+  const bufferToUse = Buffer.allocUnsafe(1024 * 1024 * 64);
+  const buffers = new Array(1024);
+  for (let i = 0; i < buffers.length; i++) {
+    buffers[i] = bufferToUse;
+  }
+
+  expect(() => Bun.concatArrayBuffers(buffers)).toThrow(/Failed to allocate/i);
+});

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1361,6 +1361,32 @@ it("Buffer.concat", () => {
   );
 });
 
+it("Buffer.concat huge", () => {
+  // largest page size of any supported platform.
+  const PAGE = 64 * 1024;
+
+  var array1 = Buffer.allocUnsafe(PAGE);
+  array1.fill("a");
+  var array2 = Buffer.allocUnsafe(PAGE);
+  array2.fill("b");
+  var array3 = Buffer.allocUnsafe(PAGE);
+  array3.fill("c");
+
+  const complete = array1.toString("hex") + array2.toString("hex") + array3.toString("hex");
+  const out = Buffer.concat([array1, array2, array3]);
+  expect(out.toString("hex")).toBe(complete);
+
+  const out2 = Buffer.concat([array1, array2, array3], PAGE);
+  expect(out2.toString("hex")).toBe(array1.toString("hex"));
+
+  const out3 = Buffer.concat([array1, array2, array3], PAGE * 1.5);
+  const out3hex = out3.toString("hex");
+  expect(out3hex).toBe(array1.toString("hex") + array2.slice(0, PAGE * 0.5).toString("hex"));
+
+  array1.fill("d");
+  expect(out3.toString("hex")).toBe(out3hex);
+});
+
 it("read", () => {
   var buf = new Buffer(1024);
   var data = new DataView(buf.buffer);


### PR DESCRIPTION
### What does this PR do?

Fixes #8034

Along the way, `Buffer.concat` gets 15% - 400% faster, depending on the input size

<img width="696" alt="image" src="https://github.com/oven-sh/bun/assets/709451/dd9a3241-18c7-44dc-a268-e30895c99df0">


### How did you verify your code works?

Tests