### PR TITLE
Force non-zero exit code whenever `bun install` has any packages which failed to install

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3000,7 +3000,7 @@ declare module "bun" {
    *
    * Due to this limitation, while the internal counter may continue beyond this point,
    * the precision of the returned value will degrade after 14.8 weeks of uptime (when the nanosecond
-   * count exceeds Number.MAX_SAFE_INTEGER). Beyond this point, the function will continue to count but 
+   * count exceeds Number.MAX_SAFE_INTEGER). Beyond this point, the function will continue to count but
    * with reduced precision, which might affect time calculations and comparisons in long-running applications.
    *
    * @returns {number} The number of nanoseconds since the process was started, with precise values up to

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -512,5 +512,5 @@ it("should link dependency without crashing", async () => {
     "[] done",
     "",
   ]);
-  expect(await exited4).toBe(0);
+  expect(await exited4).toBe(1);
 });

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -512,5 +512,7 @@ it("should link dependency without crashing", async () => {
     "[] done",
     "",
   ]);
+
+  // This should fail with a non-zero exit code.
   expect(await exited4).toBe(1);
 });


### PR DESCRIPTION
### What does this PR do?

There seem to be very subtle cases here `bun install` will fail to install a package for some reason and still end up with a non-zero exit code. It's nothing "obvious", it's not when a package fails to resolve or a package fails to download. It's more subtle. Like if the filesystem had a permissions issue and it's a dependency of a dependency, or something along those lines.

Let's see if any new test failures occur

### How did you verify your code works?

