### PR TITLE
fix to enqueue bundler tasks in correct event loop

### DIFF
--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1453,7 +1453,10 @@ pub const MiniVM = struct {
     }
 
     pub inline fn platformEventLoop(this: @This()) *JSC.PlatformEventLoop {
-        return this.mini.loop.uv_loop;
+        if (comptime Environment.isWindows) {
+            return this.mini.loop.uv_loop;
+        }
+        return this.mini.loop;
     }
 
     pub inline fn incrementPendingUnrefCounter(this: @This()) void {

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1453,7 +1453,7 @@ pub const MiniVM = struct {
     }
 
     pub inline fn platformEventLoop(this: @This()) *JSC.PlatformEventLoop {
-        return this.mini.loop;
+        return this.mini.loop.uv_loop;
     }
 
     pub inline fn incrementPendingUnrefCounter(this: @This()) void {
@@ -1508,7 +1508,7 @@ pub fn AbstractVM(inner: anytype) brk: {
 pub const MiniEventLoop = struct {
     tasks: Queue,
     concurrent_tasks: UnboundedQueue(AnyTaskWithExtraContext, .next) = .{},
-    loop: *JSC.PlatformEventLoop,
+    loop: *uws.Loop,
     allocator: std.mem.Allocator,
     file_polls_: ?*Async.FilePoll.Store = null,
     env: ?*bun.DotEnv.Loader = null,
@@ -1569,7 +1569,7 @@ pub const MiniEventLoop = struct {
         return .{
             .tasks = Queue.init(allocator),
             .allocator = allocator,
-            .loop = if (comptime bun.Environment.isPosix) uws.Loop.get() else bun.Async.Loop.get(),
+            .loop = uws.Loop.get(),
         };
     }
 

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -2497,6 +2497,14 @@ pub const UVLoop = extern struct {
         return this.internal_loop_data.iteration_nr;
     }
 
+    pub fn addActive(this: *const UVLoop, val: u32) void {
+        this.uv_loop.addActive(val);
+    }
+
+    pub fn subActive(this: *const UVLoop, val: u32) void {
+        this.uv_loop.subActive(val);
+    }
+
     pub fn isActive(this: *const UVLoop) bool {
         return this.uv_loop.isActive();
     }


### PR DESCRIPTION
### What does this PR do?

Change the event loop used to enqueue bundler tasks from the raw libuv loop to the uws loop

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
