### PR TITLE
docs: fix typos in shell.md

### DIFF
--- a/docs/runtime/shell.md
+++ b/docs/runtime/shell.md
@@ -1,8 +1,7 @@
 Bun Shell makes shell scripting with JavaScript & TypeScript fun. It's a cross-platform bash-like shell with seamless JavaScript interop.
 
-{% callout type="note" %}
-**Alpha-quality software**: Bun Shell is an unstable API still under development. If you have feature requests or run into bugs, please open an issue. There may be breaking changes in the future.
-{% /callout %}
+> [!NOTE]  
+> **Alpha-quality software**: Bun Shell is an unstable API still under development. If you have feature requests or run into bugs, please open an issue. There may be breaking changes in the future.
 
 Quickstart:
 
@@ -406,7 +405,8 @@ For simple shell scripts, instead of `/bin/sh`, you can use Bun Shell to run she
 
 To do so, just run the script with `bun` on a file with the `.bun.sh` extension.
 
-```sh#script.bun.sh
+```sh
+# script.bun.sh
 echo "Hello World! pwd=$(pwd)"
 ```
 


### PR DESCRIPTION
### What does this PR do?

Updates a few typos in docs.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

 Before, it would look like this: 
<img width="706" alt="image" src="https://github.com/oven-sh/bun/assets/1909384/8f614452-8e59-48f2-b59b-f2963fd05d4b">

### Notice

I am not sure if these docs are also used outside github, so maybe github not being able to parse % callout syntax is OK for you.

Reference: https://github.com/orgs/community/discussions/16925