### PR TITLE
fix(windows) fix performance.test.ts test

### DIFF
--- a/test/js/deno/performance/performance.test.ts
+++ b/test/js/deno/performance/performance.test.ts
@@ -14,7 +14,6 @@ test({ permissions: { hrtime: false } }, async function performanceNow() {
     resolve();
   }, 50);
   await promise;
-  
   // on Windows we use libuv with can trigger 0-5ms earlier than expected
   assert(totalTime >= 45);
 });
@@ -94,7 +93,7 @@ test(function performanceMeasure() {
         assertEquals(measure2.startTime, 0);
         assertEquals(mark1.startTime, measure1.startTime);
         assertEquals(mark1.startTime, measure2.duration);
-          // on Windows we use libuv with can trigger 0-5ms earlier than expected
+        // on Windows we use libuv with can trigger 0-5ms earlier than expected
         assert(measure1.duration >= 95, `duration below 100ms: ${measure1.duration}`);
         assert(
           measure1.duration < (later - now) * 1.5,

--- a/test/js/deno/performance/performance.test.ts
+++ b/test/js/deno/performance/performance.test.ts
@@ -12,9 +12,11 @@ test({ permissions: { hrtime: false } }, async function performanceNow() {
     const end = performance.now();
     totalTime = end - start;
     resolve();
-  }, 10);
+  }, 50);
   await promise;
-  assert(totalTime >= 10);
+  
+  // on Windows we use libuv with can trigger 0-5ms earlier than expected
+  assert(totalTime >= 45);
 });
 
 test(function timeOrigin() {
@@ -92,7 +94,8 @@ test(function performanceMeasure() {
         assertEquals(measure2.startTime, 0);
         assertEquals(mark1.startTime, measure1.startTime);
         assertEquals(mark1.startTime, measure2.duration);
-        assert(measure1.duration >= 100, `duration below 100ms: ${measure1.duration}`);
+          // on Windows we use libuv with can trigger 0-5ms earlier than expected
+        assert(measure1.duration >= 95, `duration below 100ms: ${measure1.duration}`);
         assert(
           measure1.duration < (later - now) * 1.5,
           `duration exceeds 150% of wallclock time: ${measure1.duration}ms vs ${later - now}ms`,


### PR DESCRIPTION
### What does this PR do?
on Windows libuv can trigger 0-5ms earlier a callback (normally triggers after but it can happen, specially with timers less than 50ms)

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
- [x] Test changes
### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
