### PR TITLE
[docs] fix ws/pubsub: open and message ws don't publish to topic

### DIFF
--- a/docs/api/websockets.md
+++ b/docs/api/websockets.md
@@ -182,12 +182,12 @@ const server = Bun.serve<{ username: string }>({
     open(ws) {
       const msg = `${ws.data.username} has entered the chat`;
       ws.subscribe("the-group-chat");
-      ws.publish("the-group-chat", msg);
+      server.publish("the-group-chat", msg);
     },
     message(ws, message) {
       // this is a group chat
       // so the server re-broadcasts incoming message to everyone
-      ws.publish("the-group-chat", `${ws.data.username}: ${message}`);
+      server.publish("the-group-chat", `${ws.data.username}: ${message}`);
     },
     close(ws) {
       const msg = `${ws.data.username} has left the chat`;

--- a/docs/guides/websocket/pubsub.md
+++ b/docs/guides/websocket/pubsub.md
@@ -20,11 +20,11 @@ const server = Bun.serve<{ username: string }>({
     open(ws) {
       const msg = `${ws.data.username} has entered the chat`;
       ws.subscribe("the-group-chat");
-      ws.publish("the-group-chat", msg);
+      server.publish("the-group-chat", msg);
     },
     message(ws, message) {
       // the server re-broadcasts incoming messages to everyone
-      ws.publish("the-group-chat", `${ws.data.username}: ${message}`);
+      server.publish("the-group-chat", `${ws.data.username}: ${message}`);
     },
     close(ws) {
       const msg = `${ws.data.username} has left the chat`;


### PR DESCRIPTION
### What does this PR do?

fix #8760 - fix docs in open and message callback of a websocket connection. replaced ws.publish with server.publish

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

