### PR TITLE
docs: expect.extend is implemented

### DIFF
--- a/docs/test/writing.md
+++ b/docs/test/writing.md
@@ -301,7 +301,7 @@ Bun implements the following matchers. Full Jest compatibility is on the roadmap
 
 ---
 
-- ❌
+- ✅
 - [`.extend`](https://jestjs.io/docs/expect#expectextendmatchers)
 
 ---


### PR DESCRIPTION
### What does this PR do?

This PR updates the documentation to show that `expect.extend` is now supported, according to https://github.com/oven-sh/bun/issues/1825.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
