### PR TITLE
fix(windows): fix directory cache regression "expected to end with a trailing slash"

### DIFF
--- a/packages/bun-internal-test/src/runner.node.mjs
+++ b/packages/bun-internal-test/src/runner.node.mjs
@@ -43,7 +43,7 @@ function defaultConcurrency() {
   // Concurrency causes more flaky tests, only enable it by default on windows
   // See https://github.com/oven-sh/bun/issues/8071
   if (windows) {
-    return Math.floor((cpus().length - 2) / 2);
+    return Math.floor((cpus().length - 2) / 3);
   }
   return 1;
 }

--- a/src/allocators.zig
+++ b/src/allocators.zig
@@ -634,9 +634,11 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
             return instance.map.backing_buf_used >= count;
         }
         pub fn getOrPut(self: *Self, key: []const u8) !Result {
+            std.debug.print("BSSMap.getOrPut({s})\n", .{key});
             return try self.map.getOrPut(key);
         }
         pub fn get(self: *Self, key: []const u8) ?*ValueType {
+            std.debug.print("BSSMap.get({s})\n", .{key});
             return @call(bun.callmod_inline, BSSMapType.get, .{ self.map, key });
         }
 
@@ -658,6 +660,7 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
         }
 
         pub fn put(self: *Self, key: anytype, comptime store_key: bool, result: *Result, value: ValueType) !*ValueType {
+            std.debug.print("BSSMap.put({s})\n", .{key});
             const ptr = try self.map.put(result, value);
             if (store_key) {
                 try self.putKey(key, result);

--- a/src/allocators.zig
+++ b/src/allocators.zig
@@ -634,11 +634,9 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
             return instance.map.backing_buf_used >= count;
         }
         pub fn getOrPut(self: *Self, key: []const u8) !Result {
-            std.debug.print("BSSMap.getOrPut({s})\n", .{key});
             return try self.map.getOrPut(key);
         }
         pub fn get(self: *Self, key: []const u8) ?*ValueType {
-            std.debug.print("BSSMap.get({s})\n", .{key});
             return @call(bun.callmod_inline, BSSMapType.get, .{ self.map, key });
         }
 
@@ -660,7 +658,6 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
         }
 
         pub fn put(self: *Self, key: anytype, comptime store_key: bool, result: *Result, value: ValueType) !*ValueType {
-            std.debug.print("BSSMap.put({s})\n", .{key});
             const ptr = try self.map.put(result, value);
             if (store_key) {
                 try self.putKey(key, result);

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1713,7 +1713,7 @@ pub const VirtualMachine = struct {
                                     break :name bun.strings.normalizeSlashesOnly(
                                         &specifier_cache_resolver_buf,
                                         if (dir.len == 1) dir else normalized_specifier[0 .. dir.len + 1],
-                                        '/',
+                                        std.fs.path.sep,
                                     );
                                 }
                             }

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1710,21 +1710,17 @@ pub const VirtualMachine = struct {
                             if (std.fs.path.isAbsolute(normalized_specifier)) {
                                 if (std.fs.path.dirname(normalized_specifier)) |dir| {
                                     // Normalized with trailing slash
-                                    break :name bun.strings.normalizeSlashesOnly(
-                                        &specifier_cache_resolver_buf,
-                                        if (dir.len == 1) dir else normalized_specifier[0 .. dir.len + 1],
-                                        std.fs.path.sep,
-                                    );
+                                    break :name bun.strings.normalizeSlashesOnly(&specifier_cache_resolver_buf, dir, std.fs.path.sep);
                                 }
                             }
 
                             var parts = [_]string{
                                 source_to_use,
                                 normalized_specifier,
-                                bun.pathLiteral("../"),
+                                bun.pathLiteral(".."),
                             };
 
-                            break :name bun.path.joinAbsStringBufZTrailingSlash(
+                            break :name bun.path.joinAbsStringBufZ(
                                 jsc_vm.bundler.fs.top_level_dir,
                                 &specifier_cache_resolver_buf,
                                 &parts,
@@ -1736,6 +1732,7 @@ pub const VirtualMachine = struct {
                         if (jsc_vm.bundler.resolver.bustDirCache(buster_name)) {
                             continue;
                         }
+
                         return error.ModuleNotFound;
                     },
                 };
@@ -3447,7 +3444,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                             // on windows we receive file events for all items affected by a directory change
                             // so we only need to clear the directory cache. all other effects will be handled
                             // by the file events
-                            _ = resolver.bustDirCache(file_path);
+                            _ = resolver.bustDirCache(strings.pathWithoutTrailingSlashOne(file_path));
                             continue;
                         }
                         var affected_buf: [128][]const u8 = undefined;
@@ -3497,7 +3494,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                             }
                         }
 
-                        _ = resolver.bustDirCache(file_path);
+                        _ = resolver.bustDirCache(strings.pathWithoutTrailingSlashOne(file_path));
 
                         if (entries_option) |dir_ent| {
                             var last_file_hash: GenericWatcher.HashType = std.math.maxInt(GenericWatcher.HashType);

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1732,6 +1732,7 @@ pub const VirtualMachine = struct {
                             );
                         };
 
+                        // Only re-query if we previously had something cached.
                         if (jsc_vm.bundler.resolver.bustDirCache(buster_name)) {
                             continue;
                         }

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -406,7 +406,7 @@ pub const Bundler = struct {
                         break :name bun.strings.normalizeSlashesOnly(
                             &cache_bust_buf,
                             if (dir.len == 1) dir else entry_point[0 .. dir.len + 1],
-                            '/',
+                            std.fs.path.sep,
                         );
                     }
                 }

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -403,20 +403,16 @@ pub const Bundler = struct {
                 if (std.fs.path.isAbsolute(entry_point)) {
                     if (std.fs.path.dirname(entry_point)) |dir| {
                         // Normalized with trailing slash
-                        break :name bun.strings.normalizeSlashesOnly(
-                            &cache_bust_buf,
-                            if (dir.len == 1) dir else entry_point[0 .. dir.len + 1],
-                            std.fs.path.sep,
-                        );
+                        break :name bun.strings.normalizeSlashesOnly(&cache_bust_buf, dir, std.fs.path.sep);
                     }
                 }
 
                 var parts = [_]string{
                     entry_point,
-                    bun.pathLiteral("../"),
+                    bun.pathLiteral(".."),
                 };
 
-                break :name bun.path.joinAbsStringBufZTrailingSlash(
+                break :name bun.path.joinAbsStringBufZ(
                     bundler.fs.top_level_dir,
                     &cache_bust_buf,
                     &parts,

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -336,7 +336,15 @@ if (!debug) {
 
 namespace Bun {
 namespace InternalModuleRegistryConstants {
-  ${moduleList.map((id, n) => declareASCIILiteral(`${idToEnumName(id)}Code`, outputs.get(id.slice(0, -3)))).join("\n")}
+  ${moduleList
+    .map((id, n) => {
+      const out = outputs.get(id.slice(0, -3).replaceAll("/", path.sep));
+      if (!out) {
+        throw new Error(`Missing output for ${id}`);
+      }
+      return declareASCIILiteral(`${idToEnumName(id)}Code`, out);
+    })
+    .join("\n")}
 }
 }`,
   );

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -567,9 +567,6 @@ JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES ${name}::construct(JSC::JSGlobalObj
     obj.estimatedSize
       ? `
       auto size = ${symbolName(typeName, "estimatedSize")}(ptr);
-#if ASSERT_ENABLED
-      ASSERT(size > 0);
-#endif
       vm.heap.reportExtraMemoryAllocated(instance, size);`
       : ""
   }
@@ -1231,9 +1228,6 @@ void ${name}::visitChildrenImpl(JSCell* cell, Visitor& visitor)
       estimatedSize
         ? `if (auto* ptr = thisObject->wrapped()) {
             auto size = ${symbolName(typeName, "estimatedSize")}(ptr);
-#if ASSERT_ENABLED
-            ASSERT(size > 0);
-#endif
 visitor.reportExtraMemoryVisited(size);
 }`
         : ""
@@ -1404,9 +1398,6 @@ extern "C" EncodedJSValue ${typeName}__create(Zig::GlobalObject* globalObject, v
     obj.estimatedSize
       ? `
       auto size = ${symbolName(typeName, "estimatedSize")}(ptr);
-#if ASSERT_ENABLED
-      ASSERT(size > 0);
-#endif
       vm.heap.reportExtraMemoryAllocated(instance, size);`
       : ""
   }

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -995,7 +995,7 @@ pub const FileSystem = struct {
         // https://twitter.com/jarredsumner/status/1655714084569120770
         // https://twitter.com/jarredsumner/status/1655464485245845506
         pub fn readDirectoryWithIterator(fs: *RealFS, _dir: string, _handle: ?std.fs.Dir, generation: bun.Generation, store_fd: bool, comptime Iterator: type, iterator: Iterator) !*EntriesOption {
-            var dir = _dir;
+            var dir = bun.strings.pathWithoutTrailingSlashOne(_dir);
 
             // var windows_path_buf: bun.windows.PathBuffer = undefined;
             if (comptime Environment.isWindows) {

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -1085,10 +1085,10 @@ pub fn normalizeStringBuf(
     str: []const u8,
     buf: []u8,
     comptime allow_above_root: bool,
-    comptime _platform: Platform,
+    comptime platform: Platform,
     comptime preserve_trailing_slash: bool,
 ) []u8 {
-    return normalizeStringBufT(u8, str, buf, allow_above_root, _platform, preserve_trailing_slash);
+    return normalizeStringBufT(u8, str, buf, allow_above_root, platform, preserve_trailing_slash);
 }
 
 pub fn normalizeStringBufT(
@@ -1096,12 +1096,10 @@ pub fn normalizeStringBufT(
     str: []const T,
     buf: []T,
     comptime allow_above_root: bool,
-    comptime _platform: Platform,
+    comptime platform: Platform,
     comptime preserve_trailing_slash: bool,
 ) []T {
-    const platform = comptime _platform.resolve();
-
-    switch (comptime platform) {
+    switch (comptime platform.resolve()) {
         .auto => @compileError("unreachable"),
 
         .windows => {

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1601,7 +1601,7 @@ pub const Resolver = struct {
     /// the trailing slash from a path, but also note it will only remove a SINGLE slash.
     pub fn assertValidCacheKey(path: []const u8) void {
         if (Environment.allow_assert) {
-            if (strings.charIsAnySlash(path[path.len - 1]) and !if (Environment.isWindows)
+            if (path.len > 1 and strings.charIsAnySlash(path[path.len - 1]) and !if (Environment.isWindows)
                 path.len == 3 and path[1] == ':'
             else
                 path.len == 1)

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1587,7 +1587,7 @@ pub const Resolver = struct {
     pub fn bustDirCache(r: *ThisResolver, path: string) bool {
         dev("Bust {s}", .{path});
         if (Environment.allow_assert) {
-            if (path[path.len - 1] != '/') {
+            if (path[path.len - 1] != std.fs.path.sep) {
                 std.debug.panic("Expected a trailing slash on {s}", .{path});
             }
         }

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1583,11 +1583,15 @@ pub const Resolver = struct {
     const dev = Output.scoped(.Resolver, false);
 
     /// Bust the directory cache for the given path.
+    /// Path given must be absolute native paths that contain a trailing slash.
     /// Returns `true` if something was deleted, otherwise `false`.
     pub fn bustDirCache(r: *ThisResolver, path: string) bool {
         dev("Bust {s}", .{path});
         if (Environment.allow_assert) {
             if (path[path.len - 1] != std.fs.path.sep) {
+                // This assertion is in place so that we can catch misuses that
+                // attempt to bust the cache, but end up doing nothing as they
+                // subtlely use the wrong path.
                 std.debug.panic("Expected a trailing slash on {s}", .{path});
             }
         }

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1144,7 +1144,6 @@ pub const Resolver = struct {
             if (r.debug_logs) |*debug| {
                 debug.addNoteFmt("The import \"{s}\" is being treated as an absolute path", .{import_path});
             }
-            std.debug.print("IS A ABSOLUTE {s}\n", .{import_path});
 
             // First, check path overrides from the nearest enclosing TypeScript "tsconfig.json" file
             if ((r.dirInfoCached(source_dir) catch null)) |_dir_info| {
@@ -1609,7 +1608,6 @@ pub const Resolver = struct {
             {
                 std.debug.panic("Internal Assertion Failure: Invalid cache key \"{s}\"\nSee Resolver.assertValidCacheKey for details.", .{path});
             }
-            std.debug.print("observed cache key {s}\n", .{path});
         }
     }
 
@@ -3489,7 +3487,6 @@ pub const Resolver = struct {
 
         // Is this a file?
         if (r.loadAsFile(path, extension_order)) |file| {
-            std.debug.print("IS A FILE {s}\n", .{file.path});
             // Determine the package folder by looking at the last node_modules/ folder in the path
             if (strings.lastIndexOf(file.path, "node_modules" ++ std.fs.path.sep_str)) |last_node_modules_folder| {
                 const node_modules_folder_offset = last_node_modules_folder + ("node_modules" ++ std.fs.path.sep_str).len;
@@ -3522,7 +3519,6 @@ pub const Resolver = struct {
         }
 
         // Is this a directory?
-        std.debug.print("Attempting to load \"{s}\" as a directory\n", .{path});
         if (r.debug_logs) |*debug| {
             debug.addNoteFmt("Attempting to load \"{s}\" as a directory", .{path});
             debug.increaseIndent();

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -742,6 +742,20 @@ pub fn withoutTrailingSlashWindowsPath(this: string) []const u8 {
     return href;
 }
 
+/// This will remove ONE trailing slash at the end of a string,
+/// but on Windows it will not remove the \ in "C:\"
+pub fn pathWithoutTrailingSlashOne(str: []const u8) []const u8 {
+    return if (str.len > 0 and charIsAnySlash(str[str.len - 1]))
+        if (Environment.isWindows and str.len == 3 and str[1] == ':')
+            // Preserve "C:\"
+            str
+        else
+            // Remove one slash
+            str[0 .. str.len - 1]
+    else
+        str;
+}
+
 pub fn withoutLeadingSlash(this: string) []const u8 {
     return std.mem.trimLeft(u8, this, "/");
 }

--- a/test/js/deno/fetch/body.test.ts
+++ b/test/js/deno/fetch/body.test.ts
@@ -36,7 +36,7 @@ test({
         net: true
     }
 }, async function bodyMultipartFormData() {
-    const response = await fetch("http://localhost:4545/multipart_form_data.txt");
+    const response = await fetch("http://localhost:" + PORT + "/multipart_form_data.txt");
     assert(response.body instanceof ReadableStream);
     const text = await response.text();
     const body = buildBody(text, response.headers);
@@ -51,7 +51,7 @@ test({
         net: true
     }
 }, async function bodyURLEncodedFormData() {
-    const response = await fetch("http://localhost:4545/subdir/form_urlencoded.txt");
+    const response = await fetch("http://localhost:" + PORT + "/subdir/form_urlencoded.txt");
     assert(response.body instanceof ReadableStream);
     const text = await response.text();
     const body = buildBody(text, response.headers);

--- a/test/js/deno/harness.ts
+++ b/test/js/deno/harness.ts
@@ -29,7 +29,7 @@ export function createDenoTest(path: string) {
 
   beforeAll(() => {
     server = serve({
-      port: 4545,
+      port: 0,
       fetch(request: Request): Response {
         const { url } = request;
         const { pathname, search } = new URL(url);
@@ -40,6 +40,7 @@ export function createDenoTest(path: string) {
         return Response.redirect(target.toString());
       },
     });
+    globalThis.PORT = server.port;
   });
 
   afterAll(() => {

--- a/test/regression/issue/00631.test.ts
+++ b/test/regression/issue/00631.test.ts
@@ -3,7 +3,6 @@ import { bunExe, bunEnv } from "../../harness.js";
 import { mkdirSync, rmSync, writeFileSync, readFileSync, mkdtempSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { e } from "../../js/bun/http/js-sink-sourmap-fixture/index.mjs";
 
 it("JSON strings escaped properly", async () => {
   const testDir = mkdtempSync(join(tmpdir(), "issue631-"));

--- a/test/regression/issue/00631.test.ts
+++ b/test/regression/issue/00631.test.ts
@@ -3,6 +3,7 @@ import { bunExe, bunEnv } from "../../harness.js";
 import { mkdirSync, rmSync, writeFileSync, readFileSync, mkdtempSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { e } from "../../js/bun/http/js-sink-sourmap-fixture/index.mjs";
 
 it("JSON strings escaped properly", async () => {
   const testDir = mkdtempSync(join(tmpdir(), "issue631-"));
@@ -22,6 +23,9 @@ it("JSON strings escaped properly", async () => {
     env: bunEnv,
     cwd: testDir,
   });
+  if (exitCode !== 0) {
+    console.log(stderr.toString("utf8"));
+  }
   expect(exitCode).toBe(0);
 
   const packageContents = readFileSync(join(testDir, "package.json"), { encoding: "utf8" });

--- a/test/regression/issue/03216.test.ts
+++ b/test/regression/issue/03216.test.ts
@@ -14,9 +14,10 @@ const file2 = \`\${import.meta.dir}/second.mjs\`;
 
 import { existsSync, unlinkSync, writeFileSync } from "fs";
 
-if (existsSync(file)) {
+if (existsSync(file) || existsSync(file2)) {
   console.log("temp.mjs cannot exist before running this script");
-  unlinkSync(file);
+  try { unlinkSync(file); } catch {}
+  try { unlinkSync(file2); } catch {}
   process.exit(2);
 }
 
@@ -45,7 +46,7 @@ try {
     cwd: tmp,
     env: bunEnv,
   });
-  
+
   if (result.exitCode !== 0) {
     console.log(result.stderr.toString("utf-8"));
   }

--- a/test/regression/issue/03216.test.ts
+++ b/test/regression/issue/03216.test.ts
@@ -10,6 +10,7 @@ test("runtime directory caching gets invalidated", () => {
   writeFileSync(
     join(tmp, "index.ts"),
     `const file = \`\${import.meta.dir}/temp.mjs\`;
+const file2 = \`\${import.meta.dir}/second.mjs\`;
 
 import { existsSync, unlinkSync, writeFileSync } from "fs";
 
@@ -27,6 +28,15 @@ try {
 } finally {
   unlinkSync(file);
 }
+
+writeFileSync(file2, "export default 2;");
+
+try {
+  const module = await import(file2);
+  console.log(module.default);
+} finally {
+  unlinkSync(file2);
+}
 `,
   );
 
@@ -35,7 +45,11 @@ try {
     cwd: tmp,
     env: bunEnv,
   });
+  
+  if (result.exitCode !== 0) {
+    console.log(result.stderr.toString("utf-8"));
+  }
 
   expect(result.exitCode).toBe(0);
-  expect(result.stdout.toString("utf-8")).toBe("1\n");
+  expect(result.stdout.toString("utf-8")).toBe("1\n2\n");
 });


### PR DESCRIPTION
### What does this PR do?

Fixes passing the wrong path type to `bustDirCache` for real this time. In doing so, fixes a lot of other dubious uses of the dir_cache.

I still stand by the aggressive assertion in `bustDirCache`, despite it's recent issues. It, when properly called, is essential for making sure module resolution is reliable when filesystem races happen. This PR calls that assertion in *more* places. What I found out from this is we are very inconsistent in weather there is a trailing slash in our cache keys.

A lot of existing code was uncertain on weather it took a trailing slash or not, and it doesnt seem to be documented. For example: this paradox.

<img width="818" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/1412b74f-08a3-44c9-817b-cec88e85ce52">

To fix this, **I am removing all cases where we keep the trailing slash on the key for `dir_cache`'s hash table**. This was easier than requiring trailing slashes because as fixed old cases, new ones came up that were increasingly harder to get a trailing slash on without copying the entire path into a new buffer.

In favor of making it easy to get a cache key, the normalization will remove it. See `Resolver.assertValidCacheKey` for details on the assertion. I left a very long comment here, as this fix took much longer than it should.

### How did you verify your code works?

- [X] Added another case to the original test (this issue was a windows only re-regression of #3216) that now passes.
- [X] I built a ReleaseSafe copy of bun before the regression, then used that release copy to build bun again successfully.
- [X] I verified `vite` no longer regresses
- [X] I double checked that every caller of `bustDirCache` is indeed correct.
- [ ] Testing the Mac OS build locally to ensure no regressions of the assertion.
- [ ] Running tests in CI for all platforms to ensure zero regressions across the board.