### PR TITLE
Add icu4c to macOS install dependencies section

### DIFF
--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -9,7 +9,7 @@ Using your system's package manager, install Bun's dependencies:
 {% codetabs %}
 
 ```bash#macOS (Homebrew)
-$ brew install automake ccache cmake coreutils gnu-sed go libiconv libtool ninja pkg-config rust ruby
+$ brew install automake ccache cmake coreutils gnu-sed go icu4c libiconv libtool ninja pkg-config rust ruby
 ```
 
 ```bash#Ubuntu/Debian


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds icu4c to the brew install command for macOS. I ran into the issue of:
https://bun.sh/docs/project/contributing#cannot-find-libatomic-a

after performing the documented 
> cmake -Bbuild -GNinja -DUSE_STATIC_LIBATOMIC=ON
ninja -Cbuild

I still had the issue and tried `bun setup` again resulting in the same issue. 
I then installed `icu4c` via `brew` and then `bun setup` worked.
-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

