### PR TITLE
scripts/codegen.ps1: update wsl call

### DIFF
--- a/scripts/codegen.ps1
+++ b/scripts/codegen.ps1
@@ -5,7 +5,7 @@ $Script2=(Join-Path $PSScriptRoot "../src/codegen/create_hash_table")
 $CreateHashTable=(Get-Content $Script2 -Raw)
 $CreateHashTable.Replace("`r`n","`n") | Set-Content $Script2 -Force -NoNewline
 
-& 'wsl.exe' ./scripts/cross-compile-codegen.sh win32 x64 "build"
+& 'C:\Program Files\WSL\wsl.exe' ./scripts/cross-compile-codegen.sh win32 x64 "build"
 
 Set-Content $Script1 -Force -NoNewline -Value $CrossCompileCodegen
 Set-Content $Script2 -Force -NoNewline -Value $CreateHashTable


### PR DESCRIPTION
status quo means u can run into conditions where you get:

```
PS C:\bun> .\scripts\codegen.ps1
The file cannot be accessed by the system.
```

this change allows it to always work and run as expected.