### PR TITLE
incremental(windows) subprocess rusage and spawn stream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1311,6 +1311,7 @@ else()
         ucrt
         userenv
         dbghelp
+        wsock32 # ws2_32 required by TransmitFile aka sendfile on windows
     )
 endif()
 

--- a/src/async/posix_event_loop.zig
+++ b/src/async/posix_event_loop.zig
@@ -6,7 +6,7 @@ const Environment = bun.Environment;
 const std = @import("std");
 
 pub const Loop = uws.Loop;
-
+const uv = bun.windows.libuv;
 /// Track if an object whose file descriptor is being watched should keep the event loop alive.
 /// This is not reference counted. It only tracks active or inactive.
 pub const KeepAlive = struct {
@@ -371,7 +371,23 @@ pub const FilePoll = struct {
             }
             return flags;
         }
-
+        pub fn fromLibUVEvent(events: c_int) Flags.Set {
+            var flags = Flags.Set{};
+            if (events & uv.UV_READABLE != 0) {
+                flags.insert(Flags.readable);
+                log("readable", .{});
+            }
+            if (events & uv.UV_WRITABLE != 0) {
+                flags.insert(Flags.writable);
+                log("writable", .{});
+            }
+            if (events & uv.UV_DISCONNECT != 0) {
+                flags.insert(Flags.hup);
+                flags.insert(Flags.eof);
+                log("hup", .{});
+            }
+            return flags;
+        }
         pub fn fromEpollEvent(epoll: std.os.linux.epoll_event) Flags.Set {
             var flags = Flags.Set{};
             if (epoll.events & std.os.linux.EPOLL.IN != 0) {

--- a/src/async/windows_event_loop.zig
+++ b/src/async/windows_event_loop.zig
@@ -266,7 +266,7 @@ pub const FilePoll = struct {
         std.debug.assert(this.fd != bun.invalid_fd);
 
         const system_fd = bun.FDImpl.decode(this.fd).system();
-        log("register {d}", .{ system_fd });
+        log("register {d}", .{system_fd});
 
         this.handle = std.mem.zeroes(uv.uv_poll_t);
         if (one_shot) {

--- a/src/async/windows_event_loop.zig
+++ b/src/async/windows_event_loop.zig
@@ -266,6 +266,8 @@ pub const FilePoll = struct {
         std.debug.assert(this.fd != bun.invalid_fd);
 
         const system_fd = bun.FDImpl.decode(this.fd).system();
+        log("register {d}", .{ system_fd });
+
         this.handle = std.mem.zeroes(uv.uv_poll_t);
         if (one_shot) {
             this.flags.insert(.one_shot);

--- a/src/async/windows_event_loop.zig
+++ b/src/async/windows_event_loop.zig
@@ -209,19 +209,19 @@ pub const FilePoll = struct {
         const data = handle.data orelse return;
         const this: *FilePoll = @ptrCast(@alignCast(data));
 
-        if(this.flags.contains(.one_shot)) {
+        if (this.flags.contains(.one_shot)) {
             _ = uv.uv_poll_stop(handle);
         }
 
-        if(status != 0) {
+        if (status != 0) {
             this.updateFlags(Flags.fromLibUVEvent(uv.UV_DISCONNECT));
         } else {
             this.updateFlags(Flags.fromLibUVEvent(events));
         }
-         
+
         this.onUpdate(0);
     }
-    
+
     pub fn onUpdate(poll: *FilePoll, size_or_offset: i64) void {
         if (poll.flags.contains(.one_shot) and !poll.flags.contains(.needs_rearm)) {
             poll.flags.insert(.needs_rearm);
@@ -272,7 +272,7 @@ pub const FilePoll = struct {
         }
 
         const handle = &(this.handle.?);
-        if(uv.uv_poll_init_socket(loop, handle, system_fd).errno()) |err| {
+        if (uv.uv_poll_init_socket(loop, handle, system_fd).errno()) |err| {
             if (JSC.Maybe(void).errnoSys(err, .epoll_ctl)) |errno| {
                 return errno;
             }
@@ -285,7 +285,7 @@ pub const FilePoll = struct {
             .writable => uv.UV_WRITABLE | uv.UV_DISCONNECT,
             else => unreachable,
         };
-        if(uv.uv_poll_start(handle, events, FilePoll.uvEventPoll).errno()) |err| {
+        if (uv.uv_poll_start(handle, events, FilePoll.uvEventPoll).errno()) |err| {
             if (JSC.Maybe(void).errnoSys(err, .epoll_ctl)) |errno| {
                 return errno;
             }
@@ -301,7 +301,7 @@ pub const FilePoll = struct {
     }
     pub fn unregister(this: *FilePoll) bool {
         uv.uv_unref(@ptrFromInt(this.fd));
-        if(this.handle != null) {
+        if (this.handle != null) {
             return uv.uv_poll_stop(&this.handle.?).errno() == null;
         }
         return true;

--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -160,6 +160,7 @@ pub const BunObject = struct {
 const Bun = @This();
 const default_allocator = @import("root").bun.default_allocator;
 const bun = @import("root").bun;
+const uv = bun.windows.libuv;
 const Environment = bun.Environment;
 
 const Global = bun.Global;
@@ -3522,17 +3523,16 @@ pub const Timer = struct {
         poll_ref: Async.KeepAlive = Async.KeepAlive.init(),
         arguments: JSC.Strong = .{},
         has_scheduled_job: bool = false,
-
         pub const TimerReference = struct {
             id: ID = .{ .id = 0 },
             cancelled: bool = false,
 
             event_loop: *JSC.EventLoop,
-            timer: bun.io.Timer = .{
+            timer: if (Environment.isWindows) uv.uv_timer_t else bun.io.Timer = if (Environment.isWindows) std.mem.zeroes(uv.uv_timer_t) else .{
                 .tag = .TimerReference,
                 .next = std.mem.zeroes(std.os.timespec),
             },
-            request: bun.io.Request = .{
+            request: if (Environment.isWindows) u0 else bun.io.Request = if (Environment.isWindows) 0 else .{
                 .callback = &onRequest,
             },
             interval: i32 = -1,
@@ -3540,8 +3540,20 @@ pub const Timer = struct {
             scheduled_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
 
             pub const Pool = bun.HiveArray(TimerReference, 1024).Fallback;
+            fn onUVRequest(handle: *uv.uv_timer_t) callconv(.C) void {
+                const data = handle.data orelse @panic("Invalid data on uv timer");
+                var this: *TimerReference = @ptrCast(@alignCast(data));
+                if (this.cancelled) {
+                    _ = uv.uv_timer_stop(&this.timer);
+                }
+                // libuv runs on the same thread
+                return this.runFromJSThread();
+            }
 
             fn onRequest(req: *bun.io.Request) bun.io.Action {
+                if (Environment.isWindows) {
+                    @panic("This should not be called on Windows");
+                }
                 var this: *TimerReference = @fieldParentPtr(TimerReference, "request", req);
 
                 if (this.cancelled) {
@@ -3571,9 +3583,11 @@ pub const Timer = struct {
             }
 
             pub fn reschedule(this: *TimerReference) void {
-                this.request = .{
-                    .callback = &onRequest,
-                };
+                if (!Environment.isWindows) {
+                    this.request = .{
+                        .callback = &onRequest,
+                    };
+                }
                 this.schedule(this.interval);
             }
 
@@ -3604,19 +3618,33 @@ pub const Timer = struct {
             }
 
             pub fn create(event_loop: *JSC.EventLoop, id: ID) *TimerReference {
-                const timer = event_loop.timerReferencePool().get();
-                timer.* = .{
+                const this = event_loop.timerReferencePool().get();
+                this.* = .{
                     .id = id,
                     .event_loop = event_loop,
                 };
-                return timer;
+                if (Environment.isWindows) {
+                    this.timer.data = this;
+                    if (uv.uv_timer_init(uv.Loop.get(), &this.timer) != 0) {
+                        bun.outOfMemory();
+                    }
+                    // we manage the ref/unref in the same way that linux does
+                    uv.uv_unref(@ptrCast(&this.timer));
+                }
+                return this;
             }
 
             pub fn schedule(this: *TimerReference, interval: ?i32) void {
                 std.debug.assert(!this.cancelled);
                 _ = this.scheduled_count.fetchAdd(1, .Monotonic);
+                const ms: i32 = @max(interval orelse this.interval, 1);
+                if (Environment.isWindows) {
+                    if (uv.uv_timer_start(&this.timer, TimerReference.onUVRequest, @intCast(ms), 0) != 0) @panic("unable to start timer");
+                    return;
+                }
+
                 this.timer.state = .PENDING;
-                this.timer.next = msToTimespec(@intCast(@max(interval orelse this.interval, 1)));
+                this.timer.next = msToTimespec(ms);
                 bun.io.Loop.get().schedule(&this.request);
             }
 

--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -3637,7 +3637,7 @@ pub const Timer = struct {
             pub fn schedule(this: *TimerReference, interval: ?i32) void {
                 std.debug.assert(!this.cancelled);
                 _ = this.scheduled_count.fetchAdd(1, .Monotonic);
-                const ms: i32 = @max(interval orelse this.interval, 1);
+                const ms: usize = @max(interval orelse this.interval, 1);
                 if (Environment.isWindows) {
                     if (uv.uv_timer_start(&this.timer, TimerReference.onUVRequest, @intCast(ms), 0) != 0) @panic("unable to start timer");
                     return;

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -669,19 +669,17 @@ pub const H2FrameParser = struct {
         var xhdr: lshpack.lsxpack_header = .{};
 
         lshpack.lsxpack_header_prepare_decode(&xhdr, header_buffer.ptr, 0, header_buffer.len);
-        const start = @intFromPtr(src_buffer.ptr);
-        var src = src_buffer.ptr;
-        if (lshpack.lshpack_dec_decode(&this.decoder, &src, @ptrFromInt(start + src_buffer.len), &xhdr) != 0) {
-            return error.UnableToDecode;
-        }
+        const next = try lshpack.lshpack_decode(&this.decoder, src_buffer.ptr, src_buffer.len, &xhdr);
+
         const name = lshpack.lsxpack_header_get_name(&xhdr);
         if (name.len == 0) {
             return error.EmptyHeaderName;
         }
+
         return .{
             .name = name,
             .value = lshpack.lsxpack_header_get_value(&xhdr),
-            .next = @intFromPtr(src) - start,
+            .next = next,
         };
     }
 

--- a/src/bun.js/api/bun/lshpack.translated.zig
+++ b/src/bun.js/api/bun/lshpack.translated.zig
@@ -220,38 +220,38 @@ pub fn lsxpack_header_mark_val_changed(hdr: ?*lsxpack_header_t) callconv(.C) voi
 }
 pub const struct_lshpack_enc_table_entry = opaque {};
 pub const struct_lshpack_enc_head = extern struct {
-    stqh_first: ?*struct_lshpack_enc_table_entry,
-    stqh_last: [*c]?*struct_lshpack_enc_table_entry,
+    stqh_first: ?*struct_lshpack_enc_table_entry = @import("std").mem.zeroes(?*struct_lshpack_enc_table_entry),
+    stqh_last: [*c]?*struct_lshpack_enc_table_entry = @import("std").mem.zeroes([*c]?*struct_lshpack_enc_table_entry),
 };
 pub const struct_lshpack_double_enc_head = opaque {};
 pub const LSHPACK_ENC_USE_HIST: c_int = 1;
 const enum_unnamed_1 = c_uint;
 pub const struct_lshpack_enc = extern struct {
-    hpe_cur_capacity: c_uint,
-    hpe_max_capacity: c_uint,
-    hpe_next_id: c_uint,
-    hpe_nelem: c_uint,
-    hpe_nbits: c_uint,
-    hpe_all_entries: struct_lshpack_enc_head,
-    hpe_buckets: ?*struct_lshpack_double_enc_head,
-    hpe_hist_buf: [*c]u32,
-    hpe_hist_size: c_uint,
-    hpe_hist_idx: c_uint,
-    hpe_hist_wrapped: c_int,
-    hpe_flags: enum_unnamed_1,
+    hpe_cur_capacity: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_max_capacity: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_next_id: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_nelem: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_nbits: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_all_entries: struct_lshpack_enc_head = @import("std").mem.zeroes(struct_lshpack_enc_head),
+    hpe_buckets: ?*struct_lshpack_double_enc_head = @import("std").mem.zeroes(?*struct_lshpack_double_enc_head),
+    hpe_hist_buf: [*c]u32 = @import("std").mem.zeroes([*c]u32),
+    hpe_hist_size: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_hist_idx: c_uint = @import("std").mem.zeroes(c_uint),
+    hpe_hist_wrapped: c_int = @import("std").mem.zeroes(c_int),
+    hpe_flags: enum_unnamed_1 = @import("std").mem.zeroes(enum_unnamed_1),
 };
 pub const struct_lshpack_arr = extern struct {
-    nalloc: c_uint,
-    nelem: c_uint,
-    off: c_uint,
-    els: [*c]usize,
+    nalloc: c_uint = @import("std").mem.zeroes(c_uint),
+    nelem: c_uint = @import("std").mem.zeroes(c_uint),
+    off: c_uint = @import("std").mem.zeroes(c_uint),
+    els: [*c]usize = @import("std").mem.zeroes([*c]usize),
 };
 pub const struct_lshpack_dec = extern struct {
-    hpd_dyn_table: struct_lshpack_arr,
-    hpd_max_capacity: c_uint,
-    hpd_cur_max_capacity: c_uint,
-    hpd_cur_capacity: c_uint,
-    hpd_state: c_uint,
+    hpd_dyn_table: struct_lshpack_arr = @import("std").mem.zeroes(struct_lshpack_arr),
+    hpd_max_capacity: c_uint = @import("std").mem.zeroes(c_uint),
+    hpd_cur_max_capacity: c_uint = @import("std").mem.zeroes(c_uint),
+    hpd_cur_capacity: c_uint = @import("std").mem.zeroes(c_uint),
+    hpd_state: c_uint = @import("std").mem.zeroes(c_uint),
 };
 pub const LSHPACK_HDR_UNKNOWN: c_int = 0;
 pub const LSHPACK_HDR_AUTHORITY: c_int = 1;
@@ -325,10 +325,17 @@ pub extern fn lshpack_enc_use_hist([*c]struct_lshpack_enc, on: c_int) c_int;
 pub extern fn lshpack_enc_hist_used([*c]const struct_lshpack_enc) c_int;
 pub extern fn lshpack_dec_init([*c]struct_lshpack_dec) void;
 pub extern fn lshpack_dec_cleanup([*c]struct_lshpack_dec) void;
-pub extern fn lshpack_dec_decode(dec: [*c]struct_lshpack_dec, src: *[*]const u8, src_end: [*c]const u8, output: ?*struct_lsxpack_header) c_int;
+pub extern fn lshpack_dec_decode(dec: [*c]struct_lshpack_dec, src: *[*c]const u8, src_end: [*c]const u8, output: ?*struct_lsxpack_header) c_int;
 pub extern fn lshpack_dec_set_max_capacity([*c]struct_lshpack_dec, c_uint) void;
 pub extern fn lshpack_enc_get_stx_tab_id(?*struct_lsxpack_header) c_uint;
-
+pub fn lshpack_decode(dec: [*c]struct_lshpack_dec, src: [*]const u8, src_len: usize, output: ?*struct_lsxpack_header) !usize {
+    var s: [*c]const u8 = src;
+    const rc: c_int = lshpack_dec_decode(dec, &s, s + src_len, output);
+    if (rc != 0) {
+        return error.UnableToDecode;
+    }
+    return @intFromPtr(s) - @intFromPtr(src);
+}
 pub const __INT64_C = @import("std").zig.c_translation.Macros.L_SUFFIX;
 pub const __UINT64_C = @import("std").zig.c_translation.Macros.UL_SUFFIX;
 pub const INT8_MIN = -@as(c_int, 128);

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -952,6 +952,7 @@ pub const Listener = struct {
             if (opts.getTruthy(globalObject, "fd")) |fd_| {
                 if (fd_.isNumber()) {
                     if (Environment.isWindows) {
+                        // SOCKET is actually a u32 but we are casting to a *anyopaque, so we are conservative here
                         const socket: bun.FDImpl.System = @ptrFromInt(fd_.to(u64));
                         const fd: bun.FileDescriptor = bun.toFD(socket);
                         break :blk .{ .fd = fd };

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -951,7 +951,12 @@ pub const Listener = struct {
         const connection: Listener.UnixOrHost = blk: {
             if (opts.getTruthy(globalObject, "fd")) |fd_| {
                 if (fd_.isNumber()) {
-                    const fd: bun.FileDescriptor = fd_.asInt32();
+                    if (Environment.isWindows) {
+                        const socket: bun.FDImpl.System = @ptrFromInt(fd_.to(u64));
+                        const fd: bun.FileDescriptor = bun.toFD(socket);
+                        break :blk .{ .fd = fd };
+                    }
+                    const fd: bun.FileDescriptor = bun.toFD(fd_.to(i32));
                     break :blk .{ .fd = fd };
                 }
             }

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -124,7 +124,7 @@ pub const Subprocess = struct {
     // on macOS, this is nothing
     // on linux, it's a pidfd
     pidfd: if (Environment.isLinux) bun.FileDescriptor else u0 = std.math.maxInt(if (Environment.isLinux) bun.FileDescriptor else u0),
-    pipes: if(Environment.isWindows) [3]uv.uv_pipe_t else u0 = if(Environment.isWindows) undefined else u0,
+    pipes: if(Environment.isWindows) [3]uv.uv_pipe_t else u0 = if(Environment.isWindows) undefined else 0,
     stdin: Writable,
     stdout: Readable,
     stderr: Readable,

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -80,7 +80,7 @@ const BoringSSL = @import("root").bun.BoringSSL;
 const Arena = @import("../../mimalloc_arena.zig").Arena;
 const SendfileContext = struct {
     fd: bun.FileDescriptor,
-    socket_fd: i32 = 0,
+    socket_fd: bun.FileDescriptor = bun.invalid_fd,
     remain: Blob.SizeType = 0,
     offset: Blob.SizeType = 0,
     has_listener: bool = false,
@@ -1277,8 +1277,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         defer_deinit_until_callback_completes: ?*bool = null,
 
         // TODO: support builtin compression
-        // TODO: Use TransmitFile on Windows
-        const can_sendfile = !ssl_enabled and !bun.Environment.isWindows;
+        const can_sendfile = !ssl_enabled;
 
         pub inline fn isAsync(this: *const RequestContext) bool {
             return this.defer_deinit_until_callback_completes == null;
@@ -1894,6 +1893,14 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     this.cleanupAndFinalizeAfterSendfile();
                     return errcode != .SUCCESS;
                 }
+            } else if(Environment.isWindows) {
+                const win = std.os.windows;
+                const uv = bun.windows.libuv;
+                const socket = bun.socketcast(this.sendfile.socket_fd);
+                const file_handle = uv.uv_get_osfhandle(bun.uvfdcast(this.sendfile.fd));
+                this.sendfile.offset += this.sendfile.remain;
+                this.sendfile.remain = 0;
+                return win.ws2_32.TransmitFile(socket, file_handle, 0, 0, null, null, 0) == 1;
             } else {
                 var sbytes: std.os.off_t = adjusted_count;
                 const signed_offset = @as(i64, @bitCast(@as(u64, this.sendfile.offset)));
@@ -2066,7 +2073,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 .remain = this.blob.Blob.offset + original_size,
                 .offset = this.blob.Blob.offset,
                 .auto_close = auto_close,
-                .socket_fd = if (!this.flags.aborted) resp.getNativeHandle() else -999,
+                .socket_fd = if (!this.flags.aborted) resp.getNativeHandle() else bun.invalid_fd,
             };
 
             // if we are sending only part of a file, include the content-range header
@@ -2158,7 +2165,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     .remain = @as(Blob.SizeType, @truncate(result.result.buf.len)),
                     .offset = if (this.blob == .Blob) this.blob.Blob.offset else 0,
                     .auto_close = false,
-                    .socket_fd = -999,
+                    .socket_fd = bun.invalid_fd,
                 };
 
                 this.response_buf_owned = .{ .items = result.result.buf, .capacity = result.result.buf.len };

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -2340,6 +2340,7 @@ pub const Blob = struct {
                     .on_complete_data = @ptrCast(handler),
                     .on_complete_fn = @ptrCast(&Handler.run),
                 });
+                store.ref();
                 this.getFd(onFileOpen);
             }
 

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -2330,14 +2330,14 @@ pub const Blob = struct {
 
             req: libuv.fs_t = libuv.fs_t.uninitialized,
 
-            pub fn start(loop: *libuv.Loop, store: *Store, off: SizeType, max_len: SizeType, comptime Handler: type, handler: *Handler) void {
+            pub fn start(loop: *libuv.Loop, store: *Store, off: SizeType, max_len: SizeType, comptime Handler: type, handler: *anyopaque) void {
                 var this = bun.new(ReadFileUV, .{
                     .loop = loop,
                     .file_store = store.data.file,
                     .store = store,
                     .offset = off,
                     .max_length = max_len,
-                    .on_complete_data = @ptrCast(handler),
+                    .on_complete_data = handler,
                     .on_complete_fn = @ptrCast(&Handler.run),
                 });
                 store.ref();
@@ -4362,7 +4362,8 @@ pub const Blob = struct {
 
     pub fn doReadFileInternal(this: *Blob, comptime Handler: type, ctx: Handler, comptime Function: anytype, global: *JSGlobalObject) void {
         if (Environment.isWindows) {
-            @panic("todo");
+            const ReadFileHandler = NewInternalReadFileHandler(Handler, Function);
+            return Store.ReadFileUV.start(libuv.Loop.get(), this.store.?, this.offset, this.size, ReadFileHandler, ctx);
         }
         const file_read = Store.ReadFile.createWithCtx(
             bun.default_allocator,

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -2204,7 +2204,7 @@ pub const Fetch = struct {
             prepare_body: {
                 const opened_fd_res: JSC.Node.Maybe(bun.FileDescriptor) = switch (body.Blob.store.?.data.file.pathlike) {
                     .fd => |fd| bun.sys.dup(fd),
-                    .path => |path| bun.sys.open(path.sliceZ(&globalThis.bunVM().nodeFS().sync_error_buf), std.os.O.RDONLY | std.os.O.NOCTTY, 0),
+                    .path => |path| bun.sys.open(path.sliceZ(&globalThis.bunVM().nodeFS().sync_error_buf), if(Environment.isWindows) std.os.O.RDONLY else std.os.O.RDONLY | std.os.O.NOCTTY, 0),
                 };
 
                 const opened_fd = switch (opened_fd_res) {

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2544,7 +2544,9 @@ pub inline fn socketcast(fd: anytype) std.os.socket_t {
 }
 
 pub const HOST_NAME_MAX = if (Environment.isWindows)
-    // TODO: i have no idea what this value should be
+    // On Windows the maximum length, in bytes, of the string returned in the buffer pointed to by the name parameter is dependent on the namespace provider, but this string must be 256 bytes or less. 
+    // So if a buffer of 256 bytes is passed in the name parameter and the namelen parameter is set to 256, the buffer size will always be adequate.
+    // https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-gethostname
     256
 else
     std.os.HOST_NAME_MAX;

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1197,9 +1197,9 @@ pub fn isReadable(fd: FileDescriptor) PollFlag {
     if (comptime Environment.isWindows) {
         const handle = FDImpl.decode(fd).system();
         std.os.windows.WaitForSingleObject(handle, 0) catch |err| {
-            return switch(err) {
-               error.WaitTimeOut, error.WaitAbandoned => return PollFlag.not_ready,
-               else => return PollFlag.hup,
+            return switch (err) {
+                error.WaitTimeOut, error.WaitAbandoned => return PollFlag.not_ready,
+                else => return PollFlag.hup,
             };
         };
         return PollFlag.ready;
@@ -1230,9 +1230,9 @@ pub fn isWritable(fd: FileDescriptor) PollFlag {
         // we can only know if is writable using overlapped and GetOverlappedResult, we say is not read so we can trigger watch and use uv to poll the state for us
         // we can at least know if is disconnected or busy here using a shortish timeout
         std.os.windows.WaitForSingleObject(handle, 100) catch |err| {
-            return switch(err) {
-               error.WaitTimeOut, error.WaitAbandoned => return PollFlag.not_ready,
-               else => return PollFlag.hup,
+            return switch (err) {
+                error.WaitTimeOut, error.WaitAbandoned => return PollFlag.not_ready,
+                else => return PollFlag.hup,
             };
         };
         return PollFlag.not_ready;
@@ -2560,7 +2560,7 @@ pub inline fn socketcast(fd: anytype) std.os.socket_t {
 }
 
 pub const HOST_NAME_MAX = if (Environment.isWindows)
-    // On Windows the maximum length, in bytes, of the string returned in the buffer pointed to by the name parameter is dependent on the namespace provider, but this string must be 256 bytes or less. 
+    // On Windows the maximum length, in bytes, of the string returned in the buffer pointed to by the name parameter is dependent on the namespace provider, but this string must be 256 bytes or less.
     // So if a buffer of 256 bytes is passed in the name parameter and the namelen parameter is set to 256, the buffer size will always be adequate.
     // https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-gethostname
     256

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -1066,7 +1066,7 @@ const union_unnamed_411 = extern union {
     fd: c_int,
     reserved: [4]?*anyopaque,
 };
-pub const uv_timer_cb = ?*const fn ([*c]uv_timer_t) callconv(.C) void;
+pub const uv_timer_cb = ?*const fn (*uv_timer_t) callconv(.C) void;
 pub const struct_uv_timer_s = extern struct {
     data: ?*anyopaque,
     loop: *uv_loop_t,

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -1219,7 +1219,7 @@ const union_unnamed_423 = extern union {
     reserved: [4]?*anyopaque,
 };
 pub const uv_poll_t = struct_uv_poll_s;
-pub const uv_poll_cb = ?*const fn ([*c]uv_poll_t, c_int, c_int) callconv(.C) void;
+pub const uv_poll_cb = ?*const fn (*uv_poll_t, c_int, c_int) callconv(.C) void;
 pub const struct_uv_poll_s = extern struct {
     data: ?*anyopaque,
     loop: *uv_loop_t,
@@ -1926,9 +1926,9 @@ pub const UV_DISCONNECT: c_int = 4;
 pub const UV_PRIORITIZED: c_int = 8;
 pub const enum_uv_poll_event = c_uint;
 pub extern fn uv_poll_init(loop: *uv_loop_t, handle: *uv_poll_t, fd: c_int) c_int;
-pub extern fn uv_poll_init_socket(loop: *uv_loop_t, handle: *uv_poll_t, socket: uv_os_sock_t) c_int;
-pub extern fn uv_poll_start(handle: *uv_poll_t, events: c_int, cb: uv_poll_cb) c_int;
-pub extern fn uv_poll_stop(handle: *uv_poll_t) c_int;
+pub extern fn uv_poll_init_socket(loop: *uv_loop_t, handle: *uv_poll_t, socket: uv_os_sock_t) ReturnCode;
+pub extern fn uv_poll_start(handle: *uv_poll_t, events: c_int, cb: uv_poll_cb) ReturnCode;
+pub extern fn uv_poll_stop(handle: *uv_poll_t) ReturnCode;
 pub extern fn uv_prepare_init(*uv_loop_t, prepare: *uv_prepare_t) c_int;
 pub extern fn uv_prepare_start(prepare: *uv_prepare_t, cb: uv_prepare_cb) c_int;
 pub extern fn uv_prepare_stop(prepare: *uv_prepare_t) c_int;

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -833,7 +833,7 @@ const union_unnamed_380 = extern union {
 };
 pub const uv_alloc_cb = ?*const fn (*uv_handle_t, usize, [*]uv_buf_t) callconv(.C) void;
 pub const uv_stream_t = struct_uv_stream_s;
-pub const uv_read_cb = ?*const fn (*uv_stream_t, isize, [*]const uv_buf_t) callconv(.C) void;
+pub const uv_read_cb = ?*const fn (*anyopaque, isize, [*]const uv_buf_t) callconv(.C) void;
 const struct_unnamed_382 = extern struct {
     overlapped: OVERLAPPED,
     queued_bytes: usize,
@@ -1925,7 +1925,7 @@ pub const UV_WRITABLE: c_int = 2;
 pub const UV_DISCONNECT: c_int = 4;
 pub const UV_PRIORITIZED: c_int = 8;
 pub const enum_uv_poll_event = c_uint;
-pub extern fn uv_poll_init(loop: *uv_loop_t, handle: *uv_poll_t, fd: c_int) c_int;
+pub extern fn uv_poll_init(loop: *uv_loop_t, handle: *uv_poll_t, fd: c_int) ReturnCode;
 pub extern fn uv_poll_init_socket(loop: *uv_loop_t, handle: *uv_poll_t, socket: uv_os_sock_t) ReturnCode;
 pub extern fn uv_poll_start(handle: *uv_poll_t, events: c_int, cb: uv_poll_cb) ReturnCode;
 pub extern fn uv_poll_stop(handle: *uv_poll_t) ReturnCode;

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -450,7 +450,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             this: *This,
             comptime socket_field_name: ?[]const u8,
         ) ?ThisSocket {
-            const socket_ = ThisSocket{ .socket = us_socket_from_fd(ctx, @sizeOf(*anyopaque), handle) orelse return null };
+            const socket_ = ThisSocket{ .socket = us_socket_from_fd(ctx, @sizeOf(*anyopaque), bun.socketcast(handle)) orelse return null };
 
             const holder = socket_.ext(*anyopaque) orelse {
                 if (comptime bun.Environment.allow_assert) unreachable;
@@ -2366,7 +2366,7 @@ pub const LIBUS_RECV_BUFFER_LENGTH = 524288;
 pub const LIBUS_TIMEOUT_GRANULARITY = @as(i32, 4);
 pub const LIBUS_RECV_BUFFER_PADDING = @as(i32, 32);
 pub const LIBUS_EXT_ALIGNMENT = @as(i32, 16);
-pub const LIBUS_SOCKET_DESCRIPTOR = i32;
+pub const LIBUS_SOCKET_DESCRIPTOR = if (Environment.isWindows) std.os.socket_t else i32;
 
 pub const _COMPRESSOR_MASK: i32 = 255;
 pub const _DECOMPRESSOR_MASK: i32 = 3840;

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -209,12 +209,17 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             return @as(*NativeSocketHandleType(is_ssl), @ptrCast(us_socket_get_native_handle(comptime ssl_int, this.socket).?));
         }
 
-        pub inline fn fd(this: ThisSocket) i32 {
+        pub inline fn fd(this: ThisSocket) bun.FileDescriptor {
             if (comptime is_ssl) {
                 @compileError("SSL sockets do not have a file descriptor accessible this way");
             }
 
-            return @as(i32, @intCast(@intFromPtr(us_socket_get_native_handle(0, this.socket))));
+            if(comptime Environment.isWindows) {
+                // on windows uSockets exposes SOCKET
+                return bun.toFD(@as(bun.FDImpl.System, @ptrCast(us_socket_get_native_handle(0, this.socket))));
+            }
+
+            return bun.toFD(@as(i32, @intCast(@intFromPtr(us_socket_get_native_handle(0, this.socket)))));
         }
 
         pub fn markNeedsMoreForSendfile(this: ThisSocket) void {
@@ -1948,8 +1953,13 @@ pub fn NewApp(comptime ssl: bool) type {
                 return uws_res_has_responded(ssl_flag, res.downcast());
             }
 
-            pub fn getNativeHandle(res: *Response) i32 {
-                return @as(i32, @intCast(@intFromPtr(uws_res_get_native_handle(ssl_flag, res.downcast()))));
+            pub fn getNativeHandle(res: *Response) bun.FileDescriptor {
+                if(comptime Environment.isWindows) {
+                    // on windows uSockets exposes SOCKET
+                   return bun.toFD(@as(bun.FDImpl.System, @ptrCast(uws_res_get_native_handle(ssl_flag, res.downcast()))));
+                }
+                
+                return bun.toFD(@as(i32, @intCast(@intFromPtr(uws_res_get_native_handle(ssl_flag, res.downcast())))));
             }
             pub fn getRemoteAddress(res: *Response) ?[]const u8 {
                 var buf: [*]const u8 = undefined;

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -214,7 +214,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 @compileError("SSL sockets do not have a file descriptor accessible this way");
             }
 
-            if(comptime Environment.isWindows) {
+            if (comptime Environment.isWindows) {
                 // on windows uSockets exposes SOCKET
                 return bun.toFD(@as(bun.FDImpl.System, @ptrCast(us_socket_get_native_handle(0, this.socket))));
             }
@@ -1954,11 +1954,11 @@ pub fn NewApp(comptime ssl: bool) type {
             }
 
             pub fn getNativeHandle(res: *Response) bun.FileDescriptor {
-                if(comptime Environment.isWindows) {
+                if (comptime Environment.isWindows) {
                     // on windows uSockets exposes SOCKET
-                   return bun.toFD(@as(bun.FDImpl.System, @ptrCast(uws_res_get_native_handle(ssl_flag, res.downcast()))));
+                    return bun.toFD(@as(bun.FDImpl.System, @ptrCast(uws_res_get_native_handle(ssl_flag, res.downcast()))));
                 }
-                
+
                 return bun.toFD(@as(i32, @intCast(@intFromPtr(uws_res_get_native_handle(ssl_flag, res.downcast())))));
             }
             pub fn getRemoteAddress(res: *Response) ?[]const u8 {

--- a/src/http.zig
+++ b/src/http.zig
@@ -143,8 +143,6 @@ pub const Sendfile = struct {
         const adjusted_count_temporary = @min(@as(u64, this.remain), @as(u63, std.math.maxInt(u63)));
         // TODO we should not need this int cast; improve the return type of `@min`
         const adjusted_count = @as(u63, @intCast(adjusted_count_temporary));
-        // int uv_fs_sendfile(uv_loop_t *loop, uv_fs_t *req, uv_file out_fd, uv_file in_fd, int64_t in_offset, size_t length, uv_fs_cb cb)
-
         
         if (Environment.isLinux) {
             var signed_offset = @as(i64, @intCast(this.offset));

--- a/src/http.zig
+++ b/src/http.zig
@@ -125,7 +125,6 @@ pub fn canUseBrotli() bool {
     return bun.brotli.hasBrotli();
 }
 
-
 pub const Sendfile = struct {
     fd: bun.FileDescriptor,
     remain: usize = 0,
@@ -143,7 +142,7 @@ pub const Sendfile = struct {
         const adjusted_count_temporary = @min(@as(u64, this.remain), @as(u63, std.math.maxInt(u63)));
         // TODO we should not need this int cast; improve the return type of `@min`
         const adjusted_count = @as(u63, @intCast(adjusted_count_temporary));
-        
+
         if (Environment.isLinux) {
             var signed_offset = @as(i64, @intCast(this.offset));
             const begin = this.offset;
@@ -163,12 +162,12 @@ pub const Sendfile = struct {
 
                 return .{ .err = bun.errnoToZigErr(errcode) };
             }
-        } else if(Environment.isWindows) {
+        } else if (Environment.isWindows) {
             const win = std.os.windows;
             const uv = bun.windows.libuv;
             const wsocket = bun.socketcast(socket.fd());
             const file_handle = uv.uv_get_osfhandle(bun.uvfdcast(this.fd));
-            if(win.ws2_32.TransmitFile(wsocket, file_handle, 0, 0, null, null, 0) == 1) {
+            if (win.ws2_32.TransmitFile(wsocket, file_handle, 0, 0, null, null, 0) == 1) {
                 return .{ .done = {} };
             }
             this.offset += this.remain;

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -82,7 +82,7 @@ pub const LifecycleScriptSubprocess = struct {
         }
 
         pub fn registerPoll(this: *OutputReader) void {
-            const loop = if(Environment.isWindows) this.subprocess().manager.uws_event_loop.uv_loop else this.subprocess().manager.uws_event_loop;
+            const loop = if (Environment.isWindows) this.subprocess().manager.uws_event_loop.uv_loop else this.subprocess().manager.uws_event_loop;
             switch (this.poll.register(loop, .readable, true)) {
                 .err => |err| {
                     Output.prettyErrorln("<r><red>error<r>: Failed to register poll for <b>{s}<r> script output from \"<b>{s}<r>\" due to error <b>{d} {s}<r>", .{

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -82,7 +82,8 @@ pub const LifecycleScriptSubprocess = struct {
         }
 
         pub fn registerPoll(this: *OutputReader) void {
-            switch (this.poll.register(this.subprocess().manager.uws_event_loop, .readable, true)) {
+            const loop = if(Environment.isWindows) this.subprocess().manager.uws_event_loop.uv_loop else this.subprocess().manager.uws_event_loop;
+            switch (this.poll.register(loop, .readable, true)) {
                 .err => |err| {
                     Output.prettyErrorln("<r><red>error<r>: Failed to register poll for <b>{s}<r> script output from \"<b>{s}<r>\" due to error <b>{d} {s}<r>", .{
                         this.subprocess().scriptName(),

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -653,6 +653,9 @@ pub fn openA(file_path: []const u8, flags: bun.Mode, perm: bun.Mode) Maybe(bun.F
 }
 
 pub fn open(file_path: [:0]const u8, flags: bun.Mode, perm: bun.Mode) Maybe(bun.FileDescriptor) {
+    if (comptime Environment.isWindows) {
+        return sys_uv.open(file_path, flags, perm);
+    }
     // this is what open() does anyway.
     return openat(bun.toFD((std.fs.cwd().fd)), file_path, flags, perm);
 }

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -132,36 +132,36 @@ test("formData uploads roundtrip, without a call to .body", async () => {
   server.stop(true);
 });
 
-// test("uploads roundtrip with sendfile()", async () => {
-//   var hugeTxt = "huge".repeat(1024 * 1024 * 32);
-//   const path = join(tmpdir(), "huge.txt");
-//   require("fs").writeFileSync(path, hugeTxt);
+test("uploads roundtrip with sendfile()", async () => {
+  var hugeTxt = "huge".repeat(1024 * 1024 * 32);
+  const path = join(tmpdir(), "huge.txt");
+  require("fs").writeFileSync(path, hugeTxt);
 
-//   const server = Bun.serve({
-//     port: 0,
-//     development: false,
-//     maxRequestBodySize: 1024 * 1024 * 1024 * 8,
-//     async fetch(req) {
-//       var count = 0;
-//       for await (let chunk of req.body!) {
-//         count += chunk.byteLength;
-//       }
-//       return new Response(count + "");
-//     },
-//   });
+  const server = Bun.serve({
+    port: 0,
+    development: false,
+    maxRequestBodySize: 1024 * 1024 * 1024 * 8,
+    async fetch(req) {
+      var count = 0;
+      for await (let chunk of req.body!) {
+        count += chunk.byteLength;
+      }
+      return new Response(count + "");
+    },
+  });
 
-//   const resp = await fetch("http://" + server.hostname + ":" + server.port, {
-//     body: Bun.file(path),
-//     method: "PUT",
-//   });
+  const resp = await fetch("http://" + server.hostname + ":" + server.port, {
+    body: Bun.file(path),
+    method: "PUT",
+  });
 
-//   expect(resp.status).toBe(200);
+  expect(resp.status).toBe(200);
 
-//   const body = parseInt(await resp.text());
-//   expect(body).toBe(hugeTxt.length);
+  const body = parseInt(await resp.text());
+  expect(body).toBe(hugeTxt.length);
 
-//   server.stop(true);
-// });
+  server.stop(true);
+});
 
 test("missing file throws the expected error", async () => {
   Bun.gc(true);

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -132,36 +132,36 @@ test("formData uploads roundtrip, without a call to .body", async () => {
   server.stop(true);
 });
 
-test("uploads roundtrip with sendfile()", async () => {
-  var hugeTxt = "huge".repeat(1024 * 1024 * 32);
-  const path = join(tmpdir(), "huge.txt");
-  require("fs").writeFileSync(path, hugeTxt);
+// test("uploads roundtrip with sendfile()", async () => {
+//   var hugeTxt = "huge".repeat(1024 * 1024 * 32);
+//   const path = join(tmpdir(), "huge.txt");
+//   require("fs").writeFileSync(path, hugeTxt);
 
-  const server = Bun.serve({
-    port: 0,
-    development: false,
-    maxRequestBodySize: 1024 * 1024 * 1024 * 8,
-    async fetch(req) {
-      var count = 0;
-      for await (let chunk of req.body!) {
-        count += chunk.byteLength;
-      }
-      return new Response(count + "");
-    },
-  });
+//   const server = Bun.serve({
+//     port: 0,
+//     development: false,
+//     maxRequestBodySize: 1024 * 1024 * 1024 * 8,
+//     async fetch(req) {
+//       var count = 0;
+//       for await (let chunk of req.body!) {
+//         count += chunk.byteLength;
+//       }
+//       return new Response(count + "");
+//     },
+//   });
 
-  const resp = await fetch("http://" + server.hostname + ":" + server.port, {
-    body: Bun.file(path),
-    method: "PUT",
-  });
+//   const resp = await fetch("http://" + server.hostname + ":" + server.port, {
+//     body: Bun.file(path),
+//     method: "PUT",
+//   });
 
-  expect(resp.status).toBe(200);
+//   expect(resp.status).toBe(200);
 
-  const body = parseInt(await resp.text());
-  expect(body).toBe(hugeTxt.length);
+//   const body = parseInt(await resp.text());
+//   expect(body).toBe(hugeTxt.length);
 
-  server.stop(true);
-});
+//   server.stop(true);
+// });
 
 test("missing file throws the expected error", async () => {
   Bun.gc(true);
@@ -174,7 +174,7 @@ test("missing file throws the expected error", async () => {
         method: "POST",
         proxy: "http://localhost:3000",
       });
-      expect(Bun.peek.status(resp)).toBe("rejected");
+      // expect(Bun.peek.status(resp)).toBe("rejected");
       expect(async () => await resp).toThrow("No such file or directory");
     }
   });

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -174,7 +174,7 @@ test("missing file throws the expected error", async () => {
         method: "POST",
         proxy: "http://localhost:3000",
       });
-      // expect(Bun.peek.status(resp)).toBe("rejected");
+      expect(Bun.peek.status(resp)).toBe("rejected");
       expect(async () => await resp).toThrow("No such file or directory");
     }
   });


### PR DESCRIPTION
### What does this PR do?
This is just a draft to keep some progress update probably will open a separated PR for final version and close this

Motivation this will work:
test.bat:
```bat
echo Hello!
```
index.js:
```js
const { stdout } = Bun.spawnSync({
  cmd: ["C:\\Users\\ciros\\Repos\\bun\\test.bat"],
});

console.log(stdout.toString());
```
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
