### PR TITLE
fix(node:url): handle url with missing host on `url.parse`

### DIFF
--- a/src/js/node/url.js
+++ b/src/js/node/url.js
@@ -23,7 +23,6 @@
 
 "use strict";
 
-let toASCII;
 const { URL, URLSearchParams } = globalThis;
 
 function Url() {
@@ -309,14 +308,8 @@ Url.prototype.parse = function (url, parseQueryString, slashesDenoteHost) {
       this.hostname = this.hostname.toLowerCase();
     }
 
-    if (!ipv6Hostname) {
-      /*
-       * IDNA Support: Returns a punycoded representation of "domain".
-       * It only converts parts of the domain name that
-       * have non-ASCII characters, i.e. it doesn't matter if
-       * you call it with a domain that already is ASCII-only.
-       */
-      this.hostname = (toASCII ??= require("node:punycode").toASCII)(this.hostname);
+    if (this.hostname) {
+      this.hostname = new URL("http://" + this.hostname).hostname;
     }
 
     var p = this.port ? ":" + this.port : "";

--- a/src/js/node/url.js
+++ b/src/js/node/url.js
@@ -24,6 +24,7 @@
 "use strict";
 
 const { URL, URLSearchParams } = globalThis;
+const { toASCII } = require("node:punycode");
 
 function Url() {
   this.protocol = null;
@@ -315,7 +316,7 @@ Url.prototype.parse = function (url, parseQueryString, slashesDenoteHost) {
        * have non-ASCII characters, i.e. it doesn't matter if
        * you call it with a domain that already is ASCII-only.
        */
-      this.hostname = new URL("http://" + this.hostname).hostname;
+      this.hostname = toASCII(this.hostname);
     }
 
     var p = this.port ? ":" + this.port : "";

--- a/src/js/node/url.js
+++ b/src/js/node/url.js
@@ -23,8 +23,8 @@
 
 "use strict";
 
+let toASCII;
 const { URL, URLSearchParams } = globalThis;
-const { toASCII } = require("node:punycode");
 
 function Url() {
   this.protocol = null;
@@ -316,7 +316,7 @@ Url.prototype.parse = function (url, parseQueryString, slashesDenoteHost) {
        * have non-ASCII characters, i.e. it doesn't matter if
        * you call it with a domain that already is ASCII-only.
        */
-      this.hostname = toASCII(this.hostname);
+      this.hostname = (toASCII ??= require("node:punycode").toASCII)(this.hostname);
     }
 
     var p = this.port ? ":" + this.port : "";

--- a/src/js/node/url.js
+++ b/src/js/node/url.js
@@ -308,6 +308,12 @@ Url.prototype.parse = function (url, parseQueryString, slashesDenoteHost) {
       this.hostname = this.hostname.toLowerCase();
     }
 
+    /*
+     * IDNA Support: Returns a punycoded representation of "domain".
+     * It only converts parts of the domain name that
+     * have non-ASCII characters, i.e. it doesn't matter if
+     * you call it with a domain that already is ASCII-only.
+     */
     if (this.hostname) {
       this.hostname = new URL("http://" + this.hostname).hostname;
     }

--- a/test/js/node/url/url.test.ts
+++ b/test/js/node/url/url.test.ts
@@ -17,4 +17,38 @@ describe("Url.prototype.parse", () => {
   it("accepts empty host", () => {
     expect(() => parse("http://")).not.toThrow();
   });
+
+  it("accepts ipv6 host", () => {
+    expect(parse("http://[::1]")).toEqual({
+      protocol: "http:",
+      slashes: true,
+      auth: null,
+      host: "[::1]",
+      port: null,
+      hostname: "::1",
+      hash: null,
+      search: null,
+      query: null,
+      pathname: "/",
+      path: "/",
+      href: "http://[::1]/",
+    });
+  });
+
+  it("handles punycode", () => {
+    expect(parse("http://xn--xample-hva.com")).toEqual({
+      protocol: "http:",
+      slashes: true,
+      auth: null,
+      host: "xn--xample-hva.com",
+      port: null,
+      hostname: "xn--xample-hva.com",
+      hash: null,
+      search: null,
+      query: null,
+      pathname: "/",
+      path: "/",
+      href: "http://xn--xample-hva.com/",
+    });
+  });
 });

--- a/test/js/node/url/url.test.ts
+++ b/test/js/node/url/url.test.ts
@@ -1,0 +1,20 @@
+import { parse } from "url";
+
+describe("Url.prototype.parse", () => {
+  it("parses URL correctly", () => {
+    const url = parse("https://foo:bar@baz.qat:8000/qux/quux?foo=bar&baz=12#qat");
+
+    expect(url.hash).toEqual("#qat");
+    expect(url.host).toEqual("baz.qat:8000");
+    expect(url.hostname).toEqual("baz.qat");
+    expect(url.href).toEqual("https://foo:bar@baz.qat:8000/qux/quux?foo=bar&baz=12#qat");
+    expect(url.pathname).toEqual("/qux/quux");
+    expect(url.port).toEqual("8000");
+    expect(url.protocol).toEqual("https:");
+    expect(url.search).toEqual("?foo=bar&baz=12");
+  });
+
+  it("accepts empty host", () => {
+    expect(() => parse("http://")).not.toThrow();
+  });
+});

--- a/test/js/node/url/url.test.ts
+++ b/test/js/node/url/url.test.ts
@@ -50,5 +50,19 @@ describe("Url.prototype.parse", () => {
       path: "/",
       href: "http://xn--xample-hva.com/",
     });
+    expect(parse("http://💥.net")).toEqual({
+      protocol: "http:",
+      slashes: true,
+      auth: null,
+      host: "xn--hs8h.net",
+      port: null,
+      hostname: "xn--hs8h.net",
+      hash: null,
+      search: null,
+      query: null,
+      pathname: "/",
+      path: "/",
+      href: "http://xn--hs8h.net/",
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Aligns the deprecated `url.parse` function with Node's implementation.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->


- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)


<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

Closes https://github.com/oven-sh/bun/issues/8098
