### PR TITLE
remap 0.0.0.0 to localhost on windows

### DIFF
--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -260,8 +260,6 @@ describe("net.Socket read", () => {
 
 describe("net.Socket write", () => {
   const message = "Hello World!".repeat(1024);
-  // on linux connecting to localhost doesn't work as it tries to use ipv6 or something like that
-  let hostname = process.platform === "win32" ? "localhost" : "0.0.0.0";
 
   function runWithServer(cb: (..._: any[]) => void) {
     return (done: (_?: any) => void) => {
@@ -317,7 +315,7 @@ describe("net.Socket write", () => {
     "should work with .end(data)",
     runWithServer((server, done) => {
       const socket = new Socket()
-        .connect(server.port, hostname)
+        .connect(server.port, server.hostname)
         .on("ready", () => {
           expect(socket).toBeDefined();
           expect(socket.connecting).toBe(false);
@@ -331,7 +329,7 @@ describe("net.Socket write", () => {
     "should work with .write(data).end()",
     runWithServer((server, done) => {
       const socket = new Socket()
-        .connect(server.port, hostname, () => {
+        .connect(server.port, server.hostname, () => {
           expect(socket).toBeDefined();
           expect(socket.connecting).toBe(false);
         })
@@ -345,7 +343,7 @@ describe("net.Socket write", () => {
     "should work with multiple .write()s",
     runWithServer((server, done) => {
       const socket = new Socket()
-        .connect(server.port, hostname, () => {
+        .connect(server.port, server.hostname, () => {
           expect(socket).toBeDefined();
           expect(socket.connecting).toBe(false);
         })


### PR DESCRIPTION
### What does this PR do?
On windows, connecting to 0.0.0.0 is an error, as it's an invalid address. Node remaps this to localhost to match POSIX behavior. This PR does the same.

### How did you verify your code works?
A bunch of tests now pass.
