### PR TITLE
fix: brotli decompression's multi-packet case

### DIFF
--- a/src/brotli.zig
+++ b/src/brotli.zig
@@ -143,6 +143,9 @@ pub const BrotliReaderArrayList = struct {
                 },
 
                 .needs_more_input => {
+                    if (in_remaining > 0) {
+                        @panic("Brotli wants more data");
+                    }
                     this.state = .Inflating;
                     if (is_done) {
                         this.state = .Error;

--- a/src/http.zig
+++ b/src/http.zig
@@ -1307,7 +1307,7 @@ const Decompressor = union(enum) {
             },
             .brotli => |reader| {
                 reader.input = buffer;
-                reader.total_in = @as(u32, @truncate(buffer.len));
+                reader.total_in = 0;
 
                 const initial = body_out_str.list.items.len;
                 reader.list = body_out_str.list;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fixes #8017 

When the brotli decompressor is called multiple times for multiple packets, it needs to reset its buffer pointer to 0. Unfortunately, since it is named "total_in", the old code actually set it to the end of the buffer.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

https://github.com/oven-sh/bun/compare/main...argosphil:bun:issue-8017-experiment

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
