### PR TITLE
fix!: remove worker from default conditions

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -580,13 +580,11 @@ pub const Target = enum {
         });
         array.set(Target.bun, &[_]string{
             "bun",
-            "worker",
             "node",
         });
         array.set(Target.bun_macro, &[_]string{
             "macro",
             "bun",
-            "worker",
             "node",
         });
 


### PR DESCRIPTION
### What does this PR do?

This removes "worker" from the default conditions for "bun" targets, which fixes #9255.