### PR TITLE
Ignore panic in reload

### DIFF
--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -176,7 +176,10 @@ extern "C" void on_before_reload_process_linux()
 {
     // close all file descriptors except stdin, stdout, stderr and possibly IPC.
     // if you're passing additional file descriptors to Bun, you're probably not passing more than 8.
-    bun_close_range(8, ~0U, 0U);
+    if (bun_close_range(8, ~0U, CLOSE_RANGE_CLOEXEC) != 0) {
+        // CLOSE_RANGE_CLOEXEC was added in Linux v5.11
+        bun_close_range(8, ~0U, 0);
+    }
 
     // reset all signals to default
     sigset_t signal_set;

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -166,6 +166,10 @@ extern "C" int clock_gettime_monotonic(int64_t* tv_sec, int64_t* tv_nsec)
 
 #include <sys/syscall.h>
 
+#ifndef CLOSE_RANGE_CLOEXEC
+#define CLOSE_RANGE_CLOEXEC (1U << 2)
+#endif
+
 // close_range is glibc > 2.33, which is very new
 static ssize_t bun_close_range(unsigned int start, unsigned int end, unsigned int flags)
 {
@@ -176,10 +180,8 @@ extern "C" void on_before_reload_process_linux()
 {
     // close all file descriptors except stdin, stdout, stderr and possibly IPC.
     // if you're passing additional file descriptors to Bun, you're probably not passing more than 8.
-    if (bun_close_range(8, ~0U, CLOSE_RANGE_CLOEXEC) != 0) {
-        // CLOSE_RANGE_CLOEXEC was added in Linux v5.11
-        bun_close_range(8, ~0U, 0);
-    }
+    // If this fails, it's ultimately okay, we're just trying our best to avoid leaking file descriptors.
+    bun_close_range(8, ~0U, CLOSE_RANGE_CLOEXEC);
 
     // reset all signals to default
     sigset_t signal_set;

--- a/src/output.zig
+++ b/src/output.zig
@@ -225,7 +225,9 @@ pub fn disableBuffering() void {
     if (comptime Environment.isNative) enable_buffering = false;
 }
 
-pub fn panic(comptime fmt: string, args: anytype) noreturn {
+pub noinline fn panic(comptime fmt: string, args: anytype) noreturn {
+    @setCold(true);
+
     if (Output.isEmojiEnabled()) {
         std.debug.panic(comptime Output.prettyFmt(fmt, true), args);
     } else {

--- a/src/panic_handler.zig
+++ b/src/panic_handler.zig
@@ -32,6 +32,8 @@ pub fn NewPanicHandler(comptime panic_func: fn ([]const u8, ?*std.builtin.StackT
             // This exists to ensure we flush all buffered output before panicking.
             Output.flush();
 
+            bun.maybeHandlePanicDuringProcessReload();
+
             Report.fatal(null, msg);
 
             Output.disableBuffering();

--- a/src/report.zig
+++ b/src/report.zig
@@ -337,6 +337,8 @@ pub noinline fn handleCrash(signal: i32, addr: usize) void {
 pub noinline fn globalError(err: anyerror, trace_: @TypeOf(@errorReturnTrace())) noreturn {
     @setCold(true);
 
+    bun.maybeHandlePanicDuringProcessReload();
+
     error_return_trace = trace_;
 
     if (@atomicRmw(bool, &globalError_ranOnce, .Xchg, true, .Monotonic)) {


### PR DESCRIPTION
### What does this PR do?

Ignore when a panic happens while the process is reloading in another thread

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
