### PR TITLE
add error.EISDIR where error.isDir is used

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -550,7 +550,7 @@ pub const StandaloneModuleGraph = struct {
             bun.toFD(root_dir.fd),
             bun.sliceTo(&(try std.os.toPosixPath(std.fs.path.basename(outfile))), 0),
         ) catch |err| {
-            if (err == error.IsDir) {
+            if (err == error.IsDir or err == error.EISDIR) {
                 Output.prettyErrorln("<r><red>error<r><d>:<r> {} is a directory. Please choose a different --outfile or delete the directory", .{bun.fmt.quote(outfile)});
             } else {
                 Output.prettyErrorln("<r><red>error<r><d>:<r> failed to rename {s} to {s}: {s}", .{ temp_location, outfile, @errorName(err) });

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -600,7 +600,7 @@ pub const PackageJSON = struct {
             false,
             null,
         ) catch |err| {
-            if (err != error.IsDir) {
+            if (err != error.IsDir and err != error.EISDIR) {
                 r.log.addErrorFmt(null, logger.Loc.Empty, allocator, "Cannot read file \"{s}\": {s}", .{ r.prettyPath(fs.Path.init(input_path)), @errorName(err) }) catch unreachable;
             }
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2723,6 +2723,7 @@ pub const Resolver = struct {
                     // ignore them during path resolution.
                     error.ENOENT,
                     error.ENOTDIR,
+                    error.EISDIR,
                     error.IsDir,
                     error.NotDir,
                     error.FileNotFound,


### PR DESCRIPTION
### What does this PR do?

add error.EISDIR where error.isDir is used

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
