### PR TITLE
Implement `fs.openAsBlob`

### DIFF
--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -56,7 +56,7 @@ Some methods are not optimized yet.
 
 ### [`node:fs`](https://nodejs.org/api/fs.html)
 
-🟡 Missing `Dir` `openAsBlob` `opendir` `opendirSync` `statfs` `statfsSync`
+🟡 Missing `statfs` `statfsSync`, `opendirSync`. `Dir` is partially implemented.
 
 ### [`node:http`](https://nodejs.org/api/http.html)
 

--- a/src/js/node/fs.js
+++ b/src/js/node/fs.js
@@ -330,7 +330,7 @@ var access = function access(...args) {
   lutimesSync = fs.lutimesSync.bind(fs),
   rmSync = fs.rmSync.bind(fs),
   rmdirSync = fs.rmdirSync.bind(fs),
-  writev = (fd, buffers, position, callback) => {
+  writev = function writev(fd, buffers, position, callback) {
     if (typeof position === "function") {
       callback = position;
       position = null;
@@ -343,7 +343,7 @@ var access = function access(...args) {
     fs.writev(fd, buffers, position).$then(bytesWritten => callback(null, bytesWritten, buffers), callback);
   },
   writevSync = fs.writevSync.bind(fs),
-  readv = (fd, buffers, position, callback) => {
+  readv = function readv(fd, buffers, position, callback) {
     if (typeof position === "function") {
       callback = position;
       position = null;

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -37,6 +37,7 @@ import fs, {
   readvSync,
   fstatSync,
   fdatasyncSync,
+  openAsBlob,
 } from "node:fs";
 
 import _promises, { type FileHandle } from "node:fs/promises";
@@ -45,7 +46,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { ReadStream as ReadStream_, WriteStream as WriteStream_ } from "./export-from.js";
-import { ReadStream as ReadStreamStar_, WriteStream as WriteStreamStar_, fdatasync } from "./export-star-from.js";
+import { Dir, ReadStream as ReadStreamStar_, WriteStream as WriteStreamStar_, fdatasync } from "./export-star-from.js";
 import { spawnSync } from "bun";
 
 const Buffer = globalThis.Buffer || Uint8Array;
@@ -58,6 +59,10 @@ if (!import.meta.dir) {
 function mkdirForce(path: string) {
   if (!existsSync(path)) mkdirSync(path, { recursive: true });
 }
+
+it("fs.openAsBlob", async () => {
+  expect((await openAsBlob(import.meta.path)).size).toBe(statSync(import.meta.path).size);
+});
 
 it("writing to 1, 2 are possible", () => {
   expect(fs.writeSync(1, Buffer.from("\nhello-stdout-test\n"))).toBe(19);
@@ -2291,6 +2296,13 @@ describe("fs/promises", () => {
 
   it("opendir should have a path property, issue#4995", async () => {
     expect((await fs.promises.opendir(".")).path).toBe(".");
+
+    const { promise, resolve } = Promise.withResolvers<Dir>();
+    fs.opendir(".", (err, dir) => {
+      resolve(dir);
+    });
+
+    expect((await promise).path).toBe(".");
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

- Implement `fs.openAsBlob`
- Don't use `fs.readvSync` in `fs.readv` now that we have an actual implementation of `fs.readv`
- Don't use `fs.writevSync` in `fs.writev` now that we have an actual implementation of `fs.writev`
- Add `fs.opendir` stub

### How did you verify your code works?

There are some tests