### PR TITLE
Hashing: Fix SHA-256 Typo

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1856,10 +1856,10 @@ pub const Crypto = struct {
                     // bcrypt silently truncates passwords longer than 72 bytes
                     // we use SHA512 to hash the password if it's longer than 72 bytes
                     if (password.len > 72) {
-                        var sha_256 = bun.sha.SHA512.init();
-                        defer sha_256.deinit();
-                        sha_256.update(password);
-                        sha_256.final(outbuf[0..bun.sha.SHA512.digest]);
+                        var sha_512 = bun.sha.SHA512.init();
+                        defer sha_512.deinit();
+                        sha_512.update(password);
+                        sha_512.final(outbuf[0..bun.sha.SHA512.digest]);
                         password_to_use = outbuf[0..bun.sha.SHA512.digest];
                         outbuf_slice = outbuf[bun.sha.SHA512.digest..];
                     }


### PR DESCRIPTION
### What does this PR do?

While reading through Bun's hashing code, I noticed a small typo.
The variable was incorrectly named ``sha_256`` instead of ``sha_512``.

- [x] Code changes

### How did you verify your code works?

Only a small typo in the code was fixed here.