### PR TITLE
Fix; make expect(1).toBeGreaterThan(2) throw reliably

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1703,6 +1703,7 @@ pub const Expect = struct {
             globalObject.throw(comptime Output.prettyFmt(fmt, true), .{ expected_fmt, value_fmt });
             return .zero;
         }
+	globalObject.throw(comptime Output.prettyFmt(fmt, false), .{ expected_fmt, value_fmt });
         return .zero;
     }
 
@@ -1774,6 +1775,7 @@ pub const Expect = struct {
             globalObject.throw(comptime Output.prettyFmt(fmt, true), .{ expected_fmt, value_fmt });
             return .zero;
         }
+	globalObject.throw(comptime Output.prettyFmt(fmt, false), .{ expected_fmt, value_fmt });
         return .zero;
     }
 
@@ -1845,6 +1847,7 @@ pub const Expect = struct {
             globalObject.throw(comptime Output.prettyFmt(fmt, true), .{ expected_fmt, value_fmt });
             return .zero;
         }
+        globalObject.throw(comptime Output.prettyFmt(fmt, false), .{ expected_fmt, value_fmt });
         return .zero;
     }
 

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1703,7 +1703,7 @@ pub const Expect = struct {
             globalObject.throw(comptime Output.prettyFmt(fmt, true), .{ expected_fmt, value_fmt });
             return .zero;
         }
-	globalObject.throw(comptime Output.prettyFmt(fmt, false), .{ expected_fmt, value_fmt });
+        globalObject.throw(comptime Output.prettyFmt(fmt, false), .{ expected_fmt, value_fmt });
         return .zero;
     }
 
@@ -1775,7 +1775,7 @@ pub const Expect = struct {
             globalObject.throw(comptime Output.prettyFmt(fmt, true), .{ expected_fmt, value_fmt });
             return .zero;
         }
-	globalObject.throw(comptime Output.prettyFmt(fmt, false), .{ expected_fmt, value_fmt });
+        globalObject.throw(comptime Output.prettyFmt(fmt, false), .{ expected_fmt, value_fmt });
         return .zero;
     }
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

This changes expect(...).toBeGreaterThan() to throw an exception when appropriate even when ANSI colors are not in use.

I noticed this while debugging #8833 / #8834 , and it prevented me from writing a test for it so far.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I ran a local test, which falsely succeeded before the change and failed after it.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
