### PR TITLE
Avoid manually destroying stream when IncomingMessage stream is done reading

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -655,9 +655,6 @@ function assignHeaders(object, req) {
     return false;
   }
 }
-function destroyBodyStreamNT(bodyStream) {
-  bodyStream.destroy();
-}
 
 var defaultIncomingOpts = { type: "request" };
 
@@ -749,7 +746,6 @@ async function consumeStream(self, reader: ReadableStreamDefaultReader) {
     if (self[abortedSymbol]) return;
     if (done) {
       self.push(null);
-      process.nextTick(destroyBodyStreamNT, self);
       break;
     }
     for (var v of value) {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -23,6 +23,7 @@ import { spawnSync } from "node:child_process";
 import nodefs from "node:fs";
 import { join as joinPath } from "node:path";
 import { unlinkSync } from "node:fs";
+import { PassThrough } from "node:stream";
 const { describe, expect, it, beforeAll, afterAll, createDoneDotAll } = createTest(import.meta.path);
 
 function listen(server: Server, protocol: string = "http"): Promise<URL> {
@@ -187,6 +188,15 @@ describe("node:http", () => {
               Location: `http://localhost:${server.port}/redirected`,
             });
             res.end("Got redirect!\n");
+            return;
+          }
+          if (reqUrl.pathname === "/multi-chunk-response") {
+            res.writeHead(200, { "Content-Type": "text/plain" });
+            const toWrite = "a".repeat(512);
+            for (let i = 0; i < 4; i++) {
+              res.write(toWrite);
+            }
+            res.end();
             return;
           }
           if (reqUrl.pathname === "/multiple-set-cookie") {
@@ -760,6 +770,25 @@ describe("node:http", () => {
         req.on("error", err => {
           done(err);
         });
+        req.end();
+      });
+    });
+
+    it("should correctly stream a multi-chunk response #5320", async (done) => {
+      runTest(done, (server, serverPort, done) => {
+        const req = request({ host: "localhost", port: `${serverPort}`, path: '/multi-chunk-response', method: "GET" });
+
+        req.on('error', (err) => done(err));
+
+        req.on("response", async res => {
+          const body = res.pipe(new PassThrough({ highWaterMark: 512 }));
+          const response = new Response(body);
+          const text = await response.text();
+
+          expect(text.length).toBe(2048);
+          done();
+        });
+
         req.end();
       });
     });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -774,11 +774,11 @@ describe("node:http", () => {
       });
     });
 
-    it("should correctly stream a multi-chunk response #5320", async (done) => {
+    it("should correctly stream a multi-chunk response #5320", async done => {
       runTest(done, (server, serverPort, done) => {
-        const req = request({ host: "localhost", port: `${serverPort}`, path: '/multi-chunk-response', method: "GET" });
+        const req = request({ host: "localhost", port: `${serverPort}`, path: "/multi-chunk-response", method: "GET" });
 
-        req.on('error', (err) => done(err));
+        req.on("error", err => done(err));
 
         req.on("response", async res => {
           const body = res.pipe(new PassThrough({ highWaterMark: 512 }));


### PR DESCRIPTION
### What does this PR do?
I'm hesitant to even put it anymore, but this should hopefully fix #5320 lol (although not the more infrequent child_process issue)

Basically, the stream from the `node-fetch` module (the actual one, not Bun's built-in implementation) was getting destroyed too early.

Solution is to not manually destroy it, it ends up getting destroyed at the right time later anyway in `Readable`.

### How did you verify your code works?
```ts
import hasha from "hasha";
import zlib from "zlib";
// import fetch from "node-fetch";
import fetch from "./node_modules/node-fetch/lib/index.mjs";

async function downloadZip(url2) {
  const response = await fetch(url2, { compress: false });
  if (!response.ok) throw new Error('fail');

  return await new Promise(async (resolve3, reject2) => {
    let bytesRead = 0;
    response.body
      .on("error", reject2)
      .on("data", (chunk) => { bytesRead += chunk.length });
    const gunzip = zlib.createGunzip();
    gunzip.on("error", reject2);
    const zipStream = response.body.pipe(gunzip);
    const zippedHashPromise = hasha.fromStream(response.body, { algorithm: "sha256" });
    const hashPromise = hasha.fromStream(zipStream, { algorithm: "sha256" });
    console.log("will await");
    await hashPromise;
    await zippedHashPromise;
    console.log("all okay", response.body.destroyed, bytesRead);
    resolve3();
  });
}

const url = "https://binaries.prisma.sh/all_commits/5a9203d0590c951969e85a7d07215503f4672eb9/debian-openssl-1.1.x/libquery_engine.so.node.gz";
const array = new Array(10).fill(url);

const promises = array.map((url) => downloadZip(url));

await Promise.all(promises);
console.log("DONE");
```

before these changes, `DONE` is never reached. After:
```
will await
will await
will await
will await
will await
will await
will await
will await
will await
all okay true 7291350
all okay true 7291350
all okay true 7291350
all okay true 7291350
all okay true 7291350
all okay true 7291350
all okay true 7291350
all okay true 7291350
all okay true 7291350
all okay true 7291350
DONE
```

(notice that `body` is indeed destroyed properly)

Also tested against `prisma generate` via:
```fish
# fish shell btw
rm -rf ~/.cache/prisma && for file in ./node_modules/prisma/*.so.node; rm $file; end && BUN_DEBUG_QUIET_LOGS=1 ../bun/build/bun-debug --bun x prisma generate
```

**ETA:** Also added a test to `node-http.test.ts` for this case, fails with current Bun, passes with a debug build w/ these changes