### PR TITLE
fix: ConsoleObject handles proxy better

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -32,6 +32,7 @@
 #include "JavaScriptCore/JSObject.h"
 #include "JavaScriptCore/JSSet.h"
 #include "JavaScriptCore/JSString.h"
+#include "JavaScriptCore/ProxyObject.h"
 #include "JavaScriptCore/Microtask.h"
 #include "JavaScriptCore/ObjectConstructor.h"
 #include "JavaScriptCore/ParserError.h"
@@ -5432,4 +5433,9 @@ CPP_DECL bool JSC__CustomGetterSetter__isGetterNull(JSC__CustomGetterSetter* get
 CPP_DECL bool JSC__CustomGetterSetter__isSetterNull(JSC__CustomGetterSetter* gettersetter)
 {
     return gettersetter->setter() == nullptr;
+}
+
+CPP_DECL JSC__JSValue Bun__ProxyObject__getInternalField(JSC__JSValue value, uint32_t id)
+{
+    return JSValue::encode(jsCast<ProxyObject*>(JSValue::decode(value))->internalField((ProxyObject::Field)id).get());
 }

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -5304,6 +5304,18 @@ pub const JSValue = enum(JSValueReprInt) {
         else
             null;
     }
+
+    extern fn Bun__ProxyObject__getInternalField(this: JSValue, field: ProxyInternalField) JSValue;
+
+    const ProxyInternalField = enum(u32) {
+        target = 0,
+        handler = 1,
+    };
+
+    /// Asserts `this` is a proxy
+    pub fn getProxyInternalField(this: JSValue, field: ProxyInternalField) JSValue {
+        return Bun__ProxyObject__getInternalField(this, field);
+    }
 };
 
 extern "c" fn AsyncContextFrame__withAsyncContextIfNeeded(global: *JSGlobalObject, callback: JSValue) JSValue;

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -359,7 +359,7 @@ export function windowsEnv(internalEnv: InternalEnvMap, envMapList: Array<string
       o[k] = internalEnv[k.toUpperCase()];
     }
     return o;
-  }
+  };
 
   return new Proxy(internalEnv, {
     get(_, p) {

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -353,6 +353,14 @@ export function windowsEnv(internalEnv: InternalEnvMap, envMapList: Array<string
   //
   // it throws "Cannot convert a Symbol value to a string"
 
+  (internalEnv as any)[Bun.inspect.custom] = () => {
+    let o = {};
+    for (let k of envMapList) {
+      o[k] = internalEnv[k.toUpperCase()];
+    }
+    return o;
+  }
+
   return new Proxy(internalEnv, {
     get(_, p) {
       return typeof p === "string" ? Reflect.get(internalEnv, p.toUpperCase()) : undefined;

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -244,3 +244,8 @@ myCustomName {
 {
   "": "",
 }
+{
+  hello: 2,
+}
+<Revoked Proxy>
+custom inspect

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -173,3 +173,28 @@ console.log(hole([1, 2, 3], 0));
 // It appears to not be set and I don't know why.
 
 console.log({ "": "" });
+
+{
+  // proxy
+  const proxy = Proxy.revocable({ hello: 2 }, {
+    get(target, prop, receiver) {
+      console.log('FAILED: GET', prop);
+      return Reflect.get(target, prop, receiver);
+    },
+    set(target, prop, value, receiver) {
+      console.log('FAILED: SET', prop, value);
+      return Reflect.set(target, prop, value, receiver);
+    },
+  });
+  console.log(proxy.proxy);
+  proxy.revoke();
+  console.log(proxy.proxy);
+}
+
+{
+  // proxy custom inspect
+  const proxy = new Proxy({ 
+    [Bun.inspect.custom]: () => 'custom inspect',
+  }, { });
+  console.log(proxy);
+}

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -176,16 +176,19 @@ console.log({ "": "" });
 
 {
   // proxy
-  const proxy = Proxy.revocable({ hello: 2 }, {
-    get(target, prop, receiver) {
-      console.log('FAILED: GET', prop);
-      return Reflect.get(target, prop, receiver);
+  const proxy = Proxy.revocable(
+    { hello: 2 },
+    {
+      get(target, prop, receiver) {
+        console.log("FAILED: GET", prop);
+        return Reflect.get(target, prop, receiver);
+      },
+      set(target, prop, value, receiver) {
+        console.log("FAILED: SET", prop, value);
+        return Reflect.set(target, prop, value, receiver);
+      },
     },
-    set(target, prop, value, receiver) {
-      console.log('FAILED: SET', prop, value);
-      return Reflect.set(target, prop, value, receiver);
-    },
-  });
+  );
   console.log(proxy.proxy);
   proxy.revoke();
   console.log(proxy.proxy);
@@ -193,8 +196,11 @@ console.log({ "": "" });
 
 {
   // proxy custom inspect
-  const proxy = new Proxy({ 
-    [Bun.inspect.custom]: () => 'custom inspect',
-  }, { });
+  const proxy = new Proxy(
+    {
+      [Bun.inspect.custom]: () => "custom inspect",
+    },
+    {},
+  );
   console.log(proxy);
 }


### PR DESCRIPTION
### What does this PR do?

Fixes #8822

Logging a proxy should not call it's handlers.

<img width="784" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/0def5c3a-0cdb-484c-abdb-3c8b6d1d5966">

<img width="317" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/328c726b-f609-4ed9-8fb1-b93c0a6b5a2a">
