### PR TITLE
fix(docs): fix broken links in guides

### DIFF
--- a/docs/guides/runtime/shell.md
+++ b/docs/guides/runtime/shell.md
@@ -37,4 +37,4 @@ for await (const line of $`ls -l`.lines()) {
 
 ---
 
-See [Docs > API > Shell](/api/shell) for complete documentation.
+See [Docs > API > Shell](/docs/runtime/shell) for complete documentation.

--- a/docs/guides/util/which-path-to-executable-bin.md
+++ b/docs/guides/util/which-path-to-executable-bin.md
@@ -12,4 +12,4 @@ Bun.which("bun"); // => "/home/user/.bun/bin/bun"
 
 ---
 
-See [Docs > API > Utils](/api/utils#bun-which) for complete documentation.
+See [Docs > API > Utils](/docs/api/utils#bun-which) for complete documentation.


### PR DESCRIPTION
### What does this PR do?

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes