### PR TITLE
Fix coverage.md, inaccurate example

### DIFF
--- a/docs/test/coverage.md
+++ b/docs/test/coverage.md
@@ -52,7 +52,7 @@ It is possible to specify a coverage threshold in `bunfig.toml`. If your test su
 coverageThreshold = 0.9
 
 # to set different thresholds for lines and functions
-coverageThreshold = { line = 0.9, function = 0.9 }
+coverageThreshold = { lines = 0.9, functions = 0.9 }
 ```
 
 ### Sourcemaps


### PR DESCRIPTION
See the [parser](https://github.com/oven-sh/bun/blob/f88855da4fc30fac90391c079cd9bbf734ef35b2/src/bunfig.zig#L264). #7367 is resolved when I add 's' to my bunfig.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
