### PR TITLE
Fix eqlComptimeCheckLenWithKnownType

### DIFF
--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -832,46 +832,34 @@ pub fn hasSuffixComptime(self: string, comptime alt: anytype) bool {
     return self.len >= alt.len and eqlComptimeCheckLenWithType(u8, self[self.len - alt.len ..], alt, false);
 }
 
-inline fn eqlComptimeCheckLenWithKnownType(comptime Type: type, a: []const Type, comptime b: []const Type, comptime check_len: bool) bool {
+inline fn eqlComptimeCheckLenU8(a: []const u8, comptime b: []const u8, comptime check_len: bool) bool {
     @setEvalBranchQuota(9999);
     if (comptime check_len) {
-        if (comptime b.len == 0) {
-            return a.len == 0;
-        }
-
-        switch (a.len) {
-            b.len => {},
-            else => return false,
-        }
+        if (a.len != b.len) return false;
     }
-
-    const len = comptime b.len;
-    comptime var dword_length = b.len >> if (Environment.isNative) 3 else 2;
-    const slice = b;
-    const divisor = comptime @sizeOf(Type);
 
     comptime var b_ptr: usize = 0;
 
-    inline while (dword_length > 0) : (dword_length -= 1) {
-        if (@as(usize, @bitCast(a[b_ptr..][0 .. @sizeOf(usize) / divisor].*)) != comptime @as(usize, @bitCast((slice[b_ptr..])[0 .. @sizeOf(usize) / divisor].*)))
+    inline while (b.len - b_ptr >= @sizeOf(usize)) {
+        if (@as(usize, @bitCast(a[b_ptr..][0 .. @sizeOf(usize)].*)) != comptime @as(usize, @bitCast(b[b_ptr..][0 .. @sizeOf(usize)].*)))
             return false;
         comptime b_ptr += @sizeOf(usize);
         if (comptime b_ptr == b.len) return true;
     }
 
+
     if (comptime @sizeOf(usize) == 8) {
-        if (comptime (len & 4) != 0) {
-            if (@as(u32, @bitCast(a[b_ptr..][0 .. @sizeOf(u32) / divisor].*)) != comptime @as(u32, @bitCast((slice[b_ptr..])[0 .. @sizeOf(u32) / divisor].*)))
+        if (comptime (b.len & 4) != 0) {
+            if (@as(u32, @bitCast(a[b_ptr..][0 .. @sizeOf(u32)].*)) != comptime @as(u32, @bitCast(b[b_ptr..][0 .. @sizeOf(u32)].*)))
                 return false;
-
             comptime b_ptr += @sizeOf(u32);
-
             if (comptime b_ptr == b.len) return true;
         }
     }
 
-    if (comptime (len & 2) != 0) {
-        if (@as(u16, @bitCast(a[b_ptr..][0 .. @sizeOf(u16) / divisor].*)) != comptime @as(u16, @bitCast(slice[b_ptr .. b_ptr + (@sizeOf(u16) / divisor)].*)))
+
+    if (comptime (b.len & 2) != 0) {
+        if (@as(u16, @bitCast(a[b_ptr..][0 .. @sizeOf(u16)].*)) != comptime @as(u16, @bitCast(b[b_ptr..][0 .. @sizeOf(u16)].*)))
             return false;
 
         comptime b_ptr += @sizeOf(u16);
@@ -879,9 +867,16 @@ inline fn eqlComptimeCheckLenWithKnownType(comptime Type: type, a: []const Type,
         if (comptime b_ptr == b.len) return true;
     }
 
-    if ((comptime (len & 1) != 0) and a[b_ptr] != comptime b[b_ptr]) return false;
+    if ((comptime (b.len & 1) != 0) and a[b_ptr] != comptime b[b_ptr]) return false;
 
     return true;
+}
+
+inline fn eqlComptimeCheckLenWithKnownType(comptime Type: type, a: []const Type, comptime b: []const Type, comptime check_len: bool) bool {
+    if (comptime Type != u8) {
+        return eqlComptimeCheckLenU8(std.mem.sliceAsBytes(a),  comptime std.mem.sliceAsBytes(b), comptime check_len);
+    }
+    return eqlComptimeCheckLenU8(a,  comptime b, comptime check_len);
 }
 
 /// Check if two strings are equal with one of the strings being a comptime-known value

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -841,25 +841,23 @@ inline fn eqlComptimeCheckLenU8(a: []const u8, comptime b: []const u8, comptime 
     comptime var b_ptr: usize = 0;
 
     inline while (b.len - b_ptr >= @sizeOf(usize)) {
-        if (@as(usize, @bitCast(a[b_ptr..][0 .. @sizeOf(usize)].*)) != comptime @as(usize, @bitCast(b[b_ptr..][0 .. @sizeOf(usize)].*)))
+        if (@as(usize, @bitCast(a[b_ptr..][0..@sizeOf(usize)].*)) != comptime @as(usize, @bitCast(b[b_ptr..][0..@sizeOf(usize)].*)))
             return false;
         comptime b_ptr += @sizeOf(usize);
         if (comptime b_ptr == b.len) return true;
     }
 
-
     if (comptime @sizeOf(usize) == 8) {
         if (comptime (b.len & 4) != 0) {
-            if (@as(u32, @bitCast(a[b_ptr..][0 .. @sizeOf(u32)].*)) != comptime @as(u32, @bitCast(b[b_ptr..][0 .. @sizeOf(u32)].*)))
+            if (@as(u32, @bitCast(a[b_ptr..][0..@sizeOf(u32)].*)) != comptime @as(u32, @bitCast(b[b_ptr..][0..@sizeOf(u32)].*)))
                 return false;
             comptime b_ptr += @sizeOf(u32);
             if (comptime b_ptr == b.len) return true;
         }
     }
 
-
     if (comptime (b.len & 2) != 0) {
-        if (@as(u16, @bitCast(a[b_ptr..][0 .. @sizeOf(u16)].*)) != comptime @as(u16, @bitCast(b[b_ptr..][0 .. @sizeOf(u16)].*)))
+        if (@as(u16, @bitCast(a[b_ptr..][0..@sizeOf(u16)].*)) != comptime @as(u16, @bitCast(b[b_ptr..][0..@sizeOf(u16)].*)))
             return false;
 
         comptime b_ptr += @sizeOf(u16);
@@ -874,9 +872,9 @@ inline fn eqlComptimeCheckLenU8(a: []const u8, comptime b: []const u8, comptime 
 
 inline fn eqlComptimeCheckLenWithKnownType(comptime Type: type, a: []const Type, comptime b: []const Type, comptime check_len: bool) bool {
     if (comptime Type != u8) {
-        return eqlComptimeCheckLenU8(std.mem.sliceAsBytes(a),  comptime std.mem.sliceAsBytes(b), comptime check_len);
+        return eqlComptimeCheckLenU8(std.mem.sliceAsBytes(a), comptime std.mem.sliceAsBytes(b), comptime check_len);
     }
-    return eqlComptimeCheckLenU8(a,  comptime b, comptime check_len);
+    return eqlComptimeCheckLenU8(a, comptime b, comptime check_len);
 }
 
 /// Check if two strings are equal with one of the strings being a comptime-known value

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -258,41 +258,39 @@ test(".env process variables no comments", () => {
 
 describe("package scripts load from .env.production and .env.development", () => {
   test("NODE_ENV=production", () => {
+    const pkgjson = {
+      "name": "foo",
+      "version": "2.0",
+      "scripts": {
+        "test": `${bunExe()} run index.ts`,
+      },
+    };
     const dir = tempDirWithFiles("dotenv-package-script-prod", {
       "index.ts": "console.log(process.env.TEST);",
-      "package.json": `
-      {
-        "name": "foo",
-        "version": "2.0",
-        "scripts": {
-          "test": "NODE_ENV=production ${bunExe()} run index.ts",
-        }
-      }
-      `,
+      "package.json": JSON.stringify(pkgjson),
       ".env.production": "TEST=prod",
       ".env.development": "TEST=dev",
     });
 
-    const { stdout } = bunRunAsScript(dir, "test");
+    const { stdout } = bunRunAsScript(dir, "test", {"NODE_ENV": "production"});
     expect(stdout).toBe("prod");
   });
   test("NODE_ENV=development", () => {
+    const pkgjson = {
+      "name": "foo",
+      "version": "2.0",
+      "scripts": {
+        "test": `${bunExe()} run index.ts`,
+      },
+    };
     const dir = tempDirWithFiles("dotenv-package-script-prod", {
       "index.ts": "console.log(process.env.TEST);",
-      "package.json": `
-        {
-          "name": "foo",
-          "version": "2.0",
-          "scripts": {
-            "test": "NODE_ENV=development ${bunExe()} run index.ts",
-          }
-        }
-        `,
+      "package.json": JSON.stringify(pkgjson),
       ".env.production": "TEST=prod",
       ".env.development": "TEST=dev",
     });
 
-    const { stdout } = bunRunAsScript(dir, "test");
+    const { stdout } = bunRunAsScript(dir, "test", {"NODE_ENV": "development"});
     expect(stdout).toBe("dev");
   });
 });

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -272,7 +272,7 @@ describe("package scripts load from .env.production and .env.development", () =>
       ".env.development": "TEST=dev",
     });
 
-    const { stdout } = bunRunAsScript(dir, "test", {"NODE_ENV": "production"});
+    const { stdout } = bunRunAsScript(dir, "test", { "NODE_ENV": "production" });
     expect(stdout).toBe("prod");
   });
   test("NODE_ENV=development", () => {
@@ -290,7 +290,7 @@ describe("package scripts load from .env.production and .env.development", () =>
       ".env.development": "TEST=dev",
     });
 
-    const { stdout } = bunRunAsScript(dir, "test", {"NODE_ENV": "development"});
+    const { stdout } = bunRunAsScript(dir, "test", { "NODE_ENV": "development" });
     expect(stdout).toBe("dev");
   });
 });


### PR DESCRIPTION
### What does this PR do?

This PR fixes the function `eqlComptimeCheckLenWithKnownType`, which performed invalid comparisons for types other than u8.

The fix is to specialize the function just for u8 and have the generic function cast its slices to u8 before calling the specialized version.

Furthermore this PR simplifies the implementation.

Also, some tests in env.test.ts are adapted for windows. (this is how the bug was discovered in the first place)