### PR TITLE
[windows] non-blocking TransmitFile

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -86,6 +86,7 @@ const SendfileContext = struct {
     has_listener: bool = false,
     has_set_on_writable: bool = false,
     auto_close: bool = false,
+    transmitFileContext: if (Environment.isWindows) ?bun.windows.TransmitFileContext else u0 = if (Environment.isWindows) null else 0,
 };
 const DateTime = bun.DateTime;
 const linux = std.os.linux;
@@ -1886,13 +1887,27 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     return errcode != .SUCCESS;
                 }
             } else if (Environment.isWindows) {
-                const win = std.os.windows;
-                const uv = bun.windows.libuv;
-                const socket = bun.socketcast(this.sendfile.socket_fd);
-                const file_handle = uv.uv_get_osfhandle(bun.uvfdcast(this.sendfile.fd));
-                this.sendfile.offset += this.sendfile.remain;
-                this.sendfile.remain = 0;
-                return win.ws2_32.TransmitFile(socket, file_handle, 0, 0, null, null, 0) == 1;
+                if (this.sendfile.transmitFileContext == null) {
+                    this.sendfile.transmitFileContext = bun.windows.TransmitFileContext.init();
+                }
+
+                const transmitFileContext = &(this.sendfile.transmitFileContext.?);
+
+                const sended = transmitFileContext.sendfile(this.sendfile.socket_fd, this.sendfile.fd).unwrap() catch |err| {
+                    Output.prettyErrorln("Error: {}", .{err});
+                    Output.flush();
+                    this.cleanupAndFinalizeAfterSendfile();
+                    return false;
+                };
+
+                const start = this.sendfile.offset;
+                this.sendfile.offset += sended;
+                this.sendfile.remain -|= @as(Blob.SizeType, @intCast(this.sendfile.offset -| start));
+
+                if (this.sendfile.remain == 0) {
+                    this.cleanupAndFinalizeAfterSendfile();
+                    return true;
+                }
             } else {
                 var sbytes: std.os.off_t = adjusted_count;
                 const signed_offset = @as(i64, @bitCast(@as(u64, this.sendfile.offset)));

--- a/src/http.zig
+++ b/src/http.zig
@@ -41,7 +41,6 @@ pub var http_thread: HTTPThread = undefined;
 const HiveArray = @import("./hive_array.zig").HiveArray;
 const Batch = bun.ThreadPool.Batch;
 const TaggedPointerUnion = @import("./tagged_pointer.zig").TaggedPointerUnion;
-const uv = bun.windows.libuv;
 
 const DeadSocket = opaque {};
 var dead_socket = @as(*DeadSocket, @ptrFromInt(1));
@@ -126,7 +125,6 @@ pub const Sendfile = struct {
     content_size: usize = 0,
 
     transmitFileContext: if (Environment.isWindows) ?TransmitFileContext else u0 = if (Environment.isWindows) null else 0,
-    const sendFileLog = Output.scoped(.Sendfile, false);
 
     pub fn isEligible(url: bun.URL) bool {
         return url.isHTTP() and url.href.len > 0 and FeatureFlags.streaming_file_uploads_for_http_client;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing Tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
