### PR TITLE
Add charset to text/css mime type

### DIFF
--- a/src/http/mime_type.zig
+++ b/src/http/mime_type.zig
@@ -91,7 +91,7 @@ pub const Category = enum {
 
 pub const none = MimeType.initComptime("", .none);
 pub const other = MimeType.initComptime("application/octet-stream", .other);
-pub const css = MimeType.initComptime("text/css", .css);
+pub const css = MimeType.initComptime("text/css;charset=utf-8", .css);
 pub const javascript = MimeType.initComptime("text/javascript;charset=utf-8", .javascript);
 pub const ico = MimeType.initComptime("image/vnd.microsoft.icon", .image);
 pub const html = MimeType.initComptime("text/html;charset=utf-8", .html);

--- a/test/js/bun/util/file-type.test.ts
+++ b/test/js/bun/util/file-type.test.ts
@@ -11,4 +11,9 @@ describe("util file tests", () => {
     });
     expect(custom_type.type).toBe("custom/mimetype");
   });
+
+  test("content type is text/css;charset=utf-8", () => {
+    const file = Bun.file("test.css");
+    expect(file.type).toBe("text/css;charset=utf-8");
+  });
 });

--- a/test/js/bun/util/file-type.test.ts
+++ b/test/js/bun/util/file-type.test.ts
@@ -12,7 +12,7 @@ describe("util file tests", () => {
     expect(custom_type.type).toBe("custom/mimetype");
   });
 
-  test("content type is text/css;charset=utf-8", () => {
+  test("mime-type is text/css;charset=utf-8", () => {
     const file = Bun.file("test.css");
     expect(file.type).toBe("text/css;charset=utf-8");
   });


### PR DESCRIPTION
Standard: https://www.iana.org/assignments/media-types/text/css
Extra info: https://stackoverflow.com/questions/70643383/which-mime-types-contain-charset-utf-8-directive

tl;dr almost anything that is read as text should include the charset.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fixes the warning in Edge that says to include utf-8 when Bun returns a stylesheet.

![image](https://github.com/oven-sh/bun/assets/141754874/874d21e5-74f5-4ce1-ae70-de1f463d3234)
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->
### How did you verify your code works?
Added test to ensure Bun.file("something.css") returns the correct mime type.

- [x] Code changes