### PR TITLE
[windows] fix(fetch) file:///, keepalive and tests on Windows

### DIFF
--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -2167,10 +2167,10 @@ pub const Fetch = struct {
                 }
 
                 var cwd_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                const cwd = std.os.getcwd(&cwd_buf) catch |err| {
+                const cwd = if (Environment.isWindows) (std.os.getcwd(&cwd_buf) catch |err| {
                     globalThis.throwError(err, "Failed to resolve file url");
                     return .zero;
-                };
+                }) else globalThis.bunVM().bundler.fs.top_level_dir;
 
                 const fullpath = bun.path.joinAbsStringBuf(
                     cwd,

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -2146,8 +2146,8 @@ pub const Fetch = struct {
                 @TypeOf(&stream.writer()),
                 &stream.writer(),
                 url.path,
-            ) catch {
-                globalThis.throwOutOfMemory();
+            ) catch |err| {
+                globalThis.throwError(err, "Failed to decode file url");
                 return .zero;
             }];
 
@@ -2158,8 +2158,8 @@ pub const Fetch = struct {
                         if (url_path_decoded[0] == '/') {
                             url_path_decoded = url_path_decoded[1..];
                         }
-                        break :brk PosixToWinNormalizer.resolveCWDWithExternalBufZ(&path_buf, url_path_decoded) catch {
-                            globalThis.throwOutOfMemory();
+                        break :brk PosixToWinNormalizer.resolveCWDWithExternalBufZ(&path_buf, url_path_decoded) catch |err| {
+                            globalThis.throwError(err, "Failed to resolve file url");
                             return .zero;
                         };
                     }
@@ -2167,8 +2167,8 @@ pub const Fetch = struct {
                 }
 
                 var cwd_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                const cwd = std.os.getcwd(&cwd_buf) catch {
-                    globalThis.throwOutOfMemory();
+                const cwd = std.os.getcwd(&cwd_buf) catch |err| {
+                    globalThis.throwError(err, "Failed to resolve file url");
                     return .zero;
                 };
 
@@ -2183,8 +2183,8 @@ pub const Fetch = struct {
                     .auto,
                 );
                 if (Environment.isWindows) {
-                    break :brk PosixToWinNormalizer.resolveCWDWithExternalBufZ(&path_buf2, fullpath) catch {
-                        globalThis.throwOutOfMemory();
+                    break :brk PosixToWinNormalizer.resolveCWDWithExternalBufZ(&path_buf2, fullpath) catch |err| {
+                        globalThis.throwError(err, "Failed to resolve file url");
                         return .zero;
                     };
                 }

--- a/src/http.zig
+++ b/src/http.zig
@@ -1491,8 +1491,6 @@ redirect_type: FetchRedirect = FetchRedirect.follow,
 redirect: []u8 = &.{},
 timeout: usize = 0,
 progress_node: ?*std.Progress.Node = null,
-received_keep_alive: bool = false,
-
 disable_timeout: bool = false,
 disable_keepalive: bool = false,
 disable_decompression: bool = false,
@@ -1556,7 +1554,9 @@ pub fn isKeepAlivePossible(this: *HTTPClient) bool {
         if (this.http_proxy != null and this.url.isHTTPS()) {
             return false;
         }
-        return !this.disable_keepalive;
+
+        //check state
+        if (this.state.allow_keepalive and !this.disable_keepalive) return true;
     }
     return false;
 }
@@ -1852,18 +1852,6 @@ pub const AsyncHTTP = struct {
             }
         }
         return this;
-    }
-
-    pub fn isKeepAlivePossible(this: *AsyncHTTP) bool {
-        if (comptime FeatureFlags.enable_keepalive) {
-            // is not possible to reuse Proxy with TSL, so disable keepalive if url is tunneling HTTPS
-            if (this.http_proxy != null and this.url.isHTTPS()) {
-                return false;
-            }
-            // check state
-            if (this.state.allow_keepalive and !this.disable_keepalive) return true;
-        }
-        return false;
     }
 
     pub fn initSync(allocator: std.mem.Allocator, method: Method, url: URL, headers: Headers.Entries, headers_buf: string, response_buffer: *MutableString, request_body: []const u8, timeout: usize, http_proxy: ?URL, hostname: ?[]u8, redirect_type: FetchRedirect) AsyncHTTP {

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -6,7 +6,7 @@ import { mkfifo } from "mkfifo";
 import { tmpdir } from "os";
 import { gzipSync } from "zlib";
 import { join } from "path";
-import { gc, withoutAggressiveGC, gcTick } from "harness";
+import { gc, withoutAggressiveGC, gcTick, isWindows } from "harness";
 import net from "net";
 
 const tmp_dir = mkdtempSync(join(realpathSync(tmpdir()), "fetch.test"));
@@ -844,7 +844,8 @@ describe("Bun.file", () => {
     }
   }
 
-  describe("bad permissions throws", () => {
+  // on Windows the creator of the file will be able to read from it so this test is disabled on it
+  describe.skipIf(isWindows)("bad permissions throws", () => {
     const path = join(tmp_dir, "my-new-file");
     beforeAll(async () => {
       await Bun.write(path, "hey");

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -830,7 +830,8 @@ describe("Bun.file", () => {
     return file;
   });
 
-  it("size is Infinity on a fifo", () => {
+  // this test uses libc.so or dylib so we skip on windows
+  it.skipIf(isWindows)("size is Infinity on a fifo", () => {
     const path = join(tmp_dir, "test-fifo");
     mkfifo(path);
     const { size } = Bun.file(path);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
