### PR TITLE
fix integer overflow on subprocess deinit

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1093,12 +1093,14 @@ pub const Subprocess = struct {
                 }
             }
 
+            // we check if ref_count is already zero because we might reach this function
+            // through the deinit function passed to bun.NewRefCounted(..., deinitFn).
             switch (this.*) {
                 .buffer => {
-                    this.buffer.deref();
+                    if (this.buffer.ref_count > 0) this.buffer.deref();
                 },
                 .pipe => {
-                    this.pipe.deref();
+                    if (this.pipe.ref_count > 0) this.pipe.deref();
                 },
                 else => {},
             }

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1097,10 +1097,10 @@ pub const Subprocess = struct {
             // through the deinit function passed to bun.NewRefCounted(..., deinitFn).
             switch (this.*) {
                 .buffer => {
-                    if (this.buffer.ref_count > 0) this.buffer.deref();
+                    this.buffer.deref();
                 },
                 .pipe => {
-                    if (this.pipe.ref_count > 0) this.pipe.deref();
+                    this.pipe.deref();
                 },
                 else => {},
             }

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1093,8 +1093,6 @@ pub const Subprocess = struct {
                 }
             }
 
-            // we check if ref_count is already zero because we might reach this function
-            // through the deinit function passed to bun.NewRefCounted(..., deinitFn).
             switch (this.*) {
                 .buffer => {
                     this.buffer.deref();

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -790,7 +790,7 @@ const PosixBufferedReader = struct {
 
     pub fn deinit(this: *PosixBufferedReader) void {
         this.buffer().clearAndFree();
-        this.closeHandle();
+        this.closeWithoutReporting();
     }
 
     pub fn onError(this: *PosixBufferedReader, err: bun.sys.Error) void {

--- a/src/io/PipeWriter.zig
+++ b/src/io/PipeWriter.zig
@@ -653,7 +653,7 @@ pub fn PosixStreamingWriter(
 
         pub fn deinit(this: *PosixWriter) void {
             this.buffer.clearAndFree();
-            this.close();
+            this.closeWithoutReporting();
         }
 
         pub fn hasRef(this: *PosixWriter) bool {


### PR DESCRIPTION
### What does this PR do?
`deref` on subprocess readable/writable pipes would call `deref` again in the `deinit` callback
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
