### PR TITLE
fix: sep state for assertions and hasAssertions

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -9,7 +9,6 @@ const jest = bun.JSC.Jest;
 const Jest = jest.Jest;
 const TestRunner = jest.TestRunner;
 const DescribeScope = jest.DescribeScope;
-const NeededAssertType = jest.NeededAssertType;
 const JSC = bun.JSC;
 const VirtualMachine = JSC.VirtualMachine;
 const JSGlobalObject = JSC.JSGlobalObject;
@@ -41,6 +40,9 @@ const JSTypeOfMap = bun.ComptimeStringMap([]const u8, .{
 });
 
 pub var active_test_expectation_counter: Counter = .{};
+pub var is_expecting_assertions: bool = false;
+pub var is_expecting_assertions_count: bool = false;
+pub var expected_assertions_number: u32 = 0;
 
 const log = bun.Output.scoped(.expect, false);
 
@@ -4326,8 +4328,7 @@ pub const Expect = struct {
         _ = callFrame;
         defer globalObject.bunVM().autoGarbageCollect();
 
-        if (Jest.runner.?.pending_test) |pending_test|
-            pending_test.assert_asserts(NeededAssertType.atLeastOne, 0);
+        is_expecting_assertions = true;
 
         return .undefined;
     }
@@ -4360,8 +4361,8 @@ pub const Expect = struct {
 
         const unsigned_expected_assertions: u32 = @intFromFloat(expected_assertions);
 
-        if (Jest.runner.?.pending_test) |pending_test|
-            pending_test.assert_asserts(NeededAssertType.equalToNeededAsserts, unsigned_expected_assertions);
+        is_expecting_assertions_count = true;
+        expected_assertions_number = unsigned_expected_assertions;
 
         return .undefined;
     }

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1227,16 +1227,7 @@ pub const WrappedDescribeScope = struct {
     pub const each = wrapTestFunction("describe", DescribeScope.each);
 };
 
-pub const NeededAssertType = enum(u2) {
-    none,
-    atLeastOne,
-    equalToNeededAsserts,
-};
-
 pub const TestRunnerTask = struct {
-    needed_assert_type: NeededAssertType = NeededAssertType.none,
-    needed_asserts: u32 = 0,
-
     test_id: TestRunner.Test.ID,
     describe: *DescribeScope,
     globalThis: *JSC.JSGlobalObject,
@@ -1278,6 +1269,8 @@ pub const TestRunnerTask = struct {
         // reset the global state for each test
         // prior to the run
         expect.active_test_expectation_counter = .{};
+        expect.is_expecting_assertions = false;
+        expect.is_expecting_assertions_count = false;
         jsc_vm.last_reported_error_for_dedupe = .zero;
 
         const test_id = this.test_id;
@@ -1333,33 +1326,27 @@ pub const TestRunnerTask = struct {
             return true;
         }
 
-        switch (this.needed_assert_type) {
-            NeededAssertType.none => {},
-            NeededAssertType.atLeastOne => {
-                if (expect.active_test_expectation_counter.actual == 0) {
-                    const fmt = comptime "<d>expect.hasAssertions()<r>\n\nExpected <green>at least one assertion<r> to be called but <red>received none<r>.\n";
-                    const error_value = if (Output.enable_ansi_colors)
-                        globalThis.createErrorInstance(Output.prettyFmt(fmt, true), .{})
-                    else
-                        globalThis.createErrorInstance(Output.prettyFmt(fmt, false), .{});
+        if (expect.is_expecting_assertions and expect.active_test_expectation_counter.actual == 0) {
+            const fmt = comptime "<d>expect.hasAssertions()<r>\n\nExpected <green>at least one assertion<r> to be called but <red>received none<r>.\n";
+            const error_value = if (Output.enable_ansi_colors)
+                globalThis.createErrorInstance(Output.prettyFmt(fmt, true), .{})
+            else
+                globalThis.createErrorInstance(Output.prettyFmt(fmt, false), .{});
 
-                    globalThis.*.bunVM().runErrorHandler(error_value, null);
-                    result = .{ .fail = 0 };
-                }
-            },
-            NeededAssertType.equalToNeededAsserts => {
-                if (expect.active_test_expectation_counter.actual != this.needed_asserts) {
-                    const fmt = comptime "<d>expect.assertions({})<r>\n\nExpected <green>{} assertion<r> to be called but <red>found {} assertions<r> instead.\n";
-                    const fmt_args = .{ this.needed_asserts, this.needed_asserts, expect.active_test_expectation_counter.actual };
-                    const error_value = if (Output.enable_ansi_colors)
-                        globalThis.createErrorInstance(Output.prettyFmt(fmt, true), fmt_args)
-                    else
-                        globalThis.createErrorInstance(Output.prettyFmt(fmt, false), fmt_args);
+            globalThis.*.bunVM().runErrorHandler(error_value, null);
+            result = .{ .fail = 0 };
+        }
 
-                    globalThis.*.bunVM().runErrorHandler(error_value, null);
-                    result = .{ .fail = expect.active_test_expectation_counter.actual };
-                }
-            },
+        if (expect.is_expecting_assertions_count and expect.active_test_expectation_counter.actual != expect.expected_assertions_number) {
+            const fmt = comptime "<d>expect.assertions({})<r>\n\nExpected <green>{} assertion<r> to be called but <red>found {} assertions<r> instead.\n";
+            const fmt_args = .{ expect.expected_assertions_number, expect.expected_assertions_number, expect.active_test_expectation_counter.actual };
+            const error_value = if (Output.enable_ansi_colors)
+                globalThis.createErrorInstance(Output.prettyFmt(fmt, true), fmt_args)
+            else
+                globalThis.createErrorInstance(Output.prettyFmt(fmt, false), fmt_args);
+
+            globalThis.*.bunVM().runErrorHandler(error_value, null);
+            result = .{ .fail = expect.active_test_expectation_counter.actual };
         }
 
         this.handleResult(result, .sync);
@@ -1426,11 +1413,6 @@ pub const TestRunnerTask = struct {
         }
 
         processTestResult(this, this.globalThis, result, test_, test_id, describe);
-    }
-
-    pub fn assert_asserts(this: *TestRunnerTask, assert_type: NeededAssertType, assert_count: u32) void {
-        this.needed_assert_type = assert_type;
-        this.needed_asserts = assert_count;
     }
 
     fn processTestResult(this: *TestRunnerTask, globalThis: *JSC.JSGlobalObject, result: Result, test_: TestScope, test_id: u32, describe: *DescribeScope) void {


### PR DESCRIPTION
### What does this PR do?

Makes state for `hasAssertions` and `assertions` separate as per https://github.com/oven-sh/bun/pull/9190#discussion_r1509877965.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->


- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
