### PR TITLE
chore: add types for Jest's date mocking API

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -92,6 +92,7 @@ declare module "bun:test" {
   interface Jest {
     restoreAllMocks(): void;
     fn<T extends (...args: any[]) => any>(func?: T): Mock<T>;
+    setSystemTime(now?: number | Date): void;
   }
   export const jest: Jest;
   export namespace jest {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

EDIT: Only adds type definitions for `setSystemTime` for now.

This pull request includes type definitions for Jest's date mocking API. It will help with existing tests that use `setSystemTime`, `useFakeTimers`, and `useRealTimers`. Users are currently encountering type errors when using these APIs with Bun as caputred below.

![Shot 2024-01-22 at 21 52 08@2x](https://github.com/oven-sh/bun/assets/5466341/0b47169d-6cec-45fc-b8d0-9cf638179de6)

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
