### PR TITLE
fix sys.dup on windows and make console-iterator work

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1408,11 +1408,7 @@ pub fn indexOfLine(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) c
                 continue;
             }
 
-            if (byte == '\r') {
-                if (i + 1 < bytes.len and bytes[i + 1] == '\n') {
-                    return JSC.JSValue.jsNumber(i + 1);
-                }
-            } else if (byte == '\n') {
+            if (byte == '\n') {
                 return JSC.JSValue.jsNumber(i);
             }
 

--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -38,7 +38,12 @@ export function asyncIterator(this: Console) {
           // TODO: "\r", 0x4048, 0x4049, 0x404A, 0x404B, 0x404C, 0x404D, 0x404E, 0x404F
           i = indexOf(actualChunk, last);
           while (i !== -1) {
-            yield decoder.decode(actualChunk.subarray(last, i));
+            yield decoder.decode(
+              actualChunk.subarray(
+                last,
+                process.platform === "win32" ? (actualChunk[i - 1] === 0x0d /* \r */ ? i - 1 : i) : i,
+              ),
+            );
             last = i + 1;
             i = indexOf(actualChunk, last);
           }
@@ -78,7 +83,12 @@ export function asyncIterator(this: Console) {
           while (i !== -1) {
             // This yield may end the function, in that case we need to be able to recover state
             // if the iterator was fired up again.
-            yield decoder.decode(actualChunk.subarray(last, i));
+            yield decoder.decode(
+              actualChunk.subarray(
+                last,
+                process.platform === "win32" ? (actualChunk[i - 1] === 0x0d /* \r */ ? i - 1 : i) : i,
+              ),
+            );
             last = i + 1;
             i = indexOf(actualChunk, last);
           }

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -750,6 +750,7 @@ pub fn write(fd: bun.FileDescriptor, bytes: []const u8) Maybe(usize) {
                 &bytes_written,
                 null,
             );
+            log("WriteFile({d}, {d}) = {d} (written: {d})", .{ @intFromPtr(fd.cast()), adjusted_len, rc, bytes_written });
             if (rc == 0) {
                 return .{
                     .err = Syscall.Error{
@@ -1751,13 +1752,13 @@ pub fn pipe() Maybe([2]bun.FileDescriptor) {
 
 pub fn dup(fd: bun.FileDescriptor) Maybe(bun.FileDescriptor) {
     if (comptime Environment.isWindows) {
-        const target: *windows.HANDLE = undefined;
+        var target: windows.HANDLE = undefined;
         const process = kernel32.GetCurrentProcess();
         const out = kernel32.DuplicateHandle(
             process,
             fd.cast(),
             process,
-            target,
+            &target,
             0,
             w.TRUE,
             w.DUPLICATE_SAME_ACCESS,
@@ -1767,7 +1768,7 @@ pub fn dup(fd: bun.FileDescriptor) Maybe(bun.FileDescriptor) {
                 return err;
             }
         }
-        return Maybe(bun.FileDescriptor){ .result = bun.toFD(out) };
+        return Maybe(bun.FileDescriptor){ .result = bun.toFD(target) };
     }
 
     const out = std.c.dup(fd.cast());

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -76,6 +76,17 @@ pub extern fn CommandLineToArgvW(
     pNumArgs: *c_int,
 ) [*]win32.LPWSTR;
 
+pub extern fn GetFileType(
+    hFile: win32.HANDLE,
+) callconv(windows.WINAPI) win32.DWORD;
+
+/// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfiletype#return-value
+pub const FILE_TYPE_UNKNOWN = 0x0000;
+pub const FILE_TYPE_DISK = 0x0001;
+pub const FILE_TYPE_CHAR = 0x0002;
+pub const FILE_TYPE_PIPE = 0x0003;
+pub const FILE_TYPE_REMOTE = 0x8000;
+
 pub const LPDWORD = *win32.DWORD;
 
 pub extern "kernel32" fn GetBinaryTypeW(


### PR DESCRIPTION
### What does this PR do?
Fixes `sys.dup` on windows (the function was previously nonsense as it returned a boolean return value as a file descriptor).
Also makes some changes in `streams.zig` to make iterating over consoles work.

One nasty bug remains: For some reason, when using the console iterator, `console.write` doesn't work as intended. All writes happen normally, but no content shows up in the console.

Partially fixes #8449 
