### PR TITLE
shell: Fix latin-1 template literal strings

### DIFF
--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -1960,7 +1960,14 @@ pub fn NewLexer(comptime encoding: StringEncoding) type {
 
         fn appendStringToStrPool(self: *@This(), bunstr: bun.String) !void {
             const start = self.strpool.items.len;
-            if (bunstr.is8Bit()) {
+            if (bunstr.isUTF16()) {
+                const utf16 = bunstr.utf16();
+                const additional = bun.simdutf.simdutf__utf8_length_from_utf16le(utf16.ptr, utf16.len);
+                try self.strpool.ensureUnusedCapacity(additional);
+                try bun.strings.convertUTF16ToUTF8Append(&self.strpool, bunstr.utf16());
+            } else if (bunstr.isUTF8()) {
+                try self.strpool.appendSlice(bunstr.byteSlice());
+            } else if (bunstr.is8Bit()) {
                 if (isAllAscii(bunstr.byteSlice())) {
                     try self.strpool.appendSlice(bunstr.byteSlice());
                 } else {
@@ -1972,13 +1979,6 @@ pub fn NewLexer(comptime encoding: StringEncoding) type {
                     }
                     self.strpool = try bun.strings.allocateLatin1IntoUTF8WithList(self.strpool, self.strpool.items.len, []const u8, bytes[non_ascii_idx..]);
                 }
-            } else if (bunstr.isUTF8()) {
-                try self.strpool.appendSlice(bunstr.byteSlice());
-            } else {
-                const utf16 = bunstr.utf16();
-                const additional = bun.simdutf.simdutf__utf8_length_from_utf16le(utf16.ptr, utf16.len);
-                try self.strpool.ensureUnusedCapacity(additional);
-                try bun.strings.convertUTF16ToUTF8Append(&self.strpool, bunstr.utf16());
             }
             const end = self.strpool.items.len;
             self.j += @intCast(end - start);
@@ -2911,16 +2911,15 @@ const SPECIAL_CHARS = [_]u8{ '$', '>', '&', '|', '=', ';', '\n', '{', '}', ',', 
 const BACKSLASHABLE_CHARS = [_]u8{ '$', '`', '"', '\\' };
 
 pub fn escapeBunStr(bunstr: bun.String, outbuf: *std.ArrayList(u8), comptime add_quotes: bool) !bool {
-    // latin-1 or ascii
-    if (bunstr.is8Bit()) {
-        try escape8Bit(bunstr.byteSlice(), outbuf, add_quotes);
-        return true;
-    }
     if (bunstr.isUTF16()) {
         return try escapeUtf16(bunstr.utf16(), outbuf, add_quotes);
     }
-    // Otherwise is utf-8
-    try escapeWTF8(bunstr.byteSlice(), outbuf, add_quotes);
+    if (bunstr.isUTF8()) {
+        try escapeWTF8(bunstr.byteSlice(), outbuf, add_quotes);
+        return true;
+    }
+    // otherwise should be latin-1 or ascii
+    try escape8Bit(bunstr.byteSlice(), outbuf, add_quotes);
     return true;
 }
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -269,6 +269,15 @@ describe("bunshell", () => {
     // });
   });
 
+  describe("latin-1", async () => {
+    test("basic", async () => {
+      await TestBuilder.command`echo ${"à"}`.stdout("à\n").run();
+      await TestBuilder.command`echo ${" à"}`.stdout(" à\n").run();
+      await TestBuilder.command`echo ${"à¿"}`.stdout("à¿\n").run();
+      await TestBuilder.command`echo ${'"à¿"'}`.stdout('"à¿"\n').run();
+    });
+  });
+
   test("redirect Uint8Array", async () => {
     const buffer = new Uint8Array(1 << 20);
     const result = await $`cat ${import.meta.path} > ${buffer}`;


### PR DESCRIPTION
### What does this PR do?

Fixes #9039 

Latin-1 characters in a substituted template string were being converted when escaping, but in the scenario where there is no escaping, the latin-1 byte slice was being appended instead of being converted to utf-8

- [x] Code changes

### How did you verify your code works?

Zig files changed:

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)