### PR TITLE
Make process.binding errors more specific to get better idea of which methods to support

### DIFF
--- a/src/bun.js/bindings/InternalModuleRegistry.cpp
+++ b/src/bun.js/bindings/InternalModuleRegistry.cpp
@@ -33,7 +33,9 @@ static void maybeAddCodeCoverage(JSC::VM& vm, const JSC::SourceCode& code)
 #define INTERNAL_MODULE_REGISTRY_GENERATE_(globalObject, vm, SOURCE, moduleName, urlString) \
     auto throwScope = DECLARE_THROW_SCOPE(vm);                                              \
     auto&& origin = SourceOrigin(WTF::URL(urlString));                                      \
-    SourceCode source = JSC::makeSource(SOURCE, origin,                                     \
+    SourceCode source = JSC::makeSource(                                                    \
+        SOURCE,                                                                             \
+        origin,                                                                             \
         JSC::SourceTaintedOrigin::Untainted,                                                \
         moduleName);                                                                        \
     maybeAddCodeCoverage(vm, source);                                                       \
@@ -41,7 +43,8 @@ static void maybeAddCodeCoverage(JSC::VM& vm, const JSC::SourceCode& code)
         = JSFunction::create(                                                               \
             vm,                                                                             \
             createBuiltinExecutable(                                                        \
-                vm, source,                                                                 \
+                vm,                                                                         \
+                source,                                                                     \
                 Identifier(),                                                               \
                 ImplementationVisibility::Public,                                           \
                 ConstructorKind::None,                                                      \

--- a/test/js/node/process-binding.test.ts
+++ b/test/js/node/process-binding.test.ts
@@ -1,4 +1,10 @@
 describe("process.binding", () => {
+  test("process.binding() with unsupported module property access", () => {
+    /* @ts-ignore */
+    const unsupported = process.binding("buffer");
+    expect(() => unsupported.kMaxLength).toThrow();
+  });
+
   test("process.binding('constants')", () => {
     /* @ts-ignore */
     const constants = process.binding("constants");
@@ -9,6 +15,7 @@ describe("process.binding", () => {
     expect(constants).toHaveProperty("trace");
     expect(constants).toHaveProperty("zlib");
   });
+
   test("process.binding('uv')", () => {
     /* @ts-ignore */
     const uv = process.binding("uv");

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -231,10 +231,6 @@ it("process.execArgv", () => {
   expect(process.execArgv instanceof Array).toBe(true);
 });
 
-it("process.binding", () => {
-  expect(() => process.binding("buffer")).toThrow();
-});
-
 it("process.argv in testing", () => {
   expect(process.argv).toBeInstanceOf(Array);
   expect(process.argv[0]).toBe(bunExe());


### PR DESCRIPTION


### What does this PR do?

Make process.binding errors more specific to get better idea of which methods to support


- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
