### PR TITLE
fix(windows `bun upgrade`): skip cleaning up old binary

### DIFF
--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -948,46 +948,12 @@ pub const UpgradeCommand = struct {
 
             if (Environment.isWindows) {
                 if (outdated_filename) |to_remove| {
-                    current_executable_buf[target_dir_.len] = '\\';
-                    const delete_old_script = try std.fmt.allocPrint(
-                        ctx.allocator,
-                        // What is this?
-                        // 1. spawns powershell
-                        // 2. waits for all processes with the same path as the current executable to exit (including the current process)
-                        // 3. deletes the old executable
-                        //
-                        // probably possible to hit a race condition, but i think the worst case is simply the file not getting deleted.
-                        //
-                        // in that edge case, the next time you upgrade it will simply override itself, fixing the bug.
-                        //
-                        // -NoNewWindow doesnt work, will keep the parent alive it seems
-                        // -WindowStyle Hidden seems to just do nothing, not sure why.
-                        // Using -WindowStyle Minimized seems to work, but you can spot a powershell icon appear in your taskbar for about ~1 second
-                        //
-                        // Alternative: we could simply do nothing and leave the `.outdated` file.
-                        \\Start-Process powershell.exe -WindowStyle Minimized -ArgumentList "-NoProfile","-ExecutionPolicy","Bypass","-Command",'&{{$ErrorActionPreference=''SilentlyContinue''; Get-Process|Where-Object{{ $_.Path -eq ''{s}'' }}|Wait-Process; Remove-Item -Path ''{s}'' -Force }};'; exit
-                    ,
-                        .{
-                            destination_executable,
-                            to_remove,
-                        },
-                    );
-
-                    var delete_argv = [_]string{
-                        "powershell.exe",
-                        "-NoProfile",
-                        "-ExecutionPolicy",
-                        "Bypass",
-                        "-Command",
-                        delete_old_script,
-                    };
-
-                    _ = std.ChildProcess.run(.{
-                        .allocator = ctx.allocator,
-                        .argv = &delete_argv,
-                        .cwd = tmpdir_path,
-                        .max_output_bytes = 512,
-                    }) catch {};
+                    // TODO: this file gets left on disk
+                    //
+                    // We should remove it, however we cannot remove an exe that is still running.
+                    // A prior approach was to spawn a subprocess to remove the file, but that
+                    // would open a terminal window, which steals user focus (even if minimized).
+                    _ = to_remove;
                 }
             }
         }


### PR DESCRIPTION
replacing the binary using `bun upgrade` is problematic, as you cannot delete a binary that is currently running.

my previous solution used a subprocess that outlived the upgrader, but the only way to do this on windows will create a console window for the process. "okay sure, it will flicker in the taskbar but all is fine", i thought.

it seems this window steals user focus for some reason:

<img width="639" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/45fdc886-5c78-4c5d-8693-e4a0d32119ff">

and

<img width="623" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/e1d0323e-9d0d-478d-a51b-8961d1b487ca">

yikes. i'm going to remove this behavior for now and if this problem can be solved then we can do so later. the new behavior is equal to what some other software does, for example `deno upgrade`.
