### PR TITLE
Fix prisma generate by emitting readable event on EoF

### DIFF
--- a/src/bun.js/bindings/JSReadableHelper.h
+++ b/src/bun.js/bindings/JSReadableHelper.h
@@ -6,8 +6,6 @@ namespace WebCore {
 
 JSC_DECLARE_HOST_FUNCTION(jsReadable_maybeReadMore);
 JSC_DECLARE_HOST_FUNCTION(jsReadable_resume);
-JSC_DECLARE_HOST_FUNCTION(jsReadable_emitReadable);
-JSC_DECLARE_HOST_FUNCTION(jsReadable_onEofChunk);
 JSC_DECLARE_HOST_FUNCTION(jsReadable_emitReadable_);
 
 } // namespace WebCore

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1913,10 +1913,7 @@ JSC_DEFINE_HOST_FUNCTION(functionLazyLoad,
                 JSC::JSFunction::create(vm, globalObject, 0, "resume"_s, jsReadable_resume, ImplementationVisibility::Public), 0);
             obj->putDirect(
                 vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "emitReadable"_s)),
-                JSC::JSFunction::create(vm, globalObject, 0, "emitReadable"_s, jsReadable_emitReadable, ImplementationVisibility::Public), 0);
-            obj->putDirect(
-                vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "onEofChunk"_s)),
-                JSC::JSFunction::create(vm, globalObject, 0, "onEofChunk"_s, jsReadable_onEofChunk, ImplementationVisibility::Public), 0);
+                JSC::JSFunction::create(vm, globalObject, 0, "emitReadable"_s, jsReadable_emitReadable_, ImplementationVisibility::Public), 0);
             return JSValue::encode(obj);
         }
         if (string == "events"_s) {

--- a/src/js/node/stream.js
+++ b/src/js/node/stream.js
@@ -2508,14 +2508,17 @@ var require_readable = __commonJS({
 
     var { addAbortSignal } = require_add_abort_signal();
     var eos = require_end_of_stream();
-    const { maybeReadMore: _maybeReadMore, resume, emitReadable: _emitReadable, onEofChunk } = $lazy("bun:stream");
+    const { maybeReadMore: _maybeReadMore, resume, emitReadable: _emitReadable } = $lazy("bun:stream");
     function maybeReadMore(stream, state) {
       process.nextTick(_maybeReadMore, stream, state);
     }
-    // REVERT ME
     function emitReadable(stream, state) {
       $debug("NativeReadable - emitReadable", stream.__id);
-      _emitReadable(stream, state);
+      state.needReadable = false;
+      if (!state.emittedReadable) {
+        state.emittedReadable = true;
+        process.nextTick(_emitReadable, stream, state);
+      }
     }
     var destroyImpl = require_destroy();
     var {
@@ -2623,6 +2626,24 @@ var require_readable = __commonJS({
       }
       $debug("about to maybereadmore");
       maybeReadMore(stream, state);
+    }
+    function onEofChunk(stream, state) {
+      if (state.ended) return;
+      if (state.decoder) {
+        const chunk = state.decoder.end();
+        if (chunk && chunk.length) {
+          state.buffer.push(chunk);
+          state.length += state.objectMode ? 1 : chunk.length;
+        }
+      }
+      state.ended = true;
+      if (state.sync) {
+        emitReadable(stream, state);
+      } else {
+        state.needReadable = false;
+        state.emittedReadable = true;
+        _emitReadable(stream, state);
+      }
     }
     Readable.prototype.isPaused = function () {
       const state = this._readableState;

--- a/src/js/node/stream.js
+++ b/src/js/node/stream.js
@@ -2629,11 +2629,14 @@ var require_readable = __commonJS({
     }
     function onEofChunk(stream, state) {
       if (state.ended) return;
-      if (state.decoder) {
-        const chunk = state.decoder.end();
-        if (chunk && chunk.length) {
+
+      const decoder = state.decoder;
+      if (decoder) {
+        const chunk = decoder.end();
+        const chunkLength = chunk?.length;
+        if (chunkLength) {
           state.buffer.push(chunk);
-          state.length += state.objectMode ? 1 : chunk.length;
+          state.length += state.objectMode ? 1 : chunkLength;
         }
       }
       state.ended = true;

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -163,7 +163,6 @@ interface BunLazyModules {
     maybeReadMore: Function;
     resume: Function;
     emitReadable: Function;
-    onEofChunk: Function;
     ReadableState: Function;
   };
   sqlite: any;

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -184,6 +184,20 @@ describe("createReadStream", () => {
       done();
     });
   });
+
+  it("should emit readable on end", done => {
+    const testData = "Hello world";
+    const path = join(tmpdir(), `${Date.now()}-testEmitReadableOnEnd.txt`);
+    writeFileSync(path, testData);
+    const stream = createReadStream(path);
+
+    stream.on("readable", () => {
+      const chunk = stream.read();
+      if (!chunk) {
+        done();
+      }
+    });
+  });
 });
 
 describe("Duplex", () => {


### PR DESCRIPTION
### What does this PR do?
Fixes #5320

The main reason (there's currently two) that `bunx prisma generate` fails is because of the `getHash` method that listens for the `readable` event on a `ReadStream`:
```ts
// Prisma calls this in its ensureBinariesExist method that's called before every CLI command
// ../fetch-engine/src/getHash.ts
var import_crypto2 = __toESM(require("crypto"));
var import_fs13 = __toESM(require("fs"));
function getHash(filePath) {
  const hash = import_crypto2.default.createHash("sha256");
  const input = import_fs13.default.createReadStream(filePath);
  return new Promise((resolve3) => {
    input.on("readable", () => {
      const data = input.read();
      if (data) {
        hash.update(data);
      } else {
        resolve3(hash.digest("hex"));
      }
    });
  });
}
```

There's a bug in Bun where this event is not called for EoF (i.e. where `read` returns `null`).

As such, the `else` statement is never called, and ends up causing the whole program to exit silently.

-------

This seems to be broken due to a reason related to #4409. We have:
```cpp
// src/bun.js/bindings/JSReadableHelper.cpp
EncodedJSValue emitReadable(JSGlobalObject* lexicalGlobalObject, JSObject* stream, JSReadableState* state)
{
    VM& vm = lexicalGlobalObject->vm();

    state->setBool(JSReadableState::needReadable, false);
    if (!state->getBool(JSReadableState::emittedReadable)) {
        state->setBool(JSReadableState::emittedReadable, true);
        Zig::GlobalObject* globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
        // This is the issue
        globalObject->queueMicrotask(JSValue(globalObject->emitReadableNextTickFunction()), JSValue(stream), JSValue(state), JSValue {}, JSValue {});
    }
    return JSValue::encode(jsUndefined());
}
```

From some testing, it seems this microtask only gets run _after_ the stream has been `destroyed`, at which point the event is not allowed to be emitted anymore.

Similar to #4409, it seems this needs to be called via `process.nextTick` instead so that things run in the correct order.

To fix this, I moved the `onEofChunk` method into JS (`src/js/node/stream.js`) so that I could schedule it with `process.nextTick` instead. With this change, all expected `readable` events are emitted/received, and this fixes prisma CLI commands (almost).

(P.S. Maybe there's a way to add to the `nextTick` queue from C++, but I couldn't find a straightforward way of doing it, so that's why I moved things back to JS)


### How did you verify your code works?
I added a test to `test/js/node/stream/node-stream.test.js`. It times out in previous versions of bun, but passes with these changes.

I also tested Prisma in a docker container. `bun-patched` is a bun binary built in release mode with these changes.

<details>
<summary>Dockerfile</summary>

```dockerfile
FROM debian:bullseye-slim

# Disable the runtime transpiler cache by default inside Docker containers.
# On ephemeral containers, the cache is not useful
ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}

COPY ./bun-patched /usr/local/bin/bun

RUN groupadd bun \
      --gid 1000 \
    && useradd bun \
      --uid 1000 \
      --gid bun \
      --shell /bin/sh \
      --create-home \
    && ln -s /usr/local/bin/bun /usr/local/bin/bunx \
    && which bun \
    && which bunx \
    && bun --version

WORKDIR /home/bun/app

COPY --link package.json bun.lockb ./

RUN bun install

COPY . .

RUN sed -i '1s/node/bun/' ./node_modules/prisma/build/index.js
RUN bunx prisma generate && echo "Exited" && sleep 1000
# ^ Prints the expected prisma generate success message
```

</details>

<details>
<summary>Relevant output</summary>

```
#13 [8/9] RUN sed -i '1s/node/bun/' ./node_modules/prisma/build/index.js
#13 DONE 0.2s

#14 [9/9] RUN bunx prisma generate && echo "Exited" && sleep 1000
#14 0.912 Prisma schema loaded from prisma/schema.prisma
#14 1.250
#14 1.250 ✔ Generated Prisma Client (v5.10.2) to ./node_modules/@prisma/client in 41ms
#14 1.250
#14 1.250 Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
#14 1.250 ```
#14 1.250 import { PrismaClient } from '@prisma/client'
#14 1.250 const prisma = new PrismaClient()
#14 1.250 ```
#14 1.250 or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
#14 1.250 ```
#14 1.250 import { PrismaClient } from '@prisma/client/edge'
#14 1.250 const prisma = new PrismaClient()
#14 1.250 ```
#14 1.250
#14 1.250 See other ways of importing Prisma Client: http://pris.ly/d/importing-client
#14 1.250
#14 1.250 ┌─────────────────────────────────────────────────────────────┐
#14 1.250 │  Deploying your app to serverless or edge functions?        │
#14 1.250 │  Try Prisma Accelerate for connection pooling and caching.  │
#14 1.250 │  https://pris.ly/cli/accelerate                             │
#14 1.250 └─────────────────────────────────────────────────────────────┘
#14 1.250
#14 1.429 Exited
```


</details>

### Further issues
There's still one issue with running `bunx prisma` that this PR does not address. It seems `bunx` does not resolve symlinks correctly. The "executable" (`node_modules/.bin/prisma`) is a symlink to a js file (`node_modules/prisma/build/index.js`) that makes this check:
```ts
if (eval("require.main === module")) {
   // ... actually run
}
```

but this does not return true due to the symlink. I checked `Bun.main` and it returns `node_modules/.bin/prisma`, when I believe it should resolve to the symlinked path (`node_modules/prisma/build/index.js`).  Since these don't match, it fails.

It's still possible to "manually" invoke the CLI without node now though, via:
```bash
bun run --bun ./node_modules/prisma/build/index.js generate
```

which gets around the symlink issue. For whatever reason, it also seems that:
```bash
# Replace #!/usr/bin/env node with #!/usr/bin/env bun
RUN sed -i '1s/node/bun/' ./node_modules/prisma/build/index.js
RUN bunx prisma generate
```

works as well, although I'm not sure why. Perhaps the symlink is only an issue when bun is running in `node` mode.

Without doing one of the two things above, `bunx prisma` commands will still silently fail (though for a different reason)