### PR TITLE
feat: make curl install script run the windows installer (if run through cygwin)

### DIFF
--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 if [[ ${OS:-} = Windows_NT ]]; then
     powershell -c "irm bun.sh/install.ps1|iex"
-    exit 1
+    exit $?
 fi
 
 # Reset

--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ ${OS:-} = Windows_NT ]]; then
-    echo 'error: Please install bun using Windows Subsystem for Linux'
+    powershell -c "irm bun.sh/install.ps1|iex"
     exit 1
 fi
 


### PR DESCRIPTION
This updates the *nix install script to run the Windows Powershell install script if it detects it's on Windows.