### PR TITLE
fix: bun test -t handling

### DIFF
--- a/src/bun.js/bindings/RegularExpression.zig
+++ b/src/bun.js/bindings/RegularExpression.zig
@@ -40,7 +40,7 @@ pub const RegularExpression = opaque {
 
     // Simple boolean matcher
     pub inline fn matches(this: *RegularExpression, str: bun.String) bool {
-        return Yarr__RegularExpression__matches(this, str) > 0;
+        return Yarr__RegularExpression__matches(this, str) >= 0;
     }
 
     pub inline fn searchRev(this: *RegularExpression, str: bun.String) i32 {

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1863,7 +1863,7 @@ fn eachBind(
                 var buffer: bun.MutableString = Jest.runner.?.filter_buffer;
                 buffer.reset();
                 appendParentLabel(&buffer, parent) catch @panic("Bun ran out of memory while filtering tests");
-                buffer.append(label) catch unreachable;
+                buffer.append(formattedLabel) catch unreachable;
                 const str = bun.String.fromBytes(buffer.toOwnedSliceLeaky());
                 is_skip = !regex.matches(str);
             }

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1857,7 +1857,21 @@ fn eachBind(
                 (description.toSlice(globalThis, allocator).cloneIfNeeded(allocator) catch unreachable).slice();
             const formattedLabel = formatLabel(globalThis, label, function_args, test_idx) catch return .zero;
 
-            if (each_data.is_test) {
+            var is_skip = false;
+
+            if (Jest.runner.?.filter_regex) |regex| {
+                var buffer: bun.MutableString = Jest.runner.?.filter_buffer;
+                buffer.reset();
+                appendParentLabel(&buffer, parent) catch @panic("Bun ran out of memory while filtering tests");
+                buffer.append(label) catch unreachable;
+                const str = bun.String.fromBytes(buffer.toOwnedSliceLeaky());
+                is_skip = !regex.matches(str);
+            }
+
+            if (is_skip) {
+                parent.skip_count += 1;
+                function.unprotect();
+            } else if (each_data.is_test) {
                 function.protect();
                 parent.tests.append(allocator, TestScope{
                     .label = formattedLabel,

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -632,7 +632,7 @@ describe("bun test", () => {
       ];
 
       const stderr = runTest({
-        args: ["-t", "1 \+"],
+        args: ["-t", "1 \\+"],
         input: `
           import { test, expect } from "bun:test";
 
@@ -644,9 +644,9 @@ describe("bun test", () => {
       numbers.forEach(numbers => {
         if (numbers[0] === 1) {
           expect(stderr).toContain(`${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
-	} else {
+        } else {
           expect(stderr).not.toContain(`${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
-	}
+        }
       });
     });
     test("should run tests with describe.each", () => {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -603,6 +603,52 @@ describe("bun test", () => {
         expect(stderr).toContain(`${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
       });
     });
+    test("should allow tests run with test.each to be skipped", () => {
+      const numbers = [
+        [1, 2, 3],
+        [1, 1, 2],
+        [3, 4, 7],
+      ];
+
+      const stderr = runTest({
+        args: ["-t", "$a"],
+        input: `
+          import { test, expect } from "bun:test";
+
+          test.each(${JSON.stringify(numbers)})("%i + %i = %i", (a, b, e) => {
+            expect(a + b).toBe(e);
+          });
+        `,
+      });
+      numbers.forEach(numbers => {
+        expect(stderr).not.toContain(`${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
+      });
+    });
+    test("should allow tests run with test.each to be matched", () => {
+      const numbers = [
+        [1, 2, 3],
+        [1, 1, 2],
+        [3, 4, 7],
+      ];
+
+      const stderr = runTest({
+        args: ["-t", "1 \+"],
+        input: `
+          import { test, expect } from "bun:test";
+
+          test.each(${JSON.stringify(numbers)})("%i + %i = %i", (a, b, e) => {
+            expect(a + b).toBe(e);
+          });
+        `,
+      });
+      numbers.forEach(numbers => {
+        if (numbers[0] === 1) {
+          expect(stderr).toContain(`${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
+	} else {
+          expect(stderr).not.toContain(`${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
+	}
+      });
+    });
     test("should run tests with describe.each", () => {
       const numbers = [
         [1, 2, 3],


### PR DESCRIPTION
### What does this PR do?

Fixes #8842.

This changes RegularExpression.matches to return true if the match starts at the beginning of the haystack string.

This changes jest.zig to apply the filter regex to tests which make use of the .each() construct, and skip them if appropriate.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

~Automated tests require additional changes to bun-test.test.ts which I think should be in a separate PR.~

EDIT: I have now added two basic tests to `bun-test.test.ts`.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
- [x] I ran `zig fmt` (thanks again, @Electroid)