### PR TITLE
incremental(windows) add TransmitFile and some fixes for fetch, h2 and http

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1311,6 +1311,7 @@ else()
         ucrt
         userenv
         dbghelp
+        wsock32 # ws2_32 required by TransmitFile aka sendfile on windows
     )
 endif()
 

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -669,19 +669,17 @@ pub const H2FrameParser = struct {
         var xhdr: lshpack.lsxpack_header = .{};
 
         lshpack.lsxpack_header_prepare_decode(&xhdr, header_buffer.ptr, 0, header_buffer.len);
-        const start = @intFromPtr(src_buffer.ptr);
-        var src = src_buffer.ptr;
-        if (lshpack.lshpack_dec_decode(&this.decoder, &src, @ptrFromInt(start + src_buffer.len), &xhdr) != 0) {
-            return error.UnableToDecode;
-        }
+        const next = try lshpack.lshpack_decode(&this.decoder, src_buffer.ptr, src_buffer.len, &xhdr);
+
         const name = lshpack.lsxpack_header_get_name(&xhdr);
         if (name.len == 0) {
             return error.EmptyHeaderName;
         }
+
         return .{
             .name = name,
             .value = lshpack.lsxpack_header_get_value(&xhdr),
-            .next = @intFromPtr(src) - start,
+            .next = next,
         };
     }
 

--- a/src/bun.js/api/bun/lshpack.translated.zig
+++ b/src/bun.js/api/bun/lshpack.translated.zig
@@ -220,38 +220,38 @@ pub fn lsxpack_header_mark_val_changed(hdr: ?*lsxpack_header_t) callconv(.C) voi
 }
 pub const struct_lshpack_enc_table_entry = opaque {};
 pub const struct_lshpack_enc_head = extern struct {
-    stqh_first: ?*struct_lshpack_enc_table_entry,
-    stqh_last: [*c]?*struct_lshpack_enc_table_entry,
+    stqh_first: ?*struct_lshpack_enc_table_entry = @import("std").mem.zeroes(?*struct_lshpack_enc_table_entry),
+    stqh_last: [*c]?*struct_lshpack_enc_table_entry = @import("std").mem.zeroes([*c]?*struct_lshpack_enc_table_entry),
 };
 pub const struct_lshpack_double_enc_head = opaque {};
 pub const LSHPACK_ENC_USE_HIST: c_int = 1;
 const enum_unnamed_1 = c_uint;
 pub const struct_lshpack_enc = extern struct {
-    hpe_cur_capacity: c_uint,
-    hpe_max_capacity: c_uint,
-    hpe_next_id: c_uint,
-    hpe_nelem: c_uint,
-    hpe_nbits: c_uint,
-    hpe_all_entries: struct_lshpack_enc_head,
-    hpe_buckets: ?*struct_lshpack_double_enc_head,
-    hpe_hist_buf: [*c]u32,
-    hpe_hist_size: c_uint,
-    hpe_hist_idx: c_uint,
-    hpe_hist_wrapped: c_int,
-    hpe_flags: enum_unnamed_1,
+    hpe_cur_capacity: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_max_capacity: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_next_id: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_nelem: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_nbits: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_all_entries: struct_lshpack_enc_head = @import("std").mem.zeroes(struct_lshpack_enc_head),
+    hpe_buckets: ?*struct_lshpack_double_enc_head = @import("std").mem.zeroes(?*struct_lshpack_double_enc_head),
+    hpe_hist_buf: [*c]u32 = @import("std").mem.zeroes([*c]u32),
+    hpe_hist_size: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_hist_idx: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_hist_wrapped: c_int = @import("std").mem.zeroes(c_int),
+    hpe_flags: enum_unnamed_1 = @import("std").mem.zeroes(enum_unnamed_1),
 };
 pub const struct_lshpack_arr = extern struct {
-    nalloc: c_uint,
-    nelem: c_uint,
-    off: c_uint,
-    els: [*c]usize,
+    nalloc: c_uint = @import("std").mem.zeroes(c_uint),
+    nelem: c_uint = @import("std").mem.zeroes(c_uint),
+    off: c_uint = @import("std").mem.zeroes(c_uint),
+    els: [*c]usize = @import("std").mem.zeroes([*c]usize),
 };
 pub const struct_lshpack_dec = extern struct {
-    hpd_dyn_table: struct_lshpack_arr,
-    hpd_max_capacity: c_uint,
-    hpd_cur_max_capacity: c_uint,
-    hpd_cur_capacity: c_uint,
-    hpd_state: c_uint,
+    hpd_dyn_table: struct_lshpack_arr = @import("std").mem.zeroes(struct_lshpack_arr),
+    hpd_max_capacity: c_uint = @import("std").mem.zeroes(c_uint),
+    hpd_cur_max_capacity: c_uint = @import("std").mem.zeroes(c_uint),
+    hpd_cur_capacity: c_uint = @import("std").mem.zeroes(c_uint),
+    hpd_state: c_uint = @import("std").mem.zeroes(c_uint),
 };
 pub const LSHPACK_HDR_UNKNOWN: c_int = 0;
 pub const LSHPACK_HDR_AUTHORITY: c_int = 1;
@@ -325,10 +325,17 @@ pub extern fn lshpack_enc_use_hist([*c]struct_lshpack_enc, on: c_int) c_int;
 pub extern fn lshpack_enc_hist_used([*c]const struct_lshpack_enc) c_int;
 pub extern fn lshpack_dec_init([*c]struct_lshpack_dec) void;
 pub extern fn lshpack_dec_cleanup([*c]struct_lshpack_dec) void;
-pub extern fn lshpack_dec_decode(dec: [*c]struct_lshpack_dec, src: *[*]const u8, src_end: [*c]const u8, output: ?*struct_lsxpack_header) c_int;
+pub extern fn lshpack_dec_decode(dec: [*c]struct_lshpack_dec, src: *[*c]const u8, src_end: [*c]const u8, output: ?*struct_lsxpack_header) c_int;
 pub extern fn lshpack_dec_set_max_capacity([*c]struct_lshpack_dec, c_uint) void;
 pub extern fn lshpack_enc_get_stx_tab_id(?*struct_lsxpack_header) c_uint;
-
+pub fn lshpack_decode(dec: [*c]struct_lshpack_dec, src: [*]const u8, src_len: usize, output: ?*struct_lsxpack_header) !usize {
+    var s: [*c]const u8 = src;
+    const rc: c_int = lshpack_dec_decode(dec, &s, s + src_len, output);
+    if (rc != 0) {
+        return error.UnableToDecode;
+    }
+    return @intFromPtr(s) - @intFromPtr(src);
+}
 pub const __INT64_C = @import("std").zig.c_translation.Macros.L_SUFFIX;
 pub const __UINT64_C = @import("std").zig.c_translation.Macros.UL_SUFFIX;
 pub const INT8_MIN = -@as(c_int, 128);

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -80,7 +80,7 @@ const BoringSSL = @import("root").bun.BoringSSL;
 const Arena = @import("../../mimalloc_arena.zig").Arena;
 const SendfileContext = struct {
     fd: bun.FileDescriptor,
-    socket_fd: i32 = 0,
+    socket_fd: bun.FileDescriptor = bun.invalid_fd,
     remain: Blob.SizeType = 0,
     offset: Blob.SizeType = 0,
     has_listener: bool = false,
@@ -1277,8 +1277,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         defer_deinit_until_callback_completes: ?*bool = null,
 
         // TODO: support builtin compression
-        // TODO: Use TransmitFile on Windows
-        const can_sendfile = !ssl_enabled and !bun.Environment.isWindows;
+        const can_sendfile = !ssl_enabled;
 
         pub inline fn isAsync(this: *const RequestContext) bool {
             return this.defer_deinit_until_callback_completes == null;
@@ -1894,6 +1893,14 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     this.cleanupAndFinalizeAfterSendfile();
                     return errcode != .SUCCESS;
                 }
+            } else if(Environment.isWindows) {
+                const win = std.os.windows;
+                const uv = bun.windows.libuv;
+                const socket = bun.socketcast(this.sendfile.socket_fd);
+                const file_handle = uv.uv_get_osfhandle(bun.uvfdcast(this.sendfile.fd));
+                this.sendfile.offset += this.sendfile.remain;
+                this.sendfile.remain = 0;
+                return win.ws2_32.TransmitFile(socket, file_handle, 0, 0, null, null, 0) == 1;
             } else {
                 var sbytes: std.os.off_t = adjusted_count;
                 const signed_offset = @as(i64, @bitCast(@as(u64, this.sendfile.offset)));
@@ -2066,7 +2073,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 .remain = this.blob.Blob.offset + original_size,
                 .offset = this.blob.Blob.offset,
                 .auto_close = auto_close,
-                .socket_fd = if (!this.flags.aborted) resp.getNativeHandle() else -999,
+                .socket_fd = if (!this.flags.aborted) resp.getNativeHandle() else bun.invalid_fd,
             };
 
             // if we are sending only part of a file, include the content-range header
@@ -2158,7 +2165,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     .remain = @as(Blob.SizeType, @truncate(result.result.buf.len)),
                     .offset = if (this.blob == .Blob) this.blob.Blob.offset else 0,
                     .auto_close = false,
-                    .socket_fd = -999,
+                    .socket_fd = bun.invalid_fd,
                 };
 
                 this.response_buf_owned = .{ .items = result.result.buf, .capacity = result.result.buf.len };

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -2340,6 +2340,7 @@ pub const Blob = struct {
                     .on_complete_data = @ptrCast(handler),
                     .on_complete_fn = @ptrCast(&Handler.run),
                 });
+                store.ref();
                 this.getFd(onFileOpen);
             }
 

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -2330,14 +2330,14 @@ pub const Blob = struct {
 
             req: libuv.fs_t = libuv.fs_t.uninitialized,
 
-            pub fn start(loop: *libuv.Loop, store: *Store, off: SizeType, max_len: SizeType, comptime Handler: type, handler: *Handler) void {
+            pub fn start(loop: *libuv.Loop, store: *Store, off: SizeType, max_len: SizeType, comptime Handler: type, handler: *anyopaque) void {
                 var this = bun.new(ReadFileUV, .{
                     .loop = loop,
                     .file_store = store.data.file,
                     .store = store,
                     .offset = off,
                     .max_length = max_len,
-                    .on_complete_data = @ptrCast(handler),
+                    .on_complete_data = handler,
                     .on_complete_fn = @ptrCast(&Handler.run),
                 });
                 store.ref();
@@ -4362,7 +4362,8 @@ pub const Blob = struct {
 
     pub fn doReadFileInternal(this: *Blob, comptime Handler: type, ctx: Handler, comptime Function: anytype, global: *JSGlobalObject) void {
         if (Environment.isWindows) {
-            @panic("todo");
+            const ReadFileHandler = NewInternalReadFileHandler(Handler, Function);
+            return Store.ReadFileUV.start(libuv.Loop.get(), this.store.?, this.offset, this.size, ReadFileHandler, ctx);
         }
         const file_read = Store.ReadFile.createWithCtx(
             bun.default_allocator,

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -2204,7 +2204,7 @@ pub const Fetch = struct {
             prepare_body: {
                 const opened_fd_res: JSC.Node.Maybe(bun.FileDescriptor) = switch (body.Blob.store.?.data.file.pathlike) {
                     .fd => |fd| bun.sys.dup(fd),
-                    .path => |path| bun.sys.open(path.sliceZ(&globalThis.bunVM().nodeFS().sync_error_buf), std.os.O.RDONLY | std.os.O.NOCTTY, 0),
+                    .path => |path| bun.sys.open(path.sliceZ(&globalThis.bunVM().nodeFS().sync_error_buf), if(Environment.isWindows) std.os.O.RDONLY else std.os.O.RDONLY | std.os.O.NOCTTY, 0),
                 };
 
                 const opened_fd = switch (opened_fd_res) {

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -209,12 +209,17 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             return @as(*NativeSocketHandleType(is_ssl), @ptrCast(us_socket_get_native_handle(comptime ssl_int, this.socket).?));
         }
 
-        pub inline fn fd(this: ThisSocket) i32 {
+        pub inline fn fd(this: ThisSocket) bun.FileDescriptor {
             if (comptime is_ssl) {
                 @compileError("SSL sockets do not have a file descriptor accessible this way");
             }
 
-            return @as(i32, @intCast(@intFromPtr(us_socket_get_native_handle(0, this.socket))));
+            if(comptime Environment.isWindows) {
+                // on windows uSockets exposes SOCKET
+                return bun.toFD(@as(bun.FDImpl.System, @ptrCast(us_socket_get_native_handle(0, this.socket))));
+            }
+
+            return bun.toFD(@as(i32, @intCast(@intFromPtr(us_socket_get_native_handle(0, this.socket)))));
         }
 
         pub fn markNeedsMoreForSendfile(this: ThisSocket) void {
@@ -1948,8 +1953,13 @@ pub fn NewApp(comptime ssl: bool) type {
                 return uws_res_has_responded(ssl_flag, res.downcast());
             }
 
-            pub fn getNativeHandle(res: *Response) i32 {
-                return @as(i32, @intCast(@intFromPtr(uws_res_get_native_handle(ssl_flag, res.downcast()))));
+            pub fn getNativeHandle(res: *Response) bun.FileDescriptor {
+                if(comptime Environment.isWindows) {
+                    // on windows uSockets exposes SOCKET
+                   return bun.toFD(@as(bun.FDImpl.System, @ptrCast(uws_res_get_native_handle(ssl_flag, res.downcast()))));
+                }
+                
+                return bun.toFD(@as(i32, @intCast(@intFromPtr(uws_res_get_native_handle(ssl_flag, res.downcast())))));
             }
             pub fn getRemoteAddress(res: *Response) ?[]const u8 {
                 var buf: [*]const u8 = undefined;

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -214,7 +214,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 @compileError("SSL sockets do not have a file descriptor accessible this way");
             }
 
-            if(comptime Environment.isWindows) {
+            if (comptime Environment.isWindows) {
                 // on windows uSockets exposes SOCKET
                 return bun.toFD(@as(bun.FDImpl.System, @ptrCast(us_socket_get_native_handle(0, this.socket))));
             }
@@ -1954,11 +1954,11 @@ pub fn NewApp(comptime ssl: bool) type {
             }
 
             pub fn getNativeHandle(res: *Response) bun.FileDescriptor {
-                if(comptime Environment.isWindows) {
+                if (comptime Environment.isWindows) {
                     // on windows uSockets exposes SOCKET
-                   return bun.toFD(@as(bun.FDImpl.System, @ptrCast(uws_res_get_native_handle(ssl_flag, res.downcast()))));
+                    return bun.toFD(@as(bun.FDImpl.System, @ptrCast(uws_res_get_native_handle(ssl_flag, res.downcast()))));
                 }
-                
+
                 return bun.toFD(@as(i32, @intCast(@intFromPtr(uws_res_get_native_handle(ssl_flag, res.downcast())))));
             }
             pub fn getRemoteAddress(res: *Response) ?[]const u8 {

--- a/src/http.zig
+++ b/src/http.zig
@@ -143,8 +143,6 @@ pub const Sendfile = struct {
         const adjusted_count_temporary = @min(@as(u64, this.remain), @as(u63, std.math.maxInt(u63)));
         // TODO we should not need this int cast; improve the return type of `@min`
         const adjusted_count = @as(u63, @intCast(adjusted_count_temporary));
-        // int uv_fs_sendfile(uv_loop_t *loop, uv_fs_t *req, uv_file out_fd, uv_file in_fd, int64_t in_offset, size_t length, uv_fs_cb cb)
-
         
         if (Environment.isLinux) {
             var signed_offset = @as(i64, @intCast(this.offset));

--- a/src/http.zig
+++ b/src/http.zig
@@ -125,7 +125,6 @@ pub fn canUseBrotli() bool {
     return bun.brotli.hasBrotli();
 }
 
-
 pub const Sendfile = struct {
     fd: bun.FileDescriptor,
     remain: usize = 0,
@@ -143,7 +142,7 @@ pub const Sendfile = struct {
         const adjusted_count_temporary = @min(@as(u64, this.remain), @as(u63, std.math.maxInt(u63)));
         // TODO we should not need this int cast; improve the return type of `@min`
         const adjusted_count = @as(u63, @intCast(adjusted_count_temporary));
-        
+
         if (Environment.isLinux) {
             var signed_offset = @as(i64, @intCast(this.offset));
             const begin = this.offset;
@@ -163,12 +162,12 @@ pub const Sendfile = struct {
 
                 return .{ .err = bun.errnoToZigErr(errcode) };
             }
-        } else if(Environment.isWindows) {
+        } else if (Environment.isWindows) {
             const win = std.os.windows;
             const uv = bun.windows.libuv;
             const wsocket = bun.socketcast(socket.fd());
             const file_handle = uv.uv_get_osfhandle(bun.uvfdcast(this.fd));
-            if(win.ws2_32.TransmitFile(wsocket, file_handle, 0, 0, null, null, 0) == 1) {
+            if (win.ws2_32.TransmitFile(wsocket, file_handle, 0, 0, null, null, 0) == 1) {
                 return .{ .done = {} };
             }
             this.offset += this.remain;

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -653,6 +653,9 @@ pub fn openA(file_path: []const u8, flags: bun.Mode, perm: bun.Mode) Maybe(bun.F
 }
 
 pub fn open(file_path: [:0]const u8, flags: bun.Mode, perm: bun.Mode) Maybe(bun.FileDescriptor) {
+    if (comptime Environment.isWindows) {
+        return sys_uv.open(file_path, flags, perm);
+    }
     // this is what open() does anyway.
     return openat(bun.toFD((std.fs.cwd().fd)), file_path, flags, perm);
 }

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -132,36 +132,36 @@ test("formData uploads roundtrip, without a call to .body", async () => {
   server.stop(true);
 });
 
-// test("uploads roundtrip with sendfile()", async () => {
-//   var hugeTxt = "huge".repeat(1024 * 1024 * 32);
-//   const path = join(tmpdir(), "huge.txt");
-//   require("fs").writeFileSync(path, hugeTxt);
+test("uploads roundtrip with sendfile()", async () => {
+  var hugeTxt = "huge".repeat(1024 * 1024 * 32);
+  const path = join(tmpdir(), "huge.txt");
+  require("fs").writeFileSync(path, hugeTxt);
 
-//   const server = Bun.serve({
-//     port: 0,
-//     development: false,
-//     maxRequestBodySize: 1024 * 1024 * 1024 * 8,
-//     async fetch(req) {
-//       var count = 0;
-//       for await (let chunk of req.body!) {
-//         count += chunk.byteLength;
-//       }
-//       return new Response(count + "");
-//     },
-//   });
+  const server = Bun.serve({
+    port: 0,
+    development: false,
+    maxRequestBodySize: 1024 * 1024 * 1024 * 8,
+    async fetch(req) {
+      var count = 0;
+      for await (let chunk of req.body!) {
+        count += chunk.byteLength;
+      }
+      return new Response(count + "");
+    },
+  });
 
-//   const resp = await fetch("http://" + server.hostname + ":" + server.port, {
-//     body: Bun.file(path),
-//     method: "PUT",
-//   });
+  const resp = await fetch("http://" + server.hostname + ":" + server.port, {
+    body: Bun.file(path),
+    method: "PUT",
+  });
 
-//   expect(resp.status).toBe(200);
+  expect(resp.status).toBe(200);
 
-//   const body = parseInt(await resp.text());
-//   expect(body).toBe(hugeTxt.length);
+  const body = parseInt(await resp.text());
+  expect(body).toBe(hugeTxt.length);
 
-//   server.stop(true);
-// });
+  server.stop(true);
+});
 
 test("missing file throws the expected error", async () => {
   Bun.gc(true);

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -132,36 +132,36 @@ test("formData uploads roundtrip, without a call to .body", async () => {
   server.stop(true);
 });
 
-test("uploads roundtrip with sendfile()", async () => {
-  var hugeTxt = "huge".repeat(1024 * 1024 * 32);
-  const path = join(tmpdir(), "huge.txt");
-  require("fs").writeFileSync(path, hugeTxt);
+// test("uploads roundtrip with sendfile()", async () => {
+//   var hugeTxt = "huge".repeat(1024 * 1024 * 32);
+//   const path = join(tmpdir(), "huge.txt");
+//   require("fs").writeFileSync(path, hugeTxt);
 
-  const server = Bun.serve({
-    port: 0,
-    development: false,
-    maxRequestBodySize: 1024 * 1024 * 1024 * 8,
-    async fetch(req) {
-      var count = 0;
-      for await (let chunk of req.body!) {
-        count += chunk.byteLength;
-      }
-      return new Response(count + "");
-    },
-  });
+//   const server = Bun.serve({
+//     port: 0,
+//     development: false,
+//     maxRequestBodySize: 1024 * 1024 * 1024 * 8,
+//     async fetch(req) {
+//       var count = 0;
+//       for await (let chunk of req.body!) {
+//         count += chunk.byteLength;
+//       }
+//       return new Response(count + "");
+//     },
+//   });
 
-  const resp = await fetch("http://" + server.hostname + ":" + server.port, {
-    body: Bun.file(path),
-    method: "PUT",
-  });
+//   const resp = await fetch("http://" + server.hostname + ":" + server.port, {
+//     body: Bun.file(path),
+//     method: "PUT",
+//   });
 
-  expect(resp.status).toBe(200);
+//   expect(resp.status).toBe(200);
 
-  const body = parseInt(await resp.text());
-  expect(body).toBe(hugeTxt.length);
+//   const body = parseInt(await resp.text());
+//   expect(body).toBe(hugeTxt.length);
 
-  server.stop(true);
-});
+//   server.stop(true);
+// });
 
 test("missing file throws the expected error", async () => {
   Bun.gc(true);
@@ -174,7 +174,7 @@ test("missing file throws the expected error", async () => {
         method: "POST",
         proxy: "http://localhost:3000",
       });
-      expect(Bun.peek.status(resp)).toBe("rejected");
+      // expect(Bun.peek.status(resp)).toBe("rejected");
       expect(async () => await resp).toThrow("No such file or directory");
     }
   });

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -174,7 +174,7 @@ test("missing file throws the expected error", async () => {
         method: "POST",
         proxy: "http://localhost:3000",
       });
-      // expect(Bun.peek.status(resp)).toBe("rejected");
+      expect(Bun.peek.status(resp)).toBe("rejected");
       expect(async () => await resp).toThrow("No such file or directory");
     }
   });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
