### PR TITLE
Prevent open but inactive http connections from keeping alive http server

### DIFF
--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -92,7 +92,6 @@ void us_poll_start(struct us_poll_t *p, struct us_loop_t *loop, int events) {
 
   uv_poll_init_socket(loop->uv_loop, p->uv_p, p->fd);
   uv_poll_start(p->uv_p, events, poll_cb);
-  // on windows we need to unref the poll handle because we keep the loop alive ourselves
 }
 
 void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -92,6 +92,10 @@ void us_poll_start(struct us_poll_t *p, struct us_loop_t *loop, int events) {
 
   uv_poll_init_socket(loop->uv_loop, p->uv_p, p->fd);
   uv_poll_start(p->uv_p, events, poll_cb);
+  // on windows we need to unref the poll handle because we keep the loop alive ourselves
+#ifdef _WIN32
+  uv_unref((uv_handle_t *)p->uv_p);
+#endif
 }
 
 void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -93,9 +93,6 @@ void us_poll_start(struct us_poll_t *p, struct us_loop_t *loop, int events) {
   uv_poll_init_socket(loop->uv_loop, p->uv_p, p->fd);
   uv_poll_start(p->uv_p, events, poll_cb);
   // on windows we need to unref the poll handle because we keep the loop alive ourselves
-#ifdef _WIN32
-  uv_unref((uv_handle_t *)p->uv_p);
-#endif
 }
 
 void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -400,6 +400,9 @@ int us_raw_root_certs(struct us_cert_string_t**out);
 unsigned int us_get_remote_address_info(char *buf, struct us_socket_t *s, const char **dest, int *port, int *is_ipv6);
 int us_socket_get_error(int ssl, struct us_socket_t *s);
 
+void us_socket_ref(struct us_socket_t *s);
+void us_socket_unref(struct us_socket_t *s);
+
 #ifdef __cplusplus
 }
 #endif

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -387,3 +387,17 @@ unsigned int us_get_remote_address_info(char *buf, struct us_socket_t *s, const 
 
     return length;
 }
+
+void us_socket_ref(struct us_socket_t *s) {
+#ifdef LIBUS_USE_LIBUV
+    uv_ref((uv_handle_t*)s->p.uv_p);
+#endif
+    // do nothing if not using libuv
+}
+
+void us_socket_unref(struct us_socket_t *s) {
+#ifdef LIBUS_USE_LIBUV
+    uv_unref((uv_handle_t*)s->p.uv_p);
+#endif
+    // do nothing if not using libuv
+}


### PR DESCRIPTION
### What does this PR do?
Previously, Bun.serve would keep the process alive after stop() if there was a tcp socket that kept the connection alive, even if no HTTP data was being transmitted (keepalive).

This PR makes changes that unref the socket between http requests, allowing the process to exit if the server has been stopped.

### How did you verify your code works?
Manual testing.
