### PR TITLE
create zig.exe symlink on every download-zig.sh execution

### DIFF
--- a/scripts/download-zig.sh
+++ b/scripts/download-zig.sh
@@ -59,13 +59,11 @@ update_repo_if_needed() {
     done
 
     printf "Zig was updated to ${zig_version}. Please commit new files."
-
-    # symlink extracted zig to  extracted zig.exe
-    # TODO: Workaround for https://github.com/ziglang/vscode-zig/issues/164
-    ln -sf "${extract_at}/zig" "${extract_at}/zig.exe"
-    chmod +x "${extract_at}/zig.exe"
-
   fi
+  # symlink extracted zig to  extracted zig.exe
+  # TODO: Workaround for https://github.com/ziglang/vscode-zig/issues/164
+  ln -sf "${extract_at}/zig" "${extract_at}/zig.exe"
+  chmod +x "${extract_at}/zig.exe"
 }
 
 if [ -e "${extract_at}/.version" ]; then


### PR DESCRIPTION
Symlink is not created on first setup.

see https://github.com/ziglang/vscode-zig/issues/164
and https://github.com/oven-sh/bun/pull/8147

### What does this PR do?

Moved the symlink creation out of the if statement to ensure it will be run on first clone and on subsequent updates of zig.

### How did you verify your code works?

Ran the script with empty `.cache` folder and again with zig already installed. `zig.exe` is present.