### PR TITLE
NODE_ENV=test should load .env.test even when .env.production exists

### DIFF
--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -540,7 +540,7 @@ pub const Bundler = struct {
                     this.options.setProduction(true);
                 }
 
-                if (!has_production_env and this.options.isTest()) {
+                if (this.options.isTest() or this.env.isTest()) {
                     try this.env.load(dir, this.options.env.files, .@"test");
                 } else if (this.options.production) {
                     try this.env.load(dir, this.options.env.files, .production);

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -57,6 +57,11 @@ pub const Loader = struct {
         return strings.eqlComptime(env, "production");
     }
 
+    pub fn isTest(this: *const Loader) bool {
+        const env = this.get("BUN_ENV") orelse this.get("NODE_ENV") orelse return false;
+        return strings.eqlComptime(env, "test");
+    }
+
     pub fn getNodePath(this: *Loader, fs: *Fs.FileSystem, buf: *bun.PathBuffer) ?[:0]const u8 {
         if (this.get("NODE") orelse this.get("npm_node_execpath")) |node| {
             @memcpy(buf[0..node.len], node);

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -724,3 +724,13 @@ todoOnPosix("setting process.env coerces the value to a string", () => {
   expect(process.env.SET_TO_BUN).toBe("bun!");
   expect(did_call).toBe(1);
 });
+
+test("NODE_ENV=test loads .env.test even when .env.production exists", () => {
+  const dir = tempDirWithFiles("dotenv", {
+    "index.ts": "console.log(process.env.AWESOME);",
+    ".env.production": "AWESOME=production",
+    ".env.test": "AWESOME=test",
+  });
+  const { stdout } = bunRun(`${dir}/index.ts`, { NODE_ENV: "test" });
+  expect(stdout).toBe("test");
+});


### PR DESCRIPTION
Closes https://github.com/oven-sh/bun/issues/6630

prior to this patch the test's output would be

```
Expected: "test"
Received: "undefined"
```