### PR TITLE
Update Window install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Bun supports Linux (x64 & arm64), macOS (x64 & Apple Silicon) and Windows (x64).
 curl -fsSL https://bun.sh/install | bash
 
 # on windows
+# using PowerShell
 powershell -c "irm bun.sh/install.ps1 | iex"
+# or using winget
+winget install Oven-sh.Bun
 
 # with npm
 npm install -g bun


### PR DESCRIPTION
Now that `winget` is so common, might as well give that as an example as it enables later `winget upgrade` to just work.

### What does this PR do?

Updates the install instruction for Windows platform to show an alternative of using [`winget`](https://github.com/microsoft/winget-cli) to install the `Open-sh.Bun` package you're so kindly providing.

Note that I retained the original PowerShell example (and added appropriate comment)

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

Tested on my machine using 
```sh
winget install Oven-sh.bun
```

![image](https://github.com/oven-sh/bun/assets/874059/4756d912-fec1-4351-a423-289304be8035)

