### PR TITLE
Update launch.json to use `${workspaceFolder}/build/bun-debug`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -155,7 +155,7 @@
       "type": "lldb",
       "request": "launch",
       "name": "bun run [file]",
-      "program": "bun-debug",
+      "program": "${workspaceFolder}/build/bun-debug",
       "args": ["run", "${file}"],
       "cwd": "${fileDirname}",
       "env": {


### PR DESCRIPTION
I have `./build` added to my PATH. `bun-debug` is found in terminal but not found by vscode. This was the only solution that worked for me, so I thought it could help to have it as repo default. I'm also happy to update the other launch configs.

### What does this PR do?

It updates `launch.json` to pickup the `bun-debug` executable from `${workspaceFolder}/build`

### How did you verify your code works?

Hit f5 with selected `bun run [file]` launch config.