### PR TITLE
make `import.meta` behave better when query string is provided

### DIFF
--- a/src/bun.js/bindings/ImportMetaObject.cpp
+++ b/src/bun.js/bindings/ImportMetaObject.cpp
@@ -1,3 +1,4 @@
+#include "JavaScriptCore/JSCJSValue.h"
 #include "root.h"
 #include "headers.h"
 
@@ -46,6 +47,7 @@
 #include "CommonJSModuleRecord.h"
 #include <JavaScriptCore/JSPromise.h>
 #include "PathInlines.h"
+#include "wtf/text/StringView.h"
 
 namespace Zig {
 using namespace JSC;
@@ -125,22 +127,44 @@ static JSC::EncodedJSValue functionRequireResolve(JSC::JSGlobalObject* globalObj
     }
 }
 
-Zig::ImportMetaObject* Zig::ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JSValue key)
+ImportMetaObject* ImportMetaObject::create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const WTF::String& url)
 {
-    if (WebCore::DOMURL* domURL = WebCoreCast<WebCore::JSDOMURL, WebCore__DOMURL>(JSValue::encode(key))) {
-        return create(globalObject, JSC::jsString(globalObject->vm(), domURL->href().fileSystemPath()));
+    ImportMetaObject* ptr = new (NotNull, JSC::allocateCell<ImportMetaObject>(vm)) ImportMetaObject(vm, structure, url);
+    ptr->finishCreation(vm);
+    return ptr;
+}
+
+ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, const WTF::String& url)
+{
+    VM& vm = globalObject->vm();
+    Zig::GlobalObject* zigGlobalObject = jsCast<Zig::GlobalObject*>(globalObject);
+    auto structure = zigGlobalObject->ImportMetaObjectStructure();
+    return create(vm, globalObject, structure, url);
+}
+
+ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JSValue specifierOrURL)
+{
+    if (WebCore::DOMURL* url = WebCoreCast<WebCore::JSDOMURL, WebCore__DOMURL>(JSValue::encode(specifierOrURL))) {
+        return create(globalObject, url->href().string());
     }
 
-    auto* keyString = key.toStringOrNull(globalObject);
-    if (UNLIKELY(!keyString)) {
-        return nullptr;
-    }
+    WTF::String specifier = specifierOrURL.toWTFString(globalObject);
+    ASSERT(specifier);
+    return ImportMetaObject::createFromSpecifier(globalObject, specifier);
+}
 
-    if (keyString->value(globalObject).startsWith("file://"_s)) {
-        return create(globalObject, JSC::jsString(globalObject->vm(), WTF::URL(keyString->value(globalObject)).fileSystemPath()));
+ImportMetaObject* ImportMetaObject::createFromSpecifier(JSC::JSGlobalObject* globalObject, const String& specifier)
+{
+    auto index = specifier.find('?');
+    URL url;
+    if (index != notFound) {
+        StringView view = specifier;
+        url = URL::fileURLWithFileSystemPath(view.substring(0, index));
+        url.setQuery(view.substring(index + 1));
+    } else {
+        url = URL::fileURLWithFileSystemPath(specifier);
     }
-
-    return create(globalObject, keyString);
+    return create(globalObject, url.string());
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionRequireResolve);
@@ -374,30 +398,6 @@ JSC_DEFINE_HOST_FUNCTION(functionImportMeta__resolve,
     }
 }
 
-enum class ImportMetaPropertyOffset : uint32_t {
-    url,
-    dir,
-    file,
-    path,
-    require,
-};
-static constexpr uint32_t numberOfImportMetaProperties = 5;
-
-Zig::ImportMetaObject* ImportMetaObject::create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const WTF::String& url)
-{
-    ImportMetaObject* ptr = new (NotNull, JSC::allocateCell<ImportMetaObject>(vm)) ImportMetaObject(vm, structure, url);
-    ptr->finishCreation(vm);
-    return ptr;
-}
-Zig::ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* jslobalObject, JSC::JSString* keyString)
-{
-    auto* globalObject = jsCast<Zig::GlobalObject*>(jslobalObject);
-    auto& vm = globalObject->vm();
-    auto view = keyString->value(globalObject);
-    JSC::Structure* structure = globalObject->ImportMetaObjectStructure();
-    return Zig::ImportMetaObject::create(vm, globalObject, structure, view);
-}
-
 JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_url, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
 {
     ImportMetaObject* thisObject = jsDynamicCast<ImportMetaObject*>(JSValue::decode(thisValue));
@@ -406,6 +406,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_url, (JSGlobalObject * globalO
 
     return JSValue::encode(thisObject->urlProperty.getInitializedOnMainThread(thisObject));
 }
+
 JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_dir, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
 {
     ImportMetaObject* thisObject = jsDynamicCast<ImportMetaObject*>(JSValue::decode(thisValue));
@@ -414,6 +415,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_dir, (JSGlobalObject * globalO
 
     return JSValue::encode(thisObject->dirProperty.getInitializedOnMainThread(thisObject));
 }
+
 JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_file, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
 {
     ImportMetaObject* thisObject = jsDynamicCast<ImportMetaObject*>(JSValue::decode(thisValue));
@@ -422,6 +424,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_file, (JSGlobalObject * global
 
     return JSValue::encode(thisObject->fileProperty.getInitializedOnMainThread(thisObject));
 }
+
 JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_path, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
 {
     ImportMetaObject* thisObject = jsDynamicCast<ImportMetaObject*>(JSValue::decode(thisValue));
@@ -430,6 +433,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_path, (JSGlobalObject * global
 
     return JSValue::encode(thisObject->pathProperty.getInitializedOnMainThread(thisObject));
 }
+
 JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_require, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
 {
     ImportMetaObject* thisObject = jsDynamicCast<ImportMetaObject*>(JSValue::decode(thisValue));
@@ -438,6 +442,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_require, (JSGlobalObject * glo
 
     return JSValue::encode(thisObject->requireProperty.getInitializedOnMainThread(thisObject));
 }
+
 JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_env, (JSGlobalObject * jsGlobalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
 {
     auto* globalObject = jsCast<Zig::GlobalObject*>(jsGlobalObject);
@@ -536,7 +541,6 @@ void ImportMetaObject::finishCreation(VM& vm)
         WTF::String path;
 
         if (url.isValid()) {
-
             if (url.protocolIsFile()) {
                 path = url.fileSystemPath();
             } else {
@@ -551,22 +555,18 @@ void ImportMetaObject::finishCreation(VM& vm)
     });
     this->urlProperty.initLater([](const JSC::LazyProperty<JSC::JSObject, JSC::JSString>::Initializer& init) {
         ImportMetaObject* meta = jsCast<ImportMetaObject*>(init.owner);
-        WTF::URL url = isAbsolutePath(meta->url) ? WTF::URL::fileURLWithFileSystemPath(meta->url) : WTF::URL(meta->url);
-
-        init.set(jsString(init.vm, url.string()));
+        init.set(jsString(init.vm, meta->url));
     });
     this->dirProperty.initLater([](const JSC::LazyProperty<JSC::JSObject, JSC::JSString>::Initializer& init) {
         ImportMetaObject* meta = jsCast<ImportMetaObject*>(init.owner);
 
-        WTF::URL url = isAbsolutePath(meta->url) ? WTF::URL::fileURLWithFileSystemPath(meta->url) : WTF::URL(meta->url);
+        WTF::URL url(meta->url);
         WTF::String dirname;
 
-        if (url.isValid()) {
-            if (url.protocolIsFile()) {
-                dirname = url.fileSystemPath();
-            } else {
-                dirname = url.path().toString();
-            }
+        if (url.protocolIsFile()) {
+            dirname = url.fileSystemPath();
+        } else {
+            dirname = url.path().toString();
         }
 
         if (dirname.endsWith(PLATFORM_SEP_s)) {
@@ -580,21 +580,16 @@ void ImportMetaObject::finishCreation(VM& vm)
     this->fileProperty.initLater([](const JSC::LazyProperty<JSC::JSObject, JSC::JSString>::Initializer& init) {
         ImportMetaObject* meta = jsCast<ImportMetaObject*>(init.owner);
 
-        WTF::URL url = isAbsolutePath(meta->url) ? WTF::URL::fileURLWithFileSystemPath(meta->url) : WTF::URL(meta->url);
+        WTF::URL url(meta->url);
         WTF::String path;
 
-        if (!url.isValid()) {
-            path = meta->url;
+        if (url.protocolIsFile()) {
+            path = url.fileSystemPath();
         } else {
-            if (url.protocolIsFile()) {
-                path = url.fileSystemPath();
-            } else {
-                path = url.path().toString();
-            }
+            path = url.path().toString();
         }
 
         WTF::String filename;
-
         if (path.endsWith(PLATFORM_SEP_s)) {
             filename = path.substring(path.reverseFind(PLATFORM_SEP, path.length() - 2) + 1);
         } else {
@@ -606,11 +601,8 @@ void ImportMetaObject::finishCreation(VM& vm)
     this->pathProperty.initLater([](const JSC::LazyProperty<JSC::JSObject, JSC::JSString>::Initializer& init) {
         ImportMetaObject* meta = jsCast<ImportMetaObject*>(init.owner);
 
-        WTF::URL url = isAbsolutePath(meta->url) ? WTF::URL::fileURLWithFileSystemPath(meta->url) : WTF::URL(meta->url);
-
-        if (!url.isValid()) {
-            init.set(jsString(init.vm, meta->url));
-        } else if (url.protocolIsFile()) {
+        WTF::URL url(meta->url);
+        if (url.protocolIsFile()) {
             init.set(jsString(init.vm, url.fileSystemPath()));
         } else {
             init.set(jsString(init.vm, url.path()));

--- a/src/bun.js/bindings/ImportMetaObject.h
+++ b/src/bun.js/bindings/ImportMetaObject.h
@@ -44,8 +44,8 @@ public:
     /// Fixing this means adjusting a lot of how the module resolver works to operate and handle URL
     /// escaping, see https://github.com/oven-sh/bun/issues/8640 for more details.
     ///
-    /// The above rules get a best estimate bandage to solve the problem stated in:
-    /// <TODO: Open PR as there is no issue>
+    /// The above rules get a best estimate bandage to solve the problems
+    /// stated in https://github.com/oven-sh/bun/pull/9399
     static ImportMetaObject* createFromSpecifier(JSC::JSGlobalObject* globalObject, const String& specifier);
 
     static ImportMetaObject* createRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, const WTF::String& pathString);

--- a/src/bun.js/bindings/ImportMetaObject.h
+++ b/src/bun.js/bindings/ImportMetaObject.h
@@ -23,12 +23,32 @@ class ImportMetaObject final : public JSC::JSNonFinalObject {
 public:
     using Base = JSC::JSNonFinalObject;
 
-    static ImportMetaObject* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const WTF::String& url);
+    /// Must be called with a valid url string (for `import.meta.url`)
+    static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, const String& url);
 
-    static JSObject* createRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, const WTF::String& pathString);
+    /// Creates an ImportMetaObject from a specifier or URL JSValue
+    /// - URL object -> use that url
+    /// - string -> see the below method for how the string is processed
+    /// - other -> assertion failure
+    static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSValue specifierOrURL);
 
-    static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSC::JSString* keyString);
-    static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSValue keyString);
+    /// TODO(@paperdave):
+    /// The rules for this function's input is a bit weird. `specifier` is an import path specifier aka a file path.
+    ///
+    /// - Should be an absolute path or name of a plugin module
+    /// - A '?' is handled not as a literal '?' in a file, but rather as the query string
+    /// - The string is not URL encoded, despite having a query string.
+    ///
+    /// caveat: It is impossible to have a module with a `?` in it's file name.
+    ///
+    /// Fixing this means adjusting a lot of how the module resolver works to operate and handle URL
+    /// escaping, see https://github.com/oven-sh/bun/issues/8640 for more details.
+    ///
+    /// The above rules get a best estimate bandage to solve the problem stated in:
+    /// <TODO: Open PR as there is no issue>
+    static ImportMetaObject* createFromSpecifier(JSC::JSGlobalObject* globalObject, const String& specifier);
+
+    static ImportMetaObject* createRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, const WTF::String& pathString);
 
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
@@ -57,6 +77,8 @@ public:
     LazyProperty<JSObject, JSString> pathProperty;
 
 private:
+    static ImportMetaObject* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const WTF::String& url);
+
     ImportMetaObject(JSC::VM& vm, JSC::Structure* structure, const WTF::String& url)
         : Base(vm, structure)
         , url(url)

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -4500,12 +4500,7 @@ JSC::JSObject* GlobalObject::moduleLoaderCreateImportMetaProperties(JSGlobalObje
     JSModuleRecord* record,
     JSValue val)
 {
-    JSC::VM& vm = globalObject->vm();
-    JSC::JSString* keyString = key.toStringOrNull(globalObject);
-    if (UNLIKELY(!keyString))
-        return JSC::constructEmptyObject(globalObject);
-
-    return Zig::ImportMetaObject::create(globalObject, keyString);
+    return Zig::ImportMetaObject::create(globalObject, key);
 }
 
 JSC::JSValue GlobalObject::moduleLoaderEvaluate(JSGlobalObject* lexicalGlobalObject,

--- a/test/js/bun/resolve/import-meta.test.js
+++ b/test/js/bun/resolve/import-meta.test.js
@@ -254,3 +254,17 @@ it("import.meta paths have the correct slash", () => {
   expect(import.meta.url).toStartWith("file:///");
   expect(import.meta.url).not.toInclude("\\");
 });
+
+it("import.meta is correct in a module that was imported with a query param", async () => {
+  const esm = (await import("./other.js?foo=bar")).default;
+  const cjs = require("./other-cjs.js?foo=bar").meta;
+
+  expect(esm.url).toBe(new URL("./other.js?foo=bar", import.meta.url).toString());
+  expect(cjs.url).toBe(new URL("./other-cjs.js?foo=bar", import.meta.url).toString());
+  expect(esm.path).toBe(join(import.meta.dir, "./other.js"));
+  expect(cjs.path).toBe(join(import.meta.dir, "./other-cjs.js"));
+  expect(esm.dir).toBe(import.meta.dir);
+  expect(cjs.dir).toBe(import.meta.dir);
+  expect(esm.file).toBe("other.js");
+  expect(cjs.file).toBe("other-cjs.js");
+});

--- a/test/js/bun/resolve/other-cjs.js
+++ b/test/js/bun/resolve/other-cjs.js
@@ -1,0 +1,1 @@
+module.exports = { meta: import.meta };

--- a/test/js/bun/resolve/other.js
+++ b/test/js/bun/resolve/other.js
@@ -1,0 +1,1 @@
+export default import.meta;


### PR DESCRIPTION
### What does this PR do?

Fixes #8538

While investigating this crash, I noticed import.meta is just wrong in this situation

![image](https://github.com/oven-sh/bun/assets/24465214/67784bf2-3a09-4b5d-bd84-fb3a5c39df91)

So this fixes that issue, which in turn just fixes the Windows crash for me.

What is hard about this situation is that our resolver does not actually handle URLs at all. It believes everything is a file path, which is troubling, because it is impossible to import or run a file with a `?` in it, as it thinks it includes a query string. And using %3F does not work either due to #8640

![image](https://github.com/oven-sh/bun/assets/24465214/db20ee9a-db66-4af8-83d3-a4f2b6c1fdef)

To prevent making potentially large changes to the resolver and module loading code, there is a best effort attempt to make current cases work, as well as a new assertion in `ImportMetaObject::create` to make sure it is not possible to create a bad import meta object.

### How did you verify your code works?

Added a new test, including `import.meta` in a `.cjs` file.