### PR TITLE
Update comment to include "except a built-in"

### DIFF
--- a/docs/runtime/plugins.md
+++ b/docs/runtime/plugins.md
@@ -237,7 +237,7 @@ plugin({
 
   setup(build) {
     build.module(
-      // The specifier, which can be any string
+      // The specifier, which can be any string - except a built-in, such as "buffer"
       "my-transpiled-virtual-module",
       // The callback to run when the module is imported or required for the first time
       () => {


### PR DESCRIPTION
build.module() throws for "buffer"

 9 |   setup(build) {
10 |     build.module(
         ^
error: module() cannot be used to override builtin module "buffer"

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes


Additionally this example https://bun.sh/docs/runtime/plugins#overriding-existing-modules appears incomplete, where `build` is undefined 

```
import { plugin } from "bun";
build.module("my-object-virtual-module", () => {
  return {
    exports: {
      foo: "bar",
    },
    loader: "object",
  };
});
```

