### PR TITLE
Make bun install 60% faster on Windows, improve reliability, reduce memory usage

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3000,7 +3000,7 @@ declare module "bun" {
    *
    * Due to this limitation, while the internal counter may continue beyond this point,
    * the precision of the returned value will degrade after 14.8 weeks of uptime (when the nanosecond
-   * count exceeds Number.MAX_SAFE_INTEGER). Beyond this point, the function will continue to count but 
+   * count exceeds Number.MAX_SAFE_INTEGER). Beyond this point, the function will continue to count but
    * with reduced precision, which might affect time calculations and comparisons in long-running applications.
    *
    * @returns {number} The number of nanoseconds since the process was started, with precise values up to

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -912,7 +912,7 @@ pub const ModuleLoader = struct {
                 this: *Queue,
                 package_id: Install.PackageID,
                 name: []const u8,
-                resolution: Install.Resolution,
+                resolution: *const Install.Resolution,
                 err: anyerror,
                 url: []const u8,
             ) void {
@@ -932,7 +932,7 @@ pub const ModuleLoader = struct {
                             record_ids[import_id],
                             .{
                                 .name = name,
-                                .resolution = resolution,
+                                .resolution = resolution.*,
                                 .err = err,
                                 .url = url,
                             },

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1253,7 +1253,7 @@ pub fn getFdPath(fd_: anytype, buf: *[@This().MAX_PATH_BYTES]u8) ![]u8 {
 
     if (comptime Environment.isWindows) {
         var wide_buf: WPathBuffer = undefined;
-        const wide_slice = try std.os.windows.GetFinalPathNameByHandle(fd, .{}, wide_buf[0..]);
+        const wide_slice = try windows.GetFinalPathNameByHandle(fd, .{}, wide_buf[0..]);
         const res = strings.copyUTF16IntoUTF8(buf[0..], @TypeOf(wide_slice), wide_slice, true);
         return buf[0..res.written];
     }
@@ -1291,7 +1291,7 @@ pub fn getFdPathW(fd_: anytype, buf: *WPathBuffer) ![]u16 {
     const fd = toFD(fd_).cast();
 
     if (comptime Environment.isWindows) {
-        const wide_slice = try std.os.windows.GetFinalPathNameByHandle(fd, .{}, buf);
+        const wide_slice = try windows.GetFinalPathNameByHandle(fd, .{}, buf);
 
         return wide_slice;
     }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3032,3 +3032,5 @@ pub fn SliceIterator(comptime T: type) type {
         }
     };
 }
+
+pub const Futex = @import("./futex.zig");

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -25,7 +25,7 @@ const sockaddr_un = std.os.linux.sockaddr_un;
 const BOOL = windows.BOOL;
 const Env = bun.Environment;
 
-pub const log = bun.Output.scoped(.uv, false);
+pub const log = bun.Output.scoped(.uv, true);
 
 pub const CHAR = u8;
 pub const SHORT = c_short;

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -31,7 +31,7 @@ integrity: Integrity = .{},
 url: strings.StringOrTinyString,
 package_manager: *PackageManager,
 
-pub inline fn run(this: ExtractTarball, bytes: []const u8) !Install.ExtractData {
+pub inline fn run(this: *const ExtractTarball, bytes: []const u8) !Install.ExtractData {
     if (!this.skip_verify and this.integrity.tag.isSupported()) {
         if (!this.integrity.verify(bytes)) {
             this.package_manager.log.addErrorFmt(

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -625,20 +625,20 @@ const Task = struct {
                 return hasher.final();
             }
 
+            // These cannot change:
+            // We persist them to the filesystem.
             pub fn forGitClone(url: string) IDType {
                 var hasher = Hasher.init(0);
-                hasher.update("git-clone:");
                 hasher.update(url);
-                return hasher.final();
+                return @as(u64, 4 << 61) | @as(u64, @as(u61, @truncate(hasher.final())));
             }
 
             pub fn forGitCheckout(url: string, resolved: string) IDType {
                 var hasher = Hasher.init(0);
-                hasher.update("git-checkout:");
                 hasher.update(url);
                 hasher.update("@");
                 hasher.update(resolved);
-                return hasher.final();
+                return @as(u64, 5 << 61) | @as(u64, @as(u61, @truncate(hasher.final())));
             }
         };
     }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -796,7 +796,7 @@ const Task = struct {
     }
 
     fn readAndExtract(allocator: std.mem.Allocator, tarball: *const ExtractTarball) !ExtractData {
-        const bytes = try bun.sys.File.readFromUserInput(std.fs.cwd(), tarball.url.slice(), allocator).unwrap();
+        const bytes = try File.readFromUserInput(std.fs.cwd(), tarball.url.slice(), allocator).unwrap();
         defer allocator.free(bytes);
         return tarball.run(bytes);
     }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9221,7 +9221,7 @@ pub const PackageManager = struct {
                                 };
                                 if (!Singleton.node_modules_is_ok) {
                                     if (!Environment.isWindows) {
-                                        const stat = bun.sys.fstat(bun.toFD(this.node_modules_folder.fd)).unwrap() catch |err| {
+                                        const stat = bun.sys.fstat(bun.toFD(destination_dir)).unwrap() catch |err| {
                                             Output.err("EACCES", "Permission denied while installing <b>{s}<r>", .{
                                                 this.names[package_id].slice(buf),
                                             });

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -637,7 +637,7 @@ pub fn normalizePathWindows(
     else
         dir_fd.cast();
 
-    const base_path = w.GetFinalPathNameByHandle(base_fd, w.GetFinalPathNameByHandleFormat{}, buf) catch {
+    const base_path = bun.windows.GetFinalPathNameByHandle(base_fd, w.GetFinalPathNameByHandleFormat{}, buf) catch {
         return .{ .err = .{
             .errno = @intFromEnum(bun.C.E.BADFD),
             .syscall = .open,
@@ -1906,7 +1906,7 @@ pub fn getFdPath(fd: bun.FileDescriptor, out_buffer: *[MAX_PATH_BYTES]u8) Maybe(
     switch (comptime builtin.os.tag) {
         .windows => {
             var wide_buf: [windows.PATH_MAX_WIDE]u16 = undefined;
-            const wide_slice = std.os.windows.GetFinalPathNameByHandle(fd.cast(), .{}, wide_buf[0..]) catch {
+            const wide_slice = bun.windows.GetFinalPathNameByHandle(fd.cast(), .{}, wide_buf[0..]) catch {
                 return Maybe([]u8){ .err = .{ .errno = @intFromEnum(bun.C.SystemErrno.EBADF), .syscall = .GetFinalPathNameByHandle } };
             };
 

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2676,9 +2676,13 @@ pub const File = struct {
     /// 3. Return the File handle and the buffer
     pub fn readFromUserInput(dir_fd: anytype, input_path: anytype, allocator: std.mem.Allocator) Maybe([]u8) {
         var buf: bun.PathBuffer = undefined;
-        const normalized = bun.path.normalizeBuf(input_path, &buf, .auto);
-        buf[normalized.len] = 0;
-        return readFrom(dir_fd, buf[0..normalized.len :0], allocator);
+        const normalized = bun.path.joinAbsStringBufZ(
+            bun.fs.FileSystem.instance.top_level_dir,
+            &buf,
+            &.{input_path},
+            .loose,
+        );
+        return readFrom(dir_fd, normalized, allocator);
     }
 
     /// 1. Open a file for reading

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2661,6 +2661,17 @@ pub const File = struct {
         return getFdPath(this.handle, out_buffer);
     }
 
+    /// 1. Normalize the file path
+    /// 2. Open a file for reading
+    /// 2. Read the file to a buffer
+    /// 3. Return the File handle and the buffer
+    pub fn readFromUserInput(dir_fd: anytype, input_path: anytype, allocator: std.mem.Allocator) Maybe([]u8) {
+        var buf: bun.PathBuffer = undefined;
+        const normalized = bun.path.normalizeBuf(input_path, &buf, .auto);
+        buf[normalized.len] = 0;
+        return readFrom(dir_fd, buf[0..normalized.len :0], allocator);
+    }
+
     /// 1. Open a file for reading
     /// 2. Read the file to a buffer
     /// 3. Return the File handle and the buffer

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -3352,3 +3352,12 @@ pub extern "kernel32" fn CreateDirectoryExW(
     lpNewDirectory: [*:0]const u16,
     lpSecurityAttributes: ?*win32.SECURITY_ATTRIBUTES,
 ) callconv(windows.WINAPI) BOOL;
+
+pub fn GetFinalPathNameByHandle(
+    hFile: HANDLE,
+    fmt: std.os.windows.GetFinalPathNameByHandleFormat,
+    out_buffer: []u16,
+) std.os.windows.GetFinalPathNameByHandleError![]u16 {
+    bun.sys.syslog("GetFinalPathNameByHandle({*p})", .{hFile});
+    return std.os.windows.GetFinalPathNameByHandle(hFile, fmt, out_buffer);
+}

--- a/test/cli/install/migration/complex-workspace.test.ts
+++ b/test/cli/install/migration/complex-workspace.test.ts
@@ -44,7 +44,7 @@ test("the install succeeds", async () => {
   var subprocess = Bun.spawn([bunExe(), "reset.ts"], {
     env: bunEnv,
     cwd,
-    stdio: ["ignore", "ignore", "ignore"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
   await subprocess.exited;
   if (subprocess.exitCode != 0) {
@@ -55,7 +55,7 @@ test("the install succeeds", async () => {
   subprocess = Bun.spawn([bunExe(), "install"], {
     env: bunEnv,
     cwd,
-    stdio: ["ignore", "ignore", "ignore"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
 
   await subprocess.exited;

--- a/test/integration/next-pages/test/dev-server-ssr-100.test.ts
+++ b/test/integration/next-pages/test/dev-server-ssr-100.test.ts
@@ -88,7 +88,7 @@ beforeAll(async () => {
 
   const install = Bun.spawnSync([bunExe(), "i"], {
     cwd: root,
-    env: bunEnv,
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(root, "bunstall") },
     stdout: "inherit",
     stderr: "inherit",
     stdin: "inherit",


### PR DESCRIPTION
### What does this PR do?

This changes the synchronization primitives used by bun install from using Go-like channels to instead use an unbounded mpmc queue with large pre-allocated contiguous structs that are recycled (only dynamically allocated when pre-allocated space runs out). 

This fixes deadlocks that can occur when many different packages finish extracting simultaneously when the main thread goes to sleep. 

This closes node_modules folders when there are async tasks, which fixes #10039.

On Windows, this makes `installWithHardlinks` run concurrently, which offers a 60% performance boost to cached installs.

Fixes #4066 
Fixes #5142 




![image](https://github.com/oven-sh/bun/assets/709451/65de1833-ab3e-4d8a-a463-e0b9db823679)



### How did you verify your code works?

CI