### PR TITLE
Fix for #8729

### DIFF
--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -56,6 +56,13 @@ for (let [gcTick, label] of [
           });
         }).toThrow("No such file or directory");
       });
+
+      it("does not throw for command not existing", async () => {
+        const { success } = spawnSync({
+          cmd: ["doesnotexist"],
+        });
+        expect(success).toBe(false);
+      });
     });
 
     describe("spawn", () => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->
This fixes #8729 by returning `success = false` from `Bun.spawnSync`. It goes down the already existing execution path that returns a `SystemError` in `node:child_process` since I didn't know how to return the error code/information from `Bun.spawnSync` cleanly without changing the API of `Bun.spawnSync`.

After this change, the following:
```
const { spawnSync } = require("child_process");

console.log(spawnSync("doesnotexist"));
```

Results in:
```
{
  signal: null,
  status: undefined,
  output: [ null, null, null ],
  stdout: null,
  stderr: null,
  error: 1 | const { spawnSync } = require("child_process");
2 | 
3 | console.log(spawnSync("doesnotexist"));
                ^
error: null
   errno: -1
   code: "undefined"
 syscall: "spawnSync"
   path: "doesnotexist"

      at new SystemError (node:child_process:1094:27)
      at node:child_process:247:49
      at /home/akash/Dev/bun/script.js:3:13
      at asyncFunctionResume (:1:21)
      at promiseReactionJobWithoutPromiseUnwrapAsyncContext (:1:21)
      at promiseReactionJob (:1:21)
,
}
```

This is my first issue/pull request, so I'd appreciate any advice or guidance.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote a test and verified locally it passes

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
