### PR TITLE
fix(builtin-bundler): do not replace globals when extending classes

### DIFF
--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -172,10 +172,9 @@ async function processFileSplit(filename: string): Promise<{ functions: BundledB
 // do not allow the bundler to rename a symbol to $
 ($);
 
-$$capture_start$$(${fn.async ? "async " : ""}${
-        useThis
-          ? `function(${fn.params.join(",")})`
-          : `${fn.params.length === 1 ? fn.params[0] : `(${fn.params.join(",")})`}=>`
+$$capture_start$$(${fn.async ? "async " : ""}${useThis
+        ? `function(${fn.params.join(",")})`
+        : `${fn.params.length === 1 ? fn.params[0] : `(${fn.params.join(",")})`}=>`
       } {${fn.source}}).$$capture_end$$;
 `,
     );
@@ -199,14 +198,15 @@ $$capture_start$$(${fn.async ? "async " : ""}${
       (fn.directives.sloppy
         ? captured
         : captured.replace(
-            /function\s*\(.*?\)\s*{/,
-            '$&"use strict";' +
-              (usesDebug ? createLogClientJS("BUILTINS", fn.name) : "") +
-              (usesAssert ? createAssertClientJS(fn.name) : ""),
-          )
+          /function\s*\(.*?\)\s*{/,
+          '$&"use strict";' +
+          (usesDebug ? createLogClientJS("BUILTINS", fn.name) : "") +
+          (usesAssert ? createAssertClientJS(fn.name) : ""),
+        )
       )
         .replace(/^\((async )?function\(/, "($1function (")
-        .replace(/__intrinsic__/g, "@") + "\n";
+        .replace(/__intrinsic__/g, "@")
+        .replace(/__no_intrinsic__/g, "") + "\n";
 
     bundledFunctions.push({
       name: fn.name,
@@ -282,9 +282,8 @@ for (const { basename, functions } of files) {
     const name = `${lowerBasename}${cap(fn.name)}Code`;
     bundledCPP += `// ${fn.name}
 const JSC::ConstructAbility s_${name}ConstructAbility = JSC::ConstructAbility::${fn.constructAbility};
-const JSC::InlineAttribute s_${name}InlineAttribute = JSC::InlineAttribute::${
-      fn.directives.alwaysInline ? "Always" : "None"
-    };
+const JSC::InlineAttribute s_${name}InlineAttribute = JSC::InlineAttribute::${fn.directives.alwaysInline ? "Always" : "None"
+      };
 const JSC::ConstructorKind s_${name}ConstructorKind = JSC::ConstructorKind::${fn.constructKind};
 const JSC::ImplementationVisibility s_${name}ImplementationVisibility = JSC::ImplementationVisibility::${fn.visibility};
 const int s_${name}Length = ${fn.source.length};

--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -172,9 +172,10 @@ async function processFileSplit(filename: string): Promise<{ functions: BundledB
 // do not allow the bundler to rename a symbol to $
 ($);
 
-$$capture_start$$(${fn.async ? "async " : ""}${useThis
-        ? `function(${fn.params.join(",")})`
-        : `${fn.params.length === 1 ? fn.params[0] : `(${fn.params.join(",")})`}=>`
+$$capture_start$$(${fn.async ? "async " : ""}${
+        useThis
+          ? `function(${fn.params.join(",")})`
+          : `${fn.params.length === 1 ? fn.params[0] : `(${fn.params.join(",")})`}=>`
       } {${fn.source}}).$$capture_end$$;
 `,
     );
@@ -198,11 +199,11 @@ $$capture_start$$(${fn.async ? "async " : ""}${useThis
       (fn.directives.sloppy
         ? captured
         : captured.replace(
-          /function\s*\(.*?\)\s*{/,
-          '$&"use strict";' +
-          (usesDebug ? createLogClientJS("BUILTINS", fn.name) : "") +
-          (usesAssert ? createAssertClientJS(fn.name) : ""),
-        )
+            /function\s*\(.*?\)\s*{/,
+            '$&"use strict";' +
+              (usesDebug ? createLogClientJS("BUILTINS", fn.name) : "") +
+              (usesAssert ? createAssertClientJS(fn.name) : ""),
+          )
       )
         .replace(/^\((async )?function\(/, "($1function (")
         .replace(/__intrinsic__/g, "@")
@@ -282,8 +283,9 @@ for (const { basename, functions } of files) {
     const name = `${lowerBasename}${cap(fn.name)}Code`;
     bundledCPP += `// ${fn.name}
 const JSC::ConstructAbility s_${name}ConstructAbility = JSC::ConstructAbility::${fn.constructAbility};
-const JSC::InlineAttribute s_${name}InlineAttribute = JSC::InlineAttribute::${fn.directives.alwaysInline ? "Always" : "None"
-      };
+const JSC::InlineAttribute s_${name}InlineAttribute = JSC::InlineAttribute::${
+      fn.directives.alwaysInline ? "Always" : "None"
+    };
 const JSC::ConstructorKind s_${name}ConstructorKind = JSC::ConstructorKind::${fn.constructKind};
 const JSC::ImplementationVisibility s_${name}ImplementationVisibility = JSC::ImplementationVisibility::${fn.visibility};
 const int s_${name}Length = ${fn.source.length};

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -44,7 +44,7 @@ const {
 // work, so i have lot of debug logs that blow up the console because not sure what is going on.
 // that is also the reason for using `retry` when theoretically writing a file the first time
 // should actually write the file.
-const verbose = Bun.env.VERBOSE ? console.log : () => {};
+const verbose = Bun.env.VERBOSE ? console.log : () => { };
 async function retry(n, fn) {
   var err;
   while (n > 0) {
@@ -87,12 +87,12 @@ for (let i = 0; i < moduleList.length; i++) {
 
     const processed = sliceSourceCode(
       "{" +
-        input
-          .replace(
-            /\bimport(\s*type)?\s*(\{[^}]*\}|(\*\s*as)?\s[a-zA-Z0-9_$]+)\s*from\s*['"][^'"]+['"]/g,
-            stmt => (importStatements.push(stmt), ""),
-          )
-          .replace(/export\s*{\s*}\s*;/g, ""),
+      input
+        .replace(
+          /\bimport(\s*type)?\s*(\{[^}]*\}|(\*\s*as)?\s[a-zA-Z0-9_$]+)\s*from\s*['"][^'"]+['"]/g,
+          stmt => (importStatements.push(stmt), ""),
+        )
+        .replace(/export\s*{\s*}\s*;/g, ""),
       true,
       x => requireTransformer(x, moduleList[i]),
     );
@@ -232,17 +232,18 @@ for (const entrypoint of bundledEntryPoints) {
       .replace(/import.meta.require\((.*?)\)/g, (expr, specifier) => {
         throw new Error(`Builtin Bundler: do not use import.meta.require() (in ${file_path}))`);
       })
-      .replace(/__intrinsic__/g, "@") + "\n";
+      .replace(/__intrinsic__/g, "@")
+      .replace(/__no_intrinsic__/g, "") + "\n";
   captured = captured.replace(
     /function\s*\(.*?\)\s*{/,
     '$&"use strict";' +
-      (usesDebug
-        ? createLogClientJS(
-            file_path.replace(".js", ""),
-            idToPublicSpecifierOrEnumName(file_path).replace(/^node:|^bun:/, ""),
-          )
-        : "") +
-      (usesAssert ? createAssertClientJS(idToPublicSpecifierOrEnumName(file_path).replace(/^node:|^bun:/, "")) : ""),
+    (usesDebug
+      ? createLogClientJS(
+        file_path.replace(".js", ""),
+        idToPublicSpecifierOrEnumName(file_path).replace(/^node:|^bun:/, ""),
+      )
+      : "") +
+    (usesAssert ? createAssertClientJS(idToPublicSpecifierOrEnumName(file_path).replace(/^node:|^bun:/, "")) : ""),
   );
   const outputPath = path.join(JS_DIR, file_path);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
@@ -285,12 +286,11 @@ writeIfNotChanged(
 // actually use this enum but it's probably a good thing to include.
 writeIfNotChanged(
   path.join(CODEGEN_DIR, "InternalModuleRegistry+enum.h"),
-  `${
-    moduleList
-      .map((id, n) => {
-        return `${idToEnumName(id)} = ${n},`;
-      })
-      .join("\n") + "\n"
+  `${moduleList
+    .map((id, n) => {
+      return `${idToEnumName(id)} = ${n},`;
+    })
+    .join("\n") + "\n"
   }
 `,
 );
@@ -304,16 +304,16 @@ JSValue InternalModuleRegistry::createInternalModuleById(JSGlobalObject* globalO
   switch (id) {
     // JS internal modules
     ${moduleList
-      .map((id, n) => {
-        return `case Field::${idToEnumName(id)}: {
+    .map((id, n) => {
+      return `case Field::${idToEnumName(id)}: {
       INTERNAL_MODULE_REGISTRY_GENERATE(globalObject, vm, "${idToPublicSpecifierOrEnumName(id)}"_s, ${JSON.stringify(
         id.replace(/\.[mc]?[tj]s$/, ".js"),
       )}_s, InternalModuleRegistryConstants::${idToEnumName(id)}Code, "builtin://${id
         .replace(/\.[mc]?[tj]s$/, "")
         .replace(/[^a-zA-Z0-9]+/g, "/")}"_s);
     }`;
-      })
-      .join("\n    ")}
+    })
+    .join("\n    ")}
     default: {
       __builtin_unreachable();
     }
@@ -373,8 +373,8 @@ pub const ResolvedSourceTag = enum(u32) {
 ${moduleList.map((id, n) => `    @"${idToPublicSpecifierOrEnumName(id)}" = ${(1 << 9) | n},`).join("\n")}
     // Native modules run through a different system using ESM registry.
 ${Object.entries(nativeModuleIds)
-  .map(([id, n]) => `    @"${id}" = ${(1 << 10) | n},`)
-  .join("\n")}
+    .map(([id, n]) => `    @"${id}" = ${(1 << 10) | n},`)
+    .join("\n")}
 };
 `,
 );
@@ -400,8 +400,8 @@ ${moduleList.map((id, n) => `    ${idToEnumName(id)} = ${(1 << 9) | n},`).join("
     // They also have bit 10 set to differentiate them from JS builtins.
     NativeModuleFlag = (1 << 10) | (1 << 9),
 ${Object.entries(nativeModuleEnumToId)
-  .map(([id, n]) => `    ${id} = ${(1 << 10) | n},`)
-  .join("\n")}
+    .map(([id, n]) => `    ${id} = ${(1 << 10) | n},`)
+    .join("\n")}
 };
 
 `,

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -44,7 +44,7 @@ const {
 // work, so i have lot of debug logs that blow up the console because not sure what is going on.
 // that is also the reason for using `retry` when theoretically writing a file the first time
 // should actually write the file.
-const verbose = Bun.env.VERBOSE ? console.log : () => { };
+const verbose = Bun.env.VERBOSE ? console.log : () => {};
 async function retry(n, fn) {
   var err;
   while (n > 0) {
@@ -87,12 +87,12 @@ for (let i = 0; i < moduleList.length; i++) {
 
     const processed = sliceSourceCode(
       "{" +
-      input
-        .replace(
-          /\bimport(\s*type)?\s*(\{[^}]*\}|(\*\s*as)?\s[a-zA-Z0-9_$]+)\s*from\s*['"][^'"]+['"]/g,
-          stmt => (importStatements.push(stmt), ""),
-        )
-        .replace(/export\s*{\s*}\s*;/g, ""),
+        input
+          .replace(
+            /\bimport(\s*type)?\s*(\{[^}]*\}|(\*\s*as)?\s[a-zA-Z0-9_$]+)\s*from\s*['"][^'"]+['"]/g,
+            stmt => (importStatements.push(stmt), ""),
+          )
+          .replace(/export\s*{\s*}\s*;/g, ""),
       true,
       x => requireTransformer(x, moduleList[i]),
     );
@@ -237,13 +237,13 @@ for (const entrypoint of bundledEntryPoints) {
   captured = captured.replace(
     /function\s*\(.*?\)\s*{/,
     '$&"use strict";' +
-    (usesDebug
-      ? createLogClientJS(
-        file_path.replace(".js", ""),
-        idToPublicSpecifierOrEnumName(file_path).replace(/^node:|^bun:/, ""),
-      )
-      : "") +
-    (usesAssert ? createAssertClientJS(idToPublicSpecifierOrEnumName(file_path).replace(/^node:|^bun:/, "")) : ""),
+      (usesDebug
+        ? createLogClientJS(
+            file_path.replace(".js", ""),
+            idToPublicSpecifierOrEnumName(file_path).replace(/^node:|^bun:/, ""),
+          )
+        : "") +
+      (usesAssert ? createAssertClientJS(idToPublicSpecifierOrEnumName(file_path).replace(/^node:|^bun:/, "")) : ""),
   );
   const outputPath = path.join(JS_DIR, file_path);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
@@ -286,11 +286,12 @@ writeIfNotChanged(
 // actually use this enum but it's probably a good thing to include.
 writeIfNotChanged(
   path.join(CODEGEN_DIR, "InternalModuleRegistry+enum.h"),
-  `${moduleList
-    .map((id, n) => {
-      return `${idToEnumName(id)} = ${n},`;
-    })
-    .join("\n") + "\n"
+  `${
+    moduleList
+      .map((id, n) => {
+        return `${idToEnumName(id)} = ${n},`;
+      })
+      .join("\n") + "\n"
   }
 `,
 );
@@ -304,16 +305,16 @@ JSValue InternalModuleRegistry::createInternalModuleById(JSGlobalObject* globalO
   switch (id) {
     // JS internal modules
     ${moduleList
-    .map((id, n) => {
-      return `case Field::${idToEnumName(id)}: {
+      .map((id, n) => {
+        return `case Field::${idToEnumName(id)}: {
       INTERNAL_MODULE_REGISTRY_GENERATE(globalObject, vm, "${idToPublicSpecifierOrEnumName(id)}"_s, ${JSON.stringify(
         id.replace(/\.[mc]?[tj]s$/, ".js"),
       )}_s, InternalModuleRegistryConstants::${idToEnumName(id)}Code, "builtin://${id
         .replace(/\.[mc]?[tj]s$/, "")
         .replace(/[^a-zA-Z0-9]+/g, "/")}"_s);
     }`;
-    })
-    .join("\n    ")}
+      })
+      .join("\n    ")}
     default: {
       __builtin_unreachable();
     }
@@ -373,8 +374,8 @@ pub const ResolvedSourceTag = enum(u32) {
 ${moduleList.map((id, n) => `    @"${idToPublicSpecifierOrEnumName(id)}" = ${(1 << 9) | n},`).join("\n")}
     // Native modules run through a different system using ESM registry.
 ${Object.entries(nativeModuleIds)
-    .map(([id, n]) => `    @"${id}" = ${(1 << 10) | n},`)
-    .join("\n")}
+  .map(([id, n]) => `    @"${id}" = ${(1 << 10) | n},`)
+  .join("\n")}
 };
 `,
 );
@@ -400,8 +401,8 @@ ${moduleList.map((id, n) => `    ${idToEnumName(id)} = ${(1 << 9) | n},`).join("
     // They also have bit 10 set to differentiate them from JS builtins.
     NativeModuleFlag = (1 << 10) | (1 << 9),
 ${Object.entries(nativeModuleEnumToId)
-    .map(([id, n]) => `    ${id} = ${(1 << 10) | n},`)
-    .join("\n")}
+  .map(([id, n]) => `    ${id} = ${(1 << 10) | n},`)
+  .join("\n")}
 };
 
 `,

--- a/src/codegen/replacements.ts
+++ b/src/codegen/replacements.ts
@@ -54,6 +54,8 @@ export const globalsToPrefix = [
   "undefined",
 ];
 
+replacements.push({ from: new RegExp(`\\bextends\\s+(${globalsToPrefix.join("|")})`, "g"), to: "extends __no_intrinsic__%1" });
+
 // These enums map to $<enum>IdToLabel and $<enum>LabelToId
 // Make sure to define in ./builtins.d.ts
 export const enums = {
@@ -131,7 +133,7 @@ export function applyReplacements(src: string, length: number) {
   let rest = src.slice(length);
   slice = slice.replace(/([^a-zA-Z0-9_\$])\$([a-zA-Z0-9_]+\b)/gm, `$1__intrinsic__$2`);
   for (const replacement of replacements) {
-    slice = slice.replace(replacement.from, replacement.to.replaceAll("$", "__intrinsic__"));
+    slice = slice.replace(replacement.from, replacement.to.replaceAll("$", "__intrinsic__").replaceAll('%', '$'));
   }
   let match;
   if ((match = slice.match(/__intrinsic__(debug|assert)$/)) && rest.startsWith("(")) {
@@ -154,17 +156,17 @@ export function applyReplacements(src: string, length: number) {
       }
       return [
         slice.slice(0, match.index) +
-          "(IS_BUN_DEVELOPMENT?$assert(" +
-          checkSlice.result.slice(1, -1) +
-          "," +
-          JSON.stringify(
-            checkSlice.result
-              .slice(1, -1)
-              .replace(/__intrinsic__/g, "$")
-              .trim(),
-          ) +
-          extraArgs +
-          "):void 0)",
+        "(IS_BUN_DEVELOPMENT?$assert(" +
+        checkSlice.result.slice(1, -1) +
+        "," +
+        JSON.stringify(
+          checkSlice.result
+            .slice(1, -1)
+            .replace(/__intrinsic__/g, "$")
+            .trim(),
+        ) +
+        extraArgs +
+        "):void 0)",
         rest2,
         true,
       ];

--- a/src/codegen/replacements.ts
+++ b/src/codegen/replacements.ts
@@ -54,7 +54,10 @@ export const globalsToPrefix = [
   "undefined",
 ];
 
-replacements.push({ from: new RegExp(`\\bextends\\s+(${globalsToPrefix.join("|")})`, "g"), to: "extends __no_intrinsic__%1" });
+replacements.push({
+  from: new RegExp(`\\bextends\\s+(${globalsToPrefix.join("|")})`, "g"),
+  to: "extends __no_intrinsic__%1",
+});
 
 // These enums map to $<enum>IdToLabel and $<enum>LabelToId
 // Make sure to define in ./builtins.d.ts
@@ -133,7 +136,7 @@ export function applyReplacements(src: string, length: number) {
   let rest = src.slice(length);
   slice = slice.replace(/([^a-zA-Z0-9_\$])\$([a-zA-Z0-9_]+\b)/gm, `$1__intrinsic__$2`);
   for (const replacement of replacements) {
-    slice = slice.replace(replacement.from, replacement.to.replaceAll("$", "__intrinsic__").replaceAll('%', '$'));
+    slice = slice.replace(replacement.from, replacement.to.replaceAll("$", "__intrinsic__").replaceAll("%", "$"));
   }
   let match;
   if ((match = slice.match(/__intrinsic__(debug|assert)$/)) && rest.startsWith("(")) {
@@ -156,17 +159,17 @@ export function applyReplacements(src: string, length: number) {
       }
       return [
         slice.slice(0, match.index) +
-        "(IS_BUN_DEVELOPMENT?$assert(" +
-        checkSlice.result.slice(1, -1) +
-        "," +
-        JSON.stringify(
-          checkSlice.result
-            .slice(1, -1)
-            .replace(/__intrinsic__/g, "$")
-            .trim(),
-        ) +
-        extraArgs +
-        "):void 0)",
+          "(IS_BUN_DEVELOPMENT?$assert(" +
+          checkSlice.result.slice(1, -1) +
+          "," +
+          JSON.stringify(
+            checkSlice.result
+              .slice(1, -1)
+              .replace(/__intrinsic__/g, "$")
+              .trim(),
+          ) +
+          extraArgs +
+          "):void 0)",
         rest2,
         true,
       ];

--- a/src/js/README.md
+++ b/src/js/README.md
@@ -38,13 +38,13 @@ On top of this, we have some special functions that are handled by the builtin p
 
 - `require` works, but it must be passed a **string literal** that resolves to a module within `src/js`. This call gets replaced with `$getInternalField($internalModuleRegistery, <number>)`, which directly loads the module by its generated numerical ID, skipping the resolver for inter-internal modules.
 
-- `$debug` is exactly like console.log, but is stripped in release builds. It is disabled by default, requiring you to pass one of: `BUN_DEBUG_MODULE_NAME=1`, `BUN_DEBUG_JS=1`, or `BUN_DEBUG_ALL=1`. You can also do `if($debug) {}` to check if debug env var is set.
+- `$debug()` is exactly like console.log, but is stripped in release builds. It is disabled by default, requiring you to pass one of: `BUN_DEBUG_MODULE_NAME=1`, `BUN_DEBUG_JS=1`, or `BUN_DEBUG_ALL=1`. You can also do `if($debug) {}` to check if debug env var is set.
+
+- `$assert()` in debug builds will assert the condition, but it is stripped in release builds. If an assertion fails, the program continues to run, but an error is logged in the console containing the original source condition and any extra messages specified.
 
 - `IS_BUN_DEVELOPMENT` is inlined to be `true` in all development builds.
 
-- `process.platform` is properly inlined and DCE'd. Do use this to run different code on different platforms.
-
-- `$bundleError()` is like Zig's `@compileError`. It will stop a compile from succeeding.
+- `process.platform` and `process.arch` is properly inlined and DCE'd. Do use this to run different code on different platforms.
 
 ## Builtin Modules
 

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -1,11 +1,6 @@
 // The types in this file are not publicly defined, but do exist.
 // Stuff like `Bun.fs()` and so on.
 
-/**
- * Works like the zig `@compileError` built-in, but only supports plain strings.
- */
-declare function $bundleError(error: string);
-
 type BunFSWatchOptions = { encoding?: BufferEncoding; persistent?: boolean; recursive?: boolean; signal?: AbortSignal };
 type BunWatchEventType = "rename" | "change" | "error" | "close";
 type BunWatchListener<T> = (event: WatchEventType, filename: T | undefined) => void;
@@ -51,8 +46,8 @@ type BunFS = Omit<typeof import("node:fs") & typeof import("node:fs/promises"), 
     filename: string,
     options:
       | (WatchOptions & {
-          encoding: "buffer";
-        })
+        encoding: "buffer";
+      })
       | "buffer",
     listener?: BunWatchListener<Buffer>,
   ): BunFSWatcher;

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -46,8 +46,8 @@ type BunFS = Omit<typeof import("node:fs") & typeof import("node:fs/promises"), 
     filename: string,
     options:
       | (WatchOptions & {
-        encoding: "buffer";
-      })
+          encoding: "buffer";
+        })
       | "buffer",
     listener?: BunWatchListener<Buffer>,
   ): BunFSWatcher;


### PR DESCRIPTION
### What does this PR do?

Fixes incorrect builtins codegen:

`class X extends Promise {` no longer bundles to `class X extends @Promise {`