### PR TITLE
Allow relative paths in cpAsync again

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -6546,7 +6546,7 @@ pub const NodeFS = struct {
         }
 
         const open_flags = os.O.DIRECTORY | os.O.RDONLY;
-        const fd = switch (Syscall.openatOSPath(bun.invalid_fd, src, open_flags, 0)) {
+        const fd = switch (Syscall.openatOSPath(bun.toFD(std.fs.cwd().fd), src, open_flags, 0)) {
             .err => |err| {
                 task.finishConcurrently(.{ .err = err.withPath(this.osPathIntoSyncErrorBuf(src)) });
                 return false;

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -285,6 +285,27 @@ for (const [name, copy] of impls) {
       assertContent(basename + "/hello/world/a.txt", "a");
       assertContent(basename + "/hello/world/b.txt", "b");
     });
+
+    test("relative paths for directories", async () => {
+      const basename = tempDirWithFiles("cp", {
+        "from/a.txt": "a",
+        "from/b.txt": "b",
+        "from/a.dir": { "c.txt": "c" },
+      });
+
+      const filter = jest.fn((src: string) => true);
+
+      let prev = process.cwd();
+      process.chdir(basename);
+
+      await copy("from", "result", {
+        recursive: true,
+      });
+
+      process.chdir(prev);
+
+      assertContent(basename + "/result/a.dir/c.txt", "c");
+    });
   });
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes #9024 .

A recent commit in #8649 changed cpAsync to use

```
const fd = switch (Syscall.openatOSPath(bun.invalid_fd, src, open_flags, 0)) {
```

rather than

```
const fd = switch (Syscall.open(src, open_flags, 0)) {
```

The new code doesn't accept relative paths, which caused the issue.

This patch uses the CWD file descriptor instead.

- [x] Code changes

### How did you verify your code works?

~Will add tests in a bit.~

There is a test.