### PR TITLE
Add onLongTimeout callback for WebSocket

### DIFF
--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -236,6 +236,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                     pub const onData = handleData;
                     pub const onWritable = handleWritable;
                     pub const onTimeout = handleTimeout;
+                    pub const onLongTimeout = handleTimeout;
                     pub const onConnectError = handleConnectError;
                     pub const onEnd = handleEnd;
                     pub const onHandshake = handleHandshake;
@@ -960,6 +961,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
                     pub const onData = handleData;
                     pub const onWritable = handleWritable;
                     pub const onTimeout = handleTimeout;
+                    pub const onLongTimeout = handleTimeout;
                     pub const onConnectError = handleConnectError;
                     pub const onEnd = handleEnd;
                     pub const onHandshake = handleHandshake;


### PR DESCRIPTION
### What does this PR do?

This adds the onLongTimeout callback. I don't think we use the timeout code for these websockets so I don't think this codepath is likely to be reached. But just in-case, we should define the callback so it doesn't crash in the event it would be reached

### How did you verify your code works?

CI