### PR TITLE
fix(bun-install): gracefully handle missing package removal

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -7482,11 +7482,6 @@ pub const PackageManager = struct {
                     }
                 }
 
-                if (!any_changes) {
-                    Output.prettyErrorln("\n<red>error<r><d>:<r> \"<b>{s}<r>\" is not in a package.json file", .{updates[0].name});
-                    Global.exit(1);
-                    return;
-                }
                 manager.to_remove = updates;
             },
             .link, .add => {
@@ -7587,6 +7582,11 @@ pub const PackageManager = struct {
             manager.root_package_json_file.close();
 
             if (op == .remove) {
+                if (!any_changes) {
+                    Global.exit(0);
+                    return;
+                }
+
                 var cwd = std.fs.cwd();
                 // This is not exactly correct
                 var node_modules_buf: [bun.MAX_PATH_BYTES]u8 = undefined;

--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -162,7 +162,7 @@ it("should remove existing package", async () => {
   );
 });
 
-it("should reject missing package", async () => {
+it("should not reject missing package", async () => {
   await writeFile(
     join(package_dir, "package.json"),
     JSON.stringify({
@@ -188,7 +188,7 @@ it("should reject missing package", async () => {
   });
   expect(await addExited).toBe(0);
 
-  const { stdout, stderr, exited } = spawn({
+  const { exited: rmExited } = spawn({
     cmd: [bunExe(), "remove", "pkg2"],
     cwd: package_dir,
     stdout: null,
@@ -196,18 +196,7 @@ it("should reject missing package", async () => {
     stderr: "pipe",
     env,
   });
-  expect(await exited).toBe(1);
-  expect(stdout).toBeDefined();
-  const out = await new Response(stdout).text();
-  expect(out).toEqual("");
-  expect(stderr).toBeDefined();
-  const err = await new Response(stderr).text();
-  expect(err.replace(/^(.*?) v[^\n]+/, "$1").split(/\r?\n/)).toEqual([
-    "bun remove",
-    "",
-    `error: "pkg2" is not in a package.json file`,
-    "",
-  ]);
+  expect(await rmExited).toBe(0);
 });
 
 it("should not affect if package is not installed", async () => {


### PR DESCRIPTION
### What does this PR do?

Handles gracefully the removal of missing packages from the package.json, this not only applies to `org/repo` packages but to any missing package.

This matches the NPM behavior, which doesn't error out in such cases.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->


- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
Manually tested too.
| Bun | NPM |
| --- | --- |
| ![image](https://github.com/oven-sh/bun/assets/11046907/ceeda127-1e74-4130-8bed-b98643739d0d) | ![image](https://github.com/oven-sh/bun/assets/11046907/0cb6b97c-341c-4af8-b733-1c590e981e77) |

Closes https://github.com/oven-sh/bun/issues/8032