### PR TITLE
fix(docs): prisma not installed as dev dependency

### DIFF
--- a/docs/guides/ecosystem/prisma.md
+++ b/docs/guides/ecosystem/prisma.md
@@ -21,7 +21,8 @@ $ bun init
 Then install the Prisma CLI (`prisma`) and Prisma Client (`@prisma/client`) as dependencies.
 
 ```bash
-$ bun add prisma @prisma/client
+$ bun add -d prisma
+$ bun add @prisma/client
 ```
 
 ---


### PR DESCRIPTION
Fixed simple docs error.
Added flag `-d` to `bun add prisma` (now `bun add -d prisma`)