### PR TITLE
fix(transpiler): loose equality folding bugfix

### DIFF
--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -5266,7 +5266,7 @@ pub const Expr = struct {
                                 if (r.value == 0 or r.value == 1) {
                                     equality.ok = true;
                                     equality.equal = if (r.value == 0)
-                                        l.eqlComptime("0")
+                                        l.isBlank() or l.eqlComptime("0")
                                     else if (r.value == 1)
                                         l.eqlComptime("1")
                                     else

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -5143,6 +5143,9 @@ pub const Expr = struct {
         pub const Equality = struct {
             equal: bool = false,
             ok: bool = false,
+
+            pub const @"true" = Equality{ .ok = true, .equal = true };
+            pub const @"false" = Equality{ .ok = true, .equal = false };
         };
 
         // Returns "equal, ok". If "ok" is false, then nothing is known about the two
@@ -5239,8 +5242,12 @@ pub const Expr = struct {
                 },
                 .e_big_int => |l| {
                     if (right == .e_big_int) {
-                        equality.ok = true;
-                        equality.equal = strings.eql(l.value, l.value);
+                        if (strings.eqlLong(l.value, right.e_big_int.value, true)) {
+                            return Equality.true;
+                        }
+
+                        // 0x0000n == 0n is true
+                        return .{ .ok = false };
                     } else {
                         equality.ok = switch (right) {
                             .e_null, .e_undefined => true,

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -5275,15 +5275,16 @@ pub const Expr = struct {
                         },
                         .e_number => |r| {
                             if (comptime kind == .loose) {
-                                if (r.value == 0 or r.value == 1) {
-                                    return .{
-                                        .ok = true,
-                                        .equal = if (r.value == 0)
-                                            l.isBlank() or l.eqlComptime("0")
-                                        else
-                                            l.eqlComptime("1"),
-                                    };
+                                if (r.value == 0 and (l.isBlank() or l.eqlComptime("0"))) {
+                                    return Equality.true;
                                 }
+
+                                if (r.value == 1 and l.eqlComptime("1")) {
+                                    return Equality.true;
+                                }
+
+                                // the string could still equal 0 or 1 but it could be hex, binary, octal, ...
+                                return Equality.unknown;
                             } else {
                                 return Equality.false;
                             }

--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -2958,7 +2958,7 @@ console.log(foo, array);
       expectPrinted("1 != 2", "!0");
       expectPrinted("1 != '1'", '1 != "1"');
 
-      expectPrinted("\"\" == 0", "!0");
+      expectPrinted('"" == 0', "!0");
       expectPrinted("1n == 1n", "!0");
       expectPrinted("1234n == 1234n", "!0");
       expectPrinted("0x00n == 0n", "0x00n == 0n");

--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -2958,6 +2958,13 @@ console.log(foo, array);
       expectPrinted("1 != 2", "!0");
       expectPrinted("1 != '1'", '1 != "1"');
 
+      expectPrinted("\"\" == 0", "!0");
+      expectPrinted("\"\" == 1", "!1");
+      expectPrinted("1n == 1n", "!0");
+      expectPrinted("1234n == 1234n", "!0");
+      expectPrinted("0x00n == 0n", "0x00n == 0n");
+      expectPrinted("1n == 2n", "1n == 2n");
+
       expectPrinted("'a' === '\\x61'", "!0");
       expectPrinted("'a' === '\\x62'", "!1");
       expectPrinted("'a' === 'abc'", "!1");

--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -2959,7 +2959,6 @@ console.log(foo, array);
       expectPrinted("1 != '1'", '1 != "1"');
 
       expectPrinted("\"\" == 0", "!0");
-      expectPrinted("\"\" == 1", "!1");
       expectPrinted("1n == 1n", "!0");
       expectPrinted("1234n == 1234n", "!0");
       expectPrinted("0x00n == 0n", "0x00n == 0n");


### PR DESCRIPTION
### What does this PR do?
fixes edge case involving loose equality of a string and a number or two bigints

```
"" == 0;
"-0" == 0;
1234n == 5678n;
```
before: false, false, true
after: true, true, false

fixes #8311 

### How did you verify your code works?
added tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
