### PR TITLE
fix: EnvStr.initSlice handles zero length strings more reliably.

### DIFF
--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -371,6 +371,10 @@ pub const EnvStr = packed struct {
     };
 
     inline fn initSlice(str: []const u8) EnvStr {
+        if (str.len == 0)
+            // Zero length strings may have invalid pointers, leading to a bad integer cast.
+            return .{ .tag = .slice, .ptr = @intCast(@intFromPtr(&"")), .len = 0 };
+
         return .{
             .ptr = @intCast(@intFromPtr(str.ptr)),
             .tag = .slice,
@@ -379,6 +383,11 @@ pub const EnvStr = packed struct {
     }
 
     fn initRefCounted(str: []const u8) EnvStr {
+        if (str.len == 0)
+            // Zero length strings may have invalid pointers, leading to a bad integer cast.
+            // Instead of ref-counting zero lens, just be the same as the above initSlice
+            return .{ .tag = .slice, .ptr = @intCast(@intFromPtr(&"")), .len = 0 };
+
         return .{
             .ptr = @intCast(@intFromPtr(RefCountedStr.init(str))),
             .tag = .refcounted,


### PR DESCRIPTION
### What does this PR do?

Fixes #9481

Zero length strings from the env parser seem to not have a valid address (0xffff...ff). I'm not sure why, but this fixes it by preventing the `@intCast` on the invalid address.

Another route is to use here is `@truncate`, but this needs a complex assertion to ensure the truncation is valid. This route can be taken if desired.
