### PR TITLE
docs: added fix for linking issue on Ubuntu

### DIFF
--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -283,6 +283,31 @@ $ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
 $ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
 ```
 
+### lstdc++ linking error on Ubuntu
+
+During the Bun setup process, you might encounter a similar looking linking error:
+
+```
+The C++ compiler
+
+  "/usr/bin/clang++-16"
+
+is not able to compile a simple test program.
+
+...
+
+ld.lld: error: unable to find library -lstdc++
+```
+
+This error indicates that the linker is unable to find the libstdc++ library, which is necessary for compiling C++ applications that depend on it.
+
+To resolve this issue, you may need to install the correct version of the **development** package for libstdc++ that provides the necessary headers and static library files.
+
+```bash
+sudo apt install libstdc++-12-dev
+#sudo apt install libstdc++-{version}-dev
+```
+
 ### libarchive
 
 If you see an error when compiling `libarchive`, run this:


### PR DESCRIPTION
### What does this PR do?

I had problems during `bun setup` on Ubuntu, which were fixed by installing `libstdc++-dev`.
The error message and a short description on the fix were added to the Troubleshooting section of the documentation.
This is useful to other potential contributors, who may encounter a similar error.

Side Note:
I installed a fresh Ubuntu 22.04 and neither of the two errors described in the Troubleshooting section came up.
On a fresh install everything seems to work fine.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes