### PR TITLE
Fix docs for contributing using linux

### DIFF
--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -13,7 +13,7 @@ $ brew install automake ccache cmake coreutils gnu-sed go icu4c libiconv libtool
 ```
 
 ```bash#Ubuntu/Debian
-$ sudo apt install cargo ccache cmake git golang libtool ninja-build pkg-config rustc ruby-full xz-utils
+$ sudo apt install curl wget lsb-release software-properties-common cargo ccache cmake git golang libtool ninja-build pkg-config rustc ruby-full xz-utils
 ```
 
 ```bash#Arch


### PR DESCRIPTION
### What does this PR do?
Both debian:bookworm and ubuntu:latest (jammy) do not have curl, wget, lsb_release and software-properties-common installed by default.

- [X] Documentation


### How did you verify your code works?
Created two new containers, run the apt install commands as specified.
