### PR TITLE
Update default-trusted-dependencies.txt

### DIFF
--- a/src/install/default-trusted-dependencies.txt
+++ b/src/install/default-trusted-dependencies.txt
@@ -109,6 +109,7 @@ appium-windows-driver
 applicationinsights-native-metrics
 argon2
 autorest
+auth
 aws-crt
 azure-functions-core-tools
 azure-streamanalytics-cicd

--- a/src/install/default-trusted-dependencies.txt
+++ b/src/install/default-trusted-dependencies.txt
@@ -108,8 +108,8 @@ appium-chromedriver
 appium-windows-driver
 applicationinsights-native-metrics
 argon2
-autorest
 auth
+autorest
 aws-crt
 azure-functions-core-tools
 azure-streamanalytics-cicd


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

`bunx auth` should not fail for [`auth`](https://npm.im/auth). Currently, it throws
> error: Failed to run "auth" due to error InvalidExe

Which I traced down to this file. Let me know if this is right! There is no postinstall scripts, see https://www.npmjs.com/package/auth?activeTab=code

This works fine with `pnpx auth`

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
