### PR TITLE
windows: re-enable the not posix path assertion

### DIFF
--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -641,6 +641,14 @@ pub fn startsWith(self: string, str: string) bool {
     return eqlLong(self[0..str.len], str, false);
 }
 
+pub fn startsWithGeneric(comptime T: type, self: []const T, str: []const T) bool {
+    if (str.len > self.len) {
+        return false;
+    }
+
+    return eqlLong(bun.reinterpretSlice(u8, self[0..str.len]), str, false);
+}
+
 pub inline fn endsWith(self: string, str: string) bool {
     return str.len == 0 or @call(.always_inline, std.mem.endsWith, .{ u8, self, str });
 }
@@ -832,8 +840,19 @@ pub fn hasPrefixComptimeUTF16(self: []const u16, comptime alt: []const u8) bool 
     return self.len >= alt.len and eqlComptimeCheckLenWithType(u16, self[0..alt.len], comptime toUTF16Literal(alt), false);
 }
 
-pub fn hasPrefixComptimeType(comptime T: type, self: []const T, comptime alt: []const T) bool {
-    return self.len >= alt.len and eqlComptimeCheckLenWithType(u16, self[0..alt.len], alt, false);
+pub fn hasPrefixComptimeType(comptime T: type, self: []const T, comptime alt: anytype) bool {
+    const rhs = comptime switch (T) {
+        u8 => alt,
+        u16 => switch (std.meta.Child(@TypeOf(alt))) {
+            u8 => w(alt),
+            else => |t| switch (std.meta.Child(t)) {
+                u8 => w(alt),
+                else => alt,
+            },
+        },
+        else => unreachable,
+    };
+    return self.len >= alt.len and eqlComptimeCheckLenWithType(T, self[0..rhs.len], rhs, false);
 }
 
 pub fn hasSuffixComptime(self: string, comptime alt: anytype) bool {
@@ -1634,10 +1653,22 @@ pub fn utf16Codepoint(comptime Type: type, input: Type) UTF16Replacement {
     }
 }
 
-fn windowsPathIsPosixAbsolute(utf8: []const u8) bool {
-    if (utf8.len == 0) return false;
-    if (!charIsAnySlash(utf8[0])) return false;
-    if (utf8.len > 1 and charIsAnySlash(utf8[1])) return false;
+/// '/hello' -> true
+/// '\hello' -> true
+/// 'C:/hello' -> false
+/// '\??\C:\hello' -> false
+fn windowsPathIsPosixAbsolute(comptime T: type, chars: []const T) bool {
+    if (chars.len == 0) return false;
+    if (!(chars[0] == '/' or chars[0] == '\\')) return false;
+    if (chars.len > 1 and
+        (chars[1] == '/' or chars[1] == '\\')) return false;
+    if (chars.len > 2 and
+        chars[2] == ':') return false;
+    if (chars.len > 4 and
+        chars[1] == '?' and
+        chars[2] == '?' and
+        (chars[3] == '/' or chars[3] == '\\'))
+        return windowsPathIsPosixAbsolute(T, chars[4..]);
     return true;
 }
 
@@ -1738,11 +1769,16 @@ pub fn toWDirPath(wbuf: []u16, utf8: []const u8) [:0]const u16 {
     return toWPathMaybeDir(wbuf, utf8, true);
 }
 
-pub fn assertIsValidWindowsPath(utf8: []const u8) void {
+pub fn assertIsValidWindowsPath(comptime T: type, path: []const T) void {
     if (Environment.allow_assert and Environment.isWindows) {
-        if (startsWith(utf8, ":/")) {
+        if (windowsPathIsPosixAbsolute(T, path)) {
+            std.debug.panic("Do not pass posix paths to windows APIs, was given '{s}' (missing a root like 'C:\\', see PosixToWinNormalizer for why this is an assertion)", .{
+                if (T == u8) path else std.unicode.fmtUtf16le(path),
+            });
+        }
+        if (hasPrefixComptimeType(T, path, ":/")) {
             std.debug.panic("Path passed to windows API '{s}' is almost certainly invalid. Where did the drive letter go?", .{
-                utf8,
+                if (T == u8) path else std.unicode.fmtUtf16le(path),
             });
         }
     }
@@ -1750,8 +1786,6 @@ pub fn assertIsValidWindowsPath(utf8: []const u8) void {
 
 pub fn toWPathMaybeDir(wbuf: []u16, utf8: []const u8, comptime add_trailing_lash: bool) [:0]const u16 {
     std.debug.assert(wbuf.len > 0);
-
-    assertIsValidWindowsPath(utf8);
 
     var result = bun.simdutf.convert.utf8.to.utf16.with_errors.le(
         utf8,

--- a/src/sys_uv.zig
+++ b/src/sys_uv.zig
@@ -15,6 +15,7 @@ const E = C.E;
 const linux = os.linux;
 const Maybe = JSC.Maybe;
 const kernel32 = bun.windows;
+const assertIsValidWindowsPath = bun.strings.assertIsValidWindowsPath;
 
 const uv = bun.windows.libuv;
 
@@ -38,6 +39,8 @@ pub const mkdirOSPath = bun.sys.mkdirOSPath;
 // Note: `req = undefined; req.deinit()` has a saftey-check in a debug build
 
 pub fn open(file_path: [:0]const u8, c_flags: bun.Mode, _perm: bun.Mode) Maybe(bun.FileDescriptor) {
+    assertIsValidWindowsPath(u8, file_path);
+
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
 
@@ -58,6 +61,7 @@ pub fn open(file_path: [:0]const u8, c_flags: bun.Mode, _perm: bun.Mode) Maybe(b
 }
 
 pub fn mkdir(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
+    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_mkdir(uv.Loop.get(), &req, file_path.ptr, flags, null);
@@ -70,6 +74,7 @@ pub fn mkdir(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
 }
 
 pub fn chmod(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
+    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_chmod(uv.Loop.get(), &req, file_path.ptr, flags, null);
@@ -95,6 +100,7 @@ pub fn fchmod(fd: FileDescriptor, flags: bun.Mode) Maybe(void) {
 }
 
 pub fn chown(file_path: [:0]const u8, uid: uv.uv_uid_t, gid: uv.uv_uid_t) Maybe(void) {
+    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_chown(uv.Loop.get(), &req, file_path.ptr, uid, gid, null);
@@ -121,6 +127,7 @@ pub fn fchown(fd: FileDescriptor, uid: uv.uv_uid_t, gid: uv.uv_uid_t) Maybe(void
 }
 
 pub fn access(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
+    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_access(uv.Loop.get(), &req, file_path.ptr, flags, null);
@@ -133,6 +140,7 @@ pub fn access(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
 }
 
 pub fn rmdir(file_path: [:0]const u8) Maybe(void) {
+    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_rmdir(uv.Loop.get(), &req, file_path.ptr, null);
@@ -145,6 +153,7 @@ pub fn rmdir(file_path: [:0]const u8) Maybe(void) {
 }
 
 pub fn unlink(file_path: [:0]const u8) Maybe(void) {
+    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_unlink(uv.Loop.get(), &req, file_path.ptr, null);
@@ -157,6 +166,7 @@ pub fn unlink(file_path: [:0]const u8) Maybe(void) {
 }
 
 pub fn readlink(file_path: [:0]const u8, buf: []u8) Maybe(usize) {
+    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     // Edge cases: http://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_realpath
@@ -180,6 +190,8 @@ pub fn readlink(file_path: [:0]const u8, buf: []u8) Maybe(usize) {
 }
 
 pub fn rename(from: [:0]const u8, to: [:0]const u8) Maybe(void) {
+    assertIsValidWindowsPath(u8, from);
+    assertIsValidWindowsPath(u8, to);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_rename(uv.Loop.get(), &req, from.ptr, to.ptr, null);
@@ -192,6 +204,8 @@ pub fn rename(from: [:0]const u8, to: [:0]const u8) Maybe(void) {
 }
 
 pub fn link(from: [:0]const u8, to: [:0]const u8) Maybe(void) {
+    assertIsValidWindowsPath(u8, from);
+    assertIsValidWindowsPath(u8, to);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_link(uv.Loop.get(), &req, from.ptr, to.ptr, null);
@@ -204,6 +218,8 @@ pub fn link(from: [:0]const u8, to: [:0]const u8) Maybe(void) {
 }
 
 pub fn symlinkUV(from: [:0]const u8, to: [:0]const u8, flags: c_int) Maybe(void) {
+    assertIsValidWindowsPath(u8, from);
+    assertIsValidWindowsPath(u8, to);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_symlink(uv.Loop.get(), &req, from.ptr, to.ptr, flags, null);
@@ -268,6 +284,7 @@ pub fn fsync(fd: FileDescriptor) Maybe(void) {
 }
 
 pub fn stat(path: [:0]const u8) Maybe(bun.Stat) {
+    assertIsValidWindowsPath(u8, path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_stat(uv.Loop.get(), &req, path.ptr, null);
@@ -280,6 +297,7 @@ pub fn stat(path: [:0]const u8) Maybe(bun.Stat) {
 }
 
 pub fn lstat(path: [:0]const u8) Maybe(bun.Stat) {
+    assertIsValidWindowsPath(u8, path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_lstat(uv.Loop.get(), &req, path.ptr, null);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
