### PR TITLE
fix: throw on gunzipSync/inflateSync error

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -2079,6 +2079,7 @@ pub const Crypto = struct {
                     .err => {
                         const error_instance = value.toErrorInstance(globalObject);
                         globalObject.throwValue(error_instance);
+                        return .zero;
                     },
                     .hash => |h| {
                         return JSC.ZigString.init(h).toValueGC(globalObject);

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -5274,10 +5274,8 @@ pub const JSZlib = struct {
 
         reader.readAll() catch {
             defer reader.deinit();
-            if (reader.errorMessage()) |msg| {
-                return ZigString.init(msg).toErrorInstance(globalThis);
-            }
-            return ZigString.init("Zlib returned an error").toErrorInstance(globalThis);
+            globalThis.throwValue(ZigString.init(reader.errorMessage() orelse "Zlib returned an error").toErrorInstance(globalThis));
+            return .zero;
         };
         reader.list = .{ .items = reader.list.toOwnedSlice(allocator) catch @panic("TODO") };
         reader.list.capacity = reader.list.items.len;
@@ -5306,10 +5304,8 @@ pub const JSZlib = struct {
 
         reader.readAll() catch {
             defer reader.deinit();
-            if (reader.errorMessage()) |msg| {
-                return ZigString.init(msg).toErrorInstance(globalThis);
-            }
-            return ZigString.init("Zlib returned an error").toErrorInstance(globalThis);
+            globalThis.throwValue(ZigString.init(reader.errorMessage() orelse "Zlib returned an error").toErrorInstance(globalThis));
+            return .zero;
         };
         reader.list = .{ .items = reader.list.toOwnedSlice(allocator) catch @panic("TODO") };
         reader.list.capacity = reader.list.items.len;
@@ -5336,10 +5332,8 @@ pub const JSZlib = struct {
 
         reader.readAll() catch {
             defer reader.deinit();
-            if (reader.errorMessage()) |msg| {
-                return ZigString.init(msg).toErrorInstance(globalThis);
-            }
-            return ZigString.init("Zlib returned an error").toErrorInstance(globalThis);
+            globalThis.throwValue(ZigString.init(reader.errorMessage() orelse "Zlib returned an error").toErrorInstance(globalThis));
+            return .zero;
         };
         reader.list = .{ .items = reader.list.toOwnedSlice(allocator) catch @panic("TODO") };
         reader.list.capacity = reader.list.items.len;

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -15,6 +15,16 @@ describe("zlib", () => {
     const decompressed = gunzipSync(compressed);
     expect(decompressed.join("")).toBe(data.join(""));
   });
+
+  it("should throw on invalid raw deflate data", () => {
+    const data = new TextEncoder().encode("Hello World!".repeat(1));
+    expect(() => inflateSync(data)).toThrow(new Error("invalid stored block lengths"));
+  });
+
+  it("should throw on invalid gzip data", () => {
+    const data = new TextEncoder().encode("Hello World!".repeat(1));
+    expect(() => gunzipSync(data)).toThrow(new Error("incorrect header check"));
+  });
 });
 
 import * as zlib from "node:zlib";


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fixes #8887 .

This fixes `inflateSync`, `gzipSync`, `deflateSync`, and `gunzipSync` to throw errors rather than return them. 

There's also a drive-by fix to similar error handling in the hashing code. 

- [x] Code changes

### How did you verify your code works?

I wrote automated tests for the decompression case. I do not know how to trigger a zlib error for the compression case.

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
