### PR TITLE
Update documentation: Missing toWeb

### DIFF
--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -116,7 +116,7 @@ Some methods are not optimized yet.
 
 ### [`node:stream`](https://nodejs.org/api/stream.html)
 
-🟡 Missing `getDefaultHighWaterMark` `setDefaultHighWaterMark`
+🟡 Missing `getDefaultHighWaterMark` `setDefaultHighWaterMark` `toWeb`
 
 ### [`node:string_decoder`](https://nodejs.org/api/string_decoder.html)
 


### PR DESCRIPTION
See https://github.com/oven-sh/bun/issues/3927
