### PR TITLE
fix(install): make sure `trustedDependencies` is updated after removing packages

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1979,9 +1979,9 @@ const WindowsStat = extern struct {
 
 pub const Stat = if (Environment.isWindows) windows.libuv.uv_stat_t else std.os.Stat;
 
-var _argv: [][:0]u8 = &[_][:0]u8{};
+var _argv: [][:0]const u8 = &[_][:0]const u8{};
 
-pub inline fn argv() [][:0]u8 {
+pub inline fn argv() [][:0]const u8 {
     return _argv;
 }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1177,7 +1177,7 @@ pub const Command = struct {
 
     // std.process.args allocates!
     const ArgsIterator = struct {
-        buf: [][:0]u8 = undefined,
+        buf: [][:0]const u8 = undefined,
         i: u32 = 0,
 
         pub fn next(this: *ArgsIterator) ?[]const u8 {
@@ -1415,7 +1415,7 @@ pub const Command = struct {
                 var ctx = try Command.Context.create(allocator, log, .BunxCommand);
                 ctx.debug.run_in_bun = true; // force the same version of bun used. fixes bun-debug for example
                 var args = bun.argv()[0..];
-                args[1] = @constCast("bun-repl");
+                args[1] = "bun-repl";
                 try BunxCommand.exec(ctx, args);
                 return;
             },

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -89,7 +89,7 @@ pub const InitCommand = struct {
         entry_point: string = "",
     };
 
-    pub fn exec(alloc: std.mem.Allocator, argv: [][:0]u8) !void {
+    pub fn exec(alloc: std.mem.Allocator, argv: [][:0]const u8) !void {
         const print_help = brk: {
             for (argv) |arg| {
                 if (strings.eqlComptime(arg, "--help")) {

--- a/src/deps/zig-clap/clap/args.zig
+++ b/src/deps/zig-clap/clap/args.zig
@@ -50,7 +50,7 @@ pub const OsIterator = struct {
     const Error = process.ArgIterator.InitError;
 
     arena: @import("root").bun.ArenaAllocator,
-    remain: [][:0]u8,
+    remain: [][:0]const u8,
 
     /// The executable path (this is the first argument passed to the program)
     /// TODO: Is it the right choice for this to be null? Maybe `init` should

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9682,6 +9682,11 @@ pub const PackageManager = struct {
 
                         manager.lockfile.overrides = try lockfile.overrides.clone(&lockfile, manager.lockfile, builder);
 
+                        manager.lockfile.trusted_dependencies = if (lockfile.trusted_dependencies) |trusted_dependencies|
+                            try trusted_dependencies.clone(manager.lockfile.allocator)
+                        else
+                            null;
+
                         try manager.lockfile.buffers.dependencies.ensureUnusedCapacity(manager.lockfile.allocator, len);
                         try manager.lockfile.buffers.resolutions.ensureUnusedCapacity(manager.lockfile.allocator, len);
 

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -14,25 +14,25 @@ var testCounter: number = 0;
 var port: number = 4873;
 var packageDir: string;
 
-beforeAll(async () => {
-  verdaccioServer = fork(
-    await import.meta.resolve("verdaccio/bin/verdaccio"),
-    ["-c", join(import.meta.dir, "verdaccio.yaml"), "-l", `${port}`],
-    { silent: true, execPath: "bun" },
-  );
+// beforeAll(async () => {
+//   verdaccioServer = fork(
+//     await import.meta.resolve("verdaccio/bin/verdaccio"),
+//     ["-c", join(import.meta.dir, "verdaccio.yaml"), "-l", `${port}`],
+//     { silent: true, execPath: "bun" },
+//   );
 
-  await new Promise<void>(done => {
-    verdaccioServer.on("message", (msg: { verdaccio_started: boolean }) => {
-      if (msg.verdaccio_started) {
-        done();
-      }
-    });
-  });
-});
+//   await new Promise<void>(done => {
+//     verdaccioServer.on("message", (msg: { verdaccio_started: boolean }) => {
+//       if (msg.verdaccio_started) {
+//         done();
+//       }
+//     });
+//   });
+// });
 
-afterAll(() => {
-  verdaccioServer.kill();
-});
+// afterAll(() => {
+//   verdaccioServer.kill();
+// });
 
 beforeEach(async () => {
   packageDir = mkdtempSync(join(realpathSync(tmpdir()), "bun-install-registry-" + testCounter++ + "-"));
@@ -1224,50 +1224,51 @@ describe("hoisting", async () => {
 });
 
 describe("workspaces", async () => {
-  test("it should detect duplicate workspace dependencies", async () => {
-    await writeFile(
-      join(packageDir, "package.json"),
-      JSON.stringify({
-        name: "foo",
-        workspaces: ["packages/*"],
-      }),
-    );
+  // test("it should detect duplicate workspace dependencies", async () => {
+  //   await writeFile(
+  //     join(packageDir, "package.json"),
+  //     JSON.stringify({
+  //       name: "foo",
+  //       workspaces: ["packages/*"],
+  //     }),
+  //   );
 
-    await mkdir(join(packageDir, "packages", "pkg1"), { recursive: true });
-    await writeFile(join(packageDir, "packages", "pkg1", "package.json"), JSON.stringify({ name: "pkg1" }));
-    await mkdir(join(packageDir, "packages", "pkg2"), { recursive: true });
-    await writeFile(join(packageDir, "packages", "pkg2", "package.json"), JSON.stringify({ name: "pkg1" }));
+  //   await mkdir(join(packageDir, "packages", "pkg1"), { recursive: true });
+  //   await writeFile(join(packageDir, "packages", "pkg1", "package.json"), JSON.stringify({ name: "pkg1" }));
+  //   await mkdir(join(packageDir, "packages", "pkg2"), { recursive: true });
+  //   await writeFile(join(packageDir, "packages", "pkg2", "package.json"), JSON.stringify({ name: "pkg1" }));
 
-    var { stderr, exited } = spawn({
-      cmd: [bunExe(), "install"],
-      cwd: packageDir,
-      stdout: "pipe",
-      stdin: "pipe",
-      stderr: "pipe",
-      env,
-    });
+  //   var { stderr, exited } = spawn({
+  //     cmd: [bunExe(), "install"],
+  //     cwd: packageDir,
+  //     stdout: "pipe",
+  //     stdin: "pipe",
+  //     stderr: "pipe",
+  //     env,
+  //   });
 
-    var err = await new Response(stderr).text();
-    expect(err).toContain('Workspace name "pkg1" already exists');
-    expect(await exited).toBe(1);
+  //   var err = await new Response(stderr).text();
+  //   expect(err).toContain('Workspace name "pkg1" already exists');
+  //   expect(await exited).toBe(1);
 
-    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
-    await rm(join(packageDir, "bun.lockb"), { force: true });
+  //   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  //   await rm(join(packageDir, "bun.lockb"), { force: true });
 
-    ({ stderr, exited } = spawn({
-      cmd: [bunExe(), "install"],
-      cwd: join(packageDir, "packages", "pkg1"),
-      stdout: "pipe",
-      stdin: "pipe",
-      stderr: "pipe",
-      env,
-    }));
+  //   ({ stderr, exited } = spawn({
+  //     cmd: [bunExe(), "install"],
+  //     cwd: join(packageDir, "packages", "pkg1"),
+  //     stdout: "pipe",
+  //     stdin: "pipe",
+  //     stderr: "pipe",
+  //     env,
+  //   }));
 
-    err = await new Response(stderr).text();
-    expect(err).toContain('Workspace name "pkg1" already exists');
-    expect(await exited).toBe(1);
-  });
+  //   err = await new Response(stderr).text();
+  //   expect(err).toContain('Workspace name "pkg1" already exists');
+  //   expect(await exited).toBe(1);
+  // });
   const versions = ["workspace:1.0.0", "workspace:*", "workspace:^1.0.0", "1.0.0", "*"];
+  // const versions = ["workspace:1.0.0"];
 
   for (const rootVersion of versions) {
     for (const packageVersion of versions) {
@@ -1399,133 +1400,133 @@ describe("workspaces", async () => {
       });
     }
   }
-  for (const version of versions) {
-    test(`it should allow listing workspace as dependency of the root package version ${version}`, async () => {
-      await writeFile(
-        join(packageDir, "package.json"),
-        JSON.stringify({
-          name: "foo",
-          workspaces: ["packages/*"],
-          dependencies: {
-            "workspace-1": version,
-          },
-        }),
-      );
+  // for (const version of versions) {
+  //   test(`it should allow listing workspace as dependency of the root package version ${version}`, async () => {
+  //     await writeFile(
+  //       join(packageDir, "package.json"),
+  //       JSON.stringify({
+  //         name: "foo",
+  //         workspaces: ["packages/*"],
+  //         dependencies: {
+  //           "workspace-1": version,
+  //         },
+  //       }),
+  //     );
 
-      await mkdir(join(packageDir, "packages", "workspace-1"), { recursive: true });
-      await writeFile(
-        join(packageDir, "packages", "workspace-1", "package.json"),
-        JSON.stringify({
-          name: "workspace-1",
-          version: "1.0.0",
-        }),
-      );
-      // install first from the root, the the workspace package
-      var { stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: packageDir,
-        stdout: "pipe",
-        stdin: "pipe",
-        stderr: "pipe",
-        env,
-      });
+  //     await mkdir(join(packageDir, "packages", "workspace-1"), { recursive: true });
+  //     await writeFile(
+  //       join(packageDir, "packages", "workspace-1", "package.json"),
+  //       JSON.stringify({
+  //         name: "workspace-1",
+  //         version: "1.0.0",
+  //       }),
+  //     );
+  //     // install first from the root, the the workspace package
+  //     var { stdout, stderr, exited } = spawn({
+  //       cmd: [bunExe(), "install"],
+  //       cwd: packageDir,
+  //       stdout: "pipe",
+  //       stdin: "pipe",
+  //       stderr: "pipe",
+  //       env,
+  //     });
 
-      var err = await new Response(stderr).text();
-      var out = await new Response(stdout).text();
-      expect(err).toContain("Saved lockfile");
-      expect(err).not.toContain("already exists");
-      expect(err).not.toContain("not found");
-      expect(err).not.toContain("Duplicate dependency");
-      expect(err).not.toContain('workspace dependency "workspace-1" not found');
-      expect(err).not.toContain("error:");
-      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-        "",
-        ` + workspace-1@workspace:packages${sep}workspace-1`,
-        "",
-        " 1 package installed",
-      ]);
-      expect(await exited).toBe(0);
+  //     var err = await new Response(stderr).text();
+  //     var out = await new Response(stdout).text();
+  //     expect(err).toContain("Saved lockfile");
+  //     expect(err).not.toContain("already exists");
+  //     expect(err).not.toContain("not found");
+  //     expect(err).not.toContain("Duplicate dependency");
+  //     expect(err).not.toContain('workspace dependency "workspace-1" not found');
+  //     expect(err).not.toContain("error:");
+  //     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+  //       "",
+  //       ` + workspace-1@workspace:packages${sep}workspace-1`,
+  //       "",
+  //       " 1 package installed",
+  //     ]);
+  //     expect(await exited).toBe(0);
 
-      ({ stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: join(packageDir, "packages", "workspace-1"),
-        stdout: "pipe",
-        stdin: "pipe",
-        stderr: "pipe",
-        env,
-      }));
+  //     ({ stdout, stderr, exited } = spawn({
+  //       cmd: [bunExe(), "install"],
+  //       cwd: join(packageDir, "packages", "workspace-1"),
+  //       stdout: "pipe",
+  //       stdin: "pipe",
+  //       stderr: "pipe",
+  //       env,
+  //     }));
 
-      err = await new Response(stderr).text();
-      out = await new Response(stdout).text();
-      expect(err).not.toContain("Saved lockfile");
-      expect(err).not.toContain("not found");
-      expect(err).not.toContain("already exists");
-      expect(err).not.toContain("Duplicate dependency");
-      expect(err).not.toContain('workspace dependency "workspace-1" not found');
-      expect(err).not.toContain("error:");
-      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-        "",
-        ` + workspace-1@workspace:packages${sep}workspace-1`,
-        "",
-        " 1 package installed",
-      ]);
-      expect(await exited).toBe(0);
+  //     err = await new Response(stderr).text();
+  //     out = await new Response(stdout).text();
+  //     expect(err).not.toContain("Saved lockfile");
+  //     expect(err).not.toContain("not found");
+  //     expect(err).not.toContain("already exists");
+  //     expect(err).not.toContain("Duplicate dependency");
+  //     expect(err).not.toContain('workspace dependency "workspace-1" not found');
+  //     expect(err).not.toContain("error:");
+  //     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+  //       "",
+  //       ` + workspace-1@workspace:packages${sep}workspace-1`,
+  //       "",
+  //       " 1 package installed",
+  //     ]);
+  //     expect(await exited).toBe(0);
 
-      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
-      await rm(join(packageDir, "bun.lockb"), { recursive: true, force: true });
+  //     await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  //     await rm(join(packageDir, "bun.lockb"), { recursive: true, force: true });
 
-      // install from workspace package then from root
-      ({ stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: join(packageDir, "packages", "workspace-1"),
-        stdout: "pipe",
-        stdin: "pipe",
-        stderr: "pipe",
-        env,
-      }));
+  //     // install from workspace package then from root
+  //     ({ stdout, stderr, exited } = spawn({
+  //       cmd: [bunExe(), "install"],
+  //       cwd: join(packageDir, "packages", "workspace-1"),
+  //       stdout: "pipe",
+  //       stdin: "pipe",
+  //       stderr: "pipe",
+  //       env,
+  //     }));
 
-      err = await new Response(stderr).text();
-      out = await new Response(stdout).text();
-      expect(err).toContain("Saved lockfile");
-      expect(err).not.toContain("already exists");
-      expect(err).not.toContain("not found");
-      expect(err).not.toContain("Duplicate dependency");
-      expect(err).not.toContain('workspace dependency "workspace-1" not found');
-      expect(err).not.toContain("error:");
-      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-        "",
-        ` + workspace-1@workspace:packages${sep}workspace-1`,
-        "",
-        " 1 package installed",
-      ]);
-      expect(await exited).toBe(0);
+  //     err = await new Response(stderr).text();
+  //     out = await new Response(stdout).text();
+  //     expect(err).toContain("Saved lockfile");
+  //     expect(err).not.toContain("already exists");
+  //     expect(err).not.toContain("not found");
+  //     expect(err).not.toContain("Duplicate dependency");
+  //     expect(err).not.toContain('workspace dependency "workspace-1" not found');
+  //     expect(err).not.toContain("error:");
+  //     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+  //       "",
+  //       ` + workspace-1@workspace:packages${sep}workspace-1`,
+  //       "",
+  //       " 1 package installed",
+  //     ]);
+  //     expect(await exited).toBe(0);
 
-      ({ stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: packageDir,
-        stdout: "pipe",
-        stdin: "pipe",
-        stderr: "pipe",
-        env,
-      }));
+  //     ({ stdout, stderr, exited } = spawn({
+  //       cmd: [bunExe(), "install"],
+  //       cwd: packageDir,
+  //       stdout: "pipe",
+  //       stdin: "pipe",
+  //       stderr: "pipe",
+  //       env,
+  //     }));
 
-      err = await new Response(stderr).text();
-      out = await new Response(stdout).text();
-      expect(err).not.toContain("Saved lockfile");
-      expect(err).not.toContain("already exists");
-      expect(err).not.toContain("not found");
-      expect(err).not.toContain("Duplicate dependency");
-      expect(err).not.toContain('workspace dependency "workspace-1" not found');
-      expect(err).not.toContain("error:");
-      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-        "",
-        ` + workspace-1@workspace:packages${sep}workspace-1`,
-        "",
-        " 1 package installed",
-      ]);
-      expect(await exited).toBe(0);
-    });
-  }
+  //     err = await new Response(stderr).text();
+  //     out = await new Response(stdout).text();
+  //     expect(err).not.toContain("Saved lockfile");
+  //     expect(err).not.toContain("already exists");
+  //     expect(err).not.toContain("not found");
+  //     expect(err).not.toContain("Duplicate dependency");
+  //     expect(err).not.toContain('workspace dependency "workspace-1" not found');
+  //     expect(err).not.toContain("error:");
+  //     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+  //       "",
+  //       ` + workspace-1@workspace:packages${sep}workspace-1`,
+  //       "",
+  //       " 1 package installed",
+  //     ]);
+  //     expect(await exited).toBe(0);
+  //   });
+  // }
 });
 
 test("it should re-populate .bin folder if package is reinstalled", async () => {
@@ -3709,6 +3710,181 @@ for (const forceWaiterThread of [false, true]) {
       expect(await exited).toBe(0);
 
       expect(await exists(join(packageDir, "postinstall.txt"))).toBeTrue();
+    });
+
+    describe("add trusted, delete, then add again", async () => {
+      for (const withRm of [true, false]) {
+        test.only(withRm ? "withRm" : "withoutRm", async () => {
+          await writeFile(
+            join(packageDir, "package.json"),
+            JSON.stringify({
+              name: "foo",
+              dependencies: {
+                "no-deps": "1.0.0",
+                "uses-what-bin": "1.0.0",
+              },
+            }),
+          );
+
+          let { stdout, stderr, exited } = spawn({
+            cmd: [bunExe(), "install"],
+            cwd: packageDir,
+            stdout: "pipe",
+            stderr: "pipe",
+            env,
+          });
+
+          let err = await Bun.readableStreamToText(stderr);
+          expect(err).toContain("Saved lockfile");
+          expect(err).not.toContain("not found");
+          expect(err).not.toContain("error:");
+          expect(err).not.toContain("warn:");
+          let out = await Bun.readableStreamToText(stdout);
+          expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+            "",
+            " + no-deps@1.0.0",
+            " + uses-what-bin@1.0.0",
+            "",
+            expect.stringContaining("3 packages installed"),
+            "",
+            " Blocked 1 postinstall. Run `bun pm untrusted` for details.",
+            "",
+          ]);
+          expect(await exited).toBe(0);
+          expect(await exists(join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeFalse();
+
+          ({ stdout, stderr, exited } = spawn({
+            cmd: [bunExe(), "pm", "trust", "uses-what-bin"],
+            cwd: packageDir,
+            stdout: "pipe",
+            stderr: "pipe",
+            env,
+          }));
+
+          err = await Bun.readableStreamToText(stderr);
+          expect(err).not.toContain("error:");
+          expect(err).not.toContain("warn:");
+          out = await Bun.readableStreamToText(stdout);
+          expect(out).toContain("1 script ran across 1 package");
+          expect(await exited).toBe(0);
+
+          expect(await exists(join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
+          expect(await file(join(packageDir, "package.json")).json()).toEqual({
+            name: "foo",
+            dependencies: {
+              "no-deps": "1.0.0",
+              "uses-what-bin": "1.0.0",
+            },
+            trustedDependencies: ["uses-what-bin"],
+          });
+
+          // now remove and install again
+          if (withRm) {
+            ({ stdout, stderr, exited } = spawn({
+              cmd: [bunExe(), "rm", "uses-what-bin"],
+              cwd: packageDir,
+              stdout: "pipe",
+              stderr: "pipe",
+              env,
+            }));
+
+            err = await Bun.readableStreamToText(stderr);
+            expect(err).toContain("Saved lockfile");
+            expect(err).not.toContain("not found");
+            expect(err).not.toContain("error:");
+            expect(err).not.toContain("warn:");
+            out = await Bun.readableStreamToText(stdout);
+            expect(out).toContain("1 package removed");
+            expect(out).toContain("uses-what-bin");
+            expect(await exited).toBe(0);
+          }
+          await writeFile(
+            join(packageDir, "package.json"),
+            JSON.stringify({
+              name: "foo",
+              dependencies: {
+                "no-deps": "1.0.0",
+              },
+            }),
+          );
+
+          ({ stdout, stderr, exited } = spawn({
+            cmd: [bunExe(), "install"],
+            cwd: packageDir,
+            stdout: "pipe",
+            stderr: "pipe",
+            env,
+          }));
+
+          err = await Bun.readableStreamToText(stderr);
+          expect(err).toContain("Saved lockfile");
+          expect(err).not.toContain("not found");
+          expect(err).not.toContain("error:");
+          expect(err).not.toContain("warn:");
+          out = await Bun.readableStreamToText(stdout);
+          let expected = withRm
+            ? ["", "Checked 1 install across 2 packages (no changes)"]
+            : ["", expect.stringContaining("1 package removed")];
+          expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual(expected);
+          expect(await exited).toBe(0);
+          expect(await exists(join(packageDir, "node_modules", "uses-what-bin"))).toBe(!withRm);
+
+          // add again, bun pm untrusted should report it as untrusted
+
+          await writeFile(
+            join(packageDir, "package.json"),
+            JSON.stringify({
+              name: "foo",
+              dependencies: {
+                "no-deps": "1.0.0",
+                "uses-what-bin": "1.0.0",
+              },
+            }),
+          );
+
+          ({ stdout, stderr, exited } = spawn({
+            cmd: [bunExe(), "i"],
+            cwd: packageDir,
+            stdout: "pipe",
+            stderr: "pipe",
+            env,
+          }));
+
+          err = await Bun.readableStreamToText(stderr);
+          expect(err).toContain("Saved lockfile");
+          expect(err).not.toContain("not found");
+          expect(err).not.toContain("error:");
+          expect(err).not.toContain("warn:");
+          out = await Bun.readableStreamToText(stdout);
+          expected = withRm
+            ? [
+                "",
+                " + uses-what-bin@1.0.0",
+                "",
+                expect.stringContaining("1 package installed"),
+                "",
+                " Blocked 1 postinstall. Run `bun pm untrusted` for details.",
+                "",
+              ]
+            : ["", expect.stringContaining("Checked 3 installs across 4 packages (no changes)")];
+          expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual(expected);
+
+          ({ stdout, stderr, exited } = spawn({
+            cmd: [bunExe(), "pm", "untrusted"],
+            cwd: packageDir,
+            stdout: "pipe",
+            stderr: "pipe",
+            env,
+          }));
+
+          err = await Bun.readableStreamToText(stderr);
+          expect(err).not.toContain("error:");
+          expect(err).not.toContain("warn:");
+          out = await Bun.readableStreamToText(stdout);
+          expect(out).toContain("./node_modules/uses-what-bin @1.0.0");
+          expect(await exited).toBe(0);
+        });
+      }
     });
   });
 }

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -3712,6 +3712,8 @@ for (const forceWaiterThread of [false, true]) {
     });
 
     describe("add trusted, delete, then add again", async () => {
+      // when we change bun install to delete dependencies from node_modules
+      // for both cases, we need to update this test
       for (const withRm of [true, false]) {
         test.only(withRm ? "withRm" : "withoutRm", async () => {
           await writeFile(

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -14,25 +14,25 @@ var testCounter: number = 0;
 var port: number = 4873;
 var packageDir: string;
 
-// beforeAll(async () => {
-//   verdaccioServer = fork(
-//     await import.meta.resolve("verdaccio/bin/verdaccio"),
-//     ["-c", join(import.meta.dir, "verdaccio.yaml"), "-l", `${port}`],
-//     { silent: true, execPath: "bun" },
-//   );
+beforeAll(async () => {
+  verdaccioServer = fork(
+    await import.meta.resolve("verdaccio/bin/verdaccio"),
+    ["-c", join(import.meta.dir, "verdaccio.yaml"), "-l", `${port}`],
+    { silent: true, execPath: "bun" },
+  );
 
-//   await new Promise<void>(done => {
-//     verdaccioServer.on("message", (msg: { verdaccio_started: boolean }) => {
-//       if (msg.verdaccio_started) {
-//         done();
-//       }
-//     });
-//   });
-// });
+  await new Promise<void>(done => {
+    verdaccioServer.on("message", (msg: { verdaccio_started: boolean }) => {
+      if (msg.verdaccio_started) {
+        done();
+      }
+    });
+  });
+});
 
-// afterAll(() => {
-//   verdaccioServer.kill();
-// });
+afterAll(() => {
+  verdaccioServer.kill();
+});
 
 beforeEach(async () => {
   packageDir = mkdtempSync(join(realpathSync(tmpdir()), "bun-install-registry-" + testCounter++ + "-"));
@@ -1224,51 +1224,50 @@ describe("hoisting", async () => {
 });
 
 describe("workspaces", async () => {
-  // test("it should detect duplicate workspace dependencies", async () => {
-  //   await writeFile(
-  //     join(packageDir, "package.json"),
-  //     JSON.stringify({
-  //       name: "foo",
-  //       workspaces: ["packages/*"],
-  //     }),
-  //   );
+  test("it should detect duplicate workspace dependencies", async () => {
+    await writeFile(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        workspaces: ["packages/*"],
+      }),
+    );
 
-  //   await mkdir(join(packageDir, "packages", "pkg1"), { recursive: true });
-  //   await writeFile(join(packageDir, "packages", "pkg1", "package.json"), JSON.stringify({ name: "pkg1" }));
-  //   await mkdir(join(packageDir, "packages", "pkg2"), { recursive: true });
-  //   await writeFile(join(packageDir, "packages", "pkg2", "package.json"), JSON.stringify({ name: "pkg1" }));
+    await mkdir(join(packageDir, "packages", "pkg1"), { recursive: true });
+    await writeFile(join(packageDir, "packages", "pkg1", "package.json"), JSON.stringify({ name: "pkg1" }));
+    await mkdir(join(packageDir, "packages", "pkg2"), { recursive: true });
+    await writeFile(join(packageDir, "packages", "pkg2", "package.json"), JSON.stringify({ name: "pkg1" }));
 
-  //   var { stderr, exited } = spawn({
-  //     cmd: [bunExe(), "install"],
-  //     cwd: packageDir,
-  //     stdout: "pipe",
-  //     stdin: "pipe",
-  //     stderr: "pipe",
-  //     env,
-  //   });
+    var { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
 
-  //   var err = await new Response(stderr).text();
-  //   expect(err).toContain('Workspace name "pkg1" already exists');
-  //   expect(await exited).toBe(1);
+    var err = await new Response(stderr).text();
+    expect(err).toContain('Workspace name "pkg1" already exists');
+    expect(await exited).toBe(1);
 
-  //   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
-  //   await rm(join(packageDir, "bun.lockb"), { force: true });
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await rm(join(packageDir, "bun.lockb"), { force: true });
 
-  //   ({ stderr, exited } = spawn({
-  //     cmd: [bunExe(), "install"],
-  //     cwd: join(packageDir, "packages", "pkg1"),
-  //     stdout: "pipe",
-  //     stdin: "pipe",
-  //     stderr: "pipe",
-  //     env,
-  //   }));
+    ({ stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: join(packageDir, "packages", "pkg1"),
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    }));
 
-  //   err = await new Response(stderr).text();
-  //   expect(err).toContain('Workspace name "pkg1" already exists');
-  //   expect(await exited).toBe(1);
-  // });
+    err = await new Response(stderr).text();
+    expect(err).toContain('Workspace name "pkg1" already exists');
+    expect(await exited).toBe(1);
+  });
   const versions = ["workspace:1.0.0", "workspace:*", "workspace:^1.0.0", "1.0.0", "*"];
-  // const versions = ["workspace:1.0.0"];
 
   for (const rootVersion of versions) {
     for (const packageVersion of versions) {
@@ -1400,133 +1399,133 @@ describe("workspaces", async () => {
       });
     }
   }
-  // for (const version of versions) {
-  //   test(`it should allow listing workspace as dependency of the root package version ${version}`, async () => {
-  //     await writeFile(
-  //       join(packageDir, "package.json"),
-  //       JSON.stringify({
-  //         name: "foo",
-  //         workspaces: ["packages/*"],
-  //         dependencies: {
-  //           "workspace-1": version,
-  //         },
-  //       }),
-  //     );
+  for (const version of versions) {
+    test(`it should allow listing workspace as dependency of the root package version ${version}`, async () => {
+      await writeFile(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          workspaces: ["packages/*"],
+          dependencies: {
+            "workspace-1": version,
+          },
+        }),
+      );
 
-  //     await mkdir(join(packageDir, "packages", "workspace-1"), { recursive: true });
-  //     await writeFile(
-  //       join(packageDir, "packages", "workspace-1", "package.json"),
-  //       JSON.stringify({
-  //         name: "workspace-1",
-  //         version: "1.0.0",
-  //       }),
-  //     );
-  //     // install first from the root, the the workspace package
-  //     var { stdout, stderr, exited } = spawn({
-  //       cmd: [bunExe(), "install"],
-  //       cwd: packageDir,
-  //       stdout: "pipe",
-  //       stdin: "pipe",
-  //       stderr: "pipe",
-  //       env,
-  //     });
+      await mkdir(join(packageDir, "packages", "workspace-1"), { recursive: true });
+      await writeFile(
+        join(packageDir, "packages", "workspace-1", "package.json"),
+        JSON.stringify({
+          name: "workspace-1",
+          version: "1.0.0",
+        }),
+      );
+      // install first from the root, the the workspace package
+      var { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
 
-  //     var err = await new Response(stderr).text();
-  //     var out = await new Response(stdout).text();
-  //     expect(err).toContain("Saved lockfile");
-  //     expect(err).not.toContain("already exists");
-  //     expect(err).not.toContain("not found");
-  //     expect(err).not.toContain("Duplicate dependency");
-  //     expect(err).not.toContain('workspace dependency "workspace-1" not found');
-  //     expect(err).not.toContain("error:");
-  //     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-  //       "",
-  //       ` + workspace-1@workspace:packages${sep}workspace-1`,
-  //       "",
-  //       " 1 package installed",
-  //     ]);
-  //     expect(await exited).toBe(0);
+      var err = await new Response(stderr).text();
+      var out = await new Response(stdout).text();
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("already exists");
+      expect(err).not.toContain("not found");
+      expect(err).not.toContain("Duplicate dependency");
+      expect(err).not.toContain('workspace dependency "workspace-1" not found');
+      expect(err).not.toContain("error:");
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        "",
+        ` + workspace-1@workspace:packages${sep}workspace-1`,
+        "",
+        " 1 package installed",
+      ]);
+      expect(await exited).toBe(0);
 
-  //     ({ stdout, stderr, exited } = spawn({
-  //       cmd: [bunExe(), "install"],
-  //       cwd: join(packageDir, "packages", "workspace-1"),
-  //       stdout: "pipe",
-  //       stdin: "pipe",
-  //       stderr: "pipe",
-  //       env,
-  //     }));
+      ({ stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: join(packageDir, "packages", "workspace-1"),
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      }));
 
-  //     err = await new Response(stderr).text();
-  //     out = await new Response(stdout).text();
-  //     expect(err).not.toContain("Saved lockfile");
-  //     expect(err).not.toContain("not found");
-  //     expect(err).not.toContain("already exists");
-  //     expect(err).not.toContain("Duplicate dependency");
-  //     expect(err).not.toContain('workspace dependency "workspace-1" not found');
-  //     expect(err).not.toContain("error:");
-  //     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-  //       "",
-  //       ` + workspace-1@workspace:packages${sep}workspace-1`,
-  //       "",
-  //       " 1 package installed",
-  //     ]);
-  //     expect(await exited).toBe(0);
+      err = await new Response(stderr).text();
+      out = await new Response(stdout).text();
+      expect(err).not.toContain("Saved lockfile");
+      expect(err).not.toContain("not found");
+      expect(err).not.toContain("already exists");
+      expect(err).not.toContain("Duplicate dependency");
+      expect(err).not.toContain('workspace dependency "workspace-1" not found');
+      expect(err).not.toContain("error:");
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        "",
+        ` + workspace-1@workspace:packages${sep}workspace-1`,
+        "",
+        " 1 package installed",
+      ]);
+      expect(await exited).toBe(0);
 
-  //     await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
-  //     await rm(join(packageDir, "bun.lockb"), { recursive: true, force: true });
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      await rm(join(packageDir, "bun.lockb"), { recursive: true, force: true });
 
-  //     // install from workspace package then from root
-  //     ({ stdout, stderr, exited } = spawn({
-  //       cmd: [bunExe(), "install"],
-  //       cwd: join(packageDir, "packages", "workspace-1"),
-  //       stdout: "pipe",
-  //       stdin: "pipe",
-  //       stderr: "pipe",
-  //       env,
-  //     }));
+      // install from workspace package then from root
+      ({ stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: join(packageDir, "packages", "workspace-1"),
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      }));
 
-  //     err = await new Response(stderr).text();
-  //     out = await new Response(stdout).text();
-  //     expect(err).toContain("Saved lockfile");
-  //     expect(err).not.toContain("already exists");
-  //     expect(err).not.toContain("not found");
-  //     expect(err).not.toContain("Duplicate dependency");
-  //     expect(err).not.toContain('workspace dependency "workspace-1" not found');
-  //     expect(err).not.toContain("error:");
-  //     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-  //       "",
-  //       ` + workspace-1@workspace:packages${sep}workspace-1`,
-  //       "",
-  //       " 1 package installed",
-  //     ]);
-  //     expect(await exited).toBe(0);
+      err = await new Response(stderr).text();
+      out = await new Response(stdout).text();
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("already exists");
+      expect(err).not.toContain("not found");
+      expect(err).not.toContain("Duplicate dependency");
+      expect(err).not.toContain('workspace dependency "workspace-1" not found');
+      expect(err).not.toContain("error:");
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        "",
+        ` + workspace-1@workspace:packages${sep}workspace-1`,
+        "",
+        " 1 package installed",
+      ]);
+      expect(await exited).toBe(0);
 
-  //     ({ stdout, stderr, exited } = spawn({
-  //       cmd: [bunExe(), "install"],
-  //       cwd: packageDir,
-  //       stdout: "pipe",
-  //       stdin: "pipe",
-  //       stderr: "pipe",
-  //       env,
-  //     }));
+      ({ stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      }));
 
-  //     err = await new Response(stderr).text();
-  //     out = await new Response(stdout).text();
-  //     expect(err).not.toContain("Saved lockfile");
-  //     expect(err).not.toContain("already exists");
-  //     expect(err).not.toContain("not found");
-  //     expect(err).not.toContain("Duplicate dependency");
-  //     expect(err).not.toContain('workspace dependency "workspace-1" not found');
-  //     expect(err).not.toContain("error:");
-  //     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-  //       "",
-  //       ` + workspace-1@workspace:packages${sep}workspace-1`,
-  //       "",
-  //       " 1 package installed",
-  //     ]);
-  //     expect(await exited).toBe(0);
-  //   });
-  // }
+      err = await new Response(stderr).text();
+      out = await new Response(stdout).text();
+      expect(err).not.toContain("Saved lockfile");
+      expect(err).not.toContain("already exists");
+      expect(err).not.toContain("not found");
+      expect(err).not.toContain("Duplicate dependency");
+      expect(err).not.toContain('workspace dependency "workspace-1" not found');
+      expect(err).not.toContain("error:");
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        "",
+        ` + workspace-1@workspace:packages${sep}workspace-1`,
+        "",
+        " 1 package installed",
+      ]);
+      expect(await exited).toBe(0);
+    });
+  }
 });
 
 test("it should re-populate .bin folder if package is reinstalled", async () => {

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -3715,7 +3715,7 @@ for (const forceWaiterThread of [false, true]) {
       // when we change bun install to delete dependencies from node_modules
       // for both cases, we need to update this test
       for (const withRm of [true, false]) {
-        test.only(withRm ? "withRm" : "withoutRm", async () => {
+        test(withRm ? "withRm" : "withoutRm", async () => {
           await writeFile(
             join(packageDir, "package.json"),
             JSON.stringify({


### PR DESCRIPTION
### What does this PR do?
Fixes bug when you remove a trusted dependency and install it again `bun pm untrusted` would not report the dependency.
<!-- **Please explain what your changes do**, example: -->



### How did you verify your code works?
Added a test.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
