### PR TITLE
docs<test>: update test matchers on jest compatibility

### DIFF
--- a/docs/test/writing.md
+++ b/docs/test/writing.md
@@ -327,7 +327,7 @@ Bun implements the following matchers. Full Jest compatibility is on the roadmap
 
 ---
 
-- ❌
+- ✅
 - [`.assertions()`](https://jestjs.io/docs/expect#expectassertionsnumber)
 
 ---
@@ -337,7 +337,7 @@ Bun implements the following matchers. Full Jest compatibility is on the roadmap
 
 ---
 
-- ❌
+- ✅
 - [`.hasAssertions()`](https://jestjs.io/docs/expect#expecthasassertions)
 
 ---


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
According to [Bun v1.0.30 Blog](https://bun.sh/blog/bun-v1.0.30#expect-assertions-and-expect-hasassertions-are-now-supported), `expect.assertions()` and `expect.hasAssertions()` have been supported.
That's why I updated a mathers list in the document. 
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
