### PR TITLE
feat(build): adjust arch/manjaro linux auto detect to include artix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ endif()
 if(UNIX AND NOT APPLE)
     execute_process(COMMAND cat /etc/os-release COMMAND head -n1 OUTPUT_VARIABLE LINUX_DISTRO)
 
-    if(${LINUX_DISTRO} MATCHES "NAME=\"(Arch|Manjaro) Linux\"\n")
+    if(${LINUX_DISTRO} MATCHES "NAME=\"(Arch|Manjaro|Artix) Linux\"\n")
         set(DEFAULT_USE_STATIC_LIBATOMIC OFF)
     endif()
 endif()


### PR DESCRIPTION
### What does this PR do?

Following on progress from PR #7912, in which is noted  that `bun setup`/`bun run runb` fails on a Arch Linux distributions for libatomic.

Currently, CMakeLists.txt looks for a NAME property in /etc/os-release matching "Arch Linux" or "Manjaro Linux".

This PR introduces changes to the code to include matches for also Artix Linux..

- [x] Code changes.

### How did you verify your code works?

Re-built on Arch & Manjaro in VMs, read code in CMakeLists.txt.

### Note:

Maybe on the future we could match this without specifying Linux distribution before it turns into a big mess.
