### PR TITLE
Fix decimal -> integer conversion bug in process.exit & process.exitCode

### DIFF
--- a/test/js/node/process/process-exit-decimal-fixture.js
+++ b/test/js/node/process/process-exit-decimal-fixture.js
@@ -1,0 +1,2 @@
+// Force it to be a jsDoubleNumber instead of a jsNumber
+process.exit(0.0 + eval("1.1 - 1.1"))

--- a/test/js/node/process/process-exit-decimal-fixture.js
+++ b/test/js/node/process/process-exit-decimal-fixture.js
@@ -1,2 +1,2 @@
 // Force it to be a jsDoubleNumber instead of a jsNumber
-process.exit(0.0 + eval("1.1 - 1.1"))
+process.exit(0.0 + eval("1.1 - 1.1"));

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -238,11 +238,11 @@ it("process.argv in testing", () => {
 
 describe("process.exitCode", () => {
   it("validates int", () => {
-    expect(() => (process.exitCode = "potato")).toThrow("exitCode must be a number");
-    expect(() => (process.exitCode = 1.2)).toThrow('The "code" argument must be an integer');
-    expect(() => (process.exitCode = NaN)).toThrow('The "code" argument must be an integer');
-    expect(() => (process.exitCode = Infinity)).toThrow('The "code" argument must be an integer');
-    expect(() => (process.exitCode = -Infinity)).toThrow('The "code" argument must be an integer');
+    expect(() => (process.exitCode = "potato")).toThrow(`exitCode must be an integer`);
+    expect(() => (process.exitCode = 1.2)).toThrow("exitCode must be an integer");
+    expect(() => (process.exitCode = NaN)).toThrow("exitCode must be an integer");
+    expect(() => (process.exitCode = Infinity)).toThrow("exitCode must be an integer");
+    expect(() => (process.exitCode = -Infinity)).toThrow("exitCode must be an integer");
   });
 
   it("works with implicit process.exit", () => {
@@ -513,4 +513,8 @@ it("process.constrainedMemory()", () => {
 it("process.report", () => {
   // TODO: write better tests
   JSON.stringify(process.report.getReport(), null, 2);
+});
+
+it("process.exit with jsDoubleNumber that is an integer", () => {
+  expect([join(import.meta.dir, "./process-exit-decimal-fixture.js")]).toRun();
 });


### PR DESCRIPTION
### What does this PR do?

Use `isAnyInt` instead of `isInt32` when reading the exit code for process.exit and process.exitCode. This fixes spurious "The "code" argument must be an integer` errors when using the Prisma CLI.

### How did you verify your code works?

Test