### PR TITLE
copy_file: ioctl_ficlone take EACCES, EPERM as not supported

### DIFF
--- a/src/copy_file.zig
+++ b/src/copy_file.zig
@@ -52,10 +52,9 @@ pub fn copyFile(in: InputType, out: InputType) CopyFileError!void {
                 .NOMEM => return error.OutOfMemory,
                 .NOSPC => return error.NoSpaceLeft,
                 .OVERFLOW => return error.Unseekable,
-                .PERM => return error.PermissionDenied,
                 .TXTBSY => return error.FileBusy,
                 .XDEV => {},
-                .BADF, .INVAL, .OPNOTSUPP, .NOSYS => {
+                .ACCES, .BADF, .INVAL, .OPNOTSUPP, .NOSYS, .PERM => {
                     bun.Output.debug("ioctl_ficlonerange is NOT supported", .{});
                     can_use_ioctl_ficlone_.store(-1, .Monotonic);
                 },


### PR DESCRIPTION
### What does this PR do?

This PR fixes copy failure on LXC container using ZFS as underlying file system. It may potentially fix copy failures in other environments.

I noticed the problem while running `bunx` in Arch Linux LXC container on a Proxmox VE host. strace result shows the permission denied message is printed after following syscall:

```
ioctl(17, BTRFS_IOC_CLONE or FICLONE, 18) = -1 EPERM (Operation not permitted)
```

Here's the strace excerpt for `cp` in the same LXC container (with coreutils 9.4):

```
openat(AT_FDCWD, "asdf", O_WRONLY|O_CREAT|O_EXCL, 0644) = 4
ioctl(4, BTRFS_IOC_CLONE or FICLONE, 3) = -1 EPERM (Operation not permitted)
newfstatat(4, "", {st_mode=S_IFREG|0644, st_size=0, ...}, AT_EMPTY_PATH) = 0
lseek(3, 0, SEEK_DATA)                  = 0
fadvise64(3, 0, 0, POSIX_FADV_SEQUENTIAL) = 0
lseek(3, 0, SEEK_HOLE)                  = 24838
lseek(3, 0, SEEK_SET)                   = 0
uname({sysname="Linux", nodename="arch", ...}) = 0
copy_file_range(3, NULL, 4, NULL, 24838, 0) = 24838
```

`ioctl_ficlone` may return `EPERM` (in LXC container), [`EACCES`](https://github.com/termux/termux-packages/issues/15706#issuecomment-1477266934) (in Android). Those `errno` should be taken as `FICLONE` being not supported instead of error.

Refer to this coreutils bug report https://bugs.gnu.org/62404. Here's the [fix](https://github.com/coreutils/coreutils/commit/093a8b4bfaba60005f14493ce7ef11ed665a0176#diff-77785922df73494c9b82cf14280acd36a5ec8c06c0ab750651d12ee21d9f7d52R288) in coreutils for the bug. 

- [ ] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

I'm completely new to Bun and have never used Zig. (Bun makes me interested in Zig.) So I'm not able to write a test for the code change in this PR.

- [ ] I included a test for the new code, or existing tests cover it
- [x] I build Bun with this code change and run `bunx` (symlink `bun-debug` to `bunx`), copy failure is fixed

