### PR TITLE
fix: idleTimeout in websockets  

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -183,7 +183,13 @@ void us_loop_run_bun_tick(struct us_loop_t *loop, int64_t timeoutMs, void* tickC
     if (loop->num_polls == 0)
         return;
 
-    us_loop_integrate(loop);
+    struct us_internal_callback_t *timer_callback = (struct us_internal_callback_t*)loop->data.sweep_timer;
+
+    // Only integrate the loop if we haven't already.
+    // Otherwise we will keep restarting the timer.
+    if(!timer_callback->cb) {
+        us_loop_integrate(loop);
+    }
 
     if (tickCallbackContext) {
         bun_on_tick_before(tickCallbackContext);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Before this change `us_loop_integrate` was invoked on each call to `us_loop_run_bun_tick`. 
Which caused the timer used for socket timeouts to never be invoked.

I changed the code to only integrate the timer if it hasn't been before.

Fixes #1397

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

The minimum idle timeout is 8 seconds which is a bit long for a unit test. 

I only tried the change locally instead of adding a test.
```
const idle_timeout_seconds = 8;
const allowed_timeout_deviation = 2;

let server = undefined;

let promise = new Promise((resolve, reject) => {
  let timeout = undefined;

  server = Bun.serve({
    port: 0,
    fetch(request, server) {
      const url = new URL(request.url);
      if (url.pathname === "/ws") {
        if (server.upgrade(request)) {
          return;
        }
        return new Response("Upgrade failed :(", { status: 500 });
      }
      return new Response("Bun");
    },
    websocket: {
      idleTimeout: idle_timeout_seconds,
      sendPings: false,
      open() {
        timeout = setTimeout(() => {
          reject.call();
        }, (idle_timeout_seconds + allowed_timeout_deviation) * 1000);
      },
      close() {
        clearTimeout(timeout);
        resolve.call();
      }
    },
  });
});

const ws = new WebSocket(`ws://${server.hostname}:${server.port}/ws`)

await promise
server.stop(true);

console.log("Success")
```

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
