### PR TITLE
Make duplicate simultaneous `bun install` work better

### DIFF
--- a/src/darwin_c.zig
+++ b/src/darwin_c.zig
@@ -787,3 +787,17 @@ pub fn getErrno(rc: anytype) E {
     return std.c.getErrno(rc);
 }
 pub extern "c" fn umask(Mode) Mode;
+
+// #define RENAME_SECLUDE                  0x00000001
+// #define RENAME_SWAP                     0x00000002
+// #define RENAME_EXCL                     0x00000004
+// #define RENAME_RESERVED1                0x00000008
+// #define RENAME_NOFOLLOW_ANY             0x00000010
+pub const RENAME_SECLUDE = 0x00000001;
+pub const RENAME_SWAP = 0x00000002;
+pub const RENAME_EXCL = 0x00000004;
+pub const RENAME_RESERVED1 = 0x00000008;
+pub const RENAME_NOFOLLOW_ANY = 0x00000010;
+
+// int renameatx_np(int fromfd, const char *from, int tofd, const char *to, unsigned int flags);
+pub extern "c" fn renameatx_np(fromfd: c_int, from: ?[*:0]const u8, tofd: c_int, to: ?[*:0]const u8, flags: c_uint) c_int;

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -304,7 +304,6 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
     };
     if (folder_name.len == 0 or (folder_name.len == 1 and folder_name[0] == '/')) @panic("Tried to delete root and stopped it");
     var cache_dir = this.cache_dir;
-    cache_dir.deleteTree(folder_name) catch {};
 
     // e.g. @next
     // if it's a namespace package, we need to make sure the @name folder exists
@@ -333,18 +332,62 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
             .result => {},
         }
     } else {
-        switch (bun.sys.renameat(bun.toFD(tmpdir.fd), bun.sliceTo(tmpname, 0), bun.toFD(cache_dir.fd), folder_name)) {
-            .err => |err| {
-                this.package_manager.log.addErrorFmt(
-                    null,
-                    logger.Loc.Empty,
-                    this.package_manager.allocator,
-                    "moving \"{s}\" to cache dir failed: {}\n  From: {s}\n    To: {s}",
-                    .{ name, err, tmpname, folder_name },
-                ) catch unreachable;
-                return error.InstallFailed;
-            },
-            .result => {},
+        // Attempt to gracefully handle duplicate concurrent `bun install` calls
+        //
+        // By:
+        // 1. Rename from temporary directory to cache directory and fail if it already exists
+        // 2a. If the rename fails, swap the cache directory with the temporary directory version
+        // 2b. Delete the temporary directory version ONLY if we're not using a provided temporary directory
+        // 3. If rename still fails, fallback to racily deleting the cache directory version and then renaming the temporary directory version again.
+        //
+        const src = bun.sliceTo(tmpname, 0);
+
+        var did_atomically_replace = false;
+        if (did_atomically_replace and PackageManager.using_fallback_temp_dir) tmpdir.deleteTree(src) catch {};
+
+        attempt_atomic_rename_and_fallback_to_racy_delete: {
+            {
+                // Happy path: the folder doesn't exist in the cache dir, so we can
+                // just rename it. We don't need to delete anything.
+                var err = switch (bun.sys.renameat2(bun.toFD(tmpdir.fd), src, bun.toFD(cache_dir.fd), folder_name, .{
+                    .exclude = true,
+                })) {
+                    .err => |err| err,
+                    .result => break :attempt_atomic_rename_and_fallback_to_racy_delete,
+                };
+
+                // Fallback path: the folder exists in the cache dir, it might be in a strange state
+                // let's attempt to atomically replace it with the temporary folder's version
+                if (switch (err.getErrno()) {
+                    .EXIST, .NOTEMPTY, .OPNOTSUPP => true,
+                    else => false,
+                }) {
+                    did_atomically_replace = true;
+                    switch (bun.sys.renameat2(bun.toFD(tmpdir.fd), src, bun.toFD(cache_dir.fd), folder_name, .{
+                        .exchange = true,
+                    })) {
+                        .err => {},
+                        .result => break :attempt_atomic_rename_and_fallback_to_racy_delete,
+                    }
+                    did_atomically_replace = false;
+                }
+            }
+
+            //  sad path: let's try to delete the folder and then rename it
+            cache_dir.deleteTree(src) catch {};
+            switch (bun.sys.renameat(bun.toFD(tmpdir.fd), src, bun.toFD(cache_dir.fd), folder_name)) {
+                .err => |err| {
+                    this.package_manager.log.addErrorFmt(
+                        null,
+                        logger.Loc.Empty,
+                        this.package_manager.allocator,
+                        "moving \"{s}\" to cache dir failed: {}\n  From: {s}\n    To: {s}",
+                        .{ name, err, tmpname, folder_name },
+                    ) catch unreachable;
+                    return error.InstallFailed;
+                },
+                .result => {},
+            }
         }
     }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2510,6 +2510,8 @@ pub const PackageManager = struct {
         unreachable;
     }
 
+    pub var using_fallback_temp_dir: bool = false;
+
     // We need a temporary directory that can be rename()
     // This is important for extracting files.
     //
@@ -2541,6 +2543,11 @@ pub const PackageManager = struct {
                         Output.prettyErrorln("<r><red>error<r>: bun is unable to access tempdir: {s}", .{@errorName(err)});
                         Global.crash();
                     };
+
+                    if (PackageManager.verbose_install) {
+                        Output.prettyErrorln("<r><yellow>warn<r>: bun is unable to access tempdir: {s}, using fallback", .{@errorName(err2)});
+                    }
+
                     continue :brk;
                 }
                 Output.prettyErrorln("<r><red>error<r>: {s} accessing temporary directory. Please set <b>$BUN_TMPDIR<r> or <b>$BUN_INSTALL<r>", .{
@@ -2556,6 +2563,11 @@ pub const PackageManager = struct {
                         Output.prettyErrorln("<r><red>error<r>: bun is unable to write files to tempdir: {s}", .{@errorName(err2)});
                         Global.crash();
                     };
+
+                    if (PackageManager.verbose_install) {
+                        Output.prettyErrorln("<r><d>info<r>: cannot move files from tempdir: {s}, using fallback", .{@errorName(err)});
+                    }
+
                     continue :brk;
                 }
 
@@ -2566,6 +2578,9 @@ pub const PackageManager = struct {
             };
             cache_directory.deleteFileZ(tmpname) catch {};
             break;
+        }
+        if (tried_dot_tmp) {
+            using_fallback_temp_dir = true;
         }
         if (this.options.log_level != .silent) {
             const elapsed = timer.read();

--- a/src/linux_c.zig
+++ b/src/linux_c.zig
@@ -666,3 +666,11 @@ pub extern "C" fn sys_pwritev2(
     offset: std.os.off_t,
     flags: c_uint,
 ) isize;
+
+// #define RENAME_NOREPLACE    (1 << 0)    /* Don't overwrite target */
+// #define RENAME_EXCHANGE     (1 << 1)    /* Exchange source and dest */
+// #define RENAME_WHITEOUT     (1 << 2)    /* Whiteout source */
+
+pub const RENAME_NOREPLACE = 1 << 0;
+pub const RENAME_EXCHANGE = 1 << 1;
+pub const RENAME_WHITEOUT = 1 << 2;

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1551,6 +1551,51 @@ pub fn rename(from: [:0]const u8, to: [:0]const u8) Maybe(void) {
     }
 }
 
+pub const RenameAt2Flags = packed struct {
+    exchange: bool = false,
+    exclude: bool = false,
+    nofollow: bool = false,
+
+    pub fn int(self: RenameAt2Flags) u32 {
+        var flags: u32 = 0;
+
+        if (comptime Environment.isMac) {
+            if (self.exchange) flags |= bun.C.RENAME_SWAP;
+            if (self.exclude) flags |= bun.C.RENAME_EXCL;
+            if (self.nofollow) flags |= bun.C.RENAME_NOFOLLOW_ANY;
+        } else {
+            if (self.exchange) flags |= bun.C.RENAME_EXCHANGE;
+            if (self.exclude) flags |= bun.C.RENAME_NOREPLACE;
+        }
+
+        return flags;
+    }
+};
+
+pub fn renameat2(from_dir: bun.FileDescriptor, from: [:0]const u8, to_dir: bun.FileDescriptor, to: [:0]const u8, flags: RenameAt2Flags) Maybe(void) {
+    if (Environment.isWindows) {
+        return renameat(from_dir, from, to_dir, to);
+    }
+
+    while (true) {
+        const rc = switch (comptime Environment.os) {
+            .linux => linux.renameat2(@intCast(from_dir.cast()), from.ptr, @intCast(to_dir.cast()), to.ptr, flags.int()),
+            .mac => bun.C.renameatx_np(@intCast(from_dir.cast()), from.ptr, @intCast(to_dir.cast()), to.ptr, flags.int()),
+            else => @compileError("renameat2() is not implemented on this platform"),
+        };
+
+        if (Maybe(void).errnoSys(rc, .rename)) |err| {
+            if (err.getErrno() == .INTR) continue;
+            if (comptime Environment.allow_assert)
+                log("renameat2({}, {s}, {}, {s}) = {d}", .{ from_dir, from, to_dir, to, @intFromEnum(err.getErrno()) });
+            return err;
+        }
+        if (comptime Environment.allow_assert)
+            log("renameat2({}, {s}, {}, {s}) = {d}", .{ from_dir, from, to_dir, to, 0 });
+        return Maybe(void).success;
+    }
+}
+
 pub fn renameat(from_dir: bun.FileDescriptor, from: [:0]const u8, to_dir: bun.FileDescriptor, to: [:0]const u8) Maybe(void) {
     if (Environment.isWindows) {
         var w_buf_from: bun.WPathBuffer = undefined;

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1,43 +1,95 @@
 import { spawn } from "bun";
 import { afterEach, beforeEach, expect, it } from "bun:test";
-import { bunExe, bunEnv as env, isWindows } from "harness";
-import { mkdtemp, realpath, rm, writeFile } from "fs/promises";
+import { bunExe, bunEnv, isWindows } from "harness";
+import { mkdtemp, realpath, writeFile, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { readdirSorted } from "./dummy.registry";
 import { readdirSync } from "js/node/fs/export-star-from";
 
 let x_dir: string;
+let current_tmpdir: string;
+let install_cache_dir: string;
+let env = { ...bunEnv };
 
 beforeEach(async () => {
-  x_dir = await realpath(await mkdtemp(join(tmpdir(), "bun-x.test")));
+  const waiting: Promise<void>[] = [];
+  if (current_tmpdir) {
+    waiting.push(rm(current_tmpdir, { recursive: true, force: true }));
+  }
+
+  if (install_cache_dir) {
+    waiting.push(rm(install_cache_dir, { recursive: true, force: true }));
+  }
 
   const tmp = isWindows ? tmpdir() : "/tmp";
   readdirSync(tmp).forEach(file => {
-    if (file.startsWith("bunx-")) {
-      rm(join(tmp, file), { recursive: true, force: true });
+    if (file.startsWith("bunx-") || file.startsWith("bun-x.test")) {
+      waiting.push(rm(join(tmp, file), { recursive: true, force: true }));
     }
   });
+
+  install_cache_dir = await mkdtemp(join(tmpdir(), "bun-install-cache-" + Math.random().toString(36).slice(2)));
+  current_tmpdir = await realpath(await mkdtemp(join(tmpdir(), "bun-x-tmpdir" + Math.random().toString(36).slice(2))));
+  x_dir = await realpath(await mkdtemp(join(tmpdir(), "bun-x.test" + Math.random().toString(36).slice(2))));
+
+  env.TEMP = current_tmpdir;
+  env.BUN_TMPDIR = env.TMPDIR = current_tmpdir;
+  env.BUN_INSTALL_CACHE_DIR = install_cache_dir;
+
+  await Promise.all(waiting);
 });
 
 it("should choose the tagged versions instead of the PATH versions when a tag is specified", async () => {
-  const processes = Array.from({ length: 3 }, (_, i) => {
+  const semverVersions = [
+    "7.0.0",
+    "7.1.0",
+    "7.1.1",
+    "7.1.2",
+    "7.1.3",
+    "7.2.0",
+    "7.2.1",
+    "7.2.2",
+    "7.2.3",
+    "7.3.0",
+    "7.3.1",
+    "7.3.2",
+    "7.3.3",
+    "7.3.4",
+    "7.3.5",
+    "7.3.6",
+    "7.3.7",
+    "7.3.8",
+    "7.4.0",
+    "7.5.0",
+    "7.5.1",
+    "7.5.2",
+    "7.5.3",
+    "7.5.4",
+    "7.6.0",
+  ].sort();
+  const processes = semverVersions.map((version, i) => {
     return spawn({
-      cmd: [bunExe(), "x", "semver@7.5." + i, "--help"],
+      cmd: [bunExe(), "x", "semver@" + version, "--help"],
       cwd: x_dir,
       stdout: "pipe",
       stdin: "ignore",
       stderr: "inherit",
-      env,
+      env: {
+        ...env,
+        // BUN_DEBUG_QUIET_LOGS: undefined,
+        // BUN_DEBUG: "/tmp/bun-debug.txt." + i,
+      },
     });
   });
 
-  const results = await Promise.all(processes.map(p => p.exited));
-  expect(results).toEqual([0, 0, 0]);
-  const outputs = (await Promise.all(processes.map(p => new Response(p.stdout).text()))).map(a =>
-    a.substring(0, a.indexOf("\n")),
-  );
-  expect(outputs).toEqual(["SemVer 7.5.0", "SemVer 7.5.1", "SemVer 7.5.2"]);
+  const [results, stdouts] = await Promise.all([
+    Promise.all(processes.map(p => p.exited)),
+    Promise.all(processes.map(p => new Response(p.stdout).text())),
+  ]);
+  expect(results).toEqual(semverVersions.map(() => 0));
+  const outputs = stdouts.map(a => a.substring(0, a.indexOf("\n")));
+  expect(outputs).toEqual(semverVersions.map(v => "SemVer " + v));
 });
 
 it("should install and run default (latest) version", async () => {
@@ -64,7 +116,7 @@ it("should install and run specified version", async () => {
     cmd: [bunExe(), "x", "uglify-js@3.14.1", "-v"],
     cwd: x_dir,
     stdout: "pipe",
-    stdin: "pipe",
+    stdin: "inherit",
     stderr: "pipe",
     env,
   });
@@ -83,7 +135,7 @@ it("should output usage if no arguments are passed", async () => {
     cmd: [bunExe(), "x"],
     cwd: x_dir,
     stdout: "pipe",
-    stdin: "pipe",
+    stdin: "inherit",
     stderr: "pipe",
     env,
   });
@@ -100,44 +152,46 @@ it("should output usage if no arguments are passed", async () => {
 });
 
 it("should work for @scoped packages", async () => {
+  let exited: number, err: string, out: string;
   // without cache
   const withoutCache = spawn({
-    cmd: [bunExe(), "--bun", "x", "@withfig/autocomplete-tools", "--help"],
+    cmd: [bunExe(), "--bun", "x", "@babel/cli", "--help"],
     cwd: x_dir,
     stdout: "pipe",
-    stdin: "pipe",
+    stdin: "inherit",
     stderr: "pipe",
     env,
   });
 
-  expect(withoutCache.stderr).toBeDefined();
-  let err = await new Response(withoutCache.stderr).text();
+  [err, out, exited] = await Promise.all([
+    new Response(withoutCache.stderr).text(),
+    new Response(withoutCache.stdout).text(),
+    withoutCache.exited,
+  ]);
   expect(err).not.toContain("error:");
   expect(err).not.toContain("panic:");
-  expect(withoutCache.stdout).toBeDefined();
-  let out = await new Response(withoutCache.stdout).text();
-  expect(out.trim()).toContain("Usage: @withfig/autocomplete-tools");
-  expect(await withoutCache.exited).toBe(0);
-
+  expect(out.trim()).toContain("Usage: babel [options]");
+  expect(exited).toBe(0);
   // cached
   const cached = spawn({
-    cmd: [bunExe(), "--bun", "x", "@withfig/autocomplete-tools", "--help"],
+    cmd: [bunExe(), "--bun", "x", "@babel/cli", "--help"],
     cwd: x_dir,
     stdout: "pipe",
-    stdin: "pipe",
+    stdin: "inherit",
     stderr: "pipe",
     env,
   });
 
-  expect(cached.stderr).toBeDefined();
-  err = await new Response(cached.stderr).text();
+  [err, out, exited] = await Promise.all([
+    new Response(cached.stderr).text(),
+    new Response(cached.stdout).text(),
+    cached.exited,
+  ]);
+
   expect(err).not.toContain("error:");
   expect(err).not.toContain("panic:");
-  expect(cached.stdout).toBeDefined();
-  out = await new Response(cached.stdout).text();
-  console.log({ out, err });
-  expect(out.trim()).toContain("Usage: @withfig/autocomplete-tools");
-  expect(await cached.exited).toBe(0);
+
+  expect(out.trim()).toContain("Usage: babel [options]");
 });
 
 it("should execute from current working directory", async () => {
@@ -154,19 +208,16 @@ console.log(
     cmd: [bunExe(), "--bun", "x", "uglify-js", "test.js", "--compress"],
     cwd: x_dir,
     stdout: "pipe",
-    stdin: "pipe",
+    stdin: "inherit",
     stderr: "pipe",
     env,
   });
-  expect(stderr).toBeDefined();
-  const err = await new Response(stderr).text();
+  const [err, out, exitCode] = await Promise.all([new Response(stderr).text(), new Response(stdout).text(), exited]);
   expect(err).not.toContain("error:");
   expect(err).not.toContain("panic:");
-  expect(stdout).toBeDefined();
-  const out = await new Response(stdout).text();
-  expect(out.split(/\r?\n/)).toEqual(["console.log(42);", ""]);
-  expect(await exited).toBe(0);
   expect(await readdirSorted(x_dir)).toEqual(["test.js"]);
+  expect(out.split(/\r?\n/)).toEqual(["console.log(42);", ""]);
+  expect(exitCode).toBe(0);
 });
 
 it("should work for github repository", async () => {
@@ -175,38 +226,42 @@ it("should work for github repository", async () => {
     cmd: [bunExe(), "x", "github:piuccio/cowsay", "--help"],
     cwd: x_dir,
     stdout: "pipe",
-    stdin: "pipe",
+    stdin: "inherit",
     stderr: "pipe",
     env,
   });
 
-  expect(withoutCache.stderr).toBeDefined();
-  let err = await new Response(withoutCache.stderr).text();
+  let [err, out, exited] = await Promise.all([
+    new Response(withoutCache.stderr).text(),
+    new Response(withoutCache.stdout).text(),
+    withoutCache.exited,
+  ]);
+
   expect(err).not.toContain("error:");
   expect(err).not.toContain("panic:");
-  expect(withoutCache.stdout).toBeDefined();
-  let out = await new Response(withoutCache.stdout).text();
   expect(out.trim()).toContain("Usage: " + (isWindows ? "cli.js" : "cowsay"));
-  expect(await withoutCache.exited).toBe(0);
+  expect(exited).toBe(0);
 
   // cached
   const cached = spawn({
     cmd: [bunExe(), "x", "github:piuccio/cowsay", "--help"],
     cwd: x_dir,
     stdout: "pipe",
-    stdin: "pipe",
+    stdin: "inherit",
     stderr: "pipe",
     env,
   });
 
-  expect(cached.stderr).toBeDefined();
-  err = await new Response(cached.stderr).text();
+  [err, out, exited] = await Promise.all([
+    new Response(cached.stderr).text(),
+    new Response(cached.stdout).text(),
+    cached.exited,
+  ]);
+
   expect(err).not.toContain("error:");
   expect(err).not.toContain("panic:");
-  expect(cached.stdout).toBeDefined();
-  out = await new Response(cached.stdout).text();
   expect(out.trim()).toContain("Usage: " + (isWindows ? "cli.js" : "cowsay"));
-  expect(await cached.exited).toBe(0);
+  expect(exited).toBe(0);
 });
 
 it("should work for github repository with committish", async () => {
@@ -214,37 +269,40 @@ it("should work for github repository with committish", async () => {
     cmd: [bunExe(), "x", "github:piuccio/cowsay#HEAD", "hello bun!"],
     cwd: x_dir,
     stdout: "pipe",
-    stdin: "pipe",
+    stdin: "inherit",
     stderr: "pipe",
     env,
   });
 
-  expect(withoutCache.stderr).toBeDefined();
-  let err = await new Response(withoutCache.stderr).text();
+  let [err, out, exited] = await Promise.all([
+    new Response(withoutCache.stderr).text(),
+    new Response(withoutCache.stdout).text(),
+    withoutCache.exited,
+  ]);
+
   expect(err).not.toContain("error:");
   expect(err).not.toContain("panic:");
-  expect(withoutCache.stdout).toBeDefined();
-  let out = await new Response(withoutCache.stdout).text();
-  if (!out) console.log(err);
   expect(out.trim()).toContain("hello bun!");
-  expect(await withoutCache.exited).toBe(0);
+  expect(exited).toBe(0);
 
   // cached
   const cached = spawn({
     cmd: [bunExe(), "x", "github:piuccio/cowsay#HEAD", "hello bun!"],
     cwd: x_dir,
     stdout: "pipe",
-    stdin: "pipe",
+    stdin: "inherit",
     stderr: "pipe",
     env,
   });
 
-  expect(cached.stderr).toBeDefined();
-  err = await new Response(cached.stderr).text();
+  [err, out, exited] = await Promise.all([
+    new Response(cached.stderr).text(),
+    new Response(cached.stdout).text(),
+    cached.exited,
+  ]);
+
   expect(err).not.toContain("error:");
   expect(err).not.toContain("panic:");
-  expect(cached.stdout).toBeDefined();
-  out = await new Response(cached.stdout).text();
   expect(out.trim()).toContain("hello bun!");
-  expect(await cached.exited).toBe(0);
+  expect(exited).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

This makes bun install and bunx more reliable when multiple instances of bun are installing the same dependencies into the cache simultaneously by:
- Avoid deleting the installed folder when we can rely on the operating system to eventually delete it for us
- When we cannot rely on the operating system to eventually delete it for us, attempt to atomically swap the persistent version in the bun install cache with the version in the temporary folder and delete the version in the temporary folder instead. This makes it harder to reference it from the cache while a delete is in progress, which solves it for the short path scenario but not the long path scenario
- If all else fails, fallback to deleting from the cache (original behavior)

On macOS, we use `renameatx_np` and on Linux, we use `renameat2` to first attempt to atomically move extracted tarballs from the cache directory to the destination directory. If the destination directory already has a tarball folder, we instead atomically swap the files and delete that version instead of the version

### How did you verify your code works?

Tests