### PR TITLE
Revert "fix(windows) socket and timers/performance tests"

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -3797,8 +3797,7 @@ pub const Timer = struct {
             if (vm.isInspectorEnabled()) {
                 Debugger.willDispatchAsyncCall(globalThis, .DOMTimer, Timeout.ID.asyncID(.{ .id = this.id, .kind = kind }));
             }
-            vm.eventLoop().enter();
-            defer vm.eventLoop().exit();
+
             const result = callback.callWithGlobalThis(
                 globalThis,
                 args,
@@ -4054,7 +4053,8 @@ pub const Timer = struct {
                 if (this.cancelled) {
                     _ = uv.uv_timer_stop(&this.timer);
                 }
-                this.runFromJSThread();
+                // libuv runs on the same thread
+                return this.runFromJSThread();
             }
 
             fn onRequest(req: *bun.io.Request) bun.io.Action {
@@ -4146,8 +4146,6 @@ pub const Timer = struct {
                 _ = this.scheduled_count.fetchAdd(1, .Monotonic);
                 const ms: usize = @max(interval orelse this.interval, 1);
                 if (Environment.isWindows) {
-                    // we MUST update the timer so we avoid early firing
-                    uv.uv_update_time(uv.Loop.get());
                     if (uv.uv_timer_start(&this.timer, TimerReference.onUVRequest, @intCast(ms), 0) != 0) @panic("unable to start timer");
                     return;
                 }

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -1206,7 +1206,7 @@ pub const PipeReader = struct {
         const owned = this.toOwnedSlice();
         this.state = .{ .done = owned };
         if (!this.isDone()) return;
-        // we need to ref because the process might be done and deref inside signalDoneToCmd and we wanna to keep it alive to check this.process
+        // we need to ref because the process might be done and deref inside signalDoneToCmd before we call onCloseIO
         this.ref();
         defer this.deref();
         this.trySignalDoneToCmd();
@@ -1325,9 +1325,6 @@ pub const PipeReader = struct {
             bun.default_allocator.free(this.state.done);
         }
         this.state = .{ .err = err.toSystemError() };
-        // we need to ref because the process might be done and deref inside signalDoneToCmd and we wanna to keep it alive to check this.process
-        this.ref();
-        defer this.deref();
         this.trySignalDoneToCmd();
         if (this.process) |process| {
             // this.process = null;

--- a/test/js/bun/net/keep-event-loop-alive.js
+++ b/test/js/bun/net/keep-event-loop-alive.js
@@ -1,12 +1,11 @@
 (async () => {
   const port = process.argv[2] ? parseInt(process.argv[2]) : null;
-  const hostname = process.argv[3] ? process.argv[3] : "localhost";
   await Bun.sleep(10);
   // failed connection
   console.log("test 1: failed connection");
   try {
     const socket = await Bun.connect({
-      hostname: hostname,
+      hostname: "localhost",
       port: 9999,
       socket: { data() {} },
     });
@@ -16,7 +15,7 @@
   console.log("test 2: failed connection [tls]");
   try {
     const socket = await Bun.connect({
-      hostname: hostname,
+      hostname: "localhost",
       port: 9999,
       socket: { data() {} },
       tls: true,
@@ -27,7 +26,7 @@
     // successful connection
     console.log("test 3: successful connection");
     const socket = await Bun.connect({
-      hostname: hostname,
+      hostname: "localhost",
       port,
       socket: { data() {} },
     });
@@ -36,7 +35,7 @@
     // successful connection tls
     console.log("test 4: successful connection [tls]");
     const socket2 = await Bun.connect({
-      hostname: hostname,
+      hostname: "localhost",
       port,
       socket: { data() {} },
     });

--- a/test/js/bun/net/socket-huge-fixture.js
+++ b/test/js/bun/net/socket-huge-fixture.js
@@ -19,19 +19,14 @@ var server = listen({
     open(socket) {
       console.time("send 1 GB (server)");
       socket.data.sent = socket.write(huge);
-      if (socket.data.sent === huge.length) {
-        console.timeEnd("send 1 GB (server)");
-        socket.shutdown();
-        serverResolve();
-      }
     },
     async drain(socket) {
       socket.data.sent += socket.write(huge.subarray(socket.data.sent));
-      // console.error("Sent", socket.data.sent, "bytes");
 
       if (socket.data.sent === huge.length) {
         console.timeEnd("send 1 GB (server)");
         socket.shutdown();
+        server.stop(true);
         serverResolve();
       }
     },
@@ -40,7 +35,7 @@ var server = listen({
 
 const socket = await connect({
   port: server.port,
-  hostname: server.hostname,
+  hostname: "localhost",
   data: { received: 0 },
   socket: {
     open(socket) {
@@ -50,7 +45,7 @@ const socket = await connect({
 
     data(socket, data) {
       socket.data.received += data.length;
-      // console.error("Received", data.length, "bytes");
+      console.log("Received", data.length, "bytes");
       received.update(data);
 
       if (socket.data.received === huge.length) {
@@ -63,7 +58,7 @@ const socket = await connect({
 });
 
 await Promise.all([clientPromise, serverPromise]);
-server.stop(true);
+server.stop();
 socket.end();
 
 if (received.digest("hex") !== Bun.SHA256.hash(huge, "hex")) {

--- a/test/js/bun/util/sleep-keepalive.ts
+++ b/test/js/bun/util/sleep-keepalive.ts
@@ -1,4 +1,0 @@
-(async () => {
-  await Bun.sleep(10);
-  console.log("event loop was not killed");
-})();

--- a/test/js/bun/util/sleep.test.ts
+++ b/test/js/bun/util/sleep.test.ts
@@ -58,17 +58,3 @@ test("sleep should saturate timeout values", async () => {
 
   await allExited;
 });
-
-test("sleep should keep the event loop alive", async () => {
-  const proc = Bun.spawn({
-    cmd: [bunExe(), "sleep-keepalive.ts"],
-    stderr: "inherit",
-    stdout: "pipe",
-    stdin: "inherit",
-    env: bunEnv,
-    cwd: import.meta.dir,
-  });
-  await proc.exited;
-  expect(proc.exitCode).toBe(0);
-  expect(await new Response(proc.stdout).text()).toContain("event loop was not killed");
-});


### PR DESCRIPTION
Reverts oven-sh/bun#9651

node-http2 test is segfaulting, went unnoticed due to #9630 causing tests to not run