### PR TITLE
Make shell throw by default

### DIFF
--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -250,7 +250,7 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
   class ShellPrototype {
     [cwdSymbol]: string | undefined;
     [envSymbol]: Record<string, string | undefined> | undefined;
-    [throwsSymbol]: boolean = false;
+    [throwsSymbol]: boolean = true;
 
     env(newEnv: Record<string, string | undefined>) {
       if (typeof newEnv === "undefined" || newEnv === originalDefaultEnv) {
@@ -333,7 +333,7 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
 
   BunShell[cwdSymbol] = defaultCwd;
   BunShell[envSymbol] = defaultEnv;
-  BunShell[throwsSymbol] = false;
+  BunShell[throwsSymbol] = true;
 
   Object.defineProperties(BunShell, {
     Shell: {

--- a/test/js/bun/shell/throw.test.ts
+++ b/test/js/bun/shell/throw.test.ts
@@ -1,11 +1,18 @@
 import { $ } from "bun";
 import { beforeAll, describe, test, expect } from "bun:test";
 
-beforeAll(() => {
-  $.nothrow();
-});
-
 describe("throw", () => {
+  test("throws by default", async () => {
+    let e;
+    try {
+      await $`ls ksjflkjfksjdflksdjflksdf`;
+      expect("Woops").toBe("Should have thrown");
+    } catch (err) {
+      e = err;
+    }
+    expect(e).toBeDefined();
+  });
+
   test("enabled globally", async () => {
     $.throws(true);
     let e;


### PR DESCRIPTION
### What does this PR do?

Makes the shell throw on non-zero exit codes by default

See #8821
Fixes #8544

### How did you verify your code works?

JavaScript/TypeScript modules or builtins changed:
- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
