### PR TITLE
[windows] fix which

### DIFF
--- a/src/glob.zig
+++ b/src/glob.zig
@@ -1006,10 +1006,10 @@ pub fn GlobWalker_(
         }
 
         inline fn startsWithDot(filepath: []const u8) bool {
-            if (comptime !isWindows) {
-                return filepath[0] == '.';
+            if (comptime isWindows) {
+                return filepath.len > 1 and filepath[1] == '.';
             } else {
-                return filepath[1] == '.';
+                return filepath.len > 0 and filepath[0] == '.';
             }
         }
 

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -2120,7 +2120,7 @@ pub const PosixToWinNormalizer = struct {
         return maybe_posix_path;
     }
 
-    fn resolveCWDWithExternalBuf(
+    pub fn resolveCWDWithExternalBuf(
         buf: *Buf,
         maybe_posix_path: []const u8,
     ) ![]const u8 {

--- a/src/which.zig
+++ b/src/which.zig
@@ -71,6 +71,44 @@ pub fn endsWithExtension(str: []const u8) bool {
     return false;
 }
 
+/// Check if the WPathBuffer holds a existing file path, checking also for windows extensions variants like .exe, .cmd and .bat (internally used by whichWin)
+fn searchBin(buf: *bun.WPathBuffer, path_size: usize, check_windows_extensions: bool) ?[:0]const u16 {
+    if (bun.sys.existsOSPath(buf[0..path_size :0], true))
+        return buf[0..path_size :0];
+
+    if (check_windows_extensions) {
+        buf[path_size] = '.';
+        buf[path_size + 1 + 3] = 0;
+        inline for (win_extensionsW) |ext| {
+            @memcpy(buf[path_size + 1 .. path_size + 1 + 3], ext);
+            if (bun.sys.existsOSPath(buf[0 .. path_size + 1 + ext.len :0], true))
+                return buf[0 .. path_size + 1 + ext.len :0];
+        }
+    }
+    return null;
+}
+
+/// Check if bin file exists in this path (internally used by whichWin)
+fn searchBinInPath(buf: *bun.WPathBuffer, path_buf: *[bun.MAX_PATH_BYTES]u8, path: []const u8, bin: []const u8, check_windows_extensions: bool) ?[:0]const u16 {
+    if (path.len == 0) return null;
+    const segment = if (std.fs.path.isAbsolute(path)) (PosixToWinNormalizer.resolveCWDWithExternalBuf(path_buf, path) catch return null) else path;
+    const segment_utf16 = bun.strings.convertUTF8toUTF16InBuffer(buf, segment);
+
+    var segment_len = segment.len;
+    var segment_utf16_len = segment_utf16.len;
+    if (buf[segment.len - 1] != std.fs.path.sep) {
+        buf[segment.len] = std.fs.path.sep;
+        segment_len += 1;
+        segment_utf16_len += 1;
+    }
+
+    const bin_utf16 = bun.strings.convertUTF8toUTF16InBuffer(buf[segment_len..], bin);
+    const path_size = segment_utf16_len + bin_utf16.len;
+    buf[path_size] = 0;
+
+    return searchBin(buf, path_size, check_windows_extensions);
+}
+
 /// This is the windows version of `which`.
 /// It operates on wide strings.
 /// It is similar to Get-Command in powershell.
@@ -78,87 +116,29 @@ pub fn whichWin(buf: *bun.WPathBuffer, path: []const u8, cwd: []const u8, bin: [
     if (bin.len == 0) return null;
     var path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
 
-    const no_exec_extension = !endsWithExtension(bin);
+    const check_windows_extensions = !endsWithExtension(bin);
 
     // handle absolute paths
     if (std.fs.path.isAbsolute(bin)) {
         const normalized_bin = PosixToWinNormalizer.resolveCWDWithExternalBuf(&path_buf, bin) catch return null;
         const bin_utf16 = bun.strings.convertUTF8toUTF16InBuffer(buf, normalized_bin);
         buf[bin_utf16.len] = 0;
-        if (bun.sys.existsOSPath(buf[0..normalized_bin.len :0], true))
-            return buf[0..normalized_bin.len :0];
-        if (no_exec_extension) {
-            buf[bin_utf16.len] = '.';
-            buf[bin_utf16.len + 1 + 3] = 0;
-            inline for (win_extensionsW) |ext| {
-                @memcpy(buf[normalized_bin.len + 1 .. bin_utf16.len + 1 + ext.len], ext);
-                if (bun.sys.existsOSPath(buf[0 .. normalized_bin.len + 1 + ext.len :0], true))
-                    return buf[0 .. normalized_bin.len + 1 + ext.len :0];
-            }
-        }
-        return null;
+        return searchBin(buf, bin_utf16.len, check_windows_extensions);
     }
 
-    if (cwd.len > 0) {
-        var path_iter = std.mem.tokenizeScalar(u8, cwd, std.fs.path.delimiter);
-        while (path_iter.next()) |_segment| {
-            const segment = if (std.fs.path.isAbsolute(_segment)) (PosixToWinNormalizer.resolveCWDWithExternalBuf(&path_buf, _segment) catch continue) else _segment;
-            const segment_utf16 = bun.strings.convertUTF8toUTF16InBuffer(buf, segment);
-
-            var segment_len = segment.len;
-            var segment_utf16_len = segment_utf16.len;
-            if (buf[segment.len - 1] != std.fs.path.sep) {
-                buf[segment.len] = std.fs.path.sep;
-                segment_len += 1;
-                segment_utf16_len += 1;
-            }
-
-            const bin_utf16 = bun.strings.convertUTF8toUTF16InBuffer(buf[segment_len..], bin);
-            buf[segment_utf16_len + bin_utf16.len] = 0;
-
-            if (bun.sys.existsOSPath(buf[0 .. segment_utf16_len + bin_utf16.len :0], true))
-                return buf[0 .. segment_utf16_len + bin_utf16.len :0];
-
-            if (no_exec_extension) {
-                buf[segment_utf16_len + bin_utf16.len] = '.';
-                buf[segment_utf16_len + bin_utf16.len + 1 + 3] = 0;
-                inline for (win_extensionsW) |ext| {
-                    @memcpy(buf[segment_utf16_len + bin_utf16.len + 1 .. segment_utf16_len + bin_utf16.len + 1 + 3], ext);
-                    if (bun.sys.existsOSPath(buf[0 .. segment_utf16_len + bin_utf16.len + 1 + ext.len :0], true))
-                        return buf[0 .. segment_utf16_len + bin_utf16.len + 1 + ext.len :0];
-                }
-            }
-        }
+    // check if bin is in cwd
+    if (searchBinInPath(buf, &path_buf, cwd, bin, check_windows_extensions)) |bin_path| {
+        return bin_path;
     }
+
+    // iterate over system path delimiter
     var path_iter = std.mem.tokenizeScalar(u8, path, std.fs.path.delimiter);
     while (path_iter.next()) |_segment| {
+        // we also iterate over ':' to match linux behavior
         var segment_iter = std.mem.tokenizeScalar(u8, _segment, ':');
         while (segment_iter.next()) |segment_part| {
-            const segment = if (std.fs.path.isAbsolute(segment_part)) (PosixToWinNormalizer.resolveCWDWithExternalBuf(&path_buf, segment_part) catch continue) else segment_part;
-            const segment_utf16 = bun.strings.convertUTF8toUTF16InBuffer(buf, segment);
-
-            var segment_len = segment.len;
-            var segment_utf16_len = segment_utf16.len;
-            if (buf[segment.len - 1] != std.fs.path.sep) {
-                buf[segment.len] = std.fs.path.sep;
-                segment_len += 1;
-                segment_utf16_len += 1;
-            }
-
-            const bin_utf16 = bun.strings.convertUTF8toUTF16InBuffer(buf[segment_len..], bin);
-            buf[segment_utf16_len + bin_utf16.len] = 0;
-
-            if (bun.sys.existsOSPath(buf[0 .. segment_utf16_len + bin_utf16.len :0], true))
-                return buf[0 .. segment_utf16_len + bin_utf16.len :0];
-
-            if (no_exec_extension) {
-                buf[segment_utf16_len + bin_utf16.len] = '.';
-                buf[segment_utf16_len + bin_utf16.len + 1 + 3] = 0;
-                inline for (win_extensionsW) |ext| {
-                    @memcpy(buf[segment_utf16_len + bin_utf16.len + 1 .. segment_utf16_len + bin_utf16.len + 1 + 3], ext);
-                    if (bun.sys.existsOSPath(buf[0 .. segment_utf16_len + bin_utf16.len + 1 + ext.len :0], true))
-                        return buf[0 .. segment_utf16_len + bin_utf16.len + 1 + ext.len :0];
-                }
+            if (searchBinInPath(buf, &path_buf, segment_part, bin, check_windows_extensions)) |bin_path| {
+                return bin_path;
             }
         }
     }

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -5,6 +5,7 @@ import { which } from "bun";
 import { mkdtempSync, rmSync, chmodSync, mkdirSync, unlinkSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { rmdirSync } from "js/node/fs/export-star-from";
 
 test("which", () => {
   {
@@ -15,6 +16,7 @@ test("which", () => {
   }
 
   let basedir = join(tmpdir(), "which-test-" + Math.random().toString(36).slice(2));
+  
   rmSync(basedir, { recursive: true, force: true });
   mkdirSync(basedir, { recursive: true });
   writeFixture(join(basedir, "myscript.sh"));
@@ -30,6 +32,9 @@ test("which", () => {
 
     const orig = process.cwd();
     process.chdir(tmpdir());
+    try {
+      rmdirSync("myscript.sh");
+    } catch{}
     // Our cwd is not /tmp
     expect(which("myscript.sh")).toBe(null);
 

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -16,7 +16,7 @@ test("which", () => {
   }
 
   let basedir = join(tmpdir(), "which-test-" + Math.random().toString(36).slice(2));
-  
+
   rmSync(basedir, { recursive: true, force: true });
   mkdirSync(basedir, { recursive: true });
   writeFixture(join(basedir, "myscript.sh"));
@@ -34,7 +34,7 @@ test("which", () => {
     process.chdir(tmpdir());
     try {
       rmdirSync("myscript.sh");
-    } catch{}
+    } catch {}
     // Our cwd is not /tmp
     expect(which("myscript.sh")).toBe(null);
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
