### PR TITLE
Make `bun meta` more helpful

### DIFF
--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -32,153 +32,82 @@ fn NewUint64(val: u64) Analytics.Uint64 {
 
 // This answers, "What parts of bun are people actually using?"
 pub const Features = struct {
-    pub var single_page_app_routing = false;
-    pub var tsconfig_paths = false;
-    pub var fast_refresh = false;
-    pub var hot_module_reloading = false;
-    pub var jsx = false;
-    pub var always_bundle = false;
-    pub var tsconfig = false;
-    pub var bun_bun = false;
-    pub var filesystem_router = false;
-    pub var framework = false;
-    pub var bunjs = false;
-    pub var macros = false;
-    pub var public_folder = false;
-    pub var dotenv = false;
-    pub var define = false;
-    pub var loaders = false;
-    pub var origin = false;
-    pub var external = false;
-    pub var fetch = false;
-    pub var bunfig = false;
-    pub var extracted_packages = false;
-    pub var transpiler_cache = false;
+    pub var tsconfig_paths: usize = 0;
+    pub var fast_refresh: usize = 0;
+    pub var hot_module_reloading: usize = 0;
+    pub var jsx: usize = 0;
+    pub var always_bundle: usize = 0;
+    pub var tsconfig: usize = 0;
+    pub var bun_bun: usize = 0;
+    pub var filesystem_router: usize = 0;
+    pub var framework: usize = 0;
+    pub var bunjs: usize = 0;
+    pub var macros: usize = 0;
+    pub var dotenv: usize = 0;
+    pub var define: usize = 0;
+    pub var loaders: usize = 0;
+    pub var origin: usize = 0;
+    pub var external: usize = 0;
+    pub var fetch: usize = 0;
+    pub var bunfig: usize = 0;
+    pub var spawn: usize = 0;
+    pub var extracted_packages: usize = 0;
+    pub var transpiler_cache: usize = 0;
+    pub var shell: usize = 0;
+    pub var standalone_shell: usize = 0;
+    pub var lifecycle_scripts: usize = 0;
+    pub var virtual_modules: usize = 0;
+    pub var html_rewriter: usize = 0;
+    pub var http_server: usize = 0;
+    pub var https_server: usize = 0;
+    pub var abort_signal: usize = 0;
+    pub var lockfile_migration_from_package_lock: usize = 0;
+    pub var git_dependencies: usize = 0;
+    pub var WebSocket: usize = 0;
+    pub var builtin_modules = std.enums.EnumSet(bun.JSC.HardcodedModule).initEmpty();
 
     pub fn formatter() Formatter {
         return Formatter{};
     }
     pub const Formatter = struct {
         pub fn format(_: Formatter, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-            const fields = comptime .{
-                "single_page_app_routing",
-                "tsconfig_paths",
-                "fast_refresh",
-                "hot_module_reloading",
-                "jsx",
-                "always_bundle",
-                "tsconfig",
-                "bun_bun",
-                "filesystem_router",
-                "framework",
-                "bunjs",
-                "macros",
-                "public_folder",
-                "dotenv",
-                "define",
-                "loaders",
-                "origin",
-                "external",
-                "fetch",
-                "bunfig",
-                "extracted_packages",
-                "transpiler_cache",
-            };
-            inline for (fields) |field| {
-                if (@field(Features, field)) {
-                    try writer.writeAll(field);
-                    try writer.writeAll(" ");
+            const fields = comptime brk: {
+                const info: std.builtin.Type = @typeInfo(Features);
+                var buffer: [info.Struct.decls.len][]const u8 = .{""} ** info.Struct.decls.len;
+                var count: usize = 0;
+                for (info.Struct.decls) |decl| {
+                    var f = &@field(Features, decl.name);
+                    _ = &f;
+                    const Field = @TypeOf(f);
+                    const FieldT: std.builtin.Type = @typeInfo(Field);
+                    if (FieldT.Pointer.child != usize) continue;
+                    buffer[count] = decl.name;
+                    count += 1;
                 }
+
+                break :brk buffer[0..count];
+            };
+
+            inline for (fields) |field| {
+                const count = @field(Features, field);
+                if (count > 0) {
+                    try writer.writeAll(field);
+                    if (count > 1) {
+                        try writer.print("({d}) ", .{count});
+                    } else {
+                        try writer.writeAll(" ");
+                    }
+                }
+            }
+
+            var builtins = builtin_modules.iterator();
+            while (builtins.next()) |key| {
+                try writer.writeAll("\"");
+                try writer.writeAll(@tagName(key));
+                try writer.writeAll("\" ");
             }
         }
     };
-
-    const Bitset = std.bit_set.IntegerBitSet(32);
-
-    pub const Serializer = struct {
-        inline fn shiftIndex(index: u32) !u32 {
-            return @as(u32, @intCast(@as(Bitset.MaskInt, 1) << @as(Bitset.ShiftInt, @intCast(index))));
-        }
-
-        fn writeField(comptime WriterType: type, writer: WriterType, field_name: string, index: u32) !void {
-            var output: [64]u8 = undefined;
-            const name = std.ascii.upperString(&output, field_name);
-
-            try writer.print("const Features_{s} = {d}\n", .{ name, shiftIndex(index) });
-        }
-
-        pub fn writeAll(comptime WriterType: type, writer: WriterType) !void {
-            try writer.writeAll("package analytics\n\n");
-            try writeField(WriterType, writer, "single_page_app_routing", 1);
-            try writeField(WriterType, writer, "tsconfig_paths", 2);
-            try writeField(WriterType, writer, "fast_refresh", 3);
-            try writeField(WriterType, writer, "hot_module_reloading", 4);
-            try writeField(WriterType, writer, "jsx", 5);
-            try writeField(WriterType, writer, "always_bundle", 6);
-            try writeField(WriterType, writer, "tsconfig", 7);
-            try writeField(WriterType, writer, "bun_bun", 8);
-            try writeField(WriterType, writer, "filesystem_router", 9);
-            try writeField(WriterType, writer, "framework", 10);
-            try writeField(WriterType, writer, "bunjs", 11);
-            try writeField(WriterType, writer, "macros", 12);
-            try writeField(WriterType, writer, "public_folder", 13);
-            try writeField(WriterType, writer, "dotenv", 14);
-            try writeField(WriterType, writer, "define", 15);
-            try writeField(WriterType, writer, "loaders", 16);
-            try writeField(WriterType, writer, "origin", 17);
-            try writeField(WriterType, writer, "external", 18);
-            try writeField(WriterType, writer, "fetch", 19);
-            try writer.writeAll("\n");
-        }
-    };
-
-    pub fn toInt() u32 {
-        var list = Bitset.initEmpty();
-        list.setValue(1, Features.single_page_app_routing);
-        list.setValue(2, Features.tsconfig_paths);
-        list.setValue(3, Features.fast_refresh);
-        list.setValue(4, Features.hot_module_reloading);
-        list.setValue(5, Features.jsx);
-        list.setValue(6, Features.always_bundle);
-        list.setValue(7, Features.tsconfig);
-        list.setValue(8, Features.bun_bun);
-        list.setValue(9, Features.filesystem_router);
-        list.setValue(10, Features.framework);
-        list.setValue(11, Features.bunjs);
-        list.setValue(12, Features.macros);
-        list.setValue(13, Features.public_folder);
-        list.setValue(14, Features.dotenv);
-        list.setValue(15, Features.define);
-        list.setValue(16, Features.loaders);
-        list.setValue(17, Features.origin);
-        list.setValue(18, Features.external);
-        list.setValue(19, Features.fetch);
-
-        if (comptime FeatureFlags.verbose_analytics) {
-            if (Features.single_page_app_routing) Output.pretty("<r><d>single_page_app_routing<r>,", .{});
-            if (Features.tsconfig_paths) Output.pretty("<r><d>tsconfig_paths<r>,", .{});
-            if (Features.fast_refresh) Output.pretty("<r><d>fast_refresh<r>,", .{});
-            if (Features.hot_module_reloading) Output.pretty("<r><d>hot_module_reloading<r>,", .{});
-            if (Features.jsx) Output.pretty("<r><d>jsx<r>,", .{});
-            if (Features.always_bundle) Output.pretty("<r><d>always_bundle<r>,", .{});
-            if (Features.tsconfig) Output.pretty("<r><d>tsconfig<r>,", .{});
-            if (Features.bun_bun) Output.pretty("<r><d>bun_bun<r>,", .{});
-            if (Features.filesystem_router) Output.pretty("<r><d>filesystem_router<r>,", .{});
-            if (Features.framework) Output.pretty("<r><d>framework<r>,", .{});
-            if (Features.bunjs) Output.pretty("<r><d>bunjs<r>,", .{});
-            if (Features.macros) Output.pretty("<r><d>macros<r>,", .{});
-            if (Features.public_folder) Output.pretty("<r><d>public_folder<r>,", .{});
-            if (Features.dotenv) Output.pretty("<r><d>dotenv<r>,", .{});
-            if (Features.define) Output.pretty("<r><d>define<r>,", .{});
-            if (Features.loaders) Output.pretty("<r><d>loaders<r>,", .{});
-            if (Features.origin) Output.pretty("<r><d>origin<r>,", .{});
-            if (Features.external) Output.pretty("<r><d>external<r>,", .{});
-            if (Features.fetch) Output.pretty("<r><d>fetch<r>,", .{});
-            Output.prettyln("\n", .{});
-        }
-
-        return @as(u32, list.mask);
-    }
 };
 
 pub const EventName = enum(u8) {

--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -64,6 +64,9 @@ pub const Features = struct {
     pub var lockfile_migration_from_package_lock: usize = 0;
     pub var git_dependencies: usize = 0;
     pub var WebSocket: usize = 0;
+    pub var @"Bun.stdin": usize = 0;
+    pub var @"Bun.stdout": usize = 0;
+    pub var @"Bun.stderr": usize = 0;
     pub var builtin_modules = std.enums.EnumSet(bun.JSC.HardcodedModule).initEmpty();
 
     pub fn formatter() Formatter {
@@ -101,10 +104,20 @@ pub const Features = struct {
             }
 
             var builtins = builtin_modules.iterator();
-            while (builtins.next()) |key| {
-                try writer.writeAll("\"");
-                try writer.writeAll(@tagName(key));
+            if (builtins.next()) |first| {
+                try writer.writeAll("\nBuiltins: \"");
+                try writer.writeAll(@tagName(first));
                 try writer.writeAll("\" ");
+
+                while (builtins.next()) |key| {
+                    try writer.writeAll("\"");
+                    try writer.writeAll(@tagName(key));
+                    try writer.writeAll("\" ");
+                }
+
+                try writer.writeAll("\n");
+            } else {
+                try writer.writeAll("\n");
             }
         }
     };

--- a/src/bun.js/RuntimeTranspilerCache.zig
+++ b/src/bun.js/RuntimeTranspilerCache.zig
@@ -605,7 +605,7 @@ pub const RuntimeTranspilerCache = struct {
                 debug("get(\"{s}\") = {d} bytes, ignored for debug build", .{ source.path.text, this.entry.?.output_code.byteSlice().len });
             }
         }
-        bun.Analytics.Features.transpiler_cache = true;
+        bun.Analytics.Features.transpiler_cache += 1;
 
         if (comptime bun.Environment.isDebug) {
             if (!bun_debug_restore_from_cache) {

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1145,6 +1145,7 @@ pub fn spawnProcessPosix(
     argv: [*:null]?[*:0]const u8,
     envp: [*:null]?[*:0]const u8,
 ) !JSC.Maybe(PosixSpawnResult) {
+    bun.Analytics.Features.spawn += 1;
     var actions = try PosixSpawn.Actions.init();
     defer actions.deinit();
 
@@ -1431,6 +1432,7 @@ pub fn spawnProcessWindows(
     envp: [*:null]?[*:0]const u8,
 ) !JSC.Maybe(WindowsSpawnResult) {
     bun.markWindowsOnly();
+    bun.Analytics.Features.spawn += 1;
 
     var uv_process_options = std.mem.zeroes(uv.uv_process_options_t);
 

--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -54,6 +54,7 @@ pub const HTMLRewriter = struct {
             .builder = LOLHTML.HTMLRewriter.Builder.init(),
             .context = LOLHTMLContext.new(.{}),
         };
+        bun.Analytics.Features.html_rewriter += 1;
         return rewriter;
     }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5671,6 +5671,12 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
 
             server.request_pool_allocator = RequestContext.pool.?;
 
+            if (comptime ssl_enabled_) {
+                Analytics.Features.https_server += 1;
+            } else {
+                Analytics.Features.http_server += 1;
+            }
+
             return server;
         }
 

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -2017,6 +2017,7 @@ pub const AbortSignal = extern opaque {
         this: *AbortSignal,
         reason: JSValue,
     ) *AbortSignal {
+        bun.Analytics.Features.abort_signal += 1;
         return cppFn("signal", .{ this, reason });
     }
 

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1151,7 +1151,7 @@ pub const VirtualMachine = struct {
         this.bundler.resolver.caches.fs.use_alternate_source_cache = true;
         this.macro_mode = true;
         this.event_loop = &this.macro_event_loop;
-        Analytics.Features.macros = true;
+        Analytics.Features.macros += 1;
         this.transpiler_store.enabled = false;
     }
 

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -2321,6 +2321,8 @@ pub const ModuleLoader = struct {
                 .hash = Runtime.Runtime.versionHash(),
             };
         } else if (HardcodedModule.Map.getWithEql(specifier, bun.String.eqlComptime)) |hardcoded| {
+            Analytics.Features.builtin_modules.insert(hardcoded);
+
             switch (hardcoded) {
                 .@"bun:main" => {
                     return ResolvedSource{
@@ -2514,6 +2516,7 @@ pub const ModuleLoader = struct {
                 return true;
             },
         );
+        Analytics.Features.virtual_modules += 1;
         return true;
     }
 

--- a/src/bun.js/rare_data.zig
+++ b/src/bun.js/rare_data.zig
@@ -269,6 +269,7 @@ pub fn boringEngine(rare: *RareData) *BoringSSL.ENGINE {
 }
 
 pub fn stderr(rare: *RareData) *Blob.Store {
+    bun.Analytics.Features.@"Bun.stderr" += 1;
     return rare.stderr_store orelse brk: {
         const store = default_allocator.create(Blob.Store) catch unreachable;
         var mode: bun.Mode = 0;
@@ -301,6 +302,7 @@ pub fn stderr(rare: *RareData) *Blob.Store {
 }
 
 pub fn stdout(rare: *RareData) *Blob.Store {
+    bun.Analytics.Features.@"Bun.stdout" += 1;
     return rare.stdout_store orelse brk: {
         const store = default_allocator.create(Blob.Store) catch unreachable;
         var mode: bun.Mode = 0;
@@ -331,6 +333,7 @@ pub fn stdout(rare: *RareData) *Blob.Store {
 }
 
 pub fn stdin(rare: *RareData) *Blob.Store {
+    bun.Analytics.Features.@"Bun.stdin" += 1;
     return rare.stdin_store orelse brk: {
         const store = default_allocator.create(Blob.Store) catch unreachable;
         var mode: bun.Mode = 0;

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1683,6 +1683,7 @@ pub const Fetch = struct {
         JSC.markBinding(@src());
         const globalThis = ctx.ptr();
         const arguments = callframe.arguments(2);
+        bun.Analytics.Features.fetch += 1;
 
         var exception_val = [_]JSC.C.JSValueRef{null};
         const exception: JSC.C.ExceptionRef = &exception_val;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -804,7 +804,7 @@ pub const BundleV2 = struct {
 
         if (this.bundler.router) |router| {
             defer this.bundler.resetStore();
-            Analytics.Features.filesystem_router = true;
+            Analytics.Features.filesystem_router += 1;
 
             const entry_points = try router.getEntryPoints();
             try this.graph.entry_points.ensureUnusedCapacity(this.graph.allocator, entry_points.len);

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -163,6 +163,8 @@ pub const Bunfig = struct {
         }
 
         pub fn parse(this: *Parser, comptime cmd: Command.Tag) !void {
+            Analytics.Features.bunfig += 1;
+
             const json = this.json;
             var allocator = this.allocator;
 
@@ -750,8 +752,6 @@ pub const Bunfig = struct {
                     .loaders = loader_values,
                 };
             }
-
-            Analytics.Features.bunfig += 1;
         }
 
         pub fn expect(this: *Parser, expr: js_ast.Expr, token: js_ast.Expr.Tag) !void {

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -567,7 +567,6 @@ pub const Bunfig = struct {
                     if (_bun.get("packages")) |expr| {
                         try this.expect(expr, .e_object);
                         var valid_count: usize = 0;
-                        Analytics.Features.always_bundle = true;
 
                         const object = expr.data.e_object;
                         const properties = object.properties.slice();
@@ -692,7 +691,7 @@ pub const Bunfig = struct {
                 } else {
                     this.ctx.debug.macros = .{ .map = PackageJSON.parseMacrosJSON(allocator, expr, this.log, this.source) };
                 }
-                Analytics.Features.macros = true;
+                Analytics.Features.macros += 1;
             }
 
             if (json.get("external")) |expr| {
@@ -752,7 +751,7 @@ pub const Bunfig = struct {
                 };
             }
 
-            Analytics.Features.bunfig = true;
+            Analytics.Features.bunfig += 1;
         }
 
         pub fn expect(this: *Parser, expr: js_ast.Expr, token: js_ast.Expr.Tag) !void {

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -493,7 +493,7 @@ pub const Loader = struct {
                 while (iter.next()) |file_path| {
                     if (file_path.len > 0) {
                         try this.loadEnvFileDynamic(file_path, false, true);
-                        Analytics.Features.dotenv = true;
+                        Analytics.Features.dotenv += 1;
                     }
                 }
             }
@@ -515,19 +515,19 @@ pub const Loader = struct {
             .development => {
                 if (dir.hasComptimeQuery(".env.development.local")) {
                     try this.loadEnvFile(dir_handle, ".env.development.local", false, true);
-                    Analytics.Features.dotenv = true;
+                    Analytics.Features.dotenv += 1;
                 }
             },
             .production => {
                 if (dir.hasComptimeQuery(".env.production.local")) {
                     try this.loadEnvFile(dir_handle, ".env.production.local", false, true);
-                    Analytics.Features.dotenv = true;
+                    Analytics.Features.dotenv += 1;
                 }
             },
             .@"test" => {
                 if (dir.hasComptimeQuery(".env.test.local")) {
                     try this.loadEnvFile(dir_handle, ".env.test.local", false, true);
-                    Analytics.Features.dotenv = true;
+                    Analytics.Features.dotenv += 1;
                 }
             },
         }
@@ -535,7 +535,7 @@ pub const Loader = struct {
         if (comptime suffix != .@"test") {
             if (dir.hasComptimeQuery(".env.local")) {
                 try this.loadEnvFile(dir_handle, ".env.local", false, false);
-                Analytics.Features.dotenv = true;
+                Analytics.Features.dotenv += 1;
             }
         }
 
@@ -543,26 +543,26 @@ pub const Loader = struct {
             .development => {
                 if (dir.hasComptimeQuery(".env.development")) {
                     try this.loadEnvFile(dir_handle, ".env.development", false, true);
-                    Analytics.Features.dotenv = true;
+                    Analytics.Features.dotenv += 1;
                 }
             },
             .production => {
                 if (dir.hasComptimeQuery(".env.production")) {
                     try this.loadEnvFile(dir_handle, ".env.production", false, true);
-                    Analytics.Features.dotenv = true;
+                    Analytics.Features.dotenv += 1;
                 }
             },
             .@"test" => {
                 if (dir.hasComptimeQuery(".env.test")) {
                     try this.loadEnvFile(dir_handle, ".env.test", false, true);
-                    Analytics.Features.dotenv = true;
+                    Analytics.Features.dotenv += 1;
                 }
             },
         }
 
         if (dir.hasComptimeQuery(".env")) {
             try this.loadEnvFile(dir_handle, ".env", false, false);
-            Analytics.Features.dotenv = true;
+            Analytics.Features.dotenv += 1;
         }
     }
 

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -311,6 +311,8 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 client,
                 "tcp",
             )) |out| {
+                bun.Analytics.Features.WebSocket += 1;
+
                 if (comptime ssl) {
                     if (!strings.isIPAddress(host_.slice())) {
                         out.hostname = bun.default_allocator.dupeZ(u8, host_.slice()) catch "";

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5127,7 +5127,7 @@ pub const PackageManager = struct {
                         continue;
                     }
                     manager.extracted_count += 1;
-                    bun.Analytics.Features.extracted_packages = true;
+                    bun.Analytics.Features.extracted_packages += 1;
 
                     // GitHub and tarball URL dependencies are not fully resolved until after the tarball is downloaded & extracted.
                     if (manager.processExtractedTarballPackage(&package_id, resolution, task.data.extract, comptime log_level)) |pkg| brk: {

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -88,6 +88,8 @@ pub const LifecycleScriptSubprocess = struct {
     var cwd_z_buf: bun.PathBuffer = undefined;
 
     pub fn spawnNextScript(this: *LifecycleScriptSubprocess, next_script_index: u8) !void {
+        bun.Analytics.Features.lifecycle_scripts += 1;
+
         if (!this.has_incremented_alive_count) {
             this.has_incremented_alive_count = true;
             _ = alive_count.fetchAdd(1, .Monotonic);

--- a/src/install/migration.zig
+++ b/src/install/migration.zig
@@ -140,6 +140,8 @@ pub fn migrateNPMLockfile(this: *Lockfile, allocator: Allocator, log: *logger.Lo
         return error.InvalidNPMLockfile;
     }
 
+    bun.Analytics.Features.lockfile_migration_from_package_lock += 1;
+
     // Count pass
     var builder_ = this.stringBuilder();
     var builder = &builder_;

--- a/src/install/repository.zig
+++ b/src/install/repository.zig
@@ -177,6 +177,7 @@ pub const Repository = extern struct {
         name: string,
         url: string,
     ) !std.fs.Dir {
+        bun.Analytics.Features.git_dependencies += 1;
         const folder_name = try std.fmt.bufPrintZ(&folder_name_buf, "{any}.git", .{
             bun.fmt.hexIntLower(task_id),
         });
@@ -278,6 +279,7 @@ pub const Repository = extern struct {
         url: string,
         resolved: string,
     ) !ExtractData {
+        bun.Analytics.Features.git_dependencies += 1;
         const folder_name = PackageManager.cachedGitFolderNamePrint(&folder_name_buf, resolved);
 
         var package_dir = cache_dir.openDirZ(folder_name, .{}) catch |not_found| brk: {

--- a/src/options.zig
+++ b/src/options.zig
@@ -1680,8 +1680,8 @@ pub const BundleOptions = struct {
             .transform_options = transform,
         };
 
-        Analytics.Features.define = Analytics.Features.define or transform.define != null;
-        Analytics.Features.loaders = Analytics.Features.loaders or transform.loaders != null;
+        Analytics.Features.define += @as(usize, @intFromBool(transform.define != null));
+        Analytics.Features.loaders += @as(usize, @intFromBool(transform.loaders != null));
 
         if (transform.env_files.len > 0) {
             opts.env.files = transform.env_files;
@@ -1761,13 +1761,11 @@ pub const BundleOptions = struct {
 
         opts.polyfill_node_globals = opts.target == .browser;
 
-        Analytics.Features.framework = Analytics.Features.framework or opts.framework != null;
-        Analytics.Features.filesystem_router = Analytics.Features.filesystem_router or opts.routes.routes_enabled;
-        Analytics.Features.origin = Analytics.Features.origin or transform.origin != null;
-        Analytics.Features.public_folder = Analytics.Features.public_folder or opts.routes.static_dir_enabled;
-        Analytics.Features.macros = Analytics.Features.macros or opts.target == .bun_macro;
-        Analytics.Features.external = Analytics.Features.external or transform.external.len > 0;
-        Analytics.Features.single_page_app_routing = Analytics.Features.single_page_app_routing or opts.routes.single_page_app_routing;
+        Analytics.Features.framework += @as(usize, @intFromBool(opts.framework != null));
+        Analytics.Features.filesystem_router += @as(usize, @intFromBool(opts.routes.routes_enabled));
+        Analytics.Features.origin += @as(usize, @intFromBool(opts.origin.href.len > 0));
+        Analytics.Features.macros += @as(usize, @intFromBool(opts.target == .bun_macro));
+        Analytics.Features.external += @as(usize, @intFromBool(transform.external.len > 0));
         return opts;
     }
 };

--- a/src/report.zig
+++ b/src/report.zig
@@ -130,7 +130,6 @@ pub fn printMetadata() void {
         \\<r>----- bun meta -----
     ++ "\nBun v" ++ Global.package_json_version_with_sha ++ " " ++ platform ++ " " ++ arch ++ maybe_baseline ++ " {s}\n" ++
         \\{s}: {}
-        \\
     , .{
         analytics_platform.version,
         cmd_label,

--- a/src/resolver/tsconfig_json.zig
+++ b/src/resolver/tsconfig_json.zig
@@ -117,6 +117,8 @@ pub const TSConfigJSON = struct {
         // behavior may also be different).
         const json: js_ast.Expr = (json_cache.parseTSConfig(log, source, allocator) catch null) orelse return null;
 
+        bun.Analytics.Features.tsconfig += 1;
+
         var result: TSConfigJSON = TSConfigJSON{ .abs_path = source.key_path.text, .paths = PathsMap.init(allocator) };
         errdefer allocator.free(result.paths);
         if (json.asProperty("extends")) |extends_value| {
@@ -226,6 +228,9 @@ pub const TSConfigJSON = struct {
             if (compiler_opts.expr.asProperty("paths")) |paths_prop| {
                 switch (paths_prop.expr.data) {
                     .e_object => {
+                        defer {
+                            bun.Analytics.Features.tsconfig_paths += 1;
+                        }
                         var paths = paths_prop.expr.data.e_object;
                         result.base_url_for_paths = if (result.base_url.len > 0) result.base_url else ".";
                         result.paths = PathsMap.init(allocator);

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -983,6 +983,7 @@ pub const Interpreter = struct {
             },
         };
 
+        bun.Analytics.Features.shell += 1;
         return interpreter;
     }
 
@@ -1191,6 +1192,7 @@ pub const Interpreter = struct {
     }
 
     pub fn initAndRunFromSource(mini: *JSC.MiniEventLoop, path_for_errors: []const u8, src: []const u8) !ExitCode {
+        bun.Analytics.Features.standalone_shell += 1;
         var arena = bun.ArenaAllocator.init(bun.default_allocator);
         defer arena.deinit();
 


### PR DESCRIPTION
### What does this PR do?

This makes the bun meta message that appears in crashes slightly more helpful

When running `bun test ws.test` in bun's repo

After:

```js
----- bun meta -----
Bun v1.0.35 (ff31a77c) macOS Silicon 23.4.0
TestCommand: tsconfig_paths tsconfig(3) bunfig spawn(30) http_server(4) WebSocket(34) 
Builtins: "bun:jsc" "node:child_process" "node:fs" "node:fs/promises" "node:path" "node:string_decoder" "node:util/types" "ws" 
Elapsed: 2989ms | User: 2452ms | Sys: 413ms
RSS: 101.34MB | Peak: 101.34MB | Commit: 39.90MB | Faults: 83
----- bun meta -----
```

Before:

```js
----- bun meta -----
Bun v1.0.35 (8a12c299) macOS Silicon 23.4.0
TestCommand: bunfig 
Elapsed: 924ms | User: 96ms | Sys: 109ms
RSS: 50.30MB | Peak: 50.30MB | Commit: 39.90MB | Faults: 1328
----- bun meta -----
```

### How did you verify your code works?

Manual
