### PR TITLE
construct package paths without `getFdPath` for lifecycle scripts

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9506,7 +9506,9 @@ pub const PackageManager = struct {
                 try PATH.append(std.fs.path.delimiter);
             }
             try PATH.appendSlice(strings.withoutTrailingSlash(dir.abs_path));
-            try PATH.append(std.fs.path.sep);
+            if (!(dir.abs_path.len == 1 and dir.abs_path[0] == std.fs.path.sep)) {
+                try PATH.append(std.fs.path.sep);
+            }
             try PATH.appendSlice(this.options.bin_path);
             current_dir = dir.getParent();
         }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8075,7 +8075,6 @@ pub const PackageManager = struct {
                         if (resolution.tag == .workspace or this.lockfile.hasTrustedDependency(alias)) {
                             this.enqueuePackageScriptsToLockfile(
                                 alias,
-                                name,
                                 log_level,
                                 package_id,
                                 destination_dir_subpath,
@@ -8209,7 +8208,6 @@ pub const PackageManager = struct {
                     // in `trustedDependencies`
                     this.enqueuePackageScriptsToLockfile(
                         alias,
-                        name,
                         log_level,
                         package_id,
                         destination_dir_subpath,

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8231,10 +8231,6 @@ pub const PackageManager = struct {
             var scripts: Package.Scripts = this.lockfile.packages.items(.scripts)[package_id];
             var path_buf_to_use: [bun.MAX_PATH_BYTES * 2]u8 = undefined;
 
-            if (comptime Environment.allow_assert) {
-                std.debug.assert(scripts.hasAny() or !scripts.filled);
-            }
-
             if (scripts.hasAny()) {
                 const add_node_gyp_rebuild_script = if (this.lockfile.hasTrustedDependency(folder_name) and
                     scripts.install.isEmpty() and

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1761,6 +1761,7 @@ const TaskCallbackContext = union(Tag) {
     node_modules_folder: struct {
         fd: bun.FileDescriptor,
         tree_id: Lockfile.Tree.Id,
+        node_modules_folder_path: std.ArrayList(u8),
     },
     root_dependency: DependencyID,
     root_request_id: PackageID,
@@ -7649,7 +7650,11 @@ pub const PackageManager = struct {
         manager: *PackageManager,
         lockfile: *Lockfile,
         progress: *std.Progress,
+
+        // relative paths from `nextNodeModulesFolder` will be copied into this list.
+        node_modules_folder_path: std.ArrayList(u8),
         node_modules_folder: std.fs.Dir,
+
         skip_verify_installed_version_number: bool,
         skip_delete: bool,
         force_install: bool,
@@ -7822,6 +7827,7 @@ pub const PackageManager = struct {
             this.completed_trees.deinit(allocator);
             allocator.free(this.tree_install_counts);
             this.tree_ids_to_trees_the_id_depends_on.deinit(allocator);
+            this.node_modules_folder_path.deinit();
         }
 
         /// Call when you mutate the length of `lockfile.packages`
@@ -7860,10 +7866,14 @@ pub const PackageManager = struct {
                 defer this.node_modules_folder = prev_node_modules_folder;
                 const prev_tree_id = this.current_tree_id;
                 defer this.current_tree_id = prev_tree_id;
+                const prev_node_modules_folder_path = this.node_modules_folder_path;
+                defer this.node_modules_folder_path = prev_node_modules_folder_path;
                 for (callbacks.items) |cb| {
                     this.node_modules_folder = .{ .fd = bun.fdcast(cb.node_modules_folder.fd) };
                     this.current_tree_id = cb.node_modules_folder.tree_id;
+                    this.node_modules_folder_path = cb.node_modules_folder.node_modules_folder_path;
                     this.installPackageWithNameAndResolution(dependency_id, package_id, log_level, name, resolution);
+                    cb.node_modules_folder.node_modules_folder_path.deinit();
                 }
             }
         }
@@ -8080,6 +8090,7 @@ pub const PackageManager = struct {
                                 .node_modules_folder = .{
                                     .fd = bun.toFD(this.node_modules_folder.fd),
                                     .tree_id = this.current_tree_id,
+                                    .node_modules_folder_path = this.node_modules_folder_path.clone() catch bun.outOfMemory(),
                                 },
                             };
                             switch (resolution.tag) {
@@ -8220,25 +8231,26 @@ pub const PackageManager = struct {
             var scripts: Package.Scripts = this.lockfile.packages.items(.scripts)[package_id];
             var path_buf_to_use: [bun.MAX_PATH_BYTES * 2]u8 = undefined;
 
-            if (scripts.hasAny()) {
-                var path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                const node_modules_path = bun.getFdPath(bun.toFD(this.node_modules_folder.fd), &path_buf) catch unreachable;
+            if (comptime Environment.allow_assert) {
+                std.debug.assert(scripts.hasAny() or !scripts.filled);
+            }
 
+            if (scripts.hasAny()) {
                 const add_node_gyp_rebuild_script = if (this.lockfile.hasTrustedDependency(name) and
                     scripts.install.isEmpty() and
                     scripts.postinstall.isEmpty())
                 brk: {
                     const binding_dot_gyp_path = Path.joinAbsStringZ(
-                        node_modules_path,
-                        &[_]string{ destination_dir_subpath, "binding.gyp" },
+                        this.node_modules_folder_path.items,
+                        &[_]string{ name, "binding.gyp" },
                         .posix,
                     );
 
                     break :brk Syscall.exists(binding_dot_gyp_path);
                 } else false;
 
-                const path_str = Path.joinAbsStringBufZTrailingSlash(
-                    node_modules_path,
+                const cwd = Path.joinAbsStringBufZTrailingSlash(
+                    this.node_modules_folder_path.items,
                     &path_buf_to_use,
                     &[_]string{destination_dir_subpath},
                     .posix,
@@ -8247,7 +8259,7 @@ pub const PackageManager = struct {
                 if (scripts.enqueue(
                     this.lockfile,
                     buf,
-                    path_str,
+                    cwd,
                     name,
                     resolution.tag,
                     add_node_gyp_rebuild_script,
@@ -8266,7 +8278,7 @@ pub const PackageManager = struct {
                         this.pending_lifecycle_scripts.append(this.manager.allocator, .{
                             .list = scripts_list,
                             .tree_id = this.current_tree_id,
-                        }) catch unreachable;
+                        }) catch bun.outOfMemory();
                     }
                 }
             } else if (!scripts.filled) {
@@ -8274,6 +8286,7 @@ pub const PackageManager = struct {
                     this.manager.log,
                     this.lockfile,
                     this.node_modules_folder,
+                    this.node_modules_folder_path.items,
                     destination_dir_subpath,
                     name,
                     resolution,
@@ -8317,7 +8330,7 @@ pub const PackageManager = struct {
                         this.pending_lifecycle_scripts.append(this.manager.allocator, .{
                             .list = list,
                             .tree_id = this.current_tree_id,
-                        }) catch unreachable;
+                        }) catch bun.outOfMemory();
                     }
                 }
             }
@@ -8660,6 +8673,13 @@ pub const PackageManager = struct {
                     .lockfile = this.lockfile,
                     .node = &install_node,
                     .node_modules_folder = node_modules_folder,
+                    .node_modules_folder_path = std.ArrayList(u8).fromOwnedSlice(
+                        this.allocator,
+                        try this.allocator.dupe(
+                            u8,
+                            strings.withoutTrailingSlash(FileSystem.instance.top_level_dir),
+                        ),
+                    ),
                     .progress = progress,
                     .skip_verify_installed_version_number = skip_verify_installed_version_number,
                     .skip_delete = skip_delete,
@@ -8678,11 +8698,16 @@ pub const PackageManager = struct {
                 };
             };
 
+            try installer.node_modules_folder_path.append(std.fs.path.sep);
+
             // installer.printTreeDeps();
 
             defer installer.deinit();
 
             while (iterator.nextNodeModulesFolder(&installer.completed_trees)) |node_modules| {
+                installer.node_modules_folder_path.items.len = strings.withoutTrailingSlash(FileSystem.instance.top_level_dir).len + 1;
+                try installer.node_modules_folder_path.appendSlice(node_modules.relative_path);
+
                 // We deliberately do not close this folder.
                 // If the package hasn't been downloaded, we will need to install it later
                 // We use this file descriptor to know where to put it.
@@ -9304,7 +9329,7 @@ pub const PackageManager = struct {
             manager.root_lifecycle_scripts = root.scripts.enqueue(
                 manager.lockfile,
                 manager.lockfile.buffers.string_bytes.items,
-                strings.withoutTrailingSlash(Fs.FileSystem.instance.top_level_dir),
+                strings.withoutTrailingSlash(FileSystem.instance.top_level_dir),
                 root.name.slice(manager.lockfile.buffers.string_bytes.items),
                 .root,
                 add_node_gyp_rebuild_script,
@@ -9315,7 +9340,7 @@ pub const PackageManager = struct {
                 manager.root_lifecycle_scripts = root.scripts.enqueue(
                     manager.lockfile,
                     manager.lockfile.buffers.string_bytes.items,
-                    strings.withoutTrailingSlash(Fs.FileSystem.instance.top_level_dir),
+                    strings.withoutTrailingSlash(FileSystem.instance.top_level_dir),
                     root.name.slice(manager.lockfile.buffers.string_bytes.items),
                     .root,
                     true,

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -239,9 +239,11 @@ pub const LifecycleScriptSubprocess = struct {
             }
 
             if (manager.options.log_level.isVerbose()) {
-                Output.prettyErrorln("<d>[LifecycleScriptSubprocess]<r> Spawning <b>\"{s}\"<r> script for package <b>\"{s}\"<r>", .{
+                Output.prettyErrorln("<d>[LifecycleScriptSubprocess]<r> Spawning <b>\"{s}\"<r> script for package <b>\"{s}\"<r>\ncwd: {s}\n<r><d><magenta>$<r> <d><b>{s}<r>", .{
                     this.scriptName(),
                     this.package_name,
+                    cwd,
+                    combined_script,
                 });
             }
 

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2545,19 +2545,17 @@ pub const Package = extern struct {
             log: *logger.Log,
             lockfile: *Lockfile,
             node_modules: std.fs.Dir,
+            node_modules_path: string,
             subpath: [:0]const u8,
             name: string,
             resolution: *const Resolution,
         ) !?Package.Scripts.List {
-            var node_modules_path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-            const node_modules_path = try bun.getFdPath(bun.toFD(node_modules.fd), &node_modules_path_buf);
-
-            var path_buf2: [bun.MAX_PATH_BYTES]u8 = undefined;
+            var path_buf: bun.PathBuffer = undefined;
 
             const cwd = Path.joinAbsStringBufZTrailingSlash(
                 node_modules_path,
-                &path_buf2,
-                &[_]string{subpath},
+                &path_buf,
+                &[_]string{name},
                 .auto,
             );
 
@@ -2600,8 +2598,8 @@ pub const Package = extern struct {
                 this.postinstall.isEmpty())
             brk: {
                 const binding_dot_gyp_path = Path.joinAbsStringZ(
-                    node_modules_path,
-                    &[_]string{ subpath, "binding.gyp" },
+                    cwd,
+                    &[_]string{"binding.gyp"},
                     .posix,
                 );
 

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2547,7 +2547,7 @@ pub const Package = extern struct {
             node_modules: std.fs.Dir,
             node_modules_path: string,
             subpath: [:0]const u8,
-            name: string,
+            folder_name: string,
             resolution: *const Resolution,
         ) !?Package.Scripts.List {
             var path_buf: bun.PathBuffer = undefined;
@@ -2555,7 +2555,7 @@ pub const Package = extern struct {
             const cwd = Path.joinAbsStringBufZTrailingSlash(
                 node_modules_path,
                 &path_buf,
-                &[_]string{name},
+                &[_]string{folder_name},
                 .auto,
             );
 
@@ -2593,7 +2593,7 @@ pub const Package = extern struct {
             try builder.allocate();
             this.parseAlloc(lockfile.allocator, &builder, json);
 
-            const add_node_gyp_rebuild_script = if (lockfile.hasTrustedDependency(name) and
+            const add_node_gyp_rebuild_script = if (lockfile.hasTrustedDependency(folder_name) and
                 this.install.isEmpty() and
                 this.postinstall.isEmpty())
             brk: {
@@ -2610,7 +2610,7 @@ pub const Package = extern struct {
                 lockfile,
                 tmp.buffers.string_bytes.items,
                 cwd,
-                name,
+                folder_name,
                 resolution.tag,
                 add_node_gyp_rebuild_script,
             );


### PR DESCRIPTION
### What does this PR do?
fixes:
- bug when adding `node_modules/.bin` to path at the root
- aliased packages would run lifecycle scripts in the wrong directory


### How did you verify your code works?
manually tested
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
