### PR TITLE
fix(webkit:performance): correctly track size of measures map

### DIFF
--- a/src/bun.js/bindings/webcore/PerformanceUserTiming.cpp
+++ b/src/bun.js/bindings/webcore/PerformanceUserTiming.cpp
@@ -184,6 +184,7 @@ ExceptionOr<Ref<PerformanceMeasure>> PerformanceUserTiming::measure(const String
         return measure.releaseException();
 
     addPerformanceEntry(m_measuresMap, measureName, measure.returnValue().get());
+    m_measureCounter += 1;
     return measure.releaseReturnValue();
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix an issue in `PerformanceUserTiming.cpp` that would lead to `m_measureCounter` to get out of sync with the size of `m_measuresMap`

### How did you verify your code works?

The tests now pass with debug assertions.
