### PR TITLE
feat: implemented jest.clearAllMocks, fixes #9079

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -91,6 +91,7 @@ declare module "bun:test" {
 
   interface Jest {
     restoreAllMocks(): void;
+    clearAllMocks(): void;
     fn<T extends (...args: any[]) => any>(func?: T): Mock<T>;
     setSystemTime(now?: number | Date): void;
   }

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -437,6 +437,7 @@ pub const Jest = struct {
         const mockFn = JSC.NewFunction(globalObject, ZigString.static("fn"), 1, JSMock__jsMockFn, false);
         const spyOn = JSC.NewFunction(globalObject, ZigString.static("spyOn"), 2, JSMock__jsSpyOn, false);
         const restoreAllMocks = JSC.NewFunction(globalObject, ZigString.static("restoreAllMocks"), 2, JSMock__jsRestoreAllMocks, false);
+        const clearAllMocks = JSC.NewFunction(globalObject, ZigString.static("clearAllMocks"), 2, JSMock__jsClearAllMocks, false);
         const mockModuleFn = JSC.NewFunction(globalObject, ZigString.static("module"), 2, JSMock__jsModuleMock, false);
         module.put(globalObject, ZigString.static("mock"), mockFn);
         mockFn.put(globalObject, ZigString.static("module"), mockModuleFn);
@@ -446,6 +447,7 @@ pub const Jest = struct {
         jest.put(globalObject, ZigString.static("fn"), mockFn);
         jest.put(globalObject, ZigString.static("spyOn"), spyOn);
         jest.put(globalObject, ZigString.static("restoreAllMocks"), restoreAllMocks);
+        jest.put(globalObject, ZigString.static("clearAllMocks"), clearAllMocks);
         jest.put(
             globalObject,
             ZigString.static("setSystemTime"),
@@ -476,6 +478,7 @@ pub const Jest = struct {
         vi.put(globalObject, ZigString.static("spyOn"), spyOn);
         vi.put(globalObject, ZigString.static("module"), mockModuleFn);
         vi.put(globalObject, ZigString.static("restoreAllMocks"), restoreAllMocks);
+        vi.put(globalObject, ZigString.static("clearAllMocks"), clearAllMocks);
         module.put(globalObject, ZigString.static("vi"), vi);
     }
 
@@ -486,6 +489,7 @@ pub const Jest = struct {
     extern fn JSMock__jsNow(*JSC.JSGlobalObject, *JSC.CallFrame) JSC.JSValue;
     extern fn JSMock__jsSetSystemTime(*JSC.JSGlobalObject, *JSC.CallFrame) JSC.JSValue;
     extern fn JSMock__jsRestoreAllMocks(*JSC.JSGlobalObject, *JSC.CallFrame) JSC.JSValue;
+    extern fn JSMock__jsClearAllMocks(*JSC.JSGlobalObject, *JSC.CallFrame) JSC.JSValue;
     extern fn JSMock__jsSpyOn(*JSC.JSGlobalObject, *JSC.CallFrame) JSC.JSValue;
     extern fn JSMock__jsUseFakeTimers(*JSC.JSGlobalObject, *JSC.CallFrame) JSC.JSValue;
     extern fn JSMock__jsUseRealTimers(*JSC.JSGlobalObject, *JSC.CallFrame) JSC.JSValue;

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -725,13 +725,13 @@ describe("spyOn", () => {
       // verify that the spy's history is cleared, but the spy is still intact
       expect(fn).not.toHaveBeenCalled();
       expect(fn.mock.calls).toHaveLength(0);
-      expect(obj.original()).toBe(42);
+      expect(obj.original).toBe(42);
       expect(fn).toHaveBeenCalled();
       expect(fn).toHaveBeenCalledTimes(1);
       jest.restoreAllMocks();
       expect(() => expect(obj.original).toHaveBeenCalled()).toThrow();
       expect(fn).not.toHaveBeenCalled();
-      expect(obj.original()).toBe(42);
+      expect(obj.original).toBe(42);
       expect(fn).not.toHaveBeenCalled();
     });
 
@@ -765,7 +765,7 @@ describe("spyOn", () => {
       // verify that the spy's history is cleared, but the spy is still intact
       expect(fn).not.toHaveBeenCalled();
       expect(fn.mock.calls).toHaveLength(0);
-      expect(obj.original()).toBe(42);
+      expect(obj.original).toBe(42);
       expect(fn).toHaveBeenCalled();
       expect(fn).toHaveBeenCalledTimes(1);
       jest.restoreAllMocks();

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -655,6 +655,13 @@ describe("spyOn", () => {
     expect(() => expect(fn).not.toHaveBeenCalledTimes(1)).toThrow();
     expect(fn.mock.calls).toHaveLength(1);
     expect(fn.mock.calls[0]).toBeEmpty();
+    jest.clearAllMocks();
+    // verify that the spy's history is cleared, but the spy is still intact
+    expect(fn).not.toHaveBeenCalled();
+    expect(fn.mock.calls).toHaveLength(0);
+    expect(obj.original()).toBe(42);
+    expect(fn).toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(1);
     jest.restoreAllMocks();
     expect(() => expect(obj.original).toHaveBeenCalled()).toThrow();
     expect(fn).not.toHaveBeenCalled();
@@ -714,8 +721,18 @@ describe("spyOn", () => {
       expect(fn).toHaveBeenCalledTimes(1);
       expect(fn.mock.calls).toHaveLength(1);
       expect(fn.mock.calls[0]).toBeEmpty();
+      jest.clearAllMocks();
+      // verify that the spy's history is cleared, but the spy is still intact
+      expect(fn).not.toHaveBeenCalled();
+      expect(fn.mock.calls).toHaveLength(0);
+      expect(obj.original()).toBe(42);
+      expect(fn).toHaveBeenCalled();
+      expect(fn).toHaveBeenCalledTimes(1);
       jest.restoreAllMocks();
       expect(() => expect(obj.original).toHaveBeenCalled()).toThrow();
+      expect(fn).not.toHaveBeenCalled();
+      expect(obj.original()).toBe(42);
+      expect(fn).not.toHaveBeenCalled();
     });
 
     test("spyOn on object doens't crash if object GC'd", () => {
@@ -744,6 +761,13 @@ describe("spyOn", () => {
       expect(fn).toHaveBeenCalledTimes(1);
       expect(fn.mock.calls).toHaveLength(1);
       expect(fn.mock.calls[0]).toBeEmpty();
+      jest.clearAllMocks();
+      // verify that the spy's history is cleared, but the spy is still intact
+      expect(fn).not.toHaveBeenCalled();
+      expect(fn.mock.calls).toHaveLength(0);
+      expect(obj.original()).toBe(42);
+      expect(fn).toHaveBeenCalled();
+      expect(fn).toHaveBeenCalledTimes(1);
       jest.restoreAllMocks();
       expect(() => expect(obj.original).toHaveBeenCalled()).toThrow();
       obj.original;


### PR DESCRIPTION
### What does this PR do?

This PR addresses issue #9079, which I opened today. The tracking issue for Jest compatibility, #1825, already marks `jest.clearAllMocks` as completed, but the implementation was missing. I have filled this gap and confirmed that it behaves as specified.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests.

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test mock-fn.test`)
- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test mock-fn.test`)
- [x] I added TypeScript types for the new methods, getters, or setters
