### PR TITLE
fix crash in test/transpiler/transpiler.test.js when macro isn't found

### DIFF
--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -6819,7 +6819,7 @@ pub const Macro = struct {
                                 source,
                                 import_range,
                                 log.msgs.allocator,
-                                "Macro \"{any}\" not found",
+                                "Macro \"{s}\" not found",
                                 .{import_record_path},
                                 .stmt,
                                 err,


### PR DESCRIPTION
previously this would crash here https://github.com/oven-sh/bun/blob/094750cc9/src/logger.zig#L368 up from here https://github.com/oven-sh/bun/blob/094750cc9/src/logger.zig#L868. however the use of `{any}` instead of `{s}` would mean that while the search string was `/Users/meghandenny/src/bun/test/transpiler/inline.macro.js` the actual error message appeared to be `Macro "{ 47, 85, 115, 101, 114, 115, 47, 109, 101, 103, 104, 97, 110, 100, 101, 110, 110, 121, 47, 115, 114, 99, 47, 98, 117, 110, 47, 116, 101, 115, 116, 47, 116, 114, 97, 110, 115, 112, 105, 108, 101, 114, 47, 105, 110, 108, 105, 110, 101, 46, 109, 97, 99, 114, 111, 46, 106, 115 }" not found`.

after this change the error message is `Macro "/Users/meghandenny/src/bun/test/transpiler/inline.macro.js" not found` and does not cause bun to panic as expected.