### PR TITLE
support lockfile-only option for bun install and bun update

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -92,10 +92,10 @@ _bun_completions() {
     PACKAGE_OPTIONS[REMOVE_OPTIONS_LONG]="";
     PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]="";
 
-    PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --global --cwd --backend --link-native-bins --help";
+    PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --global --cwd --backend --link-native-bins --lockfile-only --help";
     PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]="-c -y -p -f -g";
 
-    PM_OPTIONS[LONG_OPTIONS]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --no-progress --no-summary --no-verify --ignore-scripts --global --cwd --backend --link-native-bins --help"
+    PM_OPTIONS[LONG_OPTIONS]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --no-progress --no-summary --no-verify --ignore-scripts --global --cwd --backend --link-native-bins --lockfile-only --help"
     PM_OPTIONS[SHORT_OPTIONS]="-c -y -p -f -g"
 
     local cur_word="${COMP_WORDS[${COMP_CWORD}]}";

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -29,6 +29,7 @@ _bun_add_completion() {
         '--cwd[Set a specific cwd]:cwd' \
         '--backend[Platform-specific optimizations for installing dependencies]:backend:("copyfile" "hardlink" "symlink")' \
         '--link-native-bins[Link "bin" from a matching platform-specific dependency instead. Default: esbuild, turbo]:link-native-bins' \
+        '--lockfile-only[Only bun.lockb is updated]' \
         '--help[Print this help menu]' \
         '--dev[Add dependence to "devDependencies]' \
         '-d[Add dependence to "devDependencies]' \
@@ -79,6 +80,7 @@ _bun_unlink_completion() {
         '--cwd[Set a specific cwd]:cwd' \
         '--backend[Platform-specific optimizations for installing dependencies]:backend:("copyfile" "hardlink" "symlink")' \
         '--link-native-bins[Link "bin" from a matching platform-specific dependency instead. Default: esbuild, turbo]:link-native-bins' \
+        '--lockfile-only[Only bun.lockb is updated]' \
         '--help[Print this help menu]' &&
         ret=0
 
@@ -123,6 +125,7 @@ _bun_link_completion() {
         '--cwd[Set a specific cwd]:cwd' \
         '--backend[Platform-specific optimizations for installing dependencies]:backend:("copyfile" "hardlink" "symlink")' \
         '--link-native-bins[Link "bin" from a matching platform-specific dependency instead. Default: esbuild, turbo]:link-native-bins' \
+        '--lockfile-only[Only bun.lockb is updated]' \
         '--help[Print this help menu]' &&
         ret=0
 
@@ -333,6 +336,7 @@ _bun_install_completion() {
         '--cwd[Set a specific cwd]:cwd' \
         '--backend[Platform-specific optimizations for installing dependencies]:backend:("copyfile" "hardlink" "symlink")' \
         '--link-native-bins[Link "bin" from a matching platform-specific dependency instead. Default: esbuild, turbo]:link-native-bins' \
+        '--lockfile-only[Only bun.lockb is updated]' \
         '--help[Print this help menu]' \
         '--dev[Add dependence to "devDependencies]' \
         '-d[Add dependence to "devDependencies]' \
@@ -379,6 +383,7 @@ _bun_remove_completion() {
         '--cwd[Set a specific cwd]:cwd' \
         '--backend[Platform-specific optimizations for installing dependencies]:backend:("copyfile" "hardlink" "symlink")' \
         '--link-native-bins[Link "bin" from a matching platform-specific dependency instead. Default: esbuild, turbo]:link-native-bins' \
+        '--lockfile-only[Only bun.lockb is updated]' \
         '--help[Print this help menu]' &&
         ret=0
 
@@ -551,6 +556,7 @@ _bun_update_completion() {
         '--cwd[Set a specific cwd]:cwd' \
         '--backend[Platform-specific optimizations for installing dependencies]:backend:("copyfile" "hardlink" "symlink")' \
         '--link-native-bins[Link "bin" from a matching platform-specific dependency instead. Default: esbuild, turbo]:link-native-bins' \
+        '--lockfile-only[Only bun.lockb is updated]' \
         '--help[Print this help menu]' &&
         ret=0
 

--- a/completions/spec.yaml
+++ b/completions/spec.yaml
@@ -121,6 +121,7 @@ subcommands:
       - frozen-lockfile -- "Disallow changes to lockfile"
       - no-save --
       - dry-run -- "Don't install anything"
+      - lockfile-only -- "Only bun.lockb is updated"
       - force -- "Always request the latest versions from the registry & reinstall all dependencies"
       - name: cache-dir
         type: string
@@ -137,6 +138,7 @@ subcommands:
         enum: ["clonefile", "copyfile", "hardlink", "clonefile_each_dir"]
       - name: link-native-bins
         summary: 'Link "bin" from a matching platform-specific dependency instead. Default: esbuild, turbo'
+      - lockfile-only -- "Only bun.lockb is updated"
   add:
     summary: Add a dependency to package.json
     options:
@@ -173,6 +175,7 @@ subcommands:
         enum: ["clonefile", "copyfile", "hardlink", "clonefile_each_dir"]
       - name: link-native-bins
         summary: 'Link "bin" from a matching platform-specific dependency instead. Default: esbuild, turbo'
+      - lockfile-only -- "Only bun.lockb is updated"
     parameters:
       - name: package
         multiple: true
@@ -210,6 +213,7 @@ subcommands:
         enum: ["clonefile", "copyfile", "hardlink", "clonefile_each_dir"]
       - name: link-native-bins
         summary: 'Link "bin" from a matching platform-specific dependency instead. Default: esbuild, turbo'
+      - lockfile-only -- "Only bun.lockb is updated"
     parameters:
       - name: package
         multiple: true

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -130,6 +130,20 @@ $ bun install --frozen-lockfile
 
 For more information on Bun's binary lockfile `bun.lockb`, refer to [Package manager > Lockfile](/docs/install/lockfile).
 
+## Lockfile only
+
+To perform a bun.lockb update without installing any packages or updating package.json
+
+```bash
+$ bun install --lockfile-only
+```
+
+or
+
+```bash
+$ bun update --lockfile-only
+```
+
 ## Dry run
 
 To perform a dry run (i.e. don't actually install anything):
@@ -175,6 +189,9 @@ production = false
 
 # equivalent to `--frozen-lockfile` flag
 frozenLockfile = false
+
+# equivalent to `--lockfile-only` flag
+lockfileOnly = false
 
 # equivalent to `--dry-run` flag
 dryRun = false

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -55,6 +55,18 @@ To install dependencies without allowing changes to lockfile (useful on CI):
 $ bun install --frozen-lockfile
 ```
 
+To perform a bun.lockb update without installing any packages or updating package.json
+
+```bash
+$ bun install --lockfile-only
+```
+
+or
+
+```bash
+$ bun update --lockfile-only
+```
+
 To perform a dry run (i.e. don't actually install anything):
 
 ```bash
@@ -88,6 +100,9 @@ production = false
 
 # equivalent to `--frozen-lockfile` flag
 frozenLockfile = false
+
+# equivalent to `--lockfile-only` flag
+lockfileOnly = false
 
 # equivalent to `--dry-run` flag
 dryRun = false

--- a/docs/runtime/bunfig.md
+++ b/docs/runtime/bunfig.md
@@ -320,6 +320,15 @@ Whether `bun install` will actually install dependencies. Default `false`. When 
 dryRun = false
 ```
 
+### `install.lockfileOnly`
+
+When true, it's equivalent to setting `--lockfile-only` on all `bun install` commands.
+
+```toml
+[install]
+lockfileOnly = false
+```
+
 ### `install.globalDir`
 
 To configure the directory where Bun puts globally installed packages.

--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -724,6 +724,7 @@ export interface BunInstall {
   frozen_lockfile?: boolean;
   exact?: boolean;
   concurrent_scripts?: uint32;
+  lockfile_only?: boolean;
 }
 
 export interface ClientServerModule {

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -3064,6 +3064,10 @@ function decodeBunInstall(bb) {
         result["concurrent_scripts"] = bb.readUint32();
         break;
 
+      case 22:
+        result["lockfile_only"] = !!bb.readByte();
+        break;
+
       default:
         throw new Error("Attempted to parse invalid message");
     }
@@ -3202,6 +3206,13 @@ function encodeBunInstall(message, bb) {
     bb.writeByte(21);
     bb.writeUint32(value);
   }
+
+  var value = message["lockfile_only"];
+  if (value != null) {
+    bb.writeByte(22);
+    bb.writeByte(value);
+  }
+
   bb.writeByte(0);
 }
 

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -2898,6 +2898,9 @@ pub const Api = struct {
         /// concurrent_scripts
         concurrent_scripts: ?u32 = null,
 
+        /// lockfile_only
+        lockfile_only: ?bool = null,
+
         pub fn decode(reader: anytype) anyerror!BunInstall {
             var this = std.mem.zeroes(BunInstall);
 
@@ -2969,6 +2972,9 @@ pub const Api = struct {
                     },
                     21 => {
                         this.concurrent_scripts = try reader.readValue(u32);
+                    },
+                    22 => {
+                        this.lockfile_only = try reader.readValue(bool);
                     },
                     else => {
                         return error.InvalidMessage;
@@ -3062,6 +3068,10 @@ pub const Api = struct {
             if (this.concurrent_scripts) |concurrent_scripts| {
                 try writer.writeFieldID(21);
                 try writer.writeInt(concurrent_scripts);
+            }
+            if (this.lockfile_only) |lockfile_only| {
+                try writer.writeFieldID(22);
+                try writer.writeInt(@as(u8, @intFromBool(lockfile_only)));
             }
             try writer.endMessage();
         }

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -401,6 +401,12 @@ pub const Bunfig = struct {
                         }
                     }
 
+                    if (_bun.get("lockfileOnly")) |lockfile_only| {
+                        if (lockfile_only.asBool()) |value| {
+                            install.lockfile_only = value;
+                        }
+                    }
+
                     if (_bun.get("lockfile")) |lockfile_expr| {
                         if (lockfile_expr.get("print")) |lockfile| {
                             try this.expect(lockfile, .e_string);

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5218,6 +5218,7 @@ pub const PackageManager = struct {
         min_simultaneous_requests: usize = 4,
 
         max_concurrent_lifecycle_scripts: usize,
+        lockfile_only: bool = false,
 
         pub fn shouldPrintCommandName(this: *const Options) bool {
             return this.log_level != .silent and this.do.summary;
@@ -5663,6 +5664,13 @@ pub const PackageManager = struct {
                     this.enable.manifest_cache_control = false;
                     this.enable.force_install = true;
                     this.enable.force_save_lockfile = true;
+                }
+
+                if (cli.lockfile_only) {
+                    this.do.install_packages = false;
+                    this.lockfile_only = true;
+                    this.do.write_package_json = false;
+                    this.do.save_lockfile = true;
                 }
 
                 this.update.development = cli.development;
@@ -6756,6 +6764,7 @@ pub const PackageManager = struct {
         clap.parseParam("--backend <STR>                       Platform-specific optimizations for installing dependencies. " ++ platform_specific_backend_label) catch unreachable,
         clap.parseParam("--link-native-bins <STR>...           Link \"bin\" from a matching platform-specific \"optionalDependencies\" instead. Default: esbuild, turbo") catch unreachable,
         clap.parseParam("--concurrent-scripts <NUM>            Maximum number of concurrent jobs for lifecycle scripts (default 5)") catch unreachable,
+        clap.parseParam("--lockfile-only                       Only bun.lockb is updated") catch unreachable,
         // clap.parseParam("--omit <STR>...                    Skip installing dependencies of a certain type. \"dev\", \"optional\", or \"peer\"") catch unreachable,
         // clap.parseParam("--no-dedupe                        Disable automatic downgrading of dependencies that would otherwise cause unnecessary duplicate package versions ($BUN_CONFIG_NO_DEDUPLICATE)") catch unreachable,
         clap.parseParam("-h, --help                            Print this help menu") catch unreachable,
@@ -6836,6 +6845,7 @@ pub const PackageManager = struct {
         exact: bool = false,
 
         concurrent_scripts: ?usize = null,
+        lockfile_only: bool = false,
 
         const Omit = struct {
             dev: bool = false,
@@ -7069,6 +7079,8 @@ pub const PackageManager = struct {
                 // var buf: []
                 cli.concurrent_scripts = std.fmt.parseInt(usize, concurrency, 10) catch null;
             }
+
+            cli.lockfile_only = args.flag("--lockfile-only");
 
             // for (args.options("--omit")) |omit| {
             //     if (strings.eqlComptime(omit, "dev")) {


### PR DESCRIPTION
### What does this PR do?

Supports updating the bun.lockb file without having to wait for a large number of packages to be installed.
This is similar to `pnpm`'s `--lockfile-only` and `npm`'s `--package-lock-only`
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
