### PR TITLE
fix: Hang when recursively logging via ConsoleObject.messageWithTypeAndLevel 

### DIFF
--- a/test/js/web/console/console-recursive.expected.txt
+++ b/test/js/web/console/console-recursive.expected.txt
@@ -1,0 +1,2 @@
+inside size
+map: Map {}

--- a/test/js/web/console/console-recursive.expected.txt
+++ b/test/js/web/console/console-recursive.expected.txt
@@ -1,2 +1,0 @@
-inside size
-map: Map {}

--- a/test/js/web/console/console-recursive.js
+++ b/test/js/web/console/console-recursive.js
@@ -1,17 +1,16 @@
-
-// We use a relatively random string for the stderr flag. 
+// We use a relatively random string for the stderr flag.
 // Just to avoid matching against something in the executable path.
-const use_err = process.argv.includes("print_to_stderr_skmxctoznf")
+const use_err = process.argv.includes("print_to_stderr_skmxctoznf");
 
-const log_method = use_err ? console.error : console.log
+const log_method = use_err ? console.error : console.log;
 
 class MyMap extends Map {
-    get size () {
-        log_method('inside size')
-        return 0
-    }
+  get size() {
+    log_method("inside size");
+    return 0;
+  }
 }
 
-const map = new MyMap()
+const map = new MyMap();
 
-log_method('map:', map)
+log_method("map:", map);

--- a/test/js/web/console/console-recursive.js
+++ b/test/js/web/console/console-recursive.js
@@ -1,0 +1,17 @@
+
+// We use a relatively random string for the stderr flag. 
+// Just to avoid matching against something in the executable path.
+const use_err = process.argv.includes("print_to_stderr_skmxctoznf")
+
+const log_method = use_err ? console.error : console.log
+
+class MyMap extends Map {
+    get size () {
+        log_method('inside size')
+        return 0
+    }
+}
+
+const map = new MyMap()
+
+log_method('map:', map)

--- a/test/js/web/console/console-recursive.test.ts
+++ b/test/js/web/console/console-recursive.test.ts
@@ -1,0 +1,32 @@
+// @known-failing-on-windows: 1 failing
+import { file, spawn } from "bun";
+import { expect, it } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+it("should not hang when logging to stdout recursively", async () => {
+  const { stdout, exited } = spawn({
+    cmd: [bunExe(), import.meta.dir + "/console-recursive.js"],
+    stdin: null,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  expect(await exited).toBe(0);
+  const outText = await new Response(stdout).text();
+  const expectedText = await new Response(file(import.meta.dir + "/console-recursive.expected.txt")).text();
+  expect(outText.replace(/^\[.+?s\] /gm, "")).toBe(expectedText.replace(/^\[.+?s\] /gm, ""));
+});
+
+it("should not hang when logging to stderr recursively", async () => {
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), import.meta.dir + "/console-recursive.js"],
+    stdin: null,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  expect(await exited).toBe(0);
+  const outText = await new Response(stderr).text();
+  const expectedText = await new Response(file(import.meta.dir + "/console-recursive.expected.txt")).text();
+  expect(outText.replace(/^\[.+?s\] /gm, "")).toBe(expectedText.replace(/^\[.+?s\] /gm, ""));
+});

--- a/test/js/web/console/console-recursive.test.ts
+++ b/test/js/web/console/console-recursive.test.ts
@@ -1,10 +1,10 @@
 // @known-failing-on-windows: 1 failing
-import { file, spawn } from "bun";
+import { spawn } from "bun";
 import { expect, it } from "bun:test";
 import { bunExe, bunEnv } from "harness";
 
 it("should not hang when logging to stdout recursively", async () => {
-  const { stdout, exited } = spawn({
+  const { exited } = spawn({
     cmd: [bunExe(), import.meta.dir + "/console-recursive.js"],
     stdin: null,
     stdout: "pipe",
@@ -12,21 +12,15 @@ it("should not hang when logging to stdout recursively", async () => {
     env: bunEnv,
   });
   expect(await exited).toBe(0);
-  const outText = await new Response(stdout).text();
-  const expectedText = await new Response(file(import.meta.dir + "/console-recursive.expected.txt")).text();
-  expect(outText.replace(/^\[.+?s\] /gm, "")).toBe(expectedText.replace(/^\[.+?s\] /gm, ""));
 });
 
 it("should not hang when logging to stderr recursively", async () => {
-  const { stderr, exited } = spawn({
-    cmd: [bunExe(), import.meta.dir + "/console-recursive.js"],
+  const { exited } = spawn({
+    cmd: [bunExe(), import.meta.dir + "/console-recursive.js", "print_to_stderr_skmxctoznf"],
     stdin: null,
     stdout: "pipe",
     stderr: "pipe",
     env: bunEnv,
   });
   expect(await exited).toBe(0);
-  const outText = await new Response(stderr).text();
-  const expectedText = await new Response(file(import.meta.dir + "/console-recursive.expected.txt")).text();
-  expect(outText.replace(/^\[.+?s\] /gm, "")).toBe(expectedText.replace(/^\[.+?s\] /gm, ""));
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Avoid deadlock caused by recursive invocations of `messageWithTypeAndLevel`.
This is done by tracking whether the locks are already held with a threadlocal counter per mutex. 

Fixes: #8153

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests 

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
