### PR TITLE
alternate approach to env fix

### DIFF
--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -133,7 +133,7 @@ pub const Run = struct {
             try @import("./bun.js/config.zig").configureTransformOptionsForBunVM(ctx.allocator, ctx.args),
             null,
         );
-        try bundle.runEnvLoader(true);
+        try bundle.runEnvLoader(false);
         const mini = JSC.MiniEventLoop.initGlobal(bundle.env);
         mini.top_level_dir = ctx.args.absolute_working_dir orelse "";
         return try bun.shell.Interpreter.initAndRunFromFile(mini, entry_path);

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -133,7 +133,7 @@ pub const Run = struct {
             try @import("./bun.js/config.zig").configureTransformOptionsForBunVM(ctx.allocator, ctx.args),
             null,
         );
-        try bundle.runEnvLoader();
+        try bundle.runEnvLoader(false);
         const mini = JSC.MiniEventLoop.initGlobal(bundle.env);
         mini.top_level_dir = ctx.args.absolute_working_dir orelse "";
         return try bun.shell.Interpreter.initAndRunFromFile(mini, entry_path);

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -133,7 +133,7 @@ pub const Run = struct {
             try @import("./bun.js/config.zig").configureTransformOptionsForBunVM(ctx.allocator, ctx.args),
             null,
         );
-        try bundle.runEnvLoader(false);
+        try bundle.runEnvLoader(true);
         const mini = JSC.MiniEventLoop.initGlobal(bundle.env);
         mini.top_level_dir = ctx.args.absolute_working_dir orelse "";
         return try bun.shell.Interpreter.initAndRunFromFile(mini, entry_path);

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -520,7 +520,7 @@ pub const Bundler = struct {
         bundler.configureLinkerWithAutoJSX(true);
     }
 
-    pub fn runEnvLoader(this: *Bundler) !void {
+    pub fn runEnvLoader(this: *Bundler, is_script_runner: bool) !void {
         switch (this.options.env.behavior) {
             .prefix, .load_all, .load_all_without_inlining => {
                 // Step 1. Load the project root.
@@ -541,11 +541,11 @@ pub const Bundler = struct {
                 }
 
                 if (this.options.isTest() or this.env.isTest()) {
-                    try this.env.load(dir, this.options.env.files, .@"test");
+                    try this.env.load(dir, this.options.env.files, .@"test", is_script_runner);
                 } else if (this.options.production) {
-                    try this.env.load(dir, this.options.env.files, .production);
+                    try this.env.load(dir, this.options.env.files, .production, is_script_runner);
                 } else {
-                    try this.env.load(dir, this.options.env.files, .development);
+                    try this.env.load(dir, this.options.env.files, .development, is_script_runner);
                 }
             },
             .disable => {
@@ -584,7 +584,7 @@ pub const Bundler = struct {
             this.options.env.prefix = "BUN_";
         }
 
-        try this.runEnvLoader();
+        try this.runEnvLoader(false);
 
         this.options.jsx.setProduction(this.env.isProduction());
 

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -520,7 +520,7 @@ pub const Bundler = struct {
         bundler.configureLinkerWithAutoJSX(true);
     }
 
-    pub fn runEnvLoader(this: *Bundler, is_script_runner: bool) !void {
+    pub fn runEnvLoader(this: *Bundler, skip_default_env: bool) !void {
         switch (this.options.env.behavior) {
             .prefix, .load_all, .load_all_without_inlining => {
                 // Step 1. Load the project root.
@@ -541,11 +541,11 @@ pub const Bundler = struct {
                 }
 
                 if (this.options.isTest() or this.env.isTest()) {
-                    try this.env.load(dir, this.options.env.files, .@"test", is_script_runner);
+                    try this.env.load(dir, this.options.env.files, .@"test", skip_default_env);
                 } else if (this.options.production) {
-                    try this.env.load(dir, this.options.env.files, .production, is_script_runner);
+                    try this.env.load(dir, this.options.env.files, .production, skip_default_env);
                 } else {
-                    try this.env.load(dir, this.options.env.files, .development, is_script_runner);
+                    try this.env.load(dir, this.options.env.files, .development, skip_default_env);
                 }
             },
             .disable => {

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -520,7 +520,7 @@ pub const Bundler = struct {
         bundler.configureLinkerWithAutoJSX(true);
     }
 
-    pub fn runEnvLoader(this: *Bundler, load_default_env: bool) !void {
+    pub fn runEnvLoader(this: *Bundler, is_script_runner: bool) !void {
         switch (this.options.env.behavior) {
             .prefix, .load_all, .load_all_without_inlining => {
                 // Step 1. Load the project root.
@@ -541,11 +541,11 @@ pub const Bundler = struct {
                 }
 
                 if (this.options.isTest() or this.env.isTest()) {
-                    try this.env.load(dir, this.options.env.files, .@"test", load_default_env);
+                    try this.env.load(dir, this.options.env.files, .@"test", is_script_runner);
                 } else if (this.options.production) {
-                    try this.env.load(dir, this.options.env.files, .production, load_default_env);
+                    try this.env.load(dir, this.options.env.files, .production, is_script_runner);
                 } else {
-                    try this.env.load(dir, this.options.env.files, .development, load_default_env);
+                    try this.env.load(dir, this.options.env.files, .development, is_script_runner);
                 }
             },
             .disable => {

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -520,7 +520,7 @@ pub const Bundler = struct {
         bundler.configureLinkerWithAutoJSX(true);
     }
 
-    pub fn runEnvLoader(this: *Bundler, is_script_runner: bool) !void {
+    pub fn runEnvLoader(this: *Bundler, load_default_env: bool) !void {
         switch (this.options.env.behavior) {
             .prefix, .load_all, .load_all_without_inlining => {
                 // Step 1. Load the project root.
@@ -541,11 +541,11 @@ pub const Bundler = struct {
                 }
 
                 if (this.options.isTest() or this.env.isTest()) {
-                    try this.env.load(dir, this.options.env.files, .@"test", is_script_runner);
+                    try this.env.load(dir, this.options.env.files, .@"test", load_default_env);
                 } else if (this.options.production) {
-                    try this.env.load(dir, this.options.env.files, .production, is_script_runner);
+                    try this.env.load(dir, this.options.env.files, .production, load_default_env);
                 } else {
-                    try this.env.load(dir, this.options.env.files, .development, is_script_runner);
+                    try this.env.load(dir, this.options.env.files, .development, load_default_env);
                 }
             },
             .disable => {

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -882,7 +882,7 @@ pub const RunCommand = struct {
                 }
             }
 
-            this_bundler.runEnvLoader(true) catch {};
+            this_bundler.runEnvLoader(false) catch {};
         }
 
         this_bundler.env.map.putDefault("npm_config_local_prefix", this_bundler.fs.top_level_dir) catch unreachable;

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -882,7 +882,7 @@ pub const RunCommand = struct {
                 }
             }
 
-            this_bundler.runEnvLoader(false) catch {};
+            this_bundler.runEnvLoader(true) catch {};
         }
 
         this_bundler.env.map.putDefault("npm_config_local_prefix", this_bundler.fs.top_level_dir) catch unreachable;

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -850,7 +850,7 @@ pub const RunCommand = struct {
 
         this_bundler.configureLinker();
 
-        var root_dir_info = this_bundler.resolver.readDirInfo(this_bundler.fs.top_level_dir) catch |err| {
+        const root_dir_info = this_bundler.resolver.readDirInfo(this_bundler.fs.top_level_dir) catch |err| {
             if (!log_errors) return error.CouldntReadCurrentDirectory;
             if (Output.enable_ansi_colors) {
                 ctx.log.printForLogLevelWithEnableAnsiColors(Output.errorWriter(), true) catch {};
@@ -882,20 +882,7 @@ pub const RunCommand = struct {
                 }
             }
 
-            // TODO: evaluate if we can skip running this in nested calls to bun run
-            // The reason why it's unclear:
-            // - Some scripts may do NODE_ENV=production bun run foo
-            //   This would cause potentially a different .env file to be loaded
-            this_bundler.runEnvLoader() catch {};
-
-            if (root_dir_info.getEntries(0)) |dir| {
-                // Run .env again if it exists in a parent dir
-                if (this_bundler.options.production) {
-                    this_bundler.env.load(dir, this_bundler.options.env.files, .production) catch {};
-                } else {
-                    this_bundler.env.load(dir, this_bundler.options.env.files, .development) catch {};
-                }
-            }
+            this_bundler.runEnvLoader(true) catch {};
         }
 
         this_bundler.env.map.putDefault("npm_config_local_prefix", this_bundler.fs.top_level_dir) catch unreachable;

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -468,13 +468,22 @@ pub const Loader = struct {
         dir: *Fs.FileSystem.DirEntry,
         env_files: []const []const u8,
         comptime suffix: DotEnvFileSuffix,
+        is_script_runner: bool,
     ) !void {
         const start = std.time.nanoTimestamp();
 
         if (env_files.len > 0) {
             try this.loadExplicitFiles(env_files);
         } else {
-            try this.loadDefaultFiles(dir, suffix);
+            // Do not automatically load .env files in `bun run <script>`
+            // Instead, it is the responsibility of the script's instance of `bun` to load .env,
+            // so that if the script runner is NODE_ENV=development, but the script is
+            // "NODE_ENV=production bun ...", there should be no development env loaded.
+            //
+            // See https://github.com/oven-sh/bun/issues/9635#issuecomment-2021350123
+            // for more details on how this edge case works.
+            if (!is_script_runner)
+                try this.loadDefaultFiles(dir, suffix);
         }
 
         if (!this.quiet) this.printLoaded(start);
@@ -492,7 +501,7 @@ pub const Loader = struct {
                 var iter = std.mem.splitBackwardsScalar(u8, arg_value, ',');
                 while (iter.next()) |file_path| {
                     if (file_path.len > 0) {
-                        try this.loadEnvFileDynamic(file_path, false, true);
+                        try this.loadEnvFileDynamic(file_path, false);
                         Analytics.Features.dotenv = true;
                     }
                 }
@@ -514,19 +523,19 @@ pub const Loader = struct {
         switch (comptime suffix) {
             .development => {
                 if (dir.hasComptimeQuery(".env.development.local")) {
-                    try this.loadEnvFile(dir_handle, ".env.development.local", false, true);
+                    try this.loadEnvFile(dir_handle, ".env.development.local", false);
                     Analytics.Features.dotenv = true;
                 }
             },
             .production => {
                 if (dir.hasComptimeQuery(".env.production.local")) {
-                    try this.loadEnvFile(dir_handle, ".env.production.local", false, true);
+                    try this.loadEnvFile(dir_handle, ".env.production.local", false);
                     Analytics.Features.dotenv = true;
                 }
             },
             .@"test" => {
                 if (dir.hasComptimeQuery(".env.test.local")) {
-                    try this.loadEnvFile(dir_handle, ".env.test.local", false, true);
+                    try this.loadEnvFile(dir_handle, ".env.test.local", false);
                     Analytics.Features.dotenv = true;
                 }
             },
@@ -534,7 +543,7 @@ pub const Loader = struct {
 
         if (comptime suffix != .@"test") {
             if (dir.hasComptimeQuery(".env.local")) {
-                try this.loadEnvFile(dir_handle, ".env.local", false, false);
+                try this.loadEnvFile(dir_handle, ".env.local", false);
                 Analytics.Features.dotenv = true;
             }
         }
@@ -542,26 +551,26 @@ pub const Loader = struct {
         switch (comptime suffix) {
             .development => {
                 if (dir.hasComptimeQuery(".env.development")) {
-                    try this.loadEnvFile(dir_handle, ".env.development", false, true);
+                    try this.loadEnvFile(dir_handle, ".env.development", false);
                     Analytics.Features.dotenv = true;
                 }
             },
             .production => {
                 if (dir.hasComptimeQuery(".env.production")) {
-                    try this.loadEnvFile(dir_handle, ".env.production", false, true);
+                    try this.loadEnvFile(dir_handle, ".env.production", false);
                     Analytics.Features.dotenv = true;
                 }
             },
             .@"test" => {
                 if (dir.hasComptimeQuery(".env.test")) {
-                    try this.loadEnvFile(dir_handle, ".env.test", false, true);
+                    try this.loadEnvFile(dir_handle, ".env.test", false);
                     Analytics.Features.dotenv = true;
                 }
             },
         }
 
         if (dir.hasComptimeQuery(".env")) {
-            try this.loadEnvFile(dir_handle, ".env", false, false);
+            try this.loadEnvFile(dir_handle, ".env", false);
             Analytics.Features.dotenv = true;
         }
     }
@@ -636,7 +645,6 @@ pub const Loader = struct {
         dir: std.fs.Dir,
         comptime base: string,
         comptime override: bool,
-        comptime conditional: bool,
     ) !void {
         if (@field(this, base) != null) {
             return;
@@ -714,7 +722,6 @@ pub const Loader = struct {
             this.map,
             override,
             false,
-            conditional,
         );
 
         @field(this, base) = source;
@@ -724,7 +731,6 @@ pub const Loader = struct {
         this: *Loader,
         file_path: []const u8,
         comptime override: bool,
-        comptime conditional: bool,
     ) !void {
         if (this.custom_files_loaded.contains(file_path)) {
             return;
@@ -786,7 +792,6 @@ pub const Loader = struct {
             this.map,
             override,
             false,
-            conditional,
         );
 
         try this.custom_files_loaded.put(file_path, source);
@@ -1011,7 +1016,6 @@ const Parser = struct {
         map: *Map,
         comptime override: bool,
         comptime is_process: bool,
-        comptime conditional: bool,
     ) void {
         var count = map.map.count();
         while (this.pos < this.src.len) {
@@ -1032,7 +1036,7 @@ const Parser = struct {
             }
             entry.value_ptr.* = .{
                 .value = allocator.dupe(u8, value) catch unreachable,
-                .conditional = conditional,
+                .conditional = false,
             };
         }
         if (comptime !is_process) {
@@ -1044,7 +1048,7 @@ const Parser = struct {
                     allocator.free(entry.value_ptr.value);
                     entry.value_ptr.* = .{
                         .value = allocator.dupe(u8, value) catch unreachable,
-                        .conditional = conditional,
+                        .conditional = false,
                     };
                 }
             }
@@ -1057,10 +1061,9 @@ const Parser = struct {
         map: *Map,
         comptime override: bool,
         comptime is_process: bool,
-        comptime conditional: bool,
     ) void {
         var parser = Parser{ .src = source.contents };
-        parser._parse(allocator, map, override, is_process, conditional);
+        parser._parse(allocator, map, override, is_process);
     }
 };
 
@@ -1108,10 +1111,7 @@ pub const Map = struct {
 
         var iter = this.map.iterator();
         while (iter.next()) |entry| {
-            // Allow var from .env.development or .env.production to be loaded again
-            if (!entry.value_ptr.conditional) {
-                try env_map.hash_map.put(entry.key_ptr.*, entry.value_ptr.value);
-            }
+            try env_map.hash_map.put(entry.key_ptr.*, entry.value_ptr.value);
         }
 
         return .{ .unsafe_map = env_map };

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -468,7 +468,7 @@ pub const Loader = struct {
         dir: *Fs.FileSystem.DirEntry,
         env_files: []const []const u8,
         comptime suffix: DotEnvFileSuffix,
-        load_default_env: bool,
+        is_script_runner: bool,
     ) !void {
         const start = std.time.nanoTimestamp();
 
@@ -482,7 +482,7 @@ pub const Loader = struct {
             //
             // See https://github.com/oven-sh/bun/issues/9635#issuecomment-2021350123
             // for more details on how this edge case works.
-            if (load_default_env)
+            if (!is_script_runner)
                 try this.loadDefaultFiles(dir, suffix);
         }
 

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -468,7 +468,7 @@ pub const Loader = struct {
         dir: *Fs.FileSystem.DirEntry,
         env_files: []const []const u8,
         comptime suffix: DotEnvFileSuffix,
-        is_script_runner: bool,
+        skip_default_env: bool,
     ) !void {
         const start = std.time.nanoTimestamp();
 
@@ -482,7 +482,7 @@ pub const Loader = struct {
             //
             // See https://github.com/oven-sh/bun/issues/9635#issuecomment-2021350123
             // for more details on how this edge case works.
-            if (!is_script_runner)
+            if (!skip_default_env)
                 try this.loadDefaultFiles(dir, suffix);
         }
 

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -468,7 +468,7 @@ pub const Loader = struct {
         dir: *Fs.FileSystem.DirEntry,
         env_files: []const []const u8,
         comptime suffix: DotEnvFileSuffix,
-        is_script_runner: bool,
+        load_default_env: bool,
     ) !void {
         const start = std.time.nanoTimestamp();
 
@@ -482,7 +482,7 @@ pub const Loader = struct {
             //
             // See https://github.com/oven-sh/bun/issues/9635#issuecomment-2021350123
             // for more details on how this edge case works.
-            if (!is_script_runner)
+            if (load_default_env)
                 try this.loadDefaultFiles(dir, suffix);
         }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -6672,7 +6672,7 @@ pub const PackageManager = struct {
         };
 
         env.loadProcess();
-        try env.load(entries_option.entries, &[_][]u8{}, .production, false);
+        try env.load(entries_option.entries, &[_][]u8{}, .production, true);
 
         var cpu_count = @as(u32, @truncate(((try std.Thread.getCpuCount()) + 1)));
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -6672,7 +6672,7 @@ pub const PackageManager = struct {
         };
 
         env.loadProcess();
-        try env.load(entries_option.entries, &[_][]u8{}, .production, true);
+        try env.load(entries_option.entries, &[_][]u8{}, .production, false);
 
         var cpu_count = @as(u32, @truncate(((try std.Thread.getCpuCount()) + 1)));
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -6672,7 +6672,7 @@ pub const PackageManager = struct {
         };
 
         env.loadProcess();
-        try env.load(entries_option.entries, &[_][]u8{}, .production);
+        try env.load(entries_option.entries, &[_][]u8{}, .production, false);
 
         var cpu_count = @as(u32, @truncate(((try std.Thread.getCpuCount()) + 1)));
 

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1112,7 +1112,7 @@ pub const Printer = struct {
         };
 
         env_loader.loadProcess();
-        try env_loader.load(entries_option.entries, &[_][]u8{}, .production, false);
+        try env_loader.load(entries_option.entries, &[_][]u8{}, .production, true);
         var log = logger.Log.init(allocator);
         try options.load(
             allocator,

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1112,7 +1112,7 @@ pub const Printer = struct {
         };
 
         env_loader.loadProcess();
-        try env_loader.load(entries_option.entries, &[_][]u8{}, .production);
+        try env_loader.load(entries_option.entries, &[_][]u8{}, .production, false);
         var log = logger.Log.init(allocator);
         try options.load(
             allocator,

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1112,7 +1112,7 @@ pub const Printer = struct {
         };
 
         env_loader.loadProcess();
-        try env_loader.load(entries_option.entries, &[_][]u8{}, .production, true);
+        try env_loader.load(entries_option.entries, &[_][]u8{}, .production, false);
         var log = logger.Log.init(allocator);
         try options.load(
             allocator,

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -710,6 +710,84 @@ test("NODE_ENV default is not propogated in bun run", () => {
   expect(bunRunAsScript(tmp, "show-env", {}).stdout).toBe("");
 });
 
+for (const shell of ["system", "bun"]) {
+  const isWindowsCMD = isWindows && shell === "system";
+
+  const show_env_script = isWindowsCMD //
+    ? "echo ENV_FILE_NAME=%ENV_FILE_NAME%, NODE_ENV=%NODE_ENV%"
+    : "echo ENV_FILE_NAME=$ENV_FILE_NAME, NODE_ENV=$NODE_ENV";
+
+  describe(`script runner with ${shell} shell`, () => {
+    test("does not pass variables from .env files into scripts", () => {
+      const tmp = tempDirWithFiles("script-runner-env", {
+        "package.json": '{"scripts":{"show-env":"' + show_env_script + '"}}',
+
+        ".env.development": "ENV_FILE_NAME=.env.development",
+        ".env.production": "ENV_FILE_NAME=.env.production",
+        ".env.test": "ENV_FILE_NAME=.env.test",
+        ".env": "ENV_FILE_NAME=.env",
+      });
+
+      expect(bunRunAsScript(tmp, "show-env", {}, ["--shell=" + shell]).stdout).toBe("ENV_FILE_NAME=, NODE_ENV=");
+    });
+
+    for (const { NODE_ENV, expected, env_file } of [
+      {
+        NODE_ENV: "production",
+        expected: "production",
+        env_file: ".env.production",
+      },
+      {
+        NODE_ENV: "development",
+        expected: "development",
+        env_file: ".env.development",
+      },
+      {
+        NODE_ENV: undefined,
+        expected: "",
+        env_file: ".env.development",
+      },
+    ]) {
+      test("explicit NODE_ENV=" + NODE_ENV, () => {
+        const tmp = tempDirWithFiles("script-runner-env", {
+          "package.json": '{"scripts":{"show-env":"' + show_env_script + '"}}',
+
+          ".env.development": "ENV_FILE_NAME=.env.development",
+          ".env.production": "ENV_FILE_NAME=.env.production",
+          ".env.test": "ENV_FILE_NAME=.env.test",
+          ".env": "ENV_FILE_NAME=.env",
+        });
+
+        expect(bunRunAsScript(tmp, "show-env", { NODE_ENV }, ["--shell=" + shell]).stdout).toBe(
+          "ENV_FILE_NAME=, NODE_ENV=" + expected,
+        );
+      });
+
+      // This is already covered in isolation by the '.env file is loaded' describe
+      // but it is nice to have just a couple e2e tests combining script runner AND the runtime.
+      test("e2e NODE_ENV=" + NODE_ENV, () => {
+        const run_index_script = isWindowsCMD
+          ? `set NODE_ENV=${NODE_ENV} && bun run index.ts`
+          : `NODE_ENV=${NODE_ENV} bun run index.ts`;
+
+        const tmp = tempDirWithFiles("script-runner-env", {
+          "package.json": '{"scripts":{"start":"' + run_index_script + '"}}',
+          "index.ts": "console.log(`ENV_FILE_NAME=${process.env.ENV_FILE_NAME}, NODE_ENV=${process.env.NODE_ENV}`);",
+
+          ".env.development": "ENV_FILE_NAME=.env.development",
+          ".env.production": "ENV_FILE_NAME=.env.production",
+          ".env.test": "ENV_FILE_NAME=.env.test",
+          ".env": "ENV_FILE_NAME=.env",
+        });
+
+        expect(bunRunAsScript(tmp, "start", {}, ["--shell=" + shell]).stdout).toBe(
+          "ENV_FILE_NAME=" + env_file + ", NODE_ENV=" + NODE_ENV,
+        );
+      });
+    }
+  });
+}
+
 const todoOnPosix = process.platform !== "win32" ? test.todo : test;
 todoOnPosix("setting process.env coerces the value to a string", () => {
   // @ts-expect-error

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -732,8 +732,9 @@ for (const shell of ["system", "bun"]) {
         ".env": "ENV_FILE_NAME=.env",
       });
 
-      expect(bunRunAsScript(tmp, "show-env", { ...env }, ["--shell=" + shell]).stdout)
-        .toBe("ENV_FILE_NAME=N/A, NODE_ENV=" + (isWindowsCMD ? "%NODE_ENV%" : ""));
+      expect(bunRunAsScript(tmp, "show-env", { ...env }, ["--shell=" + shell]).stdout).toBe(
+        "ENV_FILE_NAME=N/A, NODE_ENV=" + (isWindowsCMD ? "%NODE_ENV%" : ""),
+      );
     });
 
     for (const { NODE_ENV, expected, env_file } of [

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -168,7 +168,12 @@ export function bunTest(file: string, env?: Record<string, string>) {
   };
 }
 
-export function bunRunAsScript(dir: string, script: string, env?: Record<string, string | undefined>, execArgv?: string[]) {
+export function bunRunAsScript(
+  dir: string,
+  script: string,
+  env?: Record<string, string | undefined>,
+  execArgv?: string[],
+) {
   const result = Bun.spawnSync([bunExe(), ...(execArgv ?? []), `run`, `${script}`], {
     cwd: dir,
     env: {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -168,7 +168,7 @@ export function bunTest(file: string, env?: Record<string, string>) {
   };
 }
 
-export function bunRunAsScript(dir: string, script: string, env?: Record<string, string>, execArgv?: string[]) {
+export function bunRunAsScript(dir: string, script: string, env?: Record<string, string | undefined>, execArgv?: string[]) {
   const result = Bun.spawnSync([bunExe(), ...(execArgv ?? []), `run`, `${script}`], {
     cwd: dir,
     env: {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -168,8 +168,8 @@ export function bunTest(file: string, env?: Record<string, string>) {
   };
 }
 
-export function bunRunAsScript(dir: string, script: string, env?: Record<string, string>) {
-  const result = Bun.spawnSync([bunExe(), `run`, `${script}`], {
+export function bunRunAsScript(dir: string, script: string, env?: Record<string, string>, execArgv?: string[]) {
+  const result = Bun.spawnSync([bunExe(), ...(execArgv ?? []), `run`, `${script}`], {
     cwd: dir,
     env: {
       ...bunEnv,


### PR DESCRIPTION
### What does this PR do?

This is an alternate version of https://github.com/oven-sh/bun/pull/9642. The other PR has a bunch of code cleanup things, but features many weird test failures. This includes only the env loader changes.

I do not want to say that this supercedes 9642, but it does fix the same bugs.

There is no way this should possibly affect serve tests, inspect tests, so forth. right???

### How did you verify your code works?

We will see if CI complains as well.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
