### PR TITLE
Partial fix for #10028

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3000,7 +3000,7 @@ declare module "bun" {
    *
    * Due to this limitation, while the internal counter may continue beyond this point,
    * the precision of the returned value will degrade after 14.8 weeks of uptime (when the nanosecond
-   * count exceeds Number.MAX_SAFE_INTEGER). Beyond this point, the function will continue to count but 
+   * count exceeds Number.MAX_SAFE_INTEGER). Beyond this point, the function will continue to count but
    * with reduced precision, which might affect time calculations and comparisons in long-running applications.
    *
    * @returns {number} The number of nanoseconds since the process was started, with precise values up to

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -748,6 +748,16 @@ pub fn openDirA(dir: std.fs.Dir, path_: []const u8) !std.fs.Dir {
     }
 }
 
+pub fn openDirForIteration(dir: std.fs.Dir, path_: []const u8) !std.fs.Dir {
+    if (comptime Environment.isWindows) {
+        const res = try sys.openDirAtWindowsA(toFD(dir.fd), path_, .{ .iterable = true, .can_rename_or_delete = false, .read_only = true }).unwrap();
+        return res.asDir();
+    } else {
+        const fd = try sys.openatA(toFD(dir.fd), path_, std.os.O.DIRECTORY | std.os.O.CLOEXEC | std.os.O.RDONLY, 0).unwrap();
+        return fd.asDir();
+    }
+}
+
 pub fn openDirAbsolute(path_: []const u8) !std.fs.Dir {
     if (comptime Environment.isWindows) {
         const res = try sys.openDirAtWindowsA(invalid_fd, path_, .{ .iterable = true, .can_rename_or_delete = true, .read_only = true }).unwrap();


### PR DESCRIPTION
### What does this PR do?

This is a partial fix for #10028

We are getting `EBUSY` in the module resolver when opening lots of directories, and we were not correctly handling errors  in the directory entry cache in these code paths before. 

I suspect this code needs to be reworked for Windows to avoid keeping parent directory handles open for any longer than necessary. That would be the better fix.

### How did you verify your code works?

We need a way to write tests that simulate system calls. This is really hard to test for right now.