### PR TITLE
console-iterator.test.ts: test using Symbol.asyncIterator

### DIFF
--- a/test/js/bun/console/console-iterator.test.ts
+++ b/test/js/bun/console/console-iterator.test.ts
@@ -74,3 +74,19 @@ it("can use the console iterator more than once", async () => {
   expect(await new Response(stdout).text()).toBe('["hello","world"]["another"]');
   proc.kill(0);
 });
+
+// https://github.com/oven-sh/bun/issues/7541
+it("can use console[Symbol.asyncIterator]", async () => {
+  const proc = spawn({
+    cmd: [bunExe(), import.meta.dir + "/" + "console-symbol-iterator-run.ts"],
+    stdin: "pipe",
+    stdout: "pipe",
+    env: bunEnv,
+  });
+  const { stdout, stdin } = proc;
+  stdin.write("hello\nworld\nbreak\nhello\nworld\nbreak\n");
+  await stdin.end();
+
+  expect(await new Response(stdout).text()).toBe('["FIRSThello","world"]["FIRSThello","world"]');
+  proc.kill(0);
+});

--- a/test/js/bun/console/console-symbol-iterator-run.ts
+++ b/test/js/bun/console/console-symbol-iterator-run.ts
@@ -1,0 +1,33 @@
+async function readInputUsingForOf() {
+  const items = [];
+  for await (const line of console) {
+    items.push(`FIRST${line}`);
+    break;
+  }
+  for await (const line of console) {
+    if (line == "break") {
+      break;
+    }
+    items.push(line);
+  }
+  return items;
+}
+
+async function readInputUsingSymbolAsyncIterator() {
+  const items = [];
+  const firstLine = (await console[Symbol.asyncIterator]().next()).value;
+  items.push(`FIRST${firstLine}`);
+  for await (const line of console) {
+    if (line == "break") {
+      break;
+    }
+    items.push(line);
+  }
+  return items;
+}
+
+const a = await readInputUsingForOf();
+console.write(JSON.stringify(a));
+
+const b = await readInputUsingSymbolAsyncIterator();
+console.write(JSON.stringify(b));


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

Adds test for #7541.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

```sh
./build/bun-debug test test/js/bun/console/console-iterator.test.ts -t "Symbol.asyncIterator"
```

fails because:

```sh
15 |
16 | async function readInputUsingSymbolAsyncIterator() {
17 |   const items = [];
18 |   const firstLine = (await console[Symbol.asyncIterator]().next()).value;
19 |   items.push(`FIRST${firstLine}`);
20 |   for await (const line of console) {
                         ^
TypeError: ReadableStream is locked
      at initializeReadableStreamDefaultReader (:1:21)
      at getReader (:1:21)
      at doAsyncGeneratorBodyCall (:1:21)
      at asyncGeneratorResumeNext (:1:21)
      at asyncGeneratorEnqueue (:1:21)
      at /Users/user/dev/bun/test/js/bun/console/console-symbol-iterator-run.ts:20:20
      at asyncFunctionResume (:1:21)
      at promiseReactionJobWithoutPromiseUnwrapAsyncContext (:1:21)
```

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
