### PR TITLE
incremental(windows) setTimeout, setInterval and setImmediate should work

### DIFF
--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -160,6 +160,7 @@ pub const BunObject = struct {
 const Bun = @This();
 const default_allocator = @import("root").bun.default_allocator;
 const bun = @import("root").bun;
+const uv = bun.windows.libuv;
 const Environment = bun.Environment;
 
 const Global = bun.Global;
@@ -3522,17 +3523,16 @@ pub const Timer = struct {
         poll_ref: Async.KeepAlive = Async.KeepAlive.init(),
         arguments: JSC.Strong = .{},
         has_scheduled_job: bool = false,
-
         pub const TimerReference = struct {
             id: ID = .{ .id = 0 },
             cancelled: bool = false,
 
             event_loop: *JSC.EventLoop,
-            timer: bun.io.Timer = .{
+            timer: if (Environment.isWindows) uv.uv_timer_t else bun.io.Timer = if (Environment.isWindows) std.mem.zeroes(uv.uv_timer_t) else .{
                 .tag = .TimerReference,
                 .next = std.mem.zeroes(std.os.timespec),
             },
-            request: bun.io.Request = .{
+            request: if (Environment.isWindows) u0 else bun.io.Request = if (Environment.isWindows) 0 else .{
                 .callback = &onRequest,
             },
             interval: i32 = -1,
@@ -3540,8 +3540,20 @@ pub const Timer = struct {
             scheduled_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
 
             pub const Pool = bun.HiveArray(TimerReference, 1024).Fallback;
+            fn onUVRequest(handle: *uv.uv_timer_t) callconv(.C) void {
+                const data = handle.data orelse @panic("Invalid data on uv timer");
+                var this: *TimerReference = @ptrCast(@alignCast(data));
+                if (this.cancelled) {
+                    _ = uv.uv_timer_stop(&this.timer);
+                }
+                // libuv runs on the same thread
+                return this.runFromJSThread();
+            }
 
             fn onRequest(req: *bun.io.Request) bun.io.Action {
+                if (Environment.isWindows) {
+                    @panic("This should not be called on Windows");
+                }
                 var this: *TimerReference = @fieldParentPtr(TimerReference, "request", req);
 
                 if (this.cancelled) {
@@ -3571,9 +3583,11 @@ pub const Timer = struct {
             }
 
             pub fn reschedule(this: *TimerReference) void {
-                this.request = .{
-                    .callback = &onRequest,
-                };
+                if (!Environment.isWindows) {
+                    this.request = .{
+                        .callback = &onRequest,
+                    };
+                }
                 this.schedule(this.interval);
             }
 
@@ -3604,19 +3618,33 @@ pub const Timer = struct {
             }
 
             pub fn create(event_loop: *JSC.EventLoop, id: ID) *TimerReference {
-                const timer = event_loop.timerReferencePool().get();
-                timer.* = .{
+                const this = event_loop.timerReferencePool().get();
+                this.* = .{
                     .id = id,
                     .event_loop = event_loop,
                 };
-                return timer;
+                if (Environment.isWindows) {
+                    this.timer.data = this;
+                    if (uv.uv_timer_init(uv.Loop.get(), &this.timer) != 0) {
+                        bun.outOfMemory();
+                    }
+                    // we manage the ref/unref in the same way that linux does
+                    uv.uv_unref(@ptrCast(&this.timer));
+                }
+                return this;
             }
 
             pub fn schedule(this: *TimerReference, interval: ?i32) void {
                 std.debug.assert(!this.cancelled);
                 _ = this.scheduled_count.fetchAdd(1, .Monotonic);
+                const ms: i32 = @max(interval orelse this.interval, 1);
+                if (Environment.isWindows) {
+                    if (uv.uv_timer_start(&this.timer, TimerReference.onUVRequest, @intCast(ms), 0) != 0) @panic("unable to start timer");
+                    return;
+                }
+
                 this.timer.state = .PENDING;
-                this.timer.next = msToTimespec(@intCast(@max(interval orelse this.interval, 1)));
+                this.timer.next = msToTimespec(ms);
                 bun.io.Loop.get().schedule(&this.request);
             }
 

--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -3637,7 +3637,7 @@ pub const Timer = struct {
             pub fn schedule(this: *TimerReference, interval: ?i32) void {
                 std.debug.assert(!this.cancelled);
                 _ = this.scheduled_count.fetchAdd(1, .Monotonic);
-                const ms: i32 = @max(interval orelse this.interval, 1);
+                const ms: usize = @max(interval orelse this.interval, 1);
                 if (Environment.isWindows) {
                     if (uv.uv_timer_start(&this.timer, TimerReference.onUVRequest, @intCast(ms), 0) != 0) @panic("unable to start timer");
                     return;

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -952,6 +952,7 @@ pub const Listener = struct {
             if (opts.getTruthy(globalObject, "fd")) |fd_| {
                 if (fd_.isNumber()) {
                     if (Environment.isWindows) {
+                        // SOCKET is actually a u32 but we are casting to a *anyopaque, so we are conservative here
                         const socket: bun.FDImpl.System = @ptrFromInt(fd_.to(u64));
                         const fd: bun.FileDescriptor = bun.toFD(socket);
                         break :blk .{ .fd = fd };

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -951,7 +951,12 @@ pub const Listener = struct {
         const connection: Listener.UnixOrHost = blk: {
             if (opts.getTruthy(globalObject, "fd")) |fd_| {
                 if (fd_.isNumber()) {
-                    const fd: bun.FileDescriptor = fd_.asInt32();
+                    if (Environment.isWindows) {
+                        const socket: bun.FDImpl.System = @ptrFromInt(fd_.to(u64));
+                        const fd: bun.FileDescriptor = bun.toFD(socket);
+                        break :blk .{ .fd = fd };
+                    }
+                    const fd: bun.FileDescriptor = bun.toFD(fd_.to(i32));
                     break :blk .{ .fd = fd };
                 }
             }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2544,7 +2544,9 @@ pub inline fn socketcast(fd: anytype) std.os.socket_t {
 }
 
 pub const HOST_NAME_MAX = if (Environment.isWindows)
-    // TODO: i have no idea what this value should be
+    // On Windows the maximum length, in bytes, of the string returned in the buffer pointed to by the name parameter is dependent on the namespace provider, but this string must be 256 bytes or less. 
+    // So if a buffer of 256 bytes is passed in the name parameter and the namelen parameter is set to 256, the buffer size will always be adequate.
+    // https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-gethostname
     256
 else
     std.os.HOST_NAME_MAX;

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2544,7 +2544,7 @@ pub inline fn socketcast(fd: anytype) std.os.socket_t {
 }
 
 pub const HOST_NAME_MAX = if (Environment.isWindows)
-    // On Windows the maximum length, in bytes, of the string returned in the buffer pointed to by the name parameter is dependent on the namespace provider, but this string must be 256 bytes or less. 
+    // On Windows the maximum length, in bytes, of the string returned in the buffer pointed to by the name parameter is dependent on the namespace provider, but this string must be 256 bytes or less.
     // So if a buffer of 256 bytes is passed in the name parameter and the namelen parameter is set to 256, the buffer size will always be adequate.
     // https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-gethostname
     256

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -1066,7 +1066,7 @@ const union_unnamed_411 = extern union {
     fd: c_int,
     reserved: [4]?*anyopaque,
 };
-pub const uv_timer_cb = ?*const fn ([*c]uv_timer_t) callconv(.C) void;
+pub const uv_timer_cb = ?*const fn (*uv_timer_t) callconv(.C) void;
 pub const struct_uv_timer_s = extern struct {
     data: ?*anyopaque,
     loop: *uv_loop_t,

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -450,7 +450,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             this: *This,
             comptime socket_field_name: ?[]const u8,
         ) ?ThisSocket {
-            const socket_ = ThisSocket{ .socket = us_socket_from_fd(ctx, @sizeOf(*anyopaque), handle) orelse return null };
+            const socket_ = ThisSocket{ .socket = us_socket_from_fd(ctx, @sizeOf(*anyopaque), bun.socketcast(handle)) orelse return null };
 
             const holder = socket_.ext(*anyopaque) orelse {
                 if (comptime bun.Environment.allow_assert) unreachable;
@@ -2366,7 +2366,7 @@ pub const LIBUS_RECV_BUFFER_LENGTH = 524288;
 pub const LIBUS_TIMEOUT_GRANULARITY = @as(i32, 4);
 pub const LIBUS_RECV_BUFFER_PADDING = @as(i32, 32);
 pub const LIBUS_EXT_ALIGNMENT = @as(i32, 16);
-pub const LIBUS_SOCKET_DESCRIPTOR = i32;
+pub const LIBUS_SOCKET_DESCRIPTOR = if (Environment.isWindows) std.os.socket_t else i32;
 
 pub const _COMPRESSOR_MASK: i32 = 255;
 pub const _DECOMPRESSOR_MASK: i32 = 3840;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

This PR also includes the code for https://github.com/oven-sh/bun/pull/8100

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
