### PR TITLE
feat: add support --conditions flag

### DIFF
--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -1755,6 +1755,9 @@ pub const Api = struct {
         /// source_map
         source_map: ?SourceMapMode = null,
 
+        /// conditions
+        conditions: []const []const u8,
+
         pub fn decode(reader: anytype) anyerror!TransformOptions {
             var this = std.mem.zeroes(TransformOptions);
 
@@ -1838,6 +1841,9 @@ pub const Api = struct {
                     },
                     25 => {
                         this.source_map = try reader.readValue(SourceMapMode);
+                    },
+                    26 => {
+                        this.conditions = try reader.readArray([]const u8);
                     },
                     else => {
                         return error.InvalidMessage;
@@ -1948,6 +1954,12 @@ pub const Api = struct {
                 try writer.writeFieldID(25);
                 try writer.writeEnum(source_map);
             }
+
+            if (this.conditions) |conditions| {
+                try writer.writeFieldID(26);
+                try writer.writeArray([]const u8, conditions);
+            }
+
             try writer.endMessage();
         }
     };

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1617,6 +1617,7 @@ pub const BundleV2 = struct {
                 .main_fields = &.{},
                 .extension_order = &.{},
                 .env_files = &.{},
+                .conditions = &.{},
             },
             completion.env,
         );

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -182,7 +182,7 @@ pub const Arguments = struct {
         clap.parseParam("--prefer-latest                   Use the latest matching versions of packages in the Bun runtime, always checking npm") catch unreachable,
         clap.parseParam("-p, --port <STR>                  Set the default port for Bun.serve") catch unreachable,
         clap.parseParam("-u, --origin <STR>") catch unreachable,
-        clap.parseParam("-c, --conditions <STR>...            Allow pass custom conditions to resolve.") catch unreachable,
+        clap.parseParam("--conditions <STR>...             Allow pass custom conditions to resolve.") catch unreachable,
     };
 
     const auto_only_params = [_]ParamType{
@@ -230,7 +230,7 @@ pub const Arguments = struct {
         clap.parseParam("--minify-whitespace              Minify whitespace") catch unreachable,
         clap.parseParam("--minify-identifiers             Minify identifiers") catch unreachable,
         clap.parseParam("--dump-environment-variables") catch unreachable,
-        clap.parseParam("-c, --conditions <STR>...        Allow pass custom conditions to resolve.") catch unreachable,
+        clap.parseParam("--conditions <STR>...            Allow pass custom conditions to resolve.") catch unreachable,
     };
     pub const build_params = build_only_params ++ transpiler_params_ ++ base_params_;
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -182,6 +182,7 @@ pub const Arguments = struct {
         clap.parseParam("--prefer-latest                   Use the latest matching versions of packages in the Bun runtime, always checking npm") catch unreachable,
         clap.parseParam("-p, --port <STR>                  Set the default port for Bun.serve") catch unreachable,
         clap.parseParam("-u, --origin <STR>") catch unreachable,
+        clap.parseParam("-c, --conditions <STR>...            Allow pass custom conditions to resolve.") catch unreachable,
     };
 
     const auto_only_params = [_]ParamType{
@@ -229,6 +230,7 @@ pub const Arguments = struct {
         clap.parseParam("--minify-whitespace              Minify whitespace") catch unreachable,
         clap.parseParam("--minify-identifiers             Minify identifiers") catch unreachable,
         clap.parseParam("--dump-environment-variables") catch unreachable,
+        clap.parseParam("--conditions <STR>...               Allow pass custom conditions to resolve.") catch unreachable,
     };
     pub const build_params = build_only_params ++ transpiler_params_ ++ base_params_;
 
@@ -525,6 +527,14 @@ pub const Arguments = struct {
             } else if (args.flag("--watch")) {
                 ctx.debug.hot_reload = .watch;
                 bun.auto_reload_on_crash = true;
+            }
+
+            if (args.options("--conditions").len > 0) {
+                var conditions = try allocator.alloc([]u8, args.options("--conditions").len);
+                for (args.options("--conditions"), 0..) |condition, i| {
+                    conditions[i] = @constCast(condition);
+                }
+                opts.conditions = conditions;
             }
 
             if (args.option("--origin")) |origin| {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -182,7 +182,7 @@ pub const Arguments = struct {
         clap.parseParam("--prefer-latest                   Use the latest matching versions of packages in the Bun runtime, always checking npm") catch unreachable,
         clap.parseParam("-p, --port <STR>                  Set the default port for Bun.serve") catch unreachable,
         clap.parseParam("-u, --origin <STR>") catch unreachable,
-        clap.parseParam("--conditions <STR>...             Allow pass custom conditions to resolve.") catch unreachable,
+        clap.parseParam("--conditions <STR>...             Pass custom conditions to resolve") catch unreachable,
     };
 
     const auto_only_params = [_]ParamType{
@@ -230,7 +230,7 @@ pub const Arguments = struct {
         clap.parseParam("--minify-whitespace              Minify whitespace") catch unreachable,
         clap.parseParam("--minify-identifiers             Minify identifiers") catch unreachable,
         clap.parseParam("--dump-environment-variables") catch unreachable,
-        clap.parseParam("--conditions <STR>...            Allow pass custom conditions to resolve.") catch unreachable,
+        clap.parseParam("--conditions <STR>...            Pass custom conditions to resolve") catch unreachable,
     };
     pub const build_params = build_only_params ++ transpiler_params_ ++ base_params_;
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -230,7 +230,7 @@ pub const Arguments = struct {
         clap.parseParam("--minify-whitespace              Minify whitespace") catch unreachable,
         clap.parseParam("--minify-identifiers             Minify identifiers") catch unreachable,
         clap.parseParam("--dump-environment-variables") catch unreachable,
-        clap.parseParam("--conditions <STR>...               Allow pass custom conditions to resolve.") catch unreachable,
+        clap.parseParam("-c, --conditions <STR>...        Allow pass custom conditions to resolve.") catch unreachable,
     };
     pub const build_params = build_only_params ++ transpiler_params_ ++ base_params_;
 
@@ -518,6 +518,12 @@ pub const Arguments = struct {
 
         ctx.passthrough = args.remaining();
 
+        if (cmd == .AutoCommand or cmd == .RunCommand or cmd == .BuildCommand) {
+            if (args.options("--conditions").len > 0) {
+                opts.conditions = args.options("--conditions");
+            }
+        }
+
         // runtime commands
         if (cmd == .AutoCommand or cmd == .RunCommand or cmd == .TestCommand or cmd == .RunAsNodeCommand) {
             const preloads = args.options("--preload");
@@ -527,14 +533,6 @@ pub const Arguments = struct {
             } else if (args.flag("--watch")) {
                 ctx.debug.hot_reload = .watch;
                 bun.auto_reload_on_crash = true;
-            }
-
-            if (args.options("--conditions").len > 0) {
-                var conditions = try allocator.alloc([]u8, args.options("--conditions").len);
-                for (args.options("--conditions"), 0..) |condition, i| {
-                    conditions[i] = @constCast(condition);
-                }
-                opts.conditions = conditions;
             }
 
             if (args.option("--origin")) |origin| {

--- a/src/options.zig
+++ b/src/options.zig
@@ -932,6 +932,14 @@ pub const ESMConditions = struct {
             .require = require_condition_map,
         };
     }
+
+    pub fn append(self: *ESMConditions, customConditions: []const string) !void {
+        for (customConditions) |condition| {
+            self.default.putAssumeCapacityNoClobber(condition, {});
+            self.import.putAssumeCapacityNoClobber(condition, {});
+            self.require.putAssumeCapacityNoClobber(condition, {});
+        }
+    }
 };
 
 pub const JSX = struct {

--- a/src/options.zig
+++ b/src/options.zig
@@ -1693,6 +1693,10 @@ pub const BundleOptions = struct {
 
         opts.conditions = try ESMConditions.init(allocator, Target.DefaultConditions.get(opts.target));
 
+        if (transform.conditions.len > 0) {
+            opts.conditions.append(transform.conditions) catch unreachable;
+        }
+
         switch (opts.target) {
             .node => {
                 opts.import_path_format = .relative;

--- a/src/options.zig
+++ b/src/options.zig
@@ -933,8 +933,12 @@ pub const ESMConditions = struct {
         };
     }
 
-    pub fn append(self: *ESMConditions, customConditions: []const string) !void {
-        for (customConditions) |condition| {
+    pub fn appendSlice(self: *ESMConditions, conditions: []const string) !void {
+        try self.default.ensureUnusedCapacity(conditions.len);
+        try self.import.ensureUnusedCapacity(conditions.len);
+        try self.require.ensureUnusedCapacity(conditions.len);
+
+        for (conditions) |condition| {
             self.default.putAssumeCapacityNoClobber(condition, {});
             self.import.putAssumeCapacityNoClobber(condition, {});
             self.require.putAssumeCapacityNoClobber(condition, {});
@@ -1694,7 +1698,7 @@ pub const BundleOptions = struct {
         opts.conditions = try ESMConditions.init(allocator, Target.DefaultConditions.get(opts.target));
 
         if (transform.conditions.len > 0) {
-            opts.conditions.append(transform.conditions) catch unreachable;
+            opts.conditions.appendSlice(transform.conditions) catch bun.outOfMemory();
         }
 
         switch (opts.target) {

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -1381,8 +1381,9 @@ describe("bundler", () => {
       "/Users/user/project/node_modules/pkg1/custom2.js": `console.log('SUCCESS')`,
     },
     outfile: "/Users/user/project/out.js",
-    bundleErrors: {
-      "/Users/user/project/src/entry.js": [`Could not resolve: "pkg1". Maybe you need to "bun install"?`],
+    conditions: ["custom2"],
+    run: {
+      stdout: "SUCCESS",
     },
   });
   itBundled("packagejson/ExportsNotExactMissingExtension", {

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -147,6 +147,10 @@ export interface BundlerTestInput {
   assetNaming?: string;
   banner?: string;
   define?: Record<string, string | number>;
+
+  /** Use for resolve custom conditions */
+  conditions?: String[];
+
   /** Default is "[name].[ext]" */
   entryNaming?: string;
   /** Default is "[name]-[hash].[ext]" */
@@ -397,6 +401,7 @@ function expectBundled(
     unsupportedCSSFeatures,
     unsupportedJSFeatures,
     useDefineForClassFields,
+    conditions,
     // @ts-expect-error
     _referenceFn,
     ...unknownProps
@@ -580,6 +585,7 @@ function expectBundled(
               `--target=${target}`,
               // `--format=${format}`,
               external && external.map(x => ["--external", x]),
+              conditions && conditions.map(x => ["--conditions", x]),
               minifyIdentifiers && `--minify-identifiers`,
               minifySyntax && `--minify-syntax`,
               minifyWhitespace && `--minify-whitespace`,
@@ -616,6 +622,7 @@ function expectBundled(
               minifyWhitespace && `--minify-whitespace`,
               globalName && `--global-name=${globalName}`,
               external && external.map(x => `--external:${x}`),
+              conditions && `--conditions=${conditions.join(",")}`,
               inject && inject.map(x => `--inject:${path.join(root, x)}`),
               define && Object.entries(define).map(([k, v]) => `--define:${k}=${v}`),
               `--jsx=${jsx.runtime === "classic" ? "transform" : "automatic"}`,

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -5,7 +5,7 @@ import { bunExe, bunEnv, tempDirWithFiles } from "harness";
 let dir: string;
 
 beforeAll(() => {
-  dir = tempDirWithFiles("custom", {
+  dir = tempDirWithFiles("customcondition", {
     "./node_modules/custom/index.js": "export const foo = 1;",
     "./node_modules/custom/not_allow.js": "throw new Error('should not be imported')",
     "./node_modules/custom/package.json": JSON.stringify({
@@ -17,9 +17,29 @@ beforeAll(() => {
         },
       },
     }),
+
+    "./node_modules/custom2/index.cjs": "module.exports.foo = 5;",
+    "./node_modules/custom2/index.mjs": "export const foo = 1;",
+    "./node_modules/custom2/not_allow.js": "throw new Error('should not be imported')",
+    "./node_modules/custom2/package.json": JSON.stringify({
+      name: "custom2",
+      exports: {
+        "./test": {
+          customcondition: {
+            import: "./index.mjs",
+            require: "./index.cjs",
+            default: "./index.mjs",
+          },
+          default: "./not_allow.js",
+        },
+      },
+      type: "module",
+    }),
   });
 
   writeFileSync(`${dir}/test.js`, `import {foo} from 'custom/test';\nconsole.log(foo);`);
+  writeFileSync(`${dir}/test.cjs`, `const {foo} = require("custom2/test");\nconsole.log(foo);`);
+
   writeFileSync(
     `${dir}/package.json`,
     JSON.stringify(
@@ -27,6 +47,7 @@ beforeAll(() => {
         name: "hello",
         imports: {
           custom: "custom",
+          custom2: "custom2",
         },
       },
       null,
@@ -36,16 +57,25 @@ beforeAll(() => {
 });
 
 it("custom condition in package.json resolves", async () => {
-  const { exitCode, stdout, stderr } = Bun.spawnSync({
+  const { exitCode, stdout } = Bun.spawnSync({
     cmd: [bunExe(), "--conditions=customcondition", `${dir}/test.js`],
     env: bunEnv,
     cwd: import.meta.dir,
   });
 
-  expect(stderr.toString("utf8")).toBe("");
-
   expect(exitCode).toBe(0);
   expect(stdout.toString("utf8")).toBe("1\n");
+});
+
+it("custom condition require in package.json resolves", async () => {
+  const { exitCode, stdout } = Bun.spawnSync({
+    cmd: [bunExe(), "-c=customcondition", `${dir}/test.cjs`],
+    env: bunEnv,
+    cwd: import.meta.dir,
+  });
+
+  expect(exitCode).toBe(0);
+  expect(stdout.toString("utf8")).toBe("5\n");
 });
 
 it("when not pass custom condition not resolves", async () => {

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -12,7 +12,7 @@ beforeAll(() => {
       name: "custom",
       exports: {
         "./test": {
-          customcondition: "./index.js",
+          first: "./index.js",
           default: "./not_allow.js",
         },
       },
@@ -25,7 +25,23 @@ beforeAll(() => {
       name: "custom2",
       exports: {
         "./test": {
-          customcondition: {
+          first: {
+            import: "./index.mjs",
+            require: "./index.cjs",
+            default: "./index.mjs",
+          },
+          default: "./not_allow.js",
+        },
+        "./test2": {
+          second: {
+            import: "./index.mjs",
+            require: "./index.cjs",
+            default: "./index.mjs",
+          },
+          default: "./not_allow.js",
+        },
+        "./test3": {
+          third: {
             import: "./index.mjs",
             require: "./index.cjs",
             default: "./index.mjs",
@@ -39,6 +55,10 @@ beforeAll(() => {
 
   writeFileSync(`${dir}/test.js`, `import {foo} from 'custom/test';\nconsole.log(foo);`);
   writeFileSync(`${dir}/test.cjs`, `const {foo} = require("custom2/test");\nconsole.log(foo);`);
+  writeFileSync(
+    `${dir}/multiple-conditions.js`,
+    `const pkg1 = require("custom2/test");\nconst pkg2 = require("custom2/test2");\nconst pkg3 = require("custom2/test3");\nconsole.log(pkg1.foo, pkg2.foo, pkg3.foo);`,
+  );
 
   writeFileSync(
     `${dir}/package.json`,
@@ -56,9 +76,9 @@ beforeAll(() => {
   );
 });
 
-it("custom condition in package.json resolves", async () => {
+it("custom condition 'import' in package.json resolves", async () => {
   const { exitCode, stdout } = Bun.spawnSync({
-    cmd: [bunExe(), "--conditions=customcondition", `${dir}/test.js`],
+    cmd: [bunExe(), "--conditions=first", `${dir}/test.js`],
     env: bunEnv,
     cwd: import.meta.dir,
   });
@@ -67,9 +87,9 @@ it("custom condition in package.json resolves", async () => {
   expect(stdout.toString("utf8")).toBe("1\n");
 });
 
-it("custom condition require in package.json resolves", async () => {
+it("custom condition 'require' in package.json resolves", async () => {
   const { exitCode, stdout } = Bun.spawnSync({
-    cmd: [bunExe(), "-c=customcondition", `${dir}/test.cjs`],
+    cmd: [bunExe(), "--conditions=first", `${dir}/test.cjs`],
     env: bunEnv,
     cwd: import.meta.dir,
   });
@@ -78,9 +98,33 @@ it("custom condition require in package.json resolves", async () => {
   expect(stdout.toString("utf8")).toBe("5\n");
 });
 
-it("when not pass custom condition not resolves", async () => {
+it("multiple conditions in package.json resolves", async () => {
+  const { exitCode, stdout } = Bun.spawnSync({
+    cmd: [bunExe(), "--conditions=first", "--conditions=second", "--conditions=third", `${dir}/multiple-conditions.js`],
+    env: bunEnv,
+    cwd: import.meta.dir,
+  });
+
+  expect(exitCode).toBe(0);
+  expect(stdout.toString("utf8")).toBe("5 5 5\n");
+});
+
+it("multiple conditions when some not specified should resolves to fallback", async () => {
+  const { exitCode, stderr } = Bun.spawnSync({
+    cmd: [bunExe(), "--conditions=first", "--conditions=second", `${dir}/multiple-conditions.js`],
+    env: bunEnv,
+    cwd: import.meta.dir,
+  });
+
+  expect(exitCode).toBe(1);
+
+  // not_allow.js is the fallback for third condition, so it should be in stderr
+  expect(stderr.toString("utf8")).toMatch("new Error('should not be imported')");
+});
+
+it("custom condition when don't match condition should resolves to default", async () => {
   const { exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), "--conditions=customcondition1", `${dir}/test.js`],
+    cmd: [bunExe(), "--conditions=first1", `${dir}/test.js`],
     env: bunEnv,
     cwd: import.meta.dir,
   });

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -1,0 +1,59 @@
+import { it, expect, beforeAll } from "bun:test";
+import { writeFileSync } from "fs";
+import { bunExe, bunEnv, tempDirWithFiles } from "harness";
+
+let dir: string;
+
+beforeAll(() => {
+  dir = tempDirWithFiles("custom", {
+    "./node_modules/custom/index.js": "export const foo = 1;",
+    "./node_modules/custom/not_allow.js": "throw new Error('should not be imported')",
+    "./node_modules/custom/package.json": JSON.stringify({
+      name: "custom",
+      exports: {
+        "./test": {
+          customcondition: "./index.js",
+          default: "./not_allow.js",
+        },
+      },
+    }),
+  });
+
+  writeFileSync(`${dir}/test.js`, `import {foo} from 'custom/test';\nconsole.log(foo);`);
+  writeFileSync(
+    `${dir}/package.json`,
+    JSON.stringify(
+      {
+        name: "hello",
+        imports: {
+          custom: "custom",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+});
+
+it("custom condition in package.json resolves", async () => {
+  const { exitCode, stdout, stderr } = Bun.spawnSync({
+    cmd: [bunExe(), "--conditions=customcondition", `${dir}/test.js`],
+    env: bunEnv,
+    cwd: import.meta.dir,
+  });
+
+  expect(stderr.toString("utf8")).toBe("");
+
+  expect(exitCode).toBe(0);
+  expect(stdout.toString("utf8")).toBe("1\n");
+});
+
+it("when not pass custom condition not resolves", async () => {
+  const { exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "--conditions=customcondition1", `${dir}/test.js`],
+    env: bunEnv,
+    cwd: import.meta.dir,
+  });
+
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
Closes https://github.com/oven-sh/bun/issues/8990

### What does this PR do?

This adds a new flag --conditions to bun run and build. When set, it will try to resolve custom conditions in package.json exports. Example:

In some NPM package have this package.json with a custom condition:

```json
{
  "name": "package",
  "exports": {
    "some-custom-condition": {
      "import": "./index.mjs",
      "require": "./index.cjs",
      "default": "./index.mjs"
    }
   "default": "./throw-error.mjs"
  }
}
```

We have this JS file importing our "package":
```js
import foo from 'package' // foo is a var with "Hello world!"

console.log(foo);
```

If we run it without passing the condition it should fall into the "throw-error.mjs" fallback because is the default, otherwise should resolves for ESM module or CJS module. Example:
```shell
bun --conditions some-custom-condition ./index.js

// prints "Hello world!"
```

The same behavior should happen in the bundle, resolving to the correct files according to the condition. Example:
```shell
bun build ./index.js --outfile ./build.js --conditions some-custom-condition
```

Our generate code should have the content for resolved custom condition export. Example for build
```js
// node_modules/package/index.js
var $foo = "Hello world!";

// src/index.js
console.log($foo);
```

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

I wrote automated tests, and create a simple "package" to test the runtime and bundler behavior.

<!-- If Zig files changed:

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->
