### PR TITLE
fix: Bun.sleep() should round its argument towards Infinity

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -4405,7 +4405,7 @@ pub const Timer = struct {
     pub fn setTimeout(
         globalThis: *JSGlobalObject,
         callback: JSValue,
-        countdown: JSValue,
+        countdown: i32,
         arguments: JSValue,
     ) callconv(.C) JSValue {
         JSC.markBinding(@src());
@@ -4413,7 +4413,7 @@ pub const Timer = struct {
         globalThis.bunVM().timer.last_id +%= 1;
 
         const interval: i32 = @max(
-            countdown.coerce(i32, globalThis),
+            countdown,
             // It must be 1 at minimum or setTimeout(cb, 0) will seemingly hang
             1,
         );

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -362,9 +362,11 @@ JSC_DEFINE_HOST_FUNCTION(functionBunSleep,
         return JSC::JSValue::encode(JSC::JSValue {});
     }
 
+    int32_t countdown = std::ceil(millisecondsValue.asNumber());
+
     Zig::GlobalObject* global = JSC::jsCast<Zig::GlobalObject*>(globalObject);
     JSC::JSPromise* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
-    Bun__Timer__setTimeout(globalObject, JSC::JSValue::encode(global->bunSleepThenCallback()), JSC::JSValue::encode(millisecondsValue), JSValue::encode(promise));
+    Bun__Timer__setTimeout(globalObject, JSC::JSValue::encode(global->bunSleepThenCallback()), countdown, JSValue::encode(promise));
     return JSC::JSValue::encode(promise);
 }
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1338,6 +1338,14 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeout,
         return JSC::JSValue::encode(JSC::JSValue {});
     }
 
+    if (UNLIKELY(!num.isNumber())) {
+        auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+        JSC::throwTypeError(globalObject, scope, "setTimeout expects a number (milliseconds)"_s);
+        return JSC::JSValue::encode(JSC::JSValue {});
+    }
+
+    int32_t countdown = std::ceil(num.asNumber());
+
 #ifdef BUN_DEBUG
     /** View the file name of the JS file that called this function
      * from a debugger */
@@ -1349,7 +1357,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeout,
     }
 #endif
 
-    return Bun__Timer__setTimeout(globalObject, JSC::JSValue::encode(job), JSC::JSValue::encode(num), JSValue::encode(arguments));
+    return Bun__Timer__setTimeout(globalObject, JSC::JSValue::encode(job), countdown, JSValue::encode(arguments));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionSetInterval,

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -804,7 +804,7 @@ ZIG_DECL JSC__JSValue Bun__Timer__clearInterval(JSC__JSGlobalObject* arg0, JSC__
 ZIG_DECL JSC__JSValue Bun__Timer__clearTimeout(JSC__JSGlobalObject* arg0, JSC__JSValue JSValue1);
 ZIG_DECL int32_t Bun__Timer__getNextID();
 ZIG_DECL JSC__JSValue Bun__Timer__setInterval(JSC__JSGlobalObject* arg0, JSC__JSValue JSValue1, JSC__JSValue JSValue2, JSC__JSValue JSValue3);
-ZIG_DECL JSC__JSValue Bun__Timer__setTimeout(JSC__JSGlobalObject* arg0, JSC__JSValue JSValue1, JSC__JSValue JSValue2, JSC__JSValue JSValue3);
+ZIG_DECL JSC__JSValue Bun__Timer__setTimeout(JSC__JSGlobalObject* arg0, JSC__JSValue JSValue1, int32_t value2, JSC__JSValue JSValue3);
 
 #endif
 

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -148,11 +148,25 @@ it("Bun.sleep propagates exceptions", async () => {
 });
 
 it("Bun.sleep works with a Date object", async () => {
+  const now = performance.now();
   var ten_ms = new Date();
   ten_ms.setMilliseconds(ten_ms.getMilliseconds() + 12);
-  const now = performance.now();
   await Bun.sleep(ten_ms);
   expect(performance.now() - now).toBeGreaterThan(11);
+});
+
+it("Bun.sleep rounds towards Infinity", async () => {
+  const now = performance.now();
+  await Bun.sleep(1.5);
+  expect(performance.now() - now).toBeGreaterThan(1.5);
+});
+
+it("Bun.sleep(Date) fulfills after Date", async () => {
+  let ten_ms = new Date();
+  ten_ms.setMilliseconds(ten_ms.getMilliseconds() + 12);
+  await Bun.sleep(ten_ms);
+  let now = new Date();
+  expect(+now).toBeGreaterThanOrEqual(+ten_ms);
 });
 
 it("node.js timers/promises setTimeout propagates exceptions", async () => {


### PR DESCRIPTION
### What does this PR do?

Fixes #8834 .

This changes Bun.sleep() to round its argument towards Infinity. It ensures Bun.sleep(1.5) does not return until at least 2 ms have passed, and Bun.sleep(Date) does not return until Date has been reached.

This assumes C's `double` is the same type as a JavaScript number, but that's true on all modern machines. It's technically possible for this code to require the math library.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests.

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)