### PR TITLE
shell: Improve `ShellError` stacktrace

### DIFF
--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -6,17 +6,21 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
     return this.toString();
   }
   class ShellError extends Error {
-    #output: ShellOutput;
-    constructor(output: ShellOutput, code: number) {
-      super(`Failed with exit code ${code}`);
+    #output?: ShellOutput = undefined;
+    constructor() {
+      super("");
+    }
+
+    initialize(output: ShellOutput, code: number) {
+      this.message = `Failed with exit code ${code}`;
       this.#output = output;
       this.name = "ShellError";
 
       // Maybe we should just print all the properties on the Error instance
       // instead of speical ones
       this.info = {
-        stderr: output.stderr,
         exitCode: code,
+        stderr: output.stderr,
         stdout: output.stdout,
       };
 
@@ -84,19 +88,30 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
     #throws: boolean = true;
     // #immediate;
     constructor(core: ShellInterpreter, throws: boolean) {
+      // Create the error immediately so it captures the stacktrace at the point
+      // of the shell script's invocation. Just creating the error should be
+      // relatively cheap, the costly work is actually computing the stacktrace
+      // (`computeErrorInfo()` in ZigGlobalObject.cpp)
+      let potentialError = new ShellError();
       let resolve, reject;
 
       super((res, rej) => {
         resolve = code => {
           const out = new ShellOutput(core.getBufferedStdout(), core.getBufferedStderr(), code);
           if (this.#throws && code !== 0) {
-            rej(new ShellError(out, code));
+            potentialError.initialize(out, code);
+            rej(potentialError);
           } else {
+            // Set to undefined to hint to the GC that this is unused so it can
+            // potentially GC it earlier
+            potentialError = undefined;
             res(out);
           }
         };
-        reject = code =>
-          rej(new ShellError(new ShellOutput(core.getBufferedStdout(), core.getBufferedStderr(), code), code));
+        reject = code => {
+          potentialError.initialize(new ShellOutput(core.getBufferedStdout(), core.getBufferedStderr(), code), code);
+          rej();
+        };
       });
 
       this.#throws = throws;

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -110,7 +110,7 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
         };
         reject = code => {
           potentialError.initialize(new ShellOutput(core.getBufferedStdout(), core.getBufferedStderr(), code), code);
-          rej();
+          rej(potentialError);
         };
       });
 


### PR DESCRIPTION
### What does this PR do?

This fixes errors thrown by Bun shell not showing the original stacktrace (Fixes #9182)

This is done by creating an Error object upfront upon creation of the `ShellPromise`.

Creating an Error object shouldn't be too costly

I put breakpoints on the `computeErrorInfo...` functions in `ZigGlobalObject.cpp` to make sure we're not doing the expensive thing of computing the stack trace, didn't seem to hit any of those functions so think we should be good

- [x] Code changes

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)