### PR TITLE
fix: flaky test

### DIFF
--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -355,7 +355,7 @@ describe("bun test", () => {
           import { test, expect } from "bun:test";
           import { sleep } from "bun";
           test("timeout", async () => {
-            await sleep(5001);
+            await sleep(5010);
           });
         `,
       });


### PR DESCRIPTION
This often fails in CI (and on my machine) non-deterministically.

The 1ms + the 5000 is likely setting up a race condition in tasks/microtasks. Just changing it to to +10ms instead of +1ms is enough.


- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes


- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

