### PR TITLE
Include Mise in the installation methods

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,6 +35,10 @@ $ docker run --rm --init --ulimit memlock=-1:-1 oven/bun
 $ proto install bun
 ```
 
+```bash#Mise
+$ mise install bun
+```
+
 {% /codetabs %}
 
 ### Windows


### PR DESCRIPTION
### What does this PR do?

Bun can be installed using [Mise](https://github.com/jdx/mise), so I'm adding it to the list of options to install Bun in Linux and macOS environments. For context, Mise is an environment manager that can install and activate tool versions. The installation instructions are codified in plugins. In the case of Bun, that's provided by [this plugin](https://github.com/cometkim/asdf-bun). 

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
There have yet to be code changes.
