### PR TITLE
fix(node:child_process): fix crash with ipc

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1925,6 +1925,7 @@ pub const Subprocess = struct {
                 });
                 return .zero;
             };
+            socket.setTimeout(0);
             pipes_to_close.append(bun.default_allocator, bun.toFD(fds[1])) catch |err| return globalThis.handleError(err, "in posix_spawn");
             actions.dup2(bun.toFD(fds[1]), bun.toFD(3)) catch |err| return globalThis.handleError(err, "in posix_spawn");
             actions.close(bun.toFD(fds[1])) catch |err| return globalThis.handleError(err, "in posix_spawn");

--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -299,6 +299,11 @@ pub fn NewIPCHandler(comptime Context: type) type {
             _: Socket,
         ) void {}
 
+        pub fn onLongTimeout(
+            _: *Context,
+            _: Socket,
+        ) void {}
+
         pub fn onConnectError(
             _: *anyopaque,
             _: Socket,

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -3076,6 +3076,7 @@ pub const VirtualMachine = struct {
             .ipc = undefined,
         };
         const socket = IPC.Socket.fromFd(context, fd, IPCInstance, instance, null) orelse @panic("Unable to start IPC");
+        socket.setTimeout(0);
         instance.ipc = .{ .socket = socket };
 
         const ptr = socket.ext(*IPCInstance);


### PR DESCRIPTION
### What does this PR do?
set timeout to 0 for ipc sockets and added `onLongTimeout` handler if 255 minutes is reached.

fixes #8287 

### How did you verify your code works?
tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
