### PR TITLE
fix(test): fix crash in `expect.toHaveProperty`

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3571,7 +3571,7 @@ JSC__JSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC__JSValue JSValue0, JS
     JSValue path = JSValue::decode(arg1);
 
     if (path.isString()) {
-        StringView pathString = path.toWTFString(globalObject);
+        String pathString = path.toWTFString(globalObject);
         uint32_t length = pathString.length();
 
         if (length == 0) {
@@ -3640,13 +3640,8 @@ JSC__JSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC__JSValue JSValue0, JS
                 jc = pathString.characterAt(j);
             }
 
-            StringView propNameStr = pathString.substring(i, j - i);
-
-            Identifier ident = propNameStr.is8Bit()
-                ? Identifier::fromString(vm, propNameStr.characters8(), propNameStr.length())
-                : Identifier::fromString(vm, propNameStr.characters16(), propNameStr.length());
-
-            PropertyName propName = PropertyName(ident);
+            String propNameStr = pathString.substring(i, j - i);
+            PropertyName propName = PropertyName(Identifier::fromString(vm, propNameStr));
 
             currProp = currProp.toObject(globalObject)->getIfPropertyExists(globalObject, propName);
             RETURN_IF_EXCEPTION(scope, {});

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3571,7 +3571,7 @@ JSC__JSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC__JSValue JSValue0, JS
     JSValue path = JSValue::decode(arg1);
 
     if (path.isString()) {
-        String pathString = path.toWTFString(globalObject);
+        StringView pathString = path.toWTFString(globalObject);
         uint32_t length = pathString.length();
 
         if (length == 0) {
@@ -3640,7 +3640,14 @@ JSC__JSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC__JSValue JSValue0, JS
                 jc = pathString.characterAt(j);
             }
 
-            PropertyName propName = PropertyName(Identifier::fromString(vm, pathString.substring(i, j - i)));
+            StringView propNameStr = pathString.substring(i, j - i);
+
+            Identifier ident = propNameStr.is8Bit()
+                ? Identifier::fromString(vm, propNameStr.characters8(), propNameStr.length())
+                : Identifier::fromString(vm, propNameStr.characters16(), propNameStr.length());
+
+            PropertyName propName = PropertyName(ident);
+
             currProp = currProp.toObject(globalObject)->getIfPropertyExists(globalObject, propName);
             RETURN_IF_EXCEPTION(scope, {});
             if (currProp.isEmpty()) {


### PR DESCRIPTION
### What does this PR do?
Passing `substring(i, j - i)` directly into `Identifier::fromString` would immediately deref the substring after creating the property name causing `getIfPropertyExists` to crash.

Changed this function to use `StringView`.
<!-- **Please explain what your changes do**, example: -->


### How did you verify your code works?
tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
