### PR TITLE
fix build

### DIFF
--- a/src/bun.js/bindings/ZigSourceProvider.cpp
+++ b/src/bun.js/bindings/ZigSourceProvider.cpp
@@ -30,7 +30,7 @@ using SourceProviderSourceType = JSC::SourceProviderSourceType;
 
 SourceOrigin toSourceOrigin(const String& specifier, bool isBuiltin)
 {
-    ASSERT_WITH_MESSAGE(!sourceURL.startsWith("file://"_s), "sourceURL should not already be a file URL");
+    ASSERT_WITH_MESSAGE(!specifier.startsWith("file://"_s), "specifier should not already be a file URL");
 
     if (isBuiltin) {
         if (specifier.startsWith("node:"_s)) {

--- a/src/bun.js/bindings/bun-spawn.cpp
+++ b/src/bun.js/bindings/bun-spawn.cpp
@@ -56,18 +56,11 @@ extern "C" ssize_t posix_spawn_bun(
 {
     volatile int status = 0;
     sigset_t blockall, oldmask;
-    int res = 0, cs = 0, e = errno;
+    int res = 0, cs = 0;
     sigfillset(&blockall);
     sigprocmask(SIG_SETMASK, &blockall, &oldmask);
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
     pid_t child = vfork();
-
-    const auto parentFailed = [&]() -> ssize_t {
-        sigprocmask(SIG_SETMASK, &oldmask, 0);
-        pthread_setcancelstate(cs, 0);
-        errno = e;
-        return res;
-    };
 
     const auto childFailed = [&]() -> ssize_t {
         res = errno;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
