### PR TITLE
vscode: highlight invisible and ambiguous characters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -81,8 +81,8 @@
   // Markdown
   "[markdown]": {
     "editor.defaultFormatter": "biomejs.biome",
-    "editor.unicodeHighlight.ambiguousCharacters": false,
-    "editor.unicodeHighlight.invisibleCharacters": false,
+    "editor.unicodeHighlight.ambiguousCharacters": true,
+    "editor.unicodeHighlight.invisibleCharacters": true,
     "diffEditor.ignoreTrimWhitespace": false,
     "editor.wordWrap": "on",
     "editor.quickSuggestions": {


### PR DESCRIPTION
makes it much more clear that the hidden characters in this test are intentional and that they exist

<img width="629" alt="image" src="https://github.com/oven-sh/bun/assets/5464072/836420e8-2c57-4c28-a844-133b722e457d">
