### PR TITLE
fix(windows): make fs.symlink normalize forward slashes to backslashes

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5717,8 +5717,16 @@ pub const NodeFS = struct {
         var to_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
 
         if (Environment.isWindows) {
+            const target: [:0]u8 = args.old_path.sliceZWithForceCopy(&this.sync_error_buf, true);
+            for (target) |*c| {
+                if (c.* == '/') {
+                    c.* = '\\';
+                }
+            }
+            // Symlinks targets on windows must contain backslashes. UV will not normalize this for us.
+            // https://github.com/oven-sh/bun/issues/8273
             return Syscall.symlinkUV(
-                args.old_path.sliceZ(&this.sync_error_buf),
+                target,
                 args.new_path.sliceZ(&to_buf),
                 switch (args.link_type) {
                     .file => 0,

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5718,13 +5718,13 @@ pub const NodeFS = struct {
 
         if (Environment.isWindows) {
             const target: [:0]u8 = args.old_path.sliceZWithForceCopy(&this.sync_error_buf, true);
+            // UV does not normalize slashes in symlink targets, but Node does
+            // See https://github.com/oven-sh/bun/issues/8273
             for (target) |*c| {
                 if (c.* == '/') {
                     c.* = '\\';
                 }
             }
-            // Symlinks targets on windows must contain backslashes. UV will not normalize this for us.
-            // https://github.com/oven-sh/bun/issues/8273
             return Syscall.symlinkUV(
                 target,
                 args.new_path.sliceZ(&to_buf),

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5720,6 +5720,8 @@ pub const NodeFS = struct {
             const target: [:0]u8 = args.old_path.sliceZWithForceCopy(&this.sync_error_buf, true);
             // UV does not normalize slashes in symlink targets, but Node does
             // See https://github.com/oven-sh/bun/issues/8273
+            //
+            // TODO: investigate if simd can be easily used here
             for (target) |*c| {
                 if (c.* == '/') {
                     c.* = '\\';

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -654,7 +654,7 @@ pub const PathLike = union(enum) {
         };
     }
 
-    pub fn sliceZWithForceCopy(this: PathLike, buf: *[bun.MAX_PATH_BYTES]u8, comptime force: bool) [:0]const u8 {
+    pub fn sliceZWithForceCopy(this: PathLike, buf: *[bun.MAX_PATH_BYTES]u8, comptime force: bool) if (force) [:0]u8 else [:0]const u8 {
         const sliced = this.slice();
 
         if (Environment.isWindows) {
@@ -663,7 +663,10 @@ pub const PathLike = union(enum) {
             }
         }
 
-        if (sliced.len == 0) return "";
+        if (sliced.len == 0) {
+            buf[0] = 0;
+            return buf[0..0 :0];
+        }
 
         if (comptime !force) {
             if (sliced[sliced.len - 1] == 0) {

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -664,6 +664,8 @@ pub const PathLike = union(enum) {
         }
 
         if (sliced.len == 0) {
+            if (comptime !force) return "";
+
             buf[0] = 0;
             return buf[0..0 :0];
         }

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -2146,7 +2146,7 @@ pub const PosixToWinNormalizer = struct {
     pub fn resolveCWDWithExternalBufZ(
         buf: *bun.PathBuffer,
         maybe_posix_path: []const u8,
-    ) ![:0]const u8 {
+    ) ![:0]u8 {
         std.debug.assert(std.fs.path.isAbsoluteWindows(maybe_posix_path));
 
         if (bun.Environment.isWindows) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1163,6 +1163,15 @@ it("readlink", () => {
   expect(readlinkSync(actual)).toBe(realpathSync(import.meta.path));
 });
 
+it.if(isWindows)("symlink on windows with forward slashes", async () => {
+  const r = join(tmpdir(), Math.random().toString(32));
+  await fs.promises.rm(join(r, "files/2024"), { recursive: true, force: true });
+  await fs.promises.mkdir(join(r, "files/2024"), { recursive: true });
+  await fs.promises.writeFile(join(r, "files/2024/123.txt"), "text");
+  await fs.promises.symlink("files/2024/123.txt", join(r, "file-sym.txt"));
+  expect(await fs.promises.readlink(join(r, "file-sym.txt"))).toBe("files\\2024\\123.txt");
+});
+
 it("realpath async", async () => {
   const actual = join(tmpdir(), Math.random().toString(32) + "-fs-realpath.txt");
   try {

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -598,6 +598,7 @@ it("path.resolve", () => {
   const failures = [];
   const slashRE = /\//g;
   const backslashRE = /\\/g;
+  const isWindows = process.platform === "win32";
 
   const resolveTests = [
     [
@@ -632,7 +633,6 @@ it("path.resolve", () => {
       ],
     ],
   ];
-  const isWindows = false;
   resolveTests.forEach(([resolve, tests]) => {
     tests.forEach(([test, expected]) => {
       const actual = resolve.apply(null, test);


### PR DESCRIPTION
### What does this PR do?

Fixes #8273

`sliceZWithForcedCopy` now returns a (mutable) []u8 slice instead of a constant one, but only if you enable force copy.
