### PR TITLE
Fix napi memory issue

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -1151,19 +1151,6 @@ extern "C" napi_status napi_create_reference(napi_env env, napi_value value,
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = globalObject->vm();
 
-    JSObject* jsObject = val.getObject();
-    NapiPrototype* object = jsDynamicCast<NapiPrototype*>(jsObject);
-    if (object && object->napiRef) {
-        *result = toNapi(object->napiRef);
-        return napi_ok;
-    }
-
-    NapiClass* object2 = jsDynamicCast<NapiClass*>(jsObject);
-    if (object2 && object2->napiRef) {
-        *result = toNapi(object2->napiRef);
-        return napi_ok;
-    }
-
     auto* ref = new NapiRef(globalObject, initial_refcount);
     if (initial_refcount > 0) {
         ref->strongRef.set(globalObject->vm(), val);
@@ -1175,12 +1162,6 @@ extern "C" napi_status napi_create_reference(napi_env env, napi_value value,
         } else {
             ref->weakValueRef.setPrimitive(val);
         }
-    }
-
-    if (object) {
-        object->napiRef = ref;
-    } else if (object2) {
-        object2->napiRef = ref;
     }
 
     *result = toNapi(ref);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fixes #7864.

(Preface: I'm no expert by far, open to pointers in the right direction to fix this properly)

It seems that there's a memory issue in `napi_create_reference`. A dangling pointer issue can happen in the following scenario:
- We `napi_create_reference` to some value, with a `NapiRef` of `0xdeadbeef`.
- Eventually, something calls `napi_delete_reference`. `0xdeadbeef` gets `delete`d.
- Once again, there's a `napi_create_reference` _to the same JS object_.

The issue is that currently the object stores a `NapiRef` -- but what if this was `delete`d already, as in the scenario above? We assume the `0xdeadbeef` pointer is still valid, but it's a dangling reference to a deleted reference, thus ensues undefined behavior.

-----

Open to suggestions about how to better address this while trying to reuse `NapiRef`s (I assume for performance reasons), but for now I've gone ahead and just deleted the code that reuses a `NapiRef`, and instead _always_ create a `new NapiRef`.

### How did you verify your code works?
I'll add some tests in a bit, but so far I've verified that my program^ works with this.
