### PR TITLE
feat(windows): implement node.exe symlink via the `--bun` flag

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1148,10 +1148,15 @@ pub const Command = struct {
         }
     };
 
-    pub fn isBunX(argv0: []const u8) bool {
-        const suffix = if (Environment.isWindows) ".exe" else "";
+    const exe_suffix = if (Environment.isWindows) ".exe" else "";
 
-        return strings.endsWithComptime(argv0, "bunx" ++ suffix) or (Environment.isDebug and strings.endsWithComptime(argv0, "bunx-debug" ++ suffix));
+    pub fn isBunX(argv0: []const u8) bool {
+        return strings.endsWithComptime(argv0, "bunx" ++ exe_suffix) or
+            (Environment.isDebug and strings.endsWithComptime(argv0, "bunx-debug" ++ exe_suffix));
+    }
+
+    pub fn isNode(argv0: []const u8) bool {
+        return strings.endsWithComptime(argv0, "node" ++ exe_suffix);
     }
 
     pub fn which() Tag {
@@ -1162,7 +1167,7 @@ pub const Command = struct {
         // symlink is argv[0]
         if (isBunX(argv0)) return .BunxCommand;
 
-        if (strings.endsWithComptime(argv0, "node")) {
+        if (isNode(argv0)) {
             @import("./deps/zig-clap/clap/streaming.zig").warn_on_unrecognized_flag = false;
             pretend_to_be_node = true;
             return .RunAsNodeCommand;

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -550,7 +550,7 @@ pub const FileSystem = struct {
                             break :brk bun.default_allocator.dupe(u8, out) catch unreachable;
                         }
 
-                        break :brk "C:/Windows/Temp";
+                        break :brk "C:\\Windows\\Temp";
                     };
                     win_tempdir_cache = value;
                     return value;

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -2999,3 +2999,9 @@ pub extern "kernel32" fn GetHostNameW(
     lpBuffer: PWSTR,
     nSize: c_int,
 ) BOOL;
+
+/// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha
+pub extern "kernel32" fn GetTempPath2W(
+    nBufferLength: DWORD, // [in]
+    lpBuffer: LPCWSTR, // [out]
+) DWORD;

--- a/src/windows_c.zig
+++ b/src/windows_c.zig
@@ -701,7 +701,7 @@ pub const SystemErrno = enum(u16) {
                 return init(@as(Win32Error, @enumFromInt(code)));
             } else {
                 if (comptime bun.Environment.allow_assert)
-                    bun.Output.debug("Unknown error code: {}\n", .{code});
+                    bun.Output.debug("Unknown error code: {any}\n", .{code});
 
                 return null;
             }


### PR DESCRIPTION
this implements --bun for windows.

it places the file at %TEMP%\bun-node-<sha>\node.exe.
it is a hard link to the current executable.

this took much longer than it should and im very mad at string_immutable.zig, the MSCPP debugger, and the unhelpful error message created by the `unreachable` keyword.

uses of std.os are safe because they are given a valid nt object path