### PR TITLE
windows: fix module.paths getter causing a crash

### DIFF
--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -1122,7 +1122,8 @@ pub fn joinStringBuf(buf: []u8, parts: anytype, comptime _platform: Platform) []
 
     var count: usize = 0;
     for (parts) |part| {
-        count += if (part.len > 0) part.len + 1 else 0;
+        if (part.len == 0) continue;
+        count += part.len + 1;
     }
 
     if (count * 2 > temp_buf.len) {
@@ -1133,9 +1134,7 @@ pub fn joinStringBuf(buf: []u8, parts: anytype, comptime _platform: Platform) []
     temp_buf[0] = 0;
 
     for (parts) |part| {
-        if (part.len == 0) {
-            continue;
-        }
+        if (part.len == 0) continue;
 
         if (written > 0) {
             temp_buf[written] = platform.separator();

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3278,8 +3278,7 @@ pub const Resolver = struct {
 
         const str = brk: {
             if (std.fs.path.isAbsolute(sliced.slice())) break :brk sliced.slice();
-            const dir_path_buf = bufs(.node_modules_paths_buf);
-            break :brk r.fs.joinBuf(&[_]string{ r.fs.top_level_dir, sliced.slice() }, dir_path_buf);
+            break :brk bun.path.join(&[_]string{ r.fs.top_level_dir, sliced.slice() }, .auto);
         };
         var arena = std.heap.ArenaAllocator.init(bun.default_allocator);
         defer arena.deinit();
@@ -3297,11 +3296,9 @@ pub const Resolver = struct {
 
                     break :brk [2]string{ path_without_trailing_slash, "/node_modules" };
                 };
-                list.append(
-                    bun.String.createUTF8(
-                        bun.strings.concat(stack_fallback_allocator.get(), &path_parts) catch unreachable,
-                    ),
-                ) catch unreachable;
+                const nodemodules_path = bun.strings.concat(stack_fallback_allocator.get(), &path_parts) catch unreachable;
+                bun.path.posixToPlatformInPlace(u8, nodemodules_path);
+                list.append(bun.String.createUTF8(nodemodules_path)) catch unreachable;
                 dir_info = (r.readDirInfo(std.fs.path.dirname(path_without_trailing_slash) orelse break) catch null) orelse break;
             }
         } else {

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3278,7 +3278,8 @@ pub const Resolver = struct {
 
         const str = brk: {
             if (std.fs.path.isAbsolute(sliced.slice())) break :brk sliced.slice();
-            break :brk bun.path.join(&[_]string{ r.fs.top_level_dir, sliced.slice() }, .auto);
+            const dir_path_buf = bufs(.node_modules_paths_buf);
+            break :brk bun.path.joinStringBuf(dir_path_buf, &[_]string{ r.fs.top_level_dir, sliced.slice() }, .auto);
         };
         var arena = std.heap.ArenaAllocator.init(bun.default_allocator);
         defer arena.deinit();

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -5273,7 +5273,7 @@ pub fn concatWithLength(
     allocator: std.mem.Allocator,
     args: []const string,
     length: usize,
-) !string {
+) ![]u8 {
     const out = try allocator.alloc(u8, length);
     var remain = out;
     for (args) |arg| {
@@ -5287,7 +5287,7 @@ pub fn concatWithLength(
 pub fn concat(
     allocator: std.mem.Allocator,
     args: []const string,
-) !string {
+) ![]u8 {
     var length: usize = 0;
     for (args) |arg| {
         length += arg.len;


### PR DESCRIPTION
ideally I'd like to add a test for this but it returns absolute paths