### PR TITLE
[windows] fix(fs.watchFile)

### DIFF
--- a/scripts/codegen.ps1
+++ b/scripts/codegen.ps1
@@ -5,7 +5,7 @@ $Script2=(Join-Path $PSScriptRoot "../src/codegen/create_hash_table")
 $CreateHashTable=(Get-Content $Script2 -Raw)
 $CreateHashTable.Replace("`r`n","`n") | Set-Content $Script2 -Force -NoNewline
 
-& 'C:\Program Files\WSL\wsl.exe' ./scripts/cross-compile-codegen.sh win32 x64 "build"
+& 'wsl.exe' ./scripts/cross-compile-codegen.sh win32 x64 "build"
 
 Set-Content $Script1 -Force -NoNewline -Value $CrossCompileCodegen
 Set-Content $Script2 -Force -NoNewline -Value $CreateHashTable

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -263,11 +263,6 @@ pub const AsyncCpTask = struct {
         vm: *JSC.VirtualMachine,
         arena: bun.ArenaAllocator,
     ) JSC.JSValue {
-        if (comptime Environment.isWindows) {
-            globalObject.throwTODO("fs.promises.cp is not implemented on Windows yet");
-            return .zero;
-        }
-
         var task = bun.new(
             AsyncCpTask,
             AsyncCpTask{
@@ -695,14 +690,14 @@ pub const AsyncReaddirRecursiveTask = struct {
 /// When clonefile cannot be used, this task is started once per file.
 pub const AsyncCpSingleFileTask = struct {
     cp_task: *AsyncCpTask,
-    src: [:0]const u8,
-    dest: [:0]const u8,
+    src: bun.OSPathSliceZ,
+    dest: bun.OSPathSliceZ,
     task: JSC.WorkPoolTask = .{ .callback = &workPoolCallback },
 
     pub fn create(
         parent: *AsyncCpTask,
-        src: [:0]const u8,
-        dest: [:0]const u8,
+        src: bun.OSPathSliceZ,
+        dest: bun.OSPathSliceZ,
     ) void {
         var task = bun.new(AsyncCpSingleFileTask, .{
             .cp_task = parent,
@@ -5722,8 +5717,18 @@ pub const NodeFS = struct {
         var to_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
 
         if (Environment.isWindows) {
+            const target: [:0]u8 = args.old_path.sliceZWithForceCopy(&this.sync_error_buf, true);
+            // UV does not normalize slashes in symlink targets, but Node does
+            // See https://github.com/oven-sh/bun/issues/8273
+            //
+            // TODO: investigate if simd can be easily used here
+            for (target) |*c| {
+                if (c.* == '/') {
+                    c.* = '\\';
+                }
+            }
             return Syscall.symlinkUV(
-                args.old_path.sliceZ(&this.sync_error_buf),
+                target,
                 args.new_path.sliceZ(&to_buf),
                 switch (args.link_type) {
                     .file => 0,
@@ -5781,6 +5786,7 @@ pub const NodeFS = struct {
 
     pub fn watchFile(_: *NodeFS, args: Arguments.WatchFile, comptime flavor: Flavor) Maybe(Return.WatchFile) {
         std.debug.assert(flavor == .sync);
+
         const watcher = args.createStatWatcher() catch |err| {
             const buf = std.fmt.allocPrint(bun.default_allocator, "{s} watching {}", .{ @errorName(err), bun.fmt.QuotedFormatter{ .text = args.path.slice() } }) catch unreachable;
             defer bun.default_allocator.free(buf);
@@ -5882,7 +5888,6 @@ pub const NodeFS = struct {
         const watcher = args.createFSWatcher() catch |err| {
             const buf = std.fmt.allocPrint(bun.default_allocator, "{s} watching {}", .{ @errorName(err), bun.fmt.QuotedFormatter{ .text = args.path.slice() } }) catch unreachable;
             defer bun.default_allocator.free(buf);
-
             args.global_this.throwValue((JSC.SystemError{
                 .message = bun.String.init(buf),
                 .code = bun.String.init(@errorName(err)),
@@ -6027,13 +6032,9 @@ pub const NodeFS = struct {
         }
 
         const flags = os.O.DIRECTORY | os.O.RDONLY;
-        var wbuf: if (Environment.isWindows) bun.WPathBuffer else void = undefined;
         const fd = switch (Syscall.openatOSPath(
             bun.toFD((std.fs.cwd().fd)),
-            if (Environment.isWindows and std.fs.path.isAbsoluteWindowsWTF16(src))
-                bun.strings.addNTPathPrefixIfNeeded(&wbuf, src)
-            else
-                src,
+            src,
             flags,
             0,
         )) {
@@ -6372,14 +6373,57 @@ pub const NodeFS = struct {
         }
 
         if (Environment.isWindows) {
-            const result = windows.CopyFileW(src, dest, @intFromBool(mode.shouldntOverwrite()));
-            if (result == bun.windows.FALSE) {
-                if (Maybe(Return.CopyFile).errnoSysP(result, .copyfile, this.osPathIntoSyncErrorBuf(src))) |e| {
-                    return e;
+            const stat_ = reuse_stat orelse switch (windows.GetFileAttributesW(src)) {
+                windows.INVALID_FILE_ATTRIBUTES => return .{ .err = .{
+                    .errno = @intFromEnum(C.SystemErrno.ENOENT),
+                    .syscall = .copyfile,
+                    .path = this.osPathIntoSyncErrorBuf(src),
+                } },
+                else => |result| result,
+            };
+            if (stat_ & windows.FILE_ATTRIBUTE_REPARSE_POINT == 0) {
+                if (windows.CopyFileW(src, dest, @intFromBool(mode.shouldntOverwrite())) == 0) {
+                    const err = windows.GetLastError();
+                    const errpath = switch (err) {
+                        .FILE_EXISTS, .ALREADY_EXISTS => dest,
+                        else => src,
+                    };
+                    return Maybe(Return.CopyFile).errnoSysP(0, .copyfile, this.osPathIntoSyncErrorBuf(errpath)) orelse .{ .err = .{
+                        .errno = @intFromEnum(C.SystemErrno.ENOENT),
+                        .syscall = .copyfile,
+                        .path = this.osPathIntoSyncErrorBuf(src),
+                    } };
                 }
+                return ret.success;
+            } else {
+                const handle = switch (bun.sys.openatWindows(bun.invalid_fd, src, os.O.RDONLY)) {
+                    .err => |err| return .{ .err = err },
+                    .result => |src_fd| src_fd,
+                };
+                var wbuf: bun.WPathBuffer = undefined;
+                const len = bun.windows.GetFinalPathNameByHandleW(handle.cast(), &wbuf, wbuf.len, 0);
+                if (len == 0) {
+                    return Maybe(Return.CopyFile).errnoSysP(0, .copyfile, this.osPathIntoSyncErrorBuf(dest)) orelse .{ .err = .{
+                        .errno = @intFromEnum(C.SystemErrno.ENOENT),
+                        .syscall = .copyfile,
+                        .path = this.osPathIntoSyncErrorBuf(dest),
+                    } };
+                }
+                const flags = if (stat_ & windows.FILE_ATTRIBUTE_DIRECTORY != 0)
+                    std.os.windows.SYMBOLIC_LINK_FLAG_DIRECTORY
+                else
+                    0;
+                if (windows.CreateSymbolicLinkW(dest, wbuf[0..len :0], flags) == 0) {
+                    return Maybe(Return.CopyFile).errnoSysP(0, .copyfile, this.osPathIntoSyncErrorBuf(dest)) orelse .{
+                        .err = .{
+                            .errno = @intFromEnum(C.SystemErrno.ENOENT),
+                            .syscall = .copyfile,
+                            .path = this.osPathIntoSyncErrorBuf(dest),
+                        },
+                    };
+                }
+                return ret.success;
             }
-
-            return ret.success;
         }
 
         return ret.todo();
@@ -6388,48 +6432,68 @@ pub const NodeFS = struct {
     /// Directory scanning + clonefile will block this thread, then each individual file copy (what the sync version
     /// calls "_copySingleFileSync") will be dispatched as a separate task.
     pub fn cpAsync(this: *NodeFS, task: *AsyncCpTask) void {
-        if (comptime Environment.isWindows) {
-            task.finishConcurrently(Maybe(Return.Cp).todo());
-            return;
-        }
-
         const args = task.args;
-        var src_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-        var dest_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-        const src = args.src.sliceZ(&src_buf);
-        const dest = args.dest.sliceZ(&dest_buf);
+        var src_buf: bun.OSPathBuffer = undefined;
+        var dest_buf: bun.OSPathBuffer = undefined;
+        const src = args.src.osPath(@ptrCast(&src_buf));
+        const dest = args.dest.osPath(@ptrCast(&dest_buf));
 
-        const stat_ = switch (Syscall.lstat(src)) {
-            .result => |result| result,
-            .err => |err| {
-                @memcpy(this.sync_error_buf[0..src.len], src);
-                task.finishConcurrently(.{ .err = err.withPath(this.sync_error_buf[0..src.len]) });
-                return;
-            },
-        };
-
-        if (!os.S.ISDIR(stat_.mode)) {
-            // This is the only file, there is no point in dispatching subtasks
-            const r = this._copySingleFileSync(
-                src,
-                dest,
-                @enumFromInt((if (args.flags.errorOnExist or !args.flags.force) Constants.COPYFILE_EXCL else @as(u8, 0))),
-                stat_,
-            );
-            if (r == .err and r.err.errno == @intFromEnum(E.EXIST) and !args.flags.errorOnExist) {
-                task.finishConcurrently(Maybe(Return.Cp).success);
+        if (Environment.isWindows) {
+            const attributes = windows.GetFileAttributesW(src);
+            if (attributes == windows.INVALID_FILE_ATTRIBUTES) {
+                task.finishConcurrently(.{ .err = .{
+                    .errno = @intFromEnum(C.SystemErrno.ENOENT),
+                    .syscall = .copyfile,
+                    .path = this.osPathIntoSyncErrorBuf(src),
+                } });
                 return;
             }
-            task.finishConcurrently(r);
-            return;
-        }
+            const file_or_symlink = (attributes & windows.FILE_ATTRIBUTE_DIRECTORY) == 0 or (attributes & windows.FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+            if (file_or_symlink) {
+                const r = this._copySingleFileSync(
+                    src,
+                    dest,
+                    @enumFromInt((if (args.flags.errorOnExist or !args.flags.force) Constants.COPYFILE_EXCL else @as(u8, 0))),
+                    attributes,
+                );
+                if (r == .err and r.err.errno == @intFromEnum(E.EXIST) and !args.flags.errorOnExist) {
+                    task.finishConcurrently(Maybe(Return.Cp).success);
+                    return;
+                }
+                task.finishConcurrently(r);
+                return;
+            }
+        } else {
+            const stat_ = switch (Syscall.lstat(src)) {
+                .result => |result| result,
+                .err => |err| {
+                    @memcpy(this.sync_error_buf[0..src.len], src);
+                    task.finishConcurrently(.{ .err = err.withPath(this.sync_error_buf[0..src.len]) });
+                    return;
+                },
+            };
 
+            if (!os.S.ISDIR(stat_.mode)) {
+                // This is the only file, there is no point in dispatching subtasks
+                const r = this._copySingleFileSync(
+                    src,
+                    dest,
+                    @enumFromInt((if (args.flags.errorOnExist or !args.flags.force) Constants.COPYFILE_EXCL else @as(u8, 0))),
+                    stat_,
+                );
+                if (r == .err and r.err.errno == @intFromEnum(E.EXIST) and !args.flags.errorOnExist) {
+                    task.finishConcurrently(Maybe(Return.Cp).success);
+                    return;
+                }
+                task.finishConcurrently(r);
+                return;
+            }
+        }
         if (!args.flags.recursive) {
-            @memcpy(this.sync_error_buf[0..src.len], src);
             task.finishConcurrently(.{ .err = .{
                 .errno = @intFromEnum(E.ISDIR),
                 .syscall = .copyfile,
-                .path = this.sync_error_buf[0..src.len],
+                .path = this.osPathIntoSyncErrorBuf(src),
             } });
             return;
         }
@@ -6446,9 +6510,9 @@ pub const NodeFS = struct {
         this: *NodeFS,
         args: Arguments.Cp.Flags,
         task: *AsyncCpTask,
-        src_buf: *[bun.MAX_PATH_BYTES]u8,
+        src_buf: *bun.OSPathBuffer,
         src_dir_len: PathString.PathInt,
-        dest_buf: *[bun.MAX_PATH_BYTES]u8,
+        dest_buf: *bun.OSPathBuffer,
         dest_dir_len: PathString.PathInt,
     ) bool {
         const src = src_buf[0..src_dir_len :0];
@@ -6477,20 +6541,30 @@ pub const NodeFS = struct {
         }
 
         const open_flags = os.O.DIRECTORY | os.O.RDONLY;
-        const fd = switch (Syscall.open(src, open_flags, 0)) {
+        const fd = switch (Syscall.openatOSPath(bun.invalid_fd, src, open_flags, 0)) {
             .err => |err| {
-                @memcpy(this.sync_error_buf[0..src.len], src);
-                task.finishConcurrently(.{ .err = err.withPath(this.sync_error_buf[0..src.len]) });
+                task.finishConcurrently(.{ .err = err.withPath(this.osPathIntoSyncErrorBuf(src)) });
                 return false;
             },
             .result => |fd_| fd_,
         };
         defer _ = Syscall.close(fd);
 
-        const mkdir_ = this.mkdirRecursive(.{
-            .path = PathLike{ .string = PathString.init(dest) },
-            .recursive = true,
-        }, .sync);
+        var buf: bun.OSPathBuffer = undefined;
+
+        // const normdest = bun.path.normalizeStringGenericTZ(bun.OSPathChar, dest, &buf, true, std.fs.path.sep, bun.path.isSepAnyT, false, true);
+        const normdest: bun.OSPathSliceZ = if (Environment.isWindows)
+            switch (bun.sys.normalizePathWindows(u16, bun.invalid_fd, dest, &buf)) {
+                .err => |err| {
+                    task.finishConcurrently(.{ .err = err });
+                    return false;
+                },
+                .result => |normdest| normdest,
+            }
+        else
+            dest;
+
+        const mkdir_ = this.mkdirRecursiveOSPath(normdest, Arguments.Mkdir.DefaultMode, false);
         switch (mkdir_) {
             .err => |err| {
                 task.finishConcurrently(.{ .err = err });
@@ -6500,59 +6574,62 @@ pub const NodeFS = struct {
         }
 
         const dir = fd.asDir();
-        var iterator = DirIterator.iterate(dir, .u8);
+        var iterator = DirIterator.iterate(dir, if (Environment.isWindows) .u16 else .u8);
         var entry = iterator.next();
         while (switch (entry) {
             .err => |err| {
-                @memcpy(this.sync_error_buf[0..src.len], src);
-                task.finishConcurrently(.{ .err = err.withPath(this.sync_error_buf[0..src.len]) });
+                // @memcpy(this.sync_error_buf[0..src.len], src);
+                task.finishConcurrently(.{ .err = err.withPath(this.osPathIntoSyncErrorBuf(src)) });
                 return false;
             },
             .result => |ent| ent,
         }) |current| : (entry = iterator.next()) {
             switch (current.kind) {
                 .directory => {
-                    @memcpy(src_buf[src_dir_len + 1 .. src_dir_len + 1 + current.name.len], current.name.slice());
+                    const cname = current.name.slice();
+                    @memcpy(src_buf[src_dir_len + 1 .. src_dir_len + 1 + cname.len], cname);
                     src_buf[src_dir_len] = std.fs.path.sep;
-                    src_buf[src_dir_len + 1 + current.name.len] = 0;
+                    src_buf[src_dir_len + 1 + cname.len] = 0;
 
-                    @memcpy(dest_buf[dest_dir_len + 1 .. dest_dir_len + 1 + current.name.len], current.name.slice());
+                    @memcpy(dest_buf[dest_dir_len + 1 .. dest_dir_len + 1 + cname.len], cname);
                     dest_buf[dest_dir_len] = std.fs.path.sep;
-                    dest_buf[dest_dir_len + 1 + current.name.len] = 0;
+                    dest_buf[dest_dir_len + 1 + cname.len] = 0;
 
                     const should_continue = this._cpAsyncDirectory(
                         args,
                         task,
                         src_buf,
-                        src_dir_len + 1 + current.name.len,
+                        @truncate(src_dir_len + 1 + cname.len),
                         dest_buf,
-                        dest_dir_len + 1 + current.name.len,
+                        @truncate(dest_dir_len + 1 + cname.len),
                     );
                     if (!should_continue) return false;
                 },
                 else => {
                     _ = task.subtask_count.fetchAdd(1, .Monotonic);
 
+                    const cname = current.name.slice();
+
                     // Allocate a path buffer for the path data
                     var path_buf = bun.default_allocator.alloc(
-                        u8,
-                        src_dir_len + 1 + current.name.len + 1 + dest_dir_len + 1 + current.name.len + 1,
-                    ) catch @panic("Out of memory");
+                        bun.OSPathChar,
+                        src_dir_len + 1 + cname.len + 1 + dest_dir_len + 1 + cname.len + 1,
+                    ) catch bun.outOfMemory();
 
                     @memcpy(path_buf[0..src_dir_len], src_buf[0..src_dir_len]);
                     path_buf[src_dir_len] = std.fs.path.sep;
-                    @memcpy(path_buf[src_dir_len + 1 .. src_dir_len + 1 + current.name.len], current.name.slice());
-                    path_buf[src_dir_len + 1 + current.name.len] = 0;
+                    @memcpy(path_buf[src_dir_len + 1 .. src_dir_len + 1 + cname.len], cname);
+                    path_buf[src_dir_len + 1 + cname.len] = 0;
 
-                    @memcpy(path_buf[src_dir_len + 1 + current.name.len + 1 .. src_dir_len + 1 + current.name.len + 1 + dest_dir_len], dest_buf[0..dest_dir_len]);
-                    path_buf[src_dir_len + 1 + current.name.len + 1 + dest_dir_len] = std.fs.path.sep;
-                    @memcpy(path_buf[src_dir_len + 1 + current.name.len + 1 + dest_dir_len + 1 .. src_dir_len + 1 + current.name.len + 1 + dest_dir_len + 1 + current.name.len], current.name.slice());
-                    path_buf[src_dir_len + 1 + current.name.len + 1 + dest_dir_len + 1 + current.name.len] = 0;
+                    @memcpy(path_buf[src_dir_len + 1 + cname.len + 1 .. src_dir_len + 1 + cname.len + 1 + dest_dir_len], dest_buf[0..dest_dir_len]);
+                    path_buf[src_dir_len + 1 + cname.len + 1 + dest_dir_len] = std.fs.path.sep;
+                    @memcpy(path_buf[src_dir_len + 1 + cname.len + 1 + dest_dir_len + 1 .. src_dir_len + 1 + cname.len + 1 + dest_dir_len + 1 + cname.len], cname);
+                    path_buf[src_dir_len + 1 + cname.len + 1 + dest_dir_len + 1 + cname.len] = 0;
 
                     AsyncCpSingleFileTask.create(
                         task,
-                        path_buf[0 .. src_dir_len + 1 + current.name.len :0],
-                        path_buf[src_dir_len + 1 + current.name.len + 1 .. src_dir_len + 1 + current.name.len + 1 + dest_dir_len + 1 + current.name.len :0],
+                        path_buf[0 .. src_dir_len + 1 + cname.len :0],
+                        path_buf[src_dir_len + 1 + cname.len + 1 .. src_dir_len + 1 + cname.len + 1 + dest_dir_len + 1 + cname.len :0],
                     );
                 },
             }

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -220,31 +220,11 @@ pub const StatWatcher = struct {
             if (arguments.nextEat()) |options_or_callable| {
                 // options
                 if (options_or_callable.isObject()) {
-                    if (options_or_callable.get(ctx, "persistent")) |persistent_| {
-                        if (!persistent_.isBoolean()) {
-                            JSC.throwInvalidArguments(
-                                "persistent must be a boolean.",
-                                .{},
-                                ctx,
-                                exception,
-                            );
-                            return null;
-                        }
-                        persistent = persistent_.toBoolean();
-                    }
+                    // default true
+                    persistent = (options_or_callable.getOptional(ctx, "persistent", bool) catch return null) orelse true;
 
-                    if (options_or_callable.get(ctx, "bigint")) |bigint_| {
-                        if (!bigint_.isBoolean()) {
-                            JSC.throwInvalidArguments(
-                                "bigint must be a boolean.",
-                                .{},
-                                ctx,
-                                exception,
-                            );
-                            return null;
-                        }
-                        bigint = bigint_.toBoolean();
-                    }
+                    // default false
+                    bigint = (options_or_callable.getOptional(ctx, "bigint", bool) catch return null) orelse false;
 
                     if (options_or_callable.get(ctx, "interval")) |interval_| {
                         if (!interval_.isNumber()) {

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -62,7 +62,7 @@ pub const StatWatcherScheduler = struct {
 
                 const vm = watcher.globalThis.bunVM();
                 this.timer = uws.Timer.create(
-                    vm.event_loop_handle orelse @panic("UWS Loop was not initialized yet."),
+                    vm.uwsLoop(),
                     this,
                 );
 
@@ -457,6 +457,7 @@ pub const StatWatcher = struct {
         if (bun.strings.startsWith(slice, "file://")) {
             slice = slice[6..];
         }
+
         var parts = [_]string{slice};
         const file_path = Path.joinAbsStringBuf(
             Fs.FileSystem.instance.top_level_dir,

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -76,10 +76,9 @@ describe("fs.watchFile", () => {
   });
 
   test("bigint stats", async () => {
-    const { resolve, promise } = Promise.withResolvers();
-
-    fs.watchFile(path.join(testDir, encodingFileName), { interval: 50, bigint: true }, (curr, prev) => {
-      resolve([curr, prev]);
+    let entries: any = [];
+    fs.watchFile(path.join(testDir, encodingFileName), { interval: 50, bigint: true }, (curr, prev) => {    
+      entries.push([curr, prev]);
     });
 
     const interval = repeat(() => {
@@ -88,11 +87,11 @@ describe("fs.watchFile", () => {
     await Bun.sleep(200);
     clearInterval(interval);
 
-    const entry = (await promise) as [fs.BigIntStats, fs.BigIntStats];
-
     fs.unwatchFile(path.join(testDir, encodingFileName));
 
-    expect(typeof entry[0].mtimeMs === "bigint").toBe(true);
+    expect(entries.length).toBeGreaterThan(0);
+
+    expect(typeof entries[0][0].mtimeMs === "bigint").toBe(true);
   });
 
   test("StatWatcherScheduler stress test (1000 watchers with random times)", async () => {

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -41,7 +41,7 @@ describe("fs.watchFile", () => {
       entries.push([curr, prev]);
     });
     let increment = 0;
-    const interval = repeat(()=> {
+    const interval = repeat(() => {
       increment++;
       fs.writeFileSync(path.join(testDir, "watch.txt"), "hello" + increment);
     });
@@ -61,9 +61,9 @@ describe("fs.watchFile", () => {
     fs.watchFile(path.join(testDir, encodingFileName), { interval: 50 }, (curr, prev) => {
       entries.push([curr, prev]);
     });
-    
+
     let increment = 0;
-    const interval = repeat(()=> {
+    const interval = repeat(() => {
       increment++;
       fs.writeFileSync(path.join(testDir, encodingFileName), "hello" + increment);
     });
@@ -81,12 +81,12 @@ describe("fs.watchFile", () => {
 
   test("bigint stats", async () => {
     let entries: any = [];
-    fs.watchFile(path.join(testDir, encodingFileName), { interval: 50, bigint: true }, (curr, prev) => {    
+    fs.watchFile(path.join(testDir, encodingFileName), { interval: 50, bigint: true }, (curr, prev) => {
       entries.push([curr, prev]);
     });
-    
+
     let increment = 0;
-    const interval = repeat(()=> {
+    const interval = repeat(() => {
       increment++;
       fs.writeFileSync(path.join(testDir, encodingFileName), "hello" + increment);
     });

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -40,8 +40,10 @@ describe("fs.watchFile", () => {
     fs.watchFile(path.join(testDir, "watch.txt"), { interval: 50 }, (curr, prev) => {
       entries.push([curr, prev]);
     });
-    const interval = repeat(() => {
-      fs.writeFileSync(path.join(testDir, "watch.txt"), "hello2");
+    let increment = 0;
+    const interval = repeat(()=> {
+      increment++;
+      fs.writeFileSync(path.join(testDir, "watch.txt"), "hello" + increment);
     });
     await Bun.sleep(200);
     clearInterval(interval);
@@ -59,9 +61,11 @@ describe("fs.watchFile", () => {
     fs.watchFile(path.join(testDir, encodingFileName), { interval: 50 }, (curr, prev) => {
       entries.push([curr, prev]);
     });
-
-    const interval = repeat(() => {
-      fs.writeFileSync(path.join(testDir, encodingFileName), "hello2");
+    
+    let increment = 0;
+    const interval = repeat(()=> {
+      increment++;
+      fs.writeFileSync(path.join(testDir, encodingFileName), "hello" + increment);
     });
     await Bun.sleep(200);
     clearInterval(interval);
@@ -80,9 +84,11 @@ describe("fs.watchFile", () => {
     fs.watchFile(path.join(testDir, encodingFileName), { interval: 50, bigint: true }, (curr, prev) => {    
       entries.push([curr, prev]);
     });
-
-    const interval = repeat(() => {
-      fs.writeFileSync(path.join(testDir, encodingFileName), "hello2");
+    
+    let increment = 0;
+    const interval = repeat(()=> {
+      increment++;
+      fs.writeFileSync(path.join(testDir, encodingFileName), "hello" + increment);
     });
     await Bun.sleep(200);
     clearInterval(interval);

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -40,7 +40,7 @@ describe("fs.watchFile", () => {
     fs.watchFile(path.join(testDir, "watch.txt"), { interval: 50 }, (curr, prev) => {
       entries.push([curr, prev]);
     });
-    const interval = repeat(()=> {
+    const interval = repeat(() => {
       fs.writeFileSync(path.join(testDir, "watch.txt"), "hello2");
     });
     await Bun.sleep(200);
@@ -59,8 +59,8 @@ describe("fs.watchFile", () => {
     fs.watchFile(path.join(testDir, encodingFileName), { interval: 50 }, (curr, prev) => {
       entries.push([curr, prev]);
     });
-    
-    const interval = repeat(()=> {
+
+    const interval = repeat(() => {
       fs.writeFileSync(path.join(testDir, encodingFileName), "hello2");
     });
     await Bun.sleep(200);
@@ -77,12 +77,12 @@ describe("fs.watchFile", () => {
 
   test("bigint stats", async () => {
     const { resolve, promise } = Promise.withResolvers();
-    
-    fs.watchFile(path.join(testDir, encodingFileName), { interval: 50, bigint: true }, (curr, prev) => {    
+
+    fs.watchFile(path.join(testDir, encodingFileName), { interval: 50, bigint: true }, (curr, prev) => {
       resolve([curr, prev]);
     });
-    
-    const interval = repeat(()=> {
+
+    const interval = repeat(() => {
       fs.writeFileSync(path.join(testDir, encodingFileName), "hello2");
     });
     await Bun.sleep(200);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing Tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
