### PR TITLE
docs: add description how to parse the CLI ARGV by the built-in `parseArg`

### DIFF
--- a/docs/guides/process/argv.md
+++ b/docs/guides/process/argv.md
@@ -19,4 +19,39 @@ $ bun run cli.tsx --flag1 --flag2 value
 
 ---
 
-To parse `argv` into a more useful format, consider using [minimist](https://github.com/minimistjs/minimist) or [commander](https://github.com/tj/commander.js).
+To parse `argv` into a more useful format, `util.parseArgs` would be helpful.
+
+Example:
+
+```ts#cli.ts
+import { parseArgs } from "util";
+
+const { values, positionals } = parseArgs({
+  args: Bun.argv,
+  options: {
+    flag1: {
+      type: 'boolean',
+    },
+    flag2: {
+      type: 'string',
+    },
+  },
+  strict: true,
+  allowPositionals: true,
+});
+
+console.log(values);
+console.log(positionals);
+```
+
+then it outputs
+
+```
+$ bun run cli.tsx --flag1 --flag2 value
+{
+  flag1: true,
+  flag2: "value",
+}
+[ "/path/to/bun", "/path/to/cli.ts" ]
+```
+


### PR DESCRIPTION
### What does this PR do?

`util.parseArg` had been introduced by https://github.com/oven-sh/bun/pull/7310, so now Bun can parse the CLI ARGV natively by the built-in function.

This pull request tweaks the document how to parse the CLI ARGV.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
