### PR TITLE
Quick "fix" for uninitialized memory used by the usockets code.

### DIFF
--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -17,7 +17,7 @@
 // clang-format off
 
 #ifndef us_malloc
-#define us_malloc malloc
+#define us_malloc(x) calloc(1, (x))
 #endif
 
 #ifndef us_realloc


### PR DESCRIPTION
This simply clears allocated memory, which avoids at least two bugs. There's a slight performance impact, which is why this should eventually be removed again, once all callers have been fixed to initialize their entire data structures.

### What does this PR do?

Fixes #9181 .

<!-- **Please explain what your changes do**, example: -->

This changes the `us_malloc` memory allocation routine to clear the memory it returns. This avoids at least two bugs:

1. `us_internal_timer_sweep` was sometimes never installed as a timer, causing a memory leak
2. `context->on_socket_long_timeout` sometimes contained uninitilaized data (ASCII in our case), causing a crash after 16 minutes when the timeout expired.

- [x] Code changes

### How did you verify your code works?

I asked the person who'd seen consistent 16-minute crashes to install the change; the crash went away.

No automated tests right now. The right way to test for this automatically is to run CI with valgrind and report any uninitialized memory uses outside of GC, I think.