### PR TITLE
Improve bun shell docs examples

### DIFF
--- a/docs/runtime/shell.md
+++ b/docs/runtime/shell.md
@@ -99,6 +99,7 @@ console.log(stderr);
 The default handling of non-zero exit codes can be configured by calling `.nothrow()` or `.throws(boolean)` on the `$` function itself.
 
 ```js
+import { $ } from "bun";
 // shell promises will not throw, meaning you will have to
 // check for `exitCode` manually on every shell command.
 $.nothrow(); // equivilent to $.throws(false)
@@ -108,6 +109,8 @@ $.throws(true);
 
 // alias for $.nothrow()
 $.throws(false);
+
+await $`something-that-may-fail`; // No exception thrown
 ```
 
 ## Redirection
@@ -149,7 +152,7 @@ The following JavaScript objects are supported for redirection to:
 To redirect the output from JavaScript objects to stdin, use the `<` operator:
 
 ```js
-import { $, file } from "bun";
+import { $ } from "bun";
 
 const response = new Response("hello i am a response body");
 

--- a/test/js/bun/shell/bunshell-file.test.ts
+++ b/test/js/bun/shell/bunshell-file.test.ts
@@ -1,4 +1,4 @@
-import { $, file } from "bun";
+import { $ } from "bun";
 import { test, expect } from "bun:test";
 
 test("$ with Bun.file prints the path", async () => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
I didn't, there is no documentation on how to run the docs website locally.
I hope to see some PR preview in CI so we can see how it looks
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
