### PR TITLE
Add support for custom Module._extensions

### DIFF
--- a/src/bun.js/bindings/CommonJSModuleRecord.cpp
+++ b/src/bun.js/bindings/CommonJSModuleRecord.cpp
@@ -68,11 +68,13 @@
 #include <JavaScriptCore/HeapAnalyzer.h>
 
 extern "C" bool Bun__isBunMain(JSC::JSGlobalObject* global, const BunString*);
+extern "C" JSC__JSValue Bun__Path__basename(JSC__JSGlobalObject* arg0, bool arg1, JSC__JSValue* arg2, uint16_t arg3);
+extern "C" JSC__JSValue Bun__Path__dirname(JSC__JSGlobalObject* arg0, bool arg1, JSC__JSValue* arg2, uint16_t arg3);
 
 namespace Bun {
 using namespace JSC;
 
-JSC_DECLARE_HOST_FUNCTION(jsFunctionRequireCommonJS);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionRequirePrivate);
 
 static bool canPerformFastEnumeration(Structure* s)
 {
@@ -103,19 +105,23 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
         return false;
     }
 
+    auto clientData = WebCore::clientData(vm);
+    auto builtinNames = clientData->builtinNames();
+    auto globalString = globalObject->commonStrings().resolveString(globalObject);
+
     JSFunction* resolveFunction = JSC::JSBoundFunction::create(vm,
         globalObject,
         globalObject->requireResolveFunctionUnbound(),
         moduleObject->id(),
-        ArgList(), 1, globalObject->commonStrings().resolveString(globalObject));
+        ArgList(), 1, globalString);
     JSFunction* requireFunction = JSC::JSBoundFunction::create(vm,
         globalObject,
         globalObject->requireFunctionUnbound(),
         moduleObject,
-        ArgList(), 1, globalObject->commonStrings().requireString(globalObject));
+        ArgList(), 1, globalString);
     requireFunction->putDirect(vm, vm.propertyNames->resolve, resolveFunction, 0);
-    moduleObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().requirePublicName(), requireFunction, 0);
 
+    moduleObject->putDirect(vm, builtinNames.requirePublicName(), requireFunction, 0);
     moduleObject->hasEvaluated = true;
 
     // This will return 0 if there was a syntax error or an allocation failure
@@ -148,11 +154,11 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
     return exception.get() == nullptr;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsFunctionLoadModule, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+JSC_DEFINE_HOST_FUNCTION(jsFunctionEvaluateCommonJSModule, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
     auto* globalObject = jsCast<Zig::GlobalObject*>(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(globalObject->vm());
-    JSCommonJSModule* moduleObject = jsDynamicCast<JSCommonJSModule*>(callframe->argument(0));
+    JSCommonJSModule* moduleObject = jsDynamicCast<JSCommonJSModule*>(callFrame->argument(0));
     if (!moduleObject) {
         RELEASE_AND_RETURN(throwScope, JSValue::encode(jsBoolean(true)));
     }
@@ -184,18 +190,18 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionLoadModule, (JSGlobalObject * lexicalGlobalOb
     RELEASE_AND_RETURN(throwScope, JSValue::encode(jsBoolean(true)));
 }
 
-JSC_DEFINE_HOST_FUNCTION(requireResolvePathsFunction, (JSGlobalObject * globalObject, CallFrame* callframe))
+JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireResolvePaths, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     return JSValue::encode(JSC::constructEmptyArray(globalObject, nullptr, 0));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsRequireCacheGetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+JSC_DEFINE_CUSTOM_GETTER(requireCacheGetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     Zig::GlobalObject* thisObject = jsCast<Zig::GlobalObject*>(globalObject);
     return JSValue::encode(thisObject->lazyRequireCacheObject());
 }
 
-JSC_DEFINE_CUSTOM_SETTER(jsRequireCacheSetter,
+JSC_DEFINE_CUSTOM_SETTER(requireCacheSetter,
     (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
         JSC::EncodedJSValue value, JSC::PropertyName propertyName))
 {
@@ -208,11 +214,11 @@ JSC_DEFINE_CUSTOM_SETTER(jsRequireCacheSetter,
 }
 
 static const HashTableValue RequireResolveFunctionPrototypeValues[] = {
-    { "paths"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, requireResolvePathsFunction, 1 } },
+    { "paths"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsFunctionRequireResolvePaths, 1 } },
 };
 
 static const HashTableValue RequireFunctionPrototypeValues[] = {
-    { "cache"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsRequireCacheGetter, jsRequireCacheSetter } },
+    { "cache"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, requireCacheGetter, requireCacheSetter } },
 };
 
 Structure* RequireFunctionPrototype::createStructure(
@@ -236,7 +242,6 @@ Structure* RequireResolveFunctionPrototype::createStructure(
 RequireResolveFunctionPrototype* RequireResolveFunctionPrototype::create(JSC::JSGlobalObject* globalObject)
 {
     auto& vm = globalObject->vm();
-
     auto* structure = RequireResolveFunctionPrototype::createStructure(vm, globalObject);
     RequireResolveFunctionPrototype* prototype = new (NotNull, JSC::allocateCell<RequireResolveFunctionPrototype>(vm)) RequireResolveFunctionPrototype(vm, structure);
     prototype->finishCreation(vm);
@@ -247,12 +252,9 @@ RequireFunctionPrototype* RequireFunctionPrototype::create(
     JSC::JSGlobalObject* globalObject)
 {
     auto& vm = globalObject->vm();
-
     auto* structure = RequireFunctionPrototype::createStructure(vm, globalObject);
     RequireFunctionPrototype* prototype = new (NotNull, JSC::allocateCell<RequireFunctionPrototype>(vm)) RequireFunctionPrototype(vm, structure);
     prototype->finishCreation(vm);
-
-    prototype->putDirect(vm, builtinNames(vm).resolvePublicName(), jsCast<Zig::GlobalObject*>(globalObject)->requireResolveFunctionUnbound(), 0);
 
     return prototype;
 }
@@ -263,26 +265,34 @@ void RequireFunctionPrototype::finishCreation(JSC::VM& vm)
     ASSERT(inherits(info()));
 
     reifyStaticProperties(vm, info(), RequireFunctionPrototypeValues, *this);
+
+    auto clientData = WebCore::clientData(vm);
+    auto* globalObject = reinterpret_cast<Zig::GlobalObject*>(this->globalObject());
+    auto builtinNames = clientData->builtinNames();
+
     JSC::JSFunction* requireDotMainFunction = JSFunction::create(
         vm,
         moduleMainCodeGenerator(vm),
-        globalObject()->globalScope());
+        globalObject->globalScope());
 
     this->putDirectAccessor(
-        globalObject(),
+        globalObject,
         JSC::Identifier::fromString(vm, "main"_s),
-        JSC::GetterSetter::create(vm, globalObject(), requireDotMainFunction, requireDotMainFunction),
+        JSC::GetterSetter::create(vm, globalObject, requireDotMainFunction, requireDotMainFunction),
         PropertyAttribute::Accessor | PropertyAttribute::ReadOnly | 0);
 
-    auto extensions = constructEmptyObject(globalObject());
+    this->putDirect(vm, builtinNames.resolvePublicName(), globalObject->requireResolveFunctionUnbound(), 0);
+
+    auto extensions = constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure());
     extensions->putDirect(vm, JSC::Identifier::fromString(vm, ".js"_s), jsBoolean(true), 0);
     extensions->putDirect(vm, JSC::Identifier::fromString(vm, ".json"_s), jsBoolean(true), 0);
     extensions->putDirect(vm, JSC::Identifier::fromString(vm, ".node"_s), jsBoolean(true), 0);
-
+    extensions->putDirect(vm, builtinNames.originalStructureIDPrivateName(), jsNumber(0), 0);
+    extensions->putDirect(vm, builtinNames.originalStructureIDPrivateName(), jsNumber(extensions->structureID().bits()), 0);
     this->putDirect(vm, JSC::Identifier::fromString(vm, "extensions"_s), extensions, 0);
 }
 
-JSC_DEFINE_CUSTOM_GETTER(getterFilename, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+JSC_DEFINE_CUSTOM_GETTER(filenameGetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
     if (UNLIKELY(!thisObject)) {
@@ -290,7 +300,20 @@ JSC_DEFINE_CUSTOM_GETTER(getterFilename, (JSC::JSGlobalObject * globalObject, JS
     }
     return JSValue::encode(thisObject->m_filename.get());
 }
-JSC_DEFINE_CUSTOM_GETTER(getterId, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+
+JSC_DEFINE_CUSTOM_SETTER(filenameSetter,
+    (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
+        JSC::EncodedJSValue value, JSC::PropertyName propertyName))
+{
+    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
+    if (!thisObject)
+        return false;
+
+    thisObject->m_filename.set(globalObject->vm(), thisObject, JSValue::decode(value).toString(globalObject));
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_GETTER(idGetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
     if (UNLIKELY(!thisObject)) {
@@ -299,16 +322,42 @@ JSC_DEFINE_CUSTOM_GETTER(getterId, (JSC::JSGlobalObject * globalObject, JSC::Enc
     return JSValue::encode(thisObject->m_id.get());
 }
 
-JSC_DEFINE_CUSTOM_GETTER(getterPath, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+JSC_DEFINE_CUSTOM_SETTER(idSetter,
+    (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
+        JSC::EncodedJSValue value, JSC::PropertyName propertyName))
+{
+    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
+    if (!thisObject)
+        return false;
+
+    thisObject->m_id.set(globalObject->vm(), thisObject, JSValue::decode(value).toString(globalObject));
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_GETTER(loadedGetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
     if (UNLIKELY(!thisObject)) {
         return JSValue::encode(jsUndefined());
     }
-    return JSValue::encode(thisObject->m_id.get());
+
+    return JSValue::encode(jsBoolean(thisObject->hasEvaluated));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(getterParent, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+JSC_DEFINE_CUSTOM_SETTER(loadedSetter,
+    (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
+        JSC::EncodedJSValue value, JSC::PropertyName propertyName))
+{
+    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
+    if (!thisObject)
+        return false;
+
+    thisObject->hasEvaluated = JSValue::decode(value).toBoolean(globalObject);
+
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_GETTER(parentGetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
     if (UNLIKELY(!thisObject)) {
@@ -334,7 +383,29 @@ JSC_DEFINE_CUSTOM_GETTER(getterParent, (JSC::JSGlobalObject * globalObject, JSC:
     return JSValue::encode(jsUndefined());
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setterPath,
+JSC_DEFINE_CUSTOM_SETTER(parentSetter,
+    (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
+        JSC::EncodedJSValue value, JSC::PropertyName propertyName))
+{
+    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
+    if (!thisObject)
+        return false;
+
+    thisObject->m_parent.set(globalObject->vm(), thisObject, JSValue::decode(value));
+
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_GETTER(pathGetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
+    if (UNLIKELY(!thisObject)) {
+        return JSValue::encode(jsUndefined());
+    }
+    return JSValue::encode(thisObject->m_id.get());
+}
+
+JSC_DEFINE_CUSTOM_SETTER(pathSetter,
     (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
         JSC::EncodedJSValue value, JSC::PropertyName propertyName))
 {
@@ -348,7 +419,7 @@ JSC_DEFINE_CUSTOM_SETTER(setterPath,
 
 extern "C" JSC::EncodedJSValue Resolver__propForRequireMainPaths(JSGlobalObject*);
 
-JSC_DEFINE_CUSTOM_GETTER(getterPaths, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+JSC_DEFINE_CUSTOM_GETTER(pathsGetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
     if (UNLIKELY(!thisObject)) {
@@ -363,17 +434,7 @@ JSC_DEFINE_CUSTOM_GETTER(getterPaths, (JSC::JSGlobalObject * globalObject, JSC::
     return JSValue::encode(thisObject->m_paths.get());
 }
 
-JSC_DEFINE_CUSTOM_GETTER(getterLoaded, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
-{
-    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!thisObject)) {
-        return JSValue::encode(jsUndefined());
-    }
-
-    return JSValue::encode(jsBoolean(thisObject->hasEvaluated));
-}
-
-JSC_DEFINE_CUSTOM_SETTER(setterPaths,
+JSC_DEFINE_CUSTOM_SETTER(pathsSetter,
     (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
         JSC::EncodedJSValue value, JSC::PropertyName propertyName))
 {
@@ -385,62 +446,14 @@ JSC_DEFINE_CUSTOM_SETTER(setterPaths,
     return true;
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setterFilename,
-    (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
-        JSC::EncodedJSValue value, JSC::PropertyName propertyName))
-{
-    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
-    if (!thisObject)
-        return false;
-
-    thisObject->m_filename.set(globalObject->vm(), thisObject, JSValue::decode(value).toString(globalObject));
-    return true;
-}
-
-JSC_DEFINE_CUSTOM_SETTER(setterId,
-    (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
-        JSC::EncodedJSValue value, JSC::PropertyName propertyName))
-{
-    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
-    if (!thisObject)
-        return false;
-
-    thisObject->m_id.set(globalObject->vm(), thisObject, JSValue::decode(value).toString(globalObject));
-    return true;
-}
-JSC_DEFINE_CUSTOM_SETTER(setterParent,
-    (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
-        JSC::EncodedJSValue value, JSC::PropertyName propertyName))
-{
-    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
-    if (!thisObject)
-        return false;
-
-    thisObject->m_parent.set(globalObject->vm(), thisObject, JSValue::decode(value));
-
-    return true;
-}
-JSC_DEFINE_CUSTOM_SETTER(setterLoaded,
-    (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
-        JSC::EncodedJSValue value, JSC::PropertyName propertyName))
-{
-    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(JSValue::decode(thisValue));
-    if (!thisObject)
-        return false;
-
-    thisObject->hasEvaluated = JSValue::decode(value).toBoolean(globalObject);
-
-    return true;
-}
-
 static JSValue createChildren(VM& vm, JSObject* object)
 {
     return constructEmptyArray(object->globalObject(), nullptr, 0);
 }
 
-JSC_DEFINE_HOST_FUNCTION(functionCommonJSModuleRecord_compile, (JSGlobalObject * globalObject, CallFrame* callframe))
+JSC_DEFINE_HOST_FUNCTION(jsFunctionCommonJSModuleRecord_compile, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
-    auto* moduleObject = jsDynamicCast<JSCommonJSModule*>(callframe->thisValue());
+    auto* moduleObject = jsDynamicCast<JSCommonJSModule*>(callFrame->thisValue());
     if (!moduleObject) {
         return JSValue::encode(jsUndefined());
     }
@@ -448,42 +461,46 @@ JSC_DEFINE_HOST_FUNCTION(functionCommonJSModuleRecord_compile, (JSGlobalObject *
     auto& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    String sourceString = callframe->argument(0).toWTFString(globalObject);
+    JSValue sourceValue = callFrame->argument(0);
+    auto sourceWTF = sourceValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, JSValue::encode({}));
 
-    String filenameString = callframe->argument(1).toWTFString(globalObject);
+    JSValue filenameValue = callFrame->argument(1);
+    auto filenameWTF = filenameValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, JSValue::encode({}));
+
+    auto filename = JSC::jsStringWithCache(vm, filenameWTF);
+    WTF::Vector<JSC::EncodedJSValue, 1> dirnameArgs;
+    dirnameArgs.reserveInitialCapacity(1);
+    dirnameArgs.unsafeAppendWithoutCapacityCheck(JSValue::encode(filenameValue));
+#if OS(WINDOWS)
+    auto dirname = JSValue::decode(Bun__Path__dirname(globalObject, true, reinterpret_cast<JSC__JSValue*>(dirnameArgs.data()), 1)).toString(globalObject);
+#else
+    auto dirname = JSValue::decode(Bun__Path__dirname(globalObject, false, reinterpret_cast<JSC__JSValue*>(dirnameArgs.data()), 1)).toString(globalObject);
+#endif
 
     String wrappedString = makeString(
         "(function(exports,require,module,__filename,__dirname){"_s,
-        sourceString,
+        sourceWTF,
         "\n})"_s);
 
-    SourceCode sourceCode = makeSource(
+    SourceCode sourceCode = JSC::makeSource(
         WTFMove(wrappedString),
-        SourceOrigin(URL::fileURLWithFileSystemPath(filenameString)),
+        SourceOrigin(URL::fileURLWithFileSystemPath(filenameWTF)),
         JSC::SourceTaintedOrigin::Untainted,
-        filenameString,
+        filenameWTF,
         WTF::TextPosition(),
         JSC::SourceProviderSourceType::Program);
     JSSourceCode* jsSourceCode = JSSourceCode::create(vm, WTFMove(sourceCode));
     moduleObject->sourceCode.set(vm, moduleObject, jsSourceCode);
-
-    auto index = filenameString.reverseFind('/', filenameString.length());
-    String dirnameString;
-    if (index != WTF::notFound) {
-        dirnameString = filenameString.substring(0, index);
-    } else {
-        dirnameString = "/"_s;
-    }
 
     WTF::NakedPtr<JSC::Exception> exception;
     evaluateCommonJSModuleOnce(
         vm,
         jsCast<Zig::GlobalObject*>(globalObject),
         moduleObject,
-        jsString(vm, dirnameString),
-        jsString(vm, filenameString),
+        dirname,
+        filename,
         exception);
 
     if (exception) {
@@ -495,15 +512,86 @@ JSC_DEFINE_HOST_FUNCTION(functionCommonJSModuleRecord_compile, (JSGlobalObject *
     return JSValue::encode(jsUndefined());
 }
 
+extern "C" JSC::EncodedJSValue jsFunctionResolveSyncPrivate(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+{
+    auto* globalObject = jsCast<Zig::GlobalObject*>(lexicalGlobalObject);
+    auto& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue moduleName = callFrame->argument(0);
+    JSValue from = callFrame->argument(1);
+    bool isESM = callFrame->argument(2).asBoolean();
+
+    if (moduleName.isUndefinedOrNull()) {
+        JSC::throwTypeError(globalObject, throwScope, "expected module name as a string"_s);
+        throwScope.release();
+        return JSValue::encode(JSValue {});
+    }
+
+    RETURN_IF_EXCEPTION(throwScope, JSValue::encode(JSValue {}));
+
+    if (globalObject->onLoadPlugins.hasVirtualModules()) {
+        if (moduleName.isString()) {
+            auto moduleStr = moduleName.toWTFString(globalObject);
+            auto resolvedString = globalObject->onLoadPlugins.resolveVirtualModule(moduleStr, from.toWTFString(globalObject));
+            if (resolvedString) {
+                if (moduleStr == resolvedString.value())
+                    return JSValue::encode(moduleName);
+                return JSValue::encode(jsString(vm, resolvedString.value()));
+            }
+        }
+    }
+
+    if (!isESM) {
+        auto overrideHandler = globalObject->m_nodeModuleOverriddenResolveFilename.get();
+        if (UNLIKELY(overrideHandler)) {
+            ASSERT(overrideHandler->isCallable());
+            auto requireMap = globalObject->requireMap();
+            auto* parentModuleObject = jsDynamicCast<Bun::JSCommonJSModule*>(requireMap->get(globalObject, from));
+
+            JSValue parentID = jsUndefined();
+            if (parentModuleObject) {
+                parentID = parentModuleObject->id();
+            } else {
+                parentID = from;
+            }
+
+            auto parentIdStr = parentID.toWTFString(globalObject);
+            auto bunStr = Bun::toString(parentIdStr);
+
+            MarkedArgumentBuffer args;
+            args.append(moduleName);
+            args.append(parentModuleObject);
+            args.append(jsBoolean(Bun__isBunMain(globalObject, &bunStr)));
+
+            // `Module` will be cached because requesting it is the only way to access `Module._resolveFilename`.
+            auto* ModuleModuleObject = jsCast<Bun::JSCommonJSModule*>(requireMap->get(globalObject, JSC::jsStringWithCache(vm, "module"_s)));
+            auto ModuleExportsObject = ModuleModuleObject->exportsObject();
+
+            return JSValue::encode(JSC::call(globalObject, overrideHandler, JSC::getCallData(overrideHandler), ModuleExportsObject, args));
+        }
+    }
+
+    auto result = Bun__resolveSync(globalObject, JSValue::encode(moduleName), JSValue::encode(from), isESM);
+
+    if (!JSValue::decode(result).isString()) {
+        JSC::throwException(globalObject, throwScope, JSValue::decode(result));
+        return JSValue::encode(JSValue {});
+    }
+
+    throwScope.release();
+    return result;
+}
+
 static const struct HashTableValue JSCommonJSModulePrototypeTableValues[] = {
-    { "_compile"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, functionCommonJSModuleRecord_compile, 2 } },
+    { "_compile"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsFunctionCommonJSModuleRecord_compile, 2 } },
     { "children"_s, static_cast<unsigned>(PropertyAttribute::PropertyCallback), NoIntrinsic, { HashTableValue::LazyPropertyType, createChildren } },
-    { "filename"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterFilename, setterFilename } },
-    { "id"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterId, setterId } },
-    { "loaded"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterLoaded, setterLoaded } },
-    { "parent"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, getterParent, setterParent } },
-    { "path"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterPath, setterPath } },
-    { "paths"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterPaths, setterPaths } },
+    { "filename"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, filenameGetter, filenameSetter } },
+    { "id"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, idGetter, idSetter } },
+    { "loaded"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, loadedGetter, loadedSetter } },
+    { "parent"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, parentGetter, parentSetter } },
+    { "path"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, pathGetter, pathSetter } },
+    { "paths"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, pathsGetter, pathsSetter } },
 };
 
 class JSCommonJSModulePrototype final : public JSC::JSNonFinalObject {
@@ -522,7 +610,7 @@ public:
     static JSC::Structure* createStructure(
         JSC::VM& vm,
         JSC::JSGlobalObject* globalObject,
-        JSC::JSValue prototype)
+        JSValue prototype)
     {
         auto* structure = JSC::Structure::create(vm, globalObject, prototype, TypeInfo(JSC::ObjectType, StructureFlags), info());
         structure->setMayBePrototype(true);
@@ -556,7 +644,7 @@ public:
             globalObject,
             clientData(vm)->builtinNames().requirePrivateName(),
             2,
-            jsFunctionRequireCommonJS, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete);
+            jsFunctionRequirePrivate, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete);
     }
 };
 
@@ -577,7 +665,6 @@ JSC::Structure* JSCommonJSModule::createStructure(
     JSC::JSGlobalObject* globalObject)
 {
     auto& vm = globalObject->vm();
-
     auto* prototype = JSCommonJSModulePrototype::create(vm, globalObject, JSCommonJSModulePrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
 
     // Do not set the number of inline properties on this structure
@@ -598,39 +685,41 @@ JSCommonJSModule* JSCommonJSModule::create(
     return cell;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsFunctionCreateCommonJSModule, (JSGlobalObject * globalObject, CallFrame* callframe))
+JSC_DEFINE_HOST_FUNCTION(jsFunctionCreateCommonJSModule, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = globalObject->vm();
-    RELEASE_ASSERT(callframe->argumentCount() == 4);
+    RELEASE_ASSERT(callFrame->argumentCount() == 4);
 
-    auto id = callframe->uncheckedArgument(0).toWTFString(globalObject);
-    JSValue object = callframe->uncheckedArgument(1);
-    JSValue hasEvaluated = callframe->uncheckedArgument(2);
+    auto id = callFrame->uncheckedArgument(0).toString(globalObject);
+    JSValue object = callFrame->uncheckedArgument(1);
+    JSValue hasEvaluated = callFrame->uncheckedArgument(2);
     ASSERT(hasEvaluated.isBoolean());
-    JSValue parent = callframe->uncheckedArgument(3);
+    JSValue parent = callFrame->uncheckedArgument(3);
 
     return JSValue::encode(JSCommonJSModule::create(jsCast<Zig::GlobalObject*>(globalObject), id, object, hasEvaluated.isTrue(), parent));
 }
 
 JSCommonJSModule* JSCommonJSModule::create(
     Zig::GlobalObject* globalObject,
-    const WTF::String& key,
+    JSC::JSString* id,
     JSValue exportsObject,
     bool hasEvaluated,
     JSValue parent)
 {
     auto& vm = globalObject->vm();
-    JSString* requireMapKey = JSC::jsStringWithCache(vm, key);
-    auto index = key.reverseFind('/', key.length());
-    JSString* dirname = jsEmptyString(vm);
-    if (index != WTF::notFound) {
-        dirname = JSC::jsSubstring(globalObject, requireMapKey, 0, index);
-    }
+    WTF::Vector<JSC::EncodedJSValue, 1> dirnameArgs;
+    dirnameArgs.reserveInitialCapacity(1);
+    dirnameArgs.unsafeAppendWithoutCapacityCheck(JSValue::encode(id));
+#if OS(WINDOWS)
+    auto dirname = JSValue::decode(Bun__Path__dirname(globalObject, true, reinterpret_cast<JSC__JSValue*>(dirnameArgs.data()), 1)).toString(globalObject);
+#else
+    auto dirname = JSValue::decode(Bun__Path__dirname(globalObject, false, reinterpret_cast<JSC__JSValue*>(dirnameArgs.data()), 1)).toString(globalObject);
+#endif
 
     auto* out = JSCommonJSModule::create(
         vm,
         globalObject->CommonJSModuleObjectStructure(),
-        requireMapKey, requireMapKey, dirname, nullptr);
+        id, id, dirname, nullptr);
 
     out->putDirect(
         vm,
@@ -837,8 +926,6 @@ void JSCommonJSModule::toSyntheticSource(JSC::JSGlobalObject* globalObject,
     JSC::MarkedArgumentBuffer& exportValues)
 {
     auto result = this->exportsObject();
-
-    auto& vm = globalObject->vm();
     populateESMExports(globalObject, result, exportNames, exportValues, this->ignoreESModuleAnnotation);
 }
 
@@ -890,23 +977,82 @@ const JSC::ClassInfo JSCommonJSModule::s_info = { "Module"_s, &Base::s_info, nul
 const JSC::ClassInfo RequireResolveFunctionPrototype::s_info = { "resolve"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(RequireResolveFunctionPrototype) };
 const JSC::ClassInfo RequireFunctionPrototype::s_info = { "require"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(RequireFunctionPrototype) };
 
-JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireCommonJS, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+JSC_DEFINE_HOST_FUNCTION(jsFunctionRequirePrivate, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
     auto* globalObject = jsCast<Zig::GlobalObject*>(lexicalGlobalObject);
     auto& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(callframe->thisValue());
-    if (!thisObject)
+    JSCommonJSModule* thisObject = jsDynamicCast<JSCommonJSModule*>(callFrame->thisValue());
+    if (!thisObject) {
         return throwVMTypeError(globalObject, throwScope);
+    }
 
-    JSValue specifierValue = callframe->argument(0);
-    WTF::String specifier = specifierValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
+
+    JSValue specifierValue = callFrame->argument(0);
+    auto specifier = specifierValue.toWTFString(globalObject);
+    auto* moduleObject = jsCast<JSCommonJSModule*>(callFrame->argument(1));
+
+    auto requireUnbound = globalObject->requireFunctionUnbound();
+    auto requireUnboundPrototype = requireUnbound->getPrototype(vm, globalObject);
+    if (requireUnboundPrototype.isObject()) {
+        JSObject* prototype = requireUnboundPrototype.getObject();
+        auto extensionsValue = prototype->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, "extensions"_s));
+        if (extensionsValue.isObject()) {
+            auto clientData = WebCore::clientData(vm);
+            auto builtinNames = clientData->builtinNames();
+            JSObject* extensionsObject = extensionsValue.getObject();
+            bool structureChanged = extensionsObject->getDirect(vm, builtinNames.originalStructureIDPrivateName()) != jsNumber(extensionsObject->structureID().bits());
+            if (UNLIKELY(structureChanged)) {
+                WTF::Vector<JSC::EncodedJSValue, 1> basenameArgs;
+                basenameArgs.reserveInitialCapacity(1);
+                basenameArgs.unsafeAppendWithoutCapacityCheck(JSC::JSValue::encode(specifierValue));
+#if OS(WINDOWS)
+                auto basename = JSValue::decode(Bun__Path__basename(globalObject, true, reinterpret_cast<JSC__JSValue*>(basenameArgs.data()), 1)).toWTFString(globalObject);
+#else
+                auto basename = JSValue::decode(Bun__Path__basename(globalObject, false, reinterpret_cast<JSC__JSValue*>(basenameArgs.data()), 1)).toWTFString(globalObject);
+#endif
+                size_t index = 0;
+                uint16_t startIndex = 0;
+                JSFunction* extHandler = nullptr;
+                // Find longest registered extension.
+                while ((index = basename.find("."_s, startIndex)) != WTF::notFound) {
+                    if (index == 0) {
+                        // Skip dotfiles like .gitignore
+                        continue;
+                    }
+                    auto extStr = basename.substring(index);
+                    auto extValue = extensionsObject->get(globalObject, JSC::Identifier::fromString(vm, extStr));
+                    if (UNLIKELY(extValue.isCallable())) {
+                        extHandler = jsCast<JSFunction*>(extValue);
+                        break;
+                    }
+                    startIndex = index + 1;
+                }
+                // Fallback to ".js".
+                if (LIKELY(!extHandler)) {
+                    auto extValue = extensionsObject->get(globalObject, JSC::Identifier::fromString(vm, ".js"_s));
+                    if (UNLIKELY(extValue.isCallable())) {
+                        extHandler = jsCast<JSFunction*>(extValue);
+                    }
+                }
+                if (UNLIKELY(extHandler)) {
+                    JSC::CallData callData = JSC::getCallData(extHandler);
+                    MarkedArgumentBuffer args;
+                    args.append(moduleObject); // module
+                    args.append(specifierValue); // id
+                    // Call Module._extensions[ext](module, id)
+                    JSC::call(globalObject, extHandler, callData, extensionsObject, args);
+                    return JSValue::encode(moduleObject->exportsObject());
+                }
+            }
+        }
+    }
 
     // Special-case for "process" to just return the process object directly.
     if (UNLIKELY(specifier == "process"_s || specifier == "node:process"_s)) {
-        jsCast<JSCommonJSModule*>(callframe->argument(1))->putDirect(vm, builtinNames(vm).exportsPublicName(), globalObject->processObject(), 0);
+        moduleObject->putDirect(vm, Bun::builtinNames(vm).exportsPublicName(), globalObject->processObject(), 0);
         return JSValue::encode(globalObject->processObject());
     }
 
@@ -918,17 +1064,16 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireCommonJS, (JSGlobalObject * lexicalGlo
     BunString typeAttributeStr = { BunStringTag::Dead };
     String typeAttribute = String();
 
-
     // We need to be able to wire in the "type" import attribute from bundled code..
     // so we do it via CommonJS require().
-    int32_t previousArgumentCount = callframe->argument(2).asInt32();
+    int32_t previousArgumentCount = callFrame->argument(2).asInt32();
     // If they called require(id), skip the check for the type attribute
     if (UNLIKELY(previousArgumentCount == 2)) {
-        JSValue val = callframe->argument(3);
-        if (val.isObject()) {
-            JSObject* obj = val.getObject();
+        JSValue attrValue = callFrame->argument(3);
+        if (attrValue.isObject()) {
+            JSObject* attrObject = attrValue.getObject();
             // This getter is expensive and rare.
-            if (auto typeValue = obj->getIfPropertyExists(globalObject, vm.propertyNames->type)) {
+            if (auto typeValue = attrObject->getIfPropertyExists(globalObject, vm.propertyNames->type)) {
                 if (typeValue.isString()) {
                     typeAttribute = typeValue.toWTFString(globalObject);
                     RETURN_IF_EXCEPTION(throwScope, {});
@@ -941,7 +1086,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireCommonJS, (JSGlobalObject * lexicalGlo
 
     JSValue fetchResult = Bun::fetchCommonJSModule(
         globalObject,
-        jsCast<JSCommonJSModule*>(callframe->argument(1)),
+        moduleObject,
         specifierValue,
         &specifierStr,
         &referrerStr,
@@ -967,15 +1112,16 @@ bool JSCommonJSModule::evaluate(
     ResolvedSource source,
     bool isBuiltIn)
 {
-    auto& vm = globalObject->vm();
     auto sourceProvider = Zig::SourceProvider::create(jsCast<Zig::GlobalObject*>(globalObject), source, JSC::SourceProviderSourceType::Program, isBuiltIn);
     this->ignoreESModuleAnnotation = source.tag == ResolvedSourceTagPackageJSONTypeModule;
     JSC::SourceCode rawInputSource(
         WTFMove(sourceProvider));
 
-    if (this->hasEvaluated)
+    if (this->hasEvaluated) {
         return true;
+    }
 
+    auto& vm = globalObject->vm();
     this->sourceCode.set(vm, this, JSC::JSSourceCode::create(vm, WTFMove(rawInputSource)));
 
     WTF::NakedPtr<JSC::Exception> exception;
@@ -1003,10 +1149,10 @@ std::optional<JSC::SourceCode> createCommonJSModule(
     bool isBuiltIn)
 {
     JSCommonJSModule* moduleObject = nullptr;
-    WTF::String sourceURL = source.source_url.toWTFString();
-
-    JSValue specifierValue = Bun::toJS(globalObject, source.specifier);
-    JSValue entry = globalObject->requireMap()->get(globalObject, specifierValue);
+    auto sourceURL = source.source_url.toWTFString();
+    auto sourceURLValue = Bun::toJS(globalObject, source.source_url);
+    auto specifierValue = Bun::toJS(globalObject, source.specifier);
+    auto entry = globalObject->requireMap()->get(globalObject, specifierValue);
 
     auto sourceProvider = Zig::SourceProvider::create(jsCast<Zig::GlobalObject*>(globalObject), source, JSC::SourceProviderSourceType::Program, isBuiltIn);
     bool ignoreESModuleAnnotation = source.tag == ResolvedSourceTagPackageJSONTypeModule;
@@ -1018,24 +1164,25 @@ std::optional<JSC::SourceCode> createCommonJSModule(
 
     if (!moduleObject) {
         auto& vm = globalObject->vm();
-        auto* requireMapKey = jsStringWithCache(vm, sourceURL);
-        auto index = sourceURL.reverseFind('/', sourceURL.length());
-        JSString* dirname = jsEmptyString(vm);
-        JSString* filename = requireMapKey;
-        if (index != WTF::notFound) {
-            dirname = JSC::jsSubstring(globalObject, requireMapKey, 0, index);
-        }
-
+        auto* id = JSC::jsStringWithCache(vm, sourceURL);
+        WTF::Vector<JSC::EncodedJSValue, 1> dirnameArgs;
+        dirnameArgs.reserveInitialCapacity(1);
+        dirnameArgs.unsafeAppendWithoutCapacityCheck(JSValue::encode(specifierValue));
+#if OS(WINDOWS)
+        auto dirname = JSValue::decode(Bun__Path__dirname(globalObject, true, reinterpret_cast<JSC__JSValue*>(dirnameArgs.data()), 1)).toString(globalObject);
+#else
+        auto dirname = JSValue::decode(Bun__Path__dirname(globalObject, false, reinterpret_cast<JSC__JSValue*>(dirnameArgs.data()), 1)).toString(globalObject);
+#endif
         moduleObject = JSCommonJSModule::create(
             vm,
             globalObject->CommonJSModuleObjectStructure(),
-            requireMapKey, filename, dirname, JSC::JSSourceCode::create(vm, SourceCode(WTFMove(sourceProvider))));
+            id, id, dirname, JSC::JSSourceCode::create(vm, SourceCode(WTFMove(sourceProvider))));
 
         moduleObject->putDirect(vm,
             WebCore::clientData(vm)->builtinNames().exportsPublicName(),
             JSC::constructEmptyObject(globalObject, globalObject->objectPrototype()), 0);
 
-        globalObject->requireMap()->set(globalObject, requireMapKey, moduleObject);
+        globalObject->requireMap()->set(globalObject, id, moduleObject);
     }
 
     moduleObject->ignoreESModuleAnnotation = ignoreESModuleAnnotation;
@@ -1067,8 +1214,8 @@ std::optional<JSC::SourceCode> createCommonJSModule(
                                 // so that it can be re-evaluated on the next require.
                                 globalObject->requireMap()->remove(globalObject, moduleObject->id());
 
-                                auto scope = DECLARE_THROW_SCOPE(vm);
-                                throwException(globalObject, scope, exception.get());
+                                auto throwScope = DECLARE_THROW_SCOPE(vm);
+                                throwException(globalObject, throwScope, exception.get());
                                 exception.clear();
                                 return;
                             }
@@ -1082,19 +1229,19 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             sourceURL));
 }
 
-JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, const WTF::String& pathString)
+JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, JSC::JSString* filename)
 {
-    ASSERT(!pathString.startsWith("file://"_s));
+    ASSERT(!filename->tryGetValue().startsWith("file://"_s));
 
     auto* globalObject = jsCast<Zig::GlobalObject*>(lexicalGlobalObject);
-
-    JSString* filename = JSC::jsStringWithCache(vm, pathString);
-    auto index = pathString.reverseFind('/', pathString.length());
-    JSString* dirname = jsEmptyString(vm);
-    if (index != WTF::notFound) {
-        dirname = JSC::jsSubstring(globalObject, filename, 0, index);
-    }
-
+    WTF::Vector<JSC::EncodedJSValue, 1> dirnameArgs;
+    dirnameArgs.reserveInitialCapacity(1);
+    dirnameArgs.unsafeAppendWithoutCapacityCheck(JSValue::encode(filename));
+#if OS(WINDOWS)
+    auto dirname = JSValue::decode(Bun__Path__dirname(globalObject, true, reinterpret_cast<JSC__JSValue*>(dirnameArgs.data()), 1)).toString(globalObject);
+#else
+    auto dirname = JSValue::decode(Bun__Path__dirname(globalObject, false, reinterpret_cast<JSC__JSValue*>(dirnameArgs.data()), 1)).toString(globalObject);
+#endif
     auto moduleObject = Bun::JSCommonJSModule::create(
         vm,
         globalObject->CommonJSModuleObjectStructure(),

--- a/src/bun.js/bindings/CommonJSModuleRecord.h
+++ b/src/bun.js/bindings/CommonJSModuleRecord.h
@@ -2,6 +2,8 @@
 #include "root.h"
 #include "headers-handwritten.h"
 
+extern "C" JSC_DECLARE_HOST_FUNCTION(jsFunctionResolveSyncPrivate);
+
 namespace Zig {
 class GlobalObject;
 }
@@ -15,7 +17,7 @@ class AbstractModuleRecord;
 namespace Bun {
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionCreateCommonJSModule);
-JSC_DECLARE_HOST_FUNCTION(jsFunctionLoadModule);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionEvaluateCommonJSModule);
 
 void populateESMExports(
     JSC::JSGlobalObject* globalObject,
@@ -61,15 +63,15 @@ public:
 
     static JSCommonJSModule* create(
         Zig::GlobalObject* globalObject,
-        const WTF::String& key,
+        JSC::JSString* id,
         JSValue exportsObject, bool hasEvaluated, JSValue parent);
 
     static JSCommonJSModule* create(
         Zig::GlobalObject* globalObject,
-        const WTF::String& key,
+        JSC::JSString* id,
         ResolvedSource resolvedSource);
 
-    static JSObject* createBoundRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, const WTF::String& pathString);
+    static JSObject* createBoundRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, JSC::JSString* filename);
 
     void toSyntheticSource(JSC::JSGlobalObject* globalObject,
         JSC::Identifier moduleKey,
@@ -81,7 +83,6 @@ public:
 
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
-
 
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
@@ -105,12 +106,6 @@ public:
     {
     }
 };
-
-JSCommonJSModule* createCommonJSModuleWithoutRunning(
-    Zig::GlobalObject* globalObject,
-    Ref<Zig::SourceProvider> sourceProvider,
-    const WTF::String& sourceURL,
-    ResolvedSource source);
 
 JSC::Structure* createCommonJSModuleStructure(
     Zig::GlobalObject* globalObject);

--- a/src/bun.js/bindings/ImportMetaObject.h
+++ b/src/bun.js/bindings/ImportMetaObject.h
@@ -8,11 +8,8 @@
 
 #include "JSDOMWrapperCache.h"
 
-extern "C" JSC_DECLARE_HOST_FUNCTION(functionImportMeta__resolveSync);
-extern "C" JSC_DECLARE_HOST_FUNCTION(functionImportMeta__resolveSyncPrivate);
 extern "C" JSC::EncodedJSValue Bun__resolve(JSC::JSGlobalObject* global, JSC::EncodedJSValue specifier, JSC::EncodedJSValue from, bool is_esm);
 extern "C" JSC::EncodedJSValue Bun__resolveSync(JSC::JSGlobalObject* global, JSC::EncodedJSValue specifier, JSC::EncodedJSValue from, bool is_esm);
-extern "C" JSC::EncodedJSValue Bun__resolveSyncWithSource(JSC::JSGlobalObject* global, JSC::EncodedJSValue specifier, BunString* from, bool is_esm);
 
 namespace Zig {
 
@@ -24,9 +21,6 @@ public:
     using Base = JSC::JSNonFinalObject;
 
     static ImportMetaObject* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const WTF::String& url);
-
-    static JSObject* createRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, const WTF::String& pathString);
-
     static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSC::JSString* keyString);
     static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSValue keyString);
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3663,21 +3663,19 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     // TODO: most/all of these private properties can be made as static globals.
     // i've noticed doing it as is will work somewhat but getDirect() wont be able to find them
 
-    putDirectBuiltinFunction(vm, this, builtinNames.createFIFOPrivateName(), streamInternalsCreateFIFOCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    putDirectBuiltinFunction(vm, this, builtinNames.createEmptyReadableStreamPrivateName(), readableStreamCreateEmptyReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    putDirectBuiltinFunction(vm, this, builtinNames.createUsedReadableStreamPrivateName(), readableStreamCreateUsedReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectBuiltinFunction(vm, this, builtinNames.consumeReadableStreamPrivateName(), readableStreamConsumeReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    putDirectBuiltinFunction(vm, this, builtinNames.createNativeReadableStreamPrivateName(), readableStreamCreateNativeReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    putDirectBuiltinFunction(vm, this, builtinNames.requireESMPrivateName(), importMetaObjectRequireESMCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    putDirectBuiltinFunction(vm, this, builtinNames.loadCJS2ESMPrivateName(), importMetaObjectLoadCJS2ESMCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    putDirectBuiltinFunction(vm, this, builtinNames.internalRequirePrivateName(), importMetaObjectInternalRequireCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    putDirectBuiltinFunction(vm, this, builtinNames.requireNativeModulePrivateName(), moduleRequireNativeModuleCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-
-    putDirectBuiltinFunction(vm, this, builtinNames.overridableRequirePrivateName(), moduleOverridableRequireCodeGenerator(vm), 0);
-
-    putDirectNativeFunction(vm, this, builtinNames.createUninitializedArrayBufferPrivateName(), 1, functionCreateUninitializedArrayBuffer, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    putDirectNativeFunction(vm, this, builtinNames.resolveSyncPrivateName(), 1, functionImportMeta__resolveSyncPrivate, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectBuiltinFunction(vm, this, builtinNames.createEmptyReadableStreamPrivateName(), readableStreamCreateEmptyReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectBuiltinFunction(vm, this, builtinNames.createFIFOPrivateName(), streamInternalsCreateFIFOCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.createInternalModuleByIdPrivateName(), 1, InternalModuleRegistry::jsCreateInternalModuleById, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectBuiltinFunction(vm, this, builtinNames.createNativeReadableStreamPrivateName(), readableStreamCreateNativeReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectNativeFunction(vm, this, builtinNames.createUninitializedArrayBufferPrivateName(), 1, functionCreateUninitializedArrayBuffer, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectBuiltinFunction(vm, this, builtinNames.createUsedReadableStreamPrivateName(), readableStreamCreateUsedReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectBuiltinFunction(vm, this, builtinNames.internalRequirePrivateName(), importMetaObjectInternalRequireCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectBuiltinFunction(vm, this, builtinNames.loadCJS2ESMPrivateName(), importMetaObjectLoadCJS2ESMCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectBuiltinFunction(vm, this, builtinNames.overridableRequirePrivateName(), moduleOverridableRequireCodeGenerator(vm), 0);
+    putDirectBuiltinFunction(vm, this, builtinNames.requireESMPrivateName(), importMetaObjectRequireESMCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectBuiltinFunction(vm, this, builtinNames.requireNativeModulePrivateName(), moduleRequireNativeModuleCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectNativeFunction(vm, this, builtinNames.resolveSyncPrivateName(), 1, jsFunctionResolveSyncPrivate, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 
     putDirectNativeFunction(vm, this,
         builtinNames.createCommonJSModulePrivateName(),
@@ -3689,7 +3687,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     putDirectNativeFunction(vm, this,
         builtinNames.evaluateCommonJSModulePrivateName(),
         2,
-        Bun::jsFunctionLoadModule,
+        Bun::jsFunctionEvaluateCommonJSModule,
         ImplementationVisibility::Public,
         NoIntrinsic,
         PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete | 0);
@@ -3793,13 +3791,13 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_builtinInternalFunctions.visit(visitor);
     thisObject->m_commonStrings.visit<Visitor>(visitor);
     visitor.append(thisObject->m_assignToStream);
+    visitor.append(thisObject->m_nodeModuleOverriddenResolveFilename);
     visitor.append(thisObject->m_readableStreamToArrayBuffer);
     visitor.append(thisObject->m_readableStreamToArrayBufferResolve);
     visitor.append(thisObject->m_readableStreamToBlob);
     visitor.append(thisObject->m_readableStreamToJSON);
     visitor.append(thisObject->m_readableStreamToText);
     visitor.append(thisObject->m_readableStreamToFormData);
-    visitor.append(thisObject->m_nodeModuleOverriddenResolveFilename);
 
     visitor.append(thisObject->m_nextTickQueue);
     visitor.append(thisObject->m_errorConstructorPrepareStackTraceValue);
@@ -3841,7 +3839,6 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_emitReadableNextTickFunction.visit(visitor);
     thisObject->m_JSBufferSubclassStructure.visit(visitor);
     thisObject->m_JSCryptoKey.visit(visitor);
-
     thisObject->m_cryptoObject.visit(visitor);
     thisObject->m_JSDOMFileConstructor.visit(visitor);
 
@@ -3857,6 +3854,7 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_lazyTestModuleObject.visit(visitor);
     thisObject->m_lazyPreloadTestModuleObject.visit(visitor);
     thisObject->m_testMatcherUtilsObject.visit(visitor);
+
     thisObject->m_commonJSModuleObjectStructure.visit(visitor);
     thisObject->m_JSSQLStatementStructure.visit(visitor);
     thisObject->m_memoryFootprintStructure.visit(visitor);

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -268,7 +268,7 @@ public:
     bool hasProcessObject() const { return m_processObject.isInitialized(); }
 
     RefPtr<WebCore::Performance> performance();
-    
+
     JSC::JSObject* processObject() { return m_processObject.getInitializedOnMainThread(this); }
     JSC::JSObject* processEnvObject() { return m_processEnvObject.getInitializedOnMainThread(this); }
     JSC::JSObject* bunObject() { return m_bunObject.getInitializedOnMainThread(this); }
@@ -362,8 +362,8 @@ public:
     mutable WriteBarrier<JSFunction> m_readableStreamToText;
     mutable WriteBarrier<JSFunction> m_readableStreamToFormData;
 
-    // This is set when doing `require('module')._resolveFilename = ...`
-    // a hack used by Next.js to inject their versions of webpack and react
+    // This is set when overriding `require('module')._resolveFilename = ...`
+    // used by projects like Next.js to inject their versions of webpack and react.
     mutable WriteBarrier<JSFunction> m_nodeModuleOverriddenResolveFilename;
 
     mutable WriteBarrier<Unknown> m_nextTickQueue;

--- a/src/codegen/replacements.ts
+++ b/src/codegen/replacements.ts
@@ -33,6 +33,7 @@ export const globalsToPrefix = [
   "ArrayBuffer",
   "Buffer",
   "Infinity",
+  "isFinite",
   "Loader",
   "Promise",
   "ReadableByteStreamController",
@@ -41,17 +42,15 @@ export const globalsToPrefix = [
   "ReadableStreamBYOBRequest",
   "ReadableStreamDefaultController",
   "ReadableStreamDefaultReader",
+  "RegExp",
+  "String",
   "TransformStream",
   "TransformStreamDefaultController",
   "Uint8Array",
-  "String",
-  "Buffer",
-  "RegExp",
+  "undefined",
   "WritableStream",
   "WritableStreamDefaultController",
   "WritableStreamDefaultWriter",
-  "isFinite",
-  "undefined",
 ];
 
 // These enums map to $<enum>IdToLabel and $<enum>LabelToId

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -407,6 +407,8 @@ declare function $streamErrored(): TODO;
 declare function $streamReadable(): TODO;
 declare function $streamWaiting(): TODO;
 declare function $streamWritable(): TODO;
+declare function $stringIndexOfInternal(searchString: string, position?: number): number;
+declare function $stringSubstring(indexStart: number, indexEnd?: number): string;
 declare function $structuredCloneForStream(): TODO;
 declare function $syscall(): TODO;
 declare function $textDecoderStreamDecoder(): TODO;
@@ -538,3 +540,8 @@ declare var $Buffer: {
 declare interface Error {
   code?: string;
 }
+
+declare var $Object: {
+  $create(o: object | null): any;
+  $create(o: object | null, properties: PropertyDescriptorMap & ThisType<any>): any;
+};

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -150,6 +150,7 @@ using namespace JSC;
     macro(once) \
     macro(options) \
     macro(origin) \
+    macro(originalStructureID) \
     macro(overridableRequire) \
     macro(ownerReadableStream) \
     macro(parse) \
@@ -217,6 +218,7 @@ using namespace JSC;
     macro(strategySizeAlgorithm) \
     macro(stream) \
     macro(structuredCloneForStream) \
+    macro(structureChanged) \
     macro(syscall) \
     macro(textDecoderStreamDecoder) \
     macro(textDecoderStreamTransform) \

--- a/test/js/node/module/moduleExtensionsChange-fixture.cjs
+++ b/test/js/node/module/moduleExtensionsChange-fixture.cjs
@@ -1,0 +1,1 @@
+module.exports = "original";

--- a/test/js/node/module/moduleExtensionsChange.cjs
+++ b/test/js/node/module/moduleExtensionsChange.cjs
@@ -1,0 +1,51 @@
+const { expect, test } = require("bun:test");
+const Module = require("node:module");
+
+test("Module._extensions change", () => {
+  const oldCjs = Module._extensions[".cjs"];
+  const oldJs = Module._extensions[".js"];
+debugger;
+  // Test default behavior.
+  const defaultResult = require("./moduleExtensionsChange-fixture.cjs");
+  expect(defaultResult).toBe("original");
+
+  // Reset.
+  delete Module._cache[require.resolve("./moduleExtensionsChange-fixture.cjs")];
+
+  // Test .cjs extension override.
+  Module._extensions[".cjs"] = function (mod, filename) {
+    mod._compile(`module.exports = "winner";`, filename);
+  };
+  const changedCjsResult = require("./moduleExtensionsChange-fixture.cjs");
+  expect(changedCjsResult).toBe("winner");
+
+  // Reset.
+  delete Module._cache[require.resolve("./moduleExtensionsChange-fixture.cjs")];
+  if (oldCjs) {
+    Module._extensions['.cjs'] = oldCjs;
+  } else {
+    delete Module._extensions['.cjs'];
+  }
+
+  // Test reverted behavior.
+  const revertedResult = require("./moduleExtensionsChange-fixture.cjs");
+  expect(revertedResult).toBe("original");
+
+  // Reset.
+  delete Module._cache[require.resolve("./moduleExtensionsChange-fixture.cjs")];
+
+  // Test fallback to .js.
+  Module._extensions[".cjs"] = function (mod, filename) {
+    mod._compile(`module.exports = "winner";`, filename);
+  };
+  const changedJsResult = require("./moduleExtensionsChange-fixture.cjs");
+  expect(changedJsResult).toBe("winner");
+
+  // Reset.
+  delete Module._cache[require.resolve("./moduleExtensionsChange-fixture.cjs")];
+  if (oldJs) {
+    Module._extensions['.js'] = oldJs;
+  } else {
+    delete Module._extensions['.js'];
+  }
+});

--- a/test/js/node/module/modulePrototypeOverwrite.cjs
+++ b/test/js/node/module/modulePrototypeOverwrite.cjs
@@ -1,17 +1,19 @@
+const { expect, test } = require("bun:test");
+const Module = require("node:module");
+
 // This behavior is required for Next.js to work
-const eql = require("assert").deepStrictEqual;
-const Module = require("module");
-
-const old = Module.prototype.require;
-Module.prototype.require = function (str) {
-  if (str === "hook") return "winner";
-  return {
-    wrap: old.call(this, str),
+test("Module.prototype.require overwrite", () => {
+  const old = Module.prototype.require;
+  Module.prototype.require = function (id) {
+    if (id === "hook") {
+      return "winner";
+    }
+    return {
+      wrap: old.call(this, id),
+    };
   };
-};
-
-// this context has the new require
-const result = require("./modulePrototypeOverwrite-fixture.cjs");
-eql(result, { wrap: "winner" });
-
-console.log("--pass--");
+  // This context has the new require
+  const result = require("./modulePrototypeOverwrite-fixture.cjs");
+  Module.prototype.require = old;
+  expect(result).toEqual({ wrap: "winner" });
+});

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,9 +1,8 @@
 // @known-failing-on-windows: 1 failing
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
-import { _nodeModulePaths, builtinModules, isBuiltin, wrap } from "module";
-import Module from "module";
-import path from "path";
+import Module, { _nodeModulePaths, builtinModules, isBuiltin, wrap } from "node:module";
+import path from "node:path";
 
 test("builtinModules exists", () => {
   expect(Array.isArray(builtinModules)).toBe(true);

--- a/test/js/node/module/resolveFilenameOverwrite.cjs
+++ b/test/js/node/module/resolveFilenameOverwrite.cjs
@@ -1,15 +1,26 @@
+const { expect, test } = require("bun:test");
+const Module = require("node:module");
+const path = require("node:path");
+
 // This behavior is required for Next.js to work
-const eql = require("assert").strictEqual;
-const path = require("path");
-const Module = require("module");
-
-const original = Module._resolveFilename;
-Module._resolveFilename = (specifier, parent, isMain) => {
-  eql(specifier.endsWith("💔"), true);
-  eql(parent.filename, path.join(__dirname, "./resolveFilenameOverwrite.cjs"));
-  return path.join(__dirname, "./resolveFilenameOverwrite-fixture.cjs");
-};
-eql(require("overwriting _resolveFilename broke 💔"), "winner");
-Module._resolveFilename = original;
-
-console.log("--pass--");
+test("Module._resolveFilename overwrite", () => {
+  let assertions = 0;
+  const old = Module._resolveFilename;
+  Module._resolveFilename = function (request, parent, isMain) {
+    expect(request.endsWith("💔")).toBe(true);
+    assertions++;
+    expect(parent.filename).toBe(path.join(__dirname, "./resolveFilenameOverwrite.cjs"));
+    assertions++;
+    expect(isMain).toBe(true);
+    assertions++;
+    expect(this).toBe(Module);
+    assertions++;
+    return path.join(__dirname, "./resolveFilenameOverwrite-fixture.cjs");
+  };
+  const result = require("overwriting _resolveFilename broke 💔");
+  Module._resolveFilename = old;
+  expect(result).toBe("winner");
+  assertions++;
+  // TODO: Replace with `expect.assertions(3)` once implemented.
+  expect(assertions).toBe(5);
+});


### PR DESCRIPTION
### What does this PR do?

Add support for custom Module._extensions

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

 I added cjs unit tests.

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
