### PR TITLE
Support `watchedFiles` in `Bun.plugin`

### DIFF
--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -1,7 +1,8 @@
-#include "JavaScriptCore/JSArray.h"
-#include "JavaScriptCore/JSCast.h"
 #include "root.h"
 #include "headers-handwritten.h"
+
+#include "JavaScriptCore/JSArray.h"
+#include "JavaScriptCore/JSCast.h"
 
 #include "ModuleLoader.h"
 

--- a/src/bun.js/bindings/ModuleLoader.h
+++ b/src/bun.js/bindings/ModuleLoader.h
@@ -1,3 +1,4 @@
+#include "helpers.h"
 #include "root.h"
 #include "headers-handwritten.h"
 
@@ -30,6 +31,7 @@ struct CodeString {
     ZigString string;
     JSC::JSValue value;
     BunLoaderType loader;
+    BunString watchedFilePath = Zig::BunStringEmpty;
 };
 
 union OnLoadResultValue {

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -305,6 +305,7 @@ extern "C" bool Bun__transpileVirtualModule(
     const BunString* referrer,
     ZigString* sourceCode,
     BunLoaderType loader,
+    BunString* watchedFilePath,
     ErrorableResolvedSource* result);
 
 extern "C" JSC::EncodedJSValue Bun__runVirtualModule(

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -3445,3 +3445,4 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
 }
 
 pub export var isBunTest: bool = false;
+

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -3445,4 +3445,3 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
 }
 
 pub export var isBunTest: bool = false;
-

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -288,6 +288,7 @@ pub const Run = struct {
     pub fn start(this: *Run) void {
         var vm = this.vm;
         vm.hot_reload = this.ctx.debug.hot_reload;
+
         vm.onUnhandledRejection = &onUnhandledRejectionBeforeClose;
 
         if (this.ctx.runtime_options.eval_script.len > 0) {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -522,9 +522,11 @@ pub const Arguments = struct {
 
             if (args.flag("--hot")) {
                 ctx.debug.hot_reload = .hot;
+                Bun__watchMode = .hot;
             } else if (args.flag("--watch")) {
                 ctx.debug.hot_reload = .watch;
                 bun.auto_reload_on_crash = true;
+                Bun__watchMode = .watch;
             }
 
             if (args.option("--origin")) |origin| {
@@ -1052,7 +1054,7 @@ pub const Command = struct {
 
     pub const MacroOptions = union(enum) { unspecified: void, disable: void, map: MacroMap };
 
-    pub const HotReload = enum {
+    pub const HotReload = enum(u8) {
         none,
         hot,
         watch,
@@ -2164,3 +2166,5 @@ pub const Command = struct {
         });
     };
 };
+
+pub export var Bun__watchMode: bun.CLI.Command.HotReload = .none;


### PR DESCRIPTION
### What does this PR do?

WIP. Lets onLoad plugins return a file path to add to watch. This makes it easier to do hot reloading with custom loaders & files.

Example code:

```js
import { plugin } from "bun";
import { compile } from "svelte/compiler";
import { readFileSync } from "fs";

await plugin({
  name: "svelte loader",
  async setup(builder) {
    builder.onLoad({ filter: /\.svelte$/ }, ({ path }) => ({
      contents: compile(readFileSync(path, "utf8"), {
        filename: path,
        generate: "ssr",
      }).js.code,
      loader: "js",
      watchedFilePaths: [path],
      // ^ watch this path
    }));
  },
});
```

If someone else wants to finish this PR, the next steps are roughly:
- Open the file path provided so that we get a file descriptor (for watching on macOS, mostly)
- Call `vm.bun_watcher.addFile`. Set `clone_path` to `true`
- A test which checks that hot-reloading works with e.g. `.svelte` files

I think it'd be fine to only support a single path to ship the initial version. 

### How did you verify your code works?

It doesn't work yet