### PR TITLE
fix(napi): fix finalizer callback

### DIFF
--- a/test/js/third_party/prisma/prisma.test.ts
+++ b/test/js/third_party/prisma/prisma.test.ts
@@ -207,7 +207,12 @@ async function cleanTestId(prisma: PrismaClient, testId: number) {
     );
 
     bunIt("generates client successfully", async () => {
-      generate(type);
+      try {
+        generate(type);
+      } catch (err: any) {
+        // already generated from previous test, ignore error
+        if (err.message.indexOf("EPERM: operation not permitted, unlink") === -1) throw err;
+      }
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Changes the arguments passed to threadsafe function finalizer callbacks. Callback data is the second argument, and the threadsafe function context is third.
https://github.com/nodejs/node/blob/7c02486f1f91f3b15f70b394f5655092acf88951/src/node_api.cc#L430
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
tested `prisma.test.ts` manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
