### PR TITLE
fix(windows): bun `link`, `unlink`, and fix tests in `test/cli/install`

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1095,7 +1095,10 @@ pub fn getFdPath(fd_: anytype, buf: *[@This().MAX_PATH_BYTES]u8) ![]u8 {
     const fd = toFD(fd_).cast();
 
     if (comptime Environment.isWindows) {
-        return std.os.getFdPath(fd, buf);
+        var wide_buf: WPathBuffer = undefined;
+        const wide_slice = try std.os.windows.GetFinalPathNameByHandle(fd, .{}, wide_buf[0..]);
+        const res = strings.copyUTF16IntoUTF8(buf[0..], @TypeOf(wide_slice), wide_slice, true);
+        return buf[0..res.written];
     }
 
     if (comptime Environment.allow_assert) {

--- a/src/c.zig
+++ b/src/c.zig
@@ -27,7 +27,6 @@ pub const darwin = @import("./darwin_c.zig");
 pub const linux = @import("./linux_c.zig");
 pub extern "c" fn chmod([*c]const u8, mode_t) c_int;
 pub extern "c" fn fchmod(std.c.fd_t, mode_t) c_int;
-pub extern "c" fn umask(mode_t) mode_t;
 pub extern "c" fn fchmodat(c_int, [*c]const u8, mode_t, c_int) c_int;
 pub extern "c" fn fchown(std.c.fd_t, std.c.uid_t, std.c.gid_t) c_int;
 pub extern "c" fn lchown(path: [*:0]const u8, std.c.uid_t, std.c.gid_t) c_int;

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -377,44 +377,47 @@ pub const BunxCommand = struct {
             }
 
             // 2. The "bin" is possibly not the same as the package name, so we load the package.json to figure out what "bin" to use
-            if (getBinName(&this_bundler, root_dir_info.getFileDescriptor(), bunx_cache_dir, initial_bin_name)) |package_name_for_bin| {
-                // if we check the bin name and its actually the same, we don't need to check $PATH here again
-                if (!strings.eqlLong(package_name_for_bin, initial_bin_name, true)) {
-                    absolute_in_cache_dir = std.fmt.bufPrint(&absolute_in_cache_dir_buf, "{s}/node_modules/.bin/{s}", .{ bunx_cache_dir, package_name_for_bin }) catch unreachable;
+            const root_dir_fd = root_dir_info.getFileDescriptor();
+            if (root_dir_fd != .zero) {
+                if (getBinName(&this_bundler, root_dir_fd, bunx_cache_dir, initial_bin_name)) |package_name_for_bin| {
+                    // if we check the bin name and its actually the same, we don't need to check $PATH here again
+                    if (!strings.eqlLong(package_name_for_bin, initial_bin_name, true)) {
+                        absolute_in_cache_dir = std.fmt.bufPrint(&absolute_in_cache_dir_buf, "{s}/node_modules/.bin/{s}", .{ bunx_cache_dir, package_name_for_bin }) catch unreachable;
 
-                    // Only use the system-installed version if there is no version specified
-                    if (update_request.version.literal.isEmpty()) {
-                        destination_ = bun.which(
+                        // Only use the system-installed version if there is no version specified
+                        if (update_request.version.literal.isEmpty()) {
+                            destination_ = bun.which(
+                                &path_buf,
+                                PATH_FOR_BIN_DIRS,
+                                if (ignore_cwd.len > 0) "" else this_bundler.fs.top_level_dir,
+                                package_name_for_bin,
+                            );
+                        }
+
+                        if (destination_ orelse bun.which(
                             &path_buf,
-                            PATH_FOR_BIN_DIRS,
+                            bunx_cache_dir,
                             if (ignore_cwd.len > 0) "" else this_bundler.fs.top_level_dir,
-                            package_name_for_bin,
-                        );
+                            absolute_in_cache_dir,
+                        )) |destination| {
+                            const out = bun.asByteSlice(destination);
+                            _ = try Run.runBinary(
+                                ctx,
+                                try this_bundler.fs.dirname_store.append(@TypeOf(out), out),
+                                this_bundler.fs.top_level_dir,
+                                this_bundler.env,
+                                passthrough,
+                                null,
+                            );
+                            // we are done!
+                            Global.exit(0);
+                        }
                     }
-
-                    if (destination_ orelse bun.which(
-                        &path_buf,
-                        bunx_cache_dir,
-                        if (ignore_cwd.len > 0) "" else this_bundler.fs.top_level_dir,
-                        absolute_in_cache_dir,
-                    )) |destination| {
-                        const out = bun.asByteSlice(destination);
-                        _ = try Run.runBinary(
-                            ctx,
-                            try this_bundler.fs.dirname_store.append(@TypeOf(out), out),
-                            this_bundler.fs.top_level_dir,
-                            this_bundler.env,
-                            passthrough,
-                            null,
-                        );
-                        // we are done!
-                        Global.exit(0);
+                } else |err| {
+                    if (err == error.NoBinFound) {
+                        Output.prettyErrorln("<r><red>error<r><d>:<r> could not determine executable to run for package <r><b>{s}<r>", .{update_request.name});
+                        Global.exit(1);
                     }
-                }
-            } else |err| {
-                if (err == error.NoBinFound) {
-                    Output.prettyErrorln("<r><red>error<r><d>:<r> could not determine executable to run for package <r><b>{s}<r>", .{update_request.name});
-                    Global.exit(1);
                 }
             }
         }

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -180,12 +180,12 @@ pub const PackageManagerCommand = struct {
         } else if (strings.eqlComptime(subcommand, "cache")) {
             var dir: [bun.MAX_PATH_BYTES]u8 = undefined;
             var fd = pm.getCacheDirectory();
-            var outpath = bun.getFdPath(fd.fd, &dir) catch |err| {
+            const outpath = bun.getFdPath(fd.fd, &dir) catch |err| {
                 Output.prettyErrorln("{s} getting cache directory", .{@errorName(err)});
                 Global.crash();
             };
 
-            outpath = Path.normalizeString(outpath, true, .auto);
+            // outpath = Path.normalizeString(outpath, true, .auto);
 
             if (pm.options.positionals.len > 1 and strings.eqlComptime(pm.options.positionals[1], "rm")) {
                 fd.close();

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -180,10 +180,12 @@ pub const PackageManagerCommand = struct {
         } else if (strings.eqlComptime(subcommand, "cache")) {
             var dir: [bun.MAX_PATH_BYTES]u8 = undefined;
             var fd = pm.getCacheDirectory();
-            const outpath = bun.getFdPath(fd.fd, &dir) catch |err| {
+            var outpath = bun.getFdPath(fd.fd, &dir) catch |err| {
                 Output.prettyErrorln("{s} getting cache directory", .{@errorName(err)});
                 Global.crash();
             };
+
+            outpath = Path.normalizeString(outpath, true, .auto);
 
             if (pm.options.positionals.len > 1 and strings.eqlComptime(pm.options.positionals[1], "rm")) {
                 fd.close();

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -380,8 +380,8 @@ fn printNodeModulesFolderStructure(
 
     for (sorted_dependencies, 0..) |dependency_id, index| {
         const package_name = dependencies[dependency_id].name.slice(string_bytes);
-
-        const possible_path = try std.fmt.allocPrint(allocator, "{s}/{s}/node_modules", .{ directory.relative_path, package_name });
+        const fmt = "{s}" ++ std.fs.path.sep_str ++ "{s}" ++ std.fs.path.sep_str ++ "node_modules";
+        const possible_path = try std.fmt.allocPrint(allocator, fmt, .{ directory.relative_path, package_name });
         defer allocator.free(possible_path);
 
         if (index + 1 == sorted_dependencies.len) {
@@ -394,7 +394,7 @@ fn printNodeModulesFolderStructure(
         while (dir_index < directories.items.len) : (dir_index += 1) {
             // Recursively print node_modules. node_modules is removed from
             // the directories list before traversal.
-            if (strings.eql(possible_path, directories.items[dir_index].relative_path)) {
+            if (strings.eqlLong(possible_path, directories.items[dir_index].relative_path, true)) {
                 found_node_modules = true;
                 const next = directories.orderedRemove(dir_index);
 

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -179,13 +179,14 @@ pub const PackageManagerCommand = struct {
             Global.exit(0);
         } else if (strings.eqlComptime(subcommand, "cache")) {
             var dir: [bun.MAX_PATH_BYTES]u8 = undefined;
-            const fd = pm.getCacheDirectory();
+            var fd = pm.getCacheDirectory();
             const outpath = bun.getFdPath(fd.fd, &dir) catch |err| {
                 Output.prettyErrorln("{s} getting cache directory", .{@errorName(err)});
                 Global.crash();
             };
 
             if (pm.options.positionals.len > 1 and strings.eqlComptime(pm.options.positionals[1], "rm")) {
+                fd.close();
                 std.fs.deleteTreeAbsolute(outpath) catch |err| {
                     Output.prettyErrorln("{s} deleting cache directory", .{@errorName(err)});
                     Global.crash();

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -422,7 +422,10 @@ pub const RunCommand = struct {
                     }
                 }
             }
-            Output.prettyErrorln("<r><red>error<r>: Failed to run \"<b>{s}<r>\" due to error <b>{s}<r>", .{ basenameOrBun(executable), @errorName(err) });
+
+            if (!silent) {
+                Output.prettyErrorln("<r><red>error<r>: Failed to run \"<b>{s}<r>\" due to error <b>{s}<r>", .{ basenameOrBun(executable), @errorName(err) });
+            }
             Global.exit(1);
         };
         switch (result) {

--- a/src/darwin_c.zig
+++ b/src/darwin_c.zig
@@ -778,3 +778,5 @@ pub const E = std.os.E;
 pub fn getErrno(rc: anytype) E {
     return std.c.getErrno(rc);
 }
+
+pub extern "c" fn umask(Mode) Mode;

--- a/src/fd.zig
+++ b/src/fd.zig
@@ -36,7 +36,7 @@ pub fn uv_get_osfhandle(in: c_int) libuv.uv_os_fd_t {
 
 pub fn uv_open_osfhandle(in: libuv.uv_os_fd_t) c_int {
     const out = libuv.uv_open_osfhandle(in);
-    log("uv_get_osfhandle({d}) = {d}", .{ @intFromPtr(in), out });
+    log("uv_open_osfhandle({d}) = {d}", .{ @intFromPtr(in), out });
     return out;
 }
 

--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -278,6 +278,8 @@ pub const Bin = extern struct {
         global_bin_dir: std.fs.Dir,
         global_bin_path: stringZ = "",
 
+        relative_path_to_bin_for_windows_global_link_offset: usize = 0,
+
         string_buf: []const u8,
         extern_string_buf: []const ExternalString,
 
@@ -310,9 +312,9 @@ pub const Bin = extern struct {
             _ = C.fchmodat(folder, target, @intCast(umask | 0o777), 0);
         }
 
-        fn setSymlinkAndPermissions(this: *Linker, target_path: [:0]const u8, dest_path: [:0]const u8) void {
-            const node_modules = this.package_installed_node_modules.asDir();
-            if (!Environment.isWindows) {
+        fn setSymlinkAndPermissions(this: *Linker, target_path: [:0]const u8, dest_path: [:0]const u8, link_global: bool) void {
+            if (comptime !Environment.isWindows) {
+                const node_modules = this.package_installed_node_modules.asDir();
                 std.os.symlinkatZ(target_path, node_modules.fd, dest_path) catch |err| {
                     // Silently ignore PathAlreadyExists if the symlink is valid.
                     // Most likely, the symlink was already created by another package
@@ -346,12 +348,20 @@ pub const Bin = extern struct {
             } else {
                 const WinBinLinkingShim = @import("./windows-shim/BinLinkingShim.zig");
 
+                const node_modules = if (link_global)
+                    this.global_bin_dir
+                else
+                    this.package_installed_node_modules.asDir();
+
                 var shim_buf: [65536]u8 = undefined;
                 var read_in_buf: [WinBinLinkingShim.Shebang.max_shebang_input_length]u8 = undefined;
                 var filename1_buf: bun.WPathBuffer = undefined;
                 var filename2_buf: bun.WPathBuffer = undefined;
+                var filename3_buf: bun.WPathBuffer = undefined;
 
-                std.debug.assert(strings.hasPrefixComptime(target_path, "..\\"));
+                if (comptime Environment.allow_assert) {
+                    std.debug.assert(strings.hasPrefixComptime(target_path, "..\\"));
+                }
 
                 const target_wpath = bun.strings.toWPathNormalized(&filename1_buf, target_path[3..]);
                 var destination_wpath: []u16 = bun.strings.convertUTF8toUTF16InBuffer(&filename2_buf, dest_path);
@@ -385,7 +395,13 @@ pub const Bin = extern struct {
                     const first_content_chunk = contents: {
                         const fd = bun.sys.openatWindows(
                             this.package_installed_node_modules,
-                            target_wpath,
+                            if (link_global)
+                                bun.strings.toWPathNormalized(
+                                    &filename3_buf,
+                                    target_path[this.relative_path_to_bin_for_windows_global_link_offset..],
+                                )
+                            else
+                                target_wpath,
                             std.os.O.RDONLY,
                         ).unwrap() catch |err| {
                             this.err = err;
@@ -502,25 +518,44 @@ pub const Bin = extern struct {
                     return;
                 }
 
-                bun.copy(u8, &target_buf, this.global_bin_path);
-                from_remain = target_buf[this.global_bin_path.len..];
-                from_remain[0] = std.fs.path.sep;
-                from_remain = from_remain[1..];
-                const abs = bun.getFdPath(this.root_node_modules_folder, &dest_buf) catch |err| {
-                    this.err = err;
-                    return;
-                };
-                remain = remain[abs.len..];
-                remain[0] = std.fs.path.sep;
-                remain = remain[1..];
+                if (comptime Environment.isWindows) {
+                    const from = this.global_bin_path;
+                    const to = bun.getFdPath(this.package_installed_node_modules, &dest_buf) catch |err| {
+                        this.err = err;
+                        return;
+                    };
+
+                    const rel = Path.relative(from, to);
+                    @memcpy(remain[0..rel.len], rel);
+                    remain = remain[rel.len..];
+                    remain[0] = std.fs.path.sep;
+                    remain = remain[1..];
+                } else {
+                    bun.copy(u8, &target_buf, this.global_bin_path);
+                    from_remain = target_buf[this.global_bin_path.len..];
+                    from_remain[0] = std.fs.path.sep;
+                    from_remain = from_remain[1..];
+                    const abs = bun.getFdPath(this.root_node_modules_folder, &dest_buf) catch |err| {
+                        this.err = err;
+                        return;
+                    };
+                    remain = remain[abs.len..];
+                    remain[0] = std.fs.path.sep;
+                    remain = remain[1..];
+                }
 
                 this.root_node_modules_folder = bun.toFD(this.global_bin_dir.fd);
+            }
+
+            if (comptime Environment.isWindows and link_global) {
+                this.relative_path_to_bin_for_windows_global_link_offset = dest_buf.len - remain.len;
             }
 
             const name = this.package_name.slice();
             bun.copy(u8, remain, name);
             remain = remain[name.len..];
             remain[0] = std.fs.path.sep;
+
             remain = remain[1..];
 
             switch (this.bin.tag) {
@@ -550,7 +585,7 @@ pub const Bin = extern struct {
                     from_remain[0] = 0;
                     const dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
 
-                    this.setSymlinkAndPermissions(target_path, dest_path);
+                    this.setSymlinkAndPermissions(target_path, dest_path, link_global);
                 },
                 .named_file => {
                     var target = this.bin.value.named_file[1].slice(this.string_buf);
@@ -570,7 +605,7 @@ pub const Bin = extern struct {
                     from_remain[0] = 0;
                     const dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
 
-                    this.setSymlinkAndPermissions(target_path, dest_path);
+                    this.setSymlinkAndPermissions(target_path, dest_path, link_global);
                 },
                 .map => {
                     var extern_string_i: u32 = this.bin.value.map.off;
@@ -601,7 +636,7 @@ pub const Bin = extern struct {
                         from_remain[0] = 0;
                         const dest_path: [:0]u8 = target_buf[0 .. @intFromPtr(from_remain.ptr) - @intFromPtr(&target_buf) :0];
 
-                        this.setSymlinkAndPermissions(target_path, dest_path);
+                        this.setSymlinkAndPermissions(target_path, dest_path, link_global);
                     }
                 },
                 .dir => {
@@ -650,7 +685,7 @@ pub const Bin = extern struct {
                                 else
                                     std.fmt.bufPrintZ(&dest_buf, "{s}", .{entry.name}) catch continue;
 
-                                this.setSymlinkAndPermissions(from_path, to_path);
+                                this.setSymlinkAndPermissions(from_path, to_path, link_global);
                             },
                             else => {},
                         }

--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -283,7 +283,7 @@ pub const Bin = extern struct {
 
         err: ?anyerror = null,
 
-        pub var umask: std.os.mode_t = 0;
+        pub var umask: bun.C.Mode = 0;
 
         var has_set_umask = false;
 
@@ -671,7 +671,7 @@ pub const Bin = extern struct {
                 dest_buf[0.."../".len].* = "../".*;
                 remain = dest_buf["../".len..];
             } else {
-                if (this.global_bin_dir.fd >= bun.invalid_fd.int()) {
+                if (bun.toFD(this.global_bin_dir.fd) == bun.invalid_fd) {
                     this.err = error.MissingGlobalBinDir;
                     return;
                 }
@@ -696,10 +696,6 @@ pub const Bin = extern struct {
             remain = remain[name.len..];
             remain[0] = std.fs.path.sep;
             remain = remain[1..];
-
-            if (comptime Environment.isWindows) {
-                @compileError("Bin.Linker.unlink() needs to be updated to generate .cmd files on Windows");
-            }
 
             switch (this.bin.tag) {
                 .none => {

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -161,12 +161,24 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
     var tmpname_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
     const name = this.name.slice();
     const basename = brk: {
-        if (name[0] == '@') {
-            if (strings.indexOfChar(name, '/')) |i| {
-                break :brk name[i + 1 ..];
+        var tmp = name;
+        if (tmp[0] == '@') {
+            if (strings.indexOfChar(tmp, '/')) |i| {
+                tmp = tmp[i + 1 ..];
             }
         }
-        break :brk name;
+
+        if (comptime Environment.isWindows) {
+            if (strings.lastIndexOfChar(tmp, ':')) |i| {
+                tmp = tmp[i + 1 ..];
+            }
+        }
+
+        if (comptime Environment.allow_assert) {
+            std.debug.assert(tmp.len > 0);
+        }
+
+        break :brk tmp;
     };
 
     var resolved: string = "";

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -289,7 +289,7 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
 
     // e.g. @next
     // if it's a namespace package, we need to make sure the @name folder exists
-    if (basename.len != name.len) {
+    if (basename.len != name.len and !this.resolution.tag.isGit()) {
         cache_dir.makeDir(std.mem.trim(u8, name[0 .. name.len - basename.len], "/")) catch {};
     }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -6553,11 +6553,6 @@ pub const PackageManager = struct {
     }
 
     pub inline fn link(ctx: Command.Context) !void {
-        if (comptime Environment.isWindows) {
-            Output.prettyErrorln("<r><red>error:<r> bun link is not supported on Windows yet", .{});
-            Global.crash();
-        }
-
         var manager = PackageManager.init(ctx, .link) catch |err| brk: {
             if (err == error.MissingPackageJSON) {
                 try attemptToCreatePackageJSON();
@@ -6647,12 +6642,37 @@ pub const PackageManager = struct {
                     }
                 }
 
-                // create the symlink
-                node_modules.symLink(Fs.FileSystem.instance.topLevelDirWithoutTrailingSlash(), name, .{ .is_directory = true }) catch |err| {
-                    if (manager.options.log_level != .silent)
-                        Output.prettyErrorln("<r><red>error:<r> failed to create symlink to node_modules in global dir due to error {s}", .{@errorName(err)});
-                    Global.crash();
-                };
+                if (comptime Environment.isWindows) {
+                    // create the junction
+                    const top_level = Fs.FileSystem.instance.topLevelDirWithoutTrailingSlash();
+                    var link_path_buf: bun.PathBuffer = undefined;
+                    @memcpy(
+                        link_path_buf[0..top_level.len],
+                        top_level,
+                    );
+                    link_path_buf[top_level.len] = 0;
+                    const link_path = link_path_buf[0..top_level.len :0];
+                    const global_path = try manager.globalLinkDirPath();
+                    const dest_path = Path.joinAbsStringZ(global_path, &.{name}, .windows);
+                    switch (bun.sys.sys_uv.symlinkUV(
+                        link_path,
+                        dest_path,
+                        bun.windows.libuv.UV_FS_SYMLINK_JUNCTION,
+                    )) {
+                        .err => |err| {
+                            Output.prettyErrorln("<r><red>error:<r> failed to create junction to node_modules in global dir due to error {}", .{err});
+                            Global.crash();
+                        },
+                        .result => {},
+                    }
+                } else {
+                    // create the symlink
+                    node_modules.symLink(Fs.FileSystem.instance.topLevelDirWithoutTrailingSlash(), name, .{ .is_directory = true }) catch |err| {
+                        if (manager.options.log_level != .silent)
+                            Output.prettyErrorln("<r><red>error:<r> failed to create symlink to node_modules in global dir due to error {s}", .{@errorName(err)});
+                        Global.crash();
+                    };
+                }
             }
 
             // Step 3b. Link any global bins
@@ -6708,11 +6728,6 @@ pub const PackageManager = struct {
     }
 
     pub inline fn unlink(ctx: Command.Context) !void {
-        if (comptime Environment.isWindows) {
-            Output.prettyErrorln("<r><red>error:<r> bun unlink is not supported on Windows yet", .{});
-            Global.crash();
-        }
-
         var manager = PackageManager.init(ctx, .unlink) catch |err| brk: {
             if (err == error.MissingPackageJSON) {
                 try attemptToCreatePackageJSON();
@@ -6769,7 +6784,7 @@ pub const PackageManager = struct {
 
             switch (Syscall.lstat(Path.joinAbsStringZ(try manager.globalLinkDirPath(), &.{name}, .auto))) {
                 .result => |stat| {
-                    if (!std.os.S.ISLNK(stat.mode)) {
+                    if (!bun.S.ISLNK(@intCast(stat.mode))) {
                         Output.prettyErrorln("<r><green>success:<r> package \"{s}\" is not globally linked, so there's nothing to do.", .{name});
                         Global.exit(0);
                     }

--- a/src/linux_c.zig
+++ b/src/linux_c.zig
@@ -577,6 +577,8 @@ pub const IFF_LOOPBACK = net_c.IFF_LOOPBACK;
 pub const Mode = u32;
 pub const E = std.os.E;
 
+pub extern "c" fn umask(Mode) Mode;
+
 pub fn getErrno(rc: anytype) E {
     return std.c.getErrno(rc);
 }

--- a/src/windows_c.zig
+++ b/src/windows_c.zig
@@ -1257,6 +1257,9 @@ const Maybe = bun.JSC.Maybe;
 
 const w = std.os.windows;
 
+extern "c" fn _umask(Mode) Mode;
+pub const umask = _umask;
+
 /// Derived from std.os.windows.renameAtW
 /// Allows more errors
 pub fn renameAtW(

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -25,7 +25,7 @@ expect.extend({
   toHaveBins,
   toBeValidBin,
   toBeWorkspaceLink,
-})
+});
 
 let port: string;
 let add_dir: string;
@@ -525,7 +525,7 @@ it("should add dependency with specified semver", async () => {
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
     name: "baz",
@@ -675,7 +675,7 @@ it("should add dependency alongside workspaces", async () => {
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readlink(join(package_dir, "node_modules", "bar"))).toBeWorkspaceLink(join("..", "packages", "bar"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
@@ -747,7 +747,7 @@ it("should add aliased dependency (npm)", async () => {
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "bar", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "bar", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "bar"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
     name: "baz",
@@ -1125,7 +1125,7 @@ it("should handle Git URL in dependencies (SCP-style)", async () => {
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect((join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBeValidBin(
+  expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
     join("..", "uglify-js", "bin", "uglifyjs"),
   );
   expect((await readdirSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("9d05c118f06c3b4c.git");

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -149,7 +149,6 @@ it("should reject invalid path without segfault", async () => {
   );
   const add_path = relative(package_dir, add_dir);
   const dep = `file://${add_path}`.replace(/\\/g, "\\\\");
-  console.log("dep:", dep);
   const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), "add", dep],
     cwd: package_dir,

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1,9 +1,9 @@
 // @known-failing-on-windows: 1 failing
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { bunExe, bunEnv as env } from "harness";
+import { bunExe, bunEnv as env, toHaveBins, toBeValidBin, toBeWorkspaceLink, ospath } from "harness";
 import { access, mkdir, mkdtemp, readlink, realpath, rm, writeFile, copyFile, appendFile } from "fs/promises";
-import { join, relative } from "path";
+import { join, relative, normalize, win32 } from "path";
 import { tmpdir } from "os";
 import {
   dummyAfterAll,
@@ -20,6 +20,12 @@ import {
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
+
+expect.extend({
+  toHaveBins,
+  toBeValidBin,
+  toBeWorkspaceLink,
+})
 
 let port: string;
 let add_dir: string;
@@ -52,8 +58,9 @@ it("should add existing package", async () => {
     }),
   );
   const add_path = relative(package_dir, add_dir);
+  const dep = `file:${add_path}`.replace(/\\/g, "\\\\");
   const { stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "add", `file:${add_path}`],
+    cmd: [bunExe(), "add", dep],
     cwd: package_dir,
     stdout: null,
     stdin: "pipe",
@@ -80,7 +87,7 @@ it("should add existing package", async () => {
         name: "bar",
         version: "0.0.2",
         dependencies: {
-          foo: `file:${add_path}`,
+          foo: dep.replace(/\\\\/g, "\\"),
         },
       },
       null,
@@ -98,8 +105,9 @@ it("should reject missing package", async () => {
     }),
   );
   const add_path = relative(package_dir, add_dir);
+  const dep = `file:${add_path}`.replace(/\\/g, "\\\\");
   const { stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "add", `file:${add_path}`],
+    cmd: [bunExe(), "add", dep],
     cwd: package_dir,
     stdout: null,
     stdin: "pipe",
@@ -110,7 +118,7 @@ it("should reject missing package", async () => {
   const err = await new Response(stderr).text();
   expect(err).toContain("bun add");
   expect(err).toContain("error: MissingPackageJSON");
-  expect(err).toContain(`note: error occured while resolving file:${add_path}`);
+  expect(err).toContain(`note: error occured while resolving ${dep}`);
 
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
@@ -140,8 +148,10 @@ it("should reject invalid path without segfault", async () => {
     }),
   );
   const add_path = relative(package_dir, add_dir);
+  const dep = `file://${add_path}`.replace(/\\/g, "\\\\");
+  console.log("dep:", dep);
   const { stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "add", `file://${add_path}`],
+    cmd: [bunExe(), "add", dep],
     cwd: package_dir,
     stdout: null,
     stdin: "pipe",
@@ -152,7 +162,7 @@ it("should reject invalid path without segfault", async () => {
   const err = await new Response(stderr).text();
   expect(err).toContain("bun add");
   expect(err).toContain("error: MissingPackageJSON");
-  expect(err).toContain(`note: error occured while resolving file://${add_path}`);
+  expect(err).toContain(`note: error occured while resolving ${dep}`);
 
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
@@ -515,8 +525,8 @@ it("should add dependency with specified semver", async () => {
   expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.3.tgz`]);
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["baz-run"]);
-  expect(await readlink(join(package_dir, "node_modules", ".bin", "baz-run"))).toBe(join("..", "baz", "index.js"));
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
+  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
     name: "baz",
@@ -576,7 +586,7 @@ it("should add dependency (GitHub)", async () => {
   expect(urls.sort()).toBeEmpty();
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["uglifyjs"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
@@ -654,7 +664,7 @@ it("should add dependency alongside workspaces", async () => {
   const out = await new Response(stdout).text();
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     "",
-    " + bar@workspace:packages/bar",
+    ospath(" + bar@workspace:packages/bar"),
     "",
     " installed baz@0.0.3 with binaries:",
     "  - baz-run",
@@ -665,9 +675,9 @@ it("should add dependency alongside workspaces", async () => {
   expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.3.tgz`]);
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["baz-run"]);
-  expect(await readlink(join(package_dir, "node_modules", ".bin", "baz-run"))).toBe(join("..", "baz", "index.js"));
-  expect(await readlink(join(package_dir, "node_modules", "bar"))).toBe(join("..", "packages", "bar"));
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
+  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(await readlink(join(package_dir, "node_modules", "bar"))).toBeWorkspaceLink(join("..", "packages", "bar"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
     name: "baz",
@@ -737,8 +747,8 @@ it("should add aliased dependency (npm)", async () => {
   expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.3.tgz`]);
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["baz-run"]);
-  expect(await readlink(join(package_dir, "node_modules", ".bin", "baz-run"))).toBe(join("..", "bar", "index.js"));
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
+  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "bar", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "bar"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
     name: "baz",
@@ -798,7 +808,7 @@ it("should add aliased dependency (GitHub)", async () => {
   expect(urls.sort()).toBeEmpty();
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["uglifyjs"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
     "@GH@mishoo-UglifyJS-e219a9a",
     "uglify",
@@ -1115,8 +1125,8 @@ it("should handle Git URL in dependencies (SCP-style)", async () => {
   expect(urls.sort()).toBeEmpty();
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["uglifyjs"]);
-  expect(await readlink(join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBe(
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
+  expect((join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBeValidBin(
     join("..", "uglify-js", "bin", "uglifyjs"),
   );
   expect((await readdirSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("9d05c118f06c3b4c.git");
@@ -1483,7 +1493,7 @@ it("should add dependency without duplication (GitHub)", async () => {
   ]);
   expect(await exited1).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["uglifyjs"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
@@ -1545,7 +1555,7 @@ it("should add dependency without duplication (GitHub)", async () => {
   ]);
   expect(await exited2).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["uglifyjs"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
@@ -1603,8 +1613,9 @@ it("should add dependencies to workspaces directly", async () => {
   );
   await writeFile(join(package_dir, "moo", "bunfig.toml"), await file(join(package_dir, "bunfig.toml")).text());
   const add_path = relative(join(package_dir, "moo"), add_dir);
+  const dep = `file:${add_path}`.replace(/\\/g, "\\\\");
   const { stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "add", `file:${add_path}`],
+    cmd: [bunExe(), "add", dep],
     cwd: join(package_dir, "moo"),
     stdout: null,
     stdin: "pipe",
@@ -1663,7 +1674,7 @@ async function installRedirectsToAdd(saveFlagFirst: boolean) {
   );
   const add_path = relative(package_dir, add_dir);
 
-  const args = [`file:${add_path}`, "--save"];
+  const args = [`file:${add_path}`.replace(/\\/g, "\\\\"), "--save"];
   if (saveFlagFirst) args.reverse();
 
   const { stdout, stderr, exited } = spawn({

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -4390,7 +4390,7 @@ it("should report error on invalid format for workspaces", async () => {
   expect(await exited).toBe(1);
 });
 
-it.only("should report error on duplicated workspace packages", async () => {
+it("should report error on duplicated workspace packages", async () => {
   await writeFile(
     join(package_dir, "package.json"),
     JSON.stringify({
@@ -5570,8 +5570,8 @@ it("should handle tarball path with existing lockfile", async () => {
   ]);
   expect(requested).toBe(4);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "bar", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["baz-run"]);
-  expect(await readlink(join(package_dir, "node_modules", ".bin", "baz-run"))).toBe(join("..", "baz", "index.js"));
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
+  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
   expect(await file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
@@ -5631,8 +5631,8 @@ it("should handle tarball path with existing lockfile", async () => {
   ]);
   expect(requested).toBe(8);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "bar", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["baz-run"]);
-  expect(await readlink(join(package_dir, "node_modules", ".bin", "baz-run"))).toBe(join("..", "baz", "index.js"));
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
+  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
   expect(await file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -4292,7 +4292,7 @@ it("should report error on invalid format for package.json", async () => {
   });
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir.replaceAll(sep, "/"), "[dir]")).toMatchSnapshot();
+  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir + sep, "[dir]/")).toMatchSnapshot();
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out).toEqual("");
@@ -4318,7 +4318,7 @@ it("should report error on invalid format for dependencies", async () => {
   });
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir.replaceAll(sep, "/"), "[dir]")).toMatchSnapshot();
+  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir + sep, "[dir]/")).toMatchSnapshot();
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out).toEqual("");
@@ -4344,7 +4344,7 @@ it("should report error on invalid format for optionalDependencies", async () =>
   });
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir.replaceAll(sep, "/"), "[dir]")).toMatchSnapshot();
+  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir + sep, "[dir]/")).toMatchSnapshot();
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out).toEqual("");
@@ -4372,7 +4372,7 @@ it("should report error on invalid format for workspaces", async () => {
   });
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir.replaceAll(sep, "/"), "[dir]")).toMatchSnapshot();
+  expect(err.replace(/^bun install v.+\n/, "bun install\n").replaceAll(package_dir + sep, "[dir]/")).toMatchSnapshot();
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out).toEqual("");

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,7 +1,7 @@
 // @known-failing-on-windows: 1 failing
 import { file, listen, Socket, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it, describe, test } from "bun:test";
-import { bunExe, bunEnv as env } from "harness";
+import { bunExe, bunEnv as env, toBeValidBin, toHaveBins } from "harness";
 import { access, mkdir, readlink as readlink, realpath, rm, writeFile, readFile } from "fs/promises";
 import { join, isAbsolute, sep, basename, dirname } from "path";
 import {
@@ -30,33 +30,8 @@ expect.extend({
     const pass = actual === expectedLinkPath;
     return { pass, message };
   },
-
-  async toHaveBins(actual: string[], expectedBins: string[]) {
-    const message = () => `Expected ${actual} to be package bins ${expectedBins}`
-
-    if (process.platform === "win32") {
-      for (var i = 0; i < actual.length; i += 2) {
-        if (!actual[i].includes(expectedBins[i / 2]) || !actual[i + 1].includes(expectedBins[i / 2])) {
-          return { pass: false, message };
-        }
-      }
-      return { pass: true, message };
-    }
-
-    return { pass: actual.every((bin, i) => bin === expectedBins[i]), message };
-  },
-
-  async toBeValidBin(actual: string, expectedLinkPath: string) {
-    const message = () => `Expected ${actual} to be a link to ${expectedLinkPath}`;
-
-    if (process.platform === "win32") {
-      const contents = await readFile(actual + ".bunx", "utf16le");
-      const expected = expectedLinkPath.slice(3);
-      return { pass: contents.includes(expected), message };
-    }
-
-    return { pass: await readlink(actual) === expectedLinkPath, message };
-  }
+  toBeValidBin,
+  toHaveBins,
 });
 
 beforeAll(dummyBeforeAll);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -4390,7 +4390,7 @@ it("should report error on invalid format for workspaces", async () => {
   expect(await exited).toBe(1);
 });
 
-it("should report error on duplicated workspace packages", async () => {
+it.only("should report error on duplicated workspace packages", async () => {
   await writeFile(
     join(package_dir, "package.json"),
     JSON.stringify({
@@ -4428,7 +4428,7 @@ it("should report error on duplicated workspace packages", async () => {
   expect(
     err
       .replace(/^bun install v.+\n/, "bun install\n")
-      .replaceAll(package_dir.replaceAll(sep, "/"), "[dir]").replaceAll(sep, "/"),
+      .replaceAll(package_dir, "[dir]").replaceAll(sep, "/"),
   ).toMatchSnapshot();
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2175,7 +2175,7 @@ it("should prefer latest-tagged dependency", async () => {
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
     name: "baz",
@@ -2370,7 +2370,7 @@ it("should handle dependency aliasing", async () => {
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "Bar"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "Bar", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "Bar", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "Bar"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "Bar", "package.json")).json()).toEqual({
     name: "baz",
@@ -2427,7 +2427,7 @@ it("should handle dependency aliasing (versioned)", async () => {
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "Bar"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "Bar", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "Bar", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "Bar"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "Bar", "package.json")).json()).toEqual({
     name: "baz",
@@ -2484,7 +2484,7 @@ it("should handle dependency aliasing (dist-tagged)", async () => {
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "Bar"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "Bar", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "Bar", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "Bar"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "Bar", "package.json")).json()).toEqual({
     name: "baz",
@@ -2545,7 +2545,7 @@ it("should not reinstall aliased dependencies", async () => {
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "Bar"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "Bar", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "Bar", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "Bar"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "Bar", "package.json")).json()).toEqual({
     name: "baz",
@@ -2583,7 +2583,7 @@ it("should not reinstall aliased dependencies", async () => {
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "Bar"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "Bar", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "Bar", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "Bar"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "Bar", "package.json")).json()).toEqual({
     name: "baz",
@@ -2653,7 +2653,7 @@ it("should handle aliased & direct dependency references", async () => {
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readlink(join(package_dir, "node_modules", "bar"))).toBeWorkspaceLink(join("..", "bar"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
@@ -2740,7 +2740,7 @@ it("should not hoist if name collides with alias", async () => {
   expect(requested).toBe(4);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar", "moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "bar", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "bar", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "bar"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
     name: "baz",
@@ -3054,7 +3054,7 @@ it("should handle aliased dependency with existing lockfile", async () => {
   expect(requested).toBe(6);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar", "baz", "moz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "bar"))).toEqual(["package.json"]);
   expect(await file(join(package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
     name: "bar",
@@ -3113,7 +3113,7 @@ it("should handle aliased dependency with existing lockfile", async () => {
   expect(requested).toBe(9);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar", "baz", "moz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "bar"))).toEqual(["package.json"]);
   expect(await file(join(package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
     name: "bar",
@@ -3526,9 +3526,7 @@ it("should handle GitHub URL in dependencies (github:user/repo#tag)", async () =
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect((join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBeValidBin(
-    join("..", "uglify", "bin", "uglifyjs"),
-  );
+  expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(join("..", "uglify", "bin", "uglifyjs"));
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
     "@GH@mishoo-UglifyJS-e219a9a",
     "uglify",
@@ -3649,9 +3647,7 @@ it("should handle GitHub URL in dependencies (git://github.com/user/repo.git#com
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect((join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBeValidBin(
-    join("..", "uglify", "bin", "uglifyjs"),
-  );
+  expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(join("..", "uglify", "bin", "uglifyjs"));
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
     "@GH@mishoo-UglifyJS-e219a9a",
     "uglify",
@@ -3966,7 +3962,11 @@ cache = false
     "uglify-js",
     "upper-case",
   ]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["he", "html-minifier", "uglifyjs"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins([
+    "he",
+    "html-minifier",
+    "uglifyjs",
+  ]);
   expect(join(package_dir, "node_modules", ".bin", "he")).toBeValidBin(join("..", "he", "bin", "he"));
   expect(join(package_dir, "node_modules", ".bin", "html-minifier")).toBeValidBin(
     join("..", "html-minifier", "cli.js"),
@@ -4020,7 +4020,11 @@ cache = false
     "uglify-js",
     "upper-case",
   ]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["he", "html-minifier", "uglifyjs"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins([
+    "he",
+    "html-minifier",
+    "uglifyjs",
+  ]);
   expect(join(package_dir, "node_modules", ".bin", "he")).toBeValidBin(join("..", "he", "bin", "he"));
   expect(join(package_dir, "node_modules", ".bin", "html-minifier")).toBeValidBin(
     join("..", "html-minifier", "cli.js"),
@@ -4109,9 +4113,7 @@ it("should consider peerDependencies during hoisting", async () => {
   expect(await readlink(join(package_dir, "node_modules", "bar"))).toBeWorkspaceLink(join("..", "bar"));
   expect(await readdirSorted(join(package_dir, "bar"))).toEqual(["node_modules", "package.json"]);
   expect(await readdirSorted(join(package_dir, "bar", "node_modules"))).toEqual([".bin", "baz"]);
-  expect((join(package_dir, "bar", "node_modules", ".bin", "baz-run"))).toBeValidBin(
-    join("..", "baz", "index.js"),
-  );
+  expect(join(package_dir, "bar", "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "bar", "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "bar", "node_modules", "baz", "package.json")).json()).toEqual({
     name: "baz",
@@ -4207,12 +4209,10 @@ it("should install peerDependencies when needed", async () => {
   expect(requested).toBe(3);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar", "baz", "moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-exec"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-exec"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-exec")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readlink(join(package_dir, "node_modules", "bar"))).toBeWorkspaceLink(join("..", "bar"));
   expect(await readdirSorted(join(package_dir, "bar"))).toEqual(["node_modules", "package.json"]);
-  expect((join(package_dir, "bar", "node_modules", ".bin", "baz-run"))).toBeValidBin(
-    join("..", "baz", "index.js"),
-  );
+  expect(join(package_dir, "bar", "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
     name: "baz",
@@ -4417,7 +4417,8 @@ it("should report error on duplicated workspace packages", async () => {
   expect(
     err
       .replace(/^bun install v.+\n/, "bun install\n")
-      .replaceAll(package_dir, "[dir]").replaceAll(sep, "/"),
+      .replaceAll(package_dir, "[dir]")
+      .replaceAll(sep, "/"),
   ).toMatchSnapshot();
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
@@ -4464,7 +4465,7 @@ it("should handle Git URL in dependencies", async () => {
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBin(["uglifyjs"]);
-  expect((join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBeValidBin(
+  expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
     join("..", "uglify-js", "bin", "uglifyjs"),
   );
   expect((await readdirSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("9694c5fe9c41ad51.git");
@@ -4526,9 +4527,7 @@ it("should handle Git URL in dependencies (SCP-style)", async () => {
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect((join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBeValidBin(
-    join("..", "uglify", "bin", "uglifyjs"),
-  );
+  expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(join("..", "uglify", "bin", "uglifyjs"));
   expect((await readdirSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("87d55589eb4217d2.git");
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify"))).toEqual([
     ".bun-tag",
@@ -4586,9 +4585,7 @@ it("should handle Git URL with committish in dependencies", async () => {
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect((join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBeValidBin(
-    join("..", "uglify", "bin", "uglifyjs"),
-  );
+  expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(join("..", "uglify", "bin", "uglifyjs"));
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
     "9694c5fe9c41ad51.git",
     "@G@e219a9a78a0d2251e4dcbd4bb9034207eb484fe8",
@@ -4735,7 +4732,7 @@ it("should de-duplicate committish in Git URLs", async () => {
     "uglify-ver",
   ]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect((join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBeValidBin(
+  expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
     join("..", "uglify-hash", "bin", "uglifyjs"),
   );
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
@@ -4841,12 +4838,16 @@ cache = false
     "uglify-js",
     "upper-case",
   ]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["he", "html-minifier", "uglifyjs"]);
-  expect((join(package_dir, "node_modules", ".bin", "he"))).toBeValidBin(join("..", "he", "bin", "he"));
-  expect((join(package_dir, "node_modules", ".bin", "html-minifier"))).toBeValidBin(
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins([
+    "he",
+    "html-minifier",
+    "uglifyjs",
+  ]);
+  expect(join(package_dir, "node_modules", ".bin", "he")).toBeValidBin(join("..", "he", "bin", "he"));
+  expect(join(package_dir, "node_modules", ".bin", "html-minifier")).toBeValidBin(
     join("..", "html-minifier", "cli.js"),
   );
-  expect((join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBeValidBin(
+  expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
     join("..", "uglify-js", "bin", "uglifyjs"),
   );
   await access(join(package_dir, "bun.lockb"));
@@ -4895,12 +4896,16 @@ cache = false
     "uglify-js",
     "upper-case",
   ]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["he", "html-minifier", "uglifyjs"]);
-  expect((join(package_dir, "node_modules", ".bin", "he"))).toBeValidBin(join("..", "he", "bin", "he"));
-  expect((join(package_dir, "node_modules", ".bin", "html-minifier"))).toBeValidBin(
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins([
+    "he",
+    "html-minifier",
+    "uglifyjs",
+  ]);
+  expect(join(package_dir, "node_modules", ".bin", "he")).toBeValidBin(join("..", "he", "bin", "he"));
+  expect(join(package_dir, "node_modules", ".bin", "html-minifier")).toBeValidBin(
     join("..", "html-minifier", "cli.js"),
   );
-  expect((join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBeValidBin(
+  expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
     join("..", "uglify-js", "bin", "uglifyjs"),
   );
   await access(join(package_dir, "bun.lockb"));
@@ -4966,12 +4971,16 @@ cache = false
     "uglify-js",
     "upper-case",
   ]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["he", "html-minifier", "uglifyjs"]);
-  expect((join(package_dir, "node_modules", ".bin", "he"))).toBeValidBin(join("..", "he", "bin", "he"));
-  expect((join(package_dir, "node_modules", ".bin", "html-minifier"))).toBeValidBin(
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins([
+    "he",
+    "html-minifier",
+    "uglifyjs",
+  ]);
+  expect(join(package_dir, "node_modules", ".bin", "he")).toBeValidBin(join("..", "he", "bin", "he"));
+  expect(join(package_dir, "node_modules", ".bin", "html-minifier")).toBeValidBin(
     join("..", "html-minifier", "cli.js"),
   );
-  expect((join(package_dir, "node_modules", ".bin", "uglifyjs"))).toBeValidBin(
+  expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
     join("..", "uglify-js", "bin", "uglifyjs"),
   );
   await access(join(package_dir, "bun.lockb"));
@@ -5122,7 +5131,7 @@ it("should handle tarball URL", async () => {
   expect(requested).toBe(1);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
     name: "baz",
@@ -5219,7 +5228,7 @@ it("should handle tarball URL with aliasing", async () => {
   expect(requested).toBe(1);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "bar", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "bar", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "bar"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
     name: "baz",
@@ -5333,7 +5342,7 @@ it("should de-duplicate dependencies alongside tarball URL", async () => {
   expect(requested).toBe(5);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "bar", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
   expect(await file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
@@ -5416,7 +5425,7 @@ it("should handle tarball URL with existing lockfile", async () => {
   expect(requested).toBe(5);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "bar", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
   expect(await file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
@@ -5478,7 +5487,7 @@ it("should handle tarball URL with existing lockfile", async () => {
   expect(requested).toBe(10);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "bar", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
   expect(await file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
@@ -5560,7 +5569,7 @@ it("should handle tarball path with existing lockfile", async () => {
   expect(requested).toBe(4);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "bar", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
   expect(await file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
@@ -5621,7 +5630,7 @@ it("should handle tarball path with existing lockfile", async () => {
   expect(requested).toBe(8);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "bar", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
   expect(await file(join(package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -4464,7 +4464,7 @@ it("should handle Git URL in dependencies", async () => {
   expect(urls.sort()).toBeEmpty();
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBin(["uglifyjs"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
   expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
     join("..", "uglify-js", "bin", "uglifyjs"),
   );

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -1,9 +1,9 @@
 // @known-failing-on-windows: 1 failing
 import { spawn, file } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { bunExe, bunEnv as env } from "harness";
+import { bunExe, bunEnv as env, toBeValidBin, toHaveBins } from "harness";
 import { access, mkdtemp, readlink, realpath, rm, writeFile, mkdir } from "fs/promises";
-import { basename, join } from "path";
+import  { basename, join, sep, dirname } from "path";
 import { tmpdir } from "os";
 import {
   dummyAfterAll,
@@ -18,6 +18,11 @@ beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
 
 let link_dir: string;
+
+expect.extend({
+  toBeValidBin,
+  toHaveBins,
+})
 
 beforeEach(async () => {
   link_dir = await mkdtemp(join(await realpath(tmpdir()), "bun-link.test"));
@@ -68,8 +73,8 @@ it("should link and unlink workspace package", async () => {
   var out = await new Response(stdout).text();
   expect(out.replace(/\s*\[[0-9\.]+ms\]\s*$/, "").split(/\r?\n/)).toEqual([
     "",
-    " + boba@workspace:packages/boba",
-    " + moo@workspace:packages/moo",
+    ` + boba@workspace:packages${sep}boba`,
+    ` + moo@workspace:packages${sep}moo`,
     "",
     " 2 packages installed",
   ]);
@@ -393,7 +398,6 @@ it("should link scoped package", async () => {
 });
 
 it("should link dependency without crashing", async () => {
-  console.log(link_dir);
   const link_name = basename(link_dir).slice("bun-link.".length) + "-really-long-name";
   await writeFile(
     join(link_dir, "package.json"),
@@ -461,8 +465,8 @@ it("should link dependency without crashing", async () => {
   ]);
   expect(await exited2).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", link_name].sort());
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual([link_name]);
-  expect(await readlink(join(package_dir, "node_modules", ".bin", link_name))).toBe(
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins([link_name]);
+  expect(join(package_dir, "node_modules", ".bin", link_name)).toBeValidBin(
     join("..", link_name, `${link_name}.js`),
   );
   expect(await readdirSorted(join(package_dir, "node_modules", link_name))).toEqual(

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -3,7 +3,7 @@ import { spawn, file } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
 import { bunExe, bunEnv as env, toBeValidBin, toHaveBins } from "harness";
 import { access, mkdtemp, readlink, realpath, rm, writeFile, mkdir } from "fs/promises";
-import  { basename, join, sep, dirname } from "path";
+import { basename, join, sep, dirname } from "path";
 import { tmpdir } from "os";
 import {
   dummyAfterAll,
@@ -22,7 +22,7 @@ let link_dir: string;
 expect.extend({
   toBeValidBin,
   toHaveBins,
-})
+});
 
 beforeEach(async () => {
   link_dir = await mkdtemp(join(await realpath(tmpdir()), "bun-link.test"));
@@ -466,9 +466,7 @@ it("should link dependency without crashing", async () => {
   expect(await exited2).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", link_name].sort());
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins([link_name]);
-  expect(join(package_dir, "node_modules", ".bin", link_name)).toBeValidBin(
-    join("..", link_name, `${link_name}.js`),
-  );
+  expect(join(package_dir, "node_modules", ".bin", link_name)).toBeValidBin(join("..", link_name, `${link_name}.js`));
   expect(await readdirSorted(join(package_dir, "node_modules", link_name))).toEqual(
     ["package.json", `${link_name}.js`].sort(),
   );

--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -53,7 +53,7 @@ it("should remove existing package", async () => {
     }),
   );
   const { exited: exited1 } = spawn({
-    cmd: [bunExe(), "add", `file:${pkg1_path}`],
+    cmd: [bunExe(), "add", `file:${pkg1_path}`.replace(/\\/g, "\\\\")],
     cwd: package_dir,
     stdout: null,
     stdin: "pipe",
@@ -62,7 +62,7 @@ it("should remove existing package", async () => {
   });
   expect(await exited1).toBe(0);
   const { exited: exited2 } = spawn({
-    cmd: [bunExe(), "add", `file:${pkg2_path}`],
+    cmd: [bunExe(), "add", `file:${pkg2_path}`.replace(/\\/g, "\\\\")],
     cwd: package_dir,
     stdout: null,
     stdin: "pipe",
@@ -180,7 +180,7 @@ it("should not reject missing package", async () => {
   );
   const pkg_path = relative(package_dir, remove_dir);
   const { exited: addExited } = spawn({
-    cmd: [bunExe(), "add", `file:${pkg_path}`],
+    cmd: [bunExe(), "add", `file:${pkg_path}`.replace(/\\/g, "\\\\")],
     cwd: package_dir,
     stdout: null,
     stdin: "pipe",
@@ -247,7 +247,7 @@ it("should retain a new line in the end of package.json", async () => {
   );
   const pkg_path = relative(package_dir, remove_dir);
   const { exited: addExited } = spawn({
-    cmd: [bunExe(), "add", `file:${pkg_path}`],
+    cmd: [bunExe(), "add", `file:${pkg_path}`.replace(/\\/g, "\\\\")],
     cwd: package_dir,
     stdout: null,
     stdin: "pipe",

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -70,7 +70,7 @@ for (let withRun of [false, true]) {
             name: "test",
             version: "0.0.0",
             scripts: {
-              "boop": "echo 'hi'",
+              "boop": "echo hi",
             },
           }),
         );
@@ -84,34 +84,36 @@ for (let withRun of [false, true]) {
         });
 
         expect(stderr.toString()).toBe("");
-        expect(stdout.toString()).toBe("hi\n");
+        expect(stdout.toString().replaceAll("\r\n", "\n")).toBe("hi\n");
         expect(exitCode).toBe(0);
       });
 
       it("--silent omits error messages", async () => {
+        const exe = process.platform === "win32" ? "bun.exe" : "bun";
         const { stdout, stderr, exitCode } = spawnSync({
-          cmd: [bunExe(), "run", "--silent", "bash", "-c", "exit 1"],
+          cmd: [bunExe(), "run", "--silent", exe, "doesnotexist"],
           cwd: run_dir,
           env: bunEnv,
         });
 
-        expect(stderr.toString()).toBe("");
+        expect(stderr.toString()).not.toEndWith(`error: "${exe}" exited with code 1\n`);
         expect(stdout.toString()).toBe("");
         expect(exitCode).toBe(1);
       });
 
       it("no --silent includes error messages", async () => {
+        const exe = process.platform === "win32" ? "bun.exe" : "bun"
         const { stdout, stderr, exitCode } = spawnSync({
-          cmd: [bunExe(), "run", "bash", "-c", "exit 1"],
+          cmd: [bunExe(), "run", exe, "doesnotexist"],
           cwd: run_dir,
           env: bunEnv,
         });
 
-        expect(stderr.toString()).toStartWith('error: "bash" exited with code 1');
+        expect(stderr.toString()).toEndWith(`error: "${exe}" exited with code 1\n`);
         expect(exitCode).toBe(1);
       });
 
-      it("exit code message works above 128", async () => {
+      it.skipIf(process.platform === "win32")("exit code message works above 128", async () => {
         const { stdout, stderr, exitCode } = spawnSync({
           cmd: [bunExe(), "run", "bash", "-c", "exit 200"],
           cwd: run_dir,
@@ -244,7 +246,7 @@ logLevel = "debug"
         });
 
         expect(stderr.toString()).toBe("");
-        expect(stdout.toString()).toBe("pre\n" + "main -a -b -c\n" + "post\n");
+        expect(stdout.toString().replaceAll("\r\n", "\n")).toBe("pre\n" + "main -a -b -c\n" + "post\n");
         expect(exitCode).toBe(0);
       });
     });

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -102,7 +102,7 @@ for (let withRun of [false, true]) {
       });
 
       it("no --silent includes error messages", async () => {
-        const exe = process.platform === "win32" ? "bun.exe" : "bun"
+        const exe = process.platform === "win32" ? "bun.exe" : "bun";
         const { stdout, stderr, exitCode } = spawnSync({
           cmd: [bunExe(), "run", exe, "doesnotexist"],
           cwd: run_dir,

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -25,7 +25,7 @@ afterEach(dummyAfterEach);
 expect.extend({
   toBeValidBin,
   toHaveBins,
-})
+});
 
 it("should update to latest version of dependency", async () => {
   const urls: string[] = [];
@@ -81,7 +81,7 @@ it("should update to latest version of dependency", async () => {
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
     name: "baz",
@@ -126,7 +126,7 @@ it("should update to latest version of dependency", async () => {
   expect(requested).toBe(4);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-exec"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-exec"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-exec")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
     name: "baz",
@@ -200,7 +200,7 @@ it("should update to latest versions of dependencies", async () => {
   expect(requested).toBe(4);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
@@ -252,7 +252,7 @@ it("should update to latest versions of dependencies", async () => {
   expect(requested).toBe(8);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "baz"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-exec"]);
-  expect((join(package_dir, "node_modules", ".bin", "baz-exec"))).toBeValidBin(join("..", "baz", "index.js"));
+  expect(join(package_dir, "node_modules", ".bin", "baz-exec")).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -1,7 +1,7 @@
 // @known-failing-on-windows: 1 failing
 import { file, listen, Socket, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { bunExe, bunEnv as env } from "harness";
+import { bunExe, bunEnv as env, toBeValidBin, toHaveBins } from "harness";
 import { readFile, access, mkdir, readlink, realpath, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import {
@@ -21,6 +21,11 @@ beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
 beforeEach(dummyBeforeEach);
 afterEach(dummyAfterEach);
+
+expect.extend({
+  toBeValidBin,
+  toHaveBins,
+})
 
 it("should update to latest version of dependency", async () => {
   const urls: string[] = [];
@@ -75,8 +80,8 @@ it("should update to latest version of dependency", async () => {
   expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.3.tgz`]);
   expect(requested).toBe(2);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["baz-run"]);
-  expect(await readlink(join(package_dir, "node_modules", ".bin", "baz-run"))).toBe(join("..", "baz", "index.js"));
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
+  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
     name: "baz",
@@ -120,8 +125,8 @@ it("should update to latest version of dependency", async () => {
   expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.5.tgz`]);
   expect(requested).toBe(4);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["baz-exec"]);
-  expect(await readlink(join(package_dir, "node_modules", ".bin", "baz-exec"))).toBe(join("..", "baz", "index.js"));
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-exec"]);
+  expect((join(package_dir, "node_modules", ".bin", "baz-exec"))).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
   expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
     name: "baz",
@@ -194,8 +199,8 @@ it("should update to latest versions of dependencies", async () => {
   ]);
   expect(requested).toBe(4);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["baz-run"]);
-  expect(await readlink(join(package_dir, "node_modules", ".bin", "baz-run"))).toBe(join("..", "baz", "index.js"));
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
+  expect((join(package_dir, "node_modules", ".bin", "baz-run"))).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
@@ -246,8 +251,8 @@ it("should update to latest versions of dependencies", async () => {
   ]);
   expect(requested).toBe(8);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toEqual(["baz-exec"]);
-  expect(await readlink(join(package_dir, "node_modules", ".bin", "baz-exec"))).toBe(join("..", "baz", "index.js"));
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-exec"]);
+  expect((join(package_dir, "node_modules", ".bin", "baz-exec"))).toBeValidBin(join("..", "baz", "index.js"));
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -261,7 +261,7 @@ export function ospath(path: string) {
 }
 
 export async function toHaveBins(actual: string[], expectedBins: string[]) {
-  const message = () => `Expected ${actual} to be package bins ${expectedBins}`
+  const message = () => `Expected ${actual} to be package bins ${expectedBins}`;
 
   if (process.platform === "win32") {
     for (var i = 0; i < actual.length; i += 2) {
@@ -284,7 +284,7 @@ export async function toBeValidBin(actual: string, expectedLinkPath: string) {
     return { pass: contents.includes(expected), message };
   }
 
-  return { pass: await readlink(actual) === expectedLinkPath, message };
+  return { pass: (await readlink(actual)) === expectedLinkPath, message };
 }
 
 export async function toBeWorkspaceLink(actual: string, expectedLinkPath: string) {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1,7 +1,7 @@
 import { gc as bunGC, unsafe, which } from "bun";
 import { expect } from "bun:test";
 import { readlink, readFile } from "fs/promises";
-import { platform } from "os";
+import { isAbsolute } from "path";
 import { openSync, closeSync } from "node:fs";
 
 export const bunEnv: NodeJS.ProcessEnv = {
@@ -285,6 +285,19 @@ export async function toBeValidBin(actual: string, expectedLinkPath: string) {
   }
 
   return { pass: await readlink(actual) === expectedLinkPath, message };
+}
+
+export async function toBeWorkspaceLink(actual: string, expectedLinkPath: string) {
+  const message = () => `Expected ${actual} to be a link to ${expectedLinkPath}`;
+
+  if (process.platform === "win32") {
+    // junctions on windows will have an absolute path
+    const pass = isAbsolute(actual) && actual.includes(expectedLinkPath.split("..").at(-1)!);
+    return { pass, message };
+  }
+
+  const pass = actual === expectedLinkPath;
+  return { pass, message };
 }
 
 export function getMaxFD(): number {


### PR DESCRIPTION
### What does this PR do?
gets bun `link` and `unlink` working on windows.

also fixes small bugs on windows for:
- `toMatchSnapshot`
- `bun pm ls`
- `bun pm cache rm`
- `bun create`
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
ci and manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
