### PR TITLE
fix header with underscore character

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -236,7 +236,8 @@ namespace uWS
             return (x == '-') |
                    ((x > '/') & (x < ':')) |
                    ((x > '@') & (x < '[')) |
-                   ((x > 96) & (x < '{'));
+                   ((x > 96) & (x < '{')) |
+                   (x == '_');
         }
 
         static inline uint64_t hasLess(uint64_t x, uint64_t n)

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -227,6 +227,12 @@ namespace uWS
             return unsignedIntegerValue;
         }
 
+        static inline bool isFieldNameFirstByte(unsigned char x)
+        {
+            return ((x > '@') & (x < '[')) |
+                   ((x > 96) & (x < '{'));
+        }
+
         /* RFC 9110 16.3.1 Field Name Registry (TLDR; alnum + hyphen is allowed)
          * [...] It MUST conform to the field-name syntax defined in Section 5.1,
          * and it SHOULD be restricted to just letters, digits,
@@ -235,33 +241,14 @@ namespace uWS
         {
             return (x == '-') |
                    ((x > '/') & (x < ':')) |
-                   ((x > '@') & (x < '[')) |
-                   ((x > 96) & (x < '{')) |
-                   (x == '_');
+                   isFieldNameFirstByte(x) |
+                   (x == '_') |
+                   (x == '.');
         }
 
         static inline uint64_t hasLess(uint64_t x, uint64_t n)
         {
             return (((x) - ~0ULL / 255 * (n)) & ~(x) & ~0ULL / 255 * 128);
-        }
-
-        static inline uint64_t hasMore(uint64_t x, uint64_t n)
-        {
-            return ((((x) + ~0ULL / 255 * (127 - (n))) | (x)) & ~0ULL / 255 * 128);
-        }
-
-        static inline uint64_t hasBetween(uint64_t x, uint64_t m, uint64_t n)
-        {
-            return (((~0ULL / 255 * (127 + (n)) - ((x) & ~0ULL / 255 * 127)) & ~(x) & (((x) & ~0ULL / 255 * 127) + ~0ULL / 255 * (127 - (m)))) & ~0ULL / 255 * 128);
-        }
-
-        static inline bool notFieldNameWord(uint64_t x)
-        {
-            return hasLess(x, '-') |
-                   hasBetween(x, '-', '0') |
-                   hasBetween(x, '9', 'A') |
-                   hasBetween(x, 'Z', 'a') |
-                   hasMore(x, 'z');
         }
 
         static inline void *consumeFieldName(char *p)
@@ -270,8 +257,9 @@ namespace uWS
             {
                 uint64_t word;
                 memcpy(&word, p, sizeof(uint64_t));
-                if (notFieldNameWord(word))
+                if (isFieldNameFirstByte(*(unsigned char *)p))
                 {
+                    *(p++) |= 0x20;
                     while (isFieldNameByte(*(unsigned char *)p))
                     {
                         *(p++) |= 0x20;

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -231,12 +231,17 @@ namespace uWS
          * [...] It MUST conform to the field-name syntax defined in Section 5.1,
          * and it SHOULD be restricted to just letters, digits,
          * and hyphen ('-') characters, with the first character being a letter. */
+        static inline bool isFieldNameFirstByte(unsigned char x)
+        {
+            return ((x > '@') & (x < '[')) |
+                   ((x > 96) & (x < '{'));
+        }
+
         static inline bool isFieldNameByte(unsigned char x)
         {
             return (x == '-') |
                    ((x > '/') & (x < ':')) |
-                   ((x > '@') & (x < '[')) |
-                   ((x > 96) & (x < '{')) |
+                   isFieldNameFirstByte(x) |
                    (x == '_') |
                    (x == '.');
         }
@@ -258,7 +263,9 @@ namespace uWS
 
         static inline bool notFieldNameWord(uint64_t x)
         {
-            return hasLess(x, 'A') |
+            return hasLess(x, '-') |
+                   hasBetween(x, '-', '0') |
+                   hasBetween(x, '9', 'A') |
                    hasBetween(x, 'Z', 'a') |
                    hasMore(x, 'z');
         }
@@ -271,6 +278,9 @@ namespace uWS
                 memcpy(&word, p, sizeof(uint64_t));
                 if (notFieldNameWord(word))
                 {
+                    if (!isFieldNameFirstByte(*(unsigned char *)p)) {
+                        return (void *)p;
+                    }
                     *(p++) |= 0x20;
                     while (isFieldNameByte(*(unsigned char *)p))
                     {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1698,3 +1698,69 @@ it("#8446 header with underscore", done => {
     }
   });
 })
+
+it("#8446 header with dot", done => {
+  const server = Server((req, res) => {
+    res.end('OK');
+  });
+  server.listen(0, async (_err, host, port) => {
+    try {
+      const res = await fetch(`http://localhost:${port}`, {
+        headers: {
+          "x.foo": "bar",
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("OK");
+      done();
+    } catch (err) {
+      done(err);
+    } finally {
+      server.close();
+    }
+  });
+})
+
+it("#8446 header start with minus", done => {
+  const server = Server((req, res) => {
+    res.end('OK');
+  });
+  server.listen(0, async (_err, host, port) => {
+    try {
+      const res = await fetch(`http://localhost:${port}`, {
+        headers: {
+          "-x-foo": "bar",
+        },
+        signal: AbortSignal.timeout(500),
+      });
+      expect.unreachable();
+    } catch (err) {
+      expect(err.message).toBe("The operation timed out.");
+      done();
+    } finally {
+      server.close();
+    }
+  });
+})
+
+it("#8446 header start with underscore", done => {
+  const server = Server((req, res) => {
+    res.end('OK');
+  });
+  server.listen(0, async (_err, host, port) => {
+    try {
+      const res = await fetch(`http://localhost:${port}`, {
+        headers: {
+          "_x-foo": "bar",
+        },
+        signal: AbortSignal.timeout(500),
+      });
+      expect.unreachable();
+    } catch (err) {
+      expect(err.message).toBe("The operation timed out.");
+      done();
+    } finally {
+      server.close();
+    }
+  });
+})

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1676,3 +1676,25 @@ it("#4415.4 IncomingMessage es5", () => {
   IncomingMessage.call(im, { url: "/foo" });
   expect(im.url).toBe("/foo");
 });
+
+it("#8446 header with underscore", done => {
+  const server = Server((req, res) => {
+    res.end('OK');
+  });
+  server.listen(0, async (_err, host, port) => {
+    try {
+      const res = await fetch(`http://localhost:${port}`, {
+        headers: {
+          "x_foo": "bar",
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("OK");
+      done();
+    } catch (err) {
+      done(err);
+    } finally {
+      server.close();
+    }
+  });
+})


### PR DESCRIPTION
### What does this PR do?
Fix response header with underscore character
Fixed: https://github.com/oven-sh/bun/issues/8446

<!-- **Please explain what your changes do**, example: -->
When bun receive request header with underscore request is stuck
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:
-->
- [X] I included a test for the new code, or existing tests cover it
- [X] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)


<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
