### PR TITLE
Fix issue where process.stdin is ended too early

### DIFF
--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -246,7 +246,6 @@ describe("PassThrough", () => {
   });
 });
 
-
 const processStdInTest = `
 const { Transform } = require("node:stream");
 

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -250,14 +250,14 @@ const processStdInTest = `
 const { Transform } = require("node:stream");
 
 let totalChunkSize = 0;
-const uppercase = new Transform({
+const transform = new Transform({
   transform(chunk, _encoding, callback) {
     totalChunkSize += chunk.length;
     callback(null, "");
   },
 });
 
-process.stdin.pipe(uppercase).pipe(process.stdout);
+process.stdin.pipe(transform).pipe(process.stdout);
 process.stdin.on("end", () => console.log(totalChunkSize));
 `;
 describe("process.stdin", () => {

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -5,6 +5,7 @@ import { join } from "path";
 import { bunExe, bunEnv } from "harness";
 import { tmpdir } from "node:os";
 import { writeFileSync, mkdirSync } from "node:fs";
+import { spawn } from "node:child_process";
 
 const isWindows = process.platform === "win32";
 
@@ -242,6 +243,43 @@ describe("PassThrough", () => {
 
     const subclass = new Subclass();
     expect(subclass instanceof PassThrough).toBe(true);
+  });
+});
+
+
+const processStdInTest = `
+const { Transform } = require("node:stream");
+
+let totalChunkSize = 0;
+const uppercase = new Transform({
+  transform(chunk, _encoding, callback) {
+    totalChunkSize += chunk.length;
+    callback(null, "");
+  },
+});
+
+process.stdin.pipe(uppercase).pipe(process.stdout);
+process.stdin.on("end", () => console.log(totalChunkSize));
+`;
+describe("process.stdin", () => {
+  it("should pipe correctly", done => {
+    mkdirSync(join(tmpdir(), "process-stdin-test"), { recursive: true });
+    writeFileSync(join(tmpdir(), "process-stdin-test/process-stdin.test.js"), processStdInTest, {});
+
+    // A sufficiently large input to make at least four chunks
+    const ARRAY_SIZE = 8_388_628;
+    const typedArray = new Uint8Array(ARRAY_SIZE).fill(97);
+
+    const { stdout, exitCode, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), "test", "process-stdin.test.js"],
+      cwd: join(tmpdir(), "process-stdin-test"),
+      env: bunEnv,
+      stdin: typedArray,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(String(stdout)).toBe(`${ARRAY_SIZE}\n`);
+    done();
   });
 });
 

--- a/test/js/third_party/prisma/helper.ts
+++ b/test/js/third_party/prisma/helper.ts
@@ -55,7 +55,7 @@ export function generate(type: string) {
 
   fs.writeFileSync(schema, content);
 
-  const result = Bun.spawnSync([bunExe(), "--bun", "x", "prisma", "generate", "--schema", schema], {
+  const result = Bun.spawnSync([bunExe(), "prisma", "generate", "--schema", schema], {
     cwd,
     env: {
       ...bunEnv,

--- a/test/js/third_party/prisma/helper.ts
+++ b/test/js/third_party/prisma/helper.ts
@@ -55,7 +55,7 @@ export function generate(type: string) {
 
   fs.writeFileSync(schema, content);
 
-  const result = Bun.spawnSync([bunExe(), "prisma", "generate", "--schema", schema], {
+  const result = Bun.spawnSync([bunExe(), "--bun", "x", "prisma", "generate", "--schema", schema], {
     cwd,
     env: {
       ...bunEnv,

--- a/test/js/third_party/prisma/prisma.test.ts
+++ b/test/js/third_party/prisma/prisma.test.ts
@@ -1,7 +1,7 @@
 // @known-failing-on-windows: 1 failing
 
-import { test as bunTest, expect, describe } from "bun:test";
-import { generateClient } from "./helper.ts";
+import { test as bunTest, it as bunIt, expect, describe } from "bun:test";
+import { generate, generateClient } from "./helper.ts";
 import type { PrismaClient } from "./prisma/types.d.ts";
 import { createCanvas } from "@napi-rs/canvas";
 
@@ -205,5 +205,9 @@ async function cleanTestId(prisma: PrismaClient, testId: number) {
       },
       20000,
     );
+
+    bunIt("generates client successfully", async () => {
+      generate(type);
+    });
   });
 });

--- a/test/js/third_party/prisma/prisma/postgres/schema.prisma
+++ b/test/js/third_party/prisma/prisma/postgres/schema.prisma
@@ -28,4 +28,32 @@ model Post {
   published Boolean @default(false)
   author    User    @relation(fields: [authorId], references: [id])
   authorId  Int
+
+  // Big schema to replicate
+  // https://github.com/oven-sh/bun/issues/5320
+  option1  Int?
+  option2  Int?
+  option3  Int?
+  option4  Int?
+  option5  Int?
+  option6  Int?
+  option7  Int?
+  option8  Int?
+  option9  Int?
+  option10 Int?
+  option11 Int?
+  option12 Int?
+  option13 Int?
+  option14 Int?
+  option15 Int?
+  option16 Int?
+  option17 Int?
+  option18 Int?
+  option19 Int?
+  option20 Int?
+  option21 Int?
+  option22 Int?
+  option23 Int?
+  option24 Int?
+  option25 Int?
 }


### PR DESCRIPTION
### What does this PR do?
Fixes #5320 (hopefully the last issue)

The issue this time is kind of similar to the last one (#9101), in that a stream is being ended too early. This one's a bit more straightforward, though I'm not sure if it's the correct behavior.

This issue only occurs with `process.stdin` since it has some custom logic in `src/js/builtins/ProcessObjectInternals.ts`. Turns out there's this line:
```ts
stream._read = function (size) {
  $debug("_read();", reader);
  if (!reader) {
    // TODO: this is wrong
    this.push(null);
  } else if (!shouldUnref) {
    internalRead(this);
  }
};
```

This TODO was, in fact, true. When a `null` is pushed, the stream ends, so this was causing the stream to be ended prematurely if `reader` wasn't defined (which happens if `ref()` isn't called before `_read()` is).

To fix this, I just made it do nothing. Once I did this, however, I also noticed that `end` is emitted twice, so I added a check for whether end was already emitted, similar to the standard code in `stream.js`.

### How did you verify your code works?
There's a test. You can also more easily test this manually by creating `test.js`:
```js
const { Transform } = require("node:stream");

let totalChunkSize = 0;
const uppercase = new Transform({
  transform(chunk, _encoding, callback) {
    totalChunkSize += chunk.length;
    callback(null, "");
  },
});

process.stdin.pipe(uppercase).pipe(process.stdout);
process.stdin.on("end", () => console.log(totalChunkSize));
```

and then run it with

```bash
printf 'a%.0s' {1..262164} | bun run test.js
```

It should output the correct size (262164). Previously it would output 196608.

I also tested with a large prisma schema -- it failed with the `JSON Parse error: Unterminated string` error before, but now successfully generates
