### PR TITLE
Regression test for #8929 (typo in child_process.js)

### DIFF
--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -219,7 +219,7 @@ describe("spawn()", () => {
   test.if(isLinux)("should handle null for first 4 positions of stdio", async () => {
     // Run a program that does nothing except pause indefinitely, thus an
     // opportunity to inspect its file descriptors.
-    const proc = spawn("sleep", ["inf"], {stdio: [null, null, null, null]});
+    const proc = spawn("sleep", ["inf"], { stdio: [null, null, null, null] });
     // Delay here because the command (above) opens and closes a bunch of
     // files when starting up, so we have to wait for it to stabilize.  This
     // still is a race condition though, would be nice to eliminate.


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

This is a test case for #8929. Also mentioned in #8841 comments, there is a race condition that I would like to solve too, but at the expense of added complexity (need to compile a program to invoke `pause()`); Working around that by delaying. Feedback welcome. Thanks!

### How did you verify your code works?

Run w/ and w/o #8929:
```
build/bun-debug test test/js/node/child_process/child_process.test.ts
```

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
