### PR TITLE
Fix FIFO data loss (#8695)

### DIFF
--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -4320,6 +4320,8 @@ pub fn NewFIFO(comptime EventLoop: JSC.EventLoopKind) type {
                 }
             }
 
+            if (this.pending.state != .pending) return;
+
             const read_result = this.read(
                 this.buf,
                 // On Linux, we end up calling ioctl() twice if we don't do this

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -479,3 +479,18 @@ describe("ENOENT", () => {
     });
   });
 });
+
+it("timed output should work", async () => {
+  const producer_file = path.join(import.meta.dir, "timed-stderr-output.js");
+
+  const producer = Bun.spawn([bunExe(), "run", producer_file], {
+    stderr: "pipe",
+  });
+
+  let text = "";
+  for await (const chunk of producer.stderr) {
+    text += [...chunk].map(x => String.fromCharCode(x)).join("");
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  expect(text).toBe("0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n");
+});

--- a/test/js/bun/io/timed-stderr-output.js
+++ b/test/js/bun/io/timed-stderr-output.js
@@ -1,4 +1,4 @@
 for (let i = 0; i <= 20; i++) {
-  console.error(i);
+  await Bun.write(Bun.stderr, i + "\n");
   await new Promise(r => setTimeout(r, 100));
 }

--- a/test/js/bun/io/timed-stderr-output.js
+++ b/test/js/bun/io/timed-stderr-output.js
@@ -1,0 +1,4 @@
+for (let i = 0; i <= 20; i++) {
+  console.error(i);
+  await new Promise(r => setTimeout(r, 100));
+}


### PR DESCRIPTION
Under certain circumstances, we would read data from FIFOs without a sensible place to put it, leading to dropped chunks in async iteration over Bun.stdin.stream().

Fixes #8695.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

This changes `FIFO.ready` so it doesn't read unconditionally from the FIFO's FD. Instead, we only do so if there is a pending Promise or handler that will receive the data.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

~This issue is sensitive to timing and I don't know how to write automated tests for it.~

I wrote a test.

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

- [x] I included a test for the new code, or an existing test covers it
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
