### PR TITLE
Documentation: `Update installation.md`

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,8 +22,7 @@ $ npm install -g bun # the last `npm` command you'll ever need
 ```
 
 ```bash#Homebrew
-$ brew tap oven-sh/bun # for macOS and Linux
-$ brew install bun
+$ brew install oven-sh/bun/bun # for macOS and Linux
 ```
 
 ```bash#Docker


### PR DESCRIPTION
Simplify homebrew installation instructions

### What does this PR do?

This PR changes the homebrew installation instructions.
It is possible to tap and install in only one command, which is always better than using 2 commands.

### How did you verify your code works?

First remove bun and untap : `brew remove bun && brew untap oven-sh/bun`
Then install bun again: `brew install oven-sh/bun/bun` 
