### PR TITLE
fix: symlinked files as entry points have wrong `import.meta.main`

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1801,7 +1801,6 @@ pub const Command = struct {
                     if (comptime Environment.isWindows) {
                         resolved = resolve_path.normalizeString(resolved, true, .windows);
                     }
-                    absolute_script_path = resolved;
                     break :brk bun.openFile(
                         resolved,
                         .{ .mode = .read_only },
@@ -1843,8 +1842,7 @@ pub const Command = struct {
 
             Global.configureAllocator(.{ .long_running = true });
 
-            // the case where this doesn't work is if the script name on disk doesn't end with a known JS-like file extension
-            absolute_script_path = absolute_script_path orelse brk: {
+            absolute_script_path = brk: {
                 if (comptime !Environment.isWindows) break :brk bun.getFdPath(file, &script_name_buf) catch return false;
 
                 var fd_path_buf: bun.PathBuffer = undefined;

--- a/test/regression/issue/08757.test.ts
+++ b/test/regression/issue/08757.test.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, symlinkSync } from "fs";
+import { tmpdir } from "os";
+import { bunRun } from "../../harness";
+
+if (process.env.IS_SUBPROCESS) {
+  console.log(process.argv[1]);
+  console.log(Bun.main);
+  console.log(import.meta.main);
+  console.log(import.meta.dir);
+  console.log(import.meta.file);
+  console.log(import.meta.path);
+  process.exit(0);
+}
+
+test("absolute path to a file that is symlinked has import.meta.main", () => {
+  const root = mkdtempSync(tmpdir() + "/bun-08757-");
+  try {
+    symlinkSync(process.argv[1], root + "/main.js");
+  } catch (e) {
+    if (process.platform == "win32") {
+      console.log("symlinkSync failed on Windows, skipping test");
+      return;
+    }
+    throw e;
+  }
+
+  const result = bunRun(root + "/main.js", {
+    IS_SUBPROCESS: "1",
+  });
+  expect(result.stdout.trim()).toBe(
+    [
+      //
+      import.meta.path,
+      import.meta.path,
+      "true",
+      import.meta.dir,
+      import.meta.file,
+      import.meta.path,
+    ].join("\n"),
+  );
+});


### PR DESCRIPTION
Regression fix from 1.0.25

Fixes #8757 

<img width="1121" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/0b6ee2e6-0e28-4be1-9e14-7b5f1d63e49d">
