### PR TITLE
fix(docs): missing `getUsernameFromCookies` variable in `websocket/pubsub` example

### DIFF
--- a/docs/guides/websocket/pubsub.md
+++ b/docs/guides/websocket/pubsub.md
@@ -7,6 +7,17 @@ Bun's server-side `WebSocket` API provides a native pub-sub API. Sockets can be 
 This code snippet implements a simple single-channel chat server.
 
 ```ts
+const getUsernameFromCookies = (cookies: string | null) => {
+  if (!cookies) return "Anonymous";
+
+  var regex = /username=([^;]+)/;
+  var match = regex.exec(cookies);
+
+  if (!match) return "Anonymous";
+
+  return match[1];
+};
+
 const server = Bun.serve<{ username: string }>({
   fetch(req, server) {
     const cookies = req.headers.get("cookie");


### PR DESCRIPTION


### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- make code from docs ready to be ready with copy-paste only

### How did you verify your code works?

- original code was missing the `getUsernameFromCookies` function, I verified it using Postman and didn't receive the error

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
