### PR TITLE
fix: request.clone() actually clones the request body.

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5328,6 +5328,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                     bun.default_allocator,
                     ctx,
                     false,
+                    .zero,
                 );
             } else {
                 const fetch_error = JSC.WebCore.Fetch.fetch_type_error_strings.get(js.JSValueGetType(ctx, first_arg.asRef()));

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -1851,7 +1851,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionBinding, (JSGlobalObject * jsGlobalObje
     if (moduleName == "pipe_wrap"_s) PROCESS_BINDING_NOT_IMPLEMENTED("pipe_wrap");
     if (moduleName == "process_wrap"_s) PROCESS_BINDING_NOT_IMPLEMENTED("process_wrap");
     if (moduleName == "signal_wrap"_s) PROCESS_BINDING_NOT_IMPLEMENTED("signal_wrap");
-    if (moduleName == "spawn_sync"_s) PROCESS_BINDING_NOT_IMPLEMENTED("spawn_sync");
+    if (moduleName == "spawn_sync"_s) PROCESS_BINDING_NOT_IMPLEMENTED_ISSUE("spawn_sync", "8694");
     if (moduleName == "stream_wrap"_s) PROCESS_BINDING_NOT_IMPLEMENTED_ISSUE("stream_wrap", "4957");
     if (moduleName == "tcp_wrap"_s) PROCESS_BINDING_NOT_IMPLEMENTED("tcp_wrap");
     if (moduleName == "tls_wrap"_s) PROCESS_BINDING_NOT_IMPLEMENTED("tls_wrap");

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2284,6 +2284,18 @@ extern "C" void ReadableStream__cancel(JSC__JSValue possibleReadableStream, Zig:
     ReadableStream::cancel(*globalObject, readableStream, exception);
 }
 
+extern "C" void ReadableStream__tee(JSC__JSValue possibleReadableStream, Zig::GlobalObject* globalObject, JSC__JSValue ptr[2])
+{
+    auto* readableStream = jsDynamicCast<JSReadableStream*>(JSC::JSValue::decode(possibleReadableStream));
+    if (UNLIKELY(!readableStream))
+        return;
+
+    if (auto pair = ReadableStream::tee(*globalObject, readableStream)) {
+        ptr[0] = JSC::JSValue::encode(pair->first);
+        ptr[1] = JSC::JSValue::encode(pair->second);
+    }
+}
+
 extern "C" void ReadableStream__detach(JSC__JSValue possibleReadableStream, Zig::GlobalObject* globalObject);
 extern "C" void ReadableStream__detach(JSC__JSValue possibleReadableStream, Zig::GlobalObject* globalObject)
 {

--- a/src/bun.js/bindings/webcore/ReadableStream.cpp
+++ b/src/bun.js/bindings/webcore/ReadableStream.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "config.h"
+#include "JavaScriptCore/JSGlobalObject.h"
 #include "ReadableStream.h"
 
 #include "Exception.h"
@@ -125,24 +126,25 @@ void ReadableStream::pipeTo(ReadableStreamSink& sink)
     invokeReadableStreamFunction(lexicalGlobalObject, privateName, JSC::jsUndefined(), arguments);
 }
 
-std::optional<std::pair<Ref<ReadableStream>, Ref<ReadableStream>>> ReadableStream::tee()
+std::optional<std::pair<JSValue, JSValue>> ReadableStream::tee(JSC::JSGlobalObject& lexicalGlobalObject, JSValue stream)
 {
-    auto& lexicalGlobalObject = *m_globalObject;
     auto* clientData = static_cast<JSVMClientData*>(lexicalGlobalObject.vm().clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamTeePrivateName();
 
     MarkedArgumentBuffer arguments;
-    arguments.append(readableStream());
+    arguments.append(stream);
     arguments.append(JSC::jsBoolean(true));
     ASSERT(!arguments.hasOverflowed());
-    auto returnedValue = invokeReadableStreamFunction(lexicalGlobalObject, privateName, JSC::jsUndefined(), arguments);
+    auto returnedValue = invokeReadableStreamFunction(lexicalGlobalObject, privateName, stream, arguments);
     if (!returnedValue)
         return {};
 
-    auto results = Detail::SequenceConverter<IDLInterface<ReadableStream>>::convert(lexicalGlobalObject, *returnedValue);
+    JSValue array = returnedValue.value();
+    auto* arrayObject = jsCast<JSArray*>(array.getObject());
+    auto first = arrayObject->getDirectIndex(&lexicalGlobalObject, 0);
+    auto second = arrayObject->getDirectIndex(&lexicalGlobalObject, 1);
 
-    ASSERT(results.size() == 2);
-    return std::make_pair(results[0].releaseNonNull(), results[1].releaseNonNull());
+    return std::make_pair(first, second);
 }
 
 void ReadableStream::lock()

--- a/src/bun.js/bindings/webcore/ReadableStream.h
+++ b/src/bun.js/bindings/webcore/ReadableStream.h
@@ -30,6 +30,7 @@
 #include "JSDOMConvert.h"
 #include "JSDOMGuardedObject.h"
 #include "JSReadableStream.h"
+#include "JavaScriptCore/JSCJSValue.h"
 
 namespace WebCore {
 
@@ -47,7 +48,7 @@ public:
     WEBCORE_EXPORT static bool isLocked(JSC::JSGlobalObject*, JSReadableStream*);
     WEBCORE_EXPORT static void cancel(WebCore::JSDOMGlobalObject& globalObject, JSReadableStream*, const WebCore::Exception& exception);
 
-    std::optional<std::pair<Ref<ReadableStream>, Ref<ReadableStream>>> tee();
+    static std::optional<std::pair<JSValue, JSValue>> tee(JSC::JSGlobalObject&, JSValue stream);
 
     void cancel(const Exception&);
     void lock();

--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -940,8 +940,11 @@ pub fn BodyMixin(comptime Type: type) type {
         pub fn getText(
             this: *Type,
             globalObject: *JSC.JSGlobalObject,
-            _: *JSC.CallFrame,
+            call_frame: *JSC.CallFrame,
         ) callconv(.C) JSC.JSValue {
+            const maybe_stream = this.tryGetBodyReadableStream(globalObject, call_frame.this());
+            if (maybe_stream) |stream| return globalObject.readableStreamToText(stream);
+
             var value: *Body.Value = this.getBodyValue();
             if (value.* == .Used) {
                 return handleBodyAlreadyUsed(globalObject);
@@ -994,8 +997,11 @@ pub fn BodyMixin(comptime Type: type) type {
         pub fn getJSON(
             this: *Type,
             globalObject: *JSC.JSGlobalObject,
-            _: *JSC.CallFrame,
+            call_frame: *JSC.CallFrame,
         ) callconv(.C) JSC.JSValue {
+            const maybe_stream = this.tryGetBodyReadableStream(globalObject, call_frame.this());
+            if (maybe_stream) |stream| return globalObject.readableStreamToJSON(stream);
+
             var value: *Body.Value = this.getBodyValue();
             if (value.* == .Used) {
                 return handleBodyAlreadyUsed(globalObject);
@@ -1024,8 +1030,11 @@ pub fn BodyMixin(comptime Type: type) type {
         pub fn getArrayBuffer(
             this: *Type,
             globalObject: *JSC.JSGlobalObject,
-            _: *JSC.CallFrame,
+            call_frame: *JSC.CallFrame,
         ) callconv(.C) JSC.JSValue {
+            const maybe_stream = this.tryGetBodyReadableStream(globalObject, call_frame.this());
+            if (maybe_stream) |stream| return globalObject.readableStreamToArrayBuffer(stream);
+
             var value: *Body.Value = this.getBodyValue();
 
             if (value.* == .Used) {
@@ -1047,8 +1056,11 @@ pub fn BodyMixin(comptime Type: type) type {
         pub fn getFormData(
             this: *Type,
             globalObject: *JSC.JSGlobalObject,
-            _: *JSC.CallFrame,
+            call_frame: *JSC.CallFrame,
         ) callconv(.C) JSC.JSValue {
+            const maybe_stream = this.tryGetBodyReadableStream(globalObject, call_frame.this());
+            if (maybe_stream) |stream| return globalObject.readableStreamToFormData(stream, .undefined);
+
             var value: *Body.Value = this.getBodyValue();
 
             if (value.* == .Used) {

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -707,7 +707,7 @@ pub const Request = struct {
     }
 
     pub fn tryGetBodyReadableStream(
-        this: *Request,
+        _: *Request,
         globalThis: *JSC.JSGlobalObject,
         this_jsvalue: JSC.JSValue,
     ) ?JSValue {
@@ -717,14 +717,6 @@ pub const Request = struct {
                 return null;
             }
             return existing_stream.toJS();
-        }
-
-        if (this.body.value.Locked.readable) |stream| {
-            if (stream.isDisturbed(globalThis)) {
-                return null;
-            }
-
-            return stream.toJS();
         }
 
         return null;

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -99,6 +99,18 @@ pub const Response = struct {
         return &this.body.value;
     }
 
+    pub fn tryGetBodyReadableStream(
+        this: *Response,
+        globalThis: *JSC.JSGlobalObject,
+        this_jsvalue: JSC.JSValue,
+    ) ?JSValue {
+        _ = this;
+        _ = globalThis;
+        _ = this_jsvalue;
+        bun.todo(@src(), {});
+        return null;
+    }
+
     pub fn getFetchHeaders(
         this: *Response,
     ) ?*FetchHeaders {

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -249,6 +249,7 @@ pub const ReadableStream = struct {
     extern fn ReadableStream__cancel(stream: JSValue, *JSGlobalObject) void;
     extern fn ReadableStream__abort(stream: JSValue, *JSGlobalObject) void;
     extern fn ReadableStream__detach(stream: JSValue, *JSGlobalObject) void;
+    extern fn ReadableStream__tee(stream: JSValue, *JSGlobalObject, [*]JSValue) void;
     extern fn ReadableStream__fromBlob(
         *JSGlobalObject,
         store: *anyopaque,
@@ -264,6 +265,17 @@ pub const ReadableStream = struct {
     pub fn isLocked(this: *const ReadableStream, globalObject: *JSGlobalObject) bool {
         JSC.markBinding(@src());
         return ReadableStream__isLocked(this.value, globalObject);
+    }
+
+    pub fn tee(this: *const ReadableStream, globalObject: *JSGlobalObject) ?[2]ReadableStream {
+        JSC.markBinding(@src());
+        var values: [2]JSC.JSValue = .{ .zero, .zero };
+        ReadableStream__tee(this.value, globalObject, &values);
+
+        return .{
+            ReadableStream.fromJS(values[0], globalObject) orelse return null,
+            ReadableStream.fromJS(values[1], globalObject) orelse return null,
+        };
     }
 
     pub fn fromJS(value: JSValue, globalThis: *JSGlobalObject) ?ReadableStream {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1416,7 +1416,7 @@ if (process.platform === "linux") {
   });
 }
 
-it("should allow cloning the request body", () => {
+it("should allow cloning the request body", async () => {
   const server = Bun.serve({
     port: 0,
     async fetch(request) {
@@ -1433,9 +1433,9 @@ it("should allow cloning the request body", () => {
   });
   try {
     const response = await fetch(`http://${server.hostname}:${server.port}`, {
-    method: "POST",
-    body: JSON.stringify({ a: 1, b: [{ c: 2 }] }),
-  });
+      method: "POST",
+      body: JSON.stringify({ a: 1, b: [{ c: 2 }] }),
+    });
     expect(response.status).toBe(200);
   } finally {
     server.stop(true);
@@ -1513,6 +1513,32 @@ it("should allow cloning the request body with .arrayBuffer", async () => {
     const response = await fetch(`http://${server.hostname}:${server.port}`, {
       method: "POST",
       body: JSON.stringify({ a: 1, b: [{ c: 2 }] }),
+    });
+    expect(response.status).toBe(200);
+  } finally {
+    server.stop(true);
+  }
+});
+
+it("should allow cloning the request body with .formData", async () => {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const a = await request.clone().formData();
+      const b = await request.formData();
+      try {
+        expect(a).toEqual(b);
+      } catch (e) {
+        console.error(e);
+        return new Response("FAIL", { status: 500 });
+      }
+      return new Response("OK");
+    },
+  });
+  try {
+    const response = await fetch(`http://${server.hostname}:${server.port}`, {
+      method: "POST",
+      body: new FormData(),
     });
     expect(response.status).toBe(200);
   } finally {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1403,7 +1403,7 @@ it("should support promise returned from error", async () => {
   server.stop(true);
 });
 
-if (process.platform === "linux")
+if (process.platform === "linux") {
   it("should use correct error when using a root range port(#7187)", () => {
     expect(() => {
       const server = Bun.serve({
@@ -1414,3 +1414,108 @@ if (process.platform === "linux")
       });
     }).toThrow("permission denied 0.0.0.0:1003");
   });
+}
+
+it("should allow cloning the request body", () => {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const a = await Bun.readableStreamToJSON(request.clone().body);
+      const b = await Bun.readableStreamToJSON(request.body);
+      try {
+        expect(a).toEqual(b);
+      } catch (e) {
+        console.error(e);
+        return new Response("FAIL", { status: 500 });
+      }
+      return new Response("OK");
+    },
+  });
+  try {
+    const response = await fetch(`http://${server.hostname}:${server.port}`, {
+    method: "POST",
+    body: JSON.stringify({ a: 1, b: [{ c: 2 }] }),
+  });
+    expect(response.status).toBe(200);
+  } finally {
+    server.stop(true);
+  }
+});
+
+it("should allow cloning the request body with .json", async () => {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const a = await request.clone().json();
+      const b = await request.json();
+      try {
+        expect(a).toEqual(b);
+      } catch (e) {
+        console.error(e);
+        return new Response("FAIL", { status: 500 });
+      }
+      return new Response("OK");
+    },
+  });
+  try {
+    const response = await fetch(`http://${server.hostname}:${server.port}`, {
+      method: "POST",
+      body: JSON.stringify({ a: 1, b: [{ c: 2 }] }),
+    });
+    expect(response.status).toBe(200);
+  } finally {
+    server.stop(true);
+  }
+});
+
+it("should allow cloning the request body with .text", async () => {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const a = await request.clone().text();
+      const b = await request.text();
+      try {
+        expect(a).toEqual(b);
+      } catch (e) {
+        console.error(e);
+        return new Response("FAIL", { status: 500 });
+      }
+      return new Response("OK");
+    },
+  });
+  try {
+    const response = await fetch(`http://${server.hostname}:${server.port}`, {
+      method: "POST",
+      body: JSON.stringify({ a: 1, b: [{ c: 2 }] }),
+    });
+    expect(response.status).toBe(200);
+  } finally {
+    server.stop(true);
+  }
+});
+
+it("should allow cloning the request body with .arrayBuffer", async () => {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const a = await request.clone().arrayBuffer();
+      const b = await request.arrayBuffer();
+      try {
+        expect(a).toEqual(b);
+      } catch (e) {
+        console.error(e);
+        return new Response("FAIL", { status: 500 });
+      }
+      return new Response("OK");
+    },
+  });
+  try {
+    const response = await fetch(`http://${server.hostname}:${server.port}`, {
+      method: "POST",
+      body: JSON.stringify({ a: 1, b: [{ c: 2 }] }),
+    });
+    expect(response.status).toBe(200);
+  } finally {
+    server.stop(true);
+  }
+});


### PR DESCRIPTION


### What does this PR do?

This makes request.clone() call .body.tee(), and then re-assigns request.body to the teed ReadableStream. 

Fixes #8515
Fixes #1381

### How did you verify your code works?

This needs tests.