### PR TITLE
fix: match node's `path.parse` on dotfiles.

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1392,7 +1392,7 @@ pub const NodeJSPathName = struct {
             if (strings.lastIndexOfChar(filename, '.')) |dot| {
                 if (dot > 0) {
                     filename = filename[0..dot];
-                    ext = filename[dot..];
+                    ext = base[dot..];
                 }
             }
         }

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1390,9 +1390,10 @@ pub const NodeJSPathName = struct {
         if (filename.len > 1) {
             // Strip off the extension
             if (strings.lastIndexOfChar(filename, '.')) |dot| {
-                ext = filename[dot..];
-                if (dot > 0)
+                if (dot > 0) {
                     filename = filename[0..dot];
+                    ext = filename[dot..];
+                }
             }
         }
 

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -835,6 +835,17 @@ describe("path.posix.parse and path.posix.format", () => {
         name: "Ł",
       },
     },
+    {
+      // https://github.com/oven-sh/bun/issues/8090
+      input: ".prettierrc",
+      expected: {
+        root: "",
+        dir: "",
+        base: ".prettierrc",
+        ext: "",
+        name: ".prettierrc",
+      },
+    },
   ];
   testCases.forEach(({ input, expected }) => {
     it(`case ${input}`, () => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

My new test started passing and no other tests started failing.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->


I am a new developer to open source. Please tell me if anything is wrong and I need to fix anything.