### PR TITLE
test for #9472 and `bun pm trust` waiter thread bugfix

### DIFF
--- a/src/cli/pm_trusted_command.zig
+++ b/src/cli/pm_trusted_command.zig
@@ -341,7 +341,7 @@ pub const TrustCommand = struct {
                     if (info.skip) continue;
 
                     while (LifecycleScriptSubprocess.alive_count.load(.Monotonic) >= pm.options.max_concurrent_lifecycle_scripts) {
-                        if (PackageManager.verbose_install) {
+                        if (pm.options.log_level.isVerbose()) {
                             if (PackageManager.hasEnoughTimePassedBetweenWaitingMessages()) Output.prettyErrorln("<d>[PackageManager]<r> waiting for {d} scripts\n", .{LifecycleScriptSubprocess.alive_count.load(.Monotonic)});
                         }
 

--- a/src/cli/pm_trusted_command.zig
+++ b/src/cli/pm_trusted_command.zig
@@ -5,6 +5,7 @@ const logger = bun.logger;
 const Environment = bun.Environment;
 const Command = @import("../cli.zig").Command;
 const Install = @import("../install/install.zig");
+const LifecycleScriptSubprocess = Install.LifecycleScriptSubprocess;
 const PackageID = Install.PackageID;
 const String = @import("../install/semver.zig").String;
 const PackageManager = Install.PackageManager;
@@ -339,6 +340,14 @@ pub const TrustCommand = struct {
                 for (entry.items) |info| {
                     if (info.skip) continue;
 
+                    while (LifecycleScriptSubprocess.alive_count.load(.Monotonic) >= pm.options.max_concurrent_lifecycle_scripts) {
+                        if (PackageManager.verbose_install) {
+                            if (PackageManager.hasEnoughTimePassedBetweenWaitingMessages()) Output.prettyErrorln("<d>[PackageManager]<r> waiting for {d} scripts\n", .{LifecycleScriptSubprocess.alive_count.load(.Monotonic)});
+                        }
+
+                        pm.sleep();
+                    }
+
                     switch (pm.options.log_level) {
                         inline else => |log_level| try pm.spawnPackageLifecycleScripts(ctx, info.scripts_list, log_level),
                     }
@@ -350,7 +359,7 @@ pub const TrustCommand = struct {
                 }
 
                 while (pm.pending_lifecycle_script_tasks.load(.Monotonic) > 0) {
-                    pm.event_loop.loop().tick();
+                    pm.sleep();
                 }
             }
         }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9549,16 +9549,19 @@ pub const PackageManager = struct {
             .auto,
         );
 
-        // might need to read scripts from disk if we are migrating from package-lock.json
+        const buf = this.lockfile.buffers.string_bytes.items;
+        // need to clone because this is a copy before Lockfile.cleanWithLogger
+        const name = this.allocator.dupe(u8, root_package.name.slice(buf)) catch bun.outOfMemory();
+        const top_level_dir_without_trailing_slash = strings.withoutTrailingSlash(FileSystem.instance.top_level_dir);
 
         if (root_package.scripts.hasAny()) {
             const add_node_gyp_rebuild_script = root_package.scripts.install.isEmpty() and root_package.scripts.preinstall.isEmpty() and Syscall.exists(binding_dot_gyp_path);
 
             this.root_lifecycle_scripts = root_package.scripts.createList(
                 this.lockfile,
-                this.lockfile.buffers.string_bytes.items,
-                strings.withoutTrailingSlash(FileSystem.instance.top_level_dir),
-                root_package.name.slice(this.lockfile.buffers.string_bytes.items),
+                buf,
+                top_level_dir_without_trailing_slash,
+                name,
                 .root,
                 add_node_gyp_rebuild_script,
             );
@@ -9567,9 +9570,9 @@ pub const PackageManager = struct {
                 // no scripts exist but auto node gyp script needs to be added
                 this.root_lifecycle_scripts = root_package.scripts.createList(
                     this.lockfile,
-                    this.lockfile.buffers.string_bytes.items,
-                    strings.withoutTrailingSlash(FileSystem.instance.top_level_dir),
-                    root_package.name.slice(this.lockfile.buffers.string_bytes.items),
+                    buf,
+                    top_level_dir_without_trailing_slash,
+                    name,
                     .root,
                     true,
                 );
@@ -9944,14 +9947,18 @@ pub const PackageManager = struct {
             manager.lockfile.verifyResolutions(manager.options.local_package_features, manager.options.remote_package_features, log_level);
         }
 
-        {
-            // append scripts to lockfile before generating new metahash
-            manager.loadRootLifecycleScripts(root);
-
+        // append scripts to lockfile before generating new metahash
+        manager.loadRootLifecycleScripts(root);
+        defer {
             if (manager.root_lifecycle_scripts) |root_scripts| {
-                root_scripts.appendToLockfile(manager.lockfile);
+                manager.allocator.free(root_scripts.package_name);
             }
+        }
 
+        if (manager.root_lifecycle_scripts) |root_scripts| {
+            root_scripts.appendToLockfile(manager.lockfile);
+        }
+        {
             const packages = manager.lockfile.packages.slice();
             for (packages.items(.resolution), packages.items(.meta), packages.items(.scripts)) |resolution, meta, scripts| {
                 if (resolution.tag == .workspace) {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9131,6 +9131,7 @@ pub const PackageManager = struct {
             this.lockfile = try this.lockfile.maybeCloneFilteringRootPackages(
                 this.options.local_package_features,
                 this.options.enable.exact_versions,
+                log_level,
             );
         }
 
@@ -9900,6 +9901,7 @@ pub const PackageManager = struct {
             manager.package_json_updates,
             manager.log,
             manager.options.enable.exact_versions,
+            log_level,
         );
         if (manager.lockfile.packages.len > 0) {
             root = manager.lockfile.packages.get(0);

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -882,7 +882,7 @@ pub fn cleanWithLogger(
         Output.prettyErrorln("Clean lockfile: {d} packages -> {d} packages in {}\n", .{
             old.packages.len,
             new.packages.len,
-            std.fmt.fmtDuration(timer.read()),
+            bun.fmt.fmtDurationOneDecimal(timer.read()),
         });
     }
 

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -617,6 +617,7 @@ pub fn maybeCloneFilteringRootPackages(
     old: *Lockfile,
     features: Features,
     exact_versions: bool,
+    comptime log_level: PackageManager.Options.LogLevel,
 ) !*Lockfile {
     const old_root_dependencies_list = old.packages.items(.dependencies)[0];
     var old_root_resolutions = old.packages.items(.resolutions)[0];
@@ -634,7 +635,7 @@ pub fn maybeCloneFilteringRootPackages(
 
     if (!any_changes) return old;
 
-    return try old.clean(&.{}, exact_versions);
+    return try old.clean(&.{}, exact_versions, log_level);
 }
 
 fn preprocessUpdateRequests(old: *Lockfile, updates: []PackageManager.UpdateRequest, exact_versions: bool) !void {
@@ -712,6 +713,7 @@ pub fn clean(
     old: *Lockfile,
     updates: []PackageManager.UpdateRequest,
     exact_versions: bool,
+    comptime log_level: PackageManager.Options.LogLevel,
 ) !*Lockfile {
     // This is wasteful, but we rarely log anything so it's fine.
     var log = logger.Log.init(bun.default_allocator);
@@ -722,7 +724,7 @@ pub fn clean(
         log.deinit();
     }
 
-    return old.cleanWithLogger(updates, &log, exact_versions);
+    return old.cleanWithLogger(updates, &log, exact_versions, log_level);
 }
 
 pub fn cleanWithLogger(
@@ -730,7 +732,10 @@ pub fn cleanWithLogger(
     updates: []PackageManager.UpdateRequest,
     log: *logger.Log,
     exact_versions: bool,
+    comptime log_level: PackageManager.Options.LogLevel,
 ) !*Lockfile {
+    var timer: if (log_level.isVerbose()) std.time.Timer else void = if (comptime log_level.isVerbose()) try std.time.Timer.start() else {};
+
     const old_trusted_dependencies = old.trusted_dependencies;
     const old_scripts = old.scripts;
     // We will only shrink the number of packages here.
@@ -871,6 +876,14 @@ pub fn cleanWithLogger(
                 }
             }
         }
+    }
+
+    if (comptime log_level.isVerbose()) {
+        Output.prettyErrorln("Clean lockfile: {d} packages -> {d} packages in {}\n", .{
+            old.packages.len,
+            new.packages.len,
+            std.fmt.fmtDuration(timer.read()),
+        });
     }
 
     return new;

--- a/src/install/migration.zig
+++ b/src/install/migration.zig
@@ -1012,7 +1012,7 @@ pub fn migrateNPMLockfile(this: *Lockfile, allocator: Allocator, log: *logger.Lo
     // This is definitely a memory leak, but it's fine because there is no install api, so this can only be leaked once per process.
     // This operation is neccecary because callers of `loadFromDisk` assume the data is written into the passed `this`.
     // You'll find that not cleaning the lockfile will cause `bun install` to not actually install anything since it doesnt have any hoisted trees.
-    this.* = (try this.cleanWithLogger(&[_]Install.PackageManager.UpdateRequest{}, log, false)).*;
+    this.* = (try this.cleanWithLogger(&[_]Install.PackageManager.UpdateRequest{}, log, false, .silent)).*;
 
     // if (Environment.isDebug) {
     //     const dump_file = try std.fs.cwd().createFileZ("after-clean.json", .{});

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6131,7 +6131,7 @@ cache = false
     " + tsd@0.22.0",
     " + typescript@5.0.4",
     "",
-    " 119 packages installed",
+    " 120 packages installed",
   ]);
   expect(await exited1).toBe(0);
   expect(await readdirSorted(package_dir)).toEqual(["bun.lockb", "bunfig.toml", "node_modules", "package.json"]);
@@ -6206,6 +6206,7 @@ cache = false
     "path-exists",
     "path-parse",
     "path-type",
+    "picocolors",
     "picomatch",
     "plur",
     "prettier",

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -3040,7 +3040,7 @@ for (const forceWaiterThread of [false, true]) {
 
     test("reach max concurrent scripts", async () => {
       const scripts = {
-        "preinstall": `${bunExe()} -e "Bun.sleepSync(500)"`,
+        "preinstall": `${bunExe().replace(/\\/g, "\\\\")} -e "Bun.sleepSync(500)"`,
       };
 
       const dependenciesList = await createPackagesWithScripts(4, scripts);
@@ -3071,7 +3071,7 @@ for (const forceWaiterThread of [false, true]) {
 
     test("stress test", async () => {
       const dependenciesList = await createPackagesWithScripts(500, {
-        "postinstall": `${bunExe()} --version`,
+        "postinstall": `${bunExe().replace(/\\/g, "\\\\")} --version`,
       });
 
       // the script is quick, default number for max concurrent scripts

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -3069,47 +3069,36 @@ for (const forceWaiterThread of [false, true]) {
       expect(await exited).toBe(0);
     });
 
-    // test("stress test", async () => {
-    //   // 1000 versions of the same package, and 1000 different packages each depending on one
-    //   // of the versions. This creates a node_modules folder for 999 of the package
-    //   // versions (minus 1 because one is hoisted) with none depending on another. This allows
-    //   // lifecycle scripts for each package to run in parallel if --lifecycle-script-jobs is set
-    //   // high enough.
-    //   const totalPackageVersions = 1000;
-    //   const maxJobs = 400;
-    //   var dependencies: any = {};
-    //   for (var i = 0; i < totalPackageVersions; i++) {
-    //     dependencies[`uses-postinstall-stress-test-1-0-${i}`] = `1.0.${i}`;
-    //   }
+    test("stress test", async () => {
+      const dependenciesList = await createPackagesWithScripts(500, {
+        "postinstall": `${bunExe()} --version`,
+      });
 
-    //   await writeFile(
-    //     join(packageDir, "package.json"),
-    //     JSON.stringify({
-    //       name: "foo",
-    //       version: "1.0.0",
-    //       dependencies,
-    //       trustedDependencies: ["postinstall-stress-test"],
-    //     }),
-    //   );
+      // the script is quick, default number for max concurrent scripts
+      var { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env: testEnv,
+      });
 
-    //   var { stdout, stderr, exited } = spawn({
-    //     cmd: [bunExe(), "install", `--lifecycle-script-jobs=${maxJobs}`],
-    //     cwd: packageDir,
-    //     stdout: "pipe",
-    //     stdin: "pipe",
-    //     stderr: "pipe",
-    //     env: testEnv,
-    //   });
+      const err = await Bun.readableStreamToText(stderr);
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("not found");
+      expect(err).not.toContain("error:");
+      const out = await Bun.readableStreamToText(stdout);
+      expect(out).not.toContain("Blocked");
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        "",
+        ...dependenciesList.map(dep => ` + ${dep}@${dep}`).sort((a, b) => a.localeCompare(b)),
+        "",
+        " 500 packages installed",
+      ]);
 
-    //   const err = await new Response(stderr).text();
-    //   expect(await exited).toBe(0);
-    //   expect(err).toContain("Saved lockfile");
-    //   expect(err).not.toContain("not found");
-    //   expect(err).not.toContain("error:");
-
-    //   await rm(join(packageDir, "node_modules", ".cache"), { recursive: true, force: true });
-    //   expect((await readdir(join(packageDir, "node_modules"), { recursive: true })).sort()).toMatchSnapshot();
-    // }, 10_000);
+      expect(await exited).toBe(0);
+    });
 
     test("it should install and use correct binary version", async () => {
       // this should install `what-bin` in two places:
@@ -3135,7 +3124,7 @@ for (const forceWaiterThread of [false, true]) {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       });
 
       var err = await new Response(stderr).text();
@@ -3184,7 +3173,7 @@ for (const forceWaiterThread of [false, true]) {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       }));
 
       expect(await exited).toBe(0);
@@ -3201,7 +3190,7 @@ for (const forceWaiterThread of [false, true]) {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       }));
 
       out = await new Response(stdout).text();
@@ -3236,7 +3225,7 @@ for (const forceWaiterThread of [false, true]) {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       });
 
       const err = await new Response(stderr).text();
@@ -3266,7 +3255,7 @@ for (const forceWaiterThread of [false, true]) {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       });
 
       expect(await exited).toBe(0);
@@ -3297,7 +3286,7 @@ for (const forceWaiterThread of [false, true]) {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       });
 
       // electron lifecycle scripts should run, uses-what-bin scripts should not run
@@ -3341,7 +3330,7 @@ for (const forceWaiterThread of [false, true]) {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       }));
 
       err = await Bun.readableStreamToText(stderr);
@@ -3382,7 +3371,7 @@ for (const forceWaiterThread of [false, true]) {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       });
 
       const err = await Bun.readableStreamToText(stderr);
@@ -3423,7 +3412,7 @@ for (const forceWaiterThread of [false, true]) {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       });
 
       var err = await Bun.readableStreamToText(stderr);
@@ -3459,7 +3448,7 @@ for (const forceWaiterThread of [false, true]) {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       }));
 
       err = await Bun.readableStreamToText(stderr);
@@ -3549,7 +3538,7 @@ for (const forceWaiterThread of [false, true]) {
             stdout: "pipe",
             stderr: "pipe",
             stdin: "pipe",
-            env,
+            env: testEnv,
           });
 
           let err = await Bun.readableStreamToText(stderr);
@@ -3581,7 +3570,7 @@ for (const forceWaiterThread of [false, true]) {
             stdout: "pipe",
             stderr: "pipe",
             stdin: "pipe",
-            env,
+            env: testEnv,
           }));
 
           err = await Bun.readableStreamToText(stderr);
@@ -3612,7 +3601,7 @@ for (const forceWaiterThread of [false, true]) {
             stdout: "pipe",
             stderr: "pipe",
             stdin: "pipe",
-            env,
+            env: testEnv,
           });
 
           const err = await Bun.readableStreamToText(stderr);
@@ -3649,7 +3638,7 @@ for (const forceWaiterThread of [false, true]) {
             stdout: "pipe",
             stderr: "pipe",
             stdin: "pipe",
-            env,
+            env: testEnv,
           });
 
           let err = await Bun.readableStreamToText(stderr);
@@ -3682,7 +3671,7 @@ for (const forceWaiterThread of [false, true]) {
             stdout: "pipe",
             stderr: "pipe",
             stdin: "pipe",
-            env,
+            env: testEnv,
           }));
 
           // oh, I didn't realize no-deps doesn't have
@@ -3731,7 +3720,7 @@ for (const forceWaiterThread of [false, true]) {
           stdout: "pipe",
           stderr: "pipe",
           stdin: "pipe",
-          env,
+          env: testEnv,
         });
 
         let err = await Bun.readableStreamToText(stderr);
@@ -3763,7 +3752,7 @@ for (const forceWaiterThread of [false, true]) {
           stdout: "pipe",
           stderr: "pipe",
           stdin: "pipe",
-          env,
+          env: testEnv,
         }));
 
         err = await Bun.readableStreamToText(stderr);
@@ -3796,7 +3785,7 @@ for (const forceWaiterThread of [false, true]) {
           stdout: "pipe",
           stderr: "pipe",
           stdin: "pipe",
-          env,
+          env: testEnv,
         });
 
         let err = await Bun.readableStreamToText(stderr);
@@ -3840,7 +3829,7 @@ for (const forceWaiterThread of [false, true]) {
           stdout: "pipe",
           stderr: "pipe",
           stdin: "pipe",
-          env,
+          env: testEnv,
         }));
 
         err = await Bun.readableStreamToText(stderr);
@@ -3879,7 +3868,7 @@ for (const forceWaiterThread of [false, true]) {
           stdout: "pipe",
           stderr: "pipe",
           stdin: "pipe",
-          env,
+          env: testEnv,
         });
 
         let err = await Bun.readableStreamToText(stderr);
@@ -3925,7 +3914,7 @@ for (const forceWaiterThread of [false, true]) {
           stdout: "pipe",
           stderr: "pipe",
           stdin: "pipe",
-          env,
+          env: testEnv,
         }));
 
         err = await Bun.readableStreamToText(stderr);
@@ -3963,7 +3952,7 @@ for (const forceWaiterThread of [false, true]) {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       });
 
       env.PATH = originalPath;
@@ -3989,7 +3978,7 @@ for (const forceWaiterThread of [false, true]) {
         cwd: packageDir,
         stdout: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       });
 
       let err = await Bun.readableStreamToText(stderr);
@@ -4017,7 +4006,7 @@ for (const forceWaiterThread of [false, true]) {
         cwd: packageDir,
         stdout: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       }));
 
       err = await Bun.readableStreamToText(stderr);
@@ -4033,7 +4022,7 @@ for (const forceWaiterThread of [false, true]) {
         cwd: packageDir,
         stdout: "pipe",
         stderr: "pipe",
-        env,
+        env: testEnv,
       }));
 
       expect(await exited).toBe(1);
@@ -4065,7 +4054,7 @@ for (const forceWaiterThread of [false, true]) {
             cwd: packageDir,
             stdout: "pipe",
             stderr: "pipe",
-            env,
+            env: testEnv,
           });
 
           let err = await Bun.readableStreamToText(stderr);
@@ -4092,7 +4081,7 @@ for (const forceWaiterThread of [false, true]) {
             cwd: packageDir,
             stdout: "pipe",
             stderr: "pipe",
-            env,
+            env: testEnv,
           }));
 
           err = await Bun.readableStreamToText(stderr);
@@ -4119,7 +4108,7 @@ for (const forceWaiterThread of [false, true]) {
               cwd: packageDir,
               stdout: "pipe",
               stderr: "pipe",
-              env,
+              env: testEnv,
             }));
 
             err = await Bun.readableStreamToText(stderr);
@@ -4147,7 +4136,7 @@ for (const forceWaiterThread of [false, true]) {
             cwd: packageDir,
             stdout: "pipe",
             stderr: "pipe",
-            env,
+            env: testEnv,
           }));
 
           err = await Bun.readableStreamToText(stderr);
@@ -4181,7 +4170,7 @@ for (const forceWaiterThread of [false, true]) {
             cwd: packageDir,
             stdout: "pipe",
             stderr: "pipe",
-            env,
+            env: testEnv,
           }));
 
           err = await Bun.readableStreamToText(stderr);
@@ -4208,7 +4197,7 @@ for (const forceWaiterThread of [false, true]) {
             cwd: packageDir,
             stdout: "pipe",
             stderr: "pipe",
-            env,
+            env: testEnv,
           }));
 
           err = await Bun.readableStreamToText(stderr);


### PR DESCRIPTION
### What does this PR do?
adds a test for #9472 and fixes `bun pm trust` hanging when waiter threads are used.

adds a test for and closes #9502 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
New and existing tests.

The test for #9472 installs 4 packages, each with 1 script that will last 500ms. The scripts can be run in parallel and maximum number of concurrent scripts is set to 2.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
