### PR TITLE
Use native AbortController & AbortSignal when `abort-controller` is loaded

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1680,13 +1680,13 @@ declare global {
     /**
      * Create an array from an iterable or async iterable object.
      * Values from the iterable are awaited.
-     * 
+     *
      * ```ts
      * await Array.fromAsync([1]); // [1]
      * await Array.fromAsync([Promise.resolve(1)]); // [1]
      * await Array.fromAsync((async function*() { yield 1 })()); // [1]
      * ```
-     * 
+     *
      * @param arrayLike - The iterable or async iterable to convert to an array.
      * @returns A {@link Promise} whose fulfillment is a new {@link Array} instance containing the values from the iterator.
      */
@@ -1697,7 +1697,7 @@ declare global {
     /**
      * Create an array from an iterable or async iterable object.
      * Values from the iterable are awaited. Results of the map function are also awaited.
-     * 
+     *
      * ```ts
      * await Array.fromAsync([1]); // [1]
      * await Array.fromAsync([Promise.resolve(1)]); // [1]
@@ -1705,7 +1705,7 @@ declare global {
      * await Array.fromAsync([1], (n) => n + 1); // [2]
      * await Array.fromAsync([1], (n) => Promise.resolve(n + 1)); // [2]
      * ```
-     * 
+     *
      * @param arrayLike - The iterable or async iterable to convert to an array.
      * @param mapFn - A mapper function that transforms each element of `arrayLike` after awaiting them.
      * @param thisArg - The `this` to which `mapFn` is bound.

--- a/packages/bun-types/test/array.test.ts
+++ b/packages/bun-types/test/array.test.ts
@@ -25,7 +25,7 @@ async function* naturals() {
   }
 }
 
-const test1 = await Array.fromAsync(naturals(), (n) => Promise.resolve(`${n}`));
+const test1 = await Array.fromAsync(naturals(), n => Promise.resolve(`${n}`));
 expectType<string[]>(test1);
 
 const test2 = await Array.fromAsync([Promise.resolve(1), Promise.resolve(2)]);

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -2333,6 +2333,7 @@ pub const ModuleLoader = struct {
                 .@"node-fetch" => return jsSyntheticModule(.@"node-fetch", specifier),
                 .@"@vercel/fetch" => return jsSyntheticModule(.vercel_fetch, specifier),
                 .@"utf-8-validate" => return jsSyntheticModule(.@"utf-8-validate", specifier),
+                .@"abort-controller" => return jsSyntheticModule(.@"abort-controller", specifier),
                 .undici => return jsSyntheticModule(.undici, specifier),
                 .ws => return jsSyntheticModule(.ws, specifier),
             }
@@ -2473,6 +2474,7 @@ const SavedSourceMap = JSC.SavedSourceMap;
 
 pub const HardcodedModule = enum {
     bun,
+    @"abort-controller",
     @"bun:ffi",
     @"bun:jsc",
     @"bun:main",
@@ -2614,6 +2616,7 @@ pub const HardcodedModule = enum {
             .{ "ws", HardcodedModule.ws },
             .{ "@vercel/fetch", HardcodedModule.@"@vercel/fetch" },
             .{ "utf-8-validate", HardcodedModule.@"utf-8-validate" },
+            .{ "abort-controller", HardcodedModule.@"abort-controller" },
         },
     );
 
@@ -2779,6 +2782,10 @@ pub const HardcodedModule = enum {
 
             .{ "inspector/promises", .{ .path = "inspector" } },
             .{ "node:inspector/promises", .{ .path = "inspector" } },
+
+            // Polyfills we force to native
+            .{ "abort-controller", .{ .path = "abort-controller" } },
+            .{ "abort-controller/polyfill", .{ .path = "abort-controller" } },
         };
 
         const node_alias_kvs = .{

--- a/src/bun.js/modules/AbortControllerModuleModule.h
+++ b/src/bun.js/modules/AbortControllerModuleModule.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "JSAbortController.h"
+#include "JSAbortSignal.h"
+
+using namespace JSC;
+using namespace WebCore;
+
+namespace Zig {
+
+inline void generateNativeModule_AbortControllerModule(
+    JSC::JSGlobalObject *lexicalGlobalObject, JSC::Identifier moduleKey,
+    Vector<JSC::Identifier, 4> &exportNames,
+    JSC::MarkedArgumentBuffer &exportValues) {
+
+  Zig::GlobalObject *globalObject =
+      reinterpret_cast<Zig::GlobalObject *>(lexicalGlobalObject);
+  JSC::VM &vm = globalObject->vm();
+
+  auto *abortController =
+      WebCore::JSAbortController::getConstructor(vm, globalObject).getObject();
+  JSValue abortSignal =
+      WebCore::JSAbortSignal::getConstructor(vm, globalObject);
+
+  const auto controllerIdent = Identifier::fromString(vm, "AbortController"_s);
+  const auto signalIdent = Identifier::fromString(vm, "AbortSignal"_s);
+  const Identifier esModuleMarker = builtinNames(vm).__esModulePublicName();
+
+  exportNames.append(vm.propertyNames->defaultKeyword);
+  exportValues.append(abortController);
+
+  exportNames.append(signalIdent);
+  exportValues.append(abortSignal);
+
+  exportNames.append(controllerIdent);
+  exportValues.append(abortController);
+
+  exportNames.append(esModuleMarker);
+  exportValues.append(jsBoolean(true));
+
+  // https://github.com/mysticatea/abort-controller/blob/a935d38e09eb95d6b633a8c42fcceec9969e7b05/dist/abort-controller.js#L125
+  abortController->putDirect(
+      vm, signalIdent, abortSignal,
+      static_cast<unsigned>(PropertyAttribute::DontEnum));
+
+  abortController->putDirect(
+      vm, controllerIdent, abortController,
+      static_cast<unsigned>(PropertyAttribute::DontEnum));
+
+  abortController->putDirect(
+      vm, vm.propertyNames->defaultKeyword, abortController,
+      static_cast<unsigned>(PropertyAttribute::DontEnum));
+}
+} // namespace Zig

--- a/src/bun.js/modules/_NativeModule.h
+++ b/src/bun.js/modules/_NativeModule.h
@@ -34,6 +34,7 @@
     macro("node:string_decoder"_s, NodeStringDecoder) \
     macro("node:util/types"_s, NodeUtilTypes)  \
     macro("utf-8-validate"_s, UTF8Validate) \
+    macro("abort-controller"_s, AbortControllerModule) \
 
 #if ASSERT_ENABLED
 

--- a/test/js/web/nationalized.test.ts
+++ b/test/js/web/nationalized.test.ts
@@ -1,0 +1,31 @@
+import { test, expect, describe } from "bun:test";
+
+// abort-controller
+// 13 million weekly downloads
+// https://github.com/mysticatea/abort-controller/blob/a935d38e09eb95d6b633a8c42fcceec9969e7b05/dist/abort-controller.js#L1
+describe("abort-controller", () => {
+  //
+  // We do not nationalie event-target-shim which this package depends on
+  // That is because it adds `defineEventTargetAttribute` which we would have to implemennt or else it would break packages that depend on it.
+  //
+
+  test("CJS", () => {
+    const AbortControllerPolyfill = require("abort-controller");
+    expect(AbortControllerPolyfill).toBe(AbortController);
+    expect(AbortControllerPolyfill.AbortSignal).toBe(AbortSignal);
+    expect(AbortControllerPolyfill.default.AbortController).toBe(AbortController);
+    expect(AbortControllerPolyfill.default.AbortSignal).toBe(AbortSignal);
+  });
+
+  test("ESM", async () => {
+    const AbortControllerPolyfill = await import("abort-controller");
+    // @ts-ignore
+    expect(AbortControllerPolyfill.AbortController).toBe(AbortController);
+    // @ts-ignore
+    expect(AbortControllerPolyfill.AbortSignal).toBe(AbortSignal);
+    // @ts-ignore
+    expect(AbortControllerPolyfill.default.AbortController).toBe(AbortController);
+    // @ts-ignore
+    expect(AbortControllerPolyfill.default.AbortSignal).toBe(AbortSignal);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Bun implements `AbortController` and `AbortSignal`. A polyfill for this is unnecessary and breaks things at runtime when used with e.g. `fetch` because we check if it's the correct class.

This does not override `event-target-shim` which `abort-controller` depends on because that adds a non-standard export and I didn't want to increase the scope of this PR

### How did you verify your code works?

There is a test 