### PR TITLE
Fix occasional test failure in setTimeout.test.js

### DIFF
--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -148,9 +148,9 @@ it("Bun.sleep propagates exceptions", async () => {
 });
 
 it("Bun.sleep works with a Date object", async () => {
+  const now = performance.now();
   var ten_ms = new Date();
   ten_ms.setMilliseconds(ten_ms.getMilliseconds() + 12);
-  const now = performance.now();
   await Bun.sleep(ten_ms);
   expect(performance.now() - now).toBeGreaterThan(11);
 });

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -152,7 +152,7 @@ it("Bun.sleep works with a Date object", async () => {
   var ten_ms = new Date();
   ten_ms.setMilliseconds(ten_ms.getMilliseconds() + 12);
   await Bun.sleep(ten_ms);
-  expect(performance.now() - now).toBeGreaterThan(11);
+  expect(performance.now() - now).toBeGreaterThan(10);
 });
 
 it("node.js timers/promises setTimeout propagates exceptions", async () => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

This modifies a timer test to call performance.now() before the critical section rather than from within it. It also fixes an incorrect expected value in the test.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

The test now succeeds reliably, even running it in a tight loop.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
