### PR TITLE
Fix lost constructors in Node.js module classes (fixes #9242)

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -431,6 +431,7 @@ function Server(options, callback) {
   return this;
 }
 Object.setPrototypeOf((Server.prototype = {}), EventEmitter.prototype);
+Server.prototype.constructor = Server; // Re-add constructor which got lost when setting prototype
 Object.setPrototypeOf(Server, EventEmitter);
 
 Server.prototype.ref = function () {
@@ -720,6 +721,7 @@ function IncomingMessage(req, defaultIncomingOpts) {
 }
 
 Object.setPrototypeOf((IncomingMessage.prototype = {}), Readable.prototype);
+IncomingMessage.prototype.constructor = IncomingMessage; // Re-add constructor which got lost when setting prototype
 Object.setPrototypeOf(IncomingMessage, Readable);
 
 IncomingMessage.prototype._construct = function (callback) {
@@ -930,6 +932,7 @@ function OutgoingMessage(options) {
 }
 
 Object.setPrototypeOf((OutgoingMessage.prototype = {}), Writable.prototype);
+OutgoingMessage.prototype.constructor = OutgoingMessage; // Re-add constructor which got lost when setting prototype
 Object.setPrototypeOf(OutgoingMessage, Writable);
 
 // Express "compress" package uses this
@@ -1134,6 +1137,7 @@ function ServerResponse(req, reply) {
   if (req.method === "HEAD") this._hasBody = false;
 }
 Object.setPrototypeOf((ServerResponse.prototype = {}), OutgoingMessage.prototype);
+ServerResponse.prototype.constructor = ServerResponse; // Re-add constructor which got lost when setting prototype
 Object.setPrototypeOf(ServerResponse, OutgoingMessage);
 
 // Express "compress" package uses this

--- a/src/js/node/stream.js
+++ b/src/js/node/stream.js
@@ -2003,6 +2003,7 @@ var require_legacy = __commonJS({
     }
     Stream.prototype = {};
     ObjectSetPrototypeOf(Stream.prototype, EE.prototype);
+    Stream.prototype.constructor = Stream; // Re-add constructor which got lost when setting prototype
     ObjectSetPrototypeOf(Stream, EE);
 
     Stream.prototype.pipe = function (dest, options) {
@@ -2282,6 +2283,7 @@ var require_readable = __commonJS({
     }
     Readable.prototype = {};
     ObjectSetPrototypeOf(Readable.prototype, Stream.prototype);
+    Readable.prototype.constructor = Readable; // Re-add constructor which got lost when setting prototype
     ObjectSetPrototypeOf(Readable, Stream);
 
     Readable.prototype.on = function (ev, fn) {
@@ -3468,6 +3470,7 @@ var require_writable = __commonJS({
     }
     Writable.prototype = {};
     ObjectSetPrototypeOf(Writable.prototype, Stream.prototype);
+    Writable.prototype.constructor = Writable; // Re-add constructor which got lost when setting prototype
     ObjectSetPrototypeOf(Writable, Stream);
     module.exports = Writable;
 
@@ -4430,6 +4433,7 @@ var require_duplex = __commonJS({
     Duplex.prototype = {};
     module.exports = Duplex;
     ObjectSetPrototypeOf(Duplex.prototype, Readable.prototype);
+    Duplex.prototype.constructor = Duplex; // Re-add constructor which got lost when setting prototype
     ObjectSetPrototypeOf(Duplex, Readable);
 
     {
@@ -4506,6 +4510,7 @@ var require_transform = __commonJS({
     }
     Transform.prototype = {};
     ObjectSetPrototypeOf(Transform.prototype, Duplex.prototype);
+    Transform.prototype.constructor = Transform; // Re-add constructor which got lost when setting prototype
     ObjectSetPrototypeOf(Transform, Duplex);
 
     module.exports = Transform;
@@ -4594,6 +4599,7 @@ var require_passthrough = __commonJS({
     PassThrough.prototype = {};
 
     ObjectSetPrototypeOf(PassThrough.prototype, Transform.prototype);
+    PassThrough.prototype.constructor = PassThrough; // Re-add constructor which got lost when setting prototype
     ObjectSetPrototypeOf(PassThrough, Transform);
 
     PassThrough.prototype._transform = function (chunk, encoding, cb) {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1705,6 +1705,23 @@ it("#4415.4 IncomingMessage es5", () => {
   expect(im.url).toBe("/foo");
 });
 
+it("#9242.1 Server has constructor", () => {
+  const s = new Server();
+  expect(s.constructor).toBe(Server);
+});
+it("#9242.2 IncomingMessage has constructor", () => {
+  const im = new IncomingMessage("http://localhost");
+  expect(im.constructor).toBe(IncomingMessage);
+});
+it("#9242.3 OutgoingMessage has constructor", () => {
+  const om = new OutgoingMessage();
+  expect(om.constructor).toBe(OutgoingMessage);
+});
+it("#9242.4 ServerResponse has constructor", () => {
+  const sr = new ServerResponse({});
+  expect(sr.constructor).toBe(ServerResponse);
+});
+
 // Windows doesnt support SIGUSR1
 if (process.platform !== "win32") {
   // By not timing out, this test passes.

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -1,5 +1,5 @@
 import { expect, describe, it } from "bun:test";
-import { Readable, Writable, Duplex, Transform, PassThrough } from "node:stream";
+import { Stream, Readable, Writable, Duplex, Transform, PassThrough } from "node:stream";
 import { createReadStream } from "node:fs";
 import { join } from "path";
 import { bunExe, bunEnv } from "harness";
@@ -441,4 +441,29 @@ it("Readable.fromWeb", async () => {
     chunks.push(chunk);
   }
   expect(Buffer.concat(chunks).toString()).toBe("Hello World!\n");
+});
+
+it("#9242.5 Stream has constructor", () => {
+  const s = new Stream({});
+  expect(s.constructor).toBe(Stream);
+});
+it("#9242.6 Readable has constructor", () => {
+  const r = new Readable({});
+  expect(r.constructor).toBe(Readable);
+});
+it("#9242.7 Writable has constructor", () => {
+  const w = new Writable({});
+  expect(w.constructor).toBe(Writable);
+});
+it("#9242.8 Duplex has constructor", () => {
+  const d = new Duplex({});
+  expect(d.constructor).toBe(Duplex);
+});
+it("#9242.9 Transform has constructor", () => {
+  const t = new Transform({});
+  expect(t.constructor).toBe(Transform);
+});
+it("#9242.10 PassThrough has constructor", () => {
+  const pt = new PassThrough({});
+  expect(pt.constructor).toBe(PassThrough);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/9242

For compatibility with Node.js a number of constructor functions should be present in their respective prototype. Since some classes are created using constructor functions on which a new prototype is set, the constructor is 'lost'. It needs to be explicitly (re)added to have it available. Alternative is to create all classes with an actual class definition (instead of constructor function on which a new prototype is set).

### How did you verify your code works?

Added tests which show the fix functions. Same tests can be used (without code changes) to verify the code failed before applying the fix. Tests performed locally.