### PR TITLE
test: Fix segfault on timeout while awaiting

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -189,7 +189,7 @@ pub const Expect = struct {
 
                     if (!globalThis.bunVM().waitForPromiseWithTimeout(promise, remaining)) {
                         if (Jest.runner.?.pending_test) |pending_test|
-                            pending_test.timeout();
+                            pending_test.timeout(false);
                         return null;
                     }
 
@@ -4306,7 +4306,7 @@ pub const Expect = struct {
 
             if (!globalObject.bunVM().waitForPromiseWithTimeout(promise, remaining)) {
                 if (Jest.runner.?.pending_test) |pending_test|
-                    pending_test.timeout();
+                    pending_test.timeout(false);
                 globalObject.throw("Timed out while awaiting the promise returned by matcher \"{s}\"", .{matcher_name});
                 return false;
             }

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -355,7 +355,7 @@ describe("bun test", () => {
           import { test, expect } from "bun:test";
           import { sleep } from "bun";
           test("timeout", async () => {
-            await sleep(5001);
+            await sleep(5010);
           });
         `,
       });


### PR DESCRIPTION
Fixes: #8069

The crash was because JSValue.zero was returned to JSC by way of Expect.getValue, without a JSC exception being raised to prevent the value from being dereferenced. The code was trying to use throwTerminationException for this purpose, but that implementation wasn't actually throwing an exception.

Future work: figure out why the exception only gets logged sometimes, because it would be nice to always get the source dump and stack trace on timeout.