### PR TITLE
Finish jest.clearAllMocks() implementation

### DIFF
--- a/src/bun.js/bindings/JSMockFunction.h
+++ b/src/bun.js/bindings/JSMockFunction.h
@@ -30,7 +30,14 @@ public:
 
     static JSMockModule create(JSC::JSGlobalObject*);
 
+    // These are used by "spyOn"
+    // This is useful for iterating through every non-GC'd spyOn
     JSC::Strong<JSC::Unknown> activeSpies;
+
+    // Every JSMockFunction::create appends to this list
+    // This is useful for iterating through every non-GC'd mock function
+    // This list includes activeSpies
+    JSC::Strong<JSC::Unknown> activeMocks;
 };
 
 class MockWithImplementationCleanupData : public JSC::JSInternalFieldObjectImpl<4> {

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -76,6 +76,20 @@ describe("mock()", () => {
     expect(fn).toHaveBeenLastCalledWith();
     expect(fn).toHaveBeenCalledWith();
   });
+
+  test("jest.clearAllMocks()", () => {
+    const func = jest.fn(() => 42);
+    expect(func).not.toHaveBeenCalled();
+    expect(func()).toBe(42);
+    expect(func).toHaveBeenCalled();
+
+    jest.clearAllMocks();
+
+    expect(func).not.toHaveBeenCalled();
+    expect(func()).toBe(42);
+    expect(func).toHaveBeenCalled();
+  });
+
   test("passes this value", () => {
     const fn = jest.fn(function hey() {
       "use strict";


### PR DESCRIPTION
### What does this PR do?

#9081 added support for `jest.clearAllMocks()` when the mock was created via `spyOn`, but not when the mock was created via `jest.fn` or `mock(() => {})`.

This adds support for those cases as well by having a separate WeakSet for all mocked functions (instead of only spies).

### How did you verify your code works?

There is a test