### PR TITLE
fix: id instead of path

### DIFF
--- a/src/js/builtins/Module.ts
+++ b/src/js/builtins/Module.ts
@@ -86,8 +86,8 @@ export function overridableRequire(this: CommonJSModuleRecord, id: string) {
 }
 
 $visibility = "Private";
-export function requireResolve(this: string | { path: string }, id: string) {
-  return $resolveSync(id, typeof this === "string" ? this : this?.path, false);
+export function requireResolve(this: string | { id: string }, id: string) {
+  return $resolveSync(id, typeof this === "string" ? this : this?.id, false);
 }
 
 $visibility = "Private";

--- a/src/js/builtins/Module.ts
+++ b/src/js/builtins/Module.ts
@@ -12,7 +12,7 @@ export function require(this: CommonJSModuleRecord, id: string) {
 $overriddenName = "require";
 $visibility = "Private";
 export function overridableRequire(this: CommonJSModuleRecord, id: string) {
-  const existing = $requireMap.$get(id) || $requireMap.$get((id = $resolveSync(id, this.path, false)));
+  const existing = $requireMap.$get(id) || $requireMap.$get((id = $resolveSync(id, this.id, false)));
   if (existing) {
     // Scenario where this is necessary:
     //


### PR DESCRIPTION
### What does this PR do?
fixes some tests
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
