### PR TITLE
Implement server.unref() and server.ref()

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2474,6 +2474,25 @@ declare module "bun" {
     requestIP(request: Request): SocketAddress | null;
 
     /**
+     * Undo a call to {@link Server.unref}
+     *
+     * If the Server has already been stopped, this does nothing.
+     *
+     * If {@link Server.ref} is called multiple times, this does nothing. Think of it as a boolean toggle.
+     */
+    ref(): void;
+
+    /**
+     * Don't keep the process alive if this server is the only thing left.
+     * Active connections may continue to keep the process alive.
+     *
+     * By default, the server is ref'd.
+     *
+     * To prevent new connections from being accepted, use {@link Server.stop}
+     */
+    unref(): void;
+
+    /**
      * How many requests are in-flight right now?
      */
     readonly pendingRequests: number;

--- a/src/bun.js/api/server.classes.ts
+++ b/src/bun.js/api/server.classes.ts
@@ -41,6 +41,12 @@ function generate(name) {
       pendingWebSockets: {
         getter: "getPendingWebSockets",
       },
+      ref: {
+        fn: "doRef",
+      },
+      unref: {
+        fn: "doUnref",
+      },
       hostname: {
         getter: "getHostname",
         cache: true,

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -4938,6 +4938,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
         const httplog = Output.scoped(.Server, false);
 
         listener: ?*App.ListenSocket = null,
+        listener_ref: bool = true,
         thisObject: JSC.JSValue = JSC.JSValue.zero,
         app: *App = undefined,
         vm: *JSC.VirtualMachine = undefined,
@@ -5755,14 +5756,26 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             if (this.poll_ref.isActive()) return;
 
             this.poll_ref.ref(this.vm);
-            this.vm.eventLoop().start_server_on_next_tick = true;
         }
 
         pub fn unref(this: *ThisServer) void {
             if (!this.poll_ref.isActive()) return;
 
-            this.poll_ref.unrefOnNextTick(this.vm);
-            this.vm.eventLoop().start_server_on_next_tick = false;
+            this.poll_ref.unref(this.vm);
+        }
+
+        pub fn doRef(this: *ThisServer, _: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) JSC.JSValue {
+            const this_value = callframe.this();
+            this.ref();
+
+            return this_value;
+        }
+
+        pub fn doUnref(this: *ThisServer, _: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) JSC.JSValue {
+            const this_value = callframe.this();
+            this.unref();
+
+            return this_value;
         }
 
         pub fn onBunInfoRequest(this: *ThisServer, req: *uws.Request, resp: *App.Response) void {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -4938,7 +4938,6 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
         const httplog = Output.scoped(.Server, false);
 
         listener: ?*App.ListenSocket = null,
-        listener_ref: bool = true,
         thisObject: JSC.JSValue = JSC.JSValue.zero,
         app: *App = undefined,
         vm: *JSC.VirtualMachine = undefined,

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -654,7 +654,6 @@ pub const EventLoop = struct {
     global: *JSGlobalObject = undefined,
     virtual_machine: *JSC.VirtualMachine = undefined,
     waker: ?Waker = null,
-    start_server_on_next_tick: bool = false,
     defer_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
     forever_timer: ?*uws.Timer = null,
     deferred_microtask_map: std.AutoArrayHashMapUnmanaged(?*anyopaque, DeferredRepeatingTask) = .{},

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -258,7 +258,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 &client_protocol_hash,
                 NonUTF8Headers.init(header_names, header_values, header_count),
             ) catch return null;
-            var vm = global.bunVM();
+            const vm = global.bunVM();
 
             var client = HTTPClient.new(.{
                 .tcp = undefined,
@@ -269,8 +269,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
 
             var host_ = host.toSlice(bun.default_allocator);
             defer host_.deinit();
-            const prev_start_server_on_next_tick = vm.eventLoop().start_server_on_next_tick;
-            vm.eventLoop().start_server_on_next_tick = true;
+
             client.poll_ref.ref(vm);
             const display_host_ = host_.slice();
             const display_host = if (bun.FeatureFlags.hardcode_localhost_to_127_0_0_1 and strings.eqlComptime(display_host_, "localhost"))
@@ -295,8 +294,6 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 out.tcp.?.timeout(120);
                 return out;
             } else {
-                vm.eventLoop().start_server_on_next_tick = prev_start_server_on_next_tick;
-
                 client.clearData();
                 client.destroy();
             }
@@ -309,7 +306,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             this.input_body_buf.len = 0;
         }
         pub fn clearData(this: *HTTPClient) void {
-            this.poll_ref.unrefOnNextTick(JSC.VirtualMachine.get());
+            this.poll_ref.unref(JSC.VirtualMachine.get());
 
             this.clearInput();
             this.body.clearAndFree(bun.default_allocator);
@@ -957,7 +954,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
         }
 
         pub fn clearData(this: *WebSocket) void {
-            this.poll_ref.unrefOnNextTick(this.globalThis.bunVM());
+            this.poll_ref.unref(this.globalThis.bunVM());
             this.clearReceiveBuffers(true);
             this.clearSendBuffers(true);
             this.ping_received = false;
@@ -1706,7 +1703,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
 
         fn dispatchAbruptClose(this: *WebSocket) void {
             var out = this.outgoing_websocket orelse return;
-            this.poll_ref.unrefOnNextTick(this.globalThis.bunVM());
+            this.poll_ref.unref(this.globalThis.bunVM());
             JSC.markBinding(@src());
             this.outgoing_websocket = null;
             out.didAbruptClose(ErrorCode.closed);
@@ -1714,7 +1711,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
 
         fn dispatchClose(this: *WebSocket, code: u16, reason: *const bun.String) void {
             var out = this.outgoing_websocket orelse return;
-            this.poll_ref.unrefOnNextTick(this.globalThis.bunVM());
+            this.poll_ref.unref(this.globalThis.bunVM());
             JSC.markBinding(@src());
             this.outgoing_websocket = null;
             out.didClose(code, reason);

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -423,3 +423,12 @@ describe("Server", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// By not timing out, this test passes.
+test("Bun.serve().unref() works", async () => {
+  expect([path.join(import.meta.dir, "unref-fixture.ts")]).toRun();
+});
+
+test("unref keeps process alive for ongoing connections", async () => {
+  expect([path.join(import.meta.dir, "unref-fixture-2.ts")]).toRun();
+});

--- a/test/js/bun/http/unref-fixture-2.ts
+++ b/test/js/bun/http/unref-fixture-2.ts
@@ -1,0 +1,32 @@
+let completed = 0;
+const server = Bun.serve({
+  async fetch(req, res) {
+    return new Response(
+      new ReadableStream({
+        async pull(controller) {
+          controller.enqueue("Hello!");
+          const { promise, resolve } = Promise.withResolvers();
+          setTimeout(() => resolve(), 100).unref();
+          await promise;
+          controller.close();
+        },
+      }),
+    );
+  },
+});
+
+process.on("beforeExit", () => {
+  console.log("Completed:", completed);
+  if (completed !== 10) {
+    process.exit(42);
+  }
+});
+
+server.unref();
+Promise.allSettled(
+  Array.from({ length: 10 }, () =>
+    fetch(server.url).then(() => {
+      completed++;
+    }),
+  ),
+);

--- a/test/js/bun/http/unref-fixture.ts
+++ b/test/js/bun/http/unref-fixture.ts
@@ -1,0 +1,14 @@
+const server = Bun.serve({
+  fetch(req: Request) {
+    return new Response(`Echo: ${req.url}`);
+  },
+  port: 0,
+});
+
+setTimeout(() => {
+  server.unref();
+}, 1);
+
+process.once("beforeExit", () => {
+  server.stop();
+});

--- a/test/js/node/http/node-http-ref-fixture.js
+++ b/test/js/node/http/node-http-ref-fixture.js
@@ -1,0 +1,19 @@
+import { createServer } from "http";
+var server = createServer((req, res) => {
+  res.end();
+}).listen(0, async (err, hostname, port) => {
+  process.on("SIGUSR1", async () => {
+    server.unref();
+
+    // check that the server is still running
+    const resp = await fetch(`http://localhost:${port}`);
+    await resp.arrayBuffer();
+    console.log("Unref'd & server still running (as expected)");
+  });
+  const resp = await fetch(`http://localhost:${port}`);
+  await resp.arrayBuffer();
+  if (resp.status !== 200) {
+    process.exit(42);
+  }
+  process.kill(process.pid, "SIGUSR1");
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1675,3 +1675,11 @@ it("#4415.4 IncomingMessage es5", () => {
   IncomingMessage.call(im, { url: "/foo" });
   expect(im.url).toBe("/foo");
 });
+
+// Windows doesnt support SIGUSR1
+if (process.platform !== "win32") {
+  // By not timing out, this test passes.
+  test(".unref() works", async () => {
+    expect([path.join(import.meta.dir, "node-http-ref-fixture.js")]).toRun();
+  });
+}


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/2524
Fixes https://github.com/oven-sh/bun/issues/4333

The following keeps Bun's process alive forever, until `server.stop()` is called:
```js
const server = Bun.serve({
  fetch(req) { return new Response(); }
});
```

What if you want to only keep the process alive while there are active connections, but don't want to stop new connections from being accepted?

Now you can with `server.unref`:

```js
const server = Bun.serve({
  fetch(req) { return new Response(); }
});

await Bun.sleep(100);
server.unref();
```

### How did you verify your code works?

A few tests