### PR TITLE
resolver: fix debug mode crash in test/bundler/bun-build-api.test.ts

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1587,7 +1587,7 @@ pub const Resolver = struct {
     pub fn bustDirCache(r: *ThisResolver, path: string) bool {
         dev("Bust {s}", .{path});
         if (Environment.allow_assert) {
-            if (path[path.len - 1] != std.fs.path.sep) {
+            if (path[path.len - 1] != '/') {
                 std.debug.panic("Expected a trailing slash on {s}", .{path});
             }
         }


### PR DESCRIPTION
path being processed here is normalized here https://github.com/oven-sh/bun/blob/bf3dbda9a2ba25bd1f13e31494626ca7e4279039/src/bun.js/javascript.zig#L1717-L1741 and so will always contain `/` even on windows