### PR TITLE
Fix tsconfig path longest prefix matching

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2876,8 +2876,8 @@ pub const Resolver = struct {
                 // because we want the output to always be deterministic
                 if (strings.startsWith(path, prefix) and
                     strings.endsWith(path, suffix) and
-                    (prefix.len >= longest_match_prefix_length and
-                    suffix.len > longest_match_suffix_length))
+                    (prefix.len > longest_match_prefix_length or
+                    (prefix.len == longest_match_prefix_length and suffix.len > longest_match_suffix_length)))
                 {
                     longest_match_prefix_length = @as(i32, @intCast(prefix.len));
                     longest_match_suffix_length = @as(i32, @intCast(suffix.len));

--- a/test/js/bun/resolve/bar/larger-index.js
+++ b/test/js/bun/resolve/bar/larger-index.js
@@ -1,0 +1,2 @@
+// this file is used in resolve.test.js
+export default {};

--- a/test/js/bun/resolve/resolve-test.js
+++ b/test/js/bun/resolve/resolve-test.js
@@ -71,6 +71,7 @@ it("import.meta.resolve", async () => {
   expect(await import.meta.resolve("foo/bar")).toBe(join(import.meta.path, "../baz.js"));
   expect(await import.meta.resolve("@faasjs/baz")).toBe(join(import.meta.path, "../baz.js"));
   expect(await import.meta.resolve("@faasjs/bar")).toBe(join(import.meta.path, "../bar/src/index.js"));
+  expect(await import.meta.resolve("@faasjs/larger/bar")).toBe(join(import.meta.path, "../bar/larger-index.js"));
 
   // works with package.json "exports"
   expect(await import.meta.resolve("package-json-exports/baz")).toBe(

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -26,7 +26,8 @@
       "node-harness": ["js/node/harness.ts"],
       "deno:harness": ["js/deno/harness.ts"],
       "foo/bar": ["js/bun/resolve/baz.js"],
-      "@faasjs/*": ["js/bun/resolve/*.js", "js/bun/resolve/*/src/index.js"]
+      "@faasjs/*": ["js/bun/resolve/*.js", "js/bun/resolve/*/src/index.js"],
+      "@faasjs/larger/*": ["js/bun/resolve/*/larger-index.js"]
     }
   },
 


### PR DESCRIPTION
### What does this PR do?

Fixes the logic for matching a tsconfig path so that it will match paths with a longer prefix when the suffix is the same length, as it previously would incorrectly only allow matches when the suffix is greater.

The comment above the if statement suggests that this change is the intended way for the check to work.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

If JavaScript/TypeScript modules or builtins changed:

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] ~~JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed~~
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

