### PR TITLE
docs: remove unncessary use of `async`

### DIFF
--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -123,7 +123,7 @@ Create mock functions with the `mock` function. Mocks are automatically reset be
 import { test, expect, mock } from "bun:test";
 const random = mock(() => Math.random());
 
-test("random", async () => {
+test("random", () => {
   const val = random();
   expect(val).toBeGreaterThan(0);
   expect(random).toHaveBeenCalled();
@@ -151,7 +151,7 @@ Snapshots are supported by `bun test`.
 // example usage of toMatchSnapshot
 import { test, expect } from "bun:test";
 
-test("snapshot", async () => {
+test("snapshot", () => {
   expect({ a: 1 }).toMatchSnapshot();
 });
 ```


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

The `async` keyword is unnecessary and could be misleading because there is no `await` calls in the test functions.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
