### PR TITLE
fix windows open flags in some cases

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1702,7 +1702,7 @@ pub const Blob = struct {
                             this.loop,
                             &this.req,
                             path,
-                            open_flags_,
+                            bun.sys.sys_uv.normalizeOpenFlags(open_flags_),
                             JSC.Node.default_permission,
                             &WrappedCallback.callback,
                         );


### PR DESCRIPTION
### What does this PR do?

This PR fixes the flags passed to uv_fs_open to be correct on windows. It also makes file truncation work on windows. Fixes issues with `Bun.write`


We should look at the situation more broadly to clean up the way we handle flags around the codebase and make sure that flags are only used in contexts where they actually make sense.

One idea is to introduce a custom `OpenFlags` type which "does the right thing" on each platform and when passed to different functions (such as native apis or libuv) converts to do the right operation.