### PR TITLE
fix: statement joining and tmpdir on windows

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -559,6 +559,14 @@ pub const FileSystem = struct {
                             break :brk bun.default_allocator.dupe(u8, out) catch bun.outOfMemory();
                         }
 
+                        if (bun.getenvZ("SystemRoot") orelse bun.getenvZ("windir")) |windir| {
+                            break :brk bun.fmt.allocPrint(
+                                bun.default_allocator,
+                                "{s}\\Temp",
+                                .{windir},
+                            ) catch bun.outOfMemory();
+                        }
+
                         var tmp_buf: bun.PathBuffer = undefined;
                         const cwd = std.os.getcwd(&tmp_buf) catch @panic("Failed to get cwd for platformTempDir");
                         const root = bun.path.windowsFilesystemRoot(cwd);

--- a/src/js/node/os.ts
+++ b/src/js/node/os.ts
@@ -4,6 +4,15 @@ var tmpdir = function () {
   var env = Bun.env;
 
   tmpdir = function () {
+    if (process.platform === "win32") {
+      // using node implementation
+      // https://github.com/nodejs/node/blob/ad5e2dab4c8306183685973387829c2f69e793da/lib/os.js#L186
+      var path = env["TEMP"] || env["TMP"] || (env["SystemRoot"] || env["windir"]) + "\\temp";
+      if (path.length > 1 && path[path.length - 1] === "\\" && !String.prototype.endsWith.$call(path, ":\\")) {
+        path = String.prototype.slice.$call(path, 0, -1);
+      }
+      return path;
+    }
     var path = env["TMPDIR"] || env["TMP"] || env["TEMP"] || "/tmp";
     const length = path.length;
     if (length > 1 && path[length - 1] === "/") path = path.slice(0, -1);


### PR DESCRIPTION
### What does this PR do?
Joining statements with commas will only happen when bundling, making runtime error stack traces more readable.

Makes sure `platformTempDir` in `fs.zig` is the same tmpdir as `node:os` `tmpdir`.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
let's see the ci results
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
