### PR TITLE
Fix regression from 648d5ae

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -392,7 +392,12 @@ LIBUS_SOCKET_DESCRIPTOR bsd_accept_socket(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd
 
     internal_finalize_bsd_addr(addr);
 
+#if defined(SOCK_CLOEXEC) && defined(SOCK_NONBLOCK)
+// skip the extra fcntl calls.
+    return accepted_fd;
+#else
     return bsd_set_nonblocking(apple_no_sigpipe(accepted_fd));
+#endif
 }
 
 int bsd_recv(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags) {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1543,7 +1543,13 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     this.flags.is_waiting_for_request_body = false;
                     resp.clearOnData();
                 }
-                resp.endStream(closeConnection);
+
+                // This will send a terminating 0\r\n\r\n chunk to the client
+                // We only want to do that if they're still expecting a body
+                // We cannot call this function if the Content-Length header was previously set
+                if (resp.state().isResponsePending())
+                    resp.endStream(closeConnection);
+
                 this.resp = null;
             }
         }

--- a/test/js/web/fetch/body-stream-excess.test.ts
+++ b/test/js/web/fetch/body-stream-excess.test.ts
@@ -1,0 +1,100 @@
+import { test, expect, describe } from "bun:test";
+import { $ } from "bun";
+
+describe("http response does not include an extraneous terminating 0\\r\\n\\r\\n", () => {
+  const scenarios = [
+    {
+      port: 0,
+
+      async fetch(req) {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller) {
+              controller.write("hello");
+              await controller.end();
+            },
+          }),
+          {
+            headers: {
+              "Content-Type": "text/plain",
+            },
+          },
+        );
+      },
+    },
+    {
+      port: 0,
+
+      async fetch(req) {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller) {
+              controller.write("hello");
+              await Bun.sleep(5);
+              await controller.end();
+            },
+          }),
+          {
+            headers: {
+              "Content-Type": "text/plain",
+            },
+          },
+        );
+      },
+    },
+    {
+      port: 0,
+
+      async fetch(req) {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller) {
+              controller.write("hello");
+              await controller.flush();
+              await controller.close();
+            },
+          }),
+          {
+            headers: {
+              "Content-Type": "text/plain",
+            },
+          },
+        );
+      },
+    },
+    {
+      port: 0,
+
+      async fetch(req) {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller) {
+              await Bun.sleep(1);
+              controller.write("hello");
+              await controller.flush();
+              await controller.close();
+            },
+          }),
+          {
+            headers: {
+              "Content-Type": "text/plain",
+            },
+          },
+        );
+      },
+    },
+  ];
+  for (let i = 0; i < scenarios.length; i++) {
+    test("scenario " + i, async () => {
+      const server = Bun.serve(scenarios[i]);
+      const { stdout, stderr } = await $`curl ${server.url} --verbose`.quiet();
+      expect(stdout.toString()).toBe("hello");
+      expect(stderr.toString()).toContain("left intact");
+      server.stop(true);
+    });
+  }
+});


### PR DESCRIPTION
### What does this PR do?

Fix regression from 648d5ae

In certain cases, Bun.serve() was sending a `0\r\n\r\n` chunk when using the Content-Length header after the data has already been fully sent, which was invalid. When HTTP clients receive this, they disconnect. This caused a performance regression, but doesn't appear to have caused issues otherwise.

### How did you verify your code works?

There are tests