### PR TITLE
`mock()` caues a type error given no arguments

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -20,7 +20,7 @@ declare module "bun:test" {
   export type Mock<T extends (...args: any[]) => any> = JestMock.Mock<T>;
 
   export const mock: {
-    <T extends (...args: any[]) => any>(Function: T): Mock<T>;
+    <T extends (...args: any[]) => any>(Function?: T): Mock<T>;
 
     /**
      * Replace the module `id` with the return value of `factory`.


### PR DESCRIPTION
### What does this PR do?

Unlike `jest.fn()`, `mock()` causes a type error when no argument is given. However, it works if you actually run the test. This pull request makes the parameter of `mock()` optional to match its implementation.

![Shot 2024-01-25 at 19 48 02@2x](https://github.com/oven-sh/bun/assets/5466341/a2907690-896f-4b52-8c4b-b148e5078727)

![Shot 2024-01-25 at 19 49 36@2x](https://github.com/oven-sh/bun/assets/5466341/38bf86b3-0013-4e0a-b7bf-f13cb132b57f)

![Shot 2024-01-25 at 19 49 56@2x](https://github.com/oven-sh/bun/assets/5466341/5238dbb0-6f93-4d7d-91a7-14ddb6fd21f4)


- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
