### PR TITLE
Fix typo in HTTP server docs: demonstates → demonstrates

### DIFF
--- a/docs/guides/http/server.md
+++ b/docs/guides/http/server.md
@@ -2,7 +2,7 @@
 name: Common HTTP server usage
 ---
 
-This starts an HTTP server listening on port `3000`. It demonstates basic routing with a number of common responses and also handles POST data from standard forms or as JSON.
+This starts an HTTP server listening on port `3000`. It demonstrates basic routing with a number of common responses and also handles POST data from standard forms or as JSON.
 
 See [`Bun.serve`](/docs/api/http) for details.
 


### PR DESCRIPTION
### What does this PR do?

Fix a simple typo.