### PR TITLE
fix: format specifier without characters in between

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -1226,7 +1226,13 @@ pub const Formatter = struct {
         var i: u32 = 0;
         var len: u32 = @as(u32, @truncate(slice.len));
         var any_non_ascii = false;
+        var hit_percent = false;
         while (i < len) : (i += 1) {
+            if (hit_percent) {
+                i = 0;
+                hit_percent = false;
+            }
+
             switch (slice[i]) {
                 '%' => {
                     i += 1;
@@ -1251,6 +1257,7 @@ pub const Formatter = struct {
                     any_non_ascii = false;
                     slice = slice[@min(slice.len, i + 1)..];
                     i = 0;
+                    hit_percent = true;
                     len = @as(u32, @truncate(slice.len));
                     const next_value = this.remaining_values[0];
                     this.remaining_values = this.remaining_values[1..];

--- a/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
@@ -59,7 +59,9 @@ test("no assertion failures", () => {
   assert.strictEqual(util.format("%d", Infinity), "Infinity");
   assert.strictEqual(util.format("%d", -Infinity), "-Infinity");
   assert.strictEqual(util.format("%d %d", 42, 43), "42 43");
+  assert.strictEqual(util.format("%d%d", 42, 43), "4243");
   assert.strictEqual(util.format("%d %d", 42), "42 %d");
+  assert.strictEqual(util.format("%d%d", 42), "42%d");
   assert.strictEqual(util.format("%d", 1180591620717411303424), "1.1805916207174113e+21");
   assert.strictEqual(util.format("%d", 1180591620717411303424n), "1180591620717411303424n");
   assert.strictEqual(
@@ -151,7 +153,9 @@ test("no assertion failures", () => {
   assert.strictEqual(util.format("%s", -0), "-0");
   assert.strictEqual(util.format("%s", "-0.0"), "-0.0");
   assert.strictEqual(util.format("%s %s", 42, 43), "42 43");
+  assert.strictEqual(util.format("%s%s", 42, 43), "4243");
   assert.strictEqual(util.format("%s %s", 42), "42 %s");
+  assert.strictEqual(util.format("%s%s", 42), "42%s");
   assert.strictEqual(util.format("%s", 42n), "42n");
   assert.strictEqual(util.format("%s", Symbol("foo")), "Symbol(foo)");
   assert.strictEqual(util.format("%s", true), "true");
@@ -239,6 +243,7 @@ test("no assertion failures", () => {
   assert.strictEqual(util.format("%j", 42), "42");
   assert.strictEqual(util.format("%j", "42"), '"42"');
   assert.strictEqual(util.format("%j %j", 42, 43), "42 43");
+  assert.strictEqual(util.format("%j%j", 42, null), "42null");
   assert.strictEqual(util.format("%j %j", 42), "42 %j");
 
   // Object format specifier

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -48,6 +48,7 @@ FooWithProp {
 /FooRegex/
 Is it a bug or a feature that formatting numbers like 123 is colored
 String 123 should be 2nd word, 456 == 456 and percent s %s == What okay
+123456 without space should work
 {
   foo: {
     name: "baz",

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -53,6 +53,8 @@ console.log("Is it a bug or a feature that formatting numbers like %d is colored
 
 console.log("String %s should be 2nd word, 456 == %s and percent s %s == %s", "123", "456", "%s", "What", "okay");
 
+console.log("%s%s without space should work", "123", "456");
+
 const infinteLoop = {
   foo: {
     name: "baz",


### PR DESCRIPTION
### What does this PR do?

Fixes the problem where format specifiers with no characters in between would not be replaced with their values in `console.log` and `util.format`. This was because the character after every format specifier was skipped when scanning.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Wrote automated tests and also tested on a mocha repo

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->


- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

fixes #9208, fixes #7304
