### PR TITLE
Fix Prisma memory leak related to napi threadsafe_function

### DIFF
--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1279,7 +1279,7 @@ pub const ThreadSafeFunction = struct {
     /// prevent it from being destroyed.
     poll_ref: Async.KeepAlive,
 
-    owning_threads: std.AutoArrayHashMapUnmanaged(u64, void) = .{},
+    thread_count: usize = 0,
     owning_thread_lock: Lock = Lock.init(),
     event_loop: *JSC.EventLoop,
 
@@ -1422,24 +1422,33 @@ pub const ThreadSafeFunction = struct {
         defer this.owning_thread_lock.unlock();
         if (this.channel.isClosed())
             return error.Closed;
-        _ = this.owning_threads.getOrPut(bun.default_allocator, std.Thread.getCurrentId()) catch unreachable;
+        this.thread_count += 1;
     }
 
-    pub fn release(this: *ThreadSafeFunction, mode: napi_threadsafe_function_release_mode) void {
+    pub fn release(this: *ThreadSafeFunction, mode: napi_threadsafe_function_release_mode) napi_status {
         this.owning_thread_lock.lock();
         defer this.owning_thread_lock.unlock();
-        if (!this.owning_threads.swapRemove(std.Thread.getCurrentId()))
-            return;
+
+        if (this.thread_count == 0) {
+            return invalidArg();
+        }
+
+        this.thread_count -= 1;
+
+        if (this.channel.isClosed()) {
+            return .ok;
+        }
 
         if (mode == .abort) {
             this.channel.close();
         }
 
-        if (this.owning_threads.count() == 0) {
+        if (mode == .abort or this.thread_count == 0) {
             this.finalizer_task = JSC.AnyTask{ .ctx = this, .callback = finalize };
             this.event_loop.enqueueTaskConcurrent(JSC.ConcurrentTask.fromCallback(this, finalize));
-            return;
         }
+
+        return .ok;
     }
 };
 
@@ -1479,10 +1488,10 @@ pub export fn napi_create_threadsafe_function(
         },
         .ctx = context,
         .channel = ThreadSafeFunction.Queue.init(max_queue_size, bun.default_allocator),
-        .owning_threads = .{},
+        .thread_count = initial_thread_count,
         .poll_ref = Async.KeepAlive.init(),
     };
-    function.owning_threads.ensureTotalCapacity(bun.default_allocator, initial_thread_count) catch return genericFailure();
+
     function.finalizer = .{ .ctx = thread_finalize_data, .fun = thread_finalize_cb };
     result.* = function;
     return .ok;
@@ -1512,8 +1521,7 @@ pub export fn napi_acquire_threadsafe_function(func: napi_threadsafe_function) n
 }
 pub export fn napi_release_threadsafe_function(func: napi_threadsafe_function, mode: napi_threadsafe_function_release_mode) napi_status {
     log("napi_release_threadsafe_function", .{});
-    func.release(mode);
-    return .ok;
+    return func.release(mode);
 }
 pub export fn napi_unref_threadsafe_function(env: napi_env, func: napi_threadsafe_function) napi_status {
     log("napi_unref_threadsafe_function", .{});


### PR DESCRIPTION
### What does this PR do?

Potentially fixes #8336 (at least partially), and maybe also #7377 (haven't tested that one though)

The `threadsafe_function` logic seems to have an error.

On `napi_create_threadsafe_function`, there is an `initial_thread_count` parameter. Currently all we do with this parameter is:
```zig
function.owning_threads.ensureTotalCapacity(bun.default_allocator, initial_thread_count) catch return genericFailure();
```

Let's assume that after calling this method, the caller never calls `napi_acquire_threadsafe_function` (which is the only way values are added to `owning_threads`). So at this point, we have a data structure with the _capacity_ of `initial_thread_count`, but with _no actual values_.

So, when it comes time to `napi_release_threadsafe_function`, this causes a bug in which the finalizer (which I assume frees some memory) is never called.
```zig
pub fn release(this: *ThreadSafeFunction, mode: napi_threadsafe_function_release_mode) void {
    this.owning_thread_lock.lock();
    defer this.owning_thread_lock.unlock();

    // owning_threads is empty, this will always return
    if (!this.owning_threads.swapRemove(std.Thread.getCurrentId()))
        return;

    // ... logic to call finalizer
}
```

I looked at the napi calls Prisma is making on the `settings.findMany` from #8336, and it seems this is what happens with prisma:
```
[napi] napi_create_promise
[napi] napi_create_string_utf8: napi_resolve_deferred
[napi] napi_create_threadsafe_function w/ initial_thread_count=1
[napi] napi_call_threadsafe_function
[napi] napi_release_threadsafe_function
[napi] napi_create_string_utf8: {"data":{"findManysettings":[]}}
[napi] napi_resolve_deferred
```

and so the finalizer for all of those `threadsafe_function`s are never called.

------

To fix this, I just swapped this `owningThreads` data structure out for a simple `thread_count` variable. On `create_threadsafe_function`, this value is simply initialized to `initial_thread_count`. On acquire, it is incremented; on release it is decremented. Once this hits zero, the finalizer is called. This is more or less what Node does as well: https://github.com/nodejs/node/blob/1263bb609fc865bae237df7d8965cf7c4e8fc3c8/src/node_api.cc#L1313

### How did you verify your code works?
I used the script provided in #8336 (tweaked it a bit to get the issue to arise faster). I let each run for one minute, then turned off the stress tester and let it run for an additional 15 seconds. I also added a `setInterval` that calls `Bun.gc(true)` every 10 seconds.

<details>
<summary>The modified script</summary>

```ts
import { PrismaClient } from "@prisma/client";
import { Elysia } from "elysia";
import { Kysely, PostgresDialect } from "kysely";
import pg from "pg";
import { DB } from "./Kysely";

const dialect = new PostgresDialect({
	pool: new pg.Pool({
		connectionString: Bun.env.DATABASE_URL,
	}),
});

export const kyselyDb = new Kysely<DB>({
	dialect,
});

export const prismaClient = new PrismaClient();

const app = new Elysia()
	.get("/kysely", () => kyselyDb.selectFrom("settings").selectAll().execute())
	.get("/prisma", () => {
		const promises = [];
		for (let i = 0; i < 50; i++) {
			promises.push(prismaClient.settings.findMany());
		}
		return Promise.all(promises);
	})
	.post("/prisma/disconnect", () => prismaClient.$disconnect())
	.post("/kysely/disconnect", () => kyselyDb.destroy())
	.post("/", () => Bun.gc(true))
	.listen(3000);

setInterval(async () => {
	console.log(
		"Memory usage: ",
		Math.trunc(process.memoryUsage.rss() / 1024 / 1024),
		"MB",
	);
}, 1000);

setInterval(() => {
	Bun.gc(true);
	console.log("Garbage collected");
}, 10_000)
```
</details>

These are the results. Both are built in `release` mode. TL;DR is:
- Without the fix, it hits 2GB within a minute. After stopping the tester and letting garbage collection run (twice!), it's still at 1.7GB.
- With the fix, it never goes over 900MB. After stopping + garbage collection, it drops back down to 275MB.

<details>
  <summary>Latest `main` (no patch)</summary>
  
```
Memory usage:  150 MB
Memory usage:  150 MB
Memory usage:  150 MB
Memory usage:  150 MB
Memory usage:  260 MB
Memory usage:  299 MB
Memory usage:  386 MB
Memory usage:  471 MB
Memory usage:  561 MB
Garbage collected
Memory usage:  624 MB
Memory usage:  705 MB
Memory usage:  815 MB
Memory usage:  885 MB
Memory usage:  965 MB
Memory usage:  1043 MB
Memory usage:  1126 MB
Memory usage:  1143 MB
Garbage collected
Memory usage:  907 MB
Memory usage:  1227 MB
Memory usage:  1294 MB
Memory usage:  1327 MB
Memory usage:  1338 MB
Memory usage:  1452 MB
Memory usage:  1434 MB
Garbage collected
Memory usage:  1378 MB
Memory usage:  1361 MB
Memory usage:  1460 MB
Memory usage:  1570 MB
Memory usage:  1550 MB
Memory usage:  1602 MB
Memory usage:  1630 MB
Memory usage:  1653 MB
Garbage collected
Memory usage:  1419 MB
Memory usage:  1464 MB
Memory usage:  1745 MB
Memory usage:  1755 MB
Memory usage:  1830 MB
Memory usage:  1811 MB
Memory usage:  1862 MB
Memory usage:  1877 MB
Garbage collected
Memory usage:  1637 MB
Memory usage:  1776 MB
Memory usage:  1911 MB
Memory usage:  1951 MB
Memory usage:  2046 MB
Memory usage:  2106 MB
Memory usage:  2077 MB
Garbage collected
Memory usage:  1994 MB
Memory usage:  2030 MB
Memory usage:  2095 MB
Memory usage:  2168 MB
Memory usage:  2185 MB
Memory usage:  2167 MB
Memory usage:  2167 MB
Memory usage:  2167 MB
Memory usage:  2167 MB
Garbage collected
Memory usage:  1732 MB
Memory usage:  1723 MB
Memory usage:  1723 MB
Memory usage:  1723 MB
Memory usage:  1723 MB
Memory usage:  1723 MB
Memory usage:  1723 MB
Memory usage:  1723 MB
Memory usage:  1723 MB
Memory usage:  1723 MB
Garbage collected
Memory usage:  1720 MB
Memory usage:  1720 MB
Memory usage:  1720 MB
```
</details>


<details>
  <summary>With this patch</summary>

```
Memory usage:  144 MB
Memory usage:  144 MB
Memory usage:  143 MB
Memory usage:  143 MB
Memory usage:  184 MB
Memory usage:  302 MB
Memory usage:  290 MB
Memory usage:  346 MB
Memory usage:  400 MB
Garbage collected
Memory usage:  407 MB
Memory usage:  518 MB
Memory usage:  582 MB
Memory usage:  622 MB
Memory usage:  702 MB
Memory usage:  741 MB
Memory usage:  768 MB
Memory usage:  763 MB
Garbage collected
Memory usage:  654 MB
Memory usage:  709 MB
Memory usage:  786 MB
Memory usage:  824 MB
Memory usage:  834 MB
Memory usage:  814 MB
Memory usage:  808 MB
Garbage collected
Memory usage:  562 MB
Memory usage:  696 MB
Memory usage:  746 MB
Memory usage:  820 MB
Memory usage:  836 MB
Memory usage:  825 MB
Memory usage:  841 MB
Garbage collected
Memory usage:  771 MB
Memory usage:  752 MB
Memory usage:  790 MB
Memory usage:  881 MB
Memory usage:  887 MB
Memory usage:  864 MB
Memory usage:  887 MB
Memory usage:  859 MB
Garbage collected
Memory usage:  745 MB
Memory usage:  776 MB
Memory usage:  766 MB
Memory usage:  789 MB
Memory usage:  852 MB
Memory usage:  847 MB
Memory usage:  821 MB
Memory usage:  821 MB
Garbage collected
Memory usage:  288 MB
Memory usage:  275 MB
Memory usage:  275 MB
Memory usage:  275 MB
Memory usage:  275 MB
Memory usage:  275 MB
```
</details>