### PR TITLE
Add shell hanging tests

### DIFF
--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -2820,6 +2820,7 @@ pub const Interpreter = struct {
             if (this.currently_executing) |child| {
                 child.deinit();
             }
+            this.io.deinit();
             this.base.interpreter.allocator.destroy(this);
         }
     };

--- a/test/js/bun/shell/shell-hang-error-fixture.js
+++ b/test/js/bun/shell/shell-hang-error-fixture.js
@@ -1,0 +1,2 @@
+Bun.$.throws(true);
+await Bun.$`not-found-command-1234 || not-found-command-5678`;

--- a/test/js/bun/shell/shell-hang-error-or-success.js
+++ b/test/js/bun/shell/shell-hang-error-or-success.js
@@ -1,0 +1,2 @@
+Bun.$.throws(true);
+await Bun.$`not-found-command-1234 || echo 42`;

--- a/test/js/bun/shell/shell-hang-first-works-second-fails.js
+++ b/test/js/bun/shell/shell-hang-first-works-second-fails.js
@@ -1,0 +1,4 @@
+Bun.$.throws(true);
+
+await Bun.$`which node`;
+await Bun.$`which which bad-command-that-does-not-exist`;

--- a/test/js/bun/shell/shell-hang-fixture-success-and-success.js
+++ b/test/js/bun/shell/shell-hang-fixture-success-and-success.js
@@ -1,0 +1,2 @@
+Bun.$.throws(true);
+await Bun.$`which node && which node`;

--- a/test/js/bun/shell/shell-hang-success-and-error.js
+++ b/test/js/bun/shell/shell-hang-success-and-error.js
@@ -1,0 +1,2 @@
+Bun.$.throws(true);
+await Bun.$`echo 1 && not-found-command-1234`;

--- a/test/js/bun/shell/shell-hang-success-fixture.js
+++ b/test/js/bun/shell/shell-hang-success-fixture.js
@@ -1,0 +1,2 @@
+Bun.$.throws(true);
+await Bun.$`echo 1 && echo 2`;

--- a/test/js/bun/shell/shell-hang.test.ts
+++ b/test/js/bun/shell/shell-hang.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import "harness";
+import path from "path";
+
+// Pass by not hanging
+const fail = [
+  "./shell-hang-error-fixture.js",
+  "./shell-hang-success-and-error.js",
+  "./shell-hang-first-works-second-fails.js",
+];
+
+// Pass by not hanging AND a 0 exit code
+const pass = [
+  "./shell-hang-error-or-success.js",
+  "./shell-hang-fixture-success-and-success.js",
+  "./shell-hang-success-fixture.js",
+];
+
+describe("fail", () => {
+  test.each(fail)(
+    "%s",
+    fixture => {
+      expect([path.join(import.meta.dir, fixture)]).not.toRun();
+    },
+    500,
+  );
+});
+
+describe("pass", () => {
+  test.each(pass)(
+    "%s",
+    fixture => {
+      expect([path.join(import.meta.dir, fixture)]).toRun();
+    },
+    500,
+  );
+});


### PR DESCRIPTION
### What does this PR do?

@zackradisic here are tests that are failing in v1.0.31 and canary but not failing in v1.0.30

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
