### PR TITLE
fix(windows): input for `bun init` and `prompt`

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2091,6 +2091,31 @@ pub const win32 = struct {
     pub var STDERR_FD: FileDescriptor = undefined;
     pub var STDIN_FD: FileDescriptor = undefined;
 
+    /// Returns the original mode
+    pub fn unsetStdioModeFlags(i: anytype, flags: w.DWORD) !w.DWORD {
+        const fd = stdio(i);
+        var original_mode: w.DWORD = 0;
+        if (windows.GetConsoleMode(fd.cast(), &original_mode) != 0) {
+            if (windows.SetConsoleMode(fd.cast(), original_mode & ~flags) == 0) {
+                return windows.getLastError();
+            }
+        } else return windows.getLastError();
+
+        return original_mode;
+    }
+
+    /// Returns the original mode
+    pub fn setStdioModeFlags(i: anytype, flags: w.DWORD) !w.DWORD {
+        const fd = stdio(i);
+        var original_mode: w.DWORD = 0;
+        if (windows.GetConsoleMode(fd.cast(), &original_mode) != 0) {
+            if (windows.SetConsoleMode(fd.cast(), original_mode | flags) == 0) {
+                return windows.getLastError();
+            }
+        } else return windows.getLastError();
+        return original_mode;
+    }
+
     const watcherChildEnv: [:0]const u16 = strings.toUTF16LiteralZ("_BUN_WATCHER_CHILD");
     // magic exit code to indicate to the watcher manager that the child process should be re-spawned
     // this was randomly generated - we need to avoid using a common exit code that might be used by the script itself

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -39,6 +39,18 @@ pub const InitCommand = struct {
 
         Output.flush();
 
+        // unset `ENABLE_VIRTUAL_TERMINAL_INPUT` on windows. This prevents backspace from
+        // deleting the entire line
+        const original_mode: if (Environment.isWindows) ?bun.windows.DWORD else void = if (comptime Environment.isWindows)
+            bun.win32.unsetStdioModeFlags(0, bun.windows.ENABLE_VIRTUAL_TERMINAL_INPUT) catch null
+        else {};
+
+        defer if (comptime Environment.isWindows) {
+            if (original_mode) |mode| {
+                _ = bun.windows.SetConsoleMode(bun.win32.STDIN_FD.cast(), mode);
+            }
+        };
+
         var input = try bun.Output.buffered_stdin.reader().readUntilDelimiterAlloc(alloc, '\n', 1024);
         if (strings.endsWithChar(input, '\r')) {
             input = input[0 .. input.len - 1];

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1637,7 +1637,7 @@ pub const PackageInstall = struct {
                 return null;
             }
 
-            return bun.errnoToZigErr(bun.windows.getLastErrno());
+            return bun.windows.getLastError();
         }
     };
 

--- a/src/output.zig
+++ b/src/output.zig
@@ -136,13 +136,7 @@ pub const Source = struct {
     export var bun_stdio_tty: [3]i32 = .{ 0, 0, 0 };
 
     const WindowsStdio = struct {
-        const w = std.os.windows;
-
-        // TODO: when https://github.com/ziglang/zig/pull/18692 merges, use std.os.windows for this
-        extern fn SetConsoleMode(console_handle: *anyopaque, mode: u32) u32;
-        extern fn SetStdHandle(nStdHandle: u32, hHandle: *anyopaque) u32;
-        extern fn GetConsoleOutputCP() u32;
-        pub extern "kernel32" fn SetConsoleCP(wCodePageID: std.os.windows.UINT) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+        const w = bun.windows;
 
         pub var console_mode = [3]?u32{ null, null, null };
         pub var console_codepage = @as(u32, 0);
@@ -166,7 +160,7 @@ pub const Source = struct {
             const handles = &.{ &stdin, &stdout, &stderr };
             inline for (console_mode, handles) |mode, handle| {
                 if (mode) |m| {
-                    _ = SetConsoleMode(handle.*, m);
+                    _ = w.SetConsoleMode(handle.*, m);
                 }
             }
 
@@ -174,15 +168,15 @@ pub const Source = struct {
                 _ = w.kernel32.SetConsoleOutputCP(console_output_codepage);
 
             if (console_codepage != 0)
-                _ = SetConsoleCP(console_codepage);
+                _ = w.SetConsoleCP(console_codepage);
         }
 
         pub fn init() void {
-            bun.windows.libuv.uv_disable_stdio_inheritance();
+            w.libuv.uv_disable_stdio_inheritance();
 
-            const stdin = w.GetStdHandle(w.STD_INPUT_HANDLE) catch bun.windows.INVALID_HANDLE_VALUE;
-            const stdout = w.GetStdHandle(w.STD_OUTPUT_HANDLE) catch bun.windows.INVALID_HANDLE_VALUE;
-            const stderr = w.GetStdHandle(w.STD_ERROR_HANDLE) catch bun.windows.INVALID_HANDLE_VALUE;
+            const stdin = std.os.windows.GetStdHandle(std.os.windows.STD_INPUT_HANDLE) catch w.INVALID_HANDLE_VALUE;
+            const stdout = std.os.windows.GetStdHandle(std.os.windows.STD_OUTPUT_HANDLE) catch w.INVALID_HANDLE_VALUE;
+            const stderr = std.os.windows.GetStdHandle(std.os.windows.STD_ERROR_HANDLE) catch w.INVALID_HANDLE_VALUE;
 
             bun.win32.STDERR_FD = if (stderr != std.os.windows.INVALID_HANDLE_VALUE) bun.toFD(stderr) else bun.invalid_fd;
             bun.win32.STDOUT_FD = if (stdout != std.os.windows.INVALID_HANDLE_VALUE) bun.toFD(stdout) else bun.invalid_fd;
@@ -196,29 +190,25 @@ pub const Source = struct {
             _ = w.kernel32.SetConsoleOutputCP(CP_UTF8);
 
             console_codepage = w.kernel32.GetConsoleOutputCP();
-            _ = SetConsoleCP(CP_UTF8);
-
-            const ENABLE_VIRTUAL_TERMINAL_INPUT = 0x200;
-            const ENABLE_WRAP_AT_EOL_OUTPUT = 0x0002;
-            const ENABLE_PROCESSED_OUTPUT = 0x0001;
+            _ = w.SetConsoleCP(CP_UTF8);
 
             var mode: w.DWORD = undefined;
             if (w.kernel32.GetConsoleMode(stdin, &mode) != 0) {
                 console_mode[0] = mode;
                 bun_stdio_tty[0] = 1;
-                _ = SetConsoleMode(stdin, mode | ENABLE_VIRTUAL_TERMINAL_INPUT);
+                _ = w.SetConsoleMode(stdin, mode | w.ENABLE_VIRTUAL_TERMINAL_INPUT);
             }
 
             if (w.kernel32.GetConsoleMode(stdout, &mode) != 0) {
                 console_mode[1] = mode;
                 bun_stdio_tty[1] = 1;
-                _ = SetConsoleMode(stdout, ENABLE_PROCESSED_OUTPUT | w.ENABLE_VIRTUAL_TERMINAL_PROCESSING | ENABLE_WRAP_AT_EOL_OUTPUT | mode);
+                _ = w.SetConsoleMode(stdout, w.ENABLE_PROCESSED_OUTPUT | std.os.windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING | w.ENABLE_WRAP_AT_EOL_OUTPUT | mode);
             }
 
             if (w.kernel32.GetConsoleMode(stderr, &mode) != 0) {
                 console_mode[2] = mode;
                 bun_stdio_tty[2] = 1;
-                _ = SetConsoleMode(stderr, ENABLE_PROCESSED_OUTPUT | w.ENABLE_VIRTUAL_TERMINAL_PROCESSING | ENABLE_WRAP_AT_EOL_OUTPUT | mode);
+                _ = w.SetConsoleMode(stderr, w.ENABLE_PROCESSED_OUTPUT | std.os.windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING | w.ENABLE_WRAP_AT_EOL_OUTPUT | mode);
             }
         }
     };

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -3028,6 +3028,10 @@ pub fn getLastErrno() bun.C.E {
     return (bun.C.SystemErrno.init(bun.windows.kernel32.GetLastError()) orelse SystemErrno.EUNKNOWN).toE();
 }
 
+pub fn getLastError() anyerror {
+    return bun.errnoToZigErr(getLastErrno());
+}
+
 pub fn translateNTStatusToErrno(err: win32.NTSTATUS) bun.C.E {
     return switch (err) {
         .SUCCESS => .SUCCESS,
@@ -3361,3 +3365,13 @@ pub fn GetFinalPathNameByHandle(
     bun.sys.syslog("GetFinalPathNameByHandle({*p})", .{hFile});
     return std.os.windows.GetFinalPathNameByHandle(hFile, fmt, out_buffer);
 }
+
+pub const ENABLE_VIRTUAL_TERMINAL_INPUT = 0x200;
+pub const ENABLE_WRAP_AT_EOL_OUTPUT = 0x0002;
+pub const ENABLE_PROCESSED_OUTPUT = 0x0001;
+
+// TODO: when https://github.com/ziglang/zig/pull/18692 merges, use std.os.windows for this
+pub extern fn SetConsoleMode(console_handle: *anyopaque, mode: u32) u32;
+pub extern fn SetStdHandle(nStdHandle: u32, hHandle: *anyopaque) u32;
+pub extern fn GetConsoleOutputCP() u32;
+pub extern "kernel32" fn SetConsoleCP(wCodePageID: std.os.windows.UINT) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;


### PR DESCRIPTION
### What does this PR do?

Disables `ENABLE_VIRTUAL_TERMINAL_INPUT` before accepting input from stdin for `bun init` and `prompt`

fixes #10017 
fixes #9861 

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
