### PR TITLE
fix(test) http2 memory leak

### DIFF
--- a/test/js/node/http2/node-http2-memory-leak.js
+++ b/test/js/node/http2/node-http2-memory-leak.js
@@ -31,7 +31,7 @@ const PAYLOAD = Buffer.from("a".repeat(128 * 1024));
 const info = await nodeEchoServer();
 
 async function runGC() {
-  for(let i = 0; i < GC_AGRESSIVENESS; i++) {
+  for (let i = 0; i < GC_AGRESSIVENESS; i++) {
     await Bun.sleep(10);
     Bun.gc(true);
   }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
http2 memory test improvement
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
- [x] Test changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Test should be more reliable on CI/CD
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
