### PR TITLE
fix: null is not an object at readableStreamCancel

### DIFF
--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1354,16 +1354,14 @@ export function readableStreamCancel(stream, reason) {
   if (state === $streamErrored) return Promise.$reject($getByIdDirectPrivate(stream, "storedError"));
   $readableStreamClose(stream);
 
-  var controller = $getByIdDirectPrivate(stream, "readableStreamController");
-  var cancel = controller.$cancel;
-  if (cancel) {
-    return cancel(controller, reason).$then(function () {});
-  }
+  const controller = $getByIdDirectPrivate(stream, "readableStreamController");
+  if (controller === null) return Promise.$resolve();
 
-  var close = controller.close;
-  if (close) {
-    return Promise.$resolve(controller.close(reason));
-  }
+  const cancel = controller.$cancel;
+  if (cancel) return cancel(controller, reason).$then(function () {});
+
+  const close = controller.close;
+  if (close) return Promise.$resolve(controller.close(reason));
 
   $throwTypeError("ReadableStreamController has no cancel or close method");
 }

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -7,7 +7,7 @@ test("zero args returns an otherwise empty 200 response", () => {
 });
 
 test("calling cancel() on response body doesn't throw", () => {
-  expect(() => new Response('').body?.cancel()).not.toThrow();
+  expect(() => new Response("").body?.cancel()).not.toThrow();
 });
 
 test("undefined args don't throw", () => {

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -6,6 +6,10 @@ test("zero args returns an otherwise empty 200 response", () => {
   expect(response.statusText).toBe("");
 });
 
+test("calling cancel() on response body doesn't throw", () => {
+  expect(() => new Response('').body?.cancel()).not.toThrow();
+});
+
 test("undefined args don't throw", () => {
   const response = new Response("", {
     status: undefined,


### PR DESCRIPTION
### What does this PR do?

Fixes #9542 

[x] Added test.

I still need to learn more about the stream lifecycle what cases the `controller` is `null`.