### PR TITLE
Fixes #9459 (shell mv regression)

### DIFF
--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -1,0 +1,46 @@
+import { $ } from "bun";
+import { describe, test, expect } from "bun:test";
+import { TestBuilder } from "../test_builder";
+import { sortedShellOutput } from "../util";
+
+describe("mv", async () => {
+  TestBuilder.command`echo foo > a; mv a b`.ensureTempDir().fileEquals("b", "foo\n").runAsTest("move file -> file");
+
+  TestBuilder.command`touch a; mkdir foo; mv a foo; ls foo`
+    .ensureTempDir()
+    .stdout("a\n")
+    .doesNotExist("a")
+    .runAsTest("move single file into a directory");
+
+  TestBuilder.command`mkdir d; mv a b c d/; ls d/`
+    .stdout(str => expect(sortedShellOutput(str)).toEqual(["a", "b", "c"]))
+    .ensureTempDir()
+    .file("a", "file")
+    .file("b", "file")
+    .file("c", "file")
+    .doesNotExist("a")
+    .doesNotExist("b")
+    .doesNotExist("c")
+    .runAsTest("move multiple files into a directory");
+
+  TestBuilder.command`mv file1.txt file2.txt does_not_exist/`
+    .exitCode(1)
+    .stderr("mv: does_not_exist/: No such file or directory\n")
+    .ensureTempDir()
+    .file("file1.txt", "hi")
+    .file("file1.txt", "hello")
+    .runAsTest("fails if destination folder does not exist");
+
+  TestBuilder.command`mkdir -p foo; mkdir -p bar; echo hi > foo/inside_foo; echo hi > bar/inside_bar; mv foo bar; ls -R bar`
+    .ensureTempDir()
+    .stdout(str =>
+      expect(sortedShellOutput(str)).toEqual(sortedShellOutput(["inside_bar", "foo", "bar/foo:", "inside_foo"])),
+    )
+    .runAsTest("move dir -> dir");
+
+  TestBuilder.command`touch a; mkdir -p foo; mv foo/ a`
+    .ensureTempDir()
+    .exitCode(20 /* ENOTDIR */)
+    .stderr("mv: a: Not a directory\n")
+    .runAsTest("move dir -> file fails");
+});

--- a/test/js/bun/shell/test_builder.ts
+++ b/test/js/bun/shell/test_builder.ts
@@ -30,6 +30,16 @@ export class TestBuilder {
     this.promise = promise;
   }
 
+  /**
+   * Start the test builder with a command:
+   *
+   * @example
+   * ```ts
+   * await TestBuilder.command`echo hi!`.stdout('hi!\n').run()
+
+   * TestBuilder.command`echo hi!`.stdout('hi!\n').runAsTest('echo works')
+   * ```
+   */
   static command(strings: TemplateStringsArray, ...expressions: any[]): TestBuilder {
     try {
       if (process.env.BUN_DEBUG_SHELL_LOG_CMD === "1") console.info("[ShellTestBuilder] Cmd", strings.join(""));
@@ -53,6 +63,20 @@ export class TestBuilder {
     return this;
   }
 
+  /**
+   * Create a file in a temp directory
+   * @param path Path to the new file, this will be inside the TestBuilder's temp directory
+   * @param contents Contents of the new file
+   * @returns
+   *
+   * @example
+   * ```ts
+   * TestBuilder.command`ls .`
+   *   .file('hi.txt', 'hi!')
+   *   .file('hello.txt', 'hello!')
+   *   .runAsTest('List files')
+   * ```
+   */
   file(path: string, contents: string): this {
     const tempdir = this.getTempDir();
     fs.writeFileSync(join(tempdir, path), contents);
@@ -76,6 +100,11 @@ export class TestBuilder {
     return this;
   }
 
+  /**
+   * Expect output from stdout
+   *
+   * @param expected - can either be a string or a function which itself calls `expect()`
+   */
   stdout(expected: string | ((stdout: string, tempDir: string) => void)): this {
     this.expected_stdout = expected;
     return this;
@@ -86,6 +115,12 @@ export class TestBuilder {
     return this;
   }
 
+  /**
+   * Makes this test use a temp directory:
+   * - The shell's cwd will be set to the temp directory
+   * - All FS functions on the `TestBuilder` will use this temp directory.
+   * @returns
+   */
   ensureTempDir(): this {
     this.getTempDir();
     return this;

--- a/test/js/bun/shell/util.ts
+++ b/test/js/bun/shell/util.ts
@@ -33,8 +33,5 @@ export const redirect = (opts?: Partial<typeof defaultRedirect>): typeof default
         ...opts,
       };
 
-export const sortedShellOutput = (output: string): string[] =>
-  output
-    .split("\n")
-    .filter(s => s.length > 0)
-    .sort();
+export const sortedShellOutput = (output: string | string[]): string[] =>
+  (Array.isArray(output) ? output : output.split("\n").filter(s => s.length > 0)).sort();


### PR DESCRIPTION
### What does this PR do?

Fixes #9459 and also adds `mv` tests

The target path in a `mv` command was pointing to undefined memory

- [x] Code changes

### How did you verify your code works?

Zig files changed:
- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
