### PR TITLE
fix(windows): do not use GetTempPath2W

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -556,7 +556,7 @@ pub const RunCommand = struct {
 
             const prefix = comptime bun.strings.w("\\??\\");
 
-            const len = bun.windows.GetTempPath2W(
+            const len = bun.windows.GetTempPathW(
                 target_path_buffer.len - prefix.len,
                 @ptrCast(&target_path_buffer[prefix.len]),
             );

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -3011,7 +3011,7 @@ pub extern "kernel32" fn GetHostNameW(
     nSize: c_int,
 ) BOOL;
 
-/// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha
+/// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw
 pub extern "kernel32" fn GetTempPathW(
     nBufferLength: DWORD, // [in]
     lpBuffer: LPCWSTR, // [out]

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -3012,7 +3012,7 @@ pub extern "kernel32" fn GetHostNameW(
 ) BOOL;
 
 /// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha
-pub extern "kernel32" fn GetTempPath2W(
+pub extern "kernel32" fn GetTempPathW(
     nBufferLength: DWORD, // [in]
     lpBuffer: LPCWSTR, // [out]
 ) DWORD;


### PR DESCRIPTION
Until we have a performance reason, we must support Windows 10 v1809 (2018).

This api is added in 2022, causing this error:

![image](https://github.com/oven-sh/bun/assets/24465214/3d0f010a-957d-497f-8b42-2a2174d6af3d)

mayhaps in the future we need a ci check that runs on an old windows box to verify this DLL thing.