### PR TITLE
feat: add support for zstd

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3315,6 +3315,49 @@ declare module "bun" {
      */
     static readonly byteLength: 32;
   }
+  
+  /** Compression options for `Bun.deflateSync` and `Bun.gzipSync` */
+  interface ZstdCompressionOptions {
+    /**
+     * The compression level to use. Must be between `-1` and `22`.
+     * - A value of `-1` uses the default compression level (Currently `3`)
+     * - A value of `0` gives no compression
+     * - A value of `1` gives least compression, fastest speed
+     * - A value of `19` gives best compression, slowest speed
+     * - A value of `20`-`22` gives the maxium compression, greater memory usage
+     */
+    level?: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22;
+
+    /**
+     * The base 2 logarithm of the window size (the size of the history buffer).
+     *
+     * Larger values of this parameter result in better compression at the expense of memory usage.
+     */
+    windowLog?:
+      | 10
+      | 11
+      | 12
+      | 13
+      | 14
+      | 15
+      | 16
+      | 17
+      | 18
+      | 19
+      | 20
+      | 21
+      | 22
+      | 23
+      | 24
+      | 25
+      | 26
+      | 27
+      | 28
+      | 29
+      | 30
+      | 31;
+    /**
+  }
 
   /** Compression options for `Bun.deflateSync` and `Bun.gzipSync` */
   interface ZlibCompressionOptions {
@@ -3412,6 +3455,20 @@ declare module "bun" {
    * @returns The output buffer with the decompressed data
    */
   function gunzipSync(data: Uint8Array | string | ArrayBuffer): Uint8Array;
+
+  /**
+   * Decompresses a chunk of data with the `zstd` algorithm.
+   * @param data The buffer of data to decompress
+   * @returns The output buffer with the decompressed data
+   */
+  function zstdDecompressSync(data: Uint8Array, options?: ZstdCompressionOptions): Uint8Array;
+
+  /**
+   * Decompresses a chunk of data with the `zstd` algorithm.
+   * @param data The buffer of data to decompress
+   * @returns The output buffer with the decompressed data
+   */
+  function zstdCompressSync(data: Uint8Array, options?: ZstdCompressionOptions): Uint8Array;
 
   type Target =
     /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3356,7 +3356,6 @@ declare module "bun" {
       | 29
       | 30
       | 31;
-    /**
   }
 
   /** Compression options for `Bun.deflateSync` and `Bun.gzipSync` */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3315,7 +3315,7 @@ declare module "bun" {
      */
     static readonly byteLength: 32;
   }
-  
+
   /** Compression options for `Bun.deflateSync` and `Bun.gzipSync` */
   interface ZstdCompressionOptions {
     /**

--- a/scripts/all-dependencies.sh
+++ b/scripts/all-dependencies.sh
@@ -55,13 +55,13 @@ dep() {
 dep base64 libbase64.a
 dep boringssl libcrypto.a libssl.a libdecrepit.a
 dep cares libcares.a
-dep libarchive libarchive.a
 dep lolhtml liblolhtml.a
 dep mimalloc-debug libmimalloc-debug.a libmimalloc-debug.o
 dep mimalloc libmimalloc.a libmimalloc.o
 dep tinycc libtcc.a
 dep zlib libz.a
 dep zstd libzstd.a
+dep libarchive libarchive.a
 dep lshpack liblshpack.a
 
 if [ "$BUILT_ANY" -eq 0 ]; then

--- a/scripts/build-libarchive.sh
+++ b/scripts/build-libarchive.sh
@@ -8,6 +8,6 @@ cd $BUN_DEPS_DIR/libarchive
 make clean || echo ""
 ./build/clean.sh || echo ""
 ./build/autogen.sh
-./configure --disable-shared --enable-static --with-pic --disable-bsdtar --disable-bsdcat --disable-rpath --enable-posix-regex-lib --without-xml2 --without-expat --without-openssl --without-iconv --without-zlib
+./configure --disable-shared --enable-static --with-pic --disable-bsdtar --disable-bsdcat --disable-rpath --enable-posix-regex-lib --without-xml2 --without-expat --without-openssl --without-iconv --with-zlib=$BUN_DEPS_OUT_DIR/libz.a --with-zstd=$BUN_DEPS_OUT_DIR/libzstd.a --without-bz2lib
 make -j$CPUS
 cp ./.libs/libarchive.a $BUN_DEPS_OUT_DIR/libarchive.a

--- a/src/bun.js/bindings/BunObject+exports.h
+++ b/src/bun.js/bindings/BunObject+exports.h
@@ -44,6 +44,8 @@
     macro(generateHeapSnapshot) \
     macro(gunzipSync) \
     macro(gzipSync) \
+    macro(zstdCompressSync) \
+    macro(zstdDecompressSync) \
     macro(indexOfLine) \
     macro(inflateSync) \
     macro(jest) \

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -559,6 +559,8 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     generateHeapSnapshot                           BunObject_callback_generateHeapSnapshot                             DontDelete|Function 1
     gunzipSync                                     BunObject_callback_gunzipSync                                       DontDelete|Function 1
     gzipSync                                       BunObject_callback_gzipSync                                         DontDelete|Function 1
+    zstdCompressSync                                       BunObject_callback_zstdCompressSync                                         DontDelete|Function 1
+    zstdDecompressSync                                       BunObject_callback_zstdDecompressSync                                         DontDelete|Function 1
     hash                                           BunObject_getter_wrap_hash                                          DontDelete|PropertyCallback
     indexOfLine                                    BunObject_callback_indexOfLine                                      DontDelete|Function 1
     inflateSync                                    BunObject_callback_inflateSync                                      DontDelete|Function 1

--- a/src/http.zig
+++ b/src/http.zig
@@ -1647,7 +1647,7 @@ const connection_closing_header = picohttp.Header{ .name = "Connection", .value 
 const accept_header = picohttp.Header{ .name = "Accept", .value = "*/*" };
 
 const accept_encoding_no_compression = "identity";
-const accept_encoding_compression = "gzip, deflate, ztd, br";
+const accept_encoding_compression = "gzip, deflate, zstd, br";
 const accept_encoding_compression_no_brotli = "gzip, deflate, zstd";
 const accept_encoding_header_compression = picohttp.Header{ .name = "Accept-Encoding", .value = accept_encoding_compression };
 const accept_encoding_header_compression_no_brotli = picohttp.Header{ .name = "Accept-Encoding", .value = accept_encoding_compression_no_brotli };

--- a/src/libarchive/libarchive.zig
+++ b/src/libarchive/libarchive.zig
@@ -221,7 +221,7 @@ pub const BufferReadStream = struct {
 
         _ = lib.archive_read_support_format_tar(this.archive);
         _ = lib.archive_read_support_format_gnutar(this.archive);
-        _ = lib.archive_read_support_compression_gzip(this.archive);
+        _ = lib.archive_read_support_compression_all(this.archive);
 
         // Ignore zeroed blocks in the archive, which occurs when multiple tar archives
         // have been concatenated together.

--- a/src/zstd.zig
+++ b/src/zstd.zig
@@ -1,0 +1,142 @@
+const std = @import("std");
+const bun = @import("root").bun;
+
+const mimalloc = @import("./allocators/mimalloc.zig");
+
+const c = bun.zstd;
+const ZSTD_DStream = c.ZSTD_DStream;
+
+test "ZstdArrayList Read" {
+    const expected_text = @embedFile("./zlib.test.txt");
+    const input = bun.asByteSlice(@embedFile("./zlib.test.zst"));
+    var list = std.ArrayListUnmanaged(u8){};
+    try list.ensureUnusedCapacity(std.heap.c_allocator, 4096);
+    var reader = try ZstdReaderArrayList.init(input, &list, std.heap.c_allocator);
+    defer reader.deinit();
+    try reader.readAll();
+
+    try std.testing.expectEqualStrings(expected_text, list.items);
+}
+
+pub const Options = struct {
+    window_log_max: ?i32 = null,
+};
+
+pub const ZstdReaderArrayList = struct {
+    pub const State = enum {
+        Uninitialized,
+        Inflating,
+        End,
+        Error,
+    };
+
+    input: []const u8,
+    list: std.ArrayListUnmanaged(u8),
+    list_allocator: std.mem.Allocator,
+    list_ptr: *std.ArrayListUnmanaged(u8),
+    zstd: ?*ZSTD_DStream,
+    state: State = State.Uninitialized,
+    total_out: usize = 0,
+    total_in: usize = 0,
+
+    pub usingnamespace bun.New(ZstdReaderArrayList);
+
+    pub fn initWithOptions(input: []const u8, list: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, options: Options) !*ZstdReaderArrayList {
+        const dstream = c.ZSTD_createDStream();
+        _ = c.ZSTD_initDStream(dstream);
+
+        if (options.window_log_max) |window_log_max| {
+            _ = c.ZSTD_DCtx_setParameter(dstream, c.ZSTD_d_windowLogMax, window_log_max);
+        }
+
+        std.debug.assert(list.items.ptr != input.ptr);
+
+        return ZstdReaderArrayList.new(
+            .{
+                .input = input,
+                .list_ptr = list,
+                .list = list.*,
+                .list_allocator = allocator,
+                .zstd = dstream,
+            },
+        );
+    }
+
+    pub fn end(this: *ZstdReaderArrayList) void {
+        this.state = .End;
+    }
+
+    pub fn readAll(this: *ZstdReaderArrayList, is_done: bool) !void {
+        defer {
+            this.list_ptr.* = this.list;
+        }
+
+        if (this.state == .End or this.state == .Error) {
+            return;
+        }
+
+        std.debug.assert(this.list.items.ptr != this.input.ptr);
+
+        while (this.state == State.Uninitialized or this.state == State.Inflating) {
+            var unused_capacity = this.list.unusedCapacitySlice();
+
+            if (unused_capacity.len < 4096) {
+                try this.list.ensureUnusedCapacity(this.list_allocator, 4096);
+                unused_capacity = this.list.unusedCapacitySlice();
+            }
+
+            std.debug.assert(unused_capacity.len > 0);
+
+            const next_in = this.input[this.total_in..];
+
+            var in_buffer: c.ZSTD_inBuffer = .{
+                .src = next_in.ptr,
+                .size = next_in.len,
+                .pos = this.total_in,
+            };
+
+            var out_buffer: c.ZSTD_outBuffer = .{
+                .dst = unused_capacity.ptr,
+                .size = unused_capacity.len,
+                .pos = this.total_out,
+            };
+
+            // https://github.com/google/brotli/blob/fef82ea10435abb1500b615b1b2c6175d429ec6c/go/cbrotli/reader.go#L15-L27
+            const result = c.ZSTD_decompressStream(
+                this.zstd,
+                &out_buffer,
+                &in_buffer,
+            );
+
+            const bytes_written = unused_capacity.len -| unused_capacity.len;
+            const bytes_read = next_in.len -| next_in.len;
+
+            this.list.items.len += bytes_written;
+            this.total_in += bytes_read;
+
+            if (c.ZSTD_isError(result) == 1) {
+                this.state = .Error;
+                if (comptime bun.Environment.allow_assert) {
+                    const code = c.ZSTD_getErrorName(result);
+                    bun.Output.debugWarn("Zstd error: {s} ({d})", .{ code, result });
+                }
+
+                return error.ZstdDecompressionError;
+            } else {
+                if (is_done) {
+                    this.end();
+                    return;
+                }
+
+                if (comptime bun.Environment.allow_assert) {
+                    std.debug.assert(this.brotli.isFinished());
+                }
+            }
+        }
+    }
+
+    pub fn deinit(this: *ZstdReaderArrayList) void {
+        _ = c.ZSTD_freeDStream(this.zstd);
+        this.destroy();
+    }
+};

--- a/src/zstd.zig
+++ b/src/zstd.zig
@@ -4,7 +4,6 @@ const bun = @import("root").bun;
 const mimalloc = @import("./allocators/mimalloc.zig");
 
 const c = bun.zstd;
-const ZSTD_DStream = c.ZSTD_DStream;
 
 test "ZstdArrayList Read" {
     const expected_text = @embedFile("./zlib.test.txt");
@@ -20,12 +19,13 @@ test "ZstdArrayList Read" {
 
 pub const Options = struct {
     window_log_max: ?i32 = null,
+    compression_level: i32 = 3,
 };
 
 pub const ZstdReaderArrayList = struct {
     pub const State = enum {
         Uninitialized,
-        Inflating,
+        Decompressing,
         End,
         Error,
     };
@@ -34,7 +34,7 @@ pub const ZstdReaderArrayList = struct {
     list: std.ArrayListUnmanaged(u8),
     list_allocator: std.mem.Allocator,
     list_ptr: *std.ArrayListUnmanaged(u8),
-    zstd: ?*ZSTD_DStream,
+    zstd: ?*c.ZSTD_DStream,
     state: State = State.Uninitialized,
     total_out: usize = 0,
     total_in: usize = 0,
@@ -77,7 +77,7 @@ pub const ZstdReaderArrayList = struct {
 
         std.debug.assert(this.list.items.ptr != this.input.ptr);
 
-        while (this.state == State.Uninitialized or this.state == State.Inflating) {
+        while (this.state == State.Uninitialized or this.state == State.Decompressing) {
             var unused_capacity = this.list.unusedCapacitySlice();
 
             if (unused_capacity.len < 4096) {
@@ -125,11 +125,8 @@ pub const ZstdReaderArrayList = struct {
             } else {
                 if (is_done) {
                     this.end();
-                    return;
-                }
 
-                if (comptime bun.Environment.allow_assert) {
-                    std.debug.assert(this.brotli.isFinished());
+                    return;
                 }
             }
         }
@@ -137,6 +134,121 @@ pub const ZstdReaderArrayList = struct {
 
     pub fn deinit(this: *ZstdReaderArrayList) void {
         _ = c.ZSTD_freeDStream(this.zstd);
+        this.destroy();
+    }
+};
+
+pub const ZstdCompressorArrayList = struct {
+    pub const State = enum {
+        Uninitialized,
+        Compressing,
+        End,
+        Error,
+    };
+
+    input: []const u8,
+    list: std.ArrayListUnmanaged(u8),
+    list_allocator: std.mem.Allocator,
+    list_ptr: *std.ArrayListUnmanaged(u8),
+    zstd: ?*c.ZSTD_CStream,
+    state: State = State.Uninitialized,
+    total_out: usize = 0,
+    total_in: usize = 0,
+
+    pub usingnamespace bun.New(ZstdCompressorArrayList);
+
+    pub fn initWithOptions(input: []const u8, list: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, options: Options) !*ZstdCompressorArrayList {
+        const cstream = c.ZSTD_createCStream();
+        _ = c.ZSTD_initCStream(cstream, options.compression_level);
+
+        if (options.window_log_max) |window_log_max| {
+            _ = c.ZSTD_CCtx_setParameter(cstream, c.ZSTD_c_windowLog, window_log_max);
+        }
+
+        std.debug.assert(list.items.ptr != input.ptr);
+
+        return ZstdCompressorArrayList.new(
+            .{
+                .input = input,
+                .list_ptr = list,
+                .list = list.*,
+                .list_allocator = allocator,
+                .zstd = cstream,
+            },
+        );
+    }
+
+    pub fn end(this: *ZstdCompressorArrayList) void {
+        this.state = .End;
+    }
+
+    pub fn readAll(this: *ZstdCompressorArrayList, is_done: bool) !void {
+        defer {
+            this.list_ptr.* = this.list;
+        }
+
+        if (this.state == .End or this.state == .Error) {
+            return;
+        }
+
+        std.debug.assert(this.list.items.ptr != this.input.ptr);
+
+        while (this.state == State.Uninitialized or this.state == State.Compressing) {
+            var unused_capacity = this.list.unusedCapacitySlice();
+
+            if (unused_capacity.len < 4096) {
+                try this.list.ensureUnusedCapacity(this.list_allocator, 4096);
+                unused_capacity = this.list.unusedCapacitySlice();
+            }
+
+            std.debug.assert(unused_capacity.len > 0);
+
+            const next_in = this.input[this.total_in..];
+
+            var in_buffer: c.ZSTD_inBuffer = .{
+                .src = next_in.ptr,
+                .size = next_in.len,
+                .pos = this.total_in,
+            };
+
+            var out_buffer: c.ZSTD_outBuffer = .{
+                .dst = unused_capacity.ptr,
+                .size = unused_capacity.len,
+                .pos = this.total_out,
+            };
+
+            // https://github.com/google/brotli/blob/fef82ea10435abb1500b615b1b2c6175d429ec6c/go/cbrotli/reader.go#L15-L27
+            const result = c.ZSTD_compressStream(
+                this.zstd,
+                &out_buffer,
+                &in_buffer,
+            );
+
+            const bytes_written = unused_capacity.len -| unused_capacity.len;
+            const bytes_read = next_in.len -| next_in.len;
+
+            this.list.items.len += bytes_written;
+            this.total_in += bytes_read;
+
+            if (c.ZSTD_isError(result) == 1) {
+                this.state = .Error;
+                if (comptime bun.Environment.allow_assert) {
+                    const code = c.ZSTD_getErrorName(result);
+                    bun.Output.debugWarn("Zstd error: {s} ({d})", .{ code, result });
+                }
+
+                return error.ZstdDecompressionError;
+            } else {
+                if (is_done) {
+                    this.end();
+                    return;
+                }
+            }
+        }
+    }
+
+    pub fn deinit(this: *ZstdCompressorArrayList) void {
+        _ = c.ZSTD_freeCStream(this.zstd);
         this.destroy();
     }
 };


### PR DESCRIPTION
### What does this PR do?

This allows custom npm registries and git dependencies to take advantage of compression formats such as zstd.
In BunOS this means large packages can be downloaded using bun with a tar.zst extension and a custom npm registry. An example of this is LLVM (4gb uncompressed).

I'm not sure that this is the right approach (in terms of removing the manual zlib decompression) but since libarchive handles the compression it works fine.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I created an minimal package.json and ran `bun add -d @types/bun` and it still works properly. Additionally, running a copy of https://github.com/bunos2/registry/commit/4a7e9491a9dd90530d0112d1fc696003cec205f2 and running `bun add @bruh/bruh` with a bunfig.toml of the following works fine as well:
```toml
[install.scopes]
"@bruh" = "http://localhost:6969"
```
Adding `@bruh/bruh` should add glibc to `node_modules/@bruh/bruh` with a lib/ directory/ containg libc.a.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

## TODO

- [x] Add zstd to http.zig
- [ ] Update http.zig to add zstd to Transfer/Content-Encoding
- [x] Add zstd to libarchive.zig
- [ ] Add tests
- [ ] Add zstd to the dependency build scripts (change the order for libarchive support)