### PR TITLE
memoize all calls to selfExePath

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -277,19 +277,16 @@ pub const StandaloneModuleGraph = struct {
         }.toClean;
 
         const cloned_executable_fd: bun.FileDescriptor = brk: {
-            var self_buf: [bun.MAX_PATH_BYTES + 1]u8 = undefined;
-            const self_exe = std.fs.selfExePath(&self_buf) catch |err| {
+            const self_exe = bun.selfExePath() catch |err| {
                 Output.prettyErrorln("<r><red>error<r><d>:<r> failed to get self executable path: {s}", .{@errorName(err)});
                 Global.exit(1);
             };
-            self_buf[self_exe.len] = 0;
-            const self_exeZ = self_buf[0..self_exe.len :0];
 
             if (comptime Environment.isWindows) {
                 // copy self and then open it for writing
 
                 var in_buf: bun.WPathBuffer = undefined;
-                strings.copyU8IntoU16(&in_buf, self_exeZ);
+                strings.copyU8IntoU16(&in_buf, self_exe);
                 in_buf[self_exe.len] = 0;
                 const in = in_buf[0..self_exe.len :0];
                 var out_buf: bun.WPathBuffer = undefined;
@@ -301,7 +298,6 @@ pub const StandaloneModuleGraph = struct {
                     Output.prettyErrorln("<r><red>error<r><d>:<r> failed to copy bun executable into temporary file: {s}", .{@errorName(err)});
                     Global.exit(1);
                 };
-
                 const file = bun.sys.openFileAtWindows(
                     bun.invalid_fd,
                     out,
@@ -322,7 +318,7 @@ pub const StandaloneModuleGraph = struct {
             if (comptime Environment.isMac) {
                 // if we're on a mac, use clonefile() if we can
                 // failure is okay, clonefile is just a fast path.
-                if (Syscall.clonefile(self_exeZ, zname) == .result) {
+                if (Syscall.clonefile(self_exe, zname) == .result) {
                     switch (Syscall.open(zname, std.os.O.RDWR | std.os.O.CLOEXEC, 0)) {
                         .result => |res| break :brk res,
                         .err => {},
@@ -376,7 +372,7 @@ pub const StandaloneModuleGraph = struct {
             };
             const self_fd = brk2: {
                 for (0..3) |retry| {
-                    switch (Syscall.open(self_exeZ, std.os.O.CLOEXEC | std.os.O.RDONLY, 0)) {
+                    switch (Syscall.open(self_exe, std.os.O.CLOEXEC | std.os.O.RDONLY, 0)) {
                         .result => |res| break :brk2 res,
                         .err => |err| {
                             if (retry < 2) {
@@ -733,10 +729,8 @@ pub const StandaloneModuleGraph = struct {
             .mac => {
                 // Use of MAX_PATH_BYTES here is valid as the resulting path is immediately
                 // opened with no modification.
-                var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                const self_exe_path = try std.fs.selfExePath(&buf);
-                buf[self_exe_path.len] = 0;
-                const file = try std.fs.openFileAbsoluteZ(buf[0..self_exe_path.len :0].ptr, .{});
+                const self_exe_path = try bun.selfExePath();
+                const file = try std.fs.openFileAbsoluteZ(self_exe_path.ptr, .{});
                 return bun.toFD(file.handle);
             },
             .windows => {

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -4852,8 +4852,7 @@ pub const Process = struct {
     }
 
     pub fn getExecPath(globalObject: *JSC.JSGlobalObject) callconv(.C) JSC.JSValue {
-        var buf: bun.PathBuffer = undefined;
-        const out = std.fs.selfExePath(&buf) catch {
+        const out = bun.selfExePath() catch {
             // if for any reason we are unable to get the executable path, we just return argv[0]
             return getArgv0(globalObject);
         };
@@ -4935,7 +4934,7 @@ pub const Process = struct {
                 bun.String.static("bun"),
             );
         } else {
-            const exe_path = std.fs.selfExePathAlloc(allocator) catch null;
+            const exe_path = bun.selfExePath() catch null;
             args_list.appendAssumeCapacity(
                 if (exe_path) |str| bun.String.fromUTF8(str) else bun.String.static("bun"),
             );

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -574,7 +574,7 @@ pub const BunxCommand = struct {
         }
 
         var args = std.BoundedArray([]const u8, 7).fromSlice(&.{
-            try std.fs.selfExePathAlloc(ctx.allocator),
+            try bun.selfExePath(),
             "add",
             install_param,
             "--no-summary",

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1400,7 +1400,7 @@ pub const CreateCommand = struct {
         if (!create_options.skip_install) {
             npm_client_ = NPMClient{
                 .tag = .bun,
-                .bin = try std.fs.selfExePathAlloc(ctx.allocator),
+                .bin = try bun.selfExePath(),
             };
         }
 

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -427,7 +427,7 @@ pub const InitCommand = struct {
         if (exists("package.json")) {
             var process = std.ChildProcess.init(
                 &.{
-                    try std.fs.selfExePathAlloc(alloc),
+                    try bun.selfExePath(),
                     "install",
                 },
                 alloc,

--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -46,7 +46,7 @@ pub const InstallCompletionsCommand = struct {
 
     const bunx_name = if (Environment.isDebug) "bunx-debug" else "bunx";
 
-    fn installBunxSymlinkPosix(allocator: std.mem.Allocator, cwd: []const u8) !void {
+    fn installBunxSymlinkPosix(cwd: []const u8) !void {
         var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
 
         // don't install it if it's already there
@@ -54,7 +54,7 @@ pub const InstallCompletionsCommand = struct {
             return;
 
         // first try installing the symlink into the same directory as the bun executable
-        const exe = try std.fs.selfExePathAlloc(allocator);
+        const exe = try bun.selfExePath();
         var target_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
         var target = std.fmt.bufPrint(&target_buf, "{s}/" ++ bunx_name, .{std.fs.path.dirname(exe).?}) catch unreachable;
         std.os.symlink(exe, target) catch {
@@ -89,7 +89,7 @@ pub const InstallCompletionsCommand = struct {
         };
     }
 
-    fn installBunxSymlinkWindows(_: std.mem.Allocator, _: []const u8) !void {
+    fn installBunxSymlinkWindows(_: []const u8) !void {
         // Because symlinks are not always allowed on windows,
         // `bunx.exe` on windows is a hardlink to `bun.exe`
         // for this to work, we need to delete and recreate the hardlink every time
@@ -130,11 +130,11 @@ pub const InstallCompletionsCommand = struct {
         }
     }
 
-    fn installBunxSymlink(allocator: std.mem.Allocator, cwd: []const u8) !void {
+    fn installBunxSymlink(cwd: []const u8) !void {
         if (Environment.isWindows) {
-            try installBunxSymlinkWindows(allocator, cwd);
+            try installBunxSymlinkWindows(cwd);
         } else {
-            try installBunxSymlinkPosix(allocator, cwd);
+            try installBunxSymlinkPosix(cwd);
         }
     }
 
@@ -190,7 +190,7 @@ pub const InstallCompletionsCommand = struct {
             Global.exit(fail_exit_code);
         };
 
-        installBunxSymlink(allocator, cwd) catch {};
+        installBunxSymlink(cwd) catch {};
 
         if (Environment.isWindows) {
             installUninstallerWindows() catch {};

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -706,8 +706,6 @@ pub const RunCommand = struct {
         return try allocator.dupeZ(u8, target_path_buffer[0 .. converted.len + file_name.len :0]);
     }
 
-    var self_exe_bin_path_buf: [bun.MAX_PATH_BYTES + 1]u8 = undefined;
-
     pub fn createFakeTemporaryNodeExecutable(PATH: *std.ArrayList(u8), optional_bun_path: *string) !void {
         // If we are already running as "node", the path should exist
         if (CLI.pretend_to_be_node) return;
@@ -722,10 +720,9 @@ pub const RunCommand = struct {
                 argv0 = bun.argv()[0];
             } else if (optional_bun_path.len == 0) {
                 // otherwise, ask the OS for the absolute path
-                var self = try std.fs.selfExePath(&self_exe_bin_path_buf);
+                const self = try bun.selfExePath();
                 if (self.len > 0) {
-                    self.ptr[self.len] = 0;
-                    argv0 = @as([*:0]const u8, @ptrCast(self.ptr));
+                    argv0 = self.ptr;
                     optional_bun_path.* = self;
                 }
             }
@@ -900,7 +897,7 @@ pub const RunCommand = struct {
 
         if (this_bundler.env.get("npm_execpath") == null) {
             // we don't care if this fails
-            if (std.fs.selfExePathAlloc(ctx.allocator)) |self_exe_path| {
+            if (bun.selfExePath()) |self_exe_path| {
                 this_bundler.env.map.putDefault("npm_execpath", self_exe_path) catch unreachable;
             } else |_| {}
         }

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -756,7 +756,8 @@ pub const UpgradeCommand = struct {
                 }
             }
 
-            const destination_executable = std.fs.selfExePath(&current_executable_buf) catch return error.UpgradeFailedMissingExecutable;
+            const destination_executable = bun.selfExePath() catch return error.UpgradeFailedMissingExecutable;
+            @memcpy((&current_executable_buf).ptr, destination_executable);
             current_executable_buf[destination_executable.len] = 0;
 
             const target_filename_ = std.fs.path.basename(destination_executable);


### PR DESCRIPTION
breaking out #9578 into multiple PRs in order to better pin down where the CI is going awry