### PR TITLE
fix(windows): fix win32 errors

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -731,6 +731,10 @@ pub const Subprocess = struct {
             if (comptime Environment.isWindows) {
                 if (std.os.windows.kernel32.TerminateProcess(this.pid.process_handle, @intCast(sig)) == 0) {
                     const err = bun.windows.getLastErrno();
+                    if (comptime Environment.allow_assert) {
+                        std.debug.assert(err != .UNKNOWN);
+                    }
+
                     // if the process was already killed don't throw
                     //
                     // "After a process has terminated, call to TerminateProcess with open

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -141,6 +141,9 @@ pub fn Maybe(comptime ResultType: type) type {
         }
 
         pub inline fn errnoSys(rc: anytype, syscall: Syscall.Tag) ?@This() {
+            if (comptime Environment.isWindows) {
+                if (rc != 0) return null;
+            }
             return switch (Syscall.getErrno(rc)) {
                 .SUCCESS => null,
                 else => |err| @This(){
@@ -164,6 +167,9 @@ pub fn Maybe(comptime ResultType: type) type {
         }
 
         pub inline fn errnoSysFd(rc: anytype, syscall: Syscall.Tag, fd: bun.FileDescriptor) ?@This() {
+            if (comptime Environment.isWindows) {
+                if (rc != 0) return null;
+            }
             return switch (Syscall.getErrno(rc)) {
                 .SUCCESS => null,
                 else => |err| @This(){
@@ -180,6 +186,9 @@ pub fn Maybe(comptime ResultType: type) type {
         pub inline fn errnoSysP(rc: anytype, syscall: Syscall.Tag, path: anytype) ?@This() {
             if (std.meta.Child(@TypeOf(path)) == u16) {
                 @compileError("Do not pass WString path to errnoSysP, it needs the path encoded as utf8");
+            }
+            if (comptime Environment.isWindows) {
+                if (rc != 0) return null;
             }
             return switch (Syscall.getErrno(rc)) {
                 .SUCCESS => null,

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -193,41 +193,11 @@ pub fn Maybe(comptime ResultType: type) type {
                 },
             };
         }
-
-        pub inline fn errnoSysWin32(rc: bun.windows.BOOL, syscall: Syscall.Tag) ?@This() {
-            if (rc != 0) return null;
-            return switch (bun.windows.getLastErrno()) {
-                .SUCCESS => null,
-                else => |err| @This(){
-                    .err = .{
-                        .errno = translateToErrInt(err),
-                        .syscall = syscall,
-                    },
-                },
-            };
-        }
-
-        pub inline fn errnoSysWin32P(rc: bun.windows.BOOL, syscall: Syscall.Tag, path: anytype) ?@This() {
-            if (std.meta.Child(@TypeOf(path)) == u16) {
-                @compileError("Do not pass WString path to errnoSysWin32P, it needs the path encoded as utf8");
-            }
-            if (rc != 0) return null;
-            return switch (bun.windows.getLastErrno()) {
-                .SUCCESS => null,
-                else => |err| @This(){
-                    .err = .{
-                        .errno = translateToErrInt(err),
-                        .syscall = syscall,
-                    },
-                },
-            };
-        }
     };
 }
 
 fn translateToErrInt(err: anytype) bun.sys.Error.Int {
     return switch (@TypeOf(err)) {
-        bun.windows.Win32Error => @intFromEnum(bun.windows.translateWinErrorToErrno(err)),
         bun.windows.NTSTATUS => @intFromEnum(bun.windows.translateNTStatusToErrno(err)),
         else => @truncate(@intFromEnum(err)),
     };

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -193,6 +193,35 @@ pub fn Maybe(comptime ResultType: type) type {
                 },
             };
         }
+
+        pub inline fn errnoSysWin32(rc: bun.windows.BOOL, syscall: Syscall.Tag) ?@This() {
+            if (rc != 0) return null;
+            return switch (bun.windows.getLastErrno()) {
+                .SUCCESS => null,
+                else => |err| @This(){
+                    .err = .{
+                        .errno = translateToErrInt(err),
+                        .syscall = syscall,
+                    },
+                },
+            };
+        }
+
+        pub inline fn errnoSysWin32P(rc: bun.windows.BOOL, syscall: Syscall.Tag, path: anytype) ?@This() {
+            if (std.meta.Child(@TypeOf(path)) == u16) {
+                @compileError("Do not pass WString path to errnoSysWin32P, it needs the path encoded as utf8");
+            }
+            if (rc != 0) return null;
+            return switch (bun.windows.getLastErrno()) {
+                .SUCCESS => null,
+                else => |err| @This(){
+                    .err = .{
+                        .errno = translateToErrInt(err),
+                        .syscall = syscall,
+                    },
+                },
+            };
+        }
     };
 }
 

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -271,7 +271,7 @@ pub fn mkdir(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
 
         .windows => {
             var wbuf: bun.WPathBuffer = undefined;
-            return Maybe(void).errnoSysWin32P(
+            return Maybe(void).errnoSysP(
                 kernel32.CreateDirectoryW(bun.strings.toWPath(&wbuf, file_path).ptr, null),
                 .mkdir,
                 file_path,
@@ -303,7 +303,7 @@ pub fn mkdirA(file_path: []const u8, flags: bun.Mode) Maybe(void) {
 
     if (comptime Environment.isWindows) {
         var wbuf: bun.WPathBuffer = undefined;
-        return Maybe(void).errnoSysWin32P(
+        return Maybe(void).errnoSysP(
             kernel32.CreateDirectoryW(bun.strings.toWPath(&wbuf, file_path).ptr, null),
             .mkdir,
             file_path,
@@ -315,7 +315,7 @@ pub fn mkdirOSPath(file_path: bun.OSPathSliceZ, flags: bun.Mode) Maybe(void) {
     return switch (Environment.os) {
         else => mkdir(file_path, flags),
         .windows => {
-            return Maybe(void).errnoSysWin32(
+            return Maybe(void).errnoSys(
                 kernel32.CreateDirectoryW(file_path, null),
                 .mkdir,
             ) orelse Maybe(void).success;

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -271,11 +271,11 @@ pub fn mkdir(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
 
         .windows => {
             var wbuf: bun.WPathBuffer = undefined;
-            const rc = kernel32.CreateDirectoryW(bun.strings.toWPath(&wbuf, file_path).ptr, null);
-            return if (rc != 0)
-                Maybe(void).success
-            else
-                Maybe(void).errnoSys(rc, .mkdir) orelse Maybe(void).success;
+            return Maybe(void).errnoSysWin32P(
+                kernel32.CreateDirectoryW(bun.strings.toWPath(&wbuf, file_path).ptr, null),
+                .mkdir,
+                file_path,
+            ) orelse Maybe(void).success;
         },
 
         else => @compileError("mkdir is not implemented on this platform"),
@@ -303,11 +303,11 @@ pub fn mkdirA(file_path: []const u8, flags: bun.Mode) Maybe(void) {
 
     if (comptime Environment.isWindows) {
         var wbuf: bun.WPathBuffer = undefined;
-        const rc = kernel32.CreateDirectoryW(bun.strings.toWPath(&wbuf, file_path).ptr, null);
-        return if (rc != 0)
-            Maybe(void).success
-        else
-            Maybe(void).errnoSys(rc, .mkdir) orelse Maybe(void).success;
+        return Maybe(void).errnoSysWin32P(
+            kernel32.CreateDirectoryW(bun.strings.toWPath(&wbuf, file_path).ptr, null),
+            .mkdir,
+            file_path,
+        ) orelse Maybe(void).success;
     }
 }
 
@@ -315,11 +315,10 @@ pub fn mkdirOSPath(file_path: bun.OSPathSliceZ, flags: bun.Mode) Maybe(void) {
     return switch (Environment.os) {
         else => mkdir(file_path, flags),
         .windows => {
-            const rc = kernel32.CreateDirectoryW(file_path, null);
-            return if (rc != 0)
-                Maybe(void).success
-            else
-                Maybe(void).errnoSys(rc, .mkdir) orelse Maybe(void).success;
+            return Maybe(void).errnoSysWin32(
+                kernel32.CreateDirectoryW(file_path, null),
+                .mkdir,
+            ) orelse Maybe(void).success;
         },
     };
 }

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -2999,6 +2999,7 @@ pub fn translateWinErrorToErrno(err: win32.Win32Error) bun.C.E {
         .NOT_ENOUGH_MEMORY => .NOMEM,
         .OUTOFMEMORY => .NOMEM,
         .INVALID_PARAMETER => .INVAL,
+        .ALREADY_EXISTS => .EXIST,
 
         else => |t| {
             // if (bun.Environment.isDebug) {

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -2938,7 +2938,7 @@ pub const Win32Error = enum(u16) {
     }
 
     pub fn toSystemErrno(this: Win32Error) ?SystemErrno {
-        return SystemErrno.init(@intFromEnum(translateWinErrorToErrno(@enumFromInt(@intFromEnum(this)))));
+        return SystemErrno.init(this);
     }
 
     pub fn fromNTStatus(status: win32.NTSTATUS) Win32Error {
@@ -2985,29 +2985,7 @@ pub extern "kernel32" fn SetFileInformationByHandle(
 ) BOOL;
 
 pub fn getLastErrno() bun.C.E {
-    return translateWinErrorToErrno(bun.windows.kernel32.GetLastError());
-}
-
-pub fn translateWinErrorToErrno(err: win32.Win32Error) bun.C.E {
-    return switch (err) {
-        .SUCCESS => .SUCCESS,
-        .FILE_NOT_FOUND => .NOENT,
-        .PATH_NOT_FOUND => .NOENT,
-        .TOO_MANY_OPEN_FILES => .NOMEM,
-        .ACCESS_DENIED => .PERM,
-        .INVALID_HANDLE => .BADF,
-        .NOT_ENOUGH_MEMORY => .NOMEM,
-        .OUTOFMEMORY => .NOMEM,
-        .INVALID_PARAMETER => .INVAL,
-        .ALREADY_EXISTS => .EXIST,
-
-        else => |t| {
-            // if (bun.Environment.isDebug) {
-            bun.Output.warn("Called translateWinErrorToErrno with {s} which does not have a mapping to errno.", .{@tagName(t)});
-            // }
-            return .UNKNOWN;
-        },
-    };
+    return (bun.C.SystemErrno.init(bun.windows.kernel32.GetLastError()) orelse SystemErrno.EUNKNOWN).toE();
 }
 
 pub fn translateNTStatusToErrno(err: win32.NTSTATUS) bun.C.E {

--- a/src/windows_c.zig
+++ b/src/windows_c.zig
@@ -701,8 +701,8 @@ pub const SystemErrno = enum(u16) {
             }
         }
 
-        if (comptime @TypeOf(code) == Win32Error) {
-            return switch (code) {
+        if (comptime @TypeOf(code) == Win32Error or @TypeOf(code) == std.os.windows.Win32Error) {
+            return switch (@as(Win32Error, @enumFromInt(@intFromEnum(code)))) {
                 Win32Error.NOACCESS => SystemErrno.EACCES,
                 Win32Error.WSAEACCES => SystemErrno.EACCES,
                 Win32Error.ELEVATION_REQUIRED => SystemErrno.EACCES,
@@ -803,7 +803,7 @@ pub const SystemErrno = enum(u16) {
                 Win32Error.META_EXPANSION_TOO_LONG => SystemErrno.E2BIG,
                 Win32Error.WSAESOCKTNOSUPPORT => SystemErrno.ESOCKTNOSUPPORT,
                 Win32Error.DELETE_PENDING => SystemErrno.EBUSY,
-                else => return null,
+                else => null,
             };
         }
 


### PR DESCRIPTION
### What does this PR do?
fixes some test regressions
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
