### PR TITLE
Fix some errors not showing up in GitHub annotations

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1157,7 +1157,7 @@ pub const DescribeScope = struct {
         if (this.shouldEvaluateScope()) {
             // Run the afterAll callbacks, in reverse order
             // unless there were no tests for this scope
-            if (this.runCallback(globalThis, .afterAll)) |err| {
+            if (this.execCallback(globalThis, .afterAll)) |err| {
                 globalThis.bunVM().onUnhandledError(globalThis, err);
             }
         }

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -584,7 +584,7 @@ pub const TestScope = struct {
         debug("onReject", .{});
         const arguments = callframe.arguments(2);
         const err = arguments.ptr[0];
-        globalThis.bunVM().runErrorHandler(err, null);
+        globalThis.bunVM().onUnhandledError(globalThis, err);
         var task: *TestRunnerTask = arguments.ptr[1].asPromisePtr(TestRunnerTask);
         task.handleResult(.{ .fail = expect.active_test_expectation_counter.actual }, .promise);
         globalThis.bunVM().autoGarbageCollect();
@@ -619,7 +619,7 @@ pub const TestScope = struct {
                     task.handleResult(.{ .pass = expect.active_test_expectation_counter.actual }, .callback);
                 } else {
                     debug("done(err)", .{});
-                    globalThis.bunVM().runErrorHandlerWithDedupe(err, null);
+                    globalThis.bunVM().onUnhandledError(globalThis, err);
                     task.handleResult(.{ .fail = expect.active_test_expectation_counter.actual }, .callback);
                 }
             } else {
@@ -678,7 +678,7 @@ pub const TestScope = struct {
         initial_value = callJSFunctionForTestRunner(vm, vm.global, this.func, this.func_arg);
 
         if (initial_value.isAnyError()) {
-            vm.runErrorHandler(initial_value, null);
+            vm.onUnhandledError(vm.global, initial_value);
 
             if (this.tag == .todo) {
                 return .{ .todo = {} };
@@ -701,7 +701,7 @@ pub const TestScope = struct {
             }
             switch (promise.status(vm.global.vm())) {
                 .Rejected => {
-                    vm.runErrorHandler(promise.result(vm.global.vm()), null);
+                    vm.onUnhandledError(vm.global, promise.result(vm.global.vm()));
 
                     if (this.tag == .todo) {
                         return .{ .todo = {} };
@@ -875,7 +875,7 @@ pub const DescribeScope = struct {
             if (args.len > 0) {
                 const err = args.ptr[0];
                 if (!err.isEmptyOrUndefinedOrNull()) {
-                    ctx.bunVM().runErrorHandlerWithDedupe(err, null);
+                    ctx.bunVM().onUnhandledError(ctx.bunVM().global, err);
                 }
             }
             scope.done = true;
@@ -1068,12 +1068,12 @@ pub const DescribeScope = struct {
                 switch (prom.status(globalObject.ptr().vm())) {
                     JSPromise.Status.Fulfilled => {},
                     else => {
-                        globalObject.bunVM().runErrorHandlerWithDedupe(prom.result(globalObject.ptr().vm()), null);
+                        globalObject.bunVM().onUnhandledError(globalObject, prom.result(globalObject.ptr().vm()));
                         return .undefined;
                     },
                 }
             } else if (result.toError()) |err| {
-                globalObject.bunVM().runErrorHandlerWithDedupe(err, null);
+                globalObject.bunVM().onUnhandledError(globalObject, err);
                 return .undefined;
             }
         }
@@ -1100,7 +1100,8 @@ pub const DescribeScope = struct {
         var i: TestRunner.Test.ID = 0;
 
         if (this.shouldEvaluateScope()) {
-            if (this.runCallback(globalObject, .beforeAll)) |_| {
+            if (this.runCallback(globalObject, .beforeAll)) |err| {
+                globalObject.bunVM().onUnhandledError(globalObject, err);
                 while (i < end) {
                     Jest.runner.?.reportFailure(i + this.test_id_start, source.path.text, tests[i].label, 0, 0, this);
                     i += 1;
@@ -1145,7 +1146,7 @@ pub const DescribeScope = struct {
 
         if (!skipped) {
             if (this.runCallback(globalThis, .afterEach)) |err| {
-                globalThis.bunVM().runErrorHandler(err, null);
+                globalThis.bunVM().onUnhandledError(globalThis, err);
             }
         }
 
@@ -1156,8 +1157,8 @@ pub const DescribeScope = struct {
         if (this.shouldEvaluateScope()) {
             // Run the afterAll callbacks, in reverse order
             // unless there were no tests for this scope
-            if (this.execCallback(globalThis, .afterAll)) |err| {
-                globalThis.bunVM().runErrorHandler(err, null);
+            if (this.runCallback(globalThis, .afterAll)) |err| {
+                globalThis.bunVM().onUnhandledError(globalThis, err);
             }
         }
 
@@ -1294,17 +1295,14 @@ pub const TestRunnerTask = struct {
         }
 
         jsc_vm.onUnhandledRejectionCtx = this;
-        if (Output.is_github_action) {
-            jsc_vm.setOnException(printGithubAnnotation);
-        }
 
         if (this.needs_before_each) {
             this.needs_before_each = false;
             const label = test_.label;
 
             if (this.describe.runCallback(globalThis, .beforeEach)) |err| {
+                jsc_vm.onUnhandledError(globalThis, err);
                 Jest.runner.?.reportFailure(test_id, this.source_file_path, label, 0, 0, this.describe);
-                jsc_vm.runErrorHandler(err, null);
                 return false;
             }
         }
@@ -1379,10 +1377,12 @@ pub const TestRunnerTask = struct {
         const test_ = this.describe.tests.items[test_id];
         var describe = this.describe;
         describe.tests.items[test_id] = test_;
+
         if (comptime from == .timeout) {
-            Output.prettyErrorln("<r><red>Timeout<r><d>:<r> test <b>{}<r> timed out after {d}ms", .{ bun.fmt.quote(test_.label), test_.timeout_millis });
-            Output.flush();
+            const err = this.globalThis.createErrorInstance("Test {} timed out after {d}ms", .{ bun.fmt.quote(test_.label), test_.timeout_millis });
+            this.globalThis.bunVM().onUnhandledError(this.globalThis, err);
         }
+
         processTestResult(this, this.globalThis, result, test_, test_id, describe);
     }
 
@@ -1433,13 +1433,12 @@ pub const TestRunnerTask = struct {
     }
 
     fn deinit(this: *TestRunnerTask) void {
-        var vm = JSC.VirtualMachine.get();
+        const vm = JSC.VirtualMachine.get();
         if (vm.onUnhandledRejectionCtx) |ctx| {
             if (ctx == @as(*anyopaque, @ptrCast(this))) {
                 vm.onUnhandledRejectionCtx = null;
             }
         }
-        vm.clearOnException();
 
         this.ref.unref(vm);
 
@@ -1652,127 +1651,6 @@ inline fn createIfScope(
     }
 
     return JSC.NewFunction(globalThis, name, 2, call, false);
-}
-
-// In Github Actions, emit an annotation that renders the error and location.
-// https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
-pub fn printGithubAnnotation(exception: *JSC.ZigException) void {
-    const name = exception.name;
-    const message = exception.message;
-    const frames = exception.stack.frames();
-    const top_frame = if (frames.len > 0) frames[0] else null;
-    const dir = bun.getenvZ("GITHUB_WORKSPACE") orelse bun.fs.FileSystem.instance.top_level_dir;
-    const allocator = bun.default_allocator;
-
-    var has_location = false;
-
-    if (top_frame) |frame| {
-        if (!frame.position.isInvalid()) {
-            const source_url = frame.source_url.toUTF8(allocator);
-            defer source_url.deinit();
-            const file = bun.path.relative(dir, source_url.slice());
-            Output.printError("\n::error file={s},line={d},col={d},title=", .{
-                file,
-                frame.position.line_start + 1,
-                frame.position.column_start,
-            });
-            has_location = true;
-        }
-    }
-
-    if (!has_location) {
-        Output.printError("\n::error title=", .{});
-    }
-
-    if (name.isEmpty() or name.eqlComptime("Error")) {
-        Output.printError("error", .{});
-    } else {
-        Output.printError("{s}", .{name.githubAction()});
-    }
-
-    if (!message.isEmpty()) {
-        const message_slice = message.toUTF8(allocator);
-        defer message_slice.deinit();
-        const msg = message_slice.slice();
-
-        var cursor: u32 = 0;
-        while (strings.indexOfNewlineOrNonASCIIOrANSI(msg, cursor)) |i| {
-            cursor = i + 1;
-            if (msg[i] == '\n') {
-                const first_line = bun.String.fromUTF8(msg[0..i]);
-                Output.printError(": {s}::", .{first_line.githubAction()});
-                break;
-            }
-        } else {
-            Output.printError(": {s}::", .{message.githubAction()});
-        }
-
-        while (strings.indexOfNewlineOrNonASCIIOrANSI(msg, cursor)) |i| {
-            cursor = i + 1;
-            if (msg[i] == '\n') {
-                break;
-            }
-        }
-
-        if (cursor > 0) {
-            const body = ZigString.init(msg[cursor..]);
-            Output.printError("{s}", .{body.githubAction()});
-        }
-    } else {
-        Output.printError("::", .{});
-    }
-
-    // TODO: cleanup and refactor to use printStackTrace()
-    if (top_frame) |_| {
-        const vm = VirtualMachine.get();
-        const origin = if (vm.is_from_devserver) &vm.origin else null;
-
-        var i: i16 = 0;
-        while (i < frames.len) : (i += 1) {
-            const frame = frames[@as(usize, @intCast(i))];
-            const source_url = frame.source_url.toUTF8(allocator);
-            defer source_url.deinit();
-            const file = bun.path.relative(dir, source_url.slice());
-            const func = frame.function_name.toUTF8(allocator);
-
-            if (file.len == 0 and func.len == 0) continue;
-
-            const has_name = std.fmt.count("{any}", .{frame.nameFormatter(
-                false,
-            )}) > 0;
-
-            // %0A = escaped newline
-            if (has_name) {
-                Output.printError(
-                    "%0A      at {any} ({any})",
-                    .{
-                        frame.nameFormatter(false),
-                        frame.sourceURLFormatter(
-                            file,
-                            origin,
-                            false,
-                            false,
-                        ),
-                    },
-                );
-            } else {
-                Output.printError(
-                    "%0A      at {any}",
-                    .{
-                        frame.sourceURLFormatter(
-                            file,
-                            origin,
-                            false,
-                            false,
-                        ),
-                    },
-                );
-            }
-        }
-    }
-
-    Output.printError("\n", .{});
-    Output.flush();
 }
 
 fn consumeArg(

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1025,8 +1025,7 @@ pub const TestCommand = struct {
 
             switch (promise.status(vm.global.vm())) {
                 .Rejected => {
-                    const result = promise.result(vm.global.vm());
-                    vm.runErrorHandler(result, null);
+                    vm.onUnhandledError(vm.global, promise.result(vm.global.vm()));
                     reporter.summary.fail += 1;
 
                     if (reporter.jest.bail == reporter.summary.fail) {
@@ -1110,8 +1109,8 @@ pub const TestCommand = struct {
 
         if (is_last) {
             if (jest.Jest.runner != null) {
-                if (jest.DescribeScope.runGlobalCallbacks(vm.global, .afterAll)) |after| {
-                    vm.global.bunVM().runErrorHandler(after, null);
+                if (jest.DescribeScope.runGlobalCallbacks(vm.global, .afterAll)) |err| {
+                    vm.onUnhandledError(vm.global, err);
                 }
             }
         }

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -493,13 +493,39 @@ describe("bun test", () => {
       });
       expect(stderr).not.toContain("::error");
     });
-    test("should annotate errors when enabled", () => {
+    test("should annotate errors in the global scope", () => {
       const stderr = runTest({
         input: `
-          import { test, expect } from "bun:test";
-          test("fail", () => {
+          throw new Error();
+        `,
+        env: {
+          GITHUB_ACTIONS: "true",
+        },
+      });
+      expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error::/);
+    });
+    test.each(["test", "describe"])("should annotate errors in a %s scope", (type) => {
+      const stderr = runTest({
+        input: `
+          import { ${type} } from "bun:test";
+          ${type}("fail", () => {
             throw new Error();
           });
+        `,
+        env: {
+          GITHUB_ACTIONS: "true",
+        },
+      });
+      expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error::/);
+    });
+    test.each(["beforeAll", "beforeEach", "afterEach", "afterAll"])("should annotate errors in a %s callback", (type) => {
+      const stderr = runTest({
+        input: `
+          import { test, ${type} } from "bun:test";
+          ${type}(() => {
+            throw new Error();
+          });
+          test("test", () => {});
         `,
         env: {
           GITHUB_ACTIONS: "true",
@@ -538,6 +564,21 @@ describe("bun test", () => {
         },
       });
       expect(stderr).toMatch(/::error title=error: Oops!::/);
+    });
+    test("should annotate a test timeout", () => {
+      const stderr = runTest({
+        input: `
+          import { test } from "bun:test";
+          test("time out", async () => {
+            await Bun.sleep(1000);
+          }, { timeout: 1 });
+        `,
+        env: {
+          FORCE_COLOR: "1",
+          GITHUB_ACTIONS: "true",
+        },
+      });
+      expect(stderr).toMatch(/::error title=error: Test \"time out\" timed out after \d+ms::/);
     });
   });
   describe(".each", () => {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -504,7 +504,7 @@ describe("bun test", () => {
       });
       expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error::/);
     });
-    test.each(["test", "describe"])("should annotate errors in a %s scope", (type) => {
+    test.each(["test", "describe"])("should annotate errors in a %s scope", type => {
       const stderr = runTest({
         input: `
           import { ${type} } from "bun:test";
@@ -518,7 +518,7 @@ describe("bun test", () => {
       });
       expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error::/);
     });
-    test.each(["beforeAll", "beforeEach", "afterEach", "afterAll"])("should annotate errors in a %s callback", (type) => {
+    test.each(["beforeAll", "beforeEach", "afterEach", "afterAll"])("should annotate errors in a %s callback", type => {
       const stderr = runTest({
         input: `
           import { test, ${type} } from "bun:test";


### PR DESCRIPTION
### What does this PR do?

- Removes dead code that checked logic for preventing `expect()` outside a test
- Changes usages in `jest.zig` and `test_command.zig` to use `vm.onUnhandledError`
- Fixes errors such as timeouts, errors throw in the global scope, and errors thrown in lifecycle hooks from not print a GitHub annotation


### How did you verify your code works?

Added tests

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
