### PR TITLE
chore(deps): migrate to zlib-ng

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@ shallow = true
 fetchRecurseSubmodules = false
 [submodule "src/deps/zlib"]
 path = src/deps/zlib
-url = https://github.com/cloudflare/zlib.git
+	url = https://github.com/zlib-ng/zlib-ng
 ignore = dirty
 depth = 1
 shallow = true

--- a/Makefile
+++ b/Makefile
@@ -629,7 +629,7 @@ libarchive:
 	(make clean || echo ""); \
 	(./build/clean.sh || echo ""); \
 	./build/autogen.sh; \
-	CFLAGS="$(CFLAGS)" $(CCACHE_CC_FLAG) ./configure --disable-shared --enable-static  --with-pic  --disable-bsdtar   --disable-bsdcat --disable-rpath --enable-posix-regex-lib  --without-xml2  --without-expat --without-openssl  --without-iconv --without-zlib; \
+	CFLAGS="$(CFLAGS)" $(CCACHE_CC_FLAG) ./configure --disable-shared --enable-static  --with-pic  --disable-bsdtar   --disable-bsdcat --disable-rpath --enable-posix-regex-lib  --without-xml2  --without-expat --without-openssl  --without-iconv --with-zlib; \
 	make -j${CPUS}; \
 	cp ./.libs/libarchive.a $(BUN_DEPS_OUT_DIR)/libarchive.a;
 
@@ -646,7 +646,7 @@ tgz-debug:
 	rm -rf $(DEBUG_PACKAGE_DIR)/tgz.o
 
 zlib:
-	cd $(BUN_DEPS_DIR)/zlib; make clean; $(CCACHE_CC_FLAG) CFLAGS="$(CFLAGS)" ./configure --static && make -j${CPUS} && cp ./libz.a $(BUN_DEPS_OUT_DIR)/libz.a
+	cd $(BUN_DEPS_DIR)/zlib; $(CCACHE_CC_FLAG) CFLAGS="$(CFLAGS)" cmake $(CMAKE_FLAGS) -G Ninja -B build -DZLIB_COMPAT=ON -DBUILD_SHARED_LIBS=OFF && ninja -C build libz.a && cp ./build/libz.a $(BUN_DEPS_OUT_DIR)/libz.a
 
 ifeq ($(POSIX_PKG_MANAGER), brew)
 PKGNAME_NINJA := ninja
@@ -930,9 +930,9 @@ clone-submodules:
 
 .PHONY: headers
 headers:
-	echo please don't run the headers generator anymore. i don't think it works. 
+	echo please don't run the headers generator anymore. i don't think it works.
 	echo if you really need it, run make headers2
-headers2: 
+headers2:
 	rm -f /tmp/build-jsc-headers src/bun.js/bindings/headers.zig
 	touch src/bun.js/bindings/headers.zig
 	$(ZIG) build headers-obj
@@ -1910,7 +1910,7 @@ vendor: assert-deps submodule vendor-without-check
 vendor-dev: assert-deps submodule npm-install-dev vendor-without-npm
 
 .PHONY: bun
-bun: 
+bun:
 	@echo 'makefile is deprecated - use `cmake` / `bun run build`'
 	@echo 'See https://bun.sh/docs/project/contributing for more details'
 


### PR DESCRIPTION
### What does this PR do?

Replaces cloudflare's zlib fork with [zlib-ng](https://github.com/zlib-ng/zlib-ng). It has the same cloudflare patches along with some other patches and is more maintained.

Not sure why there were additional whitespace changes in the makefile...

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
