### PR TITLE
handle invalid URL in Location header for fetch()

### DIFF
--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1229,6 +1229,7 @@ pub const Fetch = struct {
                     error.FailedToOpenSocket => bun.String.static("Was there a typo in the url or port?"),
                     error.TooManyRedirects => bun.String.static("The response redirected too many times. For more information, pass `verbose: true` in the second argument to fetch()"),
                     error.ConnectionRefused => bun.String.static("Unable to connect. Is the computer able to access the url?"),
+                    error.RedirectURLInvalid => bun.String.static("Redirect URL in Location header is invalid."),
 
                     error.UNABLE_TO_GET_ISSUER_CERT => bun.String.static("unable to get issuer certificate"),
                     error.UNABLE_TO_GET_CRL => bun.String.static("unable to get certificate CRL"),

--- a/src/http.zig
+++ b/src/http.zig
@@ -3574,6 +3574,10 @@ pub fn handleResponseMetadata(
 
                             const normalized_url = JSC.URL.hrefFromString(bun.String.fromBytes(string_builder.allocatedSlice()));
                             defer normalized_url.deref();
+                            if (normalized_url.tag == .Dead) {
+                                // URL__getHref failed, dont pass dead tagged string to toOwnedSlice.
+                                return error.RedirectURLInvalid;
+                            }
                             const normalized_url_str = try normalized_url.toOwnedSlice(bun.default_allocator);
 
                             const new_url = URL.parse(normalized_url_str);

--- a/src/output.zig
+++ b/src/output.zig
@@ -772,7 +772,7 @@ pub inline fn err(error_name: anytype, comptime fmt: []const u8, args: anytype) 
                 }
 
                 // TODO: convert zig errors to errno for better searchability?
-                if (errors.len == 1) break :display_name .{ comptime @errorName(errors[0]), true };
+                if (errors.len == 1) break :display_name .{ errors[0].name, true };
             }
 
             break :display_name .{ @errorName(error_name), false };


### PR DESCRIPTION
Closes https://github.com/oven-sh/bun/issues/9273

before:

crash and stack trace from above

after:

```
RedirectURLInvalid: Redirect URL in Location header is invalid.
 path: "http://localhost:3000/"
```
