### PR TITLE
Fix 'Not a string or buffer' from zlibBufferSync

### DIFF
--- a/src/js/node/zlib.js
+++ b/src/js/node/zlib.js
@@ -7,6 +7,7 @@ const assert = require("node:assert");
 const BufferModule = require("node:buffer");
 const StreamModule = require("node:stream");
 const Util = require("node:util");
+const { isAnyArrayBuffer, isArrayBufferView } = require("node:util/types");
 
 var __getOwnPropNames = Object.getOwnPropertyNames;
 var __commonJS = (cb, mod) =>
@@ -4117,8 +4118,18 @@ var require_lib = __commonJS({
       }
     }
     function zlibBufferSync(engine, buffer) {
-      if (typeof buffer === "string") buffer = Buffer2.from(buffer);
-      if (!Buffer2.isBuffer(buffer)) throw new TypeError("Not a string or buffer");
+      if (typeof buffer === "string") {
+        buffer = Buffer2.from(buffer);
+      } else if (!isArrayBufferView(buffer)) {
+        if (!isAnyArrayBuffer(buffer)) {
+          throw new ERR_INVALID_ARG_TYPE(
+            "buffer",
+            ["string", "Buffer", "TypedArray", "DataView", "ArrayBuffer"],
+            buffer,
+          );
+        }
+        buffer = Buffer.from(buffer);
+      }
       var flushFlag = engine._finishFlushFlag;
       return engine._processChunk(buffer, flushFlag);
     }
@@ -4424,6 +4435,12 @@ var require_lib = __commonJS({
     util.inherits(Unzip, Zlib);
   },
 });
+
+function ERR_INVALID_ARG_TYPE(name, type, value) {
+  const err = new TypeError(`The "${name}" argument must be of type ${type}. Received ${value?.toString()}`);
+  err.code = "ERR_INVALID_ARG_TYPE";
+  return err;
+}
 
 // zlib.js
 export default require_lib();

--- a/src/js/node/zlib.js
+++ b/src/js/node/zlib.js
@@ -4128,7 +4128,7 @@ var require_lib = __commonJS({
             buffer,
           );
         }
-        buffer = Buffer.from(buffer);
+        buffer = Buffer2.from(buffer);
       }
       var flushFlag = engine._finishFlushFlag;
       return engine._processChunk(buffer, flushFlag);


### PR DESCRIPTION
### What does this PR do?

Fixes #5309
Fixes #7984 

Our polyfill of `zlibBufferSync` was not properly checking for non-Buffers, like `Uint8Array`. I changed it to match Node's behaviour [here](https://github.com/nodejs/node/blob/e0b159ee8276c617eb774bafb8e4e1afa5edbf1c/lib/zlib.js#L165-L177).

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Since we are going to replace this with a native implementation soon, I didn't add a test, but manually tested with Tesseract.js, which ran into this issue:

```js
import { createWorker } from "tesseract.js";

(async () => {
  const worker = await createWorker("eng");
  const ret = await worker.recognize(
    "https://tesseract.projectnaptha.com/img/eng_bw.png"
  );
  console.log(ret.data.text);
  await worker.terminate();
})();
```

Before:
```
error: TypeError: Not a string or buffer
      at /code/node_modules/tesseract.js/src/createWorker.js:244:15
      at emit (node:events:122:95)
      at #onMessage (node:worker_threads:178:25)
```
After:
```
Mild Splendour of the various-vested Night!
Mother of wildly-working visions! hail
I watch thy gliding, while with watery light
Thy weak eye glimmers through a fleecy veil;
And when thou lovest thy pale orb to shroud
Behind the gather’d blackness lost on high;
And when thou dartest from the wind-rent cloud
Thy placid lightning o’er the awaken’d sky.
```
