### PR TITLE
[windows] fix timer tests

### DIFF
--- a/test/js/web/timers/setInterval.test.js
+++ b/test/js/web/timers/setInterval.test.js
@@ -27,7 +27,7 @@ it("setInterval", async () => {
   });
 
   expect(result).toBe(10);
-  expect(performance.now() - start >= 10).toBe(true);
+  expect(performance.now() - start > 9).toBe(true);
 });
 
 it("clearInterval", async () => {
@@ -66,7 +66,7 @@ it("setInterval if refreshed before run, should reschedule to run later", done =
   let timer = setInterval(() => {
     let end = Date.now();
     clearInterval(timer);
-    expect(end - start).toBeGreaterThanOrEqual(150);
+    expect(end - start).toBeGreaterThan(149);
     done();
   }, 100);
 

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -131,7 +131,7 @@ it("Bun.sleep", async () => {
   await Bun.sleep(2);
   sleeps++;
   const end = performance.now();
-  expect((end - start) * 1000).toBeGreaterThanOrEqual(3);
+  expect((end - start) * 1000).toBeGreaterThan(2);
 
   expect(sleeps).toBe(3);
 });
@@ -152,7 +152,7 @@ it("Bun.sleep works with a Date object", async () => {
   ten_ms.setMilliseconds(ten_ms.getMilliseconds() + 12);
   const now = performance.now();
   await Bun.sleep(ten_ms);
-  expect(performance.now() - now).toBeGreaterThanOrEqual(10);
+  expect(performance.now() - now).toBeGreaterThan(11);
 });
 
 it("node.js timers/promises setTimeout propagates exceptions", async () => {
@@ -251,7 +251,7 @@ it("setTimeout if refreshed before run, should reschedule to run later", done =>
   let start = Date.now();
   let timer = setTimeout(() => {
     let end = Date.now();
-    expect(end - start).toBeGreaterThanOrEqual(150);
+    expect(end - start).toBeGreaterThan(149);
     done();
   }, 100);
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
sometimes when using libuv backend we can get 1ms early events on setTimeout and setInterval
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
- [x] Test changes
### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
