### PR TITLE
ci(windows): add winget releaser workflow

### DIFF
--- a/.github/workflows/bun-release.yml
+++ b/.github/workflows/bun-release.yml
@@ -31,6 +31,10 @@ on:
         description: Should binaries be released to Homebrew?
         type: boolean
         default: false
+      use-winget:
+        description: Should binaries be published to Winget?
+        type: boolean
+        default: false
       use-s3:
         description: Should binaries be uploaded to S3?
         type: boolean
@@ -240,6 +244,28 @@ jobs:
           commit_user_name: robobun
           commit_user_email: robobun@oven.sh
           commit_author: robobun <robobun@oven.sh>
+  winget:
+    name: Publish to Winget
+    runs-on: ubuntu-latest
+    needs: sign
+    permissions:
+      contents: read
+    if: ${{ github.event_name == 'release' || github.event.inputs.use-winget == 'true' }}
+    steps:
+      - name: Publish main build
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: oven-sh.bun
+          release-tag: ${{ env.BUN_VERSION }}
+          installers-regex: '-windows-\w+\.zip$'
+          token: ${{ secrets.ROBOBUN_TOKEN }}
+      - name: Publish baseline build
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: oven-sh.bun.baseline
+          release-tag: ${{ env.BUN_VERSON }}
+          installers-regex: '-windows-\w+-baseline\.zip$'
+          token: ${{ secrets.ROBOBUN_TOKEN }}
   s3:
     name: Upload to S3
     runs-on: ubuntu-latest

--- a/.github/workflows/bun-release.yml
+++ b/.github/workflows/bun-release.yml
@@ -255,14 +255,14 @@ jobs:
       - name: Publish main build
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
-          identifier: oven-sh.bun
+          identifier: Oven-sh.Bun
           release-tag: ${{ env.BUN_VERSION }}
           installers-regex: '-windows-\w+\.zip$'
           token: ${{ secrets.ROBOBUN_TOKEN }}
       - name: Publish baseline build
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
-          identifier: oven-sh.bun.baseline
+          identifier: Oven-sh.Bun.Baseline
           release-tag: ${{ env.BUN_VERSON }}
           installers-regex: '-windows-\w+-baseline\.zip$'
           token: ${{ secrets.ROBOBUN_TOKEN }}

--- a/.github/workflows/bun-release.yml
+++ b/.github/workflows/bun-release.yml
@@ -253,14 +253,14 @@ jobs:
     if: ${{ github.event_name == 'release' || github.event.inputs.use-winget == 'true' }}
     steps:
       - name: Publish main build
-        uses: vedantmgoyal2009/winget-releaser@v2
+        uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: Oven-sh.Bun
           release-tag: ${{ env.BUN_VERSION }}
           installers-regex: '-windows-\w+\.zip$'
           token: ${{ secrets.ROBOBUN_TOKEN }}
       - name: Publish baseline build
-        uses: vedantmgoyal2009/winget-releaser@v2
+        uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: Oven-sh.Bun.Baseline
           release-tag: ${{ env.BUN_VERSON }}


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- Closes https://github.com/oven-sh/bun/issues/8116

[This action](https://github.com/vedantmgoyal2009/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

> [!NOTE]
> Only merge until the following PRs are resolved. The action only works when at least 1 version of the package already exists in winget-pkgs:
> - https://github.com/microsoft/winget-pkgs/pull/147222
> - https://github.com/microsoft/winget-pkgs/pull/147226

**Before merging this:**
1. I'm assuming `ROBOBUN_TOKEN` already has the `public_repo` scope to make commits.
2. Fork https://github.com/microsoft/winget-pkgs under @oven-sh. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.




<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
