### PR TITLE
fix typo: missing "v" prefix on installed Bun version (bun upgrade)

### DIFF
--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -493,7 +493,7 @@ pub const UpgradeCommand = struct {
             }
 
             if (!Environment.is_canary) {
-                Output.prettyErrorln("<r><b>Bun <cyan>v{s}<r> is out<r>! You're on <blue>{s}<r>\n", .{ version.name().?, Global.package_json_version });
+                Output.prettyErrorln("<r><b>Bun <cyan>v{s}<r> is out<r>! You're on <blue>v{s}<r>\n", .{ version.name().?, Global.package_json_version });
             } else {
                 Output.prettyErrorln("<r><b>Downgrading from Bun <blue>{s}-canary<r> to Bun <cyan>v{s}<r><r>\n", .{ Global.package_json_version, version.name().? });
             }


### PR DESCRIPTION
### What does this PR do?

This pull request adds the missing "v" prefix on the installed Bun version on `bun upgrade`.

<img width="622" alt="image1" src="https://github.com/oven-sh/bun/assets/72039923/9c6f9556-3f2f-480f-a939-8493bd47dc1f">