### PR TITLE
fix(uws) uWS uintmax_t  > uint64_t

### DIFF
--- a/packages/bun-uws/capi/libuwebsockets.cpp
+++ b/packages/bun-uws/capi/libuwebsockets.cpp
@@ -8,8 +8,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+// clang-format off
 #include "libuwebsockets.h"
 #include <string_view>
 #include "App.h"
@@ -976,7 +976,7 @@ extern "C"
         return value.length();
     }
 #endif
-    uws_try_end_result_t uws_res_try_end(int ssl, uws_res_t *res, const char *data, size_t length, uintmax_t total_size, bool close_connection)
+    uws_try_end_result_t uws_res_try_end(int ssl, uws_res_t *res, const char *data, size_t length, uint64_t total_size, bool close_connection)
     {
         if (ssl)
         {
@@ -1123,7 +1123,7 @@ extern "C"
         uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
         return uwsRes->write(std::string_view(data, length));
     }
-    uintmax_t uws_res_get_write_offset(int ssl, uws_res_t *res)
+    uint64_t uws_res_get_write_offset(int ssl, uws_res_t *res)
     {
         if (ssl)
         {
@@ -1133,7 +1133,7 @@ extern "C"
         uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
         return uwsRes->getWriteOffset();
     }
-    void uws_res_override_write_offset(int ssl, uws_res_t *res, uintmax_t offset)
+    void uws_res_override_write_offset(int ssl, uws_res_t *res, uint64_t offset)
     {
         if (ssl)
         {
@@ -1157,18 +1157,18 @@ extern "C"
         return uwsRes->hasResponded();
     }
 
-    void uws_res_on_writable(int ssl, uws_res_t *res, bool (*handler)(uws_res_t *res, uintmax_t, void *optional_data), void *optional_data)
+    void uws_res_on_writable(int ssl, uws_res_t *res, bool (*handler)(uws_res_t *res, uint64_t, void *optional_data), void *optional_data)
     {
         if (ssl)
         {
             uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-            uwsRes->onWritable([handler, res, optional_data](uintmax_t a)
+            uwsRes->onWritable([handler, res, optional_data](uint64_t a)
                                { return handler(res, a, optional_data); });
         }
         else
         {
             uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-            uwsRes->onWritable([handler, res, optional_data](uintmax_t a)
+            uwsRes->onWritable([handler, res, optional_data](uint64_t a)
                                { return handler(res, a, optional_data); });
         }
     }

--- a/packages/bun-uws/capi/libuwebsockets.h
+++ b/packages/bun-uws/capi/libuwebsockets.h
@@ -1,16 +1,16 @@
 /*
  * Copyright 2022 Ciro Spaciari
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- * 
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+// clang-format off
 #ifndef LIBUWS_CAPI_HEADER
 #define LIBUWS_CAPI_HEADER
 
@@ -209,7 +209,7 @@ extern "C"
 
     //Response
     DLL_EXPORT void uws_res_end(int ssl, uws_res_t *res, const char *data, size_t length, bool close_connection);
-    DLL_EXPORT uws_try_end_result_t uws_res_try_end(int ssl, uws_res_t *res, const char *data, size_t length, uintmax_t total_size, bool close_connection);
+    DLL_EXPORT uws_try_end_result_t uws_res_try_end(int ssl, uws_res_t *res, const char *data, size_t length, uint64_t total_size, bool close_connection);
     DLL_EXPORT void uws_res_cork(int ssl, uws_res_t *res, void(*callback)(uws_res_t *res, void* user_data) ,void* user_data);
     DLL_EXPORT void uws_res_pause(int ssl, uws_res_t *res);
     DLL_EXPORT void uws_res_resume(int ssl, uws_res_t *res);
@@ -220,10 +220,10 @@ extern "C"
     DLL_EXPORT void uws_res_write_header_int(int ssl, uws_res_t *res, const char *key, size_t key_length, uint64_t value);
     DLL_EXPORT void uws_res_end_without_body(int ssl, uws_res_t *res, bool close_connection);
     DLL_EXPORT bool uws_res_write(int ssl, uws_res_t *res, const char *data, size_t length);
-    DLL_EXPORT uintmax_t uws_res_get_write_offset(int ssl, uws_res_t *res);
-    DLL_EXPORT void uws_res_override_write_offset(int ssl, uws_res_t *res, uintmax_t offset);
+    DLL_EXPORT uint64_t uws_res_get_write_offset(int ssl, uws_res_t *res);
+    DLL_EXPORT void uws_res_override_write_offset(int ssl, uws_res_t *res, uint64_t offset);
     DLL_EXPORT bool uws_res_has_responded(int ssl, uws_res_t *res);
-    DLL_EXPORT void uws_res_on_writable(int ssl, uws_res_t *res, bool (*handler)(uws_res_t *res, uintmax_t, void *optional_data), void *user_data);
+    DLL_EXPORT void uws_res_on_writable(int ssl, uws_res_t *res, bool (*handler)(uws_res_t *res, uint64_t, void *optional_data), void *user_data);
     DLL_EXPORT void uws_res_on_aborted(int ssl, uws_res_t *res, void (*handler)(uws_res_t *res, void *optional_data), void *optional_data);
     DLL_EXPORT void uws_res_on_data(int ssl, uws_res_t *res, void (*handler)(uws_res_t *res, const char *chunk, size_t chunk_length, bool is_end, void *optional_data), void *optional_data);
     DLL_EXPORT void uws_res_upgrade(int ssl, uws_res_t *res, void *data, const char *sec_web_socket_key, size_t sec_web_socket_key_length, const char *sec_web_socket_protocol, size_t sec_web_socket_protocol_length, const char *sec_web_socket_extensions, size_t sec_web_socket_extensions_length, uws_socket_context_t *ws);

--- a/packages/bun-uws/src/Http3Response.h
+++ b/packages/bun-uws/src/Http3Response.h
@@ -3,7 +3,7 @@ extern "C" {
 }
 
 #include "Http3ResponseData.h"
-
+// clang-format off
 namespace uWS {
 
     /* Is a quic stream */
@@ -40,7 +40,7 @@ namespace uWS {
             return this;
         }
 
-        std::pair<bool, bool> tryEnd(std::string_view data, uintmax_t totalSize = 0) {
+        std::pair<bool, bool> tryEnd(std::string_view data, uint64_t totalSize = 0) {
             Http3ResponseData *responseData = (Http3ResponseData *) us_quic_stream_ext((us_quic_stream_t *) this);
 
             writeStatus("200 OK");
@@ -109,7 +109,7 @@ namespace uWS {
             return this;
         }
 
-        Http3Response *onWritable(MoveOnlyFunction<bool(uintmax_t)> &&handler) {
+        Http3Response *onWritable(MoveOnlyFunction<bool(uint64_t)> &&handler) {
             Http3ResponseData *responseData = (Http3ResponseData *) us_quic_stream_ext((us_quic_stream_t *) this);
 
             responseData->onWritable = std::move(handler);

--- a/packages/bun-uws/src/Http3ResponseData.h
+++ b/packages/bun-uws/src/Http3ResponseData.h
@@ -1,22 +1,22 @@
 #ifndef UWS_H3RESPONSEDATA_H
 #define UWS_H3RESPONSEDATA_H
 
-#include "MoveOnlyFunction.h"
 #include "AsyncSocketData.h"
+#include "MoveOnlyFunction.h"
 #include <string_view>
-
+// clang-format off
 namespace uWS {
     struct Http3ResponseData {
 
         MoveOnlyFunction<void()> onAborted = nullptr;
         MoveOnlyFunction<void(std::string_view, bool)> onData = nullptr;
-        MoveOnlyFunction<bool(uintmax_t)> onWritable = nullptr;
+        MoveOnlyFunction<bool(uint64_t)> onWritable = nullptr;
 
         /* Status is always first header just like for h1 */
         unsigned int headerOffset = 0;
         
         /* Write offset */
-        uintmax_t offset = 0;
+        uint64_t offset = 0;
 
         BackPressure backpressure;
     };

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+// clang-format off
 #ifndef UWS_HTTPRESPONSE_H
 #define UWS_HTTPRESPONSE_H
 
@@ -87,7 +87,7 @@ public:
 
     /* Returns true on success, indicating that it might be feasible to write more data.
      * Will start timeout if stream reaches totalSize or write failure. */
-    bool internalEnd(std::string_view data, uintmax_t totalSize, bool optional, bool allowContentLength = true, bool closeConnection = false) {
+    bool internalEnd(std::string_view data, uint64_t totalSize, bool optional, bool allowContentLength = true, bool closeConnection = false) {
         /* Write status if not already done */
         writeStatus(HTTP_200_OK);
 
@@ -435,7 +435,7 @@ public:
 
     /* Try and end the response. Returns [true, true] on success.
      * Starts a timeout in some cases. Returns [ok, hasResponded] */
-    std::pair<bool, bool> tryEnd(std::string_view data, uintmax_t totalSize = 0, bool closeConnection = false) {
+    std::pair<bool, bool> tryEnd(std::string_view data, uint64_t totalSize = 0, bool closeConnection = false) {
         return {internalEnd(data, totalSize, true, true, closeConnection), hasResponded()};
     }
 
@@ -491,14 +491,14 @@ public:
     }
 
     /* Get the current byte write offset for this Http response */
-    uintmax_t getWriteOffset() {
+    uint64_t getWriteOffset() {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         return httpResponseData->offset;
     }
 
     /* If you are messing around with sendfile you might want to override the offset. */
-    void overrideWriteOffset(uintmax_t offset) {
+    void overrideWriteOffset(uint64_t offset) {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         httpResponseData->offset = offset;
@@ -566,7 +566,7 @@ public:
     }
 
     /* Attach handler for writable HTTP response */
-    HttpResponse *onWritable(MoveOnlyFunction<bool(uintmax_t)> &&handler) {
+    HttpResponse *onWritable(MoveOnlyFunction<bool(uint64_t)> &&handler) {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         httpResponseData->onWritable = std::move(handler);
@@ -591,7 +591,7 @@ public:
     }
 
 
-    void setWriteOffset(uintmax_t offset) {
+    void setWriteOffset(uint64_t offset) {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         httpResponseData->offset = offset;

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+// clang-format off
 #ifndef UWS_HTTPRESPONSEDATA_H
 #define UWS_HTTPRESPONSEDATA_H
 
@@ -46,12 +46,12 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     }
 
     /* Caller of onWritable. It is possible onWritable calls markDone so we need to borrow it. */
-    bool callOnWritable(uintmax_t offset) {
+    bool callOnWritable(uint64_t offset) {
         /* Borrow real onWritable */
-        MoveOnlyFunction<bool(uintmax_t)> borrowedOnWritable = std::move(onWritable);
+        MoveOnlyFunction<bool(uint64_t)> borrowedOnWritable = std::move(onWritable);
 
         /* Set onWritable to placeholder */
-        onWritable = [](uintmax_t) {return true;};
+        onWritable = [](uint64_t) {return true;};
 
         /* Run borrowed onWritable */
         bool ret = borrowedOnWritable(offset);
@@ -75,11 +75,11 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     };
 
     /* Per socket event handlers */
-    MoveOnlyFunction<bool(uintmax_t)> onWritable;
+    MoveOnlyFunction<bool(uint64_t)> onWritable;
     MoveOnlyFunction<void()> onAborted;
     MoveOnlyFunction<void(std::string_view, bool)> inStream; // onData
     /* Outgoing offset */
-    uintmax_t offset = 0;
+    uint64_t offset = 0;
 
     /* Let's track number of bytes since last timeout reset in data handler */
     unsigned int received_bytes_per_timeout = 0;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1571,7 +1571,9 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             }
         }
 
-        pub fn onWritableResponseBuffer(this: *RequestContext, _: c_ulong, resp: *App.Response) callconv(.C) bool {
+        pub fn onWritableResponseBuffer(this: *RequestContext, _: uws.uintmax_t, resp: *App.Response) callconv(.C) bool {
+            ctxLog("onWritableResponseBuffer", .{});
+
             std.debug.assert(this.resp == resp);
             if (this.flags.aborted) {
                 this.finalizeForAbort();
@@ -1583,7 +1585,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         }
 
         // TODO: should we cork?
-        pub fn onWritableCompleteResponseBufferAndMetadata(this: *RequestContext, write_offset: c_ulong, resp: *App.Response) callconv(.C) bool {
+        pub fn onWritableCompleteResponseBufferAndMetadata(this: *RequestContext, write_offset: uws.uintmax_t, resp: *App.Response) callconv(.C) bool {
+            ctxLog("onWritableCompleteResponseBufferAndMetadata", .{});
             std.debug.assert(this.resp == resp);
 
             if (this.flags.aborted) {
@@ -1604,7 +1607,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             return this.sendWritableBytesForCompleteResponseBuffer(this.response_buf_owned.items, write_offset, resp);
         }
 
-        pub fn onWritableCompleteResponseBuffer(this: *RequestContext, write_offset: c_ulong, resp: *App.Response) callconv(.C) bool {
+        pub fn onWritableCompleteResponseBuffer(this: *RequestContext, write_offset: uws.uintmax_t, resp: *App.Response) callconv(.C) bool {
+            ctxLog("onWritableCompleteResponseBuffer", .{});
             std.debug.assert(this.resp == resp);
             if (this.flags.aborted) {
                 this.finalizeForAbort();
@@ -1945,7 +1949,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             return true;
         }
 
-        pub fn onWritableBytes(this: *RequestContext, write_offset: c_ulong, resp: *App.Response) callconv(.C) bool {
+        pub fn onWritableBytes(this: *RequestContext, write_offset: uws.uintmax_t, resp: *App.Response) callconv(.C) bool {
+            ctxLog("onWritableBytes", .{});
             std.debug.assert(this.resp == resp);
             if (this.flags.aborted) {
                 this.finalizeForAbort();
@@ -1960,7 +1965,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             return true;
         }
 
-        pub fn sendWritableBytesForBlob(this: *RequestContext, bytes_: []const u8, write_offset_: c_ulong, resp: *App.Response) bool {
+        pub fn sendWritableBytesForBlob(this: *RequestContext, bytes_: []const u8, write_offset_: uws.uintmax_t, resp: *App.Response) bool {
             std.debug.assert(this.resp == resp);
             const write_offset: usize = write_offset_;
 
@@ -1975,7 +1980,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             }
         }
 
-        pub fn sendWritableBytesForCompleteResponseBuffer(this: *RequestContext, bytes_: []const u8, write_offset_: c_ulong, resp: *App.Response) bool {
+        pub fn sendWritableBytesForCompleteResponseBuffer(this: *RequestContext, bytes_: []const u8, write_offset_: uws.uintmax_t, resp: *App.Response) bool {
             const write_offset: usize = write_offset_;
             std.debug.assert(this.resp == resp);
 
@@ -1991,7 +1996,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             return true;
         }
 
-        pub fn onWritableSendfile(this: *RequestContext, _: c_ulong, _: *App.Response) callconv(.C) bool {
+        pub fn onWritableSendfile(this: *RequestContext, _: uws.uintmax_t, _: *App.Response) callconv(.C) bool {
+            ctxLog("onWritableSendfile", .{});
             return this.onSendfile();
         }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1571,7 +1571,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             }
         }
 
-        pub fn onWritableResponseBuffer(this: *RequestContext, _: uws.uintmax_t, resp: *App.Response) callconv(.C) bool {
+        pub fn onWritableResponseBuffer(this: *RequestContext, _: u64, resp: *App.Response) callconv(.C) bool {
             ctxLog("onWritableResponseBuffer", .{});
 
             std.debug.assert(this.resp == resp);
@@ -1585,7 +1585,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         }
 
         // TODO: should we cork?
-        pub fn onWritableCompleteResponseBufferAndMetadata(this: *RequestContext, write_offset: uws.uintmax_t, resp: *App.Response) callconv(.C) bool {
+        pub fn onWritableCompleteResponseBufferAndMetadata(this: *RequestContext, write_offset: u64, resp: *App.Response) callconv(.C) bool {
             ctxLog("onWritableCompleteResponseBufferAndMetadata", .{});
             std.debug.assert(this.resp == resp);
 
@@ -1607,7 +1607,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             return this.sendWritableBytesForCompleteResponseBuffer(this.response_buf_owned.items, write_offset, resp);
         }
 
-        pub fn onWritableCompleteResponseBuffer(this: *RequestContext, write_offset: uws.uintmax_t, resp: *App.Response) callconv(.C) bool {
+        pub fn onWritableCompleteResponseBuffer(this: *RequestContext, write_offset: u64, resp: *App.Response) callconv(.C) bool {
             ctxLog("onWritableCompleteResponseBuffer", .{});
             std.debug.assert(this.resp == resp);
             if (this.flags.aborted) {
@@ -1949,7 +1949,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             return true;
         }
 
-        pub fn onWritableBytes(this: *RequestContext, write_offset: uws.uintmax_t, resp: *App.Response) callconv(.C) bool {
+        pub fn onWritableBytes(this: *RequestContext, write_offset: u64, resp: *App.Response) callconv(.C) bool {
             ctxLog("onWritableBytes", .{});
             std.debug.assert(this.resp == resp);
             if (this.flags.aborted) {
@@ -1965,7 +1965,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             return true;
         }
 
-        pub fn sendWritableBytesForBlob(this: *RequestContext, bytes_: []const u8, write_offset_: uws.uintmax_t, resp: *App.Response) bool {
+        pub fn sendWritableBytesForBlob(this: *RequestContext, bytes_: []const u8, write_offset_: u64, resp: *App.Response) bool {
             std.debug.assert(this.resp == resp);
             const write_offset: usize = write_offset_;
 
@@ -1980,7 +1980,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             }
         }
 
-        pub fn sendWritableBytesForCompleteResponseBuffer(this: *RequestContext, bytes_: []const u8, write_offset_: uws.uintmax_t, resp: *App.Response) bool {
+        pub fn sendWritableBytesForCompleteResponseBuffer(this: *RequestContext, bytes_: []const u8, write_offset_: u64, resp: *App.Response) bool {
             const write_offset: usize = write_offset_;
             std.debug.assert(this.resp == resp);
 
@@ -1996,7 +1996,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             return true;
         }
 
-        pub fn onWritableSendfile(this: *RequestContext, _: uws.uintmax_t, _: *App.Response) callconv(.C) bool {
+        pub fn onWritableSendfile(this: *RequestContext, _: u64, _: *App.Response) callconv(.C) bool {
             ctxLog("onWritableSendfile", .{});
             return this.onSendfile();
         }

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -2030,7 +2030,7 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
             return this.buffer.ptr[this.offset..this.buffer.cap][0..this.buffer.len];
         }
 
-        pub fn onWritable(this: *@This(), write_offset_: uws.uintmax_t, _: *UWSResponse) callconv(.C) bool {
+        pub fn onWritable(this: *@This(), write_offset_: u64, _: *UWSResponse) callconv(.C) bool {
             const write_offset: u64 = @as(u64, write_offset_);
             log("onWritable ({d})", .{write_offset});
 

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -2030,7 +2030,7 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
             return this.buffer.ptr[this.offset..this.buffer.cap][0..this.buffer.len];
         }
 
-        pub fn onWritable(this: *@This(), write_offset_: c_ulong, _: *UWSResponse) callconv(.C) bool {
+        pub fn onWritable(this: *@This(), write_offset_: uws.uintmax_t, _: *UWSResponse) callconv(.C) bool {
             const write_offset: u64 = @as(u64, write_offset_);
             log("onWritable ({d})", .{write_offset});
 

--- a/src/deps/_libusockets.h
+++ b/src/deps/_libusockets.h
@@ -123,23 +123,24 @@ typedef struct {
 
 typedef void (*uws_listen_handler)(struct us_listen_socket_t *listen_socket,
                                    void *user_data);
-typedef void (*uws_listen_domain_handler)(struct us_listen_socket_t *listen_socket, 
-                                          const char* domain, int options, 
-                                          void *user_data);
+typedef void (*uws_listen_domain_handler)(
+    struct us_listen_socket_t *listen_socket, const char *domain, int options,
+    void *user_data);
 
 typedef void (*uws_method_handler)(uws_res_t *response, uws_req_t *request,
                                    void *user_data);
 typedef void (*uws_filter_handler)(uws_res_t *response, int, void *user_data);
 typedef void (*uws_missing_server_handler)(const char *hostname,
                                            void *user_data);
-typedef void (*uws_get_headers_server_handler)(const char *header_name, 
-                                               size_t header_name_size, 
-                                               const char *header_value, 
-                                               size_t header_value_size, 
+typedef void (*uws_get_headers_server_handler)(const char *header_name,
+                                               size_t header_name_size,
+                                               const char *header_value,
+                                               size_t header_value_size,
                                                void *user_data);
 
 // Basic HTTP
-uws_app_t *uws_create_app(int ssl, struct us_bun_socket_context_options_t options);
+uws_app_t *uws_create_app(int ssl,
+                          struct us_bun_socket_context_options_t options);
 
 void uws_app_destroy(int ssl, uws_app_t *app);
 void uws_app_get(int ssl, uws_app_t *app, const char *pattern,
@@ -170,11 +171,14 @@ void uws_app_listen(int ssl, uws_app_t *app, int port,
 void uws_app_listen_with_config(int ssl, uws_app_t *app, const char *host,
                                 uint16_t port, int32_t options,
                                 uws_listen_handler handler, void *user_data);
-void uws_app_listen_domain(int ssl, uws_app_t *app, const char *domain,  size_t pathlen,
-                           uws_listen_domain_handler handler, void *user_data);
+void uws_app_listen_domain(int ssl, uws_app_t *app, const char *domain,
+                           size_t pathlen, uws_listen_domain_handler handler,
+                           void *user_data);
 
-void uws_app_listen_domain_with_options(int ssl, uws_app_t *app, const char *domain, size_t pathlen,
-                                        int options, uws_listen_domain_handler handler,
+void uws_app_listen_domain_with_options(int ssl, uws_app_t *app,
+                                        const char *domain, size_t pathlen,
+                                        int options,
+                                        uws_listen_domain_handler handler,
                                         void *user_data);
 void uws_app_domain(int ssl, uws_app_t *app, const char *server_name);
 
@@ -267,10 +271,10 @@ void uws_res_write_header_int(int ssl, uws_res_t *res, const char *key,
 void uws_res_end_without_body(int ssl, uws_res_t *res, bool close_connection);
 void uws_res_end_stream(int ssl, uws_res_t *res, bool close_connection);
 bool uws_res_write(int ssl, uws_res_t *res, const char *data, size_t length);
-uintmax_t uws_res_get_write_offset(int ssl, uws_res_t *res);
+uint64_t uws_res_get_write_offset(int ssl, uws_res_t *res);
 bool uws_res_has_responded(int ssl, uws_res_t *res);
 void uws_res_on_writable(int ssl, uws_res_t *res,
-                         bool (*handler)(uws_res_t *res, uintmax_t,
+                         bool (*handler)(uws_res_t *res, uint64_t,
                                          void *opcional_data),
                          void *user_data);
 void uws_res_on_aborted(int ssl, uws_res_t *res,
@@ -302,10 +306,12 @@ size_t uws_req_get_query(uws_req_t *res, const char *key, size_t key_length,
                          const char **dest);
 size_t uws_req_get_parameter(uws_req_t *res, unsigned short index,
                              const char **dest);
-void uws_req_for_each_header(uws_req_t *res, uws_get_headers_server_handler handler, void *user_data);
+void uws_req_for_each_header(uws_req_t *res,
+                             uws_get_headers_server_handler handler,
+                             void *user_data);
 
 struct us_loop_t *uws_get_loop();
-struct us_loop_t *uws_get_loop_with_native(void* existing_native_loop);
+struct us_loop_t *uws_get_loop_with_native(void *existing_native_loop);
 
 void uws_loop_addPostHandler(us_loop_t *loop, void *ctx_,
                              void (*cb)(void *ctx, us_loop_t *loop));
@@ -327,7 +333,7 @@ bool uws_res_try_end(int ssl, uws_res_t *res, const char *bytes, size_t len,
                      size_t total_len, bool close);
 
 void uws_res_prepare_for_sendfile(int ssl, uws_res_t *res);
-void uws_res_override_write_offset(int ssl, uws_res_t *res, uintmax_t offset);
+void uws_res_override_write_offset(int ssl, uws_res_t *res, uint64_t offset);
 
 void uws_app_close(int ssl, uws_app_t *app);
 

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1198,7 +1198,7 @@ extern "C"
     uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
     return uwsRes->write(std::string_view(data, length));
   }
-  uintmax_t uws_res_get_write_offset(int ssl, uws_res_t *res)
+  uint64_t uws_res_get_write_offset(int ssl, uws_res_t *res)
   {
     if (ssl)
     {
@@ -1221,20 +1221,20 @@ extern "C"
   }
 
   void uws_res_on_writable(int ssl, uws_res_t *res,
-                           bool (*handler)(uws_res_t *res, uintmax_t,
+                           bool (*handler)(uws_res_t *res, uint64_t,
                                            void *opcional_data),
                            void *opcional_data)
   {
     if (ssl)
     {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->onWritable([handler, res, opcional_data](uintmax_t a)
+      uwsRes->onWritable([handler, res, opcional_data](uint64_t a)
                          { return handler(res, a, opcional_data); });
     }
     else
     {
       uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->onWritable([handler, res, opcional_data](uintmax_t a)
+      uwsRes->onWritable([handler, res, opcional_data](uint64_t a)
                          { return handler(res, a, opcional_data); });
     }
   }
@@ -1492,7 +1492,7 @@ extern "C"
                    LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
   }
 
-  void uws_res_override_write_offset(int ssl, uws_res_t *res, uintmax_t offset)
+  void uws_res_override_write_offset(int ssl, uws_res_t *res, uint64_t offset)
   {
     if (ssl)
     {

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1097,7 +1097,7 @@ pub const PosixLoop = extern struct {
         us_loop_run(this);
     }
 };
-pub const uintmax_t = if (Environment.isWindows) c_ulonglong else c_ulong;
+
 extern fn uws_loop_defer(loop: *Loop, ctx: *anyopaque, cb: *const (fn (ctx: *anyopaque) callconv(.C) void)) void;
 
 extern fn us_create_timer(loop: ?*Loop, fallthrough: i32, ext_size: c_uint) *Timer;
@@ -1970,11 +1970,11 @@ pub fn NewApp(comptime ssl: bool) type {
             pub fn write(res: *Response, data: []const u8) bool {
                 return uws_res_write(ssl_flag, res.downcast(), data.ptr, data.len);
             }
-            pub fn getWriteOffset(res: *Response) uintmax_t {
+            pub fn getWriteOffset(res: *Response) u64 {
                 return uws_res_get_write_offset(ssl_flag, res.downcast());
             }
             pub fn overrideWriteOffset(res: *Response, offset: anytype) void {
-                uws_res_override_write_offset(ssl_flag, res.downcast(), @as(uintmax_t, @intCast(offset)));
+                uws_res_override_write_offset(ssl_flag, res.downcast(), @as(u64, @intCast(offset)));
             }
             pub fn hasResponded(res: *Response) bool {
                 return uws_res_has_responded(ssl_flag, res.downcast());
@@ -2018,11 +2018,11 @@ pub fn NewApp(comptime ssl: bool) type {
             pub fn onWritable(
                 res: *Response,
                 comptime UserDataType: type,
-                comptime handler: fn (UserDataType, uintmax_t, *Response) callconv(.C) bool,
+                comptime handler: fn (UserDataType, u64, *Response) callconv(.C) bool,
                 user_data: UserDataType,
             ) void {
                 const Wrapper = struct {
-                    pub fn handle(this: *uws_res, amount: uintmax_t, data: ?*anyopaque) callconv(.C) bool {
+                    pub fn handle(this: *uws_res, amount: u64, data: ?*anyopaque) callconv(.C) bool {
                         if (comptime UserDataType == void) {
                             return @call(bun.callmod_inline, handler, .{ {}, amount, castRes(this) });
                         } else {
@@ -2374,10 +2374,10 @@ extern fn uws_res_write_header(ssl: i32, res: *uws_res, key: [*c]const u8, key_l
 extern fn uws_res_write_header_int(ssl: i32, res: *uws_res, key: [*c]const u8, key_length: usize, value: u64) void;
 extern fn uws_res_end_without_body(ssl: i32, res: *uws_res, close_connection: bool) void;
 extern fn uws_res_write(ssl: i32, res: *uws_res, data: [*c]const u8, length: usize) bool;
-extern fn uws_res_get_write_offset(ssl: i32, res: *uws_res) uintmax_t;
-extern fn uws_res_override_write_offset(ssl: i32, res: *uws_res, uintmax_t) void;
+extern fn uws_res_get_write_offset(ssl: i32, res: *uws_res) u64;
+extern fn uws_res_override_write_offset(ssl: i32, res: *uws_res, u64) void;
 extern fn uws_res_has_responded(ssl: i32, res: *uws_res) bool;
-extern fn uws_res_on_writable(ssl: i32, res: *uws_res, handler: ?*const fn (*uws_res, uintmax_t, ?*anyopaque) callconv(.C) bool, user_data: ?*anyopaque) void;
+extern fn uws_res_on_writable(ssl: i32, res: *uws_res, handler: ?*const fn (*uws_res, u64, ?*anyopaque) callconv(.C) bool, user_data: ?*anyopaque) void;
 extern fn uws_res_on_aborted(ssl: i32, res: *uws_res, handler: ?*const fn (*uws_res, ?*anyopaque) callconv(.C) void, opcional_data: ?*anyopaque) void;
 extern fn uws_res_on_data(
     ssl: i32,

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1097,7 +1097,7 @@ pub const PosixLoop = extern struct {
         us_loop_run(this);
     }
 };
-const uintmax_t = c_ulong;
+pub const uintmax_t = if (Environment.isWindows) c_ulonglong else c_ulong;
 extern fn uws_loop_defer(loop: *Loop, ctx: *anyopaque, cb: *const (fn (ctx: *anyopaque) callconv(.C) void)) void;
 
 extern fn us_create_timer(loop: ?*Loop, fallthrough: i32, ext_size: c_uint) *Timer;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Existing tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
