### PR TITLE
fix debug crash in bun.strings.firstNonASCII16 when input is ascii_u16_vector_size

### DIFF
--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -4352,7 +4352,7 @@ pub fn firstNonASCII16(comptime Slice: type, slice: Slice) ?u32 {
 
     if (Environment.enableSIMD and Environment.isNative) {
         const end_ptr = remaining.ptr + remaining.len - (remaining.len % ascii_u16_vector_size);
-        if (remaining.len > ascii_u16_vector_size) {
+        if (remaining.len >= ascii_u16_vector_size) {
             while (remaining.ptr != end_ptr) {
                 const vec: AsciiU16Vector = remaining[0..ascii_u16_vector_size].*;
                 const max_value = @reduce(.Max, vec);


### PR DESCRIPTION
if the input slice length is exactly ascii_u16_vector_size then the `if` would fail and the assert on line 4388 would trip