### PR TITLE
windows: pass test/js/web/websocket/websocket.test.js

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -222,6 +222,7 @@ struct us_socket_context_t *us_create_socket_context(int ssl, struct us_loop_t *
      * context_ext_size will however be modified larger in case of SSL, to hold SSL extensions */
 
     struct us_socket_context_t *context = us_malloc(sizeof(struct us_socket_context_t) + context_ext_size);
+    memset(context, 0, sizeof(struct us_socket_context_t) + context_ext_size);
     context->loop = loop;
     context->head_sockets = 0;
     context->head_listen_sockets = 0;
@@ -252,6 +253,7 @@ struct us_socket_context_t *us_create_bun_socket_context(int ssl, struct us_loop
      * context_ext_size will however be modified larger in case of SSL, to hold SSL extensions */
 
     struct us_socket_context_t *context = us_malloc(sizeof(struct us_socket_context_t) + context_ext_size);
+    memset(context, 0, sizeof(struct us_socket_context_t) + context_ext_size);
     context->loop = loop;
     context->head_sockets = 0;
     context->head_listen_sockets = 0;


### PR DESCRIPTION
this struct contains many functions pointers, which when containing a value of uninitialized memory may be `0xCC`, `0xCD`, garbage, or similar. however later libuv and libusockets functions test if those pointers are NULL as a way to see if the particular callback has been added. being not `0x0` the checks would pass and swiftly cause a segfault later on.