### PR TITLE
Fixes #8555

### DIFF
--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -1043,17 +1043,27 @@ pub const Version = extern struct {
 
         var i: usize = 0;
 
-        i += strings.lengthOfLeadingWhitespaceASCII(input[i..]);
-        if (i == input.len) {
-            result.valid = false;
-            return result;
+        for (0..input.len) |c| {
+            switch (input[c]) {
+                // newlines & whitespace
+                ' ',
+                '\t',
+                '\n',
+                '\r',
+                std.ascii.control_code.vt,
+                std.ascii.control_code.ff,
+
+                // version separators
+                'v',
+                '=',
+                => {},
+                else => {
+                    i = c;
+                    break;
+                },
+            }
         }
 
-        if (input[i] == 'v' or input[i] == '=') {
-            i += 1;
-        }
-
-        i += strings.lengthOfLeadingWhitespaceASCII(input[i..]);
         if (i == input.len) {
             result.valid = false;
             return result;


### PR DESCRIPTION
### What does this PR do?

Some packages seem to have `v` in the "version" field in package.json. Bun currently assumes the `"version"` string always matches exactly what was in the manifest.  We could make this check looser to also remove leading/trailing ASCII whitespace, but it is unnecessary work to do so. 

### How did you verify your code works?

I didn't. Should really add a test here.