### PR TITLE
fix(windows): fix `text-decoder.test.js`

### DIFF
--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -1314,7 +1314,6 @@ pub fn withoutUTF8BOM(bytes: []const u8) []const u8 {
 /// This is intended to be used for strings that go to JavaScript
 pub fn toUTF16Alloc(allocator: std.mem.Allocator, bytes: []const u8, comptime fail_if_invalid: bool) !?[]u16 {
     if (strings.firstNonASCII(bytes)) |i| {
-        var start: ?usize = null;
         const output_: ?std.ArrayList(u16) = if (comptime bun.FeatureFlags.use_simdutf) simd: {
             const trimmed = bun.simdutf.trim.utf8(bytes);
 
@@ -1339,10 +1338,8 @@ pub fn toUTF16Alloc(allocator: std.mem.Allocator, bytes: []const u8, comptime fa
                 return error.InvalidByteSequence;
             }
 
-            start = res.count;
-
             break :simd .{
-                .items = out[0..res.count -| 1],
+                .items = out[0..i],
                 .capacity = out.len,
                 .allocator = allocator,
             };
@@ -1355,7 +1352,7 @@ pub fn toUTF16Alloc(allocator: std.mem.Allocator, bytes: []const u8, comptime fa
         };
         errdefer output.deinit();
 
-        var remaining = bytes[start orelse i ..];
+        var remaining = bytes[i..];
 
         {
             const sequence: [4]u8 = switch (remaining.len) {
@@ -1436,7 +1433,6 @@ pub fn toUTF16Alloc(allocator: std.mem.Allocator, bytes: []const u8, comptime fa
 
 pub fn toUTF16AllocNoTrim(allocator: std.mem.Allocator, bytes: []const u8, comptime fail_if_invalid: bool) !?[]u16 {
     if (strings.firstNonASCII(bytes)) |i| {
-        var start: ?usize = null;
         const output_: ?std.ArrayList(u16) = if (comptime bun.FeatureFlags.use_simdutf) simd: {
             const out_length = bun.simdutf.length.utf16.from.utf8.le(bytes);
 
@@ -1456,10 +1452,8 @@ pub fn toUTF16AllocNoTrim(allocator: std.mem.Allocator, bytes: []const u8, compt
                 return error.InvalidByteSequence;
             }
 
-            start = res.count;
-
             break :simd .{
-                .items = out[0..res.count -| 1],
+                .items = out[0..i],
                 .capacity = out.len,
                 .allocator = allocator,
             };
@@ -1472,7 +1466,7 @@ pub fn toUTF16AllocNoTrim(allocator: std.mem.Allocator, bytes: []const u8, compt
         };
         errdefer output.deinit();
 
-        var remaining = bytes[start orelse i ..];
+        var remaining = bytes[i..];
 
         {
             const sequence: [4]u8 = switch (remaining.len) {

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -1329,23 +1329,6 @@ pub fn toUTF16Alloc(allocator: std.mem.Allocator, bytes: []const u8, comptime fa
             var out = try allocator.alloc(u16, out_length);
             log("toUTF16 {d} UTF8 -> {d} UTF16", .{ bytes.len, out_length });
 
-            // avoid `.with_errors.le()` due to https://github.com/simdutf/simdutf/issues/213
-            // switch (bun.simdutf.convert.utf8.to.utf16.le(trimmed, out)) {
-            //     0 => {
-            //         if (comptime fail_if_invalid) {
-            //             allocator.free(out);
-            //             return error.InvalidByteSequence;
-            //         }
-
-            //         break :simd .{
-            //             .items = out[0..i],
-            //             .capacity = out.len,
-            //             .allocator = allocator,
-            //         };
-            //     },
-            //     else => return out,
-            // }
-
             const res = bun.simdutf.convert.utf8.to.utf16.with_errors.le(trimmed, out);
             if (res.status == .success) {
                 return out;


### PR DESCRIPTION
### What does this PR do?
`fast_avx512_convert_utf8_to_utf16` does not return the progress made converting utf8 to utf16. Instead it sets `out` to a null pointer. Now that https://github.com/simdutf/simdutf/issues/213 is closed, we can bring back the `with_errors` version that rewinds on error.
https://github.com/oven-sh/bun/blob/3e63796c15e29cbc772bf3e07d48f503642bef5c/src/bun.js/bindings/simdutf.cpp#L18911

closes #8421 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->
### How did you verify your code works?
tested `text-decoder.test.js` and `string-decoder.test.js` manually on macos and windows
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
