### PR TITLE
Introduce `bun-types/strict`

### DIFF
--- a/packages/bun-types/index.d.ts
+++ b/packages/bun-types/index.d.ts
@@ -2,12 +2,11 @@
 // Definitions by: Jarred Sumner <https://github.com/Jarred-Sumner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference lib="dom" />
 /// <reference lib="esnext" />
+
 /// <reference types="node" />
 /// <reference types="ws" />
-
-// contributors: uncomment this to detect conflicts with lib.dom.d.ts
-/// <reference lib="dom" />
 
 /// <reference path="./globals.d.ts" />
 /// <reference path="./bun.d.ts" />

--- a/packages/bun-types/package.json
+++ b/packages/bun-types/package.json
@@ -3,6 +3,16 @@
   "license": "MIT",
   "main": "",
   "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "default": null,
+      "types": "./index.d.ts"
+    },
+    "./strict": {
+      "default": null,
+      "types": "./strict.d.ts"
+    }
+  },
   "description": "Type definitions for Bun, an incredibly fast JavaScript runtime",
   "repository": {
     "type": "git",

--- a/packages/bun-types/strict.d.ts
+++ b/packages/bun-types/strict.d.ts
@@ -1,0 +1,99 @@
+/// <reference path="index.d.ts" />
+
+declare module "bun" {
+  interface TOML {
+    /**
+     * Parse a TOML string into a JavaScript object.
+     *
+     * @param {string} command The name of the executable or script
+     * @param {string} options.PATH Overrides the PATH environment variable
+     * @param {string} options.cwd Limits the search to a particular directory in which to searc
+     */
+    parse(input: string): unknown;
+  }
+
+  interface ShellPromise {
+    json(): Promise<unknown>
+  }
+
+  /**
+   * Consume all data from a {@link ReadableStream} until it closes or errors.
+   *
+   * Concatenate the chunks into a single string and parse as JSON. Chunks must be a TypedArray or an ArrayBuffer. If you need to support chunks of different types, consider {@link readableStreamToBlob}.
+   *
+   * @param stream The stream to consume.
+   * @returns A promise that resolves with the concatenated chunks as a {@link String}.
+   */
+  function readableStreamToJSON(stream: ReadableStream): Promise<unknown>;
+
+}
+
+declare namespace global {
+  interface Blob {
+    json(): Promise<unknown>
+  }
+
+  interface JSON {
+    /**
+     * Converts a JavaScript Object Notation (JSON) string into an object.
+     * @param text A valid JSON string.
+     * @param reviver A function that transforms the results. This function is called for each member of the object.
+     * If a member contains nested objects, the nested objects are transformed before the parent object is.
+    */
+    parse(text: string, reviver?: (this: any, key: string, value: any) => any): unknown;
+  }
+
+  // Allow `<Array>.filter(Boolean)` to properly reflect
+  interface Array<T> {
+    filter(predicate: BooleanConstructor, thisArg?: any): T[];
+  }
+
+  interface ReadonlyArray<T> {
+    filter(predicate: BooleanConstructor, thisArg?: any): T[];
+  }
+
+  interface ArrayConstructor {
+    isArray(arg: any): arg is unknown[];
+  }
+
+  interface ShadowRealm {
+    /**
+     * Creates a new [ShadowRealm](https://github.com/tc39/proposal-shadowrealm/blob/main/explainer.md#introduction)
+     *
+     * @example
+     *
+     * ```js
+     * const red = new ShadowRealm();
+     *
+     * // realms can import modules that will execute within it's own environment.
+     * // When the module is resolved, it captured the binding value, or creates a new
+     * // wrapped function that is connected to the callable binding.
+     * const redAdd = await red.importValue('./inside-code.js', 'add');
+     *
+     * // redAdd is a wrapped function exotic object that chains it's call to the
+     * // respective imported binding.
+     * let result = redAdd(2, 3);
+     *
+     * console.assert(result === 5); // yields true
+     *
+     * // The evaluate method can provide quick code evaluation within the constructed
+     * // shadowRealm without requiring any module loading, while it still requires CSP
+     * // relaxing.
+     * globalThis.someValue = 1;
+     * red.evaluate('globalThis.someValue = 2'); // Affects only the ShadowRealm's global
+     * console.assert(globalThis.someValue === 1);
+     *
+     * // The wrapped functions can also wrap other functions the other way around.
+     * const setUniqueValue =
+     * await red.importValue('./inside-code.js', 'setUniqueValue');
+     *
+     * // setUniqueValue = (cb) => (cb(globalThis.someValue) * 2);
+     *
+     * result = setUniqueValue((x) => x ** 3);
+     *
+     * console.assert(result === 16); // yields true
+     * ```
+     */
+    importValue(specifier: string, bindingName: string): Promise<unknown>;
+  }
+}

--- a/packages/bun-types/strict.d.ts
+++ b/packages/bun-types/strict.d.ts
@@ -1,5 +1,3 @@
-/// <reference path="index.d.ts" />
-
 declare module "bun" {
   interface TOML {
     /**
@@ -28,72 +26,76 @@ declare module "bun" {
 
 }
 
-declare namespace global {
-  interface Blob {
-    json(): Promise<unknown>
-  }
 
-  interface JSON {
-    /**
-     * Converts a JavaScript Object Notation (JSON) string into an object.
-     * @param text A valid JSON string.
-     * @param reviver A function that transforms the results. This function is called for each member of the object.
-     * If a member contains nested objects, the nested objects are transformed before the parent object is.
-    */
-    parse(text: string, reviver?: (this: any, key: string, value: any) => any): unknown;
-  }
-
-  // Allow `<Array>.filter(Boolean)` to properly reflect
-  interface Array<T> {
-    filter(predicate: BooleanConstructor, thisArg?: any): T[];
-  }
-
-  interface ReadonlyArray<T> {
-    filter(predicate: BooleanConstructor, thisArg?: any): T[];
-  }
-
-  interface ArrayConstructor {
-    isArray(arg: any): arg is unknown[];
-  }
-
-  interface ShadowRealm {
-    /**
-     * Creates a new [ShadowRealm](https://github.com/tc39/proposal-shadowrealm/blob/main/explainer.md#introduction)
-     *
-     * @example
-     *
-     * ```js
-     * const red = new ShadowRealm();
-     *
-     * // realms can import modules that will execute within it's own environment.
-     * // When the module is resolved, it captured the binding value, or creates a new
-     * // wrapped function that is connected to the callable binding.
-     * const redAdd = await red.importValue('./inside-code.js', 'add');
-     *
-     * // redAdd is a wrapped function exotic object that chains it's call to the
-     * // respective imported binding.
-     * let result = redAdd(2, 3);
-     *
-     * console.assert(result === 5); // yields true
-     *
-     * // The evaluate method can provide quick code evaluation within the constructed
-     * // shadowRealm without requiring any module loading, while it still requires CSP
-     * // relaxing.
-     * globalThis.someValue = 1;
-     * red.evaluate('globalThis.someValue = 2'); // Affects only the ShadowRealm's global
-     * console.assert(globalThis.someValue === 1);
-     *
-     * // The wrapped functions can also wrap other functions the other way around.
-     * const setUniqueValue =
-     * await red.importValue('./inside-code.js', 'setUniqueValue');
-     *
-     * // setUniqueValue = (cb) => (cb(globalThis.someValue) * 2);
-     *
-     * result = setUniqueValue((x) => x ** 3);
-     *
-     * console.assert(result === 16); // yields true
-     * ```
-     */
-    importValue(specifier: string, bindingName: string): Promise<unknown>;
-  }
+interface Blob {
+  json(): Promise<unknown>
 }
+
+interface JSON {
+  /**
+   * Converts a JavaScript Object Notation (JSON) string into an object.
+   * @param text A valid JSON string.
+   * @param reviver A function that transforms the results. This function is called for each member of the object.
+   * If a member contains nested objects, the nested objects are transformed before the parent object is.
+  */
+  parse(text: string, reviver?: (this: any, key: string, value: any) => any): unknown;
+}
+
+// Allow `<Array>.filter(Boolean)` to properly reflect
+interface Array<T> {
+  filter(predicate: BooleanConstructor, thisArg?: any): T[];
+}
+
+interface ReadonlyArray<T> {
+  filter(predicate: BooleanConstructor, thisArg?: any): T[];
+}
+
+interface ArrayConstructor {
+  isArray(arg: any): arg is unknown[];
+}
+
+interface ShadowRealm {
+  /**
+   * Creates a new [ShadowRealm](https://github.com/tc39/proposal-shadowrealm/blob/main/explainer.md#introduction)
+   *
+   * @example
+   *
+   * ```js
+   * const red = new ShadowRealm();
+   *
+   * // realms can import modules that will execute within it's own environment.
+   * // When the module is resolved, it captured the binding value, or creates a new
+   * // wrapped function that is connected to the callable binding.
+   * const redAdd = await red.importValue('./inside-code.js', 'add');
+   *
+   * // redAdd is a wrapped function exotic object that chains it's call to the
+   * // respective imported binding.
+   * let result = redAdd(2, 3);
+   *
+   * console.assert(result === 5); // yields true
+   *
+   * // The evaluate method can provide quick code evaluation within the constructed
+   * // shadowRealm without requiring any module loading, while it still requires CSP
+   * // relaxing.
+   * globalThis.someValue = 1;
+   * red.evaluate('globalThis.someValue = 2'); // Affects only the ShadowRealm's global
+   * console.assert(globalThis.someValue === 1);
+   *
+   * // The wrapped functions can also wrap other functions the other way around.
+   * const setUniqueValue =
+   * await red.importValue('./inside-code.js', 'setUniqueValue');
+   *
+   * // setUniqueValue = (cb) => (cb(globalThis.someValue) * 2);
+   *
+   * result = setUniqueValue((x) => x ** 3);
+   *
+   * console.assert(result === 16); // yields true
+   * ```
+   */
+  importValue(specifier: string, bindingName: string): Promise<unknown>;
+}
+
+// Its important for this to be at the bottom because of how overloads are calculated
+// First it finds = priority
+// This is extremely important for the `blob`, `Array` and `JSON` types to properly work
+/// <reference path="index.d.ts" />

--- a/packages/bun-types/strict.d.ts
+++ b/packages/bun-types/strict.d.ts
@@ -11,7 +11,7 @@ declare module "bun" {
   }
 
   interface ShellPromise {
-    json(): Promise<unknown>
+    json(): Promise<unknown>;
   }
 
   /**
@@ -23,12 +23,10 @@ declare module "bun" {
    * @returns A promise that resolves with the concatenated chunks as a {@link String}.
    */
   function readableStreamToJSON(stream: ReadableStream): Promise<unknown>;
-
 }
 
-
 interface Blob {
-  json(): Promise<unknown>
+  json(): Promise<unknown>;
 }
 
 interface JSON {
@@ -37,8 +35,11 @@ interface JSON {
    * @param text A valid JSON string.
    * @param reviver A function that transforms the results. This function is called for each member of the object.
    * If a member contains nested objects, the nested objects are transformed before the parent object is.
-  */
-  parse(text: string, reviver?: (this: any, key: string, value: any) => any): unknown;
+   */
+  parse(
+    text: string,
+    reviver?: (this: any, key: string, value: any) => any,
+  ): unknown;
 }
 
 // Allow `<Array>.filter(Boolean)` to properly reflect


### PR DESCRIPTION
This is a follow up to #8195 

This PR introduces **opt-in** stricter types for both bun and typescript in general.
This PR is a new version of #7543 and heavily inspired by @mattpocock's work with `ts-reset`.

### Using

All this pr simply does is introduce a new export, to use it users simply need to update their `tsconfig`.

```diff
"types": [
-  "bun-types"
+  "bun-types/strict"
]
```


### Note

This does not introduce any changes for anyone using the types, its completely opt-in for the users who want a stricter/safer/better environment to work with.

Tagging @Electroid and @paperdave since this is a followup pr.