### PR TITLE
fix(init): ignore `EndOfStream` error on ctrl-c

### DIFF
--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -232,18 +232,28 @@ pub const InitCommand = struct {
                 Output.prettyln("<r><b>bun init<r> helps you get started with a minimal project and tries to guess sensible defaults. <d>Press ^C anytime to quit<r>\n\n", .{});
                 Output.flush();
 
-                fields.name = try normalizePackageName(alloc, try prompt(
+                const name = prompt(
                     alloc,
                     "<r><cyan>package name<r> ",
                     fields.name,
                     Output.enable_ansi_colors_stdout,
-                ));
-                fields.entry_point = try prompt(
+                ) catch |err| {
+                    if (err == error.EndOfStream) return;
+                    return err;
+                };
+
+                fields.name = try normalizePackageName(alloc, name);
+
+                fields.entry_point = prompt(
                     alloc,
                     "<r><cyan>entry point<r> ",
                     fields.entry_point,
                     Output.enable_ansi_colors_stdout,
-                );
+                ) catch |err| {
+                    if (err == error.EndOfStream) return;
+                    return err;
+                };
+
                 try Output.writer().writeAll("\n");
                 Output.flush();
             } else {


### PR DESCRIPTION
### What does this PR do?
This prevents stack traces from appearing on ctrl-c in release builds on windows.
<img width="514" alt="Screenshot 2024-04-04 at 3 10 12 AM" src="https://github.com/oven-sh/bun/assets/35280289/96be069e-6ec8-4417-8fb6-0609fe80e59c">

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
