### PR TITLE
feat(auto-corking) enable auto-corking in uWS

### DIFF
--- a/packages/bun-uws/src/Loop.h
+++ b/packages/bun-uws/src/Loop.h
@@ -15,13 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+// clang-format off
 #ifndef UWS_LOOP_H
 #define UWS_LOOP_H
 
 /* The loop is lazily created per-thread and run with run() */
 
 #include "LoopData.h"
+#include "AsyncSocket.h"
 #include <libusockets.h>
 #include <iostream>
 
@@ -57,6 +58,15 @@ private:
 
         for (auto &p : loopData->postHandlers) {
             p.second((Loop *) loop);
+        }
+
+        /* auto-uncork corked socket if needed*/
+        if (loopData->corkOffset && loopData->corkedSocket != nullptr) {
+            if(loopData->corkedSocketIsSSL) {
+                ((AsyncSocket<true> *) loopData->corkedSocket)->uncork();
+            } else {
+                ((AsyncSocket<false> *) loopData->corkedSocket)->uncork();
+            }
         }
     }
 

--- a/scripts/make-old-js.ps1
+++ b/scripts/make-old-js.ps1
@@ -3,7 +3,7 @@ $npm_client = "npm"
 # & ${npm_client} i
 
 $root = Join-Path (Split-Path -Path $MyInvocation.MyCommand.Definition -Parent) "..\"
-$esbuild = Join-Path $root "node_modules\.bin\esbuild.cmd"
+$esbuild = Join-Path $root "node_modules\.bin\esbuild.exe"
 
 $env:NODE_ENV = "production"
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
When streaming this reduces the amount of write operations if we auto uncork by auto cork again when needed

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing tests and manual performance test


```js
const data = Buffer.alloc(8 * 1024, 'X');
// async iterator
async function* generate() {
  for(let i = 0; i < 10; i++) {
    // simulate something that retrieve 3 chunks of data
    await Bun.sleep(1); 
    yield data;
    yield data;
    yield data;
  }
}
const server = Bun.serve({
  port: 8080,
  fetch(req) {
    const webStream = new ReadableStream({
      async pull(controller) {
        await 1
        const it = generate();
        for await(const chunk of it) {
          controller.enqueue(chunk);
        }
        controller.close();
      } 
    });
    return new Response(webStream);
  },
});
```
![image](https://github.com/oven-sh/bun/assets/6379399/dc8c3b3d-6aae-4da2-a0cb-8d6db0fb62ac)

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
