### PR TITLE
fix(windows): use allocated memory for `\\\\.\\NUL` replacement on windows

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1529,7 +1529,7 @@ pub const Blob = struct {
                     var slice = path_or_fd.path.slice();
 
                     if (Environment.isWindows and bun.strings.eqlComptime(slice, "/dev/null")) {
-                        path_or_fd.path.deinit();
+                        path_or_fd.deinit();
                         path_or_fd.* = .{
                             .path = .{
                                 // this memory is freed with this allocator in `Blob.Store.deinit`

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1526,12 +1526,17 @@ pub const Blob = struct {
         const path: JSC.Node.PathOrFileDescriptor = brk: {
             switch (path_or_fd.*) {
                 .path => {
-                    const slice = path_or_fd.path.slice();
+                    var slice = path_or_fd.path.slice();
 
                     if (Environment.isWindows and bun.strings.eqlComptime(slice, "/dev/null")) {
-                        // it is okay to use rodata here, because the '.string' case
-                        // in PathLike.deinit does not free anything.
-                        path_or_fd.* = .{ .path = .{ .string = bun.PathString.init("\\\\.\\NUL") } };
+                        path_or_fd.path.deinit();
+                        path_or_fd.* = .{
+                            .path = .{
+                                // this memory is freed with this allocator in `Blob.Store.deinit`
+                                .string = bun.PathString.init(allocator.dupe(u8, "\\\\.\\NUL") catch bun.outOfMemory()),
+                            },
+                        };
+                        slice = path_or_fd.path.slice();
                     }
 
                     if (vm.standalone_module_graph) |graph| {


### PR DESCRIPTION
### What does this PR do?
Allocates `\\\\.\\NUL` because the memory will be freed in `Blob.Store.deinit` when it's gc'd.

If we want to keep this memory static, we could add a flag on the `Store` struct for whether `pathlike.path` is allocated or not, but I'm less certain about the lifetime of the memory if we do this.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
