### PR TITLE
Fix sqlite benchmark setup when sh isn't bash

### DIFF
--- a/bench/sqlite/package.json
+++ b/bench/sqlite/package.json
@@ -7,8 +7,8 @@
     "build": "exit 0",
     "bench:bun": "$BUN bun.js",
     "bench:node": "$NODE node.mjs",
-    "deps": "npm install && sh src/download.sh",
-    "bench:deno": "$DENO run -A --unstable deno.js",
+    "deps": "npm install && bash src/download.sh",
+    "bench:deno": "$DENO run -A --unstable-ffi deno.js",
     "bench": "bun run bench:bun && bun run bench:node && bun run bench:deno"
   }
 }


### PR DESCRIPTION
### What does this PR do?

For one benchmark, fix downloading dependencies when sh isn't bash and pass a different flag to deno because recent deno complains about the old flag.

### How did you verify your code works?

I ran the benchmark in question after making the changes. It did not fail due to sh not being bash and it did not produce noisy output from deno.
