### PR TITLE
fix: modify bcrypt to be able to verify long passwords directly

### DIFF
--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -174,16 +174,12 @@ describe("verify", () => {
   });
 });
 
-test("bcrypt longer than 72 characters is the SHA-512", async () => {
+test("bcrypt uses the SHA-512 of passwords longer than 72 characters", async () => {
   const boop = Buffer.from("hey".repeat(100));
   const hashed = await password.hash(boop, "bcrypt");
-  expect(await password.verify(Bun.SHA512.hash(boop), hashed, "bcrypt")).toBeTrue();
-});
-
-test("bcrypt shorter than 72 characters is NOT the SHA-512", async () => {
-  const boop = Buffer.from("hey".repeat(3));
-  const hashed = await password.hash(boop, "bcrypt");
-  expect(await password.verify(Bun.SHA512.hash(boop), hashed, "bcrypt")).toBeFalse();
+  expect(await password.verify(boop, hashed, "bcrypt")).toBeTrue();
+  const boop2 = Buffer.from("hey".repeat(24));
+  expect(await password.verify(boop2, hashed, "bcrypt")).toBeFalse();
 });
 
 const defaultAlgorithm = "argon2id";


### PR DESCRIPTION
Fixes #9009 

### What does this PR do?

Make the "bcrypt" algorithm (actually a variation of it) easier to use by using analogous code paths for hashing and verification.

This would break compatibility with old code, so maybe it's already too late for it.

- [x] Code changes

### How did you verify your code works?

I altered the existing automated tests.

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)