### PR TITLE
debug: introduce bun.callmod_inline

### DIFF
--- a/src/allocators.zig
+++ b/src/allocators.zig
@@ -317,7 +317,7 @@ pub fn BSSStringList(comptime _count: usize, comptime _item_length: usize) type 
         }
 
         pub fn appendMutable(self: *Self, comptime AppendType: type, _value: AppendType) ![]u8 {
-            const appended = try @call(.always_inline, append, .{ self, AppendType, _value });
+            const appended = try @call(bun.callmod_inline, append, .{ self, AppendType, _value });
             return @constCast(appended);
         }
 
@@ -637,11 +637,11 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
             return try self.map.getOrPut(key);
         }
         pub fn get(self: *Self, key: []const u8) ?*ValueType {
-            return @call(.always_inline, BSSMapType.get, .{ self.map, key });
+            return @call(bun.callmod_inline, BSSMapType.get, .{ self.map, key });
         }
 
         pub fn atIndex(self: *Self, index: IndexType) ?*ValueType {
-            return @call(.always_inline, BSSMapType.atIndex, .{ self.map, index });
+            return @call(bun.callmod_inline, BSSMapType.atIndex, .{ self.map, index });
         }
 
         pub fn keyAtIndex(_: *Self, index: IndexType) ?[]const u8 {

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -1041,7 +1041,7 @@ pub const BuildArtifact = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) callconv(.C) JSC.JSValue {
-        return @call(.always_inline, Blob.getText, .{ &this.blob, globalThis, callframe });
+        return @call(bun.callmod_inline, Blob.getText, .{ &this.blob, globalThis, callframe });
     }
 
     pub fn getJSON(
@@ -1049,27 +1049,27 @@ pub const BuildArtifact = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) callconv(.C) JSC.JSValue {
-        return @call(.always_inline, Blob.getJSON, .{ &this.blob, globalThis, callframe });
+        return @call(bun.callmod_inline, Blob.getJSON, .{ &this.blob, globalThis, callframe });
     }
     pub fn getArrayBuffer(
         this: *BuildArtifact,
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) callconv(.C) JSValue {
-        return @call(.always_inline, Blob.getArrayBuffer, .{ &this.blob, globalThis, callframe });
+        return @call(bun.callmod_inline, Blob.getArrayBuffer, .{ &this.blob, globalThis, callframe });
     }
     pub fn getSlice(
         this: *BuildArtifact,
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) callconv(.C) JSC.JSValue {
-        return @call(.always_inline, Blob.getSlice, .{ &this.blob, globalThis, callframe });
+        return @call(bun.callmod_inline, Blob.getSlice, .{ &this.blob, globalThis, callframe });
     }
     pub fn getType(
         this: *BuildArtifact,
         globalThis: *JSC.JSGlobalObject,
     ) callconv(.C) JSValue {
-        return @call(.always_inline, Blob.getType, .{ &this.blob, globalThis });
+        return @call(bun.callmod_inline, Blob.getType, .{ &this.blob, globalThis });
     }
 
     pub fn getStream(
@@ -1077,7 +1077,7 @@ pub const BuildArtifact = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) callconv(.C) JSValue {
-        return @call(.always_inline, Blob.getStream, .{
+        return @call(bun.callmod_inline, Blob.getStream, .{
             &this.blob,
             globalThis,
             callframe,
@@ -1108,11 +1108,11 @@ pub const BuildArtifact = struct {
     }
 
     pub fn getSize(this: *BuildArtifact, globalObject: *JSC.JSGlobalObject) callconv(.C) JSValue {
-        return @call(.always_inline, Blob.getSize, .{ &this.blob, globalObject });
+        return @call(bun.callmod_inline, Blob.getSize, .{ &this.blob, globalObject });
     }
 
     pub fn getMimeType(this: *BuildArtifact, globalObject: *JSC.JSGlobalObject) callconv(.C) JSValue {
-        return @call(.always_inline, Blob.getType, .{ &this.blob, globalObject });
+        return @call(bun.callmod_inline, Blob.getType, .{ &this.blob, globalObject });
     }
 
     pub fn getOutputKind(this: *BuildArtifact, globalObject: *JSC.JSGlobalObject) callconv(.C) JSValue {

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -943,11 +943,11 @@ pub fn DOMCall(
             arguments_ptr: [*]const JSC.JSValue,
             arguments_len: usize,
         ) callconv(.C) JSValue {
-            return @call(.auto, @field(Container, functionName), .{
+            return @field(Container, functionName)(
                 globalObject,
                 thisValue,
                 arguments_ptr[0..arguments_len],
-            });
+            );
         }
 
         pub const fastpath = @field(Container, functionName ++ "WithoutTypeChecks");

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -47,7 +47,7 @@ pub const JSObject = extern struct {
     pub fn Initializer(comptime Ctx: type, comptime func: fn (*Ctx, obj: *JSObject, global: *JSGlobalObject) void) type {
         return struct {
             pub fn call(this: ?*anyopaque, obj: [*c]JSObject, global: [*c]JSGlobalObject) callconv(.C) void {
-                @call(.always_inline, func, .{ @as(*Ctx, @ptrCast(@alignCast(this.?))), obj.?, global.? });
+                @call(bun.callmod_inline, func, .{ @as(*Ctx, @ptrCast(@alignCast(this.?))), obj.?, global.? });
             }
         };
     }
@@ -1833,7 +1833,7 @@ pub fn NewGlobalObject(comptime Type: type) type {
         const moduleNotImpl = "Module fetch not implemented";
         pub fn import(global: *JSGlobalObject, specifier: *String, source: *String) callconv(.C) ErrorableString {
             if (comptime @hasDecl(Type, "import")) {
-                return @call(.always_inline, Type.import, .{ global, specifier.*, source.* });
+                return @call(bun.callmod_inline, Type.import, .{ global, specifier.*, source.* });
             }
             return ErrorableString.err(error.ImportFailed, String.init(importNotImpl).toErrorInstance(global).asVoid());
         }
@@ -1845,35 +1845,35 @@ pub fn NewGlobalObject(comptime Type: type) type {
             query_string: *ZigString,
         ) callconv(.C) void {
             if (comptime @hasDecl(Type, "resolve")) {
-                @call(.always_inline, Type.resolve, .{ res, global, specifier.*, source.*, query_string, true });
+                @call(bun.callmod_inline, Type.resolve, .{ res, global, specifier.*, source.*, query_string, true });
                 return;
             }
             res.* = ErrorableString.err(error.ResolveFailed, String.init(resolveNotImpl).toErrorInstance(global).asVoid());
         }
         pub fn fetch(ret: *ErrorableResolvedSource, global: *JSGlobalObject, specifier: *String, source: *String) callconv(.C) void {
             if (comptime @hasDecl(Type, "fetch")) {
-                @call(.always_inline, Type.fetch, .{ ret, global, specifier.*, source.* });
+                @call(bun.callmod_inline, Type.fetch, .{ ret, global, specifier.*, source.* });
                 return;
             }
             ret.* = ErrorableResolvedSource.err(error.FetchFailed, String.init(moduleNotImpl).toErrorInstance(global).asVoid());
         }
         pub fn promiseRejectionTracker(global: *JSGlobalObject, promise: *JSPromise, rejection: JSPromiseRejectionOperation) callconv(.C) JSValue {
             if (comptime @hasDecl(Type, "promiseRejectionTracker")) {
-                return @call(.always_inline, Type.promiseRejectionTracker, .{ global, promise, rejection });
+                return @call(bun.callmod_inline, Type.promiseRejectionTracker, .{ global, promise, rejection });
             }
             return JSValue.jsUndefined();
         }
 
         pub fn reportUncaughtException(global: *JSGlobalObject, exception: *Exception) callconv(.C) JSValue {
             if (comptime @hasDecl(Type, "reportUncaughtException")) {
-                return @call(.always_inline, Type.reportUncaughtException, .{ global, exception });
+                return @call(bun.callmod_inline, Type.reportUncaughtException, .{ global, exception });
             }
             return JSValue.jsUndefined();
         }
 
         pub fn onCrash() callconv(.C) void {
             if (comptime @hasDecl(Type, "onCrash")) {
-                return @call(.always_inline, Type.onCrash, .{});
+                return @call(bun.callmod_inline, Type.onCrash, .{});
             }
 
             Output.flush();

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -63,26 +63,26 @@ pub const ZigGlobalObject = extern struct {
     pub fn import(global: *JSGlobalObject, specifier: *bun.String, source: *bun.String) callconv(.C) ErrorableString {
         JSC.markBinding(@src());
 
-        return @call(.always_inline, Interface.import, .{ global, specifier, source });
+        return @call(bun.callmod_inline, Interface.import, .{ global, specifier, source });
     }
     pub fn resolve(res: *ErrorableString, global: *JSGlobalObject, specifier: *bun.String, source: *bun.String, query: *ZigString) callconv(.C) void {
         JSC.markBinding(@src());
-        @call(.always_inline, Interface.resolve, .{ res, global, specifier, source, query });
+        @call(bun.callmod_inline, Interface.resolve, .{ res, global, specifier, source, query });
     }
 
     pub fn promiseRejectionTracker(global: *JSGlobalObject, promise: *JSPromise, rejection: JSPromiseRejectionOperation) callconv(.C) JSValue {
         JSC.markBinding(@src());
-        return @call(.always_inline, Interface.promiseRejectionTracker, .{ global, promise, rejection });
+        return @call(bun.callmod_inline, Interface.promiseRejectionTracker, .{ global, promise, rejection });
     }
 
     pub fn reportUncaughtException(global: *JSGlobalObject, exception: *Exception) callconv(.C) JSValue {
         JSC.markBinding(@src());
-        return @call(.always_inline, Interface.reportUncaughtException, .{ global, exception });
+        return @call(bun.callmod_inline, Interface.reportUncaughtException, .{ global, exception });
     }
 
     pub fn onCrash() callconv(.C) void {
         JSC.markBinding(@src());
-        return @call(.always_inline, Interface.onCrash, .{});
+        return @call(bun.callmod_inline, Interface.onCrash, .{});
     }
 
     pub const Export = shim.exportFunctions(

--- a/src/bun.js/bindings/shimmer.zig
+++ b/src/bun.js/bindings/shimmer.zig
@@ -192,7 +192,7 @@ pub fn Shimmer(comptime _namespace: []const u8, comptime _name: []const u8, comp
                 return matchNullable(
                     comptime @typeInfo(@TypeOf(@field(Parent, typeName))).Fn.return_type.?,
                     comptime @typeInfo(@TypeOf(Fn)).Fn.return_type.?,
-                    @call(.auto, Fn, .{}),
+                    Fn(),
                 );
             }
         }

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -177,7 +177,7 @@ pub const AnyTask = struct {
             }
 
             pub fn wrap(this: ?*anyopaque) void {
-                @call(.always_inline, Callback, .{@as(*Type, @ptrCast(@alignCast(this.?)))});
+                @call(bun.callmod_inline, Callback, .{@as(*Type, @ptrCast(@alignCast(this.?)))});
             }
         };
     }
@@ -211,7 +211,7 @@ pub const ManagedTask = struct {
             }
 
             pub fn wrap(this: ?*anyopaque) void {
-                @call(.always_inline, Callback, .{@as(*Type, @ptrCast(@alignCast(this.?)))});
+                @call(bun.callmod_inline, Callback, .{@as(*Type, @ptrCast(@alignCast(this.?)))});
             }
         };
     }

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -102,7 +102,7 @@ pub fn OpaqueWrap(comptime Context: type, comptime Function: fn (this: *Context)
     return struct {
         pub fn callback(ctx: ?*anyopaque) callconv(.C) void {
             const context: *Context = @as(*Context, @ptrCast(@alignCast(ctx.?)));
-            @call(.auto, Function, .{context});
+            Function(context);
         }
     }.callback;
 }

--- a/src/bun.js/node/fs_events.zig
+++ b/src/bun.js/node/fs_events.zig
@@ -254,7 +254,7 @@ pub const FSEventsLoop = struct {
                 }
 
                 pub fn wrap(this: ?*anyopaque) void {
-                    @call(.always_inline, Callback, .{@as(*Type, @ptrCast(@alignCast(this.?)))});
+                    @call(bun.callmod_inline, Callback, .{@as(*Type, @ptrCast(@alignCast(this.?)))});
                 }
             };
         }

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1533,7 +1533,7 @@ pub fn StatType(comptime Big: bool) type {
                     this: *This,
                     _: *JSC.JSGlobalObject,
                 ) callconv(.C) JSC.JSValue {
-                    return @call(.auto, @field(This, @tagName(decl)), .{this});
+                    return @field(This, @tagName(decl))(this);
                 }
             }.run;
         }

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1196,7 +1196,7 @@ pub fn wrapTestFunction(comptime name: []const u8, comptime func: DescribeScope.
                 globalThis.throw("Cannot use " ++ name ++ "() outside of a test file.", .{});
                 return .zero;
             }
-            return @call(.always_inline, func, .{ globalThis, callframe });
+            return @call(bun.callmod_inline, func, .{ globalThis, callframe });
         }
     }.wrapped;
 }

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -708,7 +708,7 @@ pub const StreamResult = union(Tag) {
                     this.handler = struct {
                         const handler = handler_fn;
                         pub fn onHandle(ctx_: *anyopaque, result: StreamResult.Writable) void {
-                            @call(.always_inline, handler, .{ bun.cast(*Context, ctx_), result });
+                            @call(bun.callmod_inline, handler, .{ bun.cast(*Context, ctx_), result });
                         }
                     }.onHandle;
                 }
@@ -831,7 +831,7 @@ pub const StreamResult = union(Tag) {
                 this.handler = struct {
                     const handler = handler_fn;
                     pub fn onHandle(ctx_: *anyopaque, result: StreamResult) void {
-                        @call(.always_inline, handler, .{ bun.cast(*Context, ctx_), result });
+                        @call(bun.callmod_inline, handler, .{ bun.cast(*Context, ctx_), result });
                     }
                 }.onHandle;
             }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -27,6 +27,8 @@ else
 
 pub const huge_allocator_threshold: comptime_int = @import("./memory_allocator.zig").huge_threshold;
 
+pub const callmod_inline: std.builtin.CallModifier = if (builtin.mode == .Debug) .auto else .always_inline;
+
 /// We cannot use a threadlocal memory allocator for FileSystem-related things
 /// FileSystem is a singleton.
 pub const fs_allocator = default_allocator;

--- a/src/c.zig
+++ b/src/c.zig
@@ -411,7 +411,7 @@ pub fn dlsymWithHandle(comptime Type: type, comptime name: [:0]const u8, comptim
     };
 
     if (Wrapper.loaded == .pending) {
-        const result = _dlsym(@call(.always_inline, handle_getter, .{}), name);
+        const result = _dlsym(@call(bun.callmod_inline, handle_getter, .{}), name);
 
         if (result) |ptr| {
             Wrapper.function = bun.cast(Type, ptr);

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1325,7 +1325,7 @@ pub const AnyWebSocket = union(enum) {
         const ContextType = @TypeOf(ctx);
         const Wrapper = struct {
             pub fn wrap(user_data: ?*anyopaque) callconv(.C) void {
-                @call(.always_inline, callback, .{bun.cast(ContextType, user_data.?)});
+                @call(bun.callmod_inline, callback, .{bun.cast(ContextType, user_data.?)});
             }
         };
 
@@ -1429,7 +1429,7 @@ pub const WebSocketBehavior = extern struct {
             pub fn _open(raw_ws: *RawWebSocket) callconv(.C) void {
                 var ws = @unionInit(AnyWebSocket, active_field_name, @as(*WebSocket, @ptrCast(raw_ws)));
                 const this = ws.as(Type).?;
-                @call(.always_inline, Type.onOpen, .{ this, ws });
+                @call(bun.callmod_inline, Type.onOpen, .{ this, ws });
             }
             pub fn _message(raw_ws: *RawWebSocket, message: [*c]const u8, length: usize, opcode: Opcode) callconv(.C) void {
                 var ws = @unionInit(AnyWebSocket, active_field_name, @as(*WebSocket, @ptrCast(raw_ws)));
@@ -1443,7 +1443,7 @@ pub const WebSocketBehavior = extern struct {
             pub fn _drain(raw_ws: *RawWebSocket) callconv(.C) void {
                 var ws = @unionInit(AnyWebSocket, active_field_name, @as(*WebSocket, @ptrCast(raw_ws)));
                 const this = ws.as(Type).?;
-                @call(.always_inline, Type.onDrain, .{
+                @call(bun.callmod_inline, Type.onDrain, .{
                     this,
                     ws,
                 });
@@ -1451,7 +1451,7 @@ pub const WebSocketBehavior = extern struct {
             pub fn _ping(raw_ws: *RawWebSocket, message: [*c]const u8, length: usize) callconv(.C) void {
                 var ws = @unionInit(AnyWebSocket, active_field_name, @as(*WebSocket, @ptrCast(raw_ws)));
                 const this = ws.as(Type).?;
-                @call(.always_inline, Type.onPing, .{
+                @call(bun.callmod_inline, Type.onPing, .{
                     this,
                     ws,
                     if (length > 0) message[0..length] else "",
@@ -1460,7 +1460,7 @@ pub const WebSocketBehavior = extern struct {
             pub fn _pong(raw_ws: *RawWebSocket, message: [*c]const u8, length: usize) callconv(.C) void {
                 var ws = @unionInit(AnyWebSocket, active_field_name, @as(*WebSocket, @ptrCast(raw_ws)));
                 const this = ws.as(Type).?;
-                @call(.always_inline, Type.onPong, .{
+                @call(bun.callmod_inline, Type.onPong, .{
                     this,
                     ws,
                     if (length > 0) message[0..length] else "",
@@ -1795,9 +1795,9 @@ pub fn NewApp(comptime ssl: bool) type {
             const Wrapper = struct {
                 pub fn handle(socket: ?*uws.ListenSocket, conf: uws_app_listen_config_t, data: ?*anyopaque) callconv(.C) void {
                     if (comptime UserData == void) {
-                        @call(.always_inline, handler, .{ {}, @as(?*ThisApp.ListenSocket, @ptrCast(socket)), conf });
+                        @call(bun.callmod_inline, handler, .{ {}, @as(?*ThisApp.ListenSocket, @ptrCast(socket)), conf });
                     } else {
-                        @call(.always_inline, handler, .{
+                        @call(bun.callmod_inline, handler, .{
                             @as(UserData, @ptrCast(@alignCast(data.?))),
                             @as(?*ThisApp.ListenSocket, @ptrCast(socket)),
                             conf,
@@ -1818,9 +1818,9 @@ pub fn NewApp(comptime ssl: bool) type {
             const Wrapper = struct {
                 pub fn handle(socket: ?*uws.ListenSocket, data: ?*anyopaque) callconv(.C) void {
                     if (comptime UserData == void) {
-                        @call(.always_inline, handler, .{ {}, @as(?*ThisApp.ListenSocket, @ptrCast(socket)) });
+                        @call(bun.callmod_inline, handler, .{ {}, @as(?*ThisApp.ListenSocket, @ptrCast(socket)) });
                     } else {
-                        @call(.always_inline, handler, .{
+                        @call(bun.callmod_inline, handler, .{
                             @as(UserData, @ptrCast(@alignCast(data.?))),
                             @as(?*ThisApp.ListenSocket, @ptrCast(socket)),
                         });
@@ -1841,9 +1841,9 @@ pub fn NewApp(comptime ssl: bool) type {
             const Wrapper = struct {
                 pub fn handle(socket: ?*uws.ListenSocket, _: [*:0]const u8, _: i32, data: *anyopaque) callconv(.C) void {
                     if (comptime UserData == void) {
-                        @call(.always_inline, handler, .{ {}, @as(?*ThisApp.ListenSocket, @ptrCast(socket)) });
+                        @call(bun.callmod_inline, handler, .{ {}, @as(?*ThisApp.ListenSocket, @ptrCast(socket)) });
                     } else {
-                        @call(.always_inline, handler, .{
+                        @call(bun.callmod_inline, handler, .{
                             @as(UserData, @ptrCast(@alignCast(data))),
                             @as(?*ThisApp.ListenSocket, @ptrCast(socket)),
                         });
@@ -2001,9 +2001,9 @@ pub fn NewApp(comptime ssl: bool) type {
                 const Wrapper = struct {
                     pub fn handle(this: *uws_res, amount: uintmax_t, data: ?*anyopaque) callconv(.C) bool {
                         if (comptime UserDataType == void) {
-                            return @call(.always_inline, handler, .{ {}, amount, castRes(this) });
+                            return @call(bun.callmod_inline, handler, .{ {}, amount, castRes(this) });
                         } else {
-                            return @call(.always_inline, handler, .{
+                            return @call(bun.callmod_inline, handler, .{
                                 @as(UserDataType, @ptrCast(@alignCast(data.?))),
                                 amount,
                                 castRes(this),
@@ -2022,9 +2022,9 @@ pub fn NewApp(comptime ssl: bool) type {
                 const Wrapper = struct {
                     pub fn handle(this: *uws_res, user_data: ?*anyopaque) callconv(.C) void {
                         if (comptime UserDataType == void) {
-                            @call(.always_inline, handler, .{ {}, castRes(this), {} });
+                            @call(bun.callmod_inline, handler, .{ {}, castRes(this), {} });
                         } else {
-                            @call(.always_inline, handler, .{ @as(UserDataType, @ptrCast(@alignCast(user_data.?))), castRes(this) });
+                            @call(bun.callmod_inline, handler, .{ @as(UserDataType, @ptrCast(@alignCast(user_data.?))), castRes(this) });
                         }
                     }
                 };
@@ -2048,14 +2048,14 @@ pub fn NewApp(comptime ssl: bool) type {
                 const Wrapper = struct {
                     pub fn handle(this: *uws_res, chunk_ptr: [*c]const u8, len: usize, last: bool, user_data: ?*anyopaque) callconv(.C) void {
                         if (comptime UserDataType == void) {
-                            @call(.always_inline, handler, .{
+                            @call(bun.callmod_inline, handler, .{
                                 {},
                                 castRes(this),
                                 if (len > 0) chunk_ptr[0..len] else "",
                                 last,
                             });
                         } else {
-                            @call(.always_inline, handler, .{
+                            @call(bun.callmod_inline, handler, .{
                                 @as(UserDataType, @ptrCast(@alignCast(user_data.?))),
                                 castRes(this),
                                 if (len > 0) chunk_ptr[0..len] else "",
@@ -2081,7 +2081,7 @@ pub fn NewApp(comptime ssl: bool) type {
                     opts: @TypeOf(args),
                     result: @typeInfo(@TypeOf(Function)).Fn.return_type.? = undefined,
                     pub fn run(this: *@This()) void {
-                        this.result = @call(.auto, Function, this.opts);
+                        this.result = Function(this.opts);
                     }
                 };
                 var wrapped = Wrapper{
@@ -2101,11 +2101,11 @@ pub fn NewApp(comptime ssl: bool) type {
                 const Wrapper = struct {
                     pub fn handle(user_data: ?*anyopaque) callconv(.C) void {
                         if (comptime UserDataType == void) {
-                            @call(.always_inline, handler, .{
+                            @call(bun.callmod_inline, handler, .{
                                 {},
                             });
                         } else {
-                            @call(.always_inline, handler, .{
+                            @call(bun.callmod_inline, handler, .{
                                 @as(UserDataType, @ptrCast(@alignCast(user_data.?))),
                             });
                         }
@@ -2124,12 +2124,12 @@ pub fn NewApp(comptime ssl: bool) type {
             //     const Wrapper = struct {
             //         pub fn handle(user_data: ?*anyopaque, fd: i32) callconv(.C) void {
             //             if (comptime UserDataType == void) {
-            //                 @call(.always_inline, handler, .{
+            //                 @call(bun.callmod_inline, handler, .{
             //                     {},
             //                     fd,
             //                 });
             //             } else {
-            //                 @call(.always_inline, handler, .{
+            //                 @call(bun.callmod_inline, handler, .{
             //                     @ptrCast(
             //                         UserDataType,
             //                         @alignCast( user_data.?),
@@ -2143,12 +2143,12 @@ pub fn NewApp(comptime ssl: bool) type {
             //     const OnWritable = struct {
             //         pub fn handle(socket: *Socket) callconv(.C) ?*Socket {
             //             if (comptime UserDataType == void) {
-            //                 @call(.always_inline, handler, .{
+            //                 @call(bun.callmod_inline, handler, .{
             //                     {},
             //                     fd,
             //                 });
             //             } else {
-            //                 @call(.always_inline, handler, .{
+            //                 @call(bun.callmod_inline, handler, .{
             //                     @ptrCast(
             //                         UserDataType,
             //                         @alignCast( user_data.?),
@@ -2236,7 +2236,7 @@ pub fn NewApp(comptime ssl: bool) type {
                 const ContextType = @TypeOf(ctx);
                 const Wrapper = struct {
                     pub fn wrap(user_data: ?*anyopaque) callconv(.C) void {
-                        @call(.always_inline, callback, .{bun.cast(ContextType, user_data.?)});
+                        @call(bun.callmod_inline, callback, .{bun.cast(ContextType, user_data.?)});
                     }
                 };
 

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -427,15 +427,15 @@ pub const FileSystem = struct {
 
     // }
     pub fn normalize(_: *@This(), str: string) string {
-        return @call(.always_inline, path_handler.normalizeString, .{ str, true, .auto });
+        return @call(bun.callmod_inline, path_handler.normalizeString, .{ str, true, .auto });
     }
 
     pub fn normalizeBuf(_: *@This(), buf: []u8, str: string) string {
-        return @call(.always_inline, path_handler.normalizeStringBuf, .{ str, buf, false, .auto, false });
+        return @call(bun.callmod_inline, path_handler.normalizeStringBuf, .{ str, buf, false, .auto, false });
     }
 
     pub fn join(_: *@This(), parts: anytype) string {
-        return @call(.always_inline, path_handler.joinStringBuf, .{
+        return @call(bun.callmod_inline, path_handler.joinStringBuf, .{
             &join_buf,
             parts,
             .loose,
@@ -443,7 +443,7 @@ pub const FileSystem = struct {
     }
 
     pub fn joinBuf(_: *@This(), parts: anytype, buf: []u8) string {
-        return @call(.always_inline, path_handler.joinStringBuf, .{
+        return @call(bun.callmod_inline, path_handler.joinStringBuf, .{
             buf,
             parts,
             .loose,
@@ -451,14 +451,14 @@ pub const FileSystem = struct {
     }
 
     pub fn relative(_: *@This(), from: string, to: string) string {
-        return @call(.always_inline, path_handler.relative, .{
+        return @call(bun.callmod_inline, path_handler.relative, .{
             from,
             to,
         });
     }
 
     pub fn relativePlatform(_: *@This(), from: string, to: string, comptime platform: path_handler.Platform) string {
-        return @call(.always_inline, path_handler.relativePlatform, .{
+        return @call(bun.callmod_inline, path_handler.relativePlatform, .{
             from,
             to,
             platform,
@@ -467,14 +467,14 @@ pub const FileSystem = struct {
     }
 
     pub fn relativeTo(f: *@This(), to: string) string {
-        return @call(.always_inline, path_handler.relative, .{
+        return @call(bun.callmod_inline, path_handler.relative, .{
             f.top_level_dir,
             to,
         });
     }
 
     pub fn relativeFrom(f: *@This(), from: string) string {
-        return @call(.always_inline, path_handler.relative, .{
+        return @call(bun.callmod_inline, path_handler.relative, .{
             from,
             f.top_level_dir,
         });

--- a/src/http.zig
+++ b/src/http.zig
@@ -3047,7 +3047,7 @@ pub const HTTPClientResult = struct {
 
                 pub fn wrapped_callback(ptr: *anyopaque, result: HTTPClientResult) void {
                     const casted = @as(Type, @ptrCast(@alignCast(ptr)));
-                    @call(.always_inline, callback, .{ casted, result });
+                    @call(bun.callmod_inline, callback, .{ casted, result });
                 }
             };
         }

--- a/src/install/integrity.zig
+++ b/src/install/integrity.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const strings = @import("../string_immutable.zig");
 const Crypto = @import("../sha.zig").Hashers;
+const bun = @import("root").bun;
 
 pub const Integrity = extern struct {
     const empty_digest_buf: [Integrity.digest_buf_len]u8 = [_]u8{0} ** Integrity.digest_buf_len;
@@ -33,7 +34,7 @@ pub const Integrity = extern struct {
         var i: usize = 0;
 
         // initializer should zero it out
-        if (comptime @import("root").bun.Environment.allow_assert) {
+        if (comptime bun.Environment.allow_assert) {
             for (integrity.value) |c| {
                 std.debug.assert(c == 0);
             }
@@ -159,7 +160,7 @@ pub const Integrity = extern struct {
     }
 
     pub fn verify(this: *const Integrity, bytes: []const u8) bool {
-        return @call(.always_inline, verifyByTag, .{ this.tag, bytes, &this.value });
+        return @call(bun.callmod_inline, verifyByTag, .{ this.tag, bytes, &this.value });
     }
 
     pub fn verifyByTag(tag: Tag, bytes: []const u8, sum: []const u8) bool {

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1899,7 +1899,7 @@ pub const StringBuilder = struct {
     }
 
     pub fn append(this: *StringBuilder, comptime Type: type, slice: string) Type {
-        return @call(.always_inline, appendWithHash, .{ this, Type, slice, String.Builder.stringHash(slice) });
+        return @call(bun.callmod_inline, appendWithHash, .{ this, Type, slice, String.Builder.stringHash(slice) });
     }
 
     // SlicedString is not supported due to inline strings.

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -327,7 +327,7 @@ pub const String = extern struct {
         }
 
         pub fn append(this: *Builder, comptime Type: type, slice_: string) Type {
-            return @call(.always_inline, appendWithHash, .{ this, Type, slice_, stringHash(slice_) });
+            return @call(bun.callmod_inline, appendWithHash, .{ this, Type, slice_, stringHash(slice_) });
         }
 
         pub fn appendUTF8WithoutPool(this: *Builder, comptime Type: type, slice_: string, hash: u64) Type {

--- a/src/install/windows-shim/bun_shim_impl.zig
+++ b/src/install/windows-shim/bun_shim_impl.zig
@@ -38,6 +38,7 @@
 //! When this file is updated, the new binary should be compiled and BinLinkingShim.VersionFlag.current should be updated.
 const std = @import("std");
 const builtin = @import("builtin");
+const bun = @import("root").bun;
 
 pub inline fn wliteral(comptime str: []const u8) []const u16 {
     if (!@inComptime()) @compileError("strings.w() must be called in a comptime context");
@@ -54,7 +55,7 @@ pub inline fn wliteral(comptime str: []const u8) []const u16 {
 }
 
 const is_standalone = !@hasDecl(@import("root"), "bun");
-const bunDebugMessage = @import("root").bun.Output.scoped(.bun_shim_impl, true);
+const bunDebugMessage = bun.Output.scoped(.bun_shim_impl, true);
 
 const dbg = builtin.mode == .Debug;
 
@@ -211,7 +212,7 @@ const NtWriter = std.io.Writer(w.HANDLE, error{}, writeToHandle);
 inline fn printError(comptime fmt: []const u8, args: anytype) void {
     std.fmt.format(
         NtWriter{
-            .context = @call(.always_inline, w.teb, .{})
+            .context = @call(bun.callmod_inline, w.teb, .{})
                 .ProcessEnvironmentBlock
                 .ProcessParameters
                 .hStdError,
@@ -255,7 +256,7 @@ const nt_object_prefix = [4]u16{ '\\', '?', '?', '\\' };
 
 fn launcher(bun_ctx: anytype) noreturn {
     // peb! w.teb is a couple instructions of inline asm
-    const teb: *w.TEB = @call(.always_inline, w.teb, .{});
+    const teb: *w.TEB = @call(bun.callmod_inline, w.teb, .{});
     const peb = teb.ProcessEnvironmentBlock;
     const ProcessParameters = peb.ProcessParameters;
     const CommandLine = ProcessParameters.CommandLine;
@@ -722,7 +723,7 @@ fn launcher(bun_ctx: anytype) noreturn {
 }
 
 pub const FromBunRunContext = struct {
-    const CommandContext = @import("root").bun.CLI.Command.Context;
+    const CommandContext = bun.CLI.Command.Context;
 
     /// Path like 'C:\Users\dave\project\node_modules\.bin\foo.bunx'
     base_path: []u16,

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -24,8 +24,8 @@ pub fn PipeReader(
         };
 
         pub fn read(this: *This) void {
-            const buffer = @call(.always_inline, vtable.getBuffer, .{this});
-            const fd = @call(.always_inline, vtable.getFd, .{this});
+            const buffer = @call(bun.callmod_inline, vtable.getBuffer, .{this});
+            const fd = @call(bun.callmod_inline, vtable.getFd, .{this});
             switch (bun.isReadable(fd)) {
                 .ready, .hup => {
                     readFromBlockingPipeWithoutBlocking(this, buffer, fd, 0);
@@ -40,7 +40,7 @@ pub fn PipeReader(
 
         pub fn onPoll(parent: *This, size_hint: isize) void {
             const resizable_buffer = vtable.getBuffer(parent);
-            const fd = @call(.always_inline, vtable.getFd, .{parent});
+            const fd = @call(bun.callmod_inline, vtable.getFd, .{parent});
 
             readFromBlockingPipeWithoutBlocking(parent, resizable_buffer, fd, size_hint);
         }

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -6399,7 +6399,7 @@ pub const DeclaredSymbol = struct {
         // TODO: SIMD
         for (is_top_level, refs) |top, ref| {
             if (top) {
-                @call(.always_inline, Fn, .{ ctx, ref });
+                @call(bun.callmod_inline, Fn, .{ ctx, ref });
             }
         }
     }
@@ -6607,7 +6607,7 @@ pub const Scope = struct {
         loc: logger.Loc,
 
         pub fn eql(a: Member, b: Member) bool {
-            return @call(.always_inline, Ref.eql, .{ a.ref, b.ref }) and a.loc.start == b.loc.start;
+            return @call(bun.callmod_inline, Ref.eql, .{ a.ref, b.ref }) and a.loc.start == b.loc.start;
         }
     };
 

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -11995,7 +11995,7 @@ fn NewParser_(
         }
 
         fn declareSymbol(p: *P, kind: Symbol.Kind, loc: logger.Loc, name: string) !Ref {
-            return try @call(.always_inline, declareSymbolMaybeGenerated, .{ p, kind, loc, name, false });
+            return try @call(bun.callmod_inline, declareSymbolMaybeGenerated, .{ p, kind, loc, name, false });
         }
 
         fn declareSymbolMaybeGenerated(p: *P, kind: Symbol.Kind, loc: logger.Loc, name: string, comptime is_generated: bool) !Ref {

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -4950,7 +4950,7 @@ fn NewPrinter(
                 return;
             }
 
-            @call(.always_inline, printModuleId, .{ p, p.importRecord(import_record_index).module_id });
+            @call(bun.callmod_inline, printModuleId, .{ p, p.importRecord(import_record_index).module_id });
         }
 
         pub fn printCallModuleID(p: *Printer, module_id: u32) void {
@@ -5396,11 +5396,11 @@ pub fn NewWriter(
         }
 
         pub inline fn prevChar(writer: *const Self) u8 {
-            return @call(.always_inline, getLastByte, .{&writer.ctx});
+            return @call(bun.callmod_inline, getLastByte, .{&writer.ctx});
         }
 
         pub inline fn prevPrevChar(writer: *const Self) u8 {
-            return @call(.always_inline, getLastLastByte, .{&writer.ctx});
+            return @call(bun.callmod_inline, getLastLastByte, .{&writer.ctx});
         }
 
         pub fn reserve(writer: *Self, count: u32) anyerror![*]u8 {

--- a/src/panic_handler.zig
+++ b/src/panic_handler.zig
@@ -48,7 +48,7 @@ pub fn NewPanicHandler(comptime panic_func: fn ([]const u8, ?*std.builtin.StackT
             }
 
             // // We want to always inline the panic handler so it doesn't show up in the stacktrace.
-            @call(.always_inline, panic_func, .{ msg, error_return_type, addr });
+            @call(bun.callmod_inline, panic_func, .{ msg, error_return_type, addr });
         }
     };
 }

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -103,7 +103,7 @@ pub fn getIfExistsLongestCommonPathGeneric(input: []const []const u8, comptime p
                     if (last_common_separator == null) return null;
                     break;
                 }
-                if (@call(.always_inline, isPathSeparator, .{input[0][index]})) {
+                if (@call(bun.callmod_inline, isPathSeparator, .{input[0][index]})) {
                     last_common_separator = index;
                 }
             }
@@ -125,7 +125,7 @@ pub fn getIfExistsLongestCommonPathGeneric(input: []const []const u8, comptime p
                     }
                 }
                 if (index == min_length) index -= 1;
-                if (@call(.always_inline, isPathSeparator, .{input[0][index]})) {
+                if (@call(bun.callmod_inline, isPathSeparator, .{input[0][index]})) {
                     last_common_separator = index;
                 }
             }
@@ -151,7 +151,7 @@ pub fn getIfExistsLongestCommonPathGeneric(input: []const []const u8, comptime p
     // and say, "do one of you have a path separator after what we thought was the end?"
     for (input) |str| {
         if (str.len > index) {
-            if (@call(.always_inline, isPathSeparator, .{str[index]})) {
+            if (@call(bun.callmod_inline, isPathSeparator, .{str[index]})) {
                 return str[0 .. index + 1];
             }
         }
@@ -205,7 +205,7 @@ pub fn longestCommonPathGeneric(input: []const []const u8, comptime platform: Pl
                 if (nqlAtIndexFn(comptime n, index, input)) {
                     break;
                 }
-                if (@call(.always_inline, isPathSeparator, .{input[0][index]})) {
+                if (@call(bun.callmod_inline, isPathSeparator, .{input[0][index]})) {
                     last_common_separator = index;
                 }
             }
@@ -237,7 +237,7 @@ pub fn longestCommonPathGeneric(input: []const []const u8, comptime platform: Pl
                     }
                 }
                 if (index == min_length) index -= 1;
-                if (@call(.always_inline, isPathSeparator, .{input[0][index]})) {
+                if (@call(bun.callmod_inline, isPathSeparator, .{input[0][index]})) {
                     last_common_separator = index;
                 }
             }
@@ -260,7 +260,7 @@ pub fn longestCommonPathGeneric(input: []const []const u8, comptime platform: Pl
     var idx = input.len; // Use this value as an invalid value.
     for (input, 0..) |str, i| {
         if (str.len > index) {
-            if (@call(.always_inline, isPathSeparator, .{str[index]})) {
+            if (@call(bun.callmod_inline, isPathSeparator, .{str[index]})) {
                 idx = i;
             } else {
                 idx = input.len;
@@ -572,7 +572,7 @@ fn windowsVolumeNameLenT(comptime T: type, path: []const T) struct { usize, usiz
 }
 
 pub fn windowsVolumeName(path: []const u8) []const u8 {
-    return path[0..@call(.always_inline, windowsVolumeNameLen, .{path})[0]];
+    return path[0..@call(bun.callmod_inline, windowsVolumeNameLen, .{path})[0]];
 }
 
 pub fn windowsFilesystemRoot(path: []const u8) []const u8 {
@@ -1492,7 +1492,7 @@ pub fn isSepAny(char: u8) bool {
 
 pub fn isSepAnyT(comptime T: type, char: anytype) bool {
     if (comptime @TypeOf(char) != T) @compileError("Incorrect type passed to isSepAnyT");
-    return @call(.always_inline, isSepPosixT, .{ T, char }) or @call(.always_inline, isSepWin32T, .{ T, char });
+    return @call(bun.callmod_inline, isSepPosixT, .{ T, char }) or @call(bun.callmod_inline, isSepWin32T, .{ T, char });
 }
 
 pub fn lastIndexOfSeparatorWindows(slice: []const u8) ?usize {

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -50,7 +50,7 @@ pub fn isPackagePath(path: string) bool {
     // Always check for posix absolute paths (starts with "/")
     // But don't check window's style on posix
     // For a more in depth explanation, look above where `isPackagePathNotAbsolute` is used.
-    return !std.fs.path.isAbsolute(path) and @call(.always_inline, isPackagePathNotAbsolute, .{path});
+    return !std.fs.path.isAbsolute(path) and @call(bun.callmod_inline, isPackagePathNotAbsolute, .{path});
 }
 
 pub fn isPackagePathNotAbsolute(non_absolute_path: string) bool {
@@ -1494,7 +1494,7 @@ pub const Resolver = struct {
         r: *ThisResolver,
         result: *const Result,
     ) ?*const PackageJSON {
-        return @call(.always_inline, packageJSONForResolvedNodeModuleWithIgnoreMissingName, .{ r, result, true });
+        return @call(bun.callmod_inline, packageJSONForResolvedNodeModuleWithIgnoreMissingName, .{ r, result, true });
     }
 
     // This is a fallback, hopefully not called often. It should be relatively quick because everything should be in the cache.

--- a/src/sha.zig
+++ b/src/sha.zig
@@ -50,7 +50,7 @@ fn NewEVP(
         pub fn init() @This() {
             BoringSSL.load();
 
-            const md = @call(.auto, @field(BoringSSL, MDName), .{});
+            const md = @field(BoringSSL, MDName)();
             var this = @This(){};
 
             BoringSSL.EVP_MD_CTX_init(&this.ctx);
@@ -61,7 +61,7 @@ fn NewEVP(
         }
 
         pub fn hash(bytes: []const u8, out: *Digest, engine: *BoringSSL.ENGINE) void {
-            const md = @call(.auto, @field(BoringSSL, MDName), .{});
+            const md = @field(BoringSSL, MDName)();
 
             std.debug.assert(BoringSSL.EVP_Digest(bytes.ptr, bytes.len, out, null, md, engine) == 1);
         }

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -793,7 +793,7 @@ pub fn NewInterpreter(comptime EventLoopKind: JSC.EventLoopKind) type {
                     },
                     .pipe => {
                         const func = @field(ShellState, "buffered_" ++ @tagName(iotype));
-                        const bufio: *bun.ByteList = @call(.auto, func, .{this});
+                        const bufio: *bun.ByteList = func(this);
                         bufio.append(bun.default_allocator, buf) catch bun.outOfMemory();
                         // this.parent.childDone(this, 1);
                         return .cont;

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -687,7 +687,7 @@ pub fn startsWithGeneric(comptime T: type, self: []const T, str: []const T) bool
 }
 
 pub inline fn endsWith(self: string, str: string) bool {
-    return str.len == 0 or @call(.always_inline, std.mem.endsWith, .{ u8, self, str });
+    return str.len == 0 or @call(bun.callmod_inline, std.mem.endsWith, .{ u8, self, str });
 }
 
 pub inline fn endsWithComptime(self: string, comptime str: anytype) bool {

--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -228,7 +228,7 @@ pub fn ConcurrentFunction(
 
             pub fn callback(task: *Task) void {
                 const routine = @fieldParentPtr(@This(), "task", task);
-                @call(.always_inline, Fn, routine.args);
+                @call(bun.callmod_inline, Fn, routine.args);
             }
         };
 

--- a/src/url.zig
+++ b/src/url.zig
@@ -562,7 +562,7 @@ pub const QueryStringMap = struct {
     pub fn getAll(this: *const QueryStringMap, input: string, target: []string) usize {
         const hash = bun.hash(input);
         const _slice = this.list.slice();
-        return @call(.always_inline, getAllWithHashFromOffset, .{ this, target, hash, 0, _slice });
+        return @call(bun.callmod_inline, getAllWithHashFromOffset, .{ this, target, hash, 0, _slice });
     }
 
     pub fn getAllWithHashFromOffset(this: *const QueryStringMap, target: []string, hash: u64, offset: usize, _slice: Param.List.Slice) usize {
@@ -795,7 +795,7 @@ pub const QueryStringMap = struct {
 
 pub const PercentEncoding = struct {
     pub fn decode(comptime Writer: type, writer: Writer, input: string) !u32 {
-        return @call(.always_inline, decodeFaultTolerant, .{ Writer, writer, input, null, false });
+        return @call(bun.callmod_inline, decodeFaultTolerant, .{ Writer, writer, input, null, false });
     }
 
     pub fn decodeFaultTolerant(

--- a/src/wyhash.zig
+++ b/src/wyhash.zig
@@ -70,7 +70,7 @@ const WyhashStateless = struct {
         var off: usize = 0;
         while (off < b.len) : (off += 32) {
             self.round(b[off .. off + 32]);
-            // @call(.always_inline, self.round, .{b[off .. off + 32]});
+            // @call(bun.callmod_inline, self.round, .{b[off .. off + 32]});
         }
 
         self.msg_len += b.len;
@@ -127,9 +127,9 @@ const WyhashStateless = struct {
 
         var c = WyhashStateless.init(seed);
         c.update(input[0..aligned_len]);
-        // @call(.always_inline, c.update, .{input[0..aligned_len]});
+        // @call(bun.callmod_inline, c.update, .{input[0..aligned_len]});
         return c.final(input[aligned_len..]);
-        // return @call(.always_inline, c.final, .{input[aligned_len..]});
+        // return @call(bun.callmod_inline, c.final, .{input[aligned_len..]});
     }
 };
 


### PR DESCRIPTION
when used with `@call` this will allow these call frames to not be elided from the debugger/stack traces/etc while still maintaining the use of `.always_inline` in all release modes.