### PR TITLE
windows: fix a path resolution case

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1079,17 +1079,7 @@ fn getFdPathViaCWD(fd: std.os.fd_t, buf: *[@This().MAX_PATH_BYTES]u8) ![]u8 {
     return std.os.getcwd(buf);
 }
 
-pub fn getcwd(buf_: []u8) ![]u8 {
-    if (comptime !Environment.isWindows) {
-        return std.os.getcwd(buf_);
-    }
-
-    var temp: [MAX_PATH_BYTES]u8 = undefined;
-    const temp_slice = try std.os.getcwd(&temp);
-    // Paths are normalized to use / to make more things reliable, but eventually this will have to change to be the true file sep
-    // It is possible to expose this value to JS land
-    return path.normalizeBuf(temp_slice, buf_, .auto);
-}
+pub const getcwd = std.os.getcwd;
 
 pub fn getcwdAlloc(allocator: std.mem.Allocator) ![]u8 {
     var temp: [MAX_PATH_BYTES]u8 = undefined;

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1486,6 +1486,7 @@ pub const PathName = struct {
             // This path is likely incorrect. I think it may be *possible*
             // but it is almost entirely certainly a bug.
             std.debug.assert(!strings.startsWith(_path, "/:/"));
+            std.debug.assert(!strings.startsWith(_path, "\\:\\"));
         }
 
         var path = _path;

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1482,6 +1482,12 @@ pub const PathName = struct {
     }
 
     pub fn init(_path: string) PathName {
+        if (comptime Environment.isWindows and Environment.isDebug) {
+            // This path is likely incorrect. I think it may be *possible*
+            // but it is almost entirely certainly a bug.
+            std.debug.assert(!strings.startsWith(_path, "/:/"));
+        }
+
         var path = _path;
         var base = path;
         var ext: []const u8 = undefined;

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3607,7 +3607,6 @@ pub const Resolver = struct {
 
     pub fn loadAsFile(r: *ThisResolver, path: string, extension_order: []const string) ?LoadResult {
         var rfs: *Fs.FileSystem.RealFS = &r.fs.fs;
-        std.debug.print("A:{s}\n", .{path});
 
         if (r.debug_logs) |*debug| {
             debug.addNoteFmt("Attempting to load \"{s}\" as a file", .{path});

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3469,6 +3469,10 @@ pub const Resolver = struct {
                 }
             }
 
+            if (Environment.allow_assert) {
+                std.debug.assert(std.fs.path.isAbsolute(file.path));
+            }
+
             return MatchResult{
                 .path_pair = .{ .primary = Path.init(file.path) },
                 .diff_case = file.diff_case,
@@ -3603,6 +3607,7 @@ pub const Resolver = struct {
 
     pub fn loadAsFile(r: *ThisResolver, path: string, extension_order: []const string) ?LoadResult {
         var rfs: *Fs.FileSystem.RealFS = &r.fs.fs;
+        std.debug.print("A:{s}\n", .{path});
 
         if (r.debug_logs) |*debug| {
             debug.addNoteFmt("Attempting to load \"{s}\" as a file", .{path});

--- a/test/windows-test-allowlist.txt
+++ b/test/windows-test-allowlist.txt
@@ -1,4 +1,0 @@
-# files listed in here will be run on windows
-# currently, not all tests pass on windows, so we will reduce noise
-# eventually, we can move to using a denylist.
-js/node/fs/


### PR DESCRIPTION
### What does this PR do?

fixes a case where paths during resolution became `\:\bun\path\to\thing.ts` instead of `C:\`

note: used jarreds windows device on this and accidentally comitted with his id. lol.