### PR TITLE
fix signalNumberToNameMap assignment for SIGINFO

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -742,7 +742,7 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
         signalNumberToNameMap->add(SIGWINCH, signalNames[27]);
         signalNumberToNameMap->add(SIGIO, signalNames[28]);
 #ifdef SIGINFO
-        signalNameToNumberMap->add(signalNames[29], SIGINFO);
+        signalNumberToNameMap->add(SIGINFO, signalNames[29]);
 #endif
         signalNumberToNameMap->add(SIGSYS, signalNames[30]);
     });


### PR DESCRIPTION
small typo in mapping SIG names