### PR TITLE
remove zeromq from default-trusted-deps

### DIFF
--- a/src/install/default-trusted-dependencies.txt
+++ b/src/install/default-trusted-dependencies.txt
@@ -362,6 +362,5 @@ xxhash
 yarn
 yo
 yorkie
-zeromq
 zlib-sync
 zopflipng-bin


### PR DESCRIPTION
### What

Remove `zeromq` from the list of default-trusted-deps.
Bun crashes when running zeromq. 

ex:
```
dyld[28564]: missing symbol called
[1]    28564 killed     bun run index.ts
```

There is an open issue tracking this with all the details: https://github.com/oven-sh/bun/issues/8498
