### PR TITLE
Support `conditions` in Bun.build

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1444,6 +1444,14 @@ declare module "bun" {
     // origin?: string; // e.g. http://mydomain.com
     loader?: { [k in string]: Loader };
     sourcemap?: "none" | "inline" | "external"; // default: "none"
+    /**
+     * package.json `exports` conditions used when resolving imports
+     *
+     * Equivalent to `--conditions` in `bun build` or `bun run`.
+     *
+     * https://nodejs.org/api/packages.html#exports
+     */
+    conditions?: Array<string> | string;
     minify?:
       | boolean
       | {

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1617,7 +1617,7 @@ pub const BundleV2 = struct {
                 .main_fields = &.{},
                 .extension_order = &.{},
                 .env_files = &.{},
-                .conditions = &.{},
+                .conditions = config.conditions.map.keys(),
             },
             completion.env,
         );

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -1386,6 +1386,27 @@ describe("bundler", () => {
       stdout: "SUCCESS",
     },
   });
+  itBundled("packagejson/ExportsCustomConditionsAPI", {
+    files: {
+      "/Users/user/project/src/entry.js": `import 'pkg1'`,
+      "/Users/user/project/node_modules/pkg1/package.json": /* json */ `
+        {
+          "exports": {
+            "custom1": "./custom1.js",
+            "custom2": "./custom2.js",
+            "default": "./default.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/pkg1/custom2.js": `console.log('SUCCESS')`,
+    },
+    outfile: "/Users/user/project/out.js",
+    conditions: ["custom2"],
+    backend: "api",
+    run: {
+      stdout: "SUCCESS",
+    },
+  });
   itBundled("packagejson/ExportsNotExactMissingExtension", {
     files: {
       "/Users/user/project/src/entry.js": `import 'pkg1/foo/bar'`,

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -149,7 +149,7 @@ export interface BundlerTestInput {
   define?: Record<string, string | number>;
 
   /** Use for resolve custom conditions */
-  conditions?: String[];
+  conditions?: string[];
 
   /** Default is "[name].[ext]" */
   entryNaming?: string;
@@ -906,6 +906,10 @@ function expectBundled(
           target,
           publicPath,
         } as BuildConfig;
+
+        if (conditions?.length) {
+          buildConfig.conditions = conditions;
+        }
 
         if (DEBUG) {
           if (_referenceFn) {


### PR DESCRIPTION
### What does this PR do?

#9106 added support for `bun --conditions` and `bun build --conditions`, but left out passing `conditions` to `Bun.build` . This adds it

### How did you verify your code works?

There is a test