### PR TITLE
Add types for `node:util` `styleText()`

### DIFF
--- a/packages/bun-types/overrides.d.ts
+++ b/packages/bun-types/overrides.d.ts
@@ -62,3 +62,64 @@ declare module "tls" {
 
   function connect(options: BunConnectionOptions, secureConnectListener?: () => void): TLSSocket;
 }
+
+declare module 'util' {
+  // https://nodejs.org/docs/latest/api/util.html#foreground-colors
+  type ForegroundColors =
+    | 'black'
+    | 'blackBright'
+    | 'blue'
+    | 'blueBright'
+    | 'cyan'
+    | 'cyanBright'
+    | 'gray'
+    | 'green'
+    | 'greenBright'
+    | 'grey'
+    | 'magenta'
+    | 'magentaBright'
+    | 'red'
+    | 'redBright'
+    | 'white'
+    | 'whiteBright'
+    | 'yellow'
+    | 'yellowBright';
+
+  // https://nodejs.org/docs/latest/api/util.html#background-colors
+  type BackgroundColors =
+    | 'bgBlack'
+    | 'bgBlackBright'
+    | 'bgBlue'
+    | 'bgBlueBright'
+    | 'bgCyan'
+    | 'bgCyanBright'
+    | 'bgGray'
+    | 'bgGreen'
+    | 'bgGreenBright'
+    | 'bgGrey'
+    | 'bgMagenta'
+    | 'bgMagentaBright'
+    | 'bgRed'
+    | 'bgRedBright'
+    | 'bgWhite'
+    | 'bgWhiteBright'
+    | 'bgYellow'
+    | 'bgYellowBright';
+
+  // https://nodejs.org/docs/latest/api/util.html#modifiers
+  type Modifiers =
+    | 'blink'
+    | 'bold'
+    | 'dim'
+    | 'doubleunderline'
+    | 'framed'
+    | 'hidden'
+    | 'inverse'
+    | 'italic'
+    | 'overlined'
+    | 'reset'
+    | 'strikethrough'
+    | 'underline';
+
+  function styleText(format: ForegroundColors | BackgroundColors | Modifiers, text: string): string;
+}


### PR DESCRIPTION
### What does this PR do?

The `styleText` function from `node:util` is missing types. Types are inherited from Node's `util.d.ts` type definitions, and I don't see any mention of them in any versions of `@types/node` including the latest version `20.12.4`.

`styleText` is [marked as being in "active development"](https://nodejs.org/docs/latest/api/util.html#utilstyletextformat-text), but there still should be types for those trying to use it.

This PR adds the missing types so text formatting can be done dependency-free.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes