### PR TITLE
fix(windows): `console-iterator.test.ts` fix

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -913,6 +913,7 @@ pub fn getStdin(
     store.ref();
     var blob = bun.default_allocator.create(JSC.WebCore.Blob) catch unreachable;
     blob.* = JSC.WebCore.Blob.initWithStore(store, globalThis);
+    blob.allocator = bun.default_allocator;
     return blob.toJS(globalThis);
 }
 
@@ -925,6 +926,7 @@ pub fn getStderr(
     store.ref();
     var blob = bun.default_allocator.create(JSC.WebCore.Blob) catch unreachable;
     blob.* = JSC.WebCore.Blob.initWithStore(store, globalThis);
+    blob.allocator = bun.default_allocator;
     return blob.toJS(globalThis);
 }
 
@@ -937,6 +939,7 @@ pub fn getStdout(
     store.ref();
     var blob = bun.default_allocator.create(JSC.WebCore.Blob) catch unreachable;
     blob.* = JSC.WebCore.Blob.initWithStore(store, globalThis);
+    blob.allocator = bun.default_allocator;
     return blob.toJS(globalThis);
 }
 

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1426,7 +1426,7 @@ pub const Blob = struct {
         return blob_;
     }
 
-    fn calculateEstimatedByteSize(this: *Blob) usize {
+    fn calculateEstimatedByteSize(this: *Blob) void {
         // in-memory size. not the size on disk.
         var size: usize = @sizeOf(Blob);
 
@@ -1444,7 +1444,7 @@ pub const Blob = struct {
             }
         }
 
-        return size + (this.content_type.len * @intFromBool(this.content_type_allocated));
+        this.reported_estimated_size = size + (this.content_type.len * @intFromBool(this.content_type_allocated));
     }
 
     pub fn estimatedSize(this: *Blob) callconv(.C) usize {
@@ -3409,6 +3409,8 @@ pub const Blob = struct {
             },
         }
 
+        blob.calculateEstimatedByteSize();
+
         var blob_ = bun.new(Blob, blob);
         blob_.allocator = allocator;
         return blob_;
@@ -3584,7 +3586,7 @@ pub const Blob = struct {
             std.debug.assert(this.allocator != null);
         }
 
-        this.reported_estimated_size = this.calculateEstimatedByteSize();
+        this.calculateEstimatedByteSize();
         return Blob.toJSUnchecked(globalObject, this);
     }
 

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -131,12 +131,12 @@ pub const Request = struct {
         return this.reported_estimated_size;
     }
 
-    pub fn calculateEstimatedSize(this: *Request) usize {
+    pub fn calculateEstimatedByteSize(this: *Request) usize {
         return this.body.value.estimatedSize() + this.sizeOfURL() + @sizeOf(Request);
     }
 
     pub fn toJS(this: *Request, globalObject: *JSGlobalObject) JSValue {
-        this.reported_estimated_size = this.calculateEstimatedSize();
+        this.reported_estimated_size = this.calculateEstimatedByteSize();
         return Request.toJSUnchecked(globalObject, this);
     }
 

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -131,12 +131,12 @@ pub const Request = struct {
         return this.reported_estimated_size;
     }
 
-    pub fn calculateEstimatedByteSize(this: *Request) usize {
-        return this.body.value.estimatedSize() + this.sizeOfURL() + @sizeOf(Request);
+    pub fn calculateEstimatedByteSize(this: *Request) void {
+        this.reported_estimated_size = this.body.value.estimatedSize() + this.sizeOfURL() + @sizeOf(Request);
     }
 
     pub fn toJS(this: *Request, globalObject: *JSGlobalObject) JSValue {
-        this.reported_estimated_size = this.calculateEstimatedByteSize();
+        this.calculateEstimatedByteSize();
         return Request.toJSUnchecked(globalObject, this);
     }
 
@@ -685,6 +685,8 @@ pub const Request = struct {
         {
             req.headers.?.put("content-type", req.body.value.Blob.content_type, globalThis);
         }
+
+        req.calculateEstimatedByteSize();
 
         return req;
     }

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -71,7 +71,7 @@ pub const Request = struct {
     upgrader: ?*anyopaque = null,
 
     // We must report a consistent value for this
-    reported_estimated_size: ?u63 = null,
+    reported_estimated_size: usize = 0,
 
     const RequestMixin = BodyMixin(@This());
     pub usingnamespace JSC.Codegen.JSRequest;
@@ -128,10 +128,16 @@ pub const Request = struct {
     }
 
     pub fn estimatedSize(this: *Request) callconv(.C) usize {
-        return this.reported_estimated_size orelse brk: {
-            this.reported_estimated_size = @as(u63, @truncate(this.body.value.estimatedSize() + this.sizeOfURL() + @sizeOf(Request)));
-            break :brk this.reported_estimated_size.?;
-        };
+        return this.reported_estimated_size;
+    }
+
+    pub fn calculateEstimatedSize(this: *Request) usize {
+        return this.body.value.estimatedSize() + this.sizeOfURL() + @sizeOf(Request);
+    }
+
+    pub fn toJS(this: *Request, globalObject: *JSGlobalObject) JSValue {
+        this.reported_estimated_size = this.calculateEstimatedSize();
+        return Request.toJSUnchecked(globalObject, this);
     }
 
     pub fn writeFormat(this: *Request, comptime Formatter: type, formatter: *Formatter, writer: anytype, comptime enable_ansi_colors: bool) !void {

--- a/src/bun.js/webcore/response.classes.ts
+++ b/src/bun.js/webcore/response.classes.ts
@@ -9,6 +9,7 @@ export default [
     JSType: "0b11101110",
     estimatedSize: true,
     configurable: false,
+    overridesToJS: true,
     proto: {
       text: { fn: "getText" },
       json: { fn: "getJSON" },
@@ -68,6 +69,7 @@ export default [
     JSType: "0b11101110",
     configurable: false,
     estimatedSize: true,
+    overridesToJS: true,
     klass: {
       json: {
         fn: "constructJSON",
@@ -128,6 +130,7 @@ export default [
     structuredClone: { transferable: false, tag: 254 },
     estimatedSize: true,
     values: ["stream"],
+    overridesToJS: true,
     proto: {
       text: { fn: "getText" },
       json: { fn: "getJSON" },

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -88,15 +88,15 @@ pub const Response = struct {
         return this.reported_estimated_size;
     }
 
-    pub fn calculateEstimatedByteSize(this: *Response) usize {
-        return this.body.value.estimatedSize() +
+    pub fn calculateEstimatedByteSize(this: *Response) void {
+        this.reported_estimated_size = this.body.value.estimatedSize() +
             this.url.byteSlice().len +
             this.init.status_text.byteSlice().len +
             @sizeOf(Response);
     }
 
     pub fn toJS(this: *Response, globalObject: *JSGlobalObject) JSValue {
-        this.reported_estimated_size = this.calculateEstimatedByteSize();
+        this.calculateEstimatedByteSize();
         return Response.toJSUnchecked(globalObject, this);
     }
 
@@ -506,6 +506,8 @@ pub const Response = struct {
         {
             response.init.headers.?.put("content-type", response.body.value.Blob.content_type, globalThis);
         }
+
+        response.calculateEstimatedByteSize();
 
         return response;
     }

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -66,7 +66,7 @@ pub const Response = struct {
     redirected: bool = false,
 
     // We must report a consistent value for this
-    reported_estimated_size: ?u63 = null,
+    reported_estimated_size: usize = 0,
 
     pub const getText = ResponseMixin.getText;
     pub const getBody = ResponseMixin.getBody;
@@ -85,13 +85,19 @@ pub const Response = struct {
     }
 
     pub fn estimatedSize(this: *Response) callconv(.C) usize {
-        return this.reported_estimated_size orelse brk: {
-            this.reported_estimated_size = @as(
-                u63,
-                @intCast(this.body.value.estimatedSize() + this.url.byteSlice().len + this.init.status_text.byteSlice().len + @sizeOf(Response)),
-            );
-            break :brk this.reported_estimated_size.?;
-        };
+        return this.reported_estimated_size;
+    }
+
+    pub fn calculateEstimatedByteSize(this: *Response) usize {
+        return this.body.value.estimatedSize() +
+            this.url.byteSlice().len +
+            this.init.status_text.byteSlice().len +
+            @sizeOf(Response);
+    }
+
+    pub fn toJS(this: *Response, globalObject: *JSGlobalObject) JSValue {
+        this.reported_estimated_size = this.calculateEstimatedByteSize();
+        return Response.toJSUnchecked(globalObject, this);
     }
 
     pub fn getBodyValue(

--- a/src/codegen/class-definitions.ts
+++ b/src/codegen/class-definitions.ts
@@ -43,6 +43,7 @@ export interface ClassDefinition {
   construct?: boolean;
   call?: boolean;
   finalize?: boolean;
+  overridesToJS?: boolean;
   klass: Record<string, Field>;
   proto: Record<string, Field>;
   values?: string[];
@@ -76,6 +77,7 @@ export function define(
     klass = {},
     proto = {},
     values = [],
+    overridesToJS = false,
     estimatedSize = false,
     call = false,
     construct = false,
@@ -86,6 +88,7 @@ export function define(
   return {
     ...rest,
     call,
+    overridesToJS,
     construct,
     estimatedSize,
     structuredClone,

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -565,7 +565,12 @@ JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES ${name}::construct(JSC::JSGlobalObj
     ${className(typeName)}* instance = ${className(typeName)}::create(vm, globalObject, structure, ptr);
   ${
     obj.estimatedSize
-      ? `vm.heap.reportExtraMemoryAllocated(instance, ${symbolName(obj.name, "estimatedSize")}(instance->wrapped()));`
+      ? `
+      auto size = ${symbolName(typeName, "estimatedSize")}(ptr);
+#if ASSERT_ENABLED
+      ASSERT(size > 0);
+#endif
+      vm.heap.reportExtraMemoryAllocated(instance, size);`
       : ""
   }
 
@@ -1225,7 +1230,11 @@ void ${name}::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ${
       estimatedSize
         ? `if (auto* ptr = thisObject->wrapped()) {
-visitor.reportExtraMemoryVisited(${symbolName(obj.name, "estimatedSize")}(ptr));
+            auto size = ${symbolName(typeName, "estimatedSize")}(ptr);
+#if ASSERT_ENABLED
+            ASSERT(size > 0);
+#endif
+visitor.reportExtraMemoryVisited(size);
 }`
         : ""
     }
@@ -1393,7 +1402,12 @@ extern "C" EncodedJSValue ${typeName}__create(Zig::GlobalObject* globalObject, v
   ${className(typeName)}* instance = ${className(typeName)}::create(vm, globalObject, structure, ptr);
   ${
     obj.estimatedSize
-      ? `vm.heap.reportExtraMemoryAllocated(instance, ${symbolName(obj.name, "estimatedSize")}(ptr));`
+      ? `
+      auto size = ${symbolName(typeName, "estimatedSize")}(ptr);
+#if ASSERT_ENABLED
+      ASSERT(size > 0);
+#endif
+      vm.heap.reportExtraMemoryAllocated(instance, size);`
       : ""
   }
   return JSValue::encode(instance);

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -1435,6 +1435,7 @@ function generateZig(
     construct,
     finalize,
     noConstructor = false,
+    overridesToJS = false,
     estimatedSize,
     call = false,
     values = [],
@@ -1703,6 +1704,10 @@ pub const ${className(typeName)} = struct {
   `
         : ""
     }
+
+    ${
+      !overridesToJS
+        ? `
     /// Create a new instance of ${typeName}
     pub fn toJS(this: *${typeName}, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
         JSC.markBinding(@src());
@@ -1713,6 +1718,8 @@ pub const ${className(typeName)} = struct {
         } else {
             return ${symbolName(typeName, "create")}(globalObject, this);
         }
+    }`
+        : ""
     }
 
     /// Modify the internal ptr to point to a new instance of ${typeName}.
@@ -1731,6 +1738,9 @@ pub const ${className(typeName)} = struct {
     extern fn ${symbolName(typeName, "getConstructor")}(*JSC.JSGlobalObject) JSC.JSValue;
 
     extern fn ${symbolName(typeName, "create")}(globalObject: *JSC.JSGlobalObject, ptr: ?*${typeName}) JSC.JSValue;
+
+    /// Create a new instance of ${typeName} without validating it works.
+    pub const toJSUnchecked = ${symbolName(typeName, "create")};
 
     extern fn ${typeName}__dangerouslySetPtr(JSC.JSValue, ?*${typeName}) bool;
 


### PR DESCRIPTION
### What does this PR do?
calculates estimated byte size of a `Blob` instance when `toJS` is called. This avoids accessing `Blob.Store` after it's gc'd and invalid memory. Also adds the same pattern to `Response` and `Request`.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
