### PR TITLE
bun.js: write to pointer instead of stack in bun.js/webcore/body

### DIFF
--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -1126,8 +1126,7 @@ pub fn BodyMixin(comptime Type: type) type {
                 return value.Locked.setPromise(globalObject, .{ .getBlob = {} });
             }
 
-            var blob = value.use();
-            var ptr = bun.new(Blob, blob);
+            var blob = bun.new(Blob, value.use());
             blob.allocator = getAllocator(globalObject);
 
             if (blob.content_type.len == 0 and blob.store != null) {
@@ -1140,7 +1139,7 @@ pub fn BodyMixin(comptime Type: type) type {
                 }
             }
 
-            return JSC.JSPromise.resolvedPromiseValue(globalObject, ptr.toJS(globalObject));
+            return JSC.JSPromise.resolvedPromiseValue(globalObject, blob.toJS(globalObject));
         }
     };
 }


### PR DESCRIPTION
fixes test for windows in `test\js\web\fetch\fetch.test.ts`

field writes were being done to stack value and thus not preserved when passing the pointer dupe to JS. previously tripped an assert on https://github.com/oven-sh/bun/blob/a18b44d/src/bun.js/webcore/blob.zig#L3591