### PR TITLE
Assert we drained the microtask queue since the last time we called into JavaScript

### DIFF
--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1935,8 +1935,8 @@ pub const DNSResolver = struct {
         poll: *Async.FilePoll,
     ) void {
         var vm = this.vm;
-        defer vm.drainMicrotasks();
-
+        vm.eventLoop().enter();
+        defer vm.eventLoop().exit();
         var channel = this.channel orelse {
             _ = this.polls.orderedRemove(poll.fd.int());
             poll.deinit();

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -433,27 +433,7 @@ const Handlers = struct {
             return false;
         }
 
-        const result = callback.callWithThis(this.globalObject, thisValue, data);
-        if (result.isAnyError()) {
-            this.vm.onUnhandledError(this.globalObject, result);
-        }
-
-        return true;
-    }
-
-    pub fn callErrorHandler(this: *Handlers, thisValue: JSValue, err: []const JSValue) bool {
-        const onError = this.onError;
-        if (onError == .zero) {
-            if (err.len > 0)
-                this.vm.onUnhandledError(this.globalObject, err[0]);
-
-            return false;
-        }
-
-        const result = onError.callWithThis(this.globalObject, thisValue, err);
-        if (result.isAnyError()) {
-            this.vm.onUnhandledError(this.globalObject, result);
-        }
+        this.vm.eventLoop().runCallback(callback, this.globalObject, thisValue, data);
 
         return true;
     }

--- a/src/bun.js/api/bun/lshpack.translated.zig
+++ b/src/bun.js/api/bun/lshpack.translated.zig
@@ -154,7 +154,7 @@ pub const enum_lsxpack_flag = c_uint;
 // /// limitation: we currently does not support total header size > 64KB.
 pub const struct_lsxpack_header = extern struct {
     /// the buffer for headers
-    buf: [*]u8 = undefined,
+    buf: ?[*]u8 = null,
     /// hash value for name
     name_hash: __uint32_t = 0,
     /// hash value for name + value
@@ -205,11 +205,11 @@ pub fn lsxpack_header_prepare_decode(arg_hdr: *lsxpack_header_t, arg_out: [*c]u8
 }
 
 pub fn lsxpack_header_get_name(hdr: *lsxpack_header_t) []const u8 {
-    if (hdr.name_len != 0) return hdr.buf[@as(usize, @intCast(hdr.name_offset)) .. @as(usize, @intCast(hdr.name_offset)) + hdr.name_len];
+    if (hdr.name_len != 0) return hdr.buf.?[@as(usize, @intCast(hdr.name_offset)) .. @as(usize, @intCast(hdr.name_offset)) + hdr.name_len];
     return "";
 }
 pub fn lsxpack_header_get_value(hdr: *lsxpack_header_t) []const u8 {
-    if (hdr.val_len != 0) return hdr.buf[@as(usize, @intCast(hdr.val_offset)) .. @as(usize, @intCast(hdr.val_offset)) + hdr.val_len];
+    if (hdr.val_len != 0) return hdr.buf.?[@as(usize, @intCast(hdr.val_offset)) .. @as(usize, @intCast(hdr.val_offset)) + hdr.val_len];
     return "";
 }
 pub fn lsxpack_header_get_dec_size(hdr: ?*const lsxpack_header_t) callconv(.C) usize {

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -175,13 +175,14 @@ const Handlers = struct {
 
         pub fn exit(this: *Scope, ssl: bool, wrapped: WrappedType) void {
             var vm = this.handlers.vm;
-            defer vm.drainMicrotasks();
+            defer vm.eventLoop().exit();
             this.handlers.markInactive(ssl, this.socket_context, wrapped);
         }
     };
 
     pub fn enter(this: *Handlers, context: ?*uws.SocketContext) Scope {
         this.markActive();
+        this.vm.eventLoop().enter();
         return .{
             .handlers = this,
             .socket_context = context,
@@ -1202,7 +1203,8 @@ fn NewSocket(comptime ssl: bool) type {
             const callback = handlers.onWritable;
             if (callback == .zero) return;
             var vm = handlers.vm;
-            defer vm.drainMicrotasks();
+            vm.eventLoop().enter();
+            defer vm.eventLoop().exit();
 
             const globalObject = handlers.globalObject;
             const this_value = this.getThisValue(globalObject);
@@ -1249,12 +1251,11 @@ fn NewSocket(comptime ssl: bool) type {
             defer this.markInactive();
 
             const handlers = this.handlers;
-            var vm = handlers.vm;
+            const vm = handlers.vm;
             this.poll_ref.unrefOnNextTick(vm);
 
             const callback = handlers.onConnectError;
             const globalObject = handlers.globalObject;
-            defer vm.drainMicrotasks();
             const err = JSC.SystemError{
                 .errno = errno,
                 .message = bun.String.static("Failed to connect"),
@@ -1266,6 +1267,10 @@ fn NewSocket(comptime ssl: bool) type {
                 // .code = bun.String.static(@tagName(bun.sys.getErrno(errno))),
                 // .code = bun.String.static(@tagName(@as(bun.C.E, @enumFromInt(errno)))),
             };
+            vm.eventLoop().enter();
+            defer {
+                vm.eventLoop().exit();
+            }
 
             if (callback == .zero) {
                 if (handlers.promise.trySwap()) |promise| {
@@ -1388,10 +1393,12 @@ fn NewSocket(comptime ssl: bool) type {
             } else {
                 if (callback == .zero) return;
             }
+            const vm = handlers.vm;
+            vm.eventLoop().enter();
+            defer vm.eventLoop().exit();
             const result = callback.callWithThis(globalObject, this_value, &[_]JSValue{
                 this_value,
             });
-            defer globalObject.bunVM().drainMicrotasks();
 
             if (result.toError()) |err| {
                 this.detached = true;

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1391,6 +1391,7 @@ fn NewSocket(comptime ssl: bool) type {
             const result = callback.callWithThis(globalObject, this_value, &[_]JSValue{
                 this_value,
             });
+            defer globalObject.bunVM().drainMicrotasks();
 
             if (result.toError()) |err| {
                 this.detached = true;

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -2965,15 +2965,12 @@ pub const Subprocess = struct {
                 waitpid_value,
             };
 
-            const result = callback.callWithThis(
+            globalThis.bunVM().eventLoop().runCallback(
+                callback,
                 globalThis,
                 this_value,
                 &args,
             );
-
-            if (result.isAnyError()) {
-                globalThis.bunVM().onUnhandledError(globalThis, result);
-            }
         }
     }
 
@@ -3386,15 +3383,12 @@ pub const Subprocess = struct {
             .data => |data| {
                 IPC.log("Received IPC message from child", .{});
                 if (this.ipc_callback.get()) |cb| {
-                    const result = cb.callWithThis(
+                    this.globalThis.bunVM().eventLoop().runCallback(
+                        cb,
                         this.globalThis,
                         this.this_jsvalue,
                         &[_]JSValue{ data, this.this_jsvalue },
                     );
-                    data.ensureStillAlive();
-                    if (result.isAnyError()) {
-                        this.globalThis.bunVM().onUnhandledError(this.globalThis, result);
-                    }
                 }
             },
         }

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -2796,10 +2796,9 @@ pub const Subprocess = struct {
         var vm = this.globalThis.bunVM();
         const is_sync = this.flags.is_sync;
 
-        defer {
-            if (!is_sync)
-                vm.drainMicrotasks();
-        }
+        if (!is_sync) vm.eventLoop().enter();
+        defer if (!is_sync) vm.eventLoop().exit();
+
         this.wait(false);
     }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3205,7 +3205,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                         if (readable.ptr == .Bytes) {
                             std.debug.assert(this.request_body_buf.items.len == 0);
                             var vm = this.server.vm;
-                            defer vm.drainMicrotasks();
+                            vm.eventLoop().enter();
+                            defer vm.eventLoop().exit();
 
                             if (!last) {
                                 readable.ptr.Bytes.onData(

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3751,7 +3751,9 @@ pub const ServerWebSocket = struct {
         if (onOpenHandler.isEmptyOrUndefinedOrNull()) return;
         const this_value = this.getThisValue();
         var args = [_]JSValue{this_value};
-        defer globalObject.bunVM().drainMicrotasks();
+        const loop = globalObject.bunVM().eventLoop();
+        loop.enter();
+        defer loop.exit();
 
         var corker = Corker{
             .args = &args,
@@ -3812,7 +3814,9 @@ pub const ServerWebSocket = struct {
         if (onMessageHandler.isEmptyOrUndefinedOrNull()) return;
         var globalObject = this.handler.globalObject;
         // This is the start of a task.
-        defer globalObject.bunVM().drainMicrotasks();
+        const loop = globalObject.bunVM().eventLoop();
+        loop.enter();
+        defer loop.exit();
 
         const arguments = [_]JSValue{
             this.getThisValue(),
@@ -3895,7 +3899,9 @@ pub const ServerWebSocket = struct {
                 .globalObject = globalObject,
                 .callback = handler.onDrain,
             };
-            defer globalObject.bunVM().drainMicrotasks();
+            const loop = globalObject.bunVM().eventLoop();
+            loop.enter();
+            defer loop.exit();
             this.websocket.cork(&corker, Corker.run);
             const result = corker.result;
 
@@ -3923,7 +3929,9 @@ pub const ServerWebSocket = struct {
         var globalThis = handler.globalObject;
 
         // This is the start of a task.
-        defer globalThis.bunVM().drainMicrotasks();
+        const loop = globalThis.bunVM().eventLoop();
+        loop.enter();
+        defer loop.exit();
 
         const result = cb.call(
             globalThis,
@@ -3963,7 +3971,9 @@ pub const ServerWebSocket = struct {
         var globalThis = handler.globalObject;
 
         // This is the start of a task.
-        defer globalThis.bunVM().drainMicrotasks();
+        const loop = globalThis.bunVM().eventLoop();
+        loop.enter();
+        defer loop.exit();
 
         const result = cb.call(
             globalThis,
@@ -4007,7 +4017,9 @@ pub const ServerWebSocket = struct {
         if (!handler.onClose.isEmptyOrUndefinedOrNull()) {
             var str = ZigString.init(message);
             const globalObject = handler.globalObject;
-            defer globalObject.bunVM().drainMicrotasks();
+            const loop = globalObject.bunVM().eventLoop();
+            loop.enter();
+            defer loop.exit();
             str.markUTF8();
             const result = handler.onClose.call(
                 globalObject,

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5813,6 +5813,14 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
         ) void {
             JSC.markBinding(@src());
             this.pending_requests += 1;
+            if (comptime Environment.isDebug) {
+                this.vm.eventLoop().debug.enter();
+            }
+            defer {
+                if (comptime Environment.isDebug) {
+                    this.vm.eventLoop().debug.exit();
+                }
+            }
 
             req.setYield(false);
             var ctx = this.request_pool_allocator.tryGet() catch @panic("ran out of memory");

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -432,7 +432,6 @@ pub const ZigString = extern struct {
 
         pub const byteSlice = Slice.slice;
 
-
         pub fn fromUTF8NeverFree(input: []const u8) Slice {
             return .{
                 .ptr = input.ptr,
@@ -3565,6 +3564,14 @@ pub const JSValue = enum(JSValueReprInt) {
 
     pub fn callWithGlobalThis(this: JSValue, globalThis: *JSGlobalObject, args: []const JSC.JSValue) JSC.JSValue {
         JSC.markBinding(@src());
+        if (comptime bun.Environment.isDebug) {
+            const loop = JSC.VirtualMachine.get().eventLoop();
+            loop.debug.js_call_count_outside_tick_queue += @as(usize, @intFromBool(!loop.debug.is_inside_tick_queue));
+            if (loop.debug.track_last_fn_name and !loop.debug.is_inside_tick_queue) {
+                loop.debug.last_fn_name.deref();
+                loop.debug.last_fn_name = this.getName(globalThis);
+            }
+        }
         return JSC.C.JSObjectCallAsFunctionReturnValue(
             globalThis,
             this,
@@ -3576,6 +3583,14 @@ pub const JSValue = enum(JSValueReprInt) {
 
     pub fn callWithThis(this: JSValue, globalThis: *JSGlobalObject, thisValue: JSC.JSValue, args: []const JSC.JSValue) JSC.JSValue {
         JSC.markBinding(@src());
+        if (comptime bun.Environment.isDebug) {
+            const loop = JSC.VirtualMachine.get().eventLoop();
+            loop.debug.js_call_count_outside_tick_queue += @as(usize, @intFromBool(!loop.debug.is_inside_tick_queue));
+            if (loop.debug.track_last_fn_name and !loop.debug.is_inside_tick_queue) {
+                loop.debug.last_fn_name.deref();
+                loop.debug.last_fn_name = this.getName(globalThis);
+            }
+        }
         return JSC.C.JSObjectCallAsFunctionReturnValue(
             globalThis,
             this,

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -2093,6 +2093,14 @@ inline fn createEach(
 }
 
 fn callJSFunctionForTestRunner(vm: *JSC.VirtualMachine, globalObject: *JSC.JSGlobalObject, function: JSC.JSValue, args: []const JSC.JSValue) JSC.JSValue {
+    if (comptime Environment.isDebug) {
+        vm.eventLoop().debug.enter();
+    }
+    defer {
+        if (comptime Environment.isDebug) {
+            vm.eventLoop().debug.exit();
+        }
+    }
     globalObject.clearTerminationException();
     const result = function.call(globalObject, args);
     result.ensureStillAlive();

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -942,6 +942,11 @@ pub const DescribeScope = struct {
                         this,
                     );
                     const result = callJSFunctionForTestRunner(vm, globalObject, cb, &.{done_func});
+                    if (result.toError()) |err| {
+                        Jest.runner.?.pending_test = pending_test;
+                        Jest.runner.?.did_pending_test_fail = orig_did_pending_test_fail;
+                        return err;
+                    }
                     vm.waitFor(&this.done);
                     break :brk result;
                 },
@@ -2093,18 +2098,14 @@ inline fn createEach(
 }
 
 fn callJSFunctionForTestRunner(vm: *JSC.VirtualMachine, globalObject: *JSC.JSGlobalObject, function: JSC.JSValue, args: []const JSC.JSValue) JSC.JSValue {
-    if (comptime Environment.isDebug) {
-        vm.eventLoop().debug.enter();
-    }
+    vm.eventLoop().enter();
     defer {
-        if (comptime Environment.isDebug) {
-            vm.eventLoop().debug.exit();
-        }
+        vm.eventLoop().exit();
     }
+
     globalObject.clearTerminationException();
     const result = function.call(globalObject, args);
     result.ensureStillAlive();
-    globalObject.vm().releaseWeakRefs();
-    vm.drainMicrotasks();
+
     return result;
 }

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -124,9 +124,15 @@ it("should report connection errors", async () => {
   }
   const server = listen({
     socket: {
-      data: end,
-      drain: end,
-      open: end,
+      data: function data(socket) {
+        socket.end();
+      },
+      drain: function drain(socket) {
+        socket.end();
+      },
+      open: function open(socket) {
+        socket.end();
+      },
     },
     hostname: "localhost",
     port: 0,

--- a/test/js/bun/http/js-sink-sourmap-fixture/index.mjs
+++ b/test/js/bun/http/js-sink-sourmap-fixture/index.mjs
@@ -5576,6 +5576,7 @@ const useNitroApp = () => nitroApp;
 
 try {
   const server = Bun.serve({
+    hostname: "localhost",
     port: process.env.NITRO_PORT || process.env.PORT || 3e3,
     async fetch(request) {
       const url = new URL(request.url);
@@ -5595,7 +5596,7 @@ try {
   });
   console.log(`Listening on http://localhost:${server.port}...`);
 
-  const result = await fetch(`http://${server.hostname}:${server.port}/stream`).then(res => res.text());
+  const result = await fetch(`${server.url}/stream`).then(res => res.text());
   process.exit(result == "nitroisawesome" ? 0 : 2);
 } catch {
   process.exit(1);

--- a/test/js/bun/http/rejected-promise-fixture.js
+++ b/test/js/bun/http/rejected-promise-fixture.js
@@ -1,4 +1,5 @@
 const server = Bun.serve({
+  hostname: "localhost",
   async fetch() {
     throw new Error("Error");
   },


### PR DESCRIPTION

### What does this PR do?

This adds an assertion in debug builds that checks we called `drainMicrotasks` after calling into a JavaScript function. 

This adds a helper method `EventLoop.runCallback` for calling into JavaScript functions from the top of the event loop. This will handle exceptions and release weakrefs and anything else we may need to do in the future.

This also fixes cases where we weren't draining microtasks in:
- IPC
- open() callback in Bun.listen/Bun.connect
- `open` and `close` callbacks in Bun.serve() WebSockets
- H2


The panic looks like this:
```zig
uh-oh: 1 JavaScript functions were called outside of the microtask queue without draining microtasks.

Last function name: open

Use EventLoop.runCallback() to run JavaScript functions outside of the microtask queue.

Failing to do this can lead to a large number of microtasks being queued and not being drained, which can lead to a large amount of memory being used and application slowdown.
bun will crash now 😭😭😭
```

It only tracks function names if `BUN_TRACK_LAST_FN_NAME=1`



### How did you verify your code works?

Manually