### PR TITLE
Fix assertion failure when migrating package-lock.json

### DIFF
--- a/test/cli/install/migration/out-of-sync.test.ts
+++ b/test/cli/install/migration/out-of-sync.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "bun:test";
+import path from "node:path";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+test("doesn't error when the migration is out of sync", async () => {
+  const cwd = tempDirWithFiles("out-of-sync-1", {
+    "package.json": JSON.stringify({
+      "devDependencies": {
+        "lodash": "4.17.20",
+      },
+    }),
+    "package-lock.json": JSON.stringify({
+      "name": "reproo",
+      "lockfileVersion": 3,
+      "requires": true,
+      "packages": {
+        "": {
+          "dependencies": {
+            "lodash": "4.17.21",
+          },
+          "devDependencies": {
+            "lodash": "4.17.20",
+          },
+        },
+        "node_modules/lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity":
+            "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true,
+        },
+      },
+    }),
+  });
+
+  const subprocess = Bun.spawn([bunExe(), "install"], {
+    env: bunEnv,
+    cwd,
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+
+  await subprocess.exited;
+
+  expect(subprocess.exitCode).toBe(0);
+
+  let { stdout, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "pm", "ls"],
+    env: bunEnv,
+    cwd,
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  let out = stdout.toString().trim();
+  expect(out).toContain("lodash@4.17.20");
+  // only one lodash is installed
+  expect(out.lastIndexOf("lodash")).toEqual(out.indexOf("lodash"));
+  expect(exitCode).toBe(0);
+
+  expect(await Bun.file(path.join(cwd, "node_modules/lodash/package.json")).json()).toMatchObject({
+    version: "4.17.20",
+    name: "lodash",
+  });
+});


### PR DESCRIPTION


### What does this PR do?


When a package-lock.json is out of sync with the package.json and we attempt to migrate it, there is an integer overflow that can occur when adding up how many packages were added for the summary.

This doesn't seem to be an issue in release fast builds since we use `@truncate`, however it does come up in both debug and windows builds.

This doesn't feel like the best fix. It feels like we shouldn't be in this state in the first place. But i'm not 100% sure.


Fixes the following assertion failure:

```zig
bun install v1.0.32-canary.16 (17631ce6)
[0.41ms] migrated lockfile from package-lock.json

Panic: integer overflow

bun has crashed :'(

----- bun meta -----
Bun v1.0.32-canary.16 (17631ce6) Windows x64
InstallCommand:
Elapsed: 10ms | User: 0ms | Sys: 0ms
RSS: 55.74MB | Peak: 55.74MB | Commit: 90.94MB | Faults: 13770
----- bun meta -----

0   00007FF7F19CB9F8
1   ???
2   ???
3   ???
4   ???
5   ???
6   ???
7   ???
8   ???
9   ???

Search GitHub issues https://bun.sh/issues or join in #windows channel in https://bun.sh/discord

thread 33364 panic: integer overflow
???:?:?: 0x7ff7f050c612 in ??? (bun.exe)
???:?:?: 0x7ff7f0576af0 in ??? (bun.exe)
???:?:?: 0x7ff7f058ed7b in ??? (bun.exe)
???:?:?: 0x7ff7f063b2ca in ??? (bun.exe)
???:?:?: 0x7ff7f038157f in ??? (bun.exe)
???:?:?: 0x7ff7f2e81b23 in ??? (bun.exe)
???:?:?: 0x7ff93a98257c in ??? (KERNEL32.DLL)
???:?:?: 0x7ff93b88aa57 in ??? (ntdll.dll)
```

### How did you verify your code works?

There is a test