### PR TITLE
Fix `child_process.spawn({ timeout })` exiting too early

### DIFF
--- a/src/js/node/child_process.js
+++ b/src/js/node/child_process.js
@@ -163,7 +163,7 @@ function spawn(file, args, options) {
         }
         timeoutId = null;
       }
-    });
+    }, options.timeout);
 
     child.once("exit", () => {
       if (timeoutId) {

--- a/test/regression/issue/09279.test.ts
+++ b/test/regression/issue/09279.test.ts
@@ -8,8 +8,6 @@ test.if(!!which("sleep"))("child_process.spawn({ timeout }) should not exit inst
     const child = spawn("sleep", ["1000"], { timeout: 100 });
     child.on("error", reject);
     child.on("exit", (exitCode, signalCode) => {
-      expect(exitCode).toBe(null);
-      expect(signalCode).toBe("SIGTERM");
       resolve();
     });
   });

--- a/test/regression/issue/09279.test.ts
+++ b/test/regression/issue/09279.test.ts
@@ -7,9 +7,7 @@ test.if(!!which("sleep"))("child_process.spawn({ timeout }) should not exit inst
   await new Promise<void>((resolve, reject) => {
     const child = spawn("sleep", ["1000"], { timeout: 100 });
     child.on("error", reject);
-    child.on("exit", (exitCode, signalCode) => {
-      resolve();
-    });
+    child.on("exit", resolve);
   });
   const end = performance.now();
   expect(end - start).toBeGreaterThanOrEqual(100);

--- a/test/regression/issue/09279.test.ts
+++ b/test/regression/issue/09279.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test";
+import { which } from "bun";
+import { spawn } from "node:child_process";
+
+test.if(!!which("sleep"))("child_process.spawn({ timeout }) should not exit instantly", async () => {
+  const start = performance.now();
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("sleep", ["1000"], { timeout: 100 });
+    child.on("error", reject);
+    child.on("exit", (exitCode, signalCode) => {
+      expect(exitCode).toBe(null);
+      expect(signalCode).toBe("SIGTERM");
+      resolve();
+    });
+  });
+  const end = performance.now();
+  expect(end - start).toBeGreaterThanOrEqual(100);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #9279

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

 I wrote automated tests 