### PR TITLE
Fix crash in socket

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1423,10 +1423,15 @@ fn NewSocket(comptime ssl: bool) type {
             if (this.detached) return;
 
             const handlers = this.handlers;
-            this.poll_ref.unref(handlers.vm);
 
             const callback = handlers.onEnd;
-            if (callback == .zero) return;
+            if (callback == .zero) {
+                this.poll_ref.unref(handlers.vm);
+
+                // If you don't handle TCP fin, we assume you're done.
+                this.markInactive();
+                return;
+            }
 
             // the handlers must be kept alive for the duration of the function call
             // that way if we need to call the error handler, we can

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -171,7 +171,7 @@ const Handlers = struct {
 
     pub const Scope = struct {
         handlers: *Handlers,
-        socket_context: *uws.SocketContext,
+        socket_context: ?*uws.SocketContext,
 
         pub fn exit(this: *Scope, ssl: bool, wrapped: WrappedType) void {
             var vm = this.handlers.vm;
@@ -180,7 +180,7 @@ const Handlers = struct {
         }
     };
 
-    pub fn enter(this: *Handlers, context: *uws.SocketContext) Scope {
+    pub fn enter(this: *Handlers, context: ?*uws.SocketContext) Scope {
         this.markActive();
         return .{
             .handlers = this,
@@ -203,7 +203,7 @@ const Handlers = struct {
         return true;
     }
 
-    pub fn markInactive(this: *Handlers, ssl: bool, ctx: *uws.SocketContext, wrapped: WrappedType) void {
+    pub fn markInactive(this: *Handlers, ssl: bool, ctx: ?*uws.SocketContext, wrapped: WrappedType) void {
         Listener.log("markInactive", .{});
         this.active_connections -= 1;
         if (this.active_connections == 0) {
@@ -217,7 +217,8 @@ const Handlers = struct {
                 this.unprotect();
                 // will deinit when is not wrapped or when is the TCP wrapped connection
                 if (wrapped != .tls) {
-                    ctx.deinit(ssl);
+                    if (ctx) |ctx_|
+                        ctx_.deinit(ssl);
                 }
                 bun.default_allocator.destroy(this);
             }
@@ -776,7 +777,7 @@ pub const Listener = struct {
     pub fn onCreate(comptime ssl: bool, socket: uws.NewSocketHandler(ssl)) void {
         JSC.markBinding(@src());
         log("onCreate", .{});
-        var listener: *Listener = socket.context().ext(ssl, *Listener).?.*;
+        var listener: *Listener = socket.context().?.ext(ssl, *Listener).?.*;
         const Socket = NewSocket(ssl);
         std.debug.assert(ssl == listener.ssl);
 
@@ -1135,6 +1136,7 @@ fn NewSocket(comptime ssl: bool) type {
         // `Listener` keep a list of all the sockets JSValue in there
         // This is wasteful because it means we are keeping a JSC::Weak for every single open socket
         has_pending_activity: std.atomic.Value(bool) = std.atomic.Value(bool).init(true),
+
         const This = @This();
         const log = Output.scoped(.Socket, false);
         const WriteResult = union(enum) {
@@ -1306,13 +1308,16 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn markInactive(this: *This) void {
             if (this.is_active) {
-                // we have to close the socket before the socket context is closed
-                // otherwise we will get a segfault
-                // uSockets will defer closing the TCP socket until the next tick
-                if (!this.socket.isClosed()) {
-                    this.socket.close(0, null);
-                    // onClose will call markInactive again
-                    return;
+                if (!this.detached) {
+                    // we have to close the socket before the socket context is closed
+                    // otherwise we will get a segfault
+                    // uSockets will defer closing the TCP socket until the next tick
+                    if (!this.socket.isClosed()) {
+                        this.detached = true;
+                        this.socket.close(0, null);
+                        // onClose will call markInactive again
+                        return;
+                    }
                 }
                 this.is_active = false;
                 const vm = this.handlers.vm;
@@ -1418,18 +1423,11 @@ fn NewSocket(comptime ssl: bool) type {
             log("onEnd", .{});
             if (this.detached) return;
 
-            this.detached = true;
-            defer this.markInactive();
-
             const handlers = this.handlers;
-
             this.poll_ref.unref(handlers.vm);
 
             const callback = handlers.onEnd;
             if (callback == .zero) return;
-
-            var vm = handlers.vm;
-            defer vm.drainMicrotasks();
 
             // the handlers must be kept alive for the duration of the function call
             // that way if we need to call the error handler, we can
@@ -1516,11 +1514,13 @@ fn NewSocket(comptime ssl: bool) type {
             log("onClose", .{});
             this.detached = true;
             defer this.markInactive();
+
             const handlers = this.handlers;
             this.poll_ref.unref(handlers.vm);
 
             const callback = handlers.onClose;
-            if (callback == .zero) return;
+            if (callback == .zero)
+                return;
 
             // the handlers must be kept alive for the duration of the function call
             // that way if we need to call the error handler, we can
@@ -1950,7 +1950,7 @@ fn NewSocket(comptime ssl: bool) type {
                 .success => |result| brk: {
                     if (result.wrote == result.total) {
                         this.socket.flush();
-                        this.detached = true;
+                        // markInactive does .detached = true
                         this.markInactive();
                     }
                     break :brk JSValue.jsNumber(result.wrote);
@@ -1978,8 +1978,9 @@ fn NewSocket(comptime ssl: bool) type {
                 if (!this.socket.isClosed()) {
                     this.socket.close(0, null);
                 }
-                this.markInactive();
             }
+
+            this.markInactive();
 
             this.poll_ref.unref(JSC.VirtualMachine.get());
             // need to deinit event without being attached
@@ -2826,7 +2827,7 @@ fn NewSocket(comptime ssl: bool) type {
             const TCPHandler = NewWrappedHandler(false);
 
             // reconfigure context to use the new wrapper handlers
-            Socket.unsafeConfigure(this.socket.context(), true, true, WrappedSocket, TCPHandler);
+            Socket.unsafeConfigure(this.socket.context().?, true, true, WrappedSocket, TCPHandler);
             const old_context = this.socket.context();
             const TLSHandler = NewWrappedHandler(true);
             const new_socket = this.socket.wrapTLS(

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -243,11 +243,13 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
 
             return @as(*align(alignment) ContextType, @ptrCast(@alignCast(ptr)));
         }
-        pub fn context(this: ThisSocket) *SocketContext {
+
+        /// This can be null if the socket was closed.
+        pub fn context(this: ThisSocket) ?*SocketContext {
             return us_socket_context(
                 comptime ssl_int,
                 this.socket,
-            ).?;
+            );
         }
 
         pub fn flush(this: ThisSocket) void {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -193,7 +193,7 @@ it("should handle connection error", done => {
 });
 
 it("should not leak memory when connect() fails again", async () => {
-  await expectMaxObjectTypeCount(expect, "TCPSocket", 2, 100);
+  await expectMaxObjectTypeCount(expect, "TCPSocket", 5, 100);
 });
 
 it("should allow large amounts of data to be sent and received", async () => {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -199,3 +199,45 @@ it("should not leak memory when connect() fails again", async () => {
 it("should allow large amounts of data to be sent and received", async () => {
   expect([fileURLToPath(new URL("./socket-huge-fixture.js", import.meta.url))]).toRun();
 }, 10_000);
+
+it("socket.timeout works", async () => {
+  try {
+    const { promise, resolve } = Promise.withResolvers<any>();
+
+    var server = Bun.listen({
+      socket: {
+        binaryType: "buffer",
+        open(socket) {
+          socket.write("hello");
+        },
+        data(socket, data) {
+          if (data.toString("utf-8") === "I have timed out!") {
+            client.end();
+            resolve(undefined);
+          }
+        },
+      },
+      hostname: "localhost",
+      port: 0,
+    });
+    var client = await connect({
+      hostname: "localhost",
+      port: server.port,
+      socket: {
+        timeout(socket) {
+          socket.write("I have timed out!");
+        },
+        data() {},
+        drain() {},
+        close() {},
+        end() {},
+        error() {},
+        open() {},
+      },
+    });
+    client.timeout(1);
+    await promise;
+  } finally {
+    server!.stop(true);
+  }
+}, 10_000);


### PR DESCRIPTION
### What does this PR do?

This does two things:
1) This aligns the behavior of socket timeouts with Node.js. Previously, we were closing the socket on timeout. That is not what Node does, nor is it what Bun should do.
2)  This fixes a crash where calling `.end()` a `Socket` calls `us_socket_close`, `us_socket_close` calls `onClose`, `onClose` gets a null pointer dereference

The following staacktrace (which lacks a test):
```js
uh-oh: attempt to use null value
bun will crash now 😭😭😭
[SYS] openat(-2, /Users/jarred/.bun/.bun-crash/v1.0.23-debug-1705535473316.crash) = -1

----- bun meta -----
Bun v1.0.23 (99525071) macOS Silicon 23.1.0
TestCommand: dotenv bunfig
Elapsed: 1426ms | User: 1532ms | Sys: 311ms
RSS: 0.20GB | Peak: 0.20GB | Commit: 123.26MB | Faults: 3761
----- bun meta -----

0   0x105830420 WTFGetBacktrace
1   ??? Bun__crashReportDumpStackTrace
2   ??? src.report.fatal
3   ??? src.main.panic
4   ??? src.deps.uws.NewSocketHandler(false).unsafeConfigure__anon_150794
5   ??? src.bun.js.api.bun.socket.NewSocket(false).markInactive
6   ??? src.bun.js.api.bun.socket.NewSocket(false).onClose
7   ??? src.deps.uws.NewSocketHandler(false).configure__anon_134800.SocketHandler.on_close
8   ??? us_socket_close
9   ??? src.deps.uws.NewSocketHandler(false).close
10  ??? src.bun.js.api.bun.socket.NewSocket(false).markInactive
11  ??? TCPSocketPrototype__end
12  ??? WebCore::TCPSocketPrototype__endCallback(JSC::JSGlobalObject*, JSC::CallFrame*)
13  ???
14  ??? llint_entry
15  ??? llint_entry
16  ??? llint_entry
17  ???
18  ??? llint_entry
19  ??? llint_entry
20  ???
21  ???
22  ??? vmEntryToJavaScript
23  ??? JSC::Interpreter::executeCallImpl(JSC::VM&, JSC::JSObject*, JSC::CallData const&, JSC::JSValue, JSC::ArgList const&)
24  ??? JSC::call(JSC::JSGlobalObject*, JSC::JSValue, JSC::JSValue, JSC::ArgList const&, WTF::ASCIILiteral)
25  ??? Bun::JSNextTickQueue::drain(JSC::VM&, JSC::JSGlobalObject*)
26  ??? Zig::GlobalObject::drainMicrotasks()
27  ??? JSC__JSGlobalObject__drainMicrotasks
28  ??? src.bun.js.event_loop.EventLoop.drainMicrotasksWithGlobal
29  ??? src.bun.js.event_loop.EventLoop.drainMicrotasks
30  ??? src.bun.js.javascript.VirtualMachine.drainMicrotasks
31  ??? src.bun.js.api.bun.socket.Handlers.Scope.exit
```
### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
