### PR TITLE
Fix ref-counting of Bun.file(0) etc. (#8687)

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1553,20 +1553,19 @@ pub const Blob = struct {
                     break :brk copy;
                 },
                 .fd => {
-                    switch (bun.FDTag.get(path_or_fd.fd)) {
-                        .stdin => return Blob.initWithStore(
-                            vm.rareData().stdin(),
+                    const optional_store: ?*Store = switch (bun.FDTag.get(path_or_fd.fd)) {
+                        .stdin => vm.rareData().stdin(),
+                        .stderr => vm.rareData().stderr(),
+                        .stdout => vm.rareData().stdout(),
+                        else => null,
+                    };
+
+                    if (optional_store) |store| {
+                        store.ref();
+                        return Blob.initWithStore(
+                            store,
                             globalThis,
-                        ),
-                        .stderr => return Blob.initWithStore(
-                            vm.rareData().stderr(),
-                            globalThis,
-                        ),
-                        .stdout => return Blob.initWithStore(
-                            vm.rareData().stdout(),
-                            globalThis,
-                        ),
-                        else => {},
+                        );
                     }
                     break :brk path_or_fd.*;
                 },

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -310,6 +310,14 @@ it("Bun.write(Bun.stderr, 'new TextEncoder().encode(Bun.write STDERR TEST'))", a
   expect(await Bun.write(Bun.stderr, new TextEncoder().encode("\nBun.write STDERR TEST\n\n"))).toBe(24);
 });
 
+it("Bun.file(0) survives GC", async () => {
+  for (let i = 0; i < 10; i++) {
+    let f = Bun.file(0);
+    await gcTick();
+    expect(Bun.inspect(f)).toContain("FileRef (fd: 0)");
+  }
+});
+
 // FLAKY TEST
 // Since Bun.file is resolved lazily, this needs to specifically be checked
 it("Bun.write('output.html', HTMLRewriter.transform(Bun.file)))", async done => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

This fixes ref-counting of the Blob.Store objects used for Bun.file(0)/Bun.file(1)/Bun.file(2), which are reused for multiple Blob objects.

The previous code shared one Blob.Store object between several Blobs, which led to those Blob.Store objects being collected and freed prematurely.

See #8687 for further details.

Fixes #8687 

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote an automated test, which is included.

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)