### PR TITLE
Remove documentation references to environment variable inlining because the bundler does not do so

### DIFF
--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -156,7 +156,7 @@ Like the Bun runtime, the bundler supports an array of file types out of the box
 ---
 
 - `.js` `.jsx`, `.cjs` `.mjs` `.mts` `.cts` `.ts` `.tsx`
-- Uses Bun's built-in transpiler to parse the file and transpile TypeScript/JSX syntax to vanilla JavaScript. The bundler executes a set of default transforms, including dead code elimination, tree shaking, and environment variable inlining. At the moment Bun does not attempt to down-convert syntax; if you use recently ECMAScript syntax, that will be reflected in the bundled code.
+- Uses Bun's built-in transpiler to parse the file and transpile TypeScript/JSX syntax to vanilla JavaScript. The bundler executes a set of default transforms including dead code elimination and tree shaking. At the moment Bun does not attempt to down-convert syntax; if you use recently ECMAScript syntax, that will be reflected in the bundled code.
 
 ---
 

--- a/docs/bundler/loaders.md
+++ b/docs/bundler/loaders.md
@@ -10,7 +10,7 @@ Bun uses the file extension to determine which built-in _loader_ should be used 
 
 **JavaScript**. Default for `.cjs` and `.mjs`.
 
-Parses the code and applies a set of default transforms, like dead-code elimination, tree shaking, and environment variable inlining. Note that Bun does not attempt to down-convert syntax at the moment.
+Parses the code and applies a set of default transforms like dead-code elimination and tree shaking. Note that Bun does not attempt to down-convert syntax at the moment.
 
 ### `jsx`
 


### PR DESCRIPTION
### What does this PR do?

In testing our Bun-based lambda while prepping its rollout to production, I realized that despite the documentation saying that environment variable inlining occurs when building, the bundler actually doesn't. So I'm proposing this be removed from the documentation if and until the behavior changes.

I'm creating a follow-up issue to propose the ability to make environment variable inlining configurable. I'll reference this issue in that feature request.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

The code didn't change