### PR TITLE
Close more file descriptors in `bun --watch`

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -269,6 +269,8 @@ LIBUS_SOCKET_DESCRIPTOR apple_no_sigpipe(LIBUS_SOCKET_DESCRIPTOR fd) {
 LIBUS_SOCKET_DESCRIPTOR bsd_set_nonblocking(LIBUS_SOCKET_DESCRIPTOR fd) {
 #ifdef _WIN32
     /* Libuv will set windows sockets as non-blocking */
+#elif defined(__APPLE__)
+    fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK  | O_CLOEXEC);
 #else
     fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
 #endif

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -175,6 +175,11 @@ extern "C" void on_before_reload_process_linux()
     // close all file descriptors except stdin, stdout, stderr and possibly IPC.
     // if you're passing additional file descriptors to Bun, you're probably not passing more than 8.
     bun_close_range(8, ~0U, 0U);
+
+    // reset all signals to default
+    sigset_t signal_set;
+    sigfillset(&signal_set);
+    sigprocmask(SIG_SETMASK, &signal_set, nullptr);
 }
 
 #endif

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -165,6 +165,7 @@ extern "C" int clock_gettime_monotonic(int64_t* tv_sec, int64_t* tv_nsec)
 
 #include <sys/syscall.h>
 
+// close_range is glibc > 2.33, which is very new
 static ssize_t bun_close_range(unsigned int start, unsigned int end, unsigned int flags)
 {
     return syscall(__NR_close_range, start, end, flags);

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -160,3 +160,21 @@ extern "C" int clock_gettime_monotonic(int64_t* tv_sec, int64_t* tv_nsec)
     return 0;
 }
 #endif
+
+#if OS(LINUX)
+
+#include <sys/syscall.h>
+
+static ssize_t bun_close_range(unsigned int start, unsigned int end, unsigned int flags)
+{
+    return syscall(__NR_close_range, start, end, flags);
+}
+
+extern "C" void on_before_reload_process_linux()
+{
+    // close all file descriptors except stdin, stdout, stderr and possibly IPC.
+    // if you're passing additional file descriptors to Bun, you're probably not passing more than 8.
+    bun_close_range(8, ~0U, 0U);
+}
+
+#endif

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1416,7 +1416,7 @@ pub fn reloadProcess(
         actions.inherit(posix.STDERR_FD) catch unreachable;
 
         var attrs = PosixSpawn.Attr.init() catch unreachable;
-        attrs.resetSignals();
+        attrs.resetSignals() catch {};
 
         attrs.set(
             C.POSIX_SPAWN_CLOEXEC_DEFAULT |

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1414,7 +1414,10 @@ pub fn reloadProcess(
         actions.inherit(posix.STDIN_FD) catch unreachable;
         actions.inherit(posix.STDOUT_FD) catch unreachable;
         actions.inherit(posix.STDERR_FD) catch unreachable;
+
         var attrs = PosixSpawn.Attr.init() catch unreachable;
+        attrs.resetSignals();
+
         attrs.set(
             C.POSIX_SPAWN_CLOEXEC_DEFAULT |
                 // Apple Extension: If this bit is set, rather
@@ -1430,13 +1433,22 @@ pub fn reloadProcess(
             },
             .result => |_| {},
         }
-    } else {
+    } else if (comptime Environment.isPosix) {
+        const on_before_reload_process_linux = struct {
+            pub extern "C" fn on_before_reload_process_linux() void;
+        }.on_before_reload_process_linux;
+
+        on_before_reload_process_linux();
         const err = std.os.execveZ(
             exec_path,
             newargv,
             envp,
         );
         Output.panic("Unexpected error while reloading: {s}", .{@errorName(err)});
+    } else if (comptime Environment.isWindows) {
+        @panic("TODO on Windows!");
+    } else {
+        @panic("Unsupported platform");
     }
 }
 pub var auto_reload_on_crash = false;


### PR DESCRIPTION
### What does this PR do?

Fixes #8532 

This shouldn't fix it, `POSIX_SPAWN_CLOEXEC_DEFAULT` should be handling this for us by default.  But this makes our code more careful. 

On Linux, we use `close_range` to automatically close all file descriptors before process restart > 8. If this somehow breaks your application, please either file an issue or make sure the file descriptor you pass to Bun is less than 8.

### How did you verify your code works?

CI