### PR TITLE
fix: return object from `FileHandle#read` and `FileHandle#readv`

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -301,7 +301,8 @@ class FileHandle extends EventEmitter {
 
     try {
       this[kRef]();
-      return real_export.read(fd, buffer, offset, length, position);
+      const bytesRead = real_export.read(fd, buffer, offset, length, position);
+      return { bytesRead, buffer };
     } finally {
       this[kUnref]();
     }
@@ -313,7 +314,8 @@ class FileHandle extends EventEmitter {
 
     try {
       this[kRef]();
-      return real_export.readv(fd, buffers, position);
+      const bytesRead = real_export.readv(fd, buffers, position);
+      return { bytesRead, buffers };
     } finally {
       this[kUnref]();
     }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2159,6 +2159,18 @@ describe("fs/promises", () => {
   it("opendir should have a path property, issue#4995", async () => {
     expect((await fs.promises.opendir(".")).path).toBe(".");
   });
+
+  it("FileHandle#read returns object", async () => {
+    const fd = await fs.promises.open(__filename);
+    const buf = Buffer.alloc(10);
+    expect(await fd.read(buf, 0, 10, 0)).toEqual({ bytesRead: 10, buffer: buf });
+  });
+
+  it("FileHandle#readv returns object", async () => {
+    const fd = await fs.promises.open(__filename);
+    const buffers = [Buffer.alloc(10), Buffer.alloc(10)];
+    expect(await fd.readv(buffers, 0, 20, 0)).toEqual({ bytesRead: 20, buffers });
+  });
 });
 
 it("stat on a large file", () => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fixes the `FileHandle#read` and `FileHandle#readv` methods from `fs/promises` to return an object with bytes read and buffer(s) instead of just the number of bytes read. This brings these methods in line with the NodeJS implementation. See https://nodejs.org/api/fs.html#filehandlereadoptions.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

- [x] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
- [x] I tried to run the automated tests locally, but `bun setup` failed (presumably unrelated to my changes):

```
fatal: transport 'file' not allowed
fatal: Fetched in submodule path 'src/deps/base64', but it did not contain 3a5add8652076612a8407627a42c768736a4263f. Direct fetching of that commit failed.
```

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
