### PR TITLE
fix #9861

### DIFF
--- a/src/output.zig
+++ b/src/output.zig
@@ -189,7 +189,6 @@ pub const Source = struct {
             console_codepage = w.kernel32.GetConsoleOutputCP();
             _ = SetConsoleCP(CP_UTF8);
 
-            const ENABLE_VIRTUAL_TERMINAL_INPUT = 0x200;
             const ENABLE_WRAP_AT_EOL_OUTPUT = 0x0002;
             const ENABLE_PROCESSED_OUTPUT = 0x0001;
 
@@ -197,8 +196,11 @@ pub const Source = struct {
             if (w.kernel32.GetConsoleMode(stdin, &mode) != 0) {
                 console_mode[0] = mode;
                 bun_stdio_tty[0] = 1;
-                _ = SetConsoleMode(stdin, mode | ENABLE_VIRTUAL_TERMINAL_INPUT);
             }
+
+            // ENABLE_VIRTUAL_TERMINAL_PROCESSING to enable ansi escape sequences
+            // ENABLE_PROCESSED_OUTUPT is enabled because ENABLE_VIRTUAL_TERMINAL_PROCESSING is enabled
+            // ENABLE_WRAP_AT_EOL_OUPTUT will prevent output from being cut off at the end of the line
 
             if (w.kernel32.GetConsoleMode(stdout, &mode) != 0) {
                 console_mode[1] = mode;


### PR DESCRIPTION
### What does this PR do?
removes `ENABLE_VIRTUAL_TERMINAL_INPUT`

fixes #9861 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
