### PR TITLE
[bun:sqlite] Return changed row count for sqlite insert, update, delete on statement.run()

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -520,21 +520,21 @@ declare module "bun:sqlite" {
     get(...params: ParamsType): ReturnType | null;
 
     /**
-     * Execute the prepared statement. This returns `undefined`.
+     * Execute the prepared statement. Returns the number of rows changed for INSERT, UPDATE or DELETE statements.
      *
      * @param params optional values to bind to the statement. If omitted, the statement is run with the last bound values or no parameters if there are none.
      *
      * @example
      * ```ts
-     * const stmt = db.prepare("UPDATE foo SET bar = ?");
+     * const stmt = db.prepare("INSERT INTO foo (col1) VALUES(?1)");
      * stmt.run("baz");
-     * // => undefined
+     * // => 1
      *
      * stmt.run();
-     * // => undefined
+     * // => 1
      *
      * stmt.run("foo");
-     * // => undefined
+     * // => 1
      * ```
      *
      * The following types can be used when binding parameters:

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -1780,17 +1780,20 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun, (JSC::JSGlob
         DO_REBIND(arg0);
     }
 
+    JSValue result = jsUndefined();
     int status = sqlite3_step(stmt);
+
     if (!sqlite3_stmt_readonly(stmt)) {
         castedThis->version_db->version++;
-    }
-
-    if (!castedThis->hasExecuted || castedThis->need_update()) {
-        initializeColumnNames(lexicalGlobalObject, castedThis);
+        result = jsNumber(sqlite3_changes(castedThis->version_db->db));
     }
 
     while (status == SQLITE_ROW) {
         status = sqlite3_step(stmt);
+    }
+
+    if (!castedThis->hasExecuted || castedThis->need_update()) {
+        initializeColumnNames(lexicalGlobalObject, castedThis);
     }
 
     if (UNLIKELY(status != SQLITE_DONE && status != SQLITE_OK)) {
@@ -1799,7 +1802,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun, (JSC::JSGlob
         return JSValue::encode(jsUndefined());
     }
 
-    RELEASE_AND_RETURN(scope, JSC::JSValue::encode(jsUndefined()));
+    RELEASE_AND_RETURN(scope, JSC::JSValue::encode(result));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsSQLStatementToStringFunction, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -1753,12 +1753,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun, (JSC::JSGlob
         result = jsNumber(sqlite3_changes(castedThis->version_db->db));
     }
 
-    while (status == SQLITE_ROW) {
-        status = sqlite3_step(stmt);
-    }
-
-    if (!castedThis->hasExecuted || castedThis->need_update()) {
-        initializeColumnNames(lexicalGlobalObject, castedThis);
+    if (status == SQLITE_ROW) {
+        status = sqlite3_reset(stmt);
     }
 
     if (UNLIKELY(status != SQLITE_DONE && status != SQLITE_OK)) {

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -1550,12 +1550,10 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
 
     JSValue result = jsUndefined();
     JSC::JSArray* resultArray = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, 0);
-    {
-        while (status == SQLITE_ROW) {
-            JSC::JSValue result = constructResultObject(lexicalGlobalObject, castedThis);
-            resultArray->push(lexicalGlobalObject, result);
-            status = sqlite3_step(stmt);
-        }
+    while (status == SQLITE_ROW) {
+        JSC::JSValue result = constructResultObject(lexicalGlobalObject, castedThis);
+        resultArray->push(lexicalGlobalObject, result);
+        status = sqlite3_step(stmt);
     }
     result = resultArray;
 
@@ -1701,10 +1699,11 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
     }
 
     JSValue result = jsUndefined();
-    JSC::ObjectInitializationScope initializationScope(vm);
-    JSC::GCDeferralContext deferralContext(vm);
     JSC::JSArray* resultArray = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, 0);
+
     {
+        JSC::ObjectInitializationScope initializationScope(vm);
+        JSC::GCDeferralContext deferralContext(vm);
         while (status == SQLITE_ROW) {
             JSC::JSValue row = constructResultRow(lexicalGlobalObject, castedThis, initializationScope, &deferralContext);
             resultArray->push(lexicalGlobalObject, row);

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -101,7 +101,7 @@ class Statement {
   }
 
   #runNoArgs() {
-    this.#raw.run();
+    return this.#raw.run();
   }
 
   #get(...args) {
@@ -143,8 +143,7 @@ class Statement {
   #run(...args) {
     if (args.length === 0) return this.#runNoArgs();
     var arg0 = args[0];
-
-    !isArray(arg0) && (!arg0 || typeof arg0 !== "object" || isTypedArray(arg0))
+    return !isArray(arg0) && (!arg0 || typeof arg0 !== "object" || isTypedArray(arg0))
       ? this.#raw.run(args)
       : this.#raw.run(...args);
   }

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -760,10 +760,12 @@ it("change count", () => {
         ('upd', 'val'),
         ('del', 'val')`).run(Array(6).fill('value'))).toBe(6);
 
-    expect(db.query("UPDATE foo SET name='newname' WHERE name='nonexistant'").run()).toBe(0);
+    expect(db.query("UPDATE foo SET name='newname' WHERE name='nonexistent'").run()).toBe(0);
+    expect(db.query("UPDATE foo SET name=?").run()).toBe(0);
     expect(db.query("UPDATE foo SET name='newname' WHERE name='upd'").run()).toBe(2);
-    expect(db.query("DELETE FROM foo WHERE name='nonexistant'").run()).toBe(0);
+    expect(db.query("DELETE FROM foo WHERE name='nonexistent'").run()).toBe(0);
     expect(db.query("DELETE FROM foo WHERE name='del'").run()).toBe(1);
+    expect(db.query("INSERT INTO foo(name) VALUES(?1)").run()).toBe(1);
     expect(db.query("SELECT * FROM foo").run()).toBe(undefined);
 });
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -760,7 +760,6 @@ it("change count", () => {
         ('del', 'val')`).run(Array(6).fill('value'))).toBe(6);
 
     expect(db.query("UPDATE foo SET name='newname' WHERE name='nonexistent'").run()).toBe(0);
-    expect(db.query("UPDATE foo SET name=?").run()).toBe(0);
     expect(db.query("UPDATE foo SET name='newname' WHERE name='upd'").run()).toBe(2);
     expect(db.query("DELETE FROM foo WHERE name='nonexistent'").run()).toBe(0);
     expect(db.query("DELETE FROM foo WHERE name='del'").run()).toBe(1);

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -5,7 +5,6 @@ import { spawnSync } from "bun";
 import { bunExe } from "harness";
 import { tmpdir } from "os";
 import path from "path";
-import { last } from "lodash";
 
 const tmpbase = tmpdir() + path.sep;
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -5,6 +5,7 @@ import { spawnSync } from "bun";
 import { bunExe } from "harness";
 import { tmpdir } from "os";
 import path from "path";
+import { last } from "lodash";
 
 const tmpbase = tmpdir() + path.sep;
 
@@ -435,46 +436,46 @@ it("inlineCapacity #987", async () => {
 
   const db = new Database(path);
 
-  const query = `SELECT 
-  media.mid, 
-  UPPER(media.name) as name, 
-  media.url, 
-  media.duration, 
-  time(media.duration, 'unixepoch') AS durationStr, 
-  sum(totalDurations) AS totalDurations, 
-  sum(logs.views) AS views, 
-  total.venues, 
-  total.devices, 
+  const query = `SELECT
+  media.mid,
+  UPPER(media.name) as name,
+  media.url,
+  media.duration,
+  time(media.duration, 'unixepoch') AS durationStr,
+  sum(totalDurations) AS totalDurations,
+  sum(logs.views) AS views,
+  total.venues,
+  total.devices,
   SUM(CASE WHEN day = '01' THEN logs.views ELSE 0 END) as 'vi01', SUM(CASE WHEN day = '02' THEN logs.views ELSE 0 END) as 'vi02', SUM(CASE WHEN day = '03' THEN logs.views ELSE 0 END) as 'vi03', SUM(CASE WHEN day = '04' THEN logs.views ELSE 0 END) as 'vi04', SUM(CASE WHEN day = '05' THEN logs.views ELSE 0 END) as 'vi05', SUM(CASE WHEN day = '06' THEN logs.views ELSE 0 END) as 'vi06', SUM(CASE WHEN day = '07' THEN logs.views ELSE 0 END) as 'vi07', SUM(CASE WHEN day = '08' THEN logs.views ELSE 0 END) as 'vi08', SUM(CASE WHEN day = '09' THEN logs.views ELSE 0 END) as 'vi09', SUM(CASE WHEN day = '10' THEN logs.views ELSE 0 END) as 'vi10', SUM(CASE WHEN day = '11' THEN logs.views ELSE 0 END) as 'vi11', SUM(CASE WHEN day = '12' THEN logs.views ELSE 0 END) as 'vi12', SUM(CASE WHEN day = '13' THEN logs.views ELSE 0 END) as 'vi13', SUM(CASE WHEN day = '14' THEN logs.views ELSE 0 END) as 'vi14', SUM(CASE WHEN day = '15' THEN logs.views ELSE 0 END) as 'vi15', SUM(CASE WHEN day = '16' THEN logs.views ELSE 0 END) as 'vi16', SUM(CASE WHEN day = '17' THEN logs.views ELSE 0 END) as 'vi17', SUM(CASE WHEN day = '18' THEN logs.views ELSE 0 END) as 'vi18', SUM(CASE WHEN day = '19' THEN logs.views ELSE 0 END) as 'vi19', SUM(CASE WHEN day = '20' THEN logs.views ELSE 0 END) as 'vi20', SUM(CASE WHEN day = '21' THEN logs.views ELSE 0 END) as 'vi21', SUM(CASE WHEN day = '22' THEN logs.views ELSE 0 END) as 'vi22', SUM(CASE WHEN day = '23' THEN logs.views ELSE 0 END) as 'vi23', SUM(CASE WHEN day = '24' THEN logs.views ELSE 0 END) as 'vi24', SUM(CASE WHEN day = '25' THEN logs.views ELSE 0 END) as 'vi25', SUM(CASE WHEN day = '26' THEN logs.views ELSE 0 END) as 'vi26', SUM(CASE WHEN day = '27' THEN logs.views ELSE 0 END) as 'vi27', SUM(CASE WHEN day = '28' THEN logs.views ELSE 0 END) as 'vi28', SUM(CASE WHEN day = '29' THEN logs.views ELSE 0 END) as 'vi29', SUM(CASE WHEN day = '30' THEN logs.views ELSE 0 END) as 'vi30', MAX(CASE WHEN day = '01' THEN logs.venues ELSE 0 END) as 've01', MAX(CASE WHEN day = '02' THEN logs.venues ELSE 0 END) as 've02', MAX(CASE WHEN day = '03' THEN logs.venues ELSE 0 END) as 've03', MAX(CASE WHEN day = '04' THEN logs.venues ELSE 0 END) as 've04', MAX(CASE WHEN day = '05' THEN logs.venues ELSE 0 END) as 've05', MAX(CASE WHEN day = '06' THEN logs.venues ELSE 0 END) as 've06', MAX(CASE WHEN day = '07' THEN logs.venues ELSE 0 END) as 've07', MAX(CASE WHEN day = '08' THEN logs.venues ELSE 0 END) as 've08', MAX(CASE WHEN day = '09' THEN logs.venues ELSE 0 END) as 've09', MAX(CASE WHEN day = '10' THEN logs.venues ELSE 0 END) as 've10', MAX(CASE WHEN day = '11' THEN logs.venues ELSE 0 END) as 've11', MAX(CASE WHEN day = '12' THEN logs.venues ELSE 0 END) as 've12', MAX(CASE WHEN day = '13' THEN logs.venues ELSE 0 END) as 've13', MAX(CASE WHEN day = '14' THEN logs.venues ELSE 0 END) as 've14', MAX(CASE WHEN day = '15' THEN logs.venues ELSE 0 END) as 've15', MAX(CASE WHEN day = '16' THEN logs.venues ELSE 0 END) as 've16', MAX(CASE WHEN day = '17' THEN logs.venues ELSE 0 END) as 've17', MAX(CASE WHEN day = '18' THEN logs.venues ELSE 0 END) as 've18', MAX(CASE WHEN day = '19' THEN logs.venues ELSE 0 END) as 've19', MAX(CASE WHEN day = '20' THEN logs.venues ELSE 0 END) as 've20', MAX(CASE WHEN day = '21' THEN logs.venues ELSE 0 END) as 've21', MAX(CASE WHEN day = '22' THEN logs.venues ELSE 0 END) as 've22', MAX(CASE WHEN day = '23' THEN logs.venues ELSE 0 END) as 've23', MAX(CASE WHEN day = '24' THEN logs.venues ELSE 0 END) as 've24', MAX(CASE WHEN day = '25' THEN logs.venues ELSE 0 END) as 've25', MAX(CASE WHEN day = '26' THEN logs.venues ELSE 0 END) as 've26', MAX(CASE WHEN day = '27' THEN logs.venues ELSE 0 END) as 've27', MAX(CASE WHEN day = '28' THEN logs.venues ELSE 0 END) as 've28', MAX(CASE WHEN day = '29' THEN logs.venues ELSE 0 END) as 've29', MAX(CASE WHEN day = '30' THEN logs.venues ELSE 0 END) as 've30', MAX(CASE WHEN day = '01' THEN logs.devices ELSE 0 END) as 'de01', MAX(CASE WHEN day = '02' THEN logs.devices ELSE 0 END) as 'de02', MAX(CASE WHEN day = '03' THEN logs.devices ELSE 0 END) as 'de03', MAX(CASE WHEN day = '04' THEN logs.devices ELSE 0 END) as 'de04', MAX(CASE WHEN day = '05' THEN logs.devices ELSE 0 END) as 'de05', MAX(CASE WHEN day = '06' THEN logs.devices ELSE 0 END) as 'de06', MAX(CASE WHEN day = '07' THEN logs.devices ELSE 0 END) as 'de07', MAX(CASE WHEN day = '08' THEN logs.devices ELSE 0 END) as 'de08', MAX(CASE WHEN day = '09' THEN logs.devices ELSE 0 END) as 'de09', MAX(CASE WHEN day = '10' THEN logs.devices ELSE 0 END) as 'de10', MAX(CASE WHEN day = '11' THEN logs.devices ELSE 0 END) as 'de11', MAX(CASE WHEN day = '12' THEN logs.devices ELSE 0 END) as 'de12', MAX(CASE WHEN day = '13' THEN logs.devices ELSE 0 END) as 'de13', MAX(CASE WHEN day = '14' THEN logs.devices ELSE 0 END) as 'de14', MAX(CASE WHEN day = '15' THEN logs.devices ELSE 0 END) as 'de15', MAX(CASE WHEN day = '16' THEN logs.devices ELSE 0 END) as 'de16', MAX(CASE WHEN day = '17' THEN logs.devices ELSE 0 END) as 'de17', MAX(CASE WHEN day = '18' THEN logs.devices ELSE 0 END) as 'de18', MAX(CASE WHEN day = '19' THEN logs.devices ELSE 0 END) as 'de19', MAX(CASE WHEN day = '20' THEN logs.devices ELSE 0 END) as 'de20', MAX(CASE WHEN day = '21' THEN logs.devices ELSE 0 END) as 'de21', MAX(CASE WHEN day = '22' THEN logs.devices ELSE 0 END) as 'de22', MAX(CASE WHEN day = '23' THEN logs.devices ELSE 0 END) as 'de23', MAX(CASE WHEN day = '24' THEN logs.devices ELSE 0 END) as 'de24', MAX(CASE WHEN day = '25' THEN logs.devices ELSE 0 END) as 'de25', MAX(CASE WHEN day = '26' THEN logs.devices ELSE 0 END) as 'de26', MAX(CASE WHEN day = '27' THEN logs.devices ELSE 0 END) as 'de27', MAX(CASE WHEN day = '28' THEN logs.devices ELSE 0 END) as 'de28', MAX(CASE WHEN day = '29' THEN logs.devices ELSE 0 END) as 'de29', MAX(CASE WHEN day = '30' THEN logs.devices ELSE 0 END) as 'de30'
-  FROM 
+  FROM
   (
-    SELECT 
-      logs.mid, 
-      sum(logs.duration) AS totalDurations, 
-      strftime ('%d', START, 'unixepoch', 'localtime') AS day, 
-      count(*) AS views, 
-      count(DISTINCT did) AS devices, 
-      count(DISTINCT vid) AS venues 
-    FROM 
-      logs 
+    SELECT
+      logs.mid,
+      sum(logs.duration) AS totalDurations,
+      strftime ('%d', START, 'unixepoch', 'localtime') AS day,
+      count(*) AS views,
+      count(DISTINCT did) AS devices,
+      count(DISTINCT vid) AS venues
+    FROM
+      logs
     WHERE strftime('%m-%Y', start, 'unixepoch', 'localtime')='06-2022'
-    GROUP BY 
-      day, 
+    GROUP BY
+      day,
       logs.mid
-  ) logs 
-  INNER JOIN media ON media.id = logs.mid 
+  ) logs
+  INNER JOIN media ON media.id = logs.mid
   INNER JOIN (
-    SELECT 
-      mid, 
-      count(DISTINCT vid) as venues, 
-      count(DISTINCT did) as devices 
-    FROM 
-      logs 
+    SELECT
+      mid,
+      count(DISTINCT vid) as venues,
+      count(DISTINCT did) as devices
+    FROM
+      logs
     WHERE strftime('%m-%Y', start, 'unixepoch', 'localtime')='06-2022'
-    GROUP by 
+    GROUP by
       mid
-  ) total ON logs.mid = total.mid 
-  ORDER BY 
+  ) total ON logs.mid = total.mid
+  ORDER BY
   name`;
 
   expect(Object.keys(db.query(query).all()[0]).length).toBe(99);
@@ -674,7 +675,7 @@ it("multiple statements with a schema change", () => {
   const db = new Database(":memory:");
   db.run(
     `
-    CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT); 
+    CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);
     CREATE TABLE bar (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);
 
     INSERT INTO foo (name) VALUES ('foo');
@@ -743,3 +744,36 @@ it("multiple statements", () => {
     }
   }
 });
+
+it("change count", () => {
+    const db = new Database(":memory:");
+    db.run("CREATE TABLE foo (id INTEGER PRIMARY KEY, name TEXT, game TEXT)");
+
+    expect(db.query(
+    `INSERT INTO foo
+        (name, game)
+     VALUES
+        (?1, ?2),
+        (?3, ?4),
+        (?5, ?6),
+        ('upd', 'val'),
+        ('upd', 'val'),
+        ('del', 'val')`).run(Array(6).fill('value'))).toBe(6);
+
+    expect(db.query("UPDATE foo SET name='newname' WHERE name='nonexistant'").run()).toBe(0);
+    expect(db.query("UPDATE foo SET name='newname' WHERE name='upd'").run()).toBe(2);
+    expect(db.query("DELETE FROM foo WHERE name='nonexistant'").run()).toBe(0);
+    expect(db.query("DELETE FROM foo WHERE name='del'").run()).toBe(1);
+    expect(db.query("SELECT * FROM foo").run()).toBe(undefined);
+});
+
+
+it("get rowid", () => {
+    const db = new Database(":memory:");
+    db.run("CREATE TABLE foo (id INTEGER PRIMARY KEY, name TEXT, game TEXT)");
+    expect(db.query("INSERT INTO foo (name, game) VALUES (?1, ?2)").run(['name', 'game'])).toBe(1);
+    const lastId = db.query("SELECT last_insert_rowid() as id").get().id
+    const theId = db.query("SELECT id from foo").get().id
+    expect(lastId).toBe(theId);
+});
+


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

fixes #3284 fixes #8284. Returns changed row count for sqlite insert, update, delete statements with statement.run()

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

- [x] I wrote automated tests
- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)


<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
