### PR TITLE
fix error message in bun.serve

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -861,16 +861,6 @@ pub const ServerConfig = struct {
                 }
             }
 
-            if (arg.getTruthy(global, "tls")) |tls| {
-                if (SSLConfig.inJS(global, tls, exception)) |ssl_config| {
-                    args.ssl_config = ssl_config;
-                }
-
-                if (exception.* != null) {
-                    return args;
-                }
-            }
-
             // @compatibility Bun v0.x - v0.2.1
             // this used to be top-level, now it's "tls" object
             if (args.ssl_config == null) {
@@ -916,6 +906,20 @@ pub const ServerConfig = struct {
                     conf.deinit();
                 }
                 return args;
+            }
+
+            if (arg.getTruthy(global, "tls")) |tls| {
+                if (SSLConfig.inJS(global, tls, exception)) |ssl_config| {
+                    args.ssl_config = ssl_config;
+                }
+
+                if (exception.* != null) {
+                    return args;
+                }
+
+                if (global.hasException()) {
+                    return args;
+                }
             }
         } else {
             JSC.throwInvalidArguments("Bun.serve expects an object", .{}, global, exception);

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -861,18 +861,6 @@ pub const ServerConfig = struct {
                 }
             }
 
-            // @compatibility Bun v0.x - v0.2.1
-            // this used to be top-level, now it's "tls" object
-            if (args.ssl_config == null) {
-                if (SSLConfig.inJS(global, arg, exception)) |ssl_config| {
-                    args.ssl_config = ssl_config;
-                }
-
-                if (exception.* != null) {
-                    return args;
-                }
-            }
-
             if (arg.getTruthy(global, "maxRequestBodySize")) |max_request_body_size| {
                 if (max_request_body_size.isNumber()) {
                     args.max_request_body_size = @as(u64, @intCast(@max(0, max_request_body_size.toInt64())));
@@ -910,6 +898,22 @@ pub const ServerConfig = struct {
 
             if (arg.getTruthy(global, "tls")) |tls| {
                 if (SSLConfig.inJS(global, tls, exception)) |ssl_config| {
+                    args.ssl_config = ssl_config;
+                }
+
+                if (exception.* != null) {
+                    return args;
+                }
+
+                if (global.hasException()) {
+                    return args;
+                }
+            }
+
+            // @compatibility Bun v0.x - v0.2.1
+            // this used to be top-level, now it's "tls" object
+            if (args.ssl_config == null) {
+                if (SSLConfig.inJS(global, arg, exception)) |ssl_config| {
                     args.ssl_config = ssl_config;
                 }
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5351,3 +5351,8 @@ extern "C" EncodedJSValue ExpectStatic__getPrototype(JSC::JSGlobalObject* global
 {
     return JSValue::encode(reinterpret_cast<Zig::GlobalObject*>(globalObject)->JSExpectStaticPrototype());
 }
+
+extern "C" bool JSGlobalObject__hasException(JSC::JSGlobalObject* globalObject)
+{
+    return DECLARE_CATCH_SCOPE(globalObject->vm()).exception() != 0;
+}

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -2922,6 +2922,11 @@ pub const JSGlobalObject = extern struct {
         return cppFn("getCachedObject", .{ this, key });
     }
 
+    extern fn JSGlobalObject__hasException(*JSGlobalObject) bool;
+    pub fn hasException(this: *JSGlobalObject) bool {
+        return JSGlobalObject__hasException(this);
+    }
+
     pub fn vm(this: *JSGlobalObject) *VM {
         return cppFn("vm", .{this});
     }


### PR DESCRIPTION
### What does this PR do?

Fixes #4555

This is one example why using `JSC.C.ExceptionRef` is a horrible idea. We should not be using these at any point in Bun.

This error in particular has caused many users a lot of confusion because a faulty error was printed.

The real error happens during SSLConfig.inJS (this should be named fromJS)

![image](https://github.com/oven-sh/bun/assets/24465214/606be409-8620-4083-950e-9b34aca4cfc7)

but the exception ref is not set since BunFile does not use exception refs, it uses the real exception system JSC provides.

so the null check fails, we fall down to this getter
![image](https://github.com/oven-sh/bun/assets/24465214/06dbd6ea-4a07-4573-a82a-9c01203785a7)

the getter fails because we have an exception, and so on until `fetch`

![image](https://github.com/oven-sh/bun/assets/24465214/da916bef-0667-4ac5-934b-6e933012628f)

the getter here fails, and we override the already thrown error with another error.

I've changed this to check for an exception, but that is a band-aid solution that only fixes this case.

We now print the actual first error.
<img width="783" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/eae5f651-b80e-4d42-a7d2-9657cf10aa4c">

To make this harder to hit I've also moved the check after the fetch error to make it impossible to hit the error in this way.

I would add an assertion to ensure we dont double-throw elsewhere but it seems this would make other tests fail (should be investigated one day)