### PR TITLE
internal: report all failing tests to our internal feed

### DIFF
--- a/.github/workflows/bun-windows.yml
+++ b/.github/workflows/bun-windows.yml
@@ -445,7 +445,7 @@ jobs:
           description: |
             ### ❌🪟 [${{github.event.pull_request.title}}](https://github.com/oven-sh/bun/pull/${{github.event.number}})
 
-            @${{ github.actor }}, there are **${{ steps.test.outputs.regressing_test_count }} failing testts** on Windows ${{ matrix.arch }}${{ matrix.cpu == 'nehalem' && ' Baseline' || '' }}
+            @${{ github.actor }}, there are **${{ steps.test.outputs.failing_test_count }} failing tests** on Windows ${{ matrix.arch }}${{ matrix.cpu == 'nehalem' && ' Baseline' || '' }}
 
             ${{ steps.test.outputs.failing_tests }}
 

--- a/.github/workflows/bun-windows.yml
+++ b/.github/workflows/bun-windows.yml
@@ -435,7 +435,7 @@ jobs:
           } catch {}
           $ErrorActionPreference = "Stop"
       - uses: sarisia/actions-status-discord@v1
-        if: always() && steps.test.outputs.regressing_tests != '' && github.event_name == 'pull_request'
+        if: always() && steps.test.outputs.failing_tests != '' && github.event_name == 'pull_request'
         with:
           title: ""
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
@@ -445,9 +445,9 @@ jobs:
           description: |
             ### ❌🪟 [${{github.event.pull_request.title}}](https://github.com/oven-sh/bun/pull/${{github.event.number}})
 
-            @${{ github.actor }}, there are **${{ steps.test.outputs.regressing_test_count }} test regressions** on Windows ${{ matrix.arch }}${{ matrix.cpu == 'nehalem' && ' Baseline' || '' }}
+            @${{ github.actor }}, there are **${{ steps.test.outputs.regressing_test_count }} failing testts** on Windows ${{ matrix.arch }}${{ matrix.cpu == 'nehalem' && ' Baseline' || '' }}
 
-            ${{ steps.test.outputs.regressing_tests }}
+            ${{ steps.test.outputs.failing_tests }}
 
             [Full Test Output](https://github.com/oven-sh/bun/actions/runs/${{github.run_id}})
       - name: Comment on PR

--- a/.github/workflows/bun-windows.yml
+++ b/.github/workflows/bun-windows.yml
@@ -438,7 +438,7 @@ jobs:
         if: always() && steps.test.outputs.failing_tests != '' && github.event_name == 'pull_request'
         with:
           title: ""
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          webhook: ${{ secrets.DISCORD_WEBHOOK_WINTEST }}
           status: "failure"
           noprefix: true
           nocontext: true
@@ -448,6 +448,22 @@ jobs:
             @${{ github.actor }}, there are **${{ steps.test.outputs.failing_test_count }} failing tests** on Windows ${{ matrix.arch }}${{ matrix.cpu == 'nehalem' && ' Baseline' || '' }}
 
             ${{ steps.test.outputs.failing_tests }}
+
+            [Full Test Output](https://github.com/oven-sh/bun/actions/runs/${{github.run_id}})
+      - uses: sarisia/actions-status-discord@v1
+        if: always() && steps.test.outputs.regressing_tests != '' && github.event_name == 'pull_request'
+        with:
+          title: ""
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: "failure"
+          noprefix: true
+          nocontext: true
+          description: |
+            ### ❌🪟 [${{github.event.pull_request.title}}](https://github.com/oven-sh/bun/pull/${{github.event.number}})
+
+            @${{ github.actor }}, there are **${{ steps.test.outputs.regressing_test_count }} test regressions** on Windows ${{ matrix.arch }}${{ matrix.cpu == 'nehalem' && ' Baseline' || '' }}
+
+            ${{ steps.test.outputs.regressing_tests }}
 
             [Full Test Output](https://github.com/oven-sh/bun/actions/runs/${{github.run_id}})
       - name: Comment on PR

--- a/packages/bun-internal-test/src/runner.node.mjs
+++ b/packages/bun-internal-test/src/runner.node.mjs
@@ -107,9 +107,9 @@ async function runTest(path) {
 
   const expected_crash_reason = windows
     ? await readFile(resolve(path), "utf-8").then(data => {
-        const match = data.match(/@known-failing-on-windows:(.*)\n/);
-        return match ? match[1].trim() : null;
-      })
+      const match = data.match(/@known-failing-on-windows:(.*)\n/);
+      return match ? match[1].trim() : null;
+    })
     : null;
 
   const start = Date.now();
@@ -195,8 +195,7 @@ async function runTest(path) {
   }
 
   console.log(
-    `\x1b[2m${formatTime(duration).padStart(6, " ")}\x1b[0m ${
-      passed ? "\x1b[32m✔" : expected_crash_reason ? "\x1b[33m⚠" : "\x1b[31m✖"
+    `\x1b[2m${formatTime(duration).padStart(6, " ")}\x1b[0m ${passed ? "\x1b[32m✔" : expected_crash_reason ? "\x1b[33m⚠" : "\x1b[31m✖"
     } ${name}\x1b[0m${reason ? ` (${reason})` : ""}`,
   );
 
@@ -320,10 +319,9 @@ console.log("\n" + "-".repeat(Math.min(process.stdout.columns || 40, 80)) + "\n"
 console.log(header);
 console.log("\n" + "-".repeat(Math.min(process.stdout.columns || 40, 80)) + "\n");
 
-let report = `# bun test on ${
-  process.env["GITHUB_REF"] ??
+let report = `# bun test on ${process.env["GITHUB_REF"] ??
   spawnSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf-8" }).stdout.trim()
-}
+  }
 
 \`\`\`
 ${header}
@@ -347,8 +345,7 @@ if (regressions.length > 0) {
   report += regressions
     .map(
       ({ path, reason, expected_crash_reason }) =>
-        `- [\`${path}\`](${sectionLink(path)}) ${reason}${
-          expected_crash_reason ? ` (expected: ${expected_crash_reason})` : ""
+        `- [\`${path}\`](${sectionLink(path)}) ${reason}${expected_crash_reason ? ` (expected: ${expected_crash_reason})` : ""
         }`,
     )
     .join("\n");
@@ -403,18 +400,14 @@ console.log("-> test-report.md, test-report.json");
 
 if (ci) {
   if (windows) {
-    if (regressions.length > 0) {
-      action.setFailed(`${regressions.length} regressing tests`);
-    }
     action.setOutput("regressing_tests", regressions.map(({ path }) => `- \`${path}\``).join("\n"));
     action.setOutput("regressing_test_count", regressions.length);
-  } else {
-    if (failing_tests.length > 0) {
-      action.setFailed(`${failing_tests.length} files with failing tests`);
-    }
-    action.setOutput("failing_tests", failingTestDisplay);
-    action.setOutput("failing_tests_count", failing_tests.length);
   }
+  if (failing_tests.length > 0) {
+    action.setFailed(`${failing_tests.length} files with failing tests`);
+  }
+  action.setOutput("failing_tests", failingTestDisplay);
+  action.setOutput("failing_tests_count", failing_tests.length);
   let truncated_report = report;
   if (truncated_report.length > 512 * 1000) {
     truncated_report = truncated_report.slice(0, 512 * 1000) + "\n\n...truncated...";


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
