### PR TITLE
fix(docs): correct value for `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD`

### DIFF
--- a/docs/runtime/env.md
+++ b/docs/runtime/env.md
@@ -169,7 +169,7 @@ These environment variables are read by Bun and configure aspects of its behavio
 ---
 
 - `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD`
-- If `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD=1`, then `bun --watch` will not clear the console on reload
+- If `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD=true`, then `bun --watch` will not clear the console on reload
 
 ---
 


### PR DESCRIPTION
updates the explanation in the docs - value must be `true`, not `1`
as proven in the implementation:

https://github.com/oven-sh/bun/blob/1675349667109d23984fc60fbcc1c4d0a25e70bf/src/bun.js/javascript.zig#L831
https://github.com/oven-sh/bun/blob/1675349667109d23984fc60fbcc1c4d0a25e70bf/src/bun.js/javascript.zig#L834
https://github.com/oven-sh/bun/blob/1675349667109d23984fc60fbcc1c4d0a25e70bf/src/bun.js/javascript.zig#L3432

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

- set `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD=1`
- run `bun --watch`
- change & save a watched file

You will observe that the terminal is cleared

Do the above with `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD=true` and it will work as expected