### PR TITLE
Chore - quick note on dependencies for C++

### DIFF
--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -105,7 +105,7 @@ $ export PATH="$PATH:/usr/lib/llvm16/bin"
 
 {% /codetabs %}
 
-> ⚠️ Depending on your system, you may need to install the C++ standard library independently. See the [troubleshooting section](#span-file-not-found-on-ubuntu) for more information.
+> ⚠️ Ubuntu distributions may require installation of the C++ standard library independently. See the [troubleshooting section](#span-file-not-found-on-ubuntu) for more information.
 
 ## Building Bun
 

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -105,13 +105,7 @@ $ export PATH="$PATH:/usr/lib/llvm16/bin"
 
 {% /codetabs %}
 
-Depending on your system, you may need to install the C++ standard library independently.
-
-{% codetabs %}
-```bash#Ubuntu/Debian
-sudo apt install g++-12
-```
-{%/codetabs %}
+> ⚠️ Depending on your system, you may need to install the C++ standard library independently. See the [troubleshooting section](#span-file-not-found-on-ubuntu) for more information.
 
 ## Building Bun
 
@@ -258,6 +252,16 @@ Bun relies on C++20 features like `std::span`, which are not available in GCC ve
 fatal error: 'span' file not found
 #include <span>
          ^~~~~~
+```
+
+The issue may manifest when initially running `bun setup` as Clang being unable to compile a simple program:
+
+```
+The C++ compiler
+
+  "/usr/bin/clang++-16"
+
+is not able to compile a simple test program.
 ```
 
 To fix the error, we need to update the GCC version to 11. To do this, we'll need to check if the latest version is available in the distribution's official repositories or use a third-party repository that provides GCC 11 packages. Here are general steps:

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -105,6 +105,14 @@ $ export PATH="$PATH:/usr/lib/llvm16/bin"
 
 {% /codetabs %}
 
+Depending on your system, you may need to install the C++ standard library independently.
+
+{% codetabs %}
+```bash#Ubuntu/Debian
+sudo apt install g++-12
+```
+{%/codetabs %}
+
 ## Building Bun
 
 After cloning the repository, run the following command to run the first build. This may take a while as it will clone submodules and build dependencies.


### PR DESCRIPTION
### What does this PR do?

Adds a small note on C++ standard lib dependencies when setting up bun.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes