### PR TITLE
Fix: `bun run --bun` prioritizing folders

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1680,13 +1680,13 @@ declare global {
     /**
      * Create an array from an iterable or async iterable object.
      * Values from the iterable are awaited.
-     * 
+     *
      * ```ts
      * await Array.fromAsync([1]); // [1]
      * await Array.fromAsync([Promise.resolve(1)]); // [1]
      * await Array.fromAsync((async function*() { yield 1 })()); // [1]
      * ```
-     * 
+     *
      * @param arrayLike - The iterable or async iterable to convert to an array.
      * @returns A {@link Promise} whose fulfillment is a new {@link Array} instance containing the values from the iterator.
      */
@@ -1697,7 +1697,7 @@ declare global {
     /**
      * Create an array from an iterable or async iterable object.
      * Values from the iterable are awaited. Results of the map function are also awaited.
-     * 
+     *
      * ```ts
      * await Array.fromAsync([1]); // [1]
      * await Array.fromAsync([Promise.resolve(1)]); // [1]
@@ -1705,7 +1705,7 @@ declare global {
      * await Array.fromAsync([1], (n) => n + 1); // [2]
      * await Array.fromAsync([1], (n) => Promise.resolve(n + 1)); // [2]
      * ```
-     * 
+     *
      * @param arrayLike - The iterable or async iterable to convert to an array.
      * @param mapFn - A mapper function that transforms each element of `arrayLike` after awaiting them.
      * @param thisArg - The `this` to which `mapFn` is bound.

--- a/packages/bun-types/test/array.test.ts
+++ b/packages/bun-types/test/array.test.ts
@@ -25,7 +25,7 @@ async function* naturals() {
   }
 }
 
-const test1 = await Array.fromAsync(naturals(), (n) => Promise.resolve(`${n}`));
+const test1 = await Array.fromAsync(naturals(), n => Promise.resolve(`${n}`));
 expectType<string[]>(test1);
 
 const test2 = await Array.fromAsync([Promise.resolve(1), Promise.resolve(2)]);

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1111,19 +1111,17 @@ pub const RunCommand = struct {
                 possibly_open_with_bun_js: {
                     const ext = std.fs.path.extension(script_name_to_search);
                     var has_loader = false;
-                    if (!force_using_bun) {
-                        if (options.defaultLoaders.get(ext)) |load| {
-                            has_loader = true;
-                            if (!load.canBeRunByBun())
-                                break :possibly_open_with_bun_js;
-                            // if there are preloads, allow weirdo file extensions
-                        } else {
-                            // you can have package.json scripts with file extensions in the name
-                            // eg "foo.zip"
-                            // in those cases, we don't know
-                            if (ext.len == 0 or strings.containsChar(script_name_to_search, ':'))
-                                break :possibly_open_with_bun_js;
-                        }
+                    if (options.defaultLoaders.get(ext)) |load| {
+                        has_loader = true;
+                        if (!load.canBeRunByBun())
+                            break :possibly_open_with_bun_js;
+                        // if there are preloads, allow weirdo file extensions
+                    } else {
+                        // you can have package.json scripts with file extensions in the name
+                        // eg "foo.zip"
+                        // in those cases, we don't know
+                        if (ext.len == 0 or strings.containsChar(script_name_to_search, ':'))
+                            break :possibly_open_with_bun_js;
                     }
 
                     var file_path = script_name_to_search;

--- a/test/js/node/util/parse_args/default-args.test.mjs
+++ b/test/js/node/util/parse_args/default-args.test.mjs
@@ -69,7 +69,7 @@ describe("parseArgs default args", () => {
     ["run file-test.js --bun", ["bun"], [], []], // passing --bun only to the program
     ["--bun run file-test.js --foo asdf -- --foo2 -- --foo3", ["foo"], ["asdf", "--foo2", "--", "--foo3"], ["--bun"]],
     ["run script-test --foo asdf", ["foo"], ["asdf"], []], // run script
-    ["run --bun script-test-bun --foo asdf", ["foo"], ["asdf"], ["--bun"]], // run script, with bun "--bun" arg (should not appear in argv)
+    ["run --bun script-test-bun --foo asdf", ["foo"], ["asdf"], ["--bun"]], // run script, with bun "--bun" arg
     //[`--bun -e ${evalSrc} --foo asdf`, ["foo"], ["asdf"]], // eval seems to crash when triggered from tests
     //[`--bun --eval ${evalSrc} --foo asdf`, ["foo"], ["asdf"]],
     //[`--eval "require('./file-test.js')" -- --foo asdf -- --bar`, ["foo"], ["asdf"]],

--- a/test/js/node/util/parse_args/default-args.test.mjs
+++ b/test/js/node/util/parse_args/default-args.test.mjs
@@ -80,7 +80,6 @@ describe("parseArgs default args", () => {
     expect(Object.keys(output?.values ?? {}).sort()).toEqual(valuesKeys.sort());
     expect(output?.positionals).toEqual(positionals);
     if (execArgv) {
-      console.log(output);
       expect(output?.execArgv).toEqual(execArgv);
     }
   });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fixes #7735 

![image](https://github.com/oven-sh/bun/assets/43612965/01be6952-dc7e-4cfe-a255-dd78bdc1e242)


<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
