### PR TITLE
Honor 'inherit' in stdio option of Spawn. Fixes #8844.

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1978,9 +1978,7 @@ pub const Subprocess = struct {
         var ipc_callback: JSValue = .zero;
         var stdio_pipes: std.ArrayListUnmanaged(Stdio.PipeExtra) = .{};
         var stdio_inherits: std.ArrayListUnmanaged(i32) = .{};
-        defer stdio_inherits.deinit(bun.default_allocator);
         var stdio_close: std.ArrayListUnmanaged(i32) = .{};
-        defer stdio_close.deinit(bun.default_allocator);
         var pipes_to_close: std.ArrayListUnmanaged(bun.FileDescriptor) = .{};
         defer {
             for (pipes_to_close.items) |pipe_fd| {
@@ -2162,7 +2160,7 @@ pub const Subprocess = struct {
                                         };
                                     },
                                     .inherit => {
-                                        stdio_inherits.append(bun.default_allocator,
+                                        stdio_inherits.append(allocator,
                                             @intCast(i)
                                         ) catch {
                                             globalThis.throwOutOfMemory();
@@ -2170,7 +2168,7 @@ pub const Subprocess = struct {
                                         };
                                     },
                                     else => {
-                                        stdio_close.append(bun.default_allocator,
+                                        stdio_close.append(allocator,
                                             @intCast(i)
                                         ) catch {
                                             globalThis.throwOutOfMemory();

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1,9 +1,10 @@
 // @known-failing-on-windows: 1 failing
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, test } from "bun:test";
 import { ChildProcess, spawn, execFile, exec, fork, spawnSync, execFileSync, execSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { promisify } from "node:util";
-import { bunExe, bunEnv } from "harness";
+import { openSync } from "node:fs";
+import { bunExe, bunEnv, isLinux } from "harness";
 import path from "path";
 
 const debug = process.env.DEBUG ? console.log : () => {};
@@ -259,6 +260,34 @@ describe("spawnSync()", () => {
   it("should spawn a process synchronously", () => {
     const { stdout } = spawnSync("echo", ["hello"], { encoding: "utf8" });
     expect(stdout.trim()).toBe("hello");
+  });
+
+  test.if(isLinux)("should inherit for fds >= 3", async () => {
+    const fdA = openSync("/dev/null", "r");
+    const fdB = openSync("/dev/null", "r");
+    const nulls = new Array(Math.max(fdA, fdB) + 1).fill(null);
+    {
+      const stdio = [...nulls];
+      stdio[fdA] = "inherit";
+      stdio[fdB] = "inherit";
+      const fds = new Set(spawnSync("ls", [`/dev/fd/`], { stdio, encoding: "utf8" }).stdout.split(/\s+/));
+      expect(fds.has(`${fdA}`)).toBe(true);
+      expect(fds.has(`${fdB}`)).toBe(true);
+    }
+    {
+      const stdio = [...nulls];
+      stdio[fdA] = "inherit";
+      const fds = new Set(spawnSync("ls", [`/dev/fd/`], { stdio, encoding: "utf8" }).stdout.split(/\s+/));
+      expect(fds.has(`${fdA}`)).toBe(true);
+      expect(fds.has(`${fdB}`)).toBe(false);
+    }
+    {
+      const stdio = [...nulls];
+      stdio[fdB] = "inherit";
+      const fds = new Set(spawnSync("ls", [`/dev/fd/`], { stdio, encoding: "utf8" }).stdout.split(/\s+/));
+      expect(fds.has(`${fdA}`)).toBe(false);
+      expect(fds.has(`${fdB}`)).toBe(true);
+    }
   });
 });
 

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -262,7 +262,7 @@ describe("spawnSync()", () => {
     expect(stdout.trim()).toBe("hello");
   });
 
-  test.if(isLinux)("should inherit for fds >= 3", async () => {
+  test.if(isLinux)("should support 'inherit' option in stdio for fds that are not stdin/stdout/stderr", async () => {
     const fdA = openSync("/dev/null", "r");
     const fdB = openSync("/dev/null", "r");
     const nulls = new Array(Math.max(fdA, fdB) + 1).fill(null);


### PR DESCRIPTION
### What does this PR do?

Honors the "inherit" stdio options. Fixes #8844.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests.

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
  - [ ] ~I copied the structure that was already there `stdio_pipes`. Hopefully it does the right thing, and then so does mine.~
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
  - [x] Didn't introduce new uses of JSValue
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
