### PR TITLE
Implement expect().toBeOneOf(), fix small memory leaks in expect matchers

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -874,7 +874,7 @@ declare module "bun:test" {
      */
     toStrictEqual(expected: T): void;
     /**
-     * Asserts that the value is === to an element in the expected array.
+     * Asserts that the value is deep equal to an element in the expected array.
      *
      * The value must be an array or iterable, which includes strings.
      *

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -874,6 +874,19 @@ declare module "bun:test" {
      */
     toStrictEqual(expected: T): void;
     /**
+     * Asserts that the value is === to an element in the expected array.
+     *
+     * The value must be an array or iterable, which includes strings.
+     *
+     * @example
+     * expect(1).toBeOneOf([1,2,3]);
+     * expect("foo").toBeOneOf(["foo", "bar"]);
+     * expect(true).toBeOneOf(new Set([true]));
+     *
+     * @param expected the expected value
+     */
+    toBeOneOf(expected: Array<unknown> | Iterable<unknown>): void;
+    /**
      * Asserts that a value contains what is expected.
      *
      * The value must be an array or iterable, which

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -4094,6 +4094,11 @@ pub const JSValue = enum(JSValueReprInt) {
         });
     }
 
+    pub fn hasOwnPropertyValue(this: JSValue, globalThis: *JSGlobalObject, value: JSC.JSValue) bool {
+        // TODO: add a binding for this
+        return hasOwnProperty(this, globalThis, value.getZigString(globalThis));
+    }
+
     pub fn hasOwnProperty(this: JSValue, globalThis: *JSGlobalObject, key: ZigString) bool {
         return cppFn("hasOwnProperty", .{ this, globalThis, key });
     }
@@ -4489,8 +4494,9 @@ pub const JSValue = enum(JSValueReprInt) {
     /// Call `toString()` on the JSValue and clone the result.
     /// On exception, this returns null.
     pub fn toSliceOrNull(this: JSValue, globalThis: *JSGlobalObject) ?ZigString.Slice {
-        var str = this.toStringOrNull(globalThis) orelse return null;
-        return str.toSlice(globalThis, globalThis.allocator());
+        const str = bun.String.tryFromJS(this, globalThis) orelse return null;
+        defer str.deref();
+        return str.toUTF8(bun.default_allocator);
     }
 
     /// Call `toString()` on the JSValue and clone the result.

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -719,9 +719,9 @@ pub const Expect = struct {
                 }
             }
         } else if (value.isStringLiteral() and expected.isStringLiteral()) {
-            const value_string = value.toString(globalObject).toSlice(globalObject, default_allocator);
+            const value_string = value.toSlice(globalObject, default_allocator);
             defer value_string.deinit();
-            const expected_string = expected.toString(globalObject).toSlice(globalObject, default_allocator);
+            const expected_string = expected.toSlice(globalObject, default_allocator);
             defer expected_string.deinit();
 
             if (expected_string.len == 0) { // edge case empty string is always contained
@@ -765,7 +765,7 @@ pub const Expect = struct {
         const expected_fmt = expected.toFmt(globalObject, &formatter);
         if (not) {
             const received_fmt = value.toFmt(globalObject, &formatter);
-            const expected_line = "Expected to not contain: <green>{any}<r>\n\nReceived: <red>{any}<r>\n";
+            const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
             const fmt = comptime getSignature("toContain", "<green>expected<r>", true) ++ "\n\n" ++ expected_line;
             globalObject.throwPretty(fmt, .{ expected_fmt, received_fmt });
             return .zero;
@@ -800,7 +800,7 @@ pub const Expect = struct {
         const value: JSValue = this.getValue(globalObject, thisValue, "toContainKey", "<green>expected<r>") orelse return .zero;
 
         const not = this.flags.not;
-        var pass = value.hasOwnProperty(globalObject, expected.toString(globalObject).getZigString(globalObject));
+        var pass = value.hasOwnPropertyValue(globalObject, expected);
 
         if (not) pass = !pass;
         if (pass) return thisValue;
@@ -811,7 +811,7 @@ pub const Expect = struct {
         const expected_fmt = expected.toFmt(globalObject, &formatter);
         if (not) {
             const received_fmt = value.toFmt(globalObject, &formatter);
-            const expected_line = "Expected to not contain: <green>{any}<r>\n\nReceived: <red>{any}<r>\n";
+            const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
             const fmt = comptime getSignature("toContainKey", "<green>expected<r>", true) ++ "\n\n" ++ expected_line;
             globalObject.throwPretty(fmt, .{ expected_fmt, received_fmt });
             return .zero;
@@ -860,7 +860,7 @@ pub const Expect = struct {
         while (i < count) : (i += 1) {
             const key = expected.getIndex(globalObject, i);
 
-            if (!value.hasOwnProperty(globalObject, key.toString(globalObject).getZigString(globalObject))) {
+            if (!value.hasOwnPropertyValue(globalObject, key)) {
                 pass = false;
                 break;
             }
@@ -875,7 +875,7 @@ pub const Expect = struct {
         const expected_fmt = expected.toFmt(globalObject, &formatter);
         if (not) {
             const received_fmt = value.toFmt(globalObject, &formatter);
-            const expected_line = "Expected to not contain: <green>{any}<r>\n\nReceived: <red>{any}<r>\n";
+            const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
             const fmt = comptime getSignature("toContainKeys", "<green>expected<r>", true) ++ "\n\n" ++ expected_line;
             globalObject.throwPretty(fmt, .{ expected_fmt, received_fmt });
             return .zero;
@@ -924,7 +924,7 @@ pub const Expect = struct {
         while (i < count) : (i += 1) {
             const key = expected.getIndex(globalObject, i);
 
-            if (value.hasOwnProperty(globalObject, key.toString(globalObject).getZigString(globalObject))) {
+            if (value.hasOwnPropertyValue(globalObject, key)) {
                 pass = true;
                 break;
             }
@@ -939,7 +939,7 @@ pub const Expect = struct {
         const expected_fmt = expected.toFmt(globalObject, &formatter);
         if (not) {
             const received_fmt = value.toFmt(globalObject, &formatter);
-            const expected_line = "Expected to not contain: <green>{any}<r>\n\nReceived: <red>{any}<r>\n";
+            const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
             const fmt = comptime getSignature("toContainAnyKeys", "<green>expected<r>", true) ++ "\n\n" ++ expected_line;
             globalObject.throwPretty(fmt, .{ expected_fmt, received_fmt });
             return .zero;
@@ -995,9 +995,9 @@ pub const Expect = struct {
             }
         } else if (value_type.isStringLike() and expected_type.isStringLike()) {
             if (expected_type.isStringObjectLike() and value_type.isString()) pass = false else {
-                const value_string = value.toString(globalObject).toSlice(globalObject, default_allocator);
+                const value_string = value.toSliceOrNull(globalObject) orelse return .zero;
                 defer value_string.deinit();
-                const expected_string = expected.toString(globalObject).toSlice(globalObject, default_allocator);
+                const expected_string = expected.toSliceOrNull(globalObject) orelse return .zero;
                 defer expected_string.deinit();
 
                 // jest does not have a `typeof === "string"` check for `toContainEqual`.
@@ -2582,18 +2582,19 @@ pub const Expect = struct {
         const expected = arguments[0];
         expected.ensureStillAlive();
 
-        const expectedAsStr = expected.toString(globalThis).toSlice(globalThis, default_allocator).slice();
-        incrementExpectCallCounter();
-
         if (!expected.isString()) {
             globalThis.throwInvalidArguments("toBeTypeOf() requires a string argument", .{});
             return .zero;
         }
 
-        if (!JSTypeOfMap.has(expectedAsStr)) {
+        const expected_type = expected.toBunString(globalThis);
+        defer expected_type.deref();
+        incrementExpectCallCounter();
+
+        const typeof = expected_type.inMap(JSTypeOfMap) orelse {
             globalThis.throwInvalidArguments("toBeTypeOf() requires a valid type string argument ('function', 'object', 'bigint', 'boolean', 'number', 'string', 'symbol', 'undefined')", .{});
             return .zero;
-        }
+        };
 
         const not = this.flags.not;
         var pass = false;
@@ -2621,7 +2622,7 @@ pub const Expect = struct {
             return .zero;
         }
 
-        pass = strings.eql(expectedAsStr, whatIsTheType);
+        pass = strings.eql(typeof, whatIsTheType);
 
         if (not) pass = !pass;
         if (pass) return .undefined;
@@ -2964,19 +2965,24 @@ pub const Expect = struct {
         var pass = value.isString() and expected.isString();
 
         if (pass) {
-            const valueStr = value.toString(globalThis).toSlice(globalThis, default_allocator).slice();
-            const expectedStr = expected.toString(globalThis).toSlice(globalThis, default_allocator).slice();
+            const value_slice = value.toSlice(globalThis, default_allocator);
+            defer value_slice.deinit();
+            const expected_slice = expected.toSlice(globalThis, default_allocator);
+            defer expected_slice.deinit();
+
+            const value_utf8 = value_slice.slice();
+            const expected_utf8 = expected_slice.slice();
 
             var left: usize = 0;
             var right: usize = 0;
 
             // Skip leading whitespaces
-            while (left < valueStr.len and std.ascii.isWhitespace(valueStr[left])) left += 1;
-            while (right < expectedStr.len and std.ascii.isWhitespace(expectedStr[right])) right += 1;
+            while (left < value_utf8.len and std.ascii.isWhitespace(value_utf8[left])) left += 1;
+            while (right < expected_utf8.len and std.ascii.isWhitespace(expected_utf8[right])) right += 1;
 
-            while (left < valueStr.len and right < expectedStr.len) {
-                const left_char = valueStr[left];
-                const right_char = expectedStr[right];
+            while (left < value_utf8.len and right < expected_utf8.len) {
+                const left_char = value_utf8[left];
+                const right_char = expected_utf8[right];
 
                 if (left_char != right_char) {
                     pass = false;
@@ -2987,11 +2993,11 @@ pub const Expect = struct {
                 right += 1;
 
                 // Skip trailing whitespaces
-                while (left < valueStr.len and std.ascii.isWhitespace(valueStr[left])) left += 1;
-                while (right < expectedStr.len and std.ascii.isWhitespace(expectedStr[right])) right += 1;
+                while (left < value_utf8.len and std.ascii.isWhitespace(value_utf8[left])) left += 1;
+                while (right < expected_utf8.len and std.ascii.isWhitespace(expected_utf8[right])) right += 1;
             }
 
-            if (left < valueStr.len or right < expectedStr.len) {
+            if (left < value_utf8.len or right < expected_utf8.len) {
                 pass = false;
             }
         }
@@ -3177,9 +3183,11 @@ pub const Expect = struct {
 
         var pass = value.isString();
         if (pass) {
-            const value_string = value.toString(globalThis).toSlice(globalThis, default_allocator).slice();
-            const expected_string = expected.toString(globalThis).toSlice(globalThis, default_allocator).slice();
-            pass = strings.contains(value_string, expected_string) or expected_string.len == 0;
+            const value_string = value.toSliceOrNull(globalThis) orelse return .zero;
+            defer value_string.deinit();
+            const expected_string = expected.toSliceOrNull(globalThis) orelse return .zero;
+            defer expected_string.deinit();
+            pass = strings.contains(value_string.slice(), expected_string.slice()) or expected_string.len == 0;
         }
 
         const not = this.flags.not;
@@ -3410,9 +3418,11 @@ pub const Expect = struct {
 
         var pass = value.isString();
         if (pass) {
-            const value_string = value.toString(globalThis).toSlice(globalThis, default_allocator).slice();
-            const expected_string = expected.toString(globalThis).toSlice(globalThis, default_allocator).slice();
-            pass = strings.startsWith(value_string, expected_string) or expected_string.len == 0;
+            const value_string = value.toSliceOrNull(globalThis) orelse return .zero;
+            defer value_string.deinit();
+            const expected_string = expected.toSliceOrNull(globalThis) orelse return .zero;
+            defer expected_string.deinit();
+            pass = strings.startsWith(value_string.slice(), expected_string.slice()) or expected_string.len == 0;
         }
 
         const not = this.flags.not;
@@ -3465,9 +3475,11 @@ pub const Expect = struct {
 
         var pass = value.isString();
         if (pass) {
-            const value_string = value.toString(globalThis).toSlice(globalThis, default_allocator).slice();
-            const expected_string = expected.toString(globalThis).toSlice(globalThis, default_allocator).slice();
-            pass = strings.endsWith(value_string, expected_string) or expected_string.len == 0;
+            const value_string = value.toSliceOrNull(globalThis) orelse return .zero;
+            defer value_string.deinit();
+            const expected_string = expected.toSliceOrNull(globalThis) orelse return .zero;
+            defer expected_string.deinit();
+            pass = strings.endsWith(value_string.slice(), expected_string.slice()) or expected_string.len == 0;
         }
 
         const not = this.flags.not;
@@ -4173,7 +4185,8 @@ pub const Expect = struct {
         const is_valid = valid: {
             if (result.isObject()) {
                 if (result.get(globalObject, "pass")) |pass_value| {
-                    pass = pass_value.toBoolean();
+                    pass = pass_value.toBooleanSlow(globalObject);
+                    if (globalObject.hasException()) return false;
 
                     if (result.get(globalObject, "message")) |message_value| {
                         if (!message_value.isString() and !message_value.isCallable(globalObject.vm())) {
@@ -4204,16 +4217,27 @@ pub const Expect = struct {
             message_text = bun.String.static("No message was specified for this matcher.");
         } else if (message.isString()) {
             message_text = message.toBunString(globalObject);
-        } else { // callable
+        } else {
+            if (comptime Environment.allow_assert)
+                std.debug.assert(message.isCallable(globalObject.vm())); // checked above
+
             var message_result = message.callWithGlobalThis(globalObject, &[_]JSValue{});
             std.debug.assert(!message_result.isEmpty());
             if (message_result.toError()) |err| {
                 globalObject.throwValue(err);
                 return false;
             }
-            if (message_result.toStringOrNull(globalObject)) |str| {
-                message_text = bun.String.init(str.getZigString(globalObject));
+            if (bun.String.tryFromJS(message_result, globalObject)) |str| {
+                message_text = str;
             } else {
+                var formatter = JSC.ConsoleObject.Formatter{
+                    .globalThis = globalObject,
+                    .quote_strings = true,
+                };
+                globalObject.throw(
+                    "Expected custom matcher message to return a string, but got: {}",
+                    .{message_result.toFmt(globalObject, &formatter)},
+                );
                 return false;
             }
         }
@@ -4984,7 +5008,8 @@ pub const ExpectMatcherUtils = struct {
             globalObject.throw("matcherHint: the first argument (matcher name) must be a string", .{});
             return .zero;
         }
-        const matcher_name = bun.String.init(arguments[0].toString(globalObject).getZigString(globalObject));
+        const matcher_name = arguments[0].toBunString(globalObject);
+        defer matcher_name.deref();
 
         const received = if (arguments.len > 1) arguments[1] else bun.String.static("received").toJS(globalObject);
         const expected = if (arguments.len > 2) arguments[2] else bun.String.static("expected").toJS(globalObject);
@@ -5005,7 +5030,7 @@ pub const ExpectMatcherUtils = struct {
                 return .zero;
             }
             if (options.get(globalObject, "isNot")) |val| {
-                is_not = val.toBoolean();
+                is_not = val.coerce(bool, globalObject);
             }
             if (options.get(globalObject, "comment")) |val| {
                 comment = val.toStringOrNull(globalObject);

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -628,7 +628,8 @@ pub const Expect = struct {
         if (list_value.jsTypeLoose().isArrayLike()) {
             var itr = list_value.arrayIterator(globalObject);
             while (itr.next()) |item| {
-                if (item.isSameValue(expected, globalObject)) {
+                // Confusingly, jest-extended uses `deepEqual`, instead of `toBe`
+                if (item.jestDeepEquals(expected, globalObject)) {
                     pass = true;
                     break;
                 }
@@ -647,7 +648,8 @@ pub const Expect = struct {
                     item: JSValue,
                 ) callconv(.C) void {
                     const entry = bun.cast(*ExpectedEntry, entry_.?);
-                    if (item.isSameValue(entry.expected, entry.globalObject)) {
+                    // Confusingly, jest-extended uses `deepEqual`, instead of `toBe`
+                    if (item.jestDeepEquals(entry.expected, entry.globalObject)) {
                         entry.pass.* = true;
                         // TODO(perf): break out of the `forEach` when a match is found
                     }

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -4230,6 +4230,7 @@ pub const Expect = struct {
             if (bun.String.tryFromJS(message_result, globalObject)) |str| {
                 message_text = str;
             } else {
+                if (globalObject.hasException()) return false;
                 var formatter = JSC.ConsoleObject.Formatter{
                     .globalThis = globalObject,
                     .quote_strings = true,

--- a/src/bun.js/test/jest.classes.ts
+++ b/src/bun.js/test/jest.classes.ts
@@ -470,6 +470,10 @@ export default [
         fn: "toThrowErrorMatchingInlineSnapshot",
         length: 1,
       },
+      toBeOneOf: {
+        fn: "toBeOneOf",
+        length: 1,
+      },
       not: {
         getter: "getNot",
         this: true,

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -600,8 +600,12 @@ pub const TextDecoder = struct {
 
         if (arguments.len > 1 and arguments[1].isObject()) {
             if (arguments[1].get(globalThis, "stream")) |stream| {
-                if (stream.toBoolean()) {
+                if (stream.coerce(bool, globalThis)) {
                     return this.decodeSlice(globalThis, array_buffer.slice(), true);
+                }
+
+                if (globalThis.hasException()) {
+                    return JSValue.zero;
                 }
             }
         }

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -500,14 +500,18 @@ pub const StreamStart = union(Tag) {
                 var chunk_size: JSC.WebCore.Blob.SizeType = 0;
                 var empty = true;
 
-                if (value.get(globalThis, "asUint8Array")) |as_array| {
-                    as_uint8array = as_array.toBoolean();
-                    empty = false;
+                if (value.get(globalThis, "asUint8Array")) |val| {
+                    if (val.isBoolean()) {
+                        as_uint8array = val.toBoolean();
+                        empty = false;
+                    }
                 }
 
-                if (value.get(globalThis, "stream")) |as_array| {
-                    stream = as_array.toBoolean();
-                    empty = false;
+                if (value.get(globalThis, "stream")) |val| {
+                    if (val.isBoolean()) {
+                        stream = val.toBoolean();
+                        empty = false;
+                    }
                 }
 
                 if (value.get(globalThis, "highWaterMark")) |chunkSize| {

--- a/test/js/bun/test/expect-extend.types.d.ts
+++ b/test/js/bun/test/expect-extend.types.d.ts
@@ -16,6 +16,7 @@ interface CustomMatchersForTest {
   _toCustomB(): any;
 
   _toThrowErrorMatchingSnapshot(): any; // TODO: remove when implemented
+  _toHaveMessageThatThrows(a: any, b: any): any;
 }
 
 declare module "bun:test" {

--- a/test/js/bun/test/expect-extend.types.d.ts
+++ b/test/js/bun/test/expect-extend.types.d.ts
@@ -16,7 +16,7 @@ interface CustomMatchersForTest {
   _toCustomB(): any;
 
   _toThrowErrorMatchingSnapshot(): any; // TODO: remove when implemented
-  _toHaveMessageThatThrows(a: any, b: any): any;
+  _toHaveMessageThatThrows(a: any): any;
 }
 
 declare module "bun:test" {

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -99,6 +99,36 @@ describe("jest-extended", () => {
 
   // toBeOneOf('toSatisfy()')
 
+  test("toBeOneOf()", () => {
+    expect(1).toBeOneOf([1, 2, 3]);
+    expect(2).toBeOneOf([1, 2, 3]);
+    expect(3).toBeOneOf([1, 2, 3]);
+    expect(4).not.toBeOneOf([1, 2, 3]);
+    expect("a").toBeOneOf(["a", "b", "c"]);
+    expect("b").toBeOneOf(["a", "b", "c"]);
+    expect("c").toBeOneOf(["a", "b", "c"]);
+    expect("d").not.toBeOneOf(["a", "b", "c"]);
+    expect(true).toBeOneOf([true, false]);
+    expect(false).toBeOneOf([true, false]);
+    expect(null).toBeOneOf([null, undefined]);
+    expect(undefined).toBeOneOf([null, undefined]);
+    const abc = {};
+    expect({}).not.toBeOneOf([{}, []]);
+    expect(abc).toBeOneOf([abc, {}]);
+    expect({}).not.toBeOneOf([abc, {}]);
+    try {
+      expect(0).toBeOneOf([1, 2]);
+    } catch (e) {
+      console.log(e);
+    }
+
+    try {
+      expect(1).not.toBeOneOf([1, 2]);
+    } catch (e) {
+      console.log(e);
+    }
+  });
+
   test("toBeNil()", () => {
     expect(null).toBeNil();
     expect(undefined).toBeNil();

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -121,7 +121,7 @@ describe("jest-extended", () => {
       expect.unreachable();
     } catch (e) {
       expect(e.message).not.toContain("unreachable");
-      expect(Bun.inspect(e)).not.toBeEmpty(); // verify that logging it doesn't cause a crash
+      if (typeof Bun === "object") expect(Bun.inspect(e)).not.toBeEmpty(); // verify that logging it doesn't cause a crash
     }
 
     try {
@@ -129,7 +129,7 @@ describe("jest-extended", () => {
       expect.unreachable();
     } catch (e) {
       expect(e.message).not.toContain("unreachable");
-      expect(Bun.inspect(e)).not.toBeEmpty(); // verify that logging it doesn't cause a crash
+      if (typeof Bun === "object") expect(Bun.inspect(e)).not.toBeEmpty(); // verify that logging it doesn't cause a crash
     }
   });
 

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -112,10 +112,10 @@ describe("jest-extended", () => {
     expect(false).toBeOneOf([true, false]);
     expect(null).toBeOneOf([null, undefined]);
     expect(undefined).toBeOneOf([null, undefined]);
-    const abc = {};
-    expect({}).not.toBeOneOf([{}, []]);
+    const abc = { c: 1 };
+    expect({}).not.toBeOneOf([{ b: 1 }, []]);
     expect(abc).toBeOneOf([abc, {}]);
-    expect({}).not.toBeOneOf([abc, {}]);
+    expect({}).not.toBeOneOf([abc, { a: 1 }]);
     try {
       expect(0).toBeOneOf([1, 2]);
       expect.unreachable();

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -118,14 +118,18 @@ describe("jest-extended", () => {
     expect({}).not.toBeOneOf([abc, {}]);
     try {
       expect(0).toBeOneOf([1, 2]);
+      expect.unreachable();
     } catch (e) {
-      console.log(e);
+      expect(e.message).not.toContain("unreachable");
+      expect(Bun.inspect(e)).not.toBeEmpty(); // verify that logging it doesn't cause a crash
     }
 
     try {
       expect(1).not.toBeOneOf([1, 2]);
+      expect.unreachable();
     } catch (e) {
-      console.log(e);
+      expect(e.message).not.toContain("unreachable");
+      expect(Bun.inspect(e)).not.toBeEmpty(); // verify that logging it doesn't cause a crash
     }
   });
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -70,9 +70,10 @@ it("process.release", () => {
   expect(process.release.name).toBe("node");
   const platform = process.platform == "win32" ? "windows" : process.platform;
   const arch = { arm64: "aarch64", x64: "x64" }[process.arch] || process.arch;
-  expect(process.release.sourceUrl).toEqual(
-    `https://github.com/oven-sh/bun/releases/download/bun-v${process.versions.bun}/bun-${platform}-${arch}.zip`,
-  );
+  const nonbaseline = `https://github.com/oven-sh/bun/releases/download/bun-v${process.versions.bun}/bun-${platform}-${arch}.zip`;
+  const baseline = `https://github.com/oven-sh/bun/releases/download/bun-v${process.versions.bun}/bun-${platform}-${arch}-baseline.zip`;
+
+  expect(process.release.sourceUrl).toBeOneOf([nonbaseline, baseline]);
 });
 
 it("process.env", () => {

--- a/test/preload.ts
+++ b/test/preload.ts
@@ -7,4 +7,13 @@ for (let key in process.env) {
   delete process.env[key];
 }
 
-Bun.$.env(Object.assign(process.env, harness.bunEnv));
+for (let key in harness.bunEnv) {
+  if (key === "TZ") continue;
+  if (harness.bunEnv[key] === undefined) {
+    continue;
+  }
+
+  process.env[key] = harness.bunEnv[key] + "";
+}
+
+Bun.$.env(process.env);


### PR DESCRIPTION
### What does this PR do?

Implements `expect(1).toBeOneOf([1,2,3])`

Fixes a memory leak in:
- `toEqualIgnoringWhitespace`
- `toInclude`
- `toContain`
- `toContainKeys`
- `toStartWith`
- `toEndWidth`

Fixes an edgecase where custom matchers which return a `message` function that throw an error would not propagate the exception

Removes the extra newline in some of the `.not` matchers

### How did you verify your code works?

Tests