### PR TITLE
fix: Increase max depth of expect diffs

### DIFF
--- a/src/bun.js/test/diff_format.zig
+++ b/src/bun.js/test/diff_format.zig
@@ -100,6 +100,7 @@ pub const DiffFormatter = struct {
                 .flush = false,
                 .ordered_properties = true,
                 .quote_strings = true,
+                .max_depth = 100,
             };
             ConsoleObject.format(
                 .Debug,


### PR DESCRIPTION
Fix Issue #6519

### What does this PR do?

Fix issue #6519 but having the diff formatter have a max_depth of 100 (instead of default 3).

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I used the user example in the issue.

- [ ] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

Before:

```
bun test v1.0.6 (969da088)
[... intentionally truncated]
error: expect(received).toStrictEqual(expected)

  {
    a: {
      b: {
        c: [Object ...]
      }
    }
  }

- Expected  - 0
+ Received  + 0
[... intentionally truncated]
```

After:

```
2 | 
3 | test("mytest", () => {
4 |     const a = { a: { b: { c: { d: 1 } } } };
5 |     const b = { a: { b: { c: { d: 2 } } } };
6 | 
7 |     expect(a).toStrictEqual(b);
     ^
error: expect(received).toStrictEqual(expected)

  {
    a: {
      b: {
        c: {
+         d: 1,
-         d: 2,
        },
      },
    },
  }

- Expected  - 1
+ Received  + 1

      at /Users/steve/Code/bun/test/js/test.test.js:7:2
✗ mytest [2.01ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 tests across 1 files. [66.00ms]
```
