### PR TITLE
shell: Don't immediately delimit command substitution result

### DIFF
--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -1757,7 +1757,7 @@ pub fn NewInterpreter(comptime EventLoopKind: JSC.EventLoopKind) type {
                 // "aa bbb"
 
                 this.current_out.appendSlice(stdout[a..b]) catch bun.outOfMemory();
-                this.pushCurrentOut();
+                // this.pushCurrentOut();
                 // const slice_z = this.base.interpreter.allocator.dupeZ(u8, stdout[a..b]) catch bun.outOfMemory();
                 // this.pushResultSlice(slice_z);
             }


### PR DESCRIPTION
### What does this PR do?

Fixes #8982, basically `echo $(echo id)/$(echo region)` was giving `id /region` instead of `id/region`

It was immediately delimiting the result of a command substitution, this should only happen if the result of the cmd subst has whitespace

1 line fix lol

### How did you verify your code works?


If Zig files changed:
- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
