### PR TITLE
Fix command line arguments guide so that the last output is shown

### DIFF
--- a/docs/guides/process/argv.md
+++ b/docs/guides/process/argv.md
@@ -46,7 +46,7 @@ console.log(positionals);
 
 then it outputs
 
-```
+```sh
 $ bun run cli.tsx --flag1 --flag2 value
 {
   flag1: true,


### PR DESCRIPTION
Updates this file to show the last example output. On the rendered website, the last output is not shown. I'm assuming it isn't because the markdown code block is missing the `sh` that the other example output blocks have.

### What does this PR do?

Fixes the ["Parse command-line arguments with Bun" guide](https://bun.sh/guides/process/argv) so that the last example output is shown. Currently on the guide it ends with "then it outputs" with no example output.

<img width="1422" alt="image" src="https://github.com/oven-sh/bun/assets/16639892/c71317c6-0a61-4d10-bdf8-b497f28eaa1a">

This PR adds the `sh` to the codeblock that has the output so that the output actually shows.


- [ x ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
This is simply a change in documentation, I'm not sure how to test that the markdown renders as expected though. The contributing guide mainly focuses on building `bun` itself and not the documentation site.