### PR TITLE
docs: Fix typo in code example for Transpiler.transformSync

### DIFF
--- a/docs/api/transpiler.md
+++ b/docs/api/transpiler.md
@@ -50,7 +50,7 @@ export default jsx(
 To override the default loader specified in the `new Bun.Transpiler()` constructor, pass a second argument to `.transformSync()`.
 
 ```ts
-await transpiler.transform("<div>hi!</div>", "tsx");
+await transpiler.transformSync("<div>hi!</div>", "tsx");
 ```
 
 {% details summary="Nitty gritty" %}

--- a/docs/api/transpiler.md
+++ b/docs/api/transpiler.md
@@ -50,7 +50,7 @@ export default jsx(
 To override the default loader specified in the `new Bun.Transpiler()` constructor, pass a second argument to `.transformSync()`.
 
 ```ts
-await transpiler.transformSync("<div>hi!</div>", "tsx");
+transpiler.transformSync("<div>hi!</div>", "tsx");
 ```
 
 {% details summary="Nitty gritty" %}


### PR DESCRIPTION
### What does this PR do?

Fixing a tiny typo I noticed in the code example for `Transpiler.transformSync`, where it was shown running `transform` instead.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

