### PR TITLE
fix(windows): support utf16-le files in the bundler and in `Bun.file`

### DIFF
--- a/src/bun.js/api/bun.zig
+++ b/src/bun.js/api/bun.zig
@@ -3146,7 +3146,7 @@ const TOMLObject = struct {
         var out = bun.String.fromUTF8(slice);
         defer out.deref();
 
-        return out.toJSForParseJSON(globalThis);
+        return out.toJSByParseJSON(globalThis);
     }
 };
 

--- a/src/string.zig
+++ b/src/string.zig
@@ -711,7 +711,7 @@ pub const String = extern struct {
         this: *String,
     ) JSC.JSValue;
 
-    pub fn toJSForParseJSON(self: *String, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
+    pub fn toJSByParseJSON(self: *String, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
         JSC.markBinding(@src());
         return BunString__toJSON(globalObject, self);
     }

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1040,6 +1040,7 @@ describe("bundler", () => {
     },
   });
 
+  // TODO(@paperdave): test every case of this. I had already tested it manually, but it may break later
   const requireTranspilationListESM = [
     // input, output:bun, output:node
     ["require", "import.meta.require", "__require"],

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -53,4 +53,15 @@ describe("bun build", () => {
       fs.rmSync(baseDir, { recursive: true, force: true });
     }
   });
+
+  test('works with utf8 bom', () => {
+    const tmp = fs.mkdtempSync(path.join(tmpdir(), 'bun-build-utf8-bom-'));
+    const src = path.join(tmp, 'index.js');
+    fs.writeFileSync(src, '\ufeffconsole.log("hello world");', { encoding: 'utf8' });
+    const { exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), 'build', src],
+      env: bunEnv,
+    });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -54,12 +54,12 @@ describe("bun build", () => {
     }
   });
 
-  test('works with utf8 bom', () => {
-    const tmp = fs.mkdtempSync(path.join(tmpdir(), 'bun-build-utf8-bom-'));
-    const src = path.join(tmp, 'index.js');
-    fs.writeFileSync(src, '\ufeffconsole.log("hello world");', { encoding: 'utf8' });
+  test("works with utf8 bom", () => {
+    const tmp = fs.mkdtempSync(path.join(tmpdir(), "bun-build-utf8-bom-"));
+    const src = path.join(tmp, "index.js");
+    fs.writeFileSync(src, '\ufeffconsole.log("hello world");', { encoding: "utf8" });
     const { exitCode } = Bun.spawnSync({
-      cmd: [bunExe(), 'build', src],
+      cmd: [bunExe(), "build", src],
       env: bunEnv,
     });
     expect(exitCode).toBe(0);


### PR DESCRIPTION
### What does this PR do?

This is mostly needed on Windows where files are sometimes encodeed as UTF16 with BOM. This handles this case now.

yay

I will start writing tests.