### PR TITLE
fix(http2): fix crash in http2 tests

### DIFF
--- a/test/js/node/http2/node-echo-server.fixture.js
+++ b/test/js/node/http2/node-echo-server.fixture.js
@@ -17,7 +17,7 @@ server.on("stream", (stream, headers, flags) => {
     "set-cookie": setCookie,
   });
   // errors here are not useful the test should handle on the client side
-  stream.on("error", () => {});
+  stream.on("error", err => console.error(err));
 
   if (headers["x-wait-trailer"]) {
     const response = { headers, flags };

--- a/test/js/node/http2/node-echo-server.fixture.js
+++ b/test/js/node/http2/node-echo-server.fixture.js
@@ -16,6 +16,7 @@ server.on("stream", (stream, headers, flags) => {
     ":status": 200,
     "set-cookie": setCookie,
   });
+  // errors here are not useful the test should handle on the client side
   stream.on("error", () => {});
 
   if (headers["x-wait-trailer"]) {

--- a/test/js/node/http2/node-echo-server.fixture.js
+++ b/test/js/node/http2/node-echo-server.fixture.js
@@ -16,6 +16,7 @@ server.on("stream", (stream, headers, flags) => {
     ":status": 200,
     "set-cookie": setCookie,
   });
+  stream.on("error", () => {});
 
   if (headers["x-wait-trailer"]) {
     const response = { headers, flags };

--- a/test/js/node/http2/node-http2-memory-leak.js
+++ b/test/js/node/http2/node-http2-memory-leak.js
@@ -32,7 +32,7 @@ async function runRequests(iterations) {
   for (let j = 0; j < iterations; j++) {
     let client = http2.connect(info.url, { rejectUnauthorized: false });
     let promises = [];
-    // 10 multiplex POST connections per iteration
+    // 100 multiplex POST connections per iteration
     for (let i = 0; i < 100; i++) {
       const { promise, resolve, reject } = Promise.withResolvers();
       const req = client.request({ ":path": "/post", ":method": "POST" });

--- a/test/js/node/http2/node-http2-memory-leak.js
+++ b/test/js/node/http2/node-http2-memory-leak.js
@@ -33,7 +33,7 @@ async function runRequests(iterations) {
     let client = http2.connect(info.url, { rejectUnauthorized: false });
     let promises = [];
     // 10 multiplex POST connections per iteration
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 100; i++) {
       const { promise, resolve, reject } = Promise.withResolvers();
       const req = client.request({ ":path": "/post", ":method": "POST" });
       let got_response = false;

--- a/test/js/node/http2/node-http2-memory-leak.js
+++ b/test/js/node/http2/node-http2-memory-leak.js
@@ -32,8 +32,8 @@ async function runRequests(iterations) {
   for (let j = 0; j < iterations; j++) {
     let client = http2.connect(info.url, { rejectUnauthorized: false });
     let promises = [];
-    // 100 multiplex POST connections per iteration
-    for (let i = 0; i < 100; i++) {
+    // 10 multiplex POST connections per iteration
+    for (let i = 0; i < 10; i++) {
       const { promise, resolve, reject } = Promise.withResolvers();
       const req = client.request({ ":path": "/post", ":method": "POST" });
       let got_response = false;

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -465,6 +465,7 @@ describe("Client Basics", () => {
   it("getDefaultSettings", () => {
     const settings = http2.getDefaultSettings();
     expect(settings).toEqual({
+      enableConnectProtocol: false,
       headerTableSize: 4096,
       enablePush: true,
       initialWindowSize: 65535,
@@ -483,6 +484,7 @@ describe("Client Basics", () => {
       maxConcurrentStreams: 4,
       maxHeaderListSize: 5,
       maxHeaderSize: 5,
+      enableConnectProtocol: false,
     };
     const buffer = http2.getPackedSettings(settings);
     expect(buffer.byteLength).toBe(36);


### PR DESCRIPTION
### What does this PR do?
Two settings were missing causing an `enumFromInt` call to fail (received 9 when max value is 6). Added the settings.

@cirospaciari can you check that we are using these settings correctly?
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
