### PR TITLE
Issue-6526 - clarify web docs for the use of `.only()`

### DIFF
--- a/docs/test/writing.md
+++ b/docs/test/writing.md
@@ -109,7 +109,7 @@ $ bun test --todo
 
 ## `test.only`
 
-To run a particular test or suite of tests use `test.only()` or `describe.only()`. Once declared, running `bun test --only` will only execute tests/suites that have been marked with `.only()`.
+To run a particular test or suite of tests use `test.only()` or `describe.only()`. Once declared, running `bun test --only` will only execute tests/suites that have been marked with `.only()`. Running `bun test` without the `--only` option with `test.only()` declared will result in all tests in the given suite being executed _up to_ the test with `.only()`. `describe.only()` functions the same in both execution scenarios.
 
 ```ts
 import { test, describe } from "bun:test";
@@ -133,6 +133,12 @@ The following command will only execute tests #2 and #3.
 
 ```sh
 $ bun test --only
+```
+
+The following command will only execute tests #1, #2 and #3.
+
+```sh
+$ bun test
 ```
 
 ## `test.if`

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -346,7 +346,7 @@ declare module "bun:test" {
       options?: number | TestOptions,
     ): void;
     /**
-     * Skips all other tests, except this test.
+     * Skips all other tests, except this test when run with the `--only` option.
      *
      * @param label the label for the test
      * @param fn the test function


### PR DESCRIPTION
### What does this PR do?

This updates the web docs to clarify the use of `.only()` in tests. Added similar clarification in JSDoc per the reported issue.

Fix: https://github.com/oven-sh/bun/issues/6526

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)