### PR TITLE
fix(install): auto `node-gyp` script bugfix

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8367,7 +8367,7 @@ pub const PackageManager = struct {
             if (scripts.hasAny()) {
                 const add_node_gyp_rebuild_script = if (this.lockfile.hasTrustedDependency(folder_name) and
                     scripts.install.isEmpty() and
-                    scripts.postinstall.isEmpty())
+                    scripts.preinstall.isEmpty())
                 brk: {
                     const binding_dot_gyp_path = Path.joinAbsStringZ(
                         this.node_modules_folder_path.items,
@@ -9450,7 +9450,7 @@ pub const PackageManager = struct {
             .auto,
         );
         if (root.scripts.hasAny()) {
-            const add_node_gyp_rebuild_script = root.scripts.install.isEmpty() and root.scripts.postinstall.isEmpty() and Syscall.exists(binding_dot_gyp_path);
+            const add_node_gyp_rebuild_script = root.scripts.install.isEmpty() and root.scripts.preinstall.isEmpty() and Syscall.exists(binding_dot_gyp_path);
 
             manager.root_lifecycle_scripts = root.scripts.enqueue(
                 manager.lockfile,

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2405,8 +2405,25 @@ pub const Package = extern struct {
             var counter: u8 = 0;
 
             if (add_node_gyp_rebuild_script) {
-                // missing install and postinstall, only need to check preinstall
-                if (!this.preinstall.isEmpty()) {
+                {
+                    script_index += 1;
+                    const entry: Lockfile.Scripts.Entry = .{
+                        .cwd = cwd orelse brk: {
+                            cwd = lockfile.allocator.dupe(u8, _cwd) catch unreachable;
+                            break :brk cwd.?;
+                        },
+                        .script = lockfile.allocator.dupe(u8, "node-gyp rebuild") catch unreachable,
+                        .package_name = package_name,
+                    };
+                    if (first_script_index == -1) first_script_index = @intCast(script_index);
+                    scripts[script_index] = entry;
+                    script_index += 1;
+                    lockfile.scripts.install.append(lockfile.allocator, entry) catch unreachable;
+                    counter += 1;
+                }
+
+                // missing install and preinstall, only need to check postinstall
+                if (!this.postinstall.isEmpty()) {
                     const entry: Lockfile.Scripts.Entry = .{
                         .cwd = cwd orelse brk: {
                             cwd = lockfile.allocator.dupe(u8, _cwd) catch unreachable;
@@ -2417,24 +2434,10 @@ pub const Package = extern struct {
                     };
                     if (first_script_index == -1) first_script_index = @intCast(script_index);
                     scripts[script_index] = entry;
-                    lockfile.scripts.preinstall.append(lockfile.allocator, entry) catch unreachable;
+                    lockfile.scripts.postinstall.append(lockfile.allocator, entry) catch unreachable;
                     counter += 1;
                 }
                 script_index += 1;
-
-                const entry: Lockfile.Scripts.Entry = .{
-                    .cwd = cwd orelse brk: {
-                        cwd = lockfile.allocator.dupe(u8, _cwd) catch unreachable;
-                        break :brk cwd.?;
-                    },
-                    .script = lockfile.allocator.dupe(u8, "node-gyp rebuild") catch unreachable,
-                    .package_name = package_name,
-                };
-                if (first_script_index == -1) first_script_index = @intCast(script_index);
-                scripts[script_index] = entry;
-                script_index += 2;
-                lockfile.scripts.install.append(lockfile.allocator, entry) catch unreachable;
-                counter += 1;
             } else {
                 const install_scripts = .{
                     "preinstall",
@@ -2608,7 +2611,7 @@ pub const Package = extern struct {
 
             const add_node_gyp_rebuild_script = if (lockfile.hasTrustedDependency(folder_name) and
                 this.install.isEmpty() and
-                this.postinstall.isEmpty())
+                this.preinstall.isEmpty())
             brk: {
                 const binding_dot_gyp_path = Path.joinAbsStringZ(
                     cwd,

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2341,6 +2341,14 @@ pub const Package = extern struct {
 
     meta: Meta = .{},
     bin: Bin = .{},
+
+    /// If any of these scripts run, they will run in order:
+    /// 1. preinstall
+    /// 2. install
+    /// 3. postinstall
+    /// 4. preprepare
+    /// 5. prepare
+    /// 6. postprepare
     scripts: Package.Scripts = .{},
 
     pub const Scripts = extern struct {

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -2586,7 +2586,7 @@ for (const forceWaiterThread of [false, true]) {
       expect(await exists(join(packageDir, "build.node"))).toBeTrue();
     });
 
-    test("auto node-gyp scripts work when scripts exists other than `install` and `postinstall`", async () => {
+    test("auto node-gyp scripts work when scripts exists other than `install` and `preinstall`", async () => {
       await writeFile(
         join(packageDir, "package.json"),
         JSON.stringify({
@@ -2596,7 +2596,7 @@ for (const forceWaiterThread of [false, true]) {
             "node-gyp": "1.5.0",
           },
           scripts: {
-            preinstall: "exit 0",
+            postinstall: "exit 0",
             prepare: "exit 0",
             postprepare: "exit 0",
           },
@@ -2629,7 +2629,7 @@ for (const forceWaiterThread of [false, true]) {
       expect(await exists(join(packageDir, "build.node"))).toBeTrue();
     });
 
-    for (const script of ["install", "postinstall"]) {
+    for (const script of ["install", "preinstall"]) {
       test(`does not add auto node-gyp script when ${script} script exists`, async () => {
         const packageJSON: any = {
           name: "foo",


### PR DESCRIPTION
### What does this PR do?
Auto `node-gyp` scripts can be added if `preinstall` and `install` don't exist. Previously we were checking for `install` and `postinstall`.

fixes first bug mentioned here https://github.com/microsoft/node-pty/issues/632#issuecomment-1982243227
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
existing tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
