### PR TITLE
[windows] Fix `$Path` bug

### DIFF
--- a/src/output.zig
+++ b/src/output.zig
@@ -477,7 +477,7 @@ pub fn scoped(comptime tag: @Type(.EnumLiteral), comptime disabled: bool) _log_f
                 {
                     really_disable = false;
                 } else if (bun.getenvZ("BUN_DEBUG_QUIET_LOGS")) |val| {
-                    really_disable = !strings.eqlComptime(val, "0");
+                    really_disable = really_disable or !strings.eqlComptime(val, "0");
                 }
             }
 

--- a/src/which.zig
+++ b/src/which.zig
@@ -132,14 +132,10 @@ pub fn whichWin(buf: *bun.WPathBuffer, path: []const u8, cwd: []const u8, bin: [
     }
 
     // iterate over system path delimiter
-    var path_iter = std.mem.tokenizeScalar(u8, path, std.fs.path.delimiter);
-    while (path_iter.next()) |_segment| {
-        // we also iterate over ':' to match linux behavior
-        var segment_iter = std.mem.tokenizeScalar(u8, _segment, ':');
-        while (segment_iter.next()) |segment_part| {
-            if (searchBinInPath(buf, &path_buf, segment_part, bin, check_windows_extensions)) |bin_path| {
-                return bin_path;
-            }
+    var path_iter = std.mem.tokenizeScalar(u8, path, ';');
+    while (path_iter.next()) |segment_part| {
+        if (searchBinInPath(buf, &path_buf, segment_part, bin, check_windows_extensions)) |bin_path| {
+            return bin_path;
         }
     }
 

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -2,87 +2,10 @@ import { test, expect } from "bun:test";
 
 import { which } from "bun";
 import { rmSync, chmodSync, mkdirSync, realpathSync } from "node:fs";
-import { join } from "node:path";
+import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
-import { rmdirSync } from "js/node/fs/export-star-from";
-import { isIntelMacOS } from "../../../harness";
-
-test("which", () => {
-  {
-    let existing = which("myscript.sh");
-    if (existing !== null) {
-      rmSync(existing!, { recursive: true, force: true });
-    }
-  }
-
-  let basedir = join(tmpdir(), "which-test-" + Math.random().toString(36).slice(2));
-
-  rmSync(basedir, { recursive: true, force: true });
-  mkdirSync(basedir, { recursive: true });
-  writeFixture(join(basedir, "myscript.sh"));
-  const abs = realpathSync(join(basedir, "myscript.sh"));
-
-  const origDir = process.cwd();
-  try {
-    basedir = realpathSync(basedir);
-
-    process.chdir(basedir);
-    // Our cwd is not /tmp
-    expect(which("myscript.sh")).toBe(abs);
-
-    const orig = process.cwd();
-    process.chdir(tmpdir());
-    try {
-      rmdirSync("myscript.sh");
-    } catch {}
-    // Our cwd is not /tmp
-    expect(which("myscript.sh")).toBe(null);
-
-    expect(
-      // You can override PATH
-      which("myscript.sh", {
-        PATH: basedir,
-      }),
-    ).toBe(abs);
-
-    expect(
-      // PATH works like the $PATH environment variable, respecting colons
-      which("myscript.sh", {
-        PATH: "/not-tmp:" + basedir,
-      }),
-    ).toBe(abs);
-
-    // TODO: only fails on x64 macos
-    if (!isIntelMacOS) {
-      try {
-        mkdirSync("myscript.sh");
-        chmodSync("myscript.sh", "755");
-      } catch (e) {}
-
-      // directories should not be returned
-      expect(which("myscript.sh")).toBe(null);
-    }
-
-    // "bun" is in our PATH
-    expect(which("bun")!.length > 0).toBe(true);
-
-    expect(
-      which("myscript.sh", {
-        PATH: "/not-tmp",
-      }),
-    ).toBe(null);
-
-    expect(
-      // cwd is checked first
-      which("myscript.sh", {
-        cwd: basedir,
-      }),
-    ).toBe(abs);
-  } finally {
-    process.chdir(origDir);
-    rmSync(basedir, { recursive: true, force: true });
-  }
-});
+import { cpSync, rmdirSync } from "js/node/fs/export-star-from";
+import { isIntelMacOS, isWindows } from "../../../harness";
 
 function writeFixture(path: string) {
   var fs = require("fs");
@@ -94,4 +17,95 @@ function writeFixture(path: string) {
   var script_content = "echo Hello world!";
   fs.writeFileSync(script_name, script_content);
   fs.chmodSync(script_name, "755");
+}
+
+if (isWindows) {
+  test("which", () => {
+    expect(which("cmd")).toBe("C:\\Windows\\system32\\cmd.exe");
+    expect(which("cmd.exe")).toBe("C:\\Windows\\system32\\cmd.exe");
+    expect(which("cmd.bat")).toBe(null);
+    const exe = basename(process.execPath);
+    const dir = join(process.execPath, "../");
+    expect(which(exe, { PATH: "C:\\Windows\\system32" })).toBe(null);
+    expect(which(exe, { PATH: "C:\\Windows\\system32;" + dir })).toBe(process.execPath);
+    expect(which(exe, { PATH: dir + ";C:\\Windows\\system32" })).toBe(process.execPath);
+    expect(which(exe, { PATH: dir })).toBe(process.execPath);
+  });
+} else {
+  test("which", () => {
+    {
+      let existing = which("myscript.sh");
+      if (existing !== null) {
+        rmSync(existing!, { recursive: true, force: true });
+      }
+    }
+
+    let basedir = join(tmpdir(), "which-test-" + Math.random().toString(36).slice(2));
+
+    rmSync(basedir, { recursive: true, force: true });
+    mkdirSync(basedir, { recursive: true });
+    writeFixture(join(basedir, "myscript.sh"));
+    const abs = realpathSync(join(basedir, "myscript.sh"));
+
+    const origDir = process.cwd();
+    try {
+      basedir = realpathSync(basedir);
+
+      process.chdir(basedir);
+      // Our cwd is not /tmp
+      expect(which("myscript.sh")).toBe(abs);
+
+      const orig = process.cwd();
+      process.chdir(tmpdir());
+      try {
+        rmdirSync("myscript.sh");
+      } catch {}
+      // Our cwd is not /tmp
+      expect(which("myscript.sh")).toBe(null);
+
+      expect(
+        // You can override PATH
+        which("myscript.sh", {
+          PATH: basedir,
+        }),
+      ).toBe(abs);
+
+      expect(
+        // PATH works like the $PATH environment variable, respecting colons
+        which("myscript.sh", {
+          PATH: "/not-tmp:" + basedir,
+        }),
+      ).toBe(abs);
+
+      // TODO: only fails on x64 macos
+      if (!isIntelMacOS) {
+        try {
+          mkdirSync("myscript.sh");
+          chmodSync("myscript.sh", "755");
+        } catch (e) {}
+
+        // directories should not be returned
+        expect(which("myscript.sh")).toBe(null);
+      }
+
+      // "bun" is in our PATH
+      expect(which("bun")!.length > 0).toBe(true);
+
+      expect(
+        which("myscript.sh", {
+          PATH: "/not-tmp",
+        }),
+      ).toBe(null);
+
+      expect(
+        // cwd is checked first
+        which("myscript.sh", {
+          cwd: basedir,
+        }),
+      ).toBe(abs);
+    } finally {
+      process.chdir(origDir);
+      rmSync(basedir, { recursive: true, force: true });
+    }
+  });
 }


### PR DESCRIPTION
### What does this PR do?

Previously, we'd always check `C\foo` when searching for `foo`, and `C\foo` is not valid

### How did you verify your code works?

Added tests