### PR TITLE
fix close on spawn and watch

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -947,6 +947,7 @@ pub const Subprocess = struct {
             }
 
             if (this.pipe) |pipe| {
+                pipe.data = this;
                 _ = uv.uv_close(@ptrCast(pipe), BufferedPipeInput.uvClosedCallback);
             }
         }

--- a/src/bun.js/node/win_watcher.zig
+++ b/src/bun.js/node/win_watcher.zig
@@ -361,9 +361,12 @@ pub const PathWatcher = struct {
         if (this.manager) |manager| {
             manager.unregisterWatcher(this);
         }
-
-        _ = uv.uv_fs_event_stop(&this.handle);
-        _ = uv.uv_close(@ptrCast(&this.handle), PathWatcher.uvClosedCallback);
+        if (uv.uv_is_closed(@ptrCast(&this.handle))) {
+            this.destroy();
+        } else {
+            _ = uv.uv_fs_event_stop(&this.handle);
+            _ = uv.uv_close(@ptrCast(&this.handle), PathWatcher.uvClosedCallback);
+        }
     }
 };
 

--- a/src/bun.js/node/win_watcher.zig
+++ b/src/bun.js/node/win_watcher.zig
@@ -256,6 +256,7 @@ pub const PathWatcher = struct {
     const UpdateEndCallback = *const fn (ctx: ?*anyopaque) void;
 
     fn uvEventCallback(event: *uv.uv_fs_event_t, filename: [*c]const u8, events: c_int, status: c_int) callconv(.C) void {
+        if (event.data == null) return;
         const this = bun.cast(*PathWatcher, event.data);
 
         const manager = this.manager orelse return;
@@ -348,15 +349,21 @@ pub const PathWatcher = struct {
         this.flushCallback(this.ctx);
     }
 
+    fn uvClosedCallback(handler: *anyopaque) callconv(.C) void {
+        const event = bun.cast(*uv.uv_fs_event_t, handler);
+        const this = bun.cast(*PathWatcher, event.data);
+        this.destroy();
+    }
+
     pub fn deinit(this: *PathWatcher) void {
         this.closed = false;
-        _ = uv.uv_fs_event_stop(&this.handle);
 
         if (this.manager) |manager| {
             manager.unregisterWatcher(this);
         }
 
-        this.destroy();
+        _ = uv.uv_fs_event_stop(&this.handle);
+        _ = uv.uv_close(@ptrCast(&this.handle), PathWatcher.uvClosedCallback);
     }
 };
 

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -2049,8 +2049,31 @@ pub const UVStreamSink = struct {
     signal: Signal = .{},
     next: ?Sink = null,
     buffer: bun.ByteList = .{},
+    closeCallback: CloseCallbackHandler = CloseCallbackHandler.Empty,
+    deinit_onclose: bool = false,
     pub const name = "UVStreamSink";
-    const StreamType = if(Environment.isWindows) *uv.uv_stream_t else *anyopaque;
+    const StreamType = if (Environment.isWindows) ?*uv.uv_stream_t else *anyopaque;
+
+    pub const CloseCallbackHandler = struct {
+        ctx: ?*anyopaque = null,
+        callback: ?*const fn (ctx: ?*anyopaque) void = null,
+
+        pub const Empty: CloseCallbackHandler = .{};
+
+        pub fn init(ctx: *anyopaque, callback: *const fn (ctx: ?*anyopaque) void) CloseCallbackHandler {
+            return CloseCallbackHandler{
+                .ctx = ctx,
+                .callback = callback,
+            };
+        }
+
+        pub fn run(this: *const CloseCallbackHandler) void {
+            if (this.callback) |callback| {
+                callback(this.ctx);
+            }
+        }
+    };
+
     const AsyncWriteInfo = struct {
         sink: *UVStreamSink,
         input_buffer: uv.uv_buf_t = std.mem.zeroes(uv.uv_buf_t),
@@ -2073,9 +2096,11 @@ pub const UVStreamSink = struct {
         }
 
         pub fn run(this: *AsyncWriteInfo) void {
-            if (uv.uv_write(&this.req, @ptrCast(this.sink.stream), @ptrCast(&this.input_buffer), 1, AsyncWriteInfo.uvWriteCallback).errEnum()) |err| {
-                _ = this.sink.end(bun.sys.Error.fromCode(err, .write));
-                this.deinit();
+            if (this.sink.stream) |stream| {
+                if (uv.uv_write(&this.req, @ptrCast(stream), @ptrCast(&this.input_buffer), 1, AsyncWriteInfo.uvWriteCallback).errEnum()) |err| {
+                    _ = this.sink.end(bun.sys.Error.fromCode(err, .write));
+                    this.deinit();
+                }
             }
         }
 
@@ -2087,20 +2112,21 @@ pub const UVStreamSink = struct {
 
     fn writeAsync(this: *UVStreamSink, data: []const u8) void {
         if (this.done) return;
-        if(!Environment.isWindows) @panic("UVStreamSink is only supported on Windows");
+        if (!Environment.isWindows) @panic("UVStreamSink is only supported on Windows");
 
         AsyncWriteInfo.init(this, data).run();
     }
 
     fn writeMaybeSync(this: *UVStreamSink, data: []const u8) void {
-        if(!Environment.isWindows) @panic("UVStreamSink is only supported on Windows");
+        if (!Environment.isWindows) @panic("UVStreamSink is only supported on Windows");
 
         if (this.done) return;
 
         var to_write = data;
         while (to_write.len > 0) {
+            const stream = this.stream orelse return;
             var input_buffer = uv.uv_buf_t.init(to_write);
-            const status = uv.uv_try_write(@ptrCast(this.stream), @ptrCast(&input_buffer), 1);
+            const status = uv.uv_try_write(@ptrCast(stream), @ptrCast(&input_buffer), 1);
             if (status.errEnum()) |err| {
                 if (err == bun.C.E.AGAIN) {
                     this.writeAsync(to_write);
@@ -2133,18 +2159,37 @@ pub const UVStreamSink = struct {
         return .{ .result = JSValue.jsNumber(0) };
     }
 
-    pub fn close(this: *UVStreamSink) void {
-        if(!Environment.isWindows) @panic("UVStreamSink is only supported on Windows");
-        _ = uv.uv_close(@ptrCast(this.stream), null);
+    fn uvCloseCallback(handler: *anyopaque) callconv(.C) void {
+        const event = bun.cast(*uv.uv_pipe_t, handler);
+        const this = bun.cast(*UVStreamSink, event.data);
+        if (this.deinit_onclose) {
+            this._destroy();
+        }
     }
 
-    pub fn finalize(this: *UVStreamSink) void {
+    pub fn close(this: *UVStreamSink) void {
+        if (!Environment.isWindows) @panic("UVStreamSink is only supported on Windows");
+        const stream = this.stream orelse return;
+        stream.data = this;
+        _ = uv.uv_close(@ptrCast(stream), UVStreamSink.uvCloseCallback);
+    }
+
+    fn _destroy(this: *UVStreamSink) void {
+        this.closeCallback.run();
+        this.stream = null;
         if (this.buffer.cap > 0) {
             this.buffer.listManaged(this.allocator).deinit();
             this.buffer = bun.ByteList.init("");
         }
-        this.close();
         this.allocator.destroy(this);
+    }
+
+    pub fn finalize(this: *UVStreamSink) void {
+        this.deinit_onclose = true;
+        this.close();
+        if (this.stream == null) {
+            this._destroy();
+        }
     }
 
     pub fn init(allocator: std.mem.Allocator, stream: StreamType, next: ?Sink) !*UVStreamSink {
@@ -2208,15 +2253,16 @@ pub const UVStreamSink = struct {
         this.signal.close(err);
         return .{ .result = {} };
     }
+
     pub fn destroy(this: *UVStreamSink) void {
-        if (this.buffer.cap > 0) {
-            this.buffer.listManaged(this.allocator).deinit();
-            this.buffer = bun.ByteList.init("");
-            this.head = 0;
+        if (this.stream == null) {
+            this._destroy();
+        } else {
+            this.deinit_onclose = true;
+            this.close();
         }
-        this.close();
-        this.allocator.destroy(this);
     }
+
     pub fn toJS(this: *UVStreamSink, globalThis: *JSGlobalObject) JSValue {
         return JSSink.createObject(globalThis, this);
     }

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -2284,6 +2284,13 @@ pub const union_uv_any_req = extern union {
 pub extern fn uv_loop_get_data([*c]const uv_loop_t) ?*anyopaque;
 pub extern fn uv_loop_set_data(*uv_loop_t, data: ?*anyopaque) void;
 
+pub const UV_HANDLE_CLOSED: c_int = 0x00000002;
+
+// uv_is_closing checks for closing or closed, we need to know if is indeed closed so we can deinit without call uv_close
+pub fn uv_is_closed(handle: *const uv_handle_t) bool {
+    return (handle.flags & UV_HANDLE_CLOSED != 0);
+}
+
 pub fn translateUVErrorToE(code: anytype) bun.C.E {
     return switch (code) {
         UV_EPERM => bun.C.E.PERM,


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
