### PR TITLE
[windows] Implement fs.watch on Windows

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5802,11 +5802,6 @@ pub const NodeFS = struct {
     }
 
     pub fn watch(_: *NodeFS, args: Arguments.Watch, comptime _: Flavor) Maybe(Return.Watch) {
-        if (comptime Environment.isWindows) {
-            args.global_this.throwTODO("watch is not supported on Windows yet");
-            return Maybe(Return.Watch){ .result = JSC.JSValue.undefined };
-        }
-
         const watcher = args.createFSWatcher() catch |err| {
             const buf = std.fmt.allocPrint(bun.default_allocator, "{s} watching {}", .{ @errorName(err), bun.fmt.QuotedFormatter{ .text = args.path.slice() } }) catch unreachable;
             defer bun.default_allocator.free(buf);

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -6,8 +6,6 @@ const Path = @import("../../resolver/resolve_path.zig");
 const Encoder = JSC.WebCore.Encoder;
 const Mutex = @import("../../lock.zig").Lock;
 
-const PathWatcher = @import("./path_watcher.zig");
-
 const VirtualMachine = JSC.VirtualMachine;
 const EventLoop = JSC.EventLoop;
 const PathLike = JSC.Node.PathLike;
@@ -18,6 +16,7 @@ const StoredFileDescriptorType = bun.StoredFileDescriptorType;
 const Environment = bun.Environment;
 const Async = bun.Async;
 
+const PathWatcher = if (Environment.isWindows) @import("./win_watcher.zig") else @import("./path_watcher.zig");
 pub const FSWatcher = struct {
     ctx: *VirtualMachine,
     verbose: bool = false,
@@ -556,12 +555,16 @@ pub const FSWatcher = struct {
         if (bun.strings.startsWith(slice, "file://")) {
             slice = slice[6..];
         }
+
         var parts = [_]string{
             slice,
         };
 
+        const cwd = try bun.getcwd(&buf);
+        buf[cwd.len] = std.fs.path.sep;
+
         const file_path = Path.joinAbsStringBuf(
-            Fs.FileSystem.instance.top_level_dir,
+            buf[0 .. cwd.len + 1],
             &buf,
             &parts,
             .auto,
@@ -569,6 +572,7 @@ pub const FSWatcher = struct {
 
         buf[file_path.len] = 0;
         const file_path_z = buf[0..file_path.len :0];
+
         const vm = args.global_this.bunVM();
 
         var ctx = FSWatcher.new(.{

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -563,9 +563,10 @@ pub const FSWatcher = struct {
         const cwd = try bun.getcwd(&buf);
         buf[cwd.len] = std.fs.path.sep;
 
+        var joined_buf: [bun.MAX_PATH_BYTES + 1]u8 = undefined;
         const file_path = Path.joinAbsStringBuf(
             buf[0 .. cwd.len + 1],
-            &buf,
+            &joined_buf,
             &parts,
             .auto,
         );

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -571,8 +571,8 @@ pub const FSWatcher = struct {
             .auto,
         );
 
-        buf[file_path.len] = 0;
-        const file_path_z = buf[0..file_path.len :0];
+        joined_buf[file_path.len] = 0;
+        const file_path_z = joined_buf[0..file_path.len :0];
 
         const vm = args.global_this.bunVM();
 

--- a/src/bun.js/node/win_watcher.zig
+++ b/src/bun.js/node/win_watcher.zig
@@ -1,0 +1,391 @@
+const std = @import("std");
+const bun = @import("root").bun;
+const uv = bun.windows.libuv;
+const Path = @import("../../resolver/resolve_path.zig");
+const Fs = @import("../../fs.zig");
+const Mutex = @import("../../lock.zig").Lock;
+const string = bun.string;
+const JSC = bun.JSC;
+const VirtualMachine = JSC.VirtualMachine;
+const StoredFileDescriptorType = bun.StoredFileDescriptorType;
+const Output = bun.Output;
+
+var default_manager: ?*WinPathWatcherManager = null;
+
+// TODO: make this a generic so we can reuse code with path_watcher
+// TODO: we probably should use native instead of libuv abstraction here for better performance
+pub const WinPathWatcherManager = struct {
+    const GenericWatcher = @import("../../watcher.zig");
+    const options = @import("../../options.zig");
+    pub const Watcher = GenericWatcher.NewWatcher(*WinPathWatcherManager);
+    const log = Output.scoped(.WinPathWatcherManager, false);
+    main_watcher: *Watcher,
+
+    watchers: bun.BabyList(?*PathWatcher) = .{},
+    watcher_count: u32 = 0,
+    vm: *JSC.VirtualMachine,
+    file_paths: bun.StringHashMap(PathInfo),
+    deinit_on_last_watcher: bool = false,
+    const PathInfo = struct {
+        fd: StoredFileDescriptorType = .zero,
+        is_file: bool = true,
+        path: [:0]const u8,
+        dirname: string,
+        refs: u32 = 0,
+        hash: Watcher.HashType,
+    };
+
+    fn _fdFromAbsolutePathZ(
+        this: *WinPathWatcherManager,
+        path: [:0]const u8,
+    ) !PathInfo {
+        if (this.file_paths.getEntry(path)) |entry| {
+            var info = entry.value_ptr;
+            info.refs += 1;
+            return info.*;
+        }
+        const cloned_path = try bun.default_allocator.dupeZ(u8, path);
+        errdefer bun.default_allocator.free(cloned_path);
+
+        if (std.fs.openDirAbsoluteZ(cloned_path, .{
+            .access_sub_paths = true,
+            .iterate = true,
+        })) |iterable_dir| {
+            const result = PathInfo{
+                .fd = bun.toFD(iterable_dir.fd),
+                .is_file = false,
+                .path = cloned_path,
+                .dirname = cloned_path,
+                .hash = Watcher.getHash(cloned_path),
+                .refs = 1,
+            };
+            _ = try this.file_paths.put(cloned_path, result);
+            return result;
+        } else |err| {
+            if (err == error.NotDir) {
+                const file = try std.fs.openFileAbsoluteZ(cloned_path, .{ .mode = .read_only });
+                const result = PathInfo{
+                    .fd = bun.toFD(file.handle),
+                    .is_file = true,
+                    .path = cloned_path,
+                    // if is really a file we need to get the dirname
+                    .dirname = std.fs.path.dirname(cloned_path) orelse cloned_path,
+                    .hash = Watcher.getHash(cloned_path),
+                    .refs = 1,
+                };
+                _ = try this.file_paths.put(cloned_path, result);
+                return result;
+            } else {
+                return err;
+            }
+        }
+
+        unreachable;
+    }
+
+    pub fn init(vm: *JSC.VirtualMachine) !*WinPathWatcherManager {
+        const this = try bun.default_allocator.create(WinPathWatcherManager);
+        errdefer bun.default_allocator.destroy(this);
+        var watchers = bun.BabyList(?*PathWatcher).initCapacity(bun.default_allocator, 1) catch |err| {
+            bun.default_allocator.destroy(this);
+            return err;
+        };
+        errdefer watchers.deinitWithAllocator(bun.default_allocator);
+        const manager = WinPathWatcherManager{
+            .file_paths = bun.StringHashMap(PathInfo).init(bun.default_allocator),
+            .watchers = watchers,
+            .main_watcher = try Watcher.init(
+                this,
+                vm.bundler.fs,
+                bun.default_allocator,
+            ),
+            .vm = vm,
+            .watcher_count = 0,
+        };
+
+        this.* = manager;
+        try this.main_watcher.start();
+        return this;
+    }
+
+    fn _addDirectory(this: *WinPathWatcherManager, _: *PathWatcher, path: PathInfo) !void {
+        const fd = path.fd;
+        try this.main_watcher.addDirectory(fd, path.path, path.hash, false);
+    }
+
+    fn registerWatcher(this: *WinPathWatcherManager, watcher: *PathWatcher) !void {
+        {
+            if (this.watcher_count == this.watchers.len) {
+                this.watcher_count += 1;
+                this.watchers.push(bun.default_allocator, watcher) catch |err| {
+                    this.watcher_count -= 1;
+                    return err;
+                };
+            } else {
+                var watchers = this.watchers.slice();
+                for (watchers, 0..) |w, i| {
+                    if (w == null) {
+                        watchers[i] = watcher;
+                        this.watcher_count += 1;
+                        break;
+                    }
+                }
+            }
+        }
+
+        const path = watcher.path;
+        if (path.is_file) {
+            try this.main_watcher.addFile(path.fd, path.path, path.hash, options.Loader.file, .zero, null, false);
+        } else {
+            try this._addDirectory(watcher, path);
+        }
+    }
+
+    fn _incrementPathRef(this: *WinPathWatcherManager, file_path: [:0]const u8) void {
+        if (this.file_paths.getEntry(file_path)) |entry| {
+            var path = entry.value_ptr;
+            if (path.refs > 0) {
+                path.refs += 1;
+            }
+        }
+    }
+
+    fn _decrementPathRef(this: *WinPathWatcherManager, file_path: [:0]const u8) void {
+        if (this.file_paths.getEntry(file_path)) |entry| {
+            var path = entry.value_ptr;
+            if (path.refs > 0) {
+                path.refs -= 1;
+                if (path.refs == 0) {
+                    const path_ = path.path;
+                    this.main_watcher.remove(path.hash);
+                    _ = this.file_paths.remove(path_);
+                    bun.default_allocator.free(path_);
+                }
+            }
+        }
+    }
+
+    // unregister is always called form main thread
+    fn unregisterWatcher(this: *WinPathWatcherManager, watcher: *PathWatcher) void {
+        var watchers = this.watchers.slice();
+        defer {
+            if (this.deinit_on_last_watcher and this.watcher_count == 0) {
+                this.deinit();
+            }
+        }
+
+        for (watchers, 0..) |w, i| {
+            if (w) |item| {
+                if (item == watcher) {
+                    watchers[i] = null;
+                    // if is the last one just pop
+                    if (i == watchers.len - 1) {
+                        this.watchers.len -= 1;
+                    }
+                    this.watcher_count -= 1;
+
+                    this._decrementPathRef(watcher.path.path);
+                    break;
+                }
+            }
+        }
+    }
+    fn deinit(this: *WinPathWatcherManager) void {
+        // enable to create a new manager
+        if (default_manager == this) {
+            default_manager = null;
+        }
+
+        // only deinit if no watchers are registered
+        if (this.watcher_count > 0) {
+            // wait last watcher to close
+            this.deinit_on_last_watcher = true;
+            return;
+        }
+
+        this.main_watcher.deinit(false);
+
+        if (this.watcher_count > 0) {
+            while (this.watchers.popOrNull()) |watcher| {
+                if (watcher) |w| {
+                    // unlink watcher
+                    w.manager = null;
+                }
+            }
+        }
+
+        // close all file descriptors and free paths
+        var it = this.file_paths.iterator();
+        while (it.next()) |*entry| {
+            const path = entry.value_ptr.*;
+            _ = bun.sys.close(path.fd);
+            bun.default_allocator.free(path.path);
+        }
+
+        this.file_paths.deinit();
+
+        this.watchers.deinitWithAllocator(bun.default_allocator);
+
+        bun.default_allocator.destroy(this);
+    }
+};
+
+pub const PathWatcher = struct {
+    handle: uv.uv_fs_event_t,
+    ctx: ?*anyopaque,
+    recursive: bool,
+    callback: Callback,
+    flushCallback: UpdateEndCallback,
+    manager: ?*WinPathWatcherManager,
+    path: WinPathWatcherManager.PathInfo,
+    last_change_event: ChangeEvent = .{},
+    closed: bool = false,
+    needs_flush: bool = false,
+
+    const log = Output.scoped(.WinPathWatcher, false);
+
+    pub const ChangeEvent = struct {
+        hash: WinPathWatcherManager.Watcher.HashType = 0,
+        event_type: EventType = .change,
+        time_stamp: i64 = 0,
+    };
+
+    pub const EventType = enum {
+        rename,
+        change,
+        @"error",
+    };
+    const Callback = *const fn (ctx: ?*anyopaque, path: string, is_file: bool, event_type: EventType) void;
+    const UpdateEndCallback = *const fn (ctx: ?*anyopaque) void;
+
+    fn uvEventCallback(event: *uv.uv_fs_event_t, filename: [*c]const u8, events: c_int, status: c_int) callconv(.C) void {
+        const this = bun.cast(*PathWatcher, event.data);
+
+        const manager = this.manager orelse return;
+
+        const timestamp = std.time.milliTimestamp();
+
+        if (status < 0) {
+            const err_name = uv.uv_err_name(status);
+            const err = err_name[0..bun.len(err_name)];
+            this.emit(err, 0, timestamp, false, .@"error");
+            this.flush();
+            return;
+        }
+
+        const path = if (filename) |file| file[0..bun.len(file) :0] else this.path.path;
+
+        // we need the absolute path to get the file info
+        var buf: [bun.MAX_PATH_BYTES + 1]u8 = undefined;
+        var parts = [_]string{path};
+        const cwd = Path.dirname(this.path.path, .windows);
+        @memcpy(buf[0..cwd.len], cwd);
+        buf[cwd.len] = std.fs.path.sep;
+
+        const file_path = Path.joinAbsStringBuf(
+            buf[0 .. cwd.len + 1],
+            &buf,
+            &parts,
+            .windows,
+        );
+
+        buf[file_path.len] = 0;
+        const file_path_z = buf[0..file_path.len :0];
+        const path_info = manager._fdFromAbsolutePathZ(file_path_z) catch return;
+        defer manager._decrementPathRef(path);
+        defer this.flush();
+        // events always use the relative path
+        if (events & uv.UV_RENAME != 0) {
+            this.emit(path, path_info.hash, timestamp, path_info.is_file, .rename);
+        }
+
+        if (events & uv.UV_CHANGE != 0) {
+            this.emit(path, path_info.hash, timestamp, path_info.is_file, .change);
+        }
+    }
+
+    pub fn init(manager: *WinPathWatcherManager, path: WinPathWatcherManager.PathInfo, recursive: bool, callback: Callback, updateEndCallback: UpdateEndCallback, ctx: ?*anyopaque) !*PathWatcher {
+        var this = try bun.default_allocator.create(PathWatcher);
+        errdefer this.deinit();
+        this.* = PathWatcher{
+            .handle = std.mem.zeroes(uv.uv_fs_event_t),
+            .path = path,
+            .callback = callback,
+            .manager = manager,
+            .recursive = recursive,
+            .flushCallback = updateEndCallback,
+            .ctx = ctx,
+        };
+
+        if (uv.uv_fs_event_init(manager.vm.uvLoop(), &this.handle) != 0) {
+            return error.FailedToInitializeFSEvent;
+        }
+        this.handle.data = this;
+        // UV_FS_EVENT_RECURSIVE only works for Windows and OSX
+        if (uv.uv_fs_event_start(&this.handle, PathWatcher.uvEventCallback, path.path.ptr, if (recursive) uv.UV_FS_EVENT_RECURSIVE else 0) != 0) {
+            return error.FailedToStartFSEvent;
+        }
+        // we handle this in node_fs_watcher
+        uv_unref(@ptrCast(&this.handle));
+
+        try manager.registerWatcher(this);
+        return this;
+    }
+
+    pub fn emit(this: *PathWatcher, path: string, hash: WinPathWatcherManager.Watcher.HashType, time_stamp: i64, is_file: bool, event_type: EventType) void {
+        const time_diff = time_stamp - this.last_change_event.time_stamp;
+        // skip consecutive duplicates
+        if ((this.last_change_event.time_stamp == 0 or time_diff > 1) or this.last_change_event.event_type != event_type and this.last_change_event.hash != hash) {
+            this.last_change_event.time_stamp = time_stamp;
+            this.last_change_event.event_type = event_type;
+            this.last_change_event.hash = hash;
+            this.needs_flush = true;
+            if (this.closed) return;
+            this.callback(this.ctx, path, is_file, event_type);
+        }
+    }
+
+    pub fn flush(this: *PathWatcher) void {
+        this.needs_flush = false;
+        if (this.closed) return;
+        this.flushCallback(this.ctx);
+    }
+
+    pub fn deinit(this: *PathWatcher) void {
+        this.closed = false;
+        _ = uv.uv_fs_event_stop(&this.handle);
+
+        if (this.manager) |manager| {
+            manager.unregisterWatcher(this);
+        }
+
+        bun.default_allocator.destroy(this);
+    }
+};
+
+pub fn watch(
+    vm: *VirtualMachine,
+    path: [:0]const u8,
+    recursive: bool,
+    callback: PathWatcher.Callback,
+    updateEnd: PathWatcher.UpdateEndCallback,
+    ctx: ?*anyopaque,
+) !*PathWatcher {
+    if (!bun.Environment.isWindows) {
+        @panic("win_watcher should only be used on Windows");
+    }
+
+    if (default_manager) |manager| {
+        const path_info = try manager._fdFromAbsolutePathZ(path);
+        errdefer manager._decrementPathRef(path);
+        return try PathWatcher.init(manager, path_info, recursive, callback, updateEnd, ctx);
+    } else {
+        if (default_manager == null) {
+            default_manager = try WinPathWatcherManager.init(vm);
+        }
+        const manager = default_manager.?;
+        const path_info = try manager._fdFromAbsolutePathZ(path);
+        errdefer manager._decrementPathRef(path);
+        return try PathWatcher.init(manager, path_info, recursive, callback, updateEnd, ctx);
+    }
+}

--- a/src/bun.js/node/win_watcher.zig
+++ b/src/bun.js/node/win_watcher.zig
@@ -287,8 +287,8 @@ pub const PathWatcher = struct {
             .windows,
         );
 
-        buf[file_path.len] = 0;
-        const file_path_z = buf[0..file_path.len :0];
+        joined_buf[file_path.len] = 0;
+        const file_path_z = joined_buf[0..file_path.len :0];
         const path_info = manager._fdFromAbsolutePathZ(file_path_z) catch return;
         defer manager._decrementPathRef(path);
         defer this.flush();

--- a/src/bun.js/node/win_watcher.zig
+++ b/src/bun.js/node/win_watcher.zig
@@ -326,7 +326,7 @@ pub const PathWatcher = struct {
             return error.FailedToStartFSEvent;
         }
         // we handle this in node_fs_watcher
-        uv_unref(@ptrCast(&this.handle));
+        uv.uv_unref(@ptrCast(&this.handle));
 
         try manager.registerWatcher(this);
         return this;

--- a/src/bun.js/node/win_watcher.zig
+++ b/src/bun.js/node/win_watcher.zig
@@ -35,6 +35,8 @@ pub const WinPathWatcherManager = struct {
         hash: Watcher.HashType,
     };
 
+    pub usingnamespace bun.New(WinPathWatcherManager);
+
     fn _fdFromAbsolutePathZ(
         this: *WinPathWatcherManager,
         path: [:0]const u8,
@@ -80,7 +82,7 @@ pub const WinPathWatcherManager = struct {
         var watchers = try bun.BabyList(?*PathWatcher).initCapacity(bun.default_allocator, 1);
         errdefer watchers.deinitWithAllocator(bun.default_allocator);
 
-        var this = bun.new(WinPathWatcherManager, .{
+        var this = WinPathWatcherManager.new(.{
             .file_paths = bun.StringHashMap(PathInfo).init(bun.default_allocator),
             .watchers = watchers,
             .main_watcher = undefined,
@@ -219,7 +221,7 @@ pub const WinPathWatcherManager = struct {
 
         this.watchers.deinitWithAllocator(bun.default_allocator);
 
-        bun.default_allocator.destroy(this);
+        this.destroy();
     }
 };
 
@@ -234,6 +236,8 @@ pub const PathWatcher = struct {
     last_change_event: ChangeEvent = .{},
     closed: bool = false,
     needs_flush: bool = false,
+
+    pub usingnamespace bun.New(PathWatcher);
 
     const log = Output.scoped(.WinPathWatcher, false);
 
@@ -298,7 +302,7 @@ pub const PathWatcher = struct {
     }
 
     pub fn init(manager: *WinPathWatcherManager, path: WinPathWatcherManager.PathInfo, recursive: bool, callback: Callback, updateEndCallback: UpdateEndCallback, ctx: ?*anyopaque) !*PathWatcher {
-        var this = bun.new(PathWatcher, .{
+        var this = PathWatcher.new(.{
             .handle = std.mem.zeroes(uv.uv_fs_event_t),
             .path = path,
             .callback = callback,
@@ -351,7 +355,7 @@ pub const PathWatcher = struct {
             manager.unregisterWatcher(this);
         }
 
-        bun.default_allocator.destroy(this);
+        this.destroy();
     }
 };
 

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -1329,7 +1329,7 @@ pub const struct_uv_fs_event_req_s = extern struct {
     next_req: [*c]struct_uv_req_s,
 };
 pub const uv_fs_event_t = struct_uv_fs_event_s;
-pub const uv_fs_event_cb = ?*const fn ([*c]uv_fs_event_t, [*]const u8, c_int, c_int) callconv(.C) void;
+pub const uv_fs_event_cb = ?*const fn (*uv_fs_event_t, [*c]const u8, c_int, c_int) callconv(.C) void;
 pub const struct_uv_fs_event_s = extern struct {
     data: ?*anyopaque,
     loop: *uv_loop_t,
@@ -1823,9 +1823,9 @@ pub const UV_LEAVE_GROUP: c_int = 0;
 pub const UV_JOIN_GROUP: c_int = 1;
 pub const uv_membership = c_uint;
 pub extern fn uv_translate_sys_error(sys_errno: c_int) c_int;
-pub extern fn uv_strerror(err: c_int) [*]const u8;
+pub extern fn uv_strerror(err: c_int) [*c]const u8;
 pub extern fn uv_strerror_r(err: c_int, buf: [*]u8, buflen: usize) [*]u8;
-pub extern fn uv_err_name(err: c_int) [*]const u8;
+pub extern fn uv_err_name(err: c_int) [*c]const u8;
 pub extern fn uv_err_name_r(err: c_int, buf: [*]u8, buflen: usize) [*]u8;
 pub extern fn uv_shutdown(req: [*c]uv_shutdown_t, handle: *uv_stream_t, cb: uv_shutdown_cb) c_int;
 pub extern fn uv_handle_size(@"type": uv_handle_type) usize;

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -441,7 +441,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
         // This must only be called from the watcher thread
         pub fn watchLoop(this: *Watcher) !void {
             if (Environment.isWindows) {
-                @panic("watchLoop should not be used on Windows");
+                @compileError("watchLoop should not be used on Windows");
             }
 
             this.watchloop_handle = std.Thread.getCurrentId();
@@ -685,7 +685,7 @@ pub fn NewWatcher(comptime ContextType: type) type {
                     }
                 }
             } else if (Environment.isWindows) {
-                @panic("watchLoop should not be used on Windows");
+                @compileError("watchLoop should not be used on Windows");
             }
         }
 

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -24,7 +24,7 @@ pub const WatchItemIndex = u16;
 const NoWatchItem: WatchItemIndex = std.math.maxInt(WatchItemIndex);
 const PackageJSON = @import("./resolver/package_json.zig").PackageJSON;
 
-const WATCHER_MAX_LIST = 8192;
+const WATCHER_MAX_LIST = 8096;
 
 pub const INotify = struct {
     pub const IN_CLOEXEC = std.os.O.CLOEXEC;
@@ -251,6 +251,12 @@ pub const Placeholder = struct {
 
     pub var eventlist: [WATCHER_MAX_LIST]EventListIndex = undefined;
     pub var eventlist_index: EventListIndex = 0;
+
+    pub fn isRunning() bool {
+        return true;
+    }
+
+    pub fn init() !void {}
 };
 
 const PlatformWatcher = if (Environment.isMac)
@@ -385,10 +391,6 @@ pub fn NewWatcher(comptime ContextType: type) type {
             const watcher = try allocator.create(Watcher);
             errdefer allocator.destroy(watcher);
 
-            if (comptime bun.Environment.isWindows) {
-                @panic("TODO on Windows");
-            }
-
             if (!PlatformWatcher.isRunning()) {
                 try PlatformWatcher.init();
             }
@@ -408,8 +410,10 @@ pub fn NewWatcher(comptime ContextType: type) type {
         }
 
         pub fn start(this: *Watcher) !void {
-            std.debug.assert(this.watchloop_handle == null);
-            this.thread = try std.Thread.spawn(.{}, Watcher.watchLoop, .{this});
+            if (!Environment.isWindows) {
+                std.debug.assert(this.watchloop_handle == null);
+                this.thread = try std.Thread.spawn(.{}, Watcher.watchLoop, .{this});
+            }
         }
 
         pub fn deinit(this: *Watcher, close_descriptors: bool) void {
@@ -436,6 +440,10 @@ pub fn NewWatcher(comptime ContextType: type) type {
 
         // This must only be called from the watcher thread
         pub fn watchLoop(this: *Watcher) !void {
+            if (Environment.isWindows) {
+                @panic("watchLoop should not be used on Windows");
+            }
+
             this.watchloop_handle = std.Thread.getCurrentId();
             Output.Source.configureNamedThread("File Watcher");
 
@@ -676,6 +684,8 @@ pub fn NewWatcher(comptime ContextType: type) type {
                         remaining_events -= slice.len;
                     }
                 }
+            } else if (Environment.isWindows) {
+                @panic("watchLoop should not be used on Windows");
             }
         }
 


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/8361
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
