### PR TITLE
Fix bundling for bun not using ascii_only

### DIFF
--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -6036,7 +6036,8 @@ pub fn printWithWriterAndPlatform(
     comptime generate_source_maps: bool,
 ) PrintResult {
     const PrinterType = NewPrinter(
-        false,
+        // if it's bun, it is also ascii_only
+        is_bun_platform,
         Writer,
         false,
         is_bun_platform,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -220,4 +220,13 @@ describe("bundler", () => {
     },
     run: { stdout: "Hello, world!", setCwd: true },
   });
+  itBundled("compile/Utf8", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(JSON.stringify({\u{6211}: "\u{6211}"}));
+      `,
+    },
+    run: { stdout: '{"\u{6211}":"\u{6211}"}' },
+  });
 });

--- a/test/regression/issue/09559.test.ts
+++ b/test/regression/issue/09559.test.ts
@@ -5,12 +5,14 @@ import { readdirSync } from "node:fs";
 import { join } from "path";
 
 test("bun build --target bun should support non-ascii source", async () => {
-  const files = {"index.js": `
+  const files = {
+    "index.js": `
     console.log(JSON.stringify({\u{6211}: "a"}));
 
     const \u{6211} = "b";
     console.log(JSON.stringify({\u{6211}}));
-  `};
+  `,
+  };
   const filenames = Object.keys(files);
   const source = tempDirWithFiles("source", files);
 
@@ -19,4 +21,4 @@ test("bun build --target bun should support non-ascii source", async () => {
   const result = await $`${bunExe()} ${join(source, "bundle.js")}`.text();
 
   expect(result).toBe(`{"\u{6211}":"a"}\n{"\u{6211}":"b"}\n`);
-})
+});

--- a/test/regression/issue/09559.test.ts
+++ b/test/regression/issue/09559.test.ts
@@ -6,10 +6,10 @@ import { join } from "path";
 
 test("bun build --target bun should support non-ascii source", async () => {
   const files = {"index.js": `
-    console.log(JSON.stringify({我: "a"}));
+    console.log(JSON.stringify({\u{6211}: "a"}));
 
-    const 我 = "b";
-    console.log(JSON.stringify({我}));
+    const \u{6211} = "b";
+    console.log(JSON.stringify({\u{6211}}));
   `};
   const filenames = Object.keys(files);
   const source = tempDirWithFiles("source", files);
@@ -17,6 +17,6 @@ test("bun build --target bun should support non-ascii source", async () => {
   $.throws(true);
   await $`${bunExe()} build --target bun ${join(source, "index.js")} --outfile ${join(source, "bundle.js")}`;
   const result = await $`${bunExe()} ${join(source, "bundle.js")}`.text();
-  
-  expect(result).toBe(`{"我":"a"}\n{"我":"b"}\n`);
+
+  expect(result).toBe(`{"\u{6211}":"a"}\n{"\u{6211}":"b"}\n`);
 })

--- a/test/regression/issue/09559.test.ts
+++ b/test/regression/issue/09559.test.ts
@@ -1,0 +1,22 @@
+import { $ } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { readdirSync } from "node:fs";
+import { join } from "path";
+
+test("bun build --target bun should support non-ascii source", async () => {
+  const files = {"index.js": `
+    console.log(JSON.stringify({我: "a"}));
+
+    const 我 = "b";
+    console.log(JSON.stringify({我}));
+  `};
+  const filenames = Object.keys(files);
+  const source = tempDirWithFiles("source", files);
+
+  $.throws(true);
+  await $`${bunExe()} build --target bun ${join(source, "index.js")} --outfile ${join(source, "bundle.js")}`;
+  const result = await $`${bunExe()} ${join(source, "bundle.js")}`.text();
+  
+  expect(result).toBe(`{"我":"a"}\n{"我":"b"}\n`);
+})


### PR DESCRIPTION
### What does this PR do?

Fixes #9559

In printWithWriterAndPlatform(), its NewPrinter call was always setting ascii_only to false, but that means when bundling for the bun target, the code is not emitted as ascii only and there will be errors when running because it tries to run as latin1.

This code

```js
console.log(JSON.stringify({我: "a"}));

const 我 = "b";
console.log(JSON.stringify({我}));
```

When built with `bun build --target bun code.js` now emits:

```js
// @bun
// code.js
console.log(JSON.stringify({ "\u{6211}": "a" }));
var \u{6211} = "b";
console.log(JSON.stringify({ "\u{6211}": \u{6211} }));
```

instead of:

```js
// @bun
// code.js
console.log(JSON.stringify({ "我": "a" }));
var 我 = "b";
console.log(JSON.stringify({ "我": 我 }));
```

It also works with `bun build --compile`.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Added a regression test for the issue

It tests `bun build --target bun` and not `bun build --compile` because compile takes a second and they're both the same issue.

If Zig files changed:

- [ ] N/A I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] N/A JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
