### PR TITLE
shell: Fix escaped newlines and add more tests

### DIFF
--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -2629,6 +2629,16 @@ pub fn NewLexer(comptime encoding: StringEncoding) type {
                     }
                     continue;
                 }
+                // Treat newline preceded by backslash as whitespace
+                else if (char == '\n') {
+                    if (comptime bun.Environment.allow_assert) {
+                        std.debug.assert(input.escaped);
+                    }
+                    if (self.chars.state != .Double) {
+                        try self.break_word_impl(true, true, false);
+                    }
+                    continue;
+                }
 
                 try self.appendCharToStrPool(char);
             }
@@ -2979,9 +2989,11 @@ pub fn NewLexer(comptime encoding: StringEncoding) type {
                 },
                 .normal => try self.tokens.append(.OpenParen),
             }
+            const prev_quote_state = self.chars.state;
             var sublexer = self.make_sublexer(kind);
             try sublexer.lex();
             self.continue_from_sublexer(&sublexer);
+            self.chars.state = prev_quote_state;
         }
 
         fn appendStringToStrPool(self: *@This(), bunstr: bun.String) !void {
@@ -3440,6 +3452,7 @@ pub fn ShellCharIter(comptime encoding: StringEncoding) type {
                         else => return .{ .char = char, .escaped = false },
                     }
                 },
+                // We checked `self.state == .Single` above so this is impossible
                 .Single => unreachable,
             }
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -371,11 +371,11 @@ describe("bunshell", () => {
   // bar
   //
   // I'm not sure why, this isn't documented behavior, so I'm choosing to ignore it.
-  describe('gnu_quote', () => {
-// An unfortunate consequence of our use of String.raw and tagged template
-// functions for the shell make it so that we have to use { raw: string } to do
-// backtick command substitution
-const BACKTICK = {raw: '`'}
+  describe("gnu_quote", () => {
+    // An unfortunate consequence of our use of String.raw and tagged template
+    // functions for the shell make it so that we have to use { raw: string } to do
+    // backtick command substitution
+    const BACKTICK = { raw: "`" };
 
     // Single Quote
     TestBuilder.command`
@@ -386,9 +386,10 @@ bar'
 echo 'foo\
 bar'
 `
-.stdout('foo\nbar\nfoo\nbar\nfoo\\\nbar\n').runAsTest('Single Quote')
+      .stdout("foo\nbar\nfoo\nbar\nfoo\\\nbar\n")
+      .runAsTest("Single Quote");
 
-TestBuilder.command`
+    TestBuilder.command`
 echo "foo
 bar"
 echo "foo
@@ -396,9 +397,10 @@ bar"
 echo "foo\
 bar"
 `
-.stdout('foo\nbar\nfoo\nbar\nfoobar\n').runAsTest('Double Quote');
+      .stdout("foo\nbar\nfoo\nbar\nfoobar\n")
+      .runAsTest("Double Quote");
 
-TestBuilder.command`
+    TestBuilder.command`
 echo ${BACKTICK}echo 'foo
 bar'${BACKTICK}
 echo ${BACKTICK}echo 'foo
@@ -406,14 +408,15 @@ bar'${BACKTICK}
 echo ${BACKTICK}echo 'foo\
 bar'${BACKTICK}
 `
-.stdout(`foo bar
+      .stdout(
+        `foo bar
 foo bar
-foobar\n`)
-.todo('insane backtick behavior')
-.runAsTest('Backslash Single Quote');
+foobar\n`,
+      )
+      .todo("insane backtick behavior")
+      .runAsTest("Backslash Single Quote");
 
-
-TestBuilder.command`
+    TestBuilder.command`
 echo "${BACKTICK}echo 'foo
 bar'${BACKTICK}"
 echo "${BACKTICK}echo 'foo
@@ -421,15 +424,17 @@ bar'${BACKTICK}"
 echo "${BACKTICK}echo 'foo\
 bar'${BACKTICK}"
 `
-.stdout(`foo
+      .stdout(
+        `foo
 bar
 foo
 bar
-foobar\n`)
-.todo('insane backtick behavior')
-.runAsTest('Double Quote Backslash Single Quote');
+foobar\n`,
+      )
+      .todo("insane backtick behavior")
+      .runAsTest("Double Quote Backslash Single Quote");
 
-TestBuilder.command`
+    TestBuilder.command`
 echo $(echo 'foo
 bar')
 echo $(echo 'foo
@@ -437,11 +442,14 @@ bar')
 echo $(echo 'foo\
 bar')
 `
-.stdout(`foo bar
+      .stdout(
+        `foo bar
 foo bar
-foo\\ bar\n`).runAsTest('Dollar Paren Single Quote');
+foo\\ bar\n`,
+      )
+      .runAsTest("Dollar Paren Single Quote");
 
-TestBuilder.command`
+    TestBuilder.command`
 echo "$(echo 'foo
 bar')"
 echo "$(echo 'foo
@@ -449,14 +457,17 @@ bar')"
 echo "$(echo 'foo\
 bar')"
 `
-.stdout(`foo
+      .stdout(
+        `foo
 bar
 foo
 bar
 foo\\
-bar\n`).runAsTest('Dollar Paren Double Quote');
+bar\n`,
+      )
+      .runAsTest("Dollar Paren Double Quote");
 
-TestBuilder.command`
+    TestBuilder.command`
 echo "$(echo 'foo
 bar')"
 echo "$(echo 'foo
@@ -464,47 +475,51 @@ bar')"
 echo "$(echo 'foo\
 bar')"
 `
-.stdout(`foo
+      .stdout(
+        `foo
 bar
 foo
 bar
 foo\\
-bar\n`).runAsTest('Double Quote Dollar Paren Single Quote');
+bar\n`,
+      )
+      .runAsTest("Double Quote Dollar Paren Single Quote");
+  });
 
-  })
+  describe("escaped_newline", () => {
+    const printArgs = /* ts */ `console.log(JSON.stringify(process.argv))`;
 
-  describe('escaped_newline', () => {
-    const printArgs = /* ts */`console.log(JSON.stringify(process.argv))`
-
-    TestBuilder.command/* sh */`${BUN} run ./code.ts hi hello \
+    TestBuilder.command/* sh */ `${BUN} run ./code.ts hi hello \
     on a newline!
   `
-    .ensureTempDir()
-    .file('code.ts', printArgs)
-    .stdout(out => expect(JSON.parse(out).slice(2)).toEqual(["hi", "hello", "on", "a", "newline!"]))
-    .runAsTest('single')
+      .ensureTempDir()
+      .file("code.ts", printArgs)
+      .stdout(out => expect(JSON.parse(out).slice(2)).toEqual(["hi", "hello", "on", "a", "newline!"]))
+      .runAsTest("single");
 
-    TestBuilder.command/* sh */`${BUN} run ./code.ts hi hello \
+    TestBuilder.command/* sh */ `${BUN} run ./code.ts hi hello \
     on a newline! \
     and \
     a few \
     others!
   `
-    .ensureTempDir()
-    .file('code.ts', printArgs)
-    .stdout(out => expect(JSON.parse(out).slice(2)).toEqual(["hi", "hello", "on", "a", "newline!", "and", "a",  "few", "others!"]))
-    .runAsTest('many')
+      .ensureTempDir()
+      .file("code.ts", printArgs)
+      .stdout(out =>
+        expect(JSON.parse(out).slice(2)).toEqual(["hi", "hello", "on", "a", "newline!", "and", "a", "few", "others!"]),
+      )
+      .runAsTest("many");
 
-    TestBuilder.command/* sh */`${BUN} run ./code.ts hi hello \
+    TestBuilder.command/* sh */ `${BUN} run ./code.ts hi hello \
     on a newline! \
     ooga"
 booga"
   `
-    .ensureTempDir()
-    .file('code.ts', printArgs)
-    .stdout(out => expect(JSON.parse(out).slice(2)).toEqual(["hi", "hello", "on", "a", "newline!", "ooga\nbooga"]))
-    .runAsTest('quotes')
-  })
+      .ensureTempDir()
+      .file("code.ts", printArgs)
+      .stdout(out => expect(JSON.parse(out).slice(2)).toEqual(["hi", "hello", "on", "a", "newline!", "ooga\nbooga"]))
+      .runAsTest("quotes");
+  });
 
   describe("glob expansion", () => {
     // Issue #8403: https://github.com/oven-sh/bun/issues/8403

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -351,6 +351,161 @@ describe("bunshell", () => {
     expect(stdout.toString()).toEqual(`noice\n`);
   });
 
+  // Ported from GNU bash "quote.tests"
+  // https://github.com/bminor/bash/blob/f3b6bd19457e260b65d11f2712ec3da56cef463f/tests/quote.tests#L1
+  // Some backtick tests are skipped, because of insane behavior:
+  // For some reason, even though $(...) and `...` are suppoed to be equivalent,
+  // doing:
+  // echo "`echo 'foo\
+  // bar'`"
+  //
+  // gives:
+  // foobar
+  //
+  // While doing the same, but with $(...):
+  // echo "$(echo 'foo\
+  // bar')"
+  //
+  // gives:
+  // foo\
+  // bar
+  //
+  // I'm not sure why, this isn't documented behavior, so I'm choosing to ignore it.
+  describe('gnu_quote', () => {
+// An unfortunate consequence of our use of String.raw and tagged template
+// functions for the shell make it so that we have to use { raw: string } to do
+// backtick command substitution
+const BACKTICK = {raw: '`'}
+
+    // Single Quote
+    TestBuilder.command`
+echo 'foo
+bar'
+echo 'foo
+bar'
+echo 'foo\
+bar'
+`
+.stdout('foo\nbar\nfoo\nbar\nfoo\\\nbar\n').runAsTest('Single Quote')
+
+TestBuilder.command`
+echo "foo
+bar"
+echo "foo
+bar"
+echo "foo\
+bar"
+`
+.stdout('foo\nbar\nfoo\nbar\nfoobar\n').runAsTest('Double Quote');
+
+TestBuilder.command`
+echo ${BACKTICK}echo 'foo
+bar'${BACKTICK}
+echo ${BACKTICK}echo 'foo
+bar'${BACKTICK}
+echo ${BACKTICK}echo 'foo\
+bar'${BACKTICK}
+`
+.stdout(`foo bar
+foo bar
+foobar\n`)
+.todo('insane backtick behavior')
+.runAsTest('Backslash Single Quote');
+
+
+TestBuilder.command`
+echo "${BACKTICK}echo 'foo
+bar'${BACKTICK}"
+echo "${BACKTICK}echo 'foo
+bar'${BACKTICK}"
+echo "${BACKTICK}echo 'foo\
+bar'${BACKTICK}"
+`
+.stdout(`foo
+bar
+foo
+bar
+foobar\n`)
+.todo('insane backtick behavior')
+.runAsTest('Double Quote Backslash Single Quote');
+
+TestBuilder.command`
+echo $(echo 'foo
+bar')
+echo $(echo 'foo
+bar')
+echo $(echo 'foo\
+bar')
+`
+.stdout(`foo bar
+foo bar
+foo\\ bar\n`).runAsTest('Dollar Paren Single Quote');
+
+TestBuilder.command`
+echo "$(echo 'foo
+bar')"
+echo "$(echo 'foo
+bar')"
+echo "$(echo 'foo\
+bar')"
+`
+.stdout(`foo
+bar
+foo
+bar
+foo\\
+bar\n`).runAsTest('Dollar Paren Double Quote');
+
+TestBuilder.command`
+echo "$(echo 'foo
+bar')"
+echo "$(echo 'foo
+bar')"
+echo "$(echo 'foo\
+bar')"
+`
+.stdout(`foo
+bar
+foo
+bar
+foo\\
+bar\n`).runAsTest('Double Quote Dollar Paren Single Quote');
+
+  })
+
+  describe('escaped_newline', () => {
+    const printArgs = /* ts */`console.log(JSON.stringify(process.argv))`
+
+    TestBuilder.command/* sh */`${BUN} run ./code.ts hi hello \
+    on a newline!
+  `
+    .ensureTempDir()
+    .file('code.ts', printArgs)
+    .stdout(out => expect(JSON.parse(out).slice(2)).toEqual(["hi", "hello", "on", "a", "newline!"]))
+    .runAsTest('single')
+
+    TestBuilder.command/* sh */`${BUN} run ./code.ts hi hello \
+    on a newline! \
+    and \
+    a few \
+    others!
+  `
+    .ensureTempDir()
+    .file('code.ts', printArgs)
+    .stdout(out => expect(JSON.parse(out).slice(2)).toEqual(["hi", "hello", "on", "a", "newline!", "and", "a",  "few", "others!"]))
+    .runAsTest('many')
+
+    TestBuilder.command/* sh */`${BUN} run ./code.ts hi hello \
+    on a newline! \
+    ooga"
+booga"
+  `
+    .ensureTempDir()
+    .file('code.ts', printArgs)
+    .stdout(out => expect(JSON.parse(out).slice(2)).toEqual(["hi", "hello", "on", "a", "newline!", "ooga\nbooga"]))
+    .runAsTest('quotes')
+  })
+
   describe("glob expansion", () => {
     // Issue #8403: https://github.com/oven-sh/bun/issues/8403
     TestBuilder.command`ls *.sdfljsfsdf`


### PR DESCRIPTION
### What does this PR do?
- [x] Code changes

Fixes escaped newlines in Bun shell not giving the correct output

This also adds some escaping/quoting tests ported from GNU bash's test suite

Fixes #9879

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
