### PR TITLE
fix(install): allow installing without lockfile with `--production`

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -10032,7 +10032,7 @@ pub const PackageManager = struct {
             root = .{};
             manager.lockfile.initEmpty(ctx.allocator);
 
-            if (manager.options.enable.frozen_lockfile) {
+            if (manager.options.enable.frozen_lockfile and load_lockfile_result != .not_found) {
                 if (comptime log_level != .silent) {
                     Output.prettyErrorln("<r><red>error<r>: lockfile had changes, but lockfile is frozen", .{});
                 }
@@ -10231,7 +10231,7 @@ pub const PackageManager = struct {
 
         const packages_len_before_install = manager.lockfile.packages.len;
 
-        if (manager.options.enable.frozen_lockfile) {
+        if (manager.options.enable.frozen_lockfile and load_lockfile_result != .not_found) {
             if (manager.lockfile.hasMetaHashChanged(PackageManager.verbose_install or manager.options.do.print_meta_hash_string, packages_len_before_install) catch false) {
                 if (comptime log_level != .silent) {
                     Output.prettyErrorln("<r><red>error<r><d>:<r> lockfile had changes, but lockfile is frozen", .{});

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6037,9 +6037,12 @@ it("should handle --cwd", async () => {
 });
 
 it("should handle --frozen-lockfile", async () => {
+  let urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": { as: "0.0.3" }, "0.0.5": { as: "0.0.5" } }));
+
   await writeFile(
     join(package_dir, "package.json"),
-    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { bar: "0.0.2" } }),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
   );
 
   // save the lockfile once
@@ -6047,12 +6050,22 @@ it("should handle --frozen-lockfile", async () => {
     await spawn({
       cmd: [bunExe(), "install"],
       cwd: package_dir,
-      stdout: "inherit",
-      stdin: "inherit",
-      stderr: "inherit",
+      stdout: "ignore",
+      stdin: "ignore",
+      stderr: "ignore",
       env,
     }).exited,
   ).toBe(0);
+
+  // change version of baz in package.json
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: { baz: "0.0.5" },
+    }),
+  );
 
   const { stderr, exited } = spawn({
     cmd: [bunExe(), "install", "--frozen-lockfile"],
@@ -6070,9 +6083,12 @@ it("should handle --frozen-lockfile", async () => {
 });
 
 it("should handle frozenLockfile in config file", async () => {
+  let urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": { as: "0.0.3" }, "0.0.5": { as: "0.0.5" } }));
+
   await writeFile(
     join(package_dir, "package.json"),
-    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { bar: "0.0.2" } }),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
   );
 
   // save the lockfile once
@@ -6080,9 +6096,9 @@ it("should handle frozenLockfile in config file", async () => {
     await spawn({
       cmd: [bunExe(), "install"],
       cwd: package_dir,
-      stdout: "inherit",
-      stdin: "inherit",
-      stderr: "inherit",
+      stdout: "ignore",
+      stdin: "ignore",
+      stderr: "ignore",
       env,
     }).exited,
   ).toBe(0);
@@ -6092,7 +6108,18 @@ it("should handle frozenLockfile in config file", async () => {
     `
 [install]
 frozenLockfile = true
+registry = "${root_url}"
 `,
+  );
+
+  // change version of baz in package.json
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: { baz: "0.0.5" },
+    }),
   );
 
   const { stderr, exited } = spawn({

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6042,6 +6042,18 @@ it("should handle --frozen-lockfile", async () => {
     JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { bar: "0.0.2" } }),
   );
 
+  // save the lockfile once
+  expect(
+    await spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "inherit",
+      stdin: "inherit",
+      stderr: "inherit",
+      env,
+    }).exited,
+  ).toBe(0);
+
   const { stderr, exited } = spawn({
     cmd: [bunExe(), "install", "--frozen-lockfile"],
     cwd: package_dir,
@@ -6062,6 +6074,19 @@ it("should handle frozenLockfile in config file", async () => {
     join(package_dir, "package.json"),
     JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { bar: "0.0.2" } }),
   );
+
+  // save the lockfile once
+  expect(
+    await spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "inherit",
+      stdin: "inherit",
+      stderr: "inherit",
+      env,
+    }).exited,
+  ).toBe(0);
+
   await writeFile(
     join(package_dir, "bunfig.toml"),
     `


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
