### PR TITLE
Replace `std.unicode.fmtUtf16le` with `bun.fmt.utf16`

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -506,7 +506,7 @@ pub const StandaloneModuleGraph = struct {
 
             bun.C.moveOpenedFileAtLoose(fd, bun.toFD(root_dir.fd), outfile_slice, true).unwrap() catch |err| {
                 if (err == error.EISDIR) {
-                    Output.errGeneric("{} is a directory. Please choose a different --outfile or delete the directory", .{std.unicode.fmtUtf16le(outfile_slice)});
+                    Output.errGeneric("{} is a directory. Please choose a different --outfile or delete the directory", .{bun.fmt.utf16(outfile_slice)});
                 } else {
                     Output.err(err, "failed to move executable to result path", .{});
                 }

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -709,7 +709,7 @@ pub const ZigString = extern struct {
         }
 
         if (self.is16Bit()) {
-            try bun.fmt.formatUTF16(self.utf16Slice(), writer);
+            try bun.fmt.formatUTF16Type(@TypeOf(self.utf16Slice()), self.utf16Slice(), writer);
             return;
         }
 

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -661,7 +661,7 @@ fn windowsUserUniqueId() u32 {
     }
     const name = buf[0..size];
     if (Environment.isWindows) {
-        Output.scoped(.windowsUserUniqueId, false)("username: {}", .{std.unicode.fmtUtf16le(name)});
+        Output.scoped(.windowsUserUniqueId, false)("username: {}", .{bun.fmt.utf16(name)});
     }
     return bun.hash32(std.mem.sliceAsBytes(name));
 }

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1376,7 +1376,7 @@ pub const RunCommand = struct {
             var command_line = DirectBinLaunch.direct_launch_buffer[l..];
 
             debug("Attempting to find and load bunx file: '{}'", .{
-                std.unicode.fmtUtf16le(path_to_use),
+                bun.fmt.utf16(path_to_use),
             });
             if (Environment.allow_assert) {
                 std.debug.assert(std.fs.path.isAbsoluteWindowsWTF16(path_to_use));
@@ -1410,8 +1410,8 @@ pub const RunCommand = struct {
 
             if (Environment.isDebug) {
                 debug("run_ctx.handle: '{}'", .{bun.FDImpl.fromSystem(handle)});
-                debug("run_ctx.base_path: '{}'", .{std.unicode.fmtUtf16le(run_ctx.base_path)});
-                debug("run_ctx.arguments: '{}'", .{std.unicode.fmtUtf16le(run_ctx.arguments)});
+                debug("run_ctx.base_path: '{}'", .{bun.fmt.utf16(run_ctx.base_path)});
+                debug("run_ctx.arguments: '{}'", .{bun.fmt.utf16(run_ctx.arguments)});
                 debug("run_ctx.force_use_bun: '{}'", .{run_ctx.force_use_bun});
             }
 

--- a/src/fd.zig
+++ b/src/fd.zig
@@ -350,7 +350,7 @@ pub const FDImpl = packed struct {
                                 const path = std.os.windows.GetFinalPathNameByHandle(handle, .{ .volume_name = .Dos }, &fd_path) catch break :print_with_path;
                                 return try writer.print("{d}[{}]", .{
                                     this.value.as_system,
-                                    std.unicode.fmtUtf16le(path),
+                                    bun.fmt.utf16(path),
                                 });
                             }
                         }

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -79,7 +79,7 @@ pub fn formatUTF16TypeEscapeBackslashes(comptime Slice: type, slice_: Slice, wri
     }
 }
 
-pub fn formatUTF16(slice_: []align(1) const u16, writer: anytype) !void {
+pub fn utf16(slice_: []align(1) const u16, writer: anytype) !void {
     return formatUTF16Type([]align(1) const u16, slice_, writer);
 }
 

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -79,8 +79,8 @@ pub fn formatUTF16TypeEscapeBackslashes(comptime Slice: type, slice_: Slice, wri
     }
 }
 
-pub fn utf16(slice_: []align(1) const u16, writer: anytype) !void {
-    return formatUTF16Type([]align(1) const u16, slice_, writer);
+pub inline fn utf16(slice_: []const u16) FormatUTF16 {
+    return FormatUTF16{ .buf = slice_ };
 }
 
 pub const FormatUTF16 = struct {

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -117,10 +117,6 @@ pub const PathFormatOptions = struct {
     escape_backslashes: bool = false,
 };
 
-pub fn fmtUTF16(buf: []const u16) FormatUTF16 {
-    return FormatUTF16{ .buf = buf };
-}
-
 pub const FormatOSPath = if (Environment.isWindows) FormatUTF16 else FormatUTF8;
 
 pub fn fmtOSPath(buf: bun.OSPathSlice, options: PathFormatOptions) FormatOSPath {

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -735,7 +735,7 @@ pub const FileSystem = struct {
                 else
                     bun.strings.toWPathNormalized(&existing_buf, name);
                 if (comptime Environment.allow_assert) {
-                    debug("moveFileExW({s}, {s})", .{ bun.fmt.fmtUTF16(existing), bun.fmt.fmtUTF16(new) });
+                    debug("moveFileExW({s}, {s})", .{ bun.fmt.utf16(existing), bun.fmt.utf16(new) });
                 }
 
                 if (bun.windows.kernel32.MoveFileExW(existing.ptr, new.ptr, bun.windows.MOVEFILE_COPY_ALLOWED | bun.windows.MOVEFILE_REPLACE_EXISTING | bun.windows.MOVEFILE_WRITE_THROUGH) == bun.windows.FALSE) {

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -326,7 +326,7 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
                     logger.Loc.Empty,
                     this.package_manager.allocator,
                     "moving \"{s}\" to cache dir failed: {}\n  From: {s}\n    To: {}",
-                    .{ name, err, tmpname, std.unicode.fmtUtf16le(folder_name_w) },
+                    .{ name, err, tmpname, bun.fmt.utf16(folder_name_w) },
                 ) catch unreachable;
                 return error.InstallFailed;
             },

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -1829,12 +1829,12 @@ pub fn assertIsValidWindowsPath(comptime T: type, path: []const T) void {
             isWindowsAbsolutePathMissingDriveLetter(T, path))
         {
             std.debug.panic("Internal Error: Do not pass posix paths to Windows APIs, was given '{s}'" ++ if (Environment.isDebug) " (missing a root like 'C:\\', see PosixToWinNormalizer for why this is an assertion)" else ". Please open an issue on GitHub with a reproduction.", .{
-                if (T == u8) path else std.unicode.fmtUtf16le(path),
+                if (T == u8) path else bun.fmt.utf16(path),
             });
         }
         if (hasPrefixComptimeType(T, path, ":/") and Environment.isDebug) {
             std.debug.panic("Path passed to windows API '{s}' is almost certainly invalid. Where did the drive letter go?", .{
-                if (T == u8) path else std.unicode.fmtUtf16le(path),
+                if (T == u8) path else bun.fmt.utf16(path),
             });
         }
     }
@@ -4508,13 +4508,6 @@ test "firstNonASCII16" {
         const no = std.mem.bytesAsSlice(u16, toUTF16Literal("aspdokasdpokasdpokasd aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd123123aspdokasdpokasdpokasdaspdokasdpokasdpokasdaspdokasdpokasdpokasd12312🙂3"));
         try std.testing.expectEqual(@as(u32, 366), firstNonASCII16(@TypeOf(no), no).?);
     }
-}
-
-test "print UTF16" {
-    var err = std.io.getStdErr();
-    const utf16 = comptime toUTF16Literal("❌ ✅ opkay ");
-    try bun.fmt.str.formatUTF16(utf16, err.writer());
-    // std.unicode.fmtUtf16le(utf16le: []const u16)
 }
 
 /// Convert potentially ill-formed UTF-8 or UTF-16 bytes to a Unicode Codepoint.

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -331,11 +331,11 @@ pub fn chdirOSPath(destination: bun.OSPathSliceZ) Maybe(void) {
 
     if (comptime Environment.isWindows) {
         if (kernel32.SetCurrentDirectory(destination) == windows.FALSE) {
-            log("SetCurrentDirectory({}) = {d}", .{ bun.fmt.fmtUTF16(destination), kernel32.GetLastError() });
+            log("SetCurrentDirectory({}) = {d}", .{ bun.fmt.utf16(destination), kernel32.GetLastError() });
             return Maybe(void).errnoSys(0, .chdir) orelse Maybe(void).success;
         }
 
-        log("SetCurrentDirectory({}) = {d}", .{ bun.fmt.fmtUTF16(destination), 0 });
+        log("SetCurrentDirectory({}) = {d}", .{ bun.fmt.utf16(destination), 0 });
 
         return Maybe(void).success;
     }
@@ -604,11 +604,11 @@ pub fn openDirAtWindowsNtPath(
             // - access_mask probably needs w.SYNCHRONIZE,
             // - options probably needs w.FILE_SYNCHRONOUS_IO_NONALERT
             // - disposition probably needs w.FILE_OPEN
-            bun.Output.debugWarn("NtCreateFile({}, {}) = {s} (dir) = {d}\nYou are calling this function with the wrong flags!!!", .{ dirFd, bun.fmt.fmtUTF16(path), @tagName(rc), @intFromPtr(fd) });
+            bun.Output.debugWarn("NtCreateFile({}, {}) = {s} (dir) = {d}\nYou are calling this function with the wrong flags!!!", .{ dirFd, bun.fmt.utf16(path), @tagName(rc), @intFromPtr(fd) });
         } else if (rc == .OBJECT_PATH_SYNTAX_BAD or rc == .OBJECT_NAME_INVALID) {
-            bun.Output.debugWarn("NtCreateFile({}, {}) = {s} (dir) = {d}\nYou are calling this function without normalizing the path correctly!!!", .{ dirFd, bun.fmt.fmtUTF16(path), @tagName(rc), @intFromPtr(fd) });
+            bun.Output.debugWarn("NtCreateFile({}, {}) = {s} (dir) = {d}\nYou are calling this function without normalizing the path correctly!!!", .{ dirFd, bun.fmt.utf16(path), @tagName(rc), @intFromPtr(fd) });
         } else {
-            log("NtCreateFile({}, {}) = {s} (dir) = {d}", .{ dirFd, bun.fmt.fmtUTF16(path), @tagName(rc), @intFromPtr(fd) });
+            log("NtCreateFile({}, {}) = {s} (dir) = {d}", .{ dirFd, bun.fmt.utf16(path), @tagName(rc), @intFromPtr(fd) });
         }
     }
 
@@ -758,12 +758,12 @@ pub fn openFileAtWindowsNtPath(
                 // - access_mask probably needs w.SYNCHRONIZE,
                 // - options probably needs w.FILE_SYNCHRONOUS_IO_NONALERT
                 // - disposition probably needs w.FILE_OPEN
-                bun.Output.debugWarn("NtCreateFile({}, {}) = {s} (file) = {d}\nYou are calling this function with the wrong flags!!!", .{ dir, bun.fmt.fmtUTF16(path), @tagName(rc), @intFromPtr(result) });
+                bun.Output.debugWarn("NtCreateFile({}, {}) = {s} (file) = {d}\nYou are calling this function with the wrong flags!!!", .{ dir, bun.fmt.utf16(path), @tagName(rc), @intFromPtr(result) });
             } else if (rc == .OBJECT_PATH_SYNTAX_BAD or rc == .OBJECT_NAME_INVALID) {
                 // See above comment. For absolute paths you must have \??\ at the start.
-                bun.Output.debugWarn("NtCreateFile({}, {}) = {s} (file) = {d}\nYou are calling this function without normalizing the path correctly!!!", .{ dir, bun.fmt.fmtUTF16(path), @tagName(rc), @intFromPtr(result) });
+                bun.Output.debugWarn("NtCreateFile({}, {}) = {s} (file) = {d}\nYou are calling this function without normalizing the path correctly!!!", .{ dir, bun.fmt.utf16(path), @tagName(rc), @intFromPtr(result) });
             } else {
-                log("NtCreateFile({}, {}) = {s} (file) = {d}", .{ dir, bun.fmt.fmtUTF16(path), @tagName(rc), @intFromPtr(result) });
+                log("NtCreateFile({}, {}) = {s} (file) = {d}", .{ dir, bun.fmt.utf16(path), @tagName(rc), @intFromPtr(result) });
             }
         }
 
@@ -1740,7 +1740,7 @@ pub fn existsOSPath(path: bun.OSPathSliceZ, file_only: bool) bool {
         assertIsValidWindowsPath(bun.OSPathChar, path);
         const attributes = kernel32.GetFileAttributesW(path.ptr);
         if (Environment.isDebug) {
-            log("GetFileAttributesW({}) = {d}", .{ bun.fmt.fmtUTF16(path), attributes });
+            log("GetFileAttributesW({}) = {d}", .{ bun.fmt.utf16(path), attributes });
         }
         if (attributes == windows.INVALID_FILE_ATTRIBUTES) {
             return false;
@@ -1830,7 +1830,7 @@ pub fn isExecutableFileOSPath(path: bun.OSPathSliceZ) bool {
         //     else => false,
         // };
 
-        // log("GetBinaryTypeW({}) = {d}. isExecutable={}", .{ bun.fmt.fmtUTF16(path), out, result });
+        // log("GetBinaryTypeW({}) = {d}. isExecutable={}", .{ bun.fmt.utf16(path), out, result });
 
         // return result;
     }

--- a/src/windows_c.zig
+++ b/src/windows_c.zig
@@ -1345,7 +1345,7 @@ pub fn moveOpenedFileAt(
         @intCast(struct_len), // already checked for error.NameTooLong
         .FileRenameInformationEx,
     );
-    log("moveOpenedFileAt({} ->> {} '{}', {s}) = {s}", .{ src_fd, new_dir_fd, std.unicode.fmtUtf16le(new_file_name), if (replace_if_exists) "replace_if_exists" else "no flag", @tagName(rc) });
+    log("moveOpenedFileAt({} ->> {} '{}', {s}) = {s}", .{ src_fd, new_dir_fd, bun.fmt.utf16(new_file_name), if (replace_if_exists) "replace_if_exists" else "no flag", @tagName(rc) });
 
     if (bun.Environment.isDebug) {
         if (rc == .ACCESS_DENIED) {


### PR DESCRIPTION
### What does this PR do?

We should generally avoid using std.unicode.* at runtime in Bun.

This:
- Renames `bun.fmt.formatUTF16` -> `bun.fmt.utf16` to make it easier to find/type
- Replaces usages of `std.unicode.fmtUtf16Le` with `bun.fmt.utf16`

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
