### PR TITLE
A few fixes related to CommonJS module loading

### DIFF
--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -27,6 +27,7 @@
 #include "JSDOMOperation.h"
 
 #include "GCDefferalContext.h"
+#include "wtf/text/StringImpl.h"
 
 extern "C" void mi_free(void* ptr);
 
@@ -559,4 +560,9 @@ extern "C" bool WTFStringImpl__isThreadSafe(
     //     return wtf->characters8() == reinterpret_cast_ptr<const LChar*>(reinterpret_cast<const uint8_t*>(wtf) + tailOffset<const LChar*>());
 
     // return wtf->characters16() == reinterpret_cast_ptr<const UChar*>(reinterpret_cast<const uint16_t*>(wtf) + tailOffset<const UChar*>());
+}
+
+extern "C" void Bun__WTFStringImpl__ensureHash(WTF::StringImpl* str)
+{
+    str->hash();
 }

--- a/src/bun.js/bindings/CommonJSModuleRecord.h
+++ b/src/bun.js/bindings/CommonJSModuleRecord.h
@@ -34,30 +34,34 @@ public:
     mutable JSC::WriteBarrier<JSString> m_dirname;
     mutable JSC::WriteBarrier<Unknown> m_paths;
     mutable JSC::WriteBarrier<Unknown> m_parent;
-    mutable JSC::WriteBarrier<JSSourceCode> sourceCode;
     bool ignoreESModuleAnnotation { false };
+    JSC::SourceCode sourceCode = JSC::SourceCode();
+
+    void setSourceCode(JSC::SourceCode&& sourceCode);
 
     static void destroy(JSC::JSCell*);
     ~JSCommonJSModule();
 
+    void clearSourceCode() { sourceCode = JSC::SourceCode(); }
+
     void finishCreation(JSC::VM& vm,
         JSC::JSString* id, JSValue filename,
-        JSC::JSString* dirname, JSC::JSSourceCode* sourceCode);
+        JSC::JSString* dirname, const JSC::SourceCode& sourceCode);
 
     static JSC::Structure* createStructure(JSC::JSGlobalObject* globalObject);
 
-    bool evaluate(Zig::GlobalObject* globalObject, const WTF::String& sourceURL, ResolvedSource resolvedSource, bool isBuiltIn);
-    inline bool evaluate(Zig::GlobalObject* globalObject, const WTF::String& sourceURL, ResolvedSource resolvedSource)
+    bool evaluate(Zig::GlobalObject* globalObject, const WTF::String& sourceURL, ResolvedSource& resolvedSource, bool isBuiltIn);
+    inline bool evaluate(Zig::GlobalObject* globalObject, const WTF::String& sourceURL, ResolvedSource& resolvedSource)
     {
         return evaluate(globalObject, sourceURL, resolvedSource, false);
     }
     bool evaluate(Zig::GlobalObject* globalObject, const WTF::String& key, const SyntheticSourceProvider::SyntheticSourceGenerator& generator);
-    bool evaluate(Zig::GlobalObject* globalObject, const WTF::String& key, JSSourceCode* sourceCode);
+    bool evaluate(Zig::GlobalObject* globalObject, const WTF::String& key, const JSC::SourceCode& sourceCode);
 
     static JSCommonJSModule* create(JSC::VM& vm, JSC::Structure* structure,
         JSC::JSString* id,
         JSValue filename,
-        JSC::JSString* dirname, JSC::JSSourceCode* sourceCode);
+        JSC::JSString* dirname, const JSC::SourceCode& sourceCode);
 
     static JSCommonJSModule* create(
         Zig::GlobalObject* globalObject,
@@ -82,7 +86,6 @@ public:
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
 
-
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, SubspaceAccess mode>
@@ -106,23 +109,17 @@ public:
     }
 };
 
-JSCommonJSModule* createCommonJSModuleWithoutRunning(
-    Zig::GlobalObject* globalObject,
-    Ref<Zig::SourceProvider> sourceProvider,
-    const WTF::String& sourceURL,
-    ResolvedSource source);
-
 JSC::Structure* createCommonJSModuleStructure(
     Zig::GlobalObject* globalObject);
 
 std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
-    ResolvedSource source,
+    ResolvedSource& source,
     bool isBuiltIn);
 
 inline std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
-    ResolvedSource source)
+    ResolvedSource& source)
 {
     return createCommonJSModule(globalObject, source, false);
 }

--- a/src/bun.js/bindings/CommonJSModuleRecord.h
+++ b/src/bun.js/bindings/CommonJSModuleRecord.h
@@ -1,6 +1,8 @@
 #pragma once
+#include "JavaScriptCore/JSGlobalObject.h"
 #include "root.h"
 #include "headers-handwritten.h"
+#include "wtf/NakedPtr.h"
 
 namespace Zig {
 class GlobalObject;
@@ -83,6 +85,8 @@ public:
     JSValue exportsObject();
     JSValue id();
 
+    bool load(JSC::VM& vm, Zig::GlobalObject* globalObject, WTF::NakedPtr<JSC::Exception>&);
+
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
 
@@ -114,14 +118,16 @@ JSC::Structure* createCommonJSModuleStructure(
 
 std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
+    JSC::JSValue specifierValue,
     ResolvedSource& source,
     bool isBuiltIn);
 
 inline std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
+    JSC::JSValue specifierValue,
     ResolvedSource& source)
 {
-    return createCommonJSModule(globalObject, source, false);
+    return createCommonJSModule(globalObject, specifierValue, source, false);
 }
 
 class RequireResolveFunctionPrototype final : public JSC::JSNonFinalObject {

--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -764,7 +764,7 @@ static JSValue fetchESMSourceCode(
             return pendingCtx;
         }
     } else {
-        ASSERT(Bun__transpileFile(bunVM, globalObject, specifier, referrer, typeAttribute, res, false) == nullptr);
+        Bun__transpileFile(bunVM, globalObject, specifier, referrer, typeAttribute, res, false);
         getSourceCodeStringForDeref();
     }
 

--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -1,5 +1,3 @@
-#include "JavaScriptCore/BuiltinNames.h"
-#include "JavaScriptCore/JSCast.h"
 #include "root.h"
 #include "headers-handwritten.h"
 #include "JavaScriptCore/JSGlobalObject.h"

--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -596,7 +596,7 @@ JSValue fetchCommonJSModule(
         RELEASE_AND_RETURN(scope, jsNumber(-1));
     }
 
-    ASSERT(Bun__transpileFile(bunVM, globalObject, specifier, referrer, typeAttribute, res, false) == nullptr);
+    Bun__transpileFile(bunVM, globalObject, specifier, referrer, typeAttribute, res, false);
     getSourceCodeStringForDeref();
 
     if (res->success && res->result.value.commonJSExportsLen) {

--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -424,6 +424,7 @@ extern "C" void Bun__onFulfillAsyncModule(
                 if (auto isEvaluated = entry.getObject()->getIfPropertyExists(globalObject, Bun::builtinNames(vm).evaluatedPublicName())) {
                     if (isEvaluated.isTrue()) {
                         // it's a race! we lost.
+                        // https://github.com/oven-sh/bun/issues/6946
                         return;
                     }
                 }

--- a/src/bun.js/bindings/ModuleLoader.h
+++ b/src/bun.js/bindings/ModuleLoader.h
@@ -88,6 +88,7 @@ public:
 
 JSValue fetchESMSourceCodeSync(
     Zig::GlobalObject* globalObject,
+    JSValue spceifierJS,
     ErrorableResolvedSource* res,
     BunString* specifier,
     BunString* referrer,
@@ -95,6 +96,7 @@ JSValue fetchESMSourceCodeSync(
 
 JSValue fetchESMSourceCodeAsync(
     Zig::GlobalObject* globalObject,
+    JSValue spceifierJS,
     ErrorableResolvedSource* res,
     BunString* specifier,
     BunString* referrer,

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -814,8 +814,9 @@ extern "C" JSC__JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionFulfillModuleSync,
-    (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+    (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
+    Zig::GlobalObject* globalObject = jsCast<Zig::GlobalObject*>(lexicalGlobalObject);
 
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -836,7 +837,8 @@ JSC_DEFINE_HOST_FUNCTION(functionFulfillModuleSync,
     res.result.err.ptr = nullptr;
 
     JSValue result = Bun::fetchESMSourceCodeSync(
-        reinterpret_cast<Zig::GlobalObject*>(globalObject),
+        globalObject,
+        key,
         &res,
         &specifier,
         &specifier,
@@ -4480,6 +4482,7 @@ JSC::JSInternalPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalOb
 
     JSValue result = Bun::fetchESMSourceCodeAsync(
         reinterpret_cast<Zig::GlobalObject*>(globalObject),
+        key,
         &res,
         &moduleKeyBun,
         &source,

--- a/src/bun.js/bindings/ZigSourceProvider.cpp
+++ b/src/bun.js/bindings/ZigSourceProvider.cpp
@@ -28,8 +28,6 @@ using SourceOrigin = JSC::SourceOrigin;
 using String = WTF::String;
 using SourceProviderSourceType = JSC::SourceProviderSourceType;
 
-extern "C" unsigned Bun__transpiler_generation_number;
-
 static uintptr_t getSourceProviderMapKey(ResolvedSource& resolvedSource)
 {
     switch (resolvedSource.source_code.tag) {

--- a/src/bun.js/bindings/ZigSourceProvider.h
+++ b/src/bun.js/bindings/ZigSourceProvider.h
@@ -23,7 +23,7 @@ class GlobalObject;
 void forEachSourceProvider(WTF::Function<void(JSC::SourceID)>);
 JSC::SourceID sourceIDForSourceURL(const WTF::String& sourceURL);
 void* sourceMappingForSourceURL(const WTF::String& sourceURL);
-
+JSC::SourceOrigin toSourceOrigin(const String& sourceURL, bool isBuiltin);
 class SourceProvider final : public JSC::SourceProvider {
     WTF_MAKE_FAST_ALLOCATED;
     using Base = JSC::SourceProvider;
@@ -36,7 +36,7 @@ class SourceProvider final : public JSC::SourceProvider {
     using SourceOrigin = JSC::SourceOrigin;
 
 public:
-    static Ref<SourceProvider> create(Zig::GlobalObject*, ResolvedSource resolvedSource, JSC::SourceProviderSourceType sourceType = JSC::SourceProviderSourceType::Module, bool isBuiltIn = false);
+    static Ref<SourceProvider> create(Zig::GlobalObject*, ResolvedSource& resolvedSource, JSC::SourceProviderSourceType sourceType = JSC::SourceProviderSourceType::Module, bool isBuiltIn = false);
     ~SourceProvider();
     unsigned hash() const override;
     StringView source() const override { return StringView(m_source.get()); }

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3062,7 +3062,7 @@ void JSC__JSInternalPromise__rejectAsHandledException(JSC__JSInternalPromise* ar
 JSC__JSInternalPromise* JSC__JSInternalPromise__rejectedPromise(JSC__JSGlobalObject* arg0,
     JSC__JSValue JSValue1)
 {
-    return reinterpret_cast<JSC::JSInternalPromise*>(
+    return jsCast<JSC::JSInternalPromise*>(
         JSC::JSInternalPromise::rejectedPromise(arg0, JSC::JSValue::decode(JSValue1)));
 }
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -1,5 +1,7 @@
+
 #include "root.h"
 
+#include "JavaScriptCore/DeleteAllCodeEffort.h"
 #include "headers.h"
 
 #include "BunClientData.h"
@@ -4587,8 +4589,11 @@ JSC__JSValue JSC__VM__runGC(JSC__VM* vm, bool sync)
     WTF::releaseFastMallocFreeMemory();
 
     if (sync) {
+        vm->clearSourceProviderCaches();
+        vm->heap.deleteAllUnlinkedCodeBlocks(JSC::PreventCollectionAndDeleteAllCode);
         vm->heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);
     } else {
+        vm->heap.deleteAllUnlinkedCodeBlocks(JSC::DeleteAllCodeIfNotCollecting);
         vm->heap.collectSync(JSC::CollectionScope::Full);
     }
 

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -311,7 +311,7 @@ extern "C" JSC::EncodedJSValue Bun__runVirtualModule(
     JSC::JSGlobalObject* global,
     const BunString* specifier);
 
-extern "C" void* Bun__transpileFile(
+extern "C" JSC::JSInternalPromise* Bun__transpileFile(
     void* bunVM,
     JSC::JSGlobalObject* global,
     const BunString* specifier,

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -86,6 +86,8 @@ const Dependency = @import("../install/dependency.zig");
 const Async = bun.Async;
 const String = bun.String;
 
+const debug = Output.scoped(.ModuleLoader, true);
+
 // Setting BUN_OVERRIDE_MODULE_PATH to the path to the bun repo will make it so modules are loaded
 // from there instead of the ones embedded into the binary.
 // In debug mode, this is set automatically for you, using the path relative to this file.
@@ -217,16 +219,40 @@ fn setBreakPointOnFirstLine() bool {
 }
 
 pub const RuntimeTranspilerStore = struct {
-    const debug = Output.scoped(.compile, false);
-
     generation_number: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
     store: TranspilerJob.Store,
     enabled: bool = true,
+    queue: Queue = Queue{},
+
+    pub const Queue = bun.UnboundedQueue(TranspilerJob, .next);
 
     pub fn init(allocator: std.mem.Allocator) RuntimeTranspilerStore {
         return RuntimeTranspilerStore{
             .store = TranspilerJob.Store.init(allocator),
         };
+    }
+
+    // Thsi is run at the top of the event loop on the JS thread.
+    pub fn drain(this: *RuntimeTranspilerStore) void {
+        var batch = this.queue.popBatch();
+        var iter = batch.iterator();
+        if (iter.next()) |job| {
+            // we run just one job first to see if there are more
+            job.runFromJSThread();
+        } else {
+            return;
+        }
+        var vm = @fieldParentPtr(JSC.VirtualMachine, "transpiler_store", this);
+        const event_loop = vm.eventLoop();
+        const global = vm.global;
+        const jsc_vm = vm.jsc;
+        while (iter.next()) |job| {
+            // if there are more, we need to drain the microtasks from the previous run
+            event_loop.drainMicrotasksWithGlobal(global, jsc_vm);
+            job.runFromJSThread();
+        }
+
+        // immediately after this is called, the microtasks will be drained again.
     }
 
     pub fn transpile(
@@ -236,7 +262,6 @@ pub const RuntimeTranspilerStore = struct {
         path: Fs.Path,
         referrer: []const u8,
     ) *anyopaque {
-        debug("transpile({s})", .{path.text});
         var job: *TranspilerJob = this.store.get();
         const owned_path = Fs.Path.init(bun.default_allocator.dupe(u8, path.text) catch unreachable);
         const promise = JSC.JSInternalPromise.create(globalObject);
@@ -253,6 +278,8 @@ pub const RuntimeTranspilerStore = struct {
                 .file = {},
             },
         };
+        if (comptime Environment.allow_assert)
+            debug("transpile({s}, {s}, async)", .{ path.text, @tagName(job.loader) });
         job.schedule();
         return promise;
     }
@@ -271,6 +298,7 @@ pub const RuntimeTranspilerStore = struct {
         parse_error: ?anyerror = null,
         resolved_source: ResolvedSource = ResolvedSource{},
         work_task: JSC.WorkPoolTask = .{ .callback = runFromWorkerThread },
+        next: ?*TranspilerJob = null,
 
         pub const Store = bun.HiveArray(TranspilerJob, 64).Fallback;
 
@@ -302,9 +330,8 @@ pub const RuntimeTranspilerStore = struct {
         threadlocal var source_code_printer: ?*js_printer.BufferPrinter = null;
 
         pub fn dispatchToMainThread(this: *TranspilerJob) void {
-            this.vm.eventLoop().enqueueTaskConcurrent(
-                JSC.ConcurrentTask.fromCallback(this, runFromJSThread),
-            );
+            this.vm.transpiler_store.queue.push(this);
+            this.vm.eventLoop().enqueueTaskConcurrent(JSC.ConcurrentTask.createFrom(&this.vm.transpiler_store));
         }
 
         pub fn runFromJSThread(this: *TranspilerJob) void {
@@ -679,8 +706,6 @@ pub const RuntimeTranspilerStore = struct {
 pub const ModuleLoader = struct {
     transpile_source_code_arena: ?*bun.ArenaAllocator = null,
     eval_source: ?*logger.Source = null,
-
-    const debug = Output.scoped(.ModuleLoader, true);
 
     /// This must be called after calling transpileSourceCode
     pub fn resetArena(this: *ModuleLoader, jsc_vm: *VirtualMachine) void {
@@ -1077,6 +1102,7 @@ pub const ModuleLoader = struct {
             var spec = bun.String.init(ZigString.init(this.specifier).withEncoding());
             var ref = bun.String.init(ZigString.init(this.referrer).withEncoding());
             Bun__onFulfillAsyncModule(
+                this.globalThis,
                 this.promise.get().?,
                 &errorable,
                 &spec,
@@ -1119,6 +1145,7 @@ pub const ModuleLoader = struct {
             log.deinit();
 
             Bun__onFulfillAsyncModule(
+                globalThis,
                 promise,
                 &errorable,
                 &specifier,
@@ -1431,6 +1458,7 @@ pub const ModuleLoader = struct {
         }
 
         extern "C" fn Bun__onFulfillAsyncModule(
+            globalObject: *JSC.JSGlobalObject,
             promiseValue: JSC.JSValue,
             res: *JSC.ErrorableResolvedSource,
             specifier: *bun.String,
@@ -2147,7 +2175,6 @@ pub const ModuleLoader = struct {
         JSC.markBinding(@src());
         var log = logger.Log.init(jsc_vm.bundler.allocator);
         defer log.deinit();
-        debug("transpileFile: {any}", .{specifier_ptr.*});
 
         var _specifier = specifier_ptr.toUTF8(jsc_vm.allocator);
         var referrer_slice = referrer.toUTF8(jsc_vm.allocator);
@@ -2223,6 +2250,9 @@ pub const ModuleLoader = struct {
                 break :loader options.Loader.tsx;
             }
         };
+
+        if (comptime Environment.allow_assert)
+            debug("transpile({s}, {s}, sync)", .{ specifier, @tagName(synchronous_loader) });
 
         defer jsc_vm.module_loader.resetArena(jsc_vm);
 

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -677,10 +677,10 @@ pub const RuntimeTranspilerStore = struct {
 
                 // In a benchmarking loading @babel/standalone 100 times:
                 //
-                // Before ensureHash:
+                // After ensureHash:
                 // 354.00 ms    4.2%	354.00 ms	 	  WTF::StringImpl::hashSlowCase() const
                 //
-                // After ensureHash:
+                // Before ensureHash:
                 // 506.00 ms    6.1%	506.00 ms	 	  WTF::StringImpl::hashSlowCase() const
                 //
                 result.value.WTFStringImpl.ensureHash();

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -440,7 +440,7 @@ pub const RuntimeTranspilerStore = struct {
                 .hot, .watch => {
                     if (vm.bun_watcher.indexOf(hash)) |index| {
                         const _fd = vm.bun_watcher.watchlist().items(.fd)[index];
-                        fd = if (_fd.int() > 0) _fd else null;
+                        fd = if (!_fd.isStdio()) _fd else null;
                         package_json = vm.bun_watcher.watchlist().items(.package_json)[index];
                     }
                 },

--- a/src/bun.js/modules/NodeModuleModule.h
+++ b/src/bun.js/modules/NodeModuleModule.h
@@ -124,7 +124,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeModuleModuleConstructor,
   }
 
   auto *out = Bun::JSCommonJSModule::create(vm, structure, idString, jsNull(),
-                                            dirname, nullptr);
+                                            dirname, SourceCode());
 
   if (!parentValue.isUndefined())
     out->putDirect(vm, JSC::Identifier::fromString(vm, "parent"_s), parentValue,

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -20,24 +20,10 @@ namespace WebCore {
 using namespace JSC;
 
 #define BUN_COMMON_PRIVATE_IDENTIFIERS_EACH_PROPERTY_NAME(macro) \
-    macro(AbortSignal) \
-    macro(Buffer) \
-    macro(Bun) \
-    macro(Loader) \
-    macro(ReadableByteStreamController) \
-    macro(ReadableStream) \
-    macro(ReadableStreamBYOBReader) \
-    macro(ReadableStreamBYOBRequest) \
-    macro(ReadableStreamDefaultController) \
-    macro(ReadableStreamDefaultReader) \
-    macro(TransformStream) \
-    macro(TransformStreamDefaultController) \
-    macro(WritableStream) \
-    macro(WritableStreamDefaultController) \
-    macro(WritableStreamDefaultWriter) \
     macro(__esModule) \
     macro(_events) \
     macro(abortAlgorithm) \
+    macro(AbortSignal) \
     macro(abortSteps) \
     macro(addEventListener) \
     macro(appendFromJS) \
@@ -49,6 +35,8 @@ using namespace JSC;
     macro(backpressureChangePromise) \
     macro(basename) \
     macro(body) \
+    macro(Buffer) \
+    macro(Bun) \
     macro(bunNativePtr) \
     macro(bunNativeType) \
     macro(byobRequest) \
@@ -58,11 +46,11 @@ using namespace JSC;
     macro(cloneArrayBuffer) \
     macro(close) \
     macro(closeAlgorithm) \
-    macro(closeRequest) \
-    macro(closeRequested) \
     macro(closed) \
     macro(closedPromise) \
     macro(closedPromiseCapability) \
+    macro(closeRequest) \
+    macro(closeRequested) \
     macro(code) \
     macro(connect) \
     macro(consumeReadableStream) \
@@ -75,8 +63,8 @@ using namespace JSC;
     macro(createInternalModuleById) \
     macro(createNativeReadableStream) \
     macro(createReadableStream) \
-    macro(createUsedReadableStream) \
     macro(createUninitializedArrayBuffer) \
+    macro(createUsedReadableStream) \
     macro(createWritableStreamFromInternal) \
     macro(cwd) \
     macro(data) \
@@ -95,6 +83,7 @@ using namespace JSC;
     macro(errno) \
     macro(errorSteps) \
     macro(evaluateCommonJSModule) \
+    macro(evaluated) \
     macro(execArgv) \
     macro(exports) \
     macro(extname) \
@@ -138,13 +127,14 @@ using namespace JSC;
     macro(lazy) \
     macro(lazyStreamPrototypeMap) \
     macro(loadCJS2ESM) \
+    macro(Loader) \
     macro(localStreams) \
     macro(main) \
     macro(makeDOMException) \
     macro(makeGetterTypeError) \
     macro(makeThisTypeError) \
-    macro(mockedFunction) \
     macro(method) \
+    macro(mockedFunction) \
     macro(nextTick) \
     macro(normalize) \
     macro(on) \
@@ -177,12 +167,18 @@ using namespace JSC;
     macro(put) \
     macro(queue) \
     macro(read) \
-    macro(readIntoRequests) \
-    macro(readRequests) \
     macro(readable) \
+    macro(ReadableByteStreamController) \
+    macro(ReadableStream) \
+    macro(ReadableStreamBYOBReader) \
+    macro(ReadableStreamBYOBRequest) \
     macro(readableStreamController) \
+    macro(ReadableStreamDefaultController) \
+    macro(ReadableStreamDefaultReader) \
     macro(readableStreamToArray) \
     macro(reader) \
+    macro(readIntoRequests) \
+    macro(readRequests) \
     macro(readyPromise) \
     macro(readyPromiseCapability) \
     macro(redirect) \
@@ -226,6 +222,8 @@ using namespace JSC;
     macro(toNamespacedPath) \
     macro(trace) \
     macro(transformAlgorithm) \
+    macro(TransformStream) \
+    macro(TransformStreamDefaultController) \
     macro(uncork) \
     macro(underlyingByteSource) \
     macro(underlyingSink) \
@@ -239,10 +237,13 @@ using namespace JSC;
     macro(view) \
     macro(whenSignalAborted) \
     macro(writable) \
+    macro(WritableStream) \
+    macro(WritableStreamDefaultController) \
+    macro(WritableStreamDefaultWriter) \
     macro(write) \
     macro(writeAlgorithm) \
-    macro(writeRequests) \
     macro(writer) \
+    macro(writeRequests) \
     macro(writing) \
     macro(written) \
 

--- a/src/js/builtins/ImportMetaObject.ts
+++ b/src/js/builtins/ImportMetaObject.ts
@@ -4,32 +4,62 @@ $visibility = "Private";
 export function loadCJS2ESM(this: ImportMetaObject, resolvedSpecifier: string) {
   var loader = Loader;
   var queue = $createFIFO();
-  var key = resolvedSpecifier;
+  let key = resolvedSpecifier;
+  const registry = loader.registry;
+
   while (key) {
     // we need to explicitly check because state could be $ModuleFetch
     // it will throw this error if we do not:
     //    $throwTypeError("Requested module is already fetched.");
-    var entry = loader.registry.$get(key)!;
+    let entry = registry.$get(key)!,
+      moduleRecordPromise,
+      state,
+      // entry.fetch is a Promise<SourceCode>
+      // SourceCode is not a string, it's a JSC::SourceCode object
+      fetch: Promise<SourceCode> | undefined;
 
-    if ((entry?.state ?? 0) <= $ModuleFetch) {
-      $fulfillModuleSync(key);
-      entry = loader.registry.$get(key)!;
+    if (entry) {
+      ({ state = 0, fetch } = entry);
     }
 
-    // entry.fetch is a Promise<SourceCode>
-    // SourceCode is not a string, it's a JSC::SourceCode object
-    // this pulls it out of the promise without delaying by a tick
-    // the promise is already fullfilled by $fullfillModuleSync
-    var sourceCodeObject = $getPromiseInternalField(entry.fetch, $promiseFieldReactionsOrResult);
-    // parseModule() returns a Promise, but the value is already fulfilled
-    // so we just pull it out of the promise here once again
-    // But, this time we do it a little more carefully because this is a JSC function call and not bun source code
-    var moduleRecordPromise = loader.parseModule(key, sourceCodeObject);
-    var mod = entry.module;
+    if (
+      // if we need to fetch it
+      state <= $ModuleFetch &&
+      // either:
+      // - we've never fetched it
+      // - a fetch is in progress
+      (!$isPromise(fetch) || $getPromiseInternalField(fetch, $promiseFieldFlags) & $promiseStateMask) ===
+        $promiseStatePending
+    ) {
+      // force it to be no longer pending
+      $fulfillModuleSync(key);
+
+      entry = registry.$get(key)!;
+
+      // the state can transition here
+      // https://github.com/oven-sh/bun/issues/8965
+      if (entry) {
+        ({ state = 0, fetch } = entry);
+      }
+    }
+
+    if (state < $ModuleLink && $isPromise(fetch)) {
+      // This will probably never happen, but just in case
+      if (($getPromiseInternalField(fetch, $promiseFieldFlags) & $promiseStateMask) === $promiseStatePending) {
+        throw new TypeError(`require() async module "${key}" is unsupported. use "await import()" instead.`);
+      }
+
+      // this pulls it out of the promise without delaying by a tick
+      // the promise is already fullfilled by $fullfillModuleSync
+      const sourceCodeObject = $getPromiseInternalField(fetch, $promiseFieldReactionsOrResult);
+      moduleRecordPromise = loader.parseModule(key, sourceCodeObject);
+    }
+    let mod = entry?.module;
+
     if (moduleRecordPromise && $isPromise(moduleRecordPromise)) {
-      var reactionsOrResult = $getPromiseInternalField(moduleRecordPromise, $promiseFieldReactionsOrResult);
-      var flags = $getPromiseInternalField(moduleRecordPromise, $promiseFieldFlags);
-      var state = flags & $promiseStateMask;
+      let reactionsOrResult = $getPromiseInternalField(moduleRecordPromise, $promiseFieldReactionsOrResult);
+      let flags = $getPromiseInternalField(moduleRecordPromise, $promiseFieldFlags);
+      let state = flags & $promiseStateMask;
       // this branch should never happen, but just to be safe
       if (state === $promiseStatePending || (reactionsOrResult && $isPromise(reactionsOrResult))) {
         throw new TypeError(`require() async module "${key}" is unsupported. use "await import()" instead.`);
@@ -51,15 +81,15 @@ export function loadCJS2ESM(this: ImportMetaObject, resolvedSpecifier: string) {
 
     // This is very similar to "requestInstantiate" in ModuleLoader.js in JavaScriptCore.
     $setStateToMax(entry, $ModuleLink);
-    var dependenciesMap = mod.dependenciesMap;
-    var requestedModules = loader.requestedModules(mod);
-    var dependencies = $newArrayWithSize<string>(requestedModules.length);
+    const dependenciesMap = mod.dependenciesMap;
+    const requestedModules = loader.requestedModules(mod);
+    const dependencies = $newArrayWithSize<string>(requestedModules.length);
     for (var i = 0, length = requestedModules.length; i < length; ++i) {
-      var depName = requestedModules[i];
+      const depName = requestedModules[i];
       // optimization: if it starts with a slash then it's an absolute path
       // we don't need to run the resolver a 2nd time
-      var depKey = depName[0] === "/" ? depName : loader.resolve(depName, key);
-      var depEntry = loader.ensureRegistered(depKey);
+      const depKey = depName[0] === "/" ? depName : loader.resolve(depName, key);
+      const depEntry = loader.ensureRegistered(depKey);
 
       if (depEntry.state < $ModuleLink) {
         queue.push(depKey);
@@ -76,7 +106,7 @@ export function loadCJS2ESM(this: ImportMetaObject, resolvedSpecifier: string) {
     entry.isSatisfied = true;
 
     key = queue.shift();
-    while (key && (loader.registry.$get(key)?.state ?? $ModuleFetch) >= $ModuleLink) {
+    while (key && (registry.$get(key)?.state ?? $ModuleFetch) >= $ModuleLink) {
       key = queue.shift();
     }
   }
@@ -90,7 +120,7 @@ export function loadCJS2ESM(this: ImportMetaObject, resolvedSpecifier: string) {
     );
   }
 
-  return loader.registry.$get(resolvedSpecifier);
+  return registry.$get(resolvedSpecifier);
 }
 
 $visibility = "Private";

--- a/src/js/builtins/ImportMetaObject.ts
+++ b/src/js/builtins/ImportMetaObject.ts
@@ -13,23 +13,24 @@ export function loadCJS2ESM(this: ImportMetaObject, resolvedSpecifier: string) {
     //    $throwTypeError("Requested module is already fetched.");
     let entry = registry.$get(key)!,
       moduleRecordPromise,
-      state,
+      state = 0,
       // entry.fetch is a Promise<SourceCode>
       // SourceCode is not a string, it's a JSC::SourceCode object
       fetch: Promise<SourceCode> | undefined;
 
     if (entry) {
-      ({ state = 0, fetch } = entry);
+      ({ state, fetch } = entry);
     }
 
     if (
+      !entry ||
       // if we need to fetch it
-      state <= $ModuleFetch &&
-      // either:
-      // - we've never fetched it
-      // - a fetch is in progress
-      (!$isPromise(fetch) || $getPromiseInternalField(fetch, $promiseFieldFlags) & $promiseStateMask) ===
-        $promiseStatePending
+      (state <= $ModuleFetch &&
+        // either:
+        // - we've never fetched it
+        // - a fetch is in progress
+        (!$isPromise(fetch) ||
+          ($getPromiseInternalField(fetch, $promiseFieldFlags) & $promiseStateMask) === $promiseStatePending))
     ) {
       // force it to be no longer pending
       $fulfillModuleSync(key);

--- a/src/string.zig
+++ b/src/string.zig
@@ -121,6 +121,13 @@ pub const WTFStringImplStruct = extern struct {
         return ZigString.Slice.init(this.refCountAllocator(), this.latin1Slice());
     }
 
+    extern fn Bun__WTFStringImpl__ensureHash(this: WTFStringImpl) void;
+    /// Compute the hash() if necessary
+    pub fn ensureHash(this: WTFStringImpl) void {
+        JSC.markBinding(@src());
+        Bun__WTFStringImpl__ensureHash(this);
+    }
+
     pub fn toUTF8(this: WTFStringImpl, allocator: std.mem.Allocator) ZigString.Slice {
         if (this.is8Bit()) {
             if (bun.strings.toUTF8FromLatin1(allocator, this.latin1Slice()) catch bun.outOfMemory()) |utf8| {

--- a/test/js/bun/util/text-loader-fixture-dynamic-import-stress.ts
+++ b/test/js/bun/util/text-loader-fixture-dynamic-import-stress.ts
@@ -1,7 +1,8 @@
-const count = process.platform === "win32" ? 10_000 : 100_000;
+const count = process.platform === "win32" ? 1000 : 10_000;
 for (let i = 0; i < count; i++) {
   await import("./text-loader-fixture-text-file.txt?" + i++);
 }
+Bun.gc(true);
 
 const { default: text } = await import("./text-loader-fixture-text-file.txt");
 

--- a/test/regression/issue/06946/06946.test.ts
+++ b/test/regression/issue/06946/06946.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+test("06946", async () => {
+  const buns = Array.from(
+    { length: 25 },
+    () =>
+      Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dir, "t.mjs")],
+        cwd: import.meta.dir,
+        stdio: ["inherit", "inherit", "inherit"],
+        env: bunEnv,
+      }).exited,
+  );
+
+  const exited = await Promise.all(buns);
+  expect(exited).toEqual(Array.from({ length: 25 }, () => 0));
+});

--- a/test/regression/issue/06946/l.js
+++ b/test/regression/issue/06946/l.js
@@ -1,0 +1,3 @@
+class Logger {}
+exports.Logger = Logger;
+console.log("l.js has loaded");

--- a/test/regression/issue/06946/t.mjs
+++ b/test/regression/issue/06946/t.mjs
@@ -1,0 +1,4 @@
+import { Logger } from "./l";
+import "./t2";
+Logger.apply;
+console.log("t1 end");

--- a/test/regression/issue/06946/t2.js
+++ b/test/regression/issue/06946/t2.js
@@ -1,0 +1,3 @@
+console.log("t2 begin");
+require("./t3");
+console.log("t2 end");

--- a/test/regression/issue/06946/t3.mjs
+++ b/test/regression/issue/06946/t3.mjs
@@ -1,0 +1,5 @@
+console.log("t3 begin");
+import { Logger } from "./l";
+console.log("t3 end");
+Logger.apply;
+console.log("t3 postend");

--- a/test/regression/issue/08965/08965.test.ts
+++ b/test/regression/issue/08965/08965.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+test("08965", async () => {
+  const buns = Array.from(
+    { length: 25 },
+    () =>
+      Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dir, "1.ts")],
+        cwd: import.meta.dir,
+        stdio: ["inherit", "inherit", "inherit"],
+        env: bunEnv,
+      }).exited,
+  );
+
+  const exited = await Promise.all(buns);
+  expect(exited).toEqual(Array.from({ length: 25 }, () => 0));
+});

--- a/test/regression/issue/08965/1.ts
+++ b/test/regression/issue/08965/1.ts
@@ -1,0 +1,8 @@
+import SomeClass from "./3";
+
+import { config } from "./5";
+
+const client = {};
+
+console.log(SomeClass);
+client.config = config;

--- a/test/regression/issue/08965/3.ts
+++ b/test/regression/issue/08965/3.ts
@@ -1,0 +1,3 @@
+import somedata = require("./4");
+
+export default class SomeClass {}

--- a/test/regression/issue/08965/4.js
+++ b/test/regression/issue/08965/4.js
@@ -1,0 +1,4 @@
+// 4.js
+const config = require(`./5`);
+
+module.exports = {};

--- a/test/regression/issue/08965/5.ts
+++ b/test/regression/issue/08965/5.ts
@@ -1,0 +1,6 @@
+const config_ = {};
+
+type GeneratedConfigType = typeof config_;
+export interface Config extends GeneratedConfigType {}
+
+export const config = config_ as Config;


### PR DESCRIPTION
### What does this PR do?

- Add extra checks to ensure source code is always freed when it should be
- Optimization: precompute the hash upfront for source code transpiled on another thread. This seems
- Make `Bun.gc(true)` free more memory
- Make `CommonJSModule` store the JSC::SourceCode directly instead of using `JSC::JSSourceCode`. Goal is to free it earlier instead of whenever GC decides to free it.
- Fixes https://github.com/oven-sh/bun/issues/6946
- Fixes https://github.com/oven-sh/bun/issues/8965
- Fixes a bug where bun loads & transpiles the same code twice(!)


### How did you verify your code works?

It doesn't work yet 

It crashes in release builds, but not debug builds

I suspect something fishy with either GC or a C++ use-after-move somewhere. Worst case I revert it back
