### PR TITLE
Re-sync `URL` from WebKit + set `ERR_MISSING_ARGS`

### DIFF
--- a/bench/snippets/url.mjs
+++ b/bench/snippets/url.mjs
@@ -1,20 +1,19 @@
 import { bench, run } from "./runner.mjs";
 
-
 bench(`new URL('https://example.com/')`, () => {
-  const url = new URL('https://example.com/')
-})
+  const url = new URL("https://example.com/");
+});
 
 bench(`new URL('https://example.com')`, () => {
-  const url = new URL('https://example.com')
-})
+  const url = new URL("https://example.com");
+});
 
 bench(`new URL('https://www.example.com')`, () => {
-  const url = new URL('https://www.example.com')
-})
+  const url = new URL("https://www.example.com");
+});
 
 bench(`new URL('https://www.example.com/')`, () => {
-  const url = new URL('https://www.example.com/')
-})
+  const url = new URL("https://www.example.com/");
+});
 
-await run()
+await run();

--- a/bench/snippets/url.mjs
+++ b/bench/snippets/url.mjs
@@ -1,0 +1,7 @@
+import { bench, run } from './runner.mjs'
+
+bench('url', () => {
+  const url = new URL('https://example.com/')
+})
+
+await run()

--- a/bench/snippets/url.mjs
+++ b/bench/snippets/url.mjs
@@ -1,7 +1,20 @@
 import { bench, run } from "./runner.mjs";
 
-bench("url", () => {
-  const url = new URL("https://example.com/");
-});
 
-await run();
+bench(`new URL('https://example.com/')`, () => {
+  const url = new URL('https://example.com/')
+})
+
+bench(`new URL('https://example.com')`, () => {
+  const url = new URL('https://example.com')
+})
+
+bench(`new URL('https://www.example.com')`, () => {
+  const url = new URL('https://www.example.com')
+})
+
+bench(`new URL('https://www.example.com/')`, () => {
+  const url = new URL('https://www.example.com/')
+})
+
+await run()

--- a/bench/snippets/url.mjs
+++ b/bench/snippets/url.mjs
@@ -1,7 +1,7 @@
-import { bench, run } from './runner.mjs'
+import { bench, run } from "./runner.mjs";
 
-bench('url', () => {
-  const url = new URL('https://example.com/')
-})
+bench("url", () => {
+  const url = new URL("https://example.com/");
+});
 
-await run()
+await run();

--- a/src/bun.js/bindings/DOMURL.cpp
+++ b/src/bun.js/bindings/DOMURL.cpp
@@ -49,7 +49,7 @@ namespace WebCore {
 
 static inline String redact(const String& input)
 {
-    if (input.contains("@"_s))
+    if (input.contains('@'))
         return "<redacted>"_s;
 
     return makeString('"', input, '"');
@@ -59,6 +59,14 @@ inline DOMURL::DOMURL(URL&& completeURL)
     : m_url(WTFMove(completeURL))
 {
     ASSERT(m_url.isValid());
+}
+
+ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url)
+{
+    URL completeURL { url };
+    if (!completeURL.isValid())
+        return Exception { TypeError, makeString(redact(url), " cannot be parsed as a URL.") };
+    return adoptRef(*new DOMURL(WTFMove(completeURL)));
 }
 
 ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const URL& base)

--- a/src/bun.js/bindings/DOMURL.cpp
+++ b/src/bun.js/bindings/DOMURL.cpp
@@ -23,16 +23,27 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#include "config.h"
 #include "DOMURL.h"
 
-// #include "ActiveDOMObject.h"
+#include "ActiveDOMObject.h"
 // #include "Blob.h"
 // #include "BlobURL.h"
 // #include "MemoryCache.h"
 // #include "PublicURLManager.h"
 // #include "ResourceRequest.h"
+#include "ScriptExecutionContext.h"
+// #include "SecurityOrigin.h"
 #include "URLSearchParams.h"
-// #include <wtf/MainThread.h>
+#include <wtf/MainThread.h>
+
+class URLRegistrable {
+public:
+};
+
+class Blob {
+public:
+};
 
 namespace WebCore {
 
@@ -44,21 +55,10 @@ static inline String redact(const String& input)
     return makeString('"', input, '"');
 }
 
-inline DOMURL::DOMURL(URL&& completeURL, const URL& baseURL)
-    : m_baseURL(baseURL)
-    , m_url(WTFMove(completeURL))
+inline DOMURL::DOMURL(URL&& completeURL)
+    : m_url(WTFMove(completeURL))
 {
-}
-
-DOMURL::~DOMURL() = default;
-
-bool DOMURL::canParse(const String& url, const String& base)
-{
-    URL baseURL { base };
-    if (!base.isNull() && !baseURL.isValid())
-        return false;
-    URL completeURL { baseURL, url };
-    return completeURL.isValid();
+    ASSERT(m_url.isValid());
 }
 
 ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const URL& base)
@@ -67,7 +67,7 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const URL& base)
     URL completeURL { base, url };
     if (!completeURL.isValid())
         return Exception { TypeError, makeString(redact(url), " cannot be parsed as a URL.") };
-    return adoptRef(*new DOMURL(WTFMove(completeURL), base));
+    return adoptRef(*new DOMURL(WTFMove(completeURL)));
 }
 
 ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const String& base)
@@ -78,9 +78,27 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const String& base)
     return create(url, baseURL);
 }
 
-ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const DOMURL& base)
+DOMURL::~DOMURL() = default;
+
+static URL parseInternal(const String& url, const String& base)
 {
-    return create(url, base.href());
+    URL baseURL { base };
+    if (!base.isNull() && !baseURL.isValid())
+        return {};
+    return { baseURL, url };
+}
+
+RefPtr<DOMURL> DOMURL::parse(const String& url, const String& base)
+{
+    auto completeURL = parseInternal(url, base);
+    if (!completeURL.isValid())
+        return {};
+    return adoptRef(*new DOMURL(WTFMove(completeURL)));
+}
+
+bool DOMURL::canParse(const String& url, const String& base)
+{
+    return parseInternal(url, base).isValid();
 }
 
 ExceptionOr<void> DOMURL::setHref(const String& url)
@@ -96,26 +114,27 @@ ExceptionOr<void> DOMURL::setHref(const String& url)
     return {};
 }
 
-void DOMURL::setQuery(const String& query)
+String DOMURL::createObjectURL(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
 {
-    m_url.setQuery(query);
+    UNUSED_PARAM(blob);
+    UNUSED_PARAM(scriptExecutionContext);
+    return String();
+    // return createPublicURL(scriptExecutionContext, blob);
 }
 
-// String DOMURL::createObjectURL(Blob& blob)
-// {
-//     return createPublicURL(scriptExecutionContext, blob);
-// }
+String DOMURL::createPublicURL(ScriptExecutionContext& scriptExecutionContext, URLRegistrable& registrable)
+{
+    // URL publicURL = BlobURL::createPublicURL(scriptExecutionContext.securityOrigin());
+    // if (publicURL.isEmpty())
+    //     return String();
 
-// String DOMURL::createPublicURL(URLRegistrable& registrable)
-// {
-//     URL publicURL = BlobURL::createPublicURL(scriptExecutionContext.securityOrigin());
-//     if (publicURL.isEmpty())
-//         return String();
+    // scriptExecutionContext.publicURLManager().registerURL(publicURL, registrable);
 
-//     scriptExecutionContext.publicURLManager().registerURL(publicURL, registrable);
-
-//     return publicURL.string();
-// }
+    // return publicURL.string();
+    UNUSED_PARAM(scriptExecutionContext);
+    UNUSED_PARAM(registrable);
+    return String();
+}
 
 URLSearchParams& DOMURL::searchParams()
 {
@@ -124,15 +143,17 @@ URLSearchParams& DOMURL::searchParams()
     return *m_searchParams;
 }
 
-// void DOMURL::revokeObjectURL(const String& urlString)
-// {
-//     // URL url(URL(), urlString);
-//     // ResourceRequest request(url);
-//     // request.setDomainForCachePartition(scriptExecutionContext.domainForCachePartition());
+void DOMURL::revokeObjectURL(ScriptExecutionContext& scriptExecutionContext, const String& urlString)
+{
+    // URL url { urlString };
+    // ResourceRequest request(url);
+    // request.setDomainForCachePartition(scriptExecutionContext.domainForCachePartition());
 
-//     // MemoryCache::removeRequestFromSessionCaches(scriptExecutionContext, request);
+    // MemoryCache::removeRequestFromSessionCaches(scriptExecutionContext, request);
 
-//     // scriptExecutionContext.publicURLManager().revoke(url);
-// }
+    // scriptExecutionContext.publicURLManager().revoke(url);
+    UNUSED_PARAM(scriptExecutionContext);
+    UNUSED_PARAM(urlString);
+}
 
 } // namespace WebCore

--- a/src/bun.js/bindings/DOMURL.h
+++ b/src/bun.js/bindings/DOMURL.h
@@ -35,36 +35,38 @@
 
 namespace WebCore {
 
+class Blob;
+class ScriptExecutionContext;
+class URLRegistrable;
 class URLSearchParams;
 
 class DOMURL final : public RefCounted<DOMURL>, public CanMakeWeakPtr<DOMURL>, public URLDecomposition {
 public:
     static ExceptionOr<Ref<DOMURL>> create(const String& url, const String& base);
-    static ExceptionOr<Ref<DOMURL>> create(const String& url, const DOMURL& base);
-    ~DOMURL();
+    WEBCORE_EXPORT ~DOMURL();
 
+    static RefPtr<DOMURL> parse(const String& url, const String& base);
     static bool canParse(const String& url, const String& base);
+
     const URL& href() const { return m_url; }
     ExceptionOr<void> setHref(const String&);
-    void setQuery(const String&);
 
     URLSearchParams& searchParams();
 
     const String& toJSON() const { return m_url.string(); }
 
-    // static String createObjectURL(ScriptExecutionContext&, Blob&);
-    // static void revokeObjectURL(ScriptExecutionContext&, const String&);
+    static String createObjectURL(ScriptExecutionContext&, Blob&);
+    static void revokeObjectURL(ScriptExecutionContext&, const String&);
 
-    // static String createPublicURL(ScriptExecutionContext&, URLRegistrable&);
+    static String createPublicURL(ScriptExecutionContext&, URLRegistrable&);
 
 private:
     static ExceptionOr<Ref<DOMURL>> create(const String& url, const URL& base);
-    DOMURL(URL&& completeURL, const URL& baseURL);
+    DOMURL(URL&& completeURL);
 
     URL fullURL() const final { return m_url; }
     void setFullURL(const URL& fullURL) final { setHref(fullURL.string()); }
 
-    URL m_baseURL;
     URL m_url;
     RefPtr<URLSearchParams> m_searchParams;
 };

--- a/src/bun.js/bindings/DOMURL.h
+++ b/src/bun.js/bindings/DOMURL.h
@@ -43,6 +43,7 @@ class URLSearchParams;
 class DOMURL final : public RefCounted<DOMURL>, public CanMakeWeakPtr<DOMURL>, public URLDecomposition {
 public:
     static ExceptionOr<Ref<DOMURL>> create(const String& url, const String& base);
+    static ExceptionOr<Ref<DOMURL>> create(const String& url);
     WEBCORE_EXPORT ~DOMURL();
 
     static RefPtr<DOMURL> parse(const String& url, const String& base);

--- a/src/bun.js/bindings/URLSearchParams.cpp
+++ b/src/bun.js/bindings/URLSearchParams.cpp
@@ -165,7 +165,7 @@ String URLSearchParams::toString() const
 void URLSearchParams::updateURL()
 {
     if (m_associatedURL)
-        m_associatedURL->setQuery(WTF::URLParser::serialize(m_pairs));
+        m_associatedURL->setSearch(WTF::URLParser::serialize(m_pairs));
 }
 
 void URLSearchParams::updateFromAssociatedURL()

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -2709,7 +2709,7 @@ pub const JSGlobalObject = extern struct {
         got: usize,
     ) JSC.JSValue {
         return JSC.toTypeErrorWithCode(
-            "NOT_ENOUGH_ARGUMENTS",
+            @tagName(JSC.Node.ErrorCode.ERR_MISSING_ARGS),
             "Not enough arguments to '" ++ name_ ++ "'. Expected {d}, got {d}.",
             .{ expected, got },
             this,

--- a/src/bun.js/bindings/webcore/JSDOMOperation.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMOperation.cpp
@@ -1,0 +1,22 @@
+#include "root.h"
+
+#include "BunClientData.h"
+#include "JSDOMOperation.h"
+#include "BunBuiltinNames.h"
+
+#undef createNotEnoughArgumentsError
+
+namespace WebCore {
+
+JSC::JSObject* createNotEnoughArgumentsErrorBun(JSC::JSGlobalObject* globalObject)
+{
+    JSC::JSObject* error = JSC::createNotEnoughArgumentsError(globalObject);
+    if (LIKELY(error)) {
+        auto& vm = globalObject->vm();
+        const auto& names = WebCore::builtinNames(vm);
+        error->putDirect(vm, names.codePublicName(), JSC::jsString(vm, WTF::String("ERR_MISSING_ARGS"_s)), 0);
+    }
+
+    return error;
+}
+}

--- a/src/bun.js/bindings/webcore/JSDOMOperation.h
+++ b/src/bun.js/bindings/webcore/JSDOMOperation.h
@@ -49,7 +49,7 @@ public:
     static JSC::EncodedJSValue call(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, const char* operationName)
     {
         auto throwScope = DECLARE_THROW_SCOPE(JSC::getVM(&lexicalGlobalObject));
-        
+
         auto* thisObject = cast(lexicalGlobalObject, callFrame);
         if constexpr (shouldThrow != CastedThisErrorBehavior::Assert) {
             if (UNLIKELY(!thisObject))
@@ -58,7 +58,7 @@ public:
             ASSERT(thisObject);
 
         ASSERT_GC_OBJECT_INHERITS(thisObject, JSClass::info());
-        
+
         // FIXME: We should refactor the binding generated code to use references for lexicalGlobalObject and thisObject.
         RELEASE_AND_RETURN(throwScope, (operation(&lexicalGlobalObject, &callFrame, thisObject)));
     }
@@ -70,5 +70,13 @@ public:
         return operation(&lexicalGlobalObject, &callFrame);
     }
 };
+
+// Rewrite all usages of JSC::createNotEnoughArgumentsError to use our own version.
+// Our version adds the "code" property from Node.js.
+JSC::JSObject* createNotEnoughArgumentsErrorBun(JSGlobalObject* globalObject);
+
+#ifndef createNotEnoughArgumentsError
+#define createNotEnoughArgumentsError WebCore::createNotEnoughArgumentsErrorBun
+#endif
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcore/JSDOMURL.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMURL.cpp
@@ -152,7 +152,7 @@ template<> EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMURLDOMConstructor::const
     EnsureStillAliveScope argument1 = callFrame->argument(1);
     auto base = argument1.value().isUndefined() ? String() : convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-    auto object = DOMURL::create(WTFMove(url), WTFMove(base));
+    auto object = base.isEmpty() ? DOMURL::create(WTFMove(url)) : DOMURL::create(WTFMove(url), WTFMove(base));
     if constexpr (IsExceptionOr<decltype(object)>)
         RETURN_IF_EXCEPTION(throwScope, {});
     static_assert(TypeOrExceptionOrUnderlyingType<decltype(object)>::isRef);

--- a/src/bun.js/bindings/webcore/JSDOMURL.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMURL.cpp
@@ -18,19 +18,20 @@
     Boston, MA 02110-1301, USA.
 */
 
-#include "root.h"
+#include "config.h"
 #include "JSDOMURL.h"
 
 #include "ActiveDOMObject.h"
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "IDLTypes.h"
-// #include "JSBlob.h"
 #include "JSDOMAttribute.h"
 #include "JSDOMBinding.h"
 #include "JSDOMConstructor.h"
 #include "JSDOMConvertBase.h"
+#include "JSDOMConvertBoolean.h"
 #include "JSDOMConvertInterface.h"
+#include "JSDOMConvertNullable.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObject.h"
@@ -43,7 +44,7 @@
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/HeapAnalyzer.h>
-
+#include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
@@ -61,10 +62,11 @@ using namespace JSC;
 
 // Functions
 
+static JSC_DECLARE_HOST_FUNCTION(jsDOMURLConstructorFunction_parse);
+static JSC_DECLARE_HOST_FUNCTION(jsDOMURLConstructorFunction_canParse);
 static JSC_DECLARE_HOST_FUNCTION(jsDOMURLPrototypeFunction_toJSON);
 static JSC_DECLARE_HOST_FUNCTION(jsDOMURLConstructorFunction_createObjectURL);
 static JSC_DECLARE_HOST_FUNCTION(jsDOMURLConstructorFunction_revokeObjectURL);
-static JSC_DECLARE_HOST_FUNCTION(jsDOMURLConstructorFunction_canParse);
 static JSC_DECLARE_HOST_FUNCTION(jsDOMURLPrototypeFunction_toString);
 
 // Attributes
@@ -130,17 +132,20 @@ using JSDOMURLDOMConstructor = JSDOMConstructor<JSDOMURL>;
 /* Hash table for constructor */
 
 static const HashTableValue JSDOMURLConstructorTableValues[] = {
+    { "parse"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsDOMURLConstructorFunction_parse, 1 } },
+    { "canParse"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsDOMURLConstructorFunction_canParse, 1 } },
     { "createObjectURL"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsDOMURLConstructorFunction_createObjectURL, 1 } },
     { "revokeObjectURL"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsDOMURLConstructorFunction_revokeObjectURL, 1 } },
-    { "canParse"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsDOMURLConstructorFunction_canParse, 1 } },
 };
 
-static inline JSC::EncodedJSValue constructJSDOMURL1(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
+template<> EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMURLDOMConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    auto& vm = lexicalGlobalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto* castedThis = jsCast<JSDOMURLDOMConstructor*>(callFrame->jsCallee());
     ASSERT(castedThis);
+    if (UNLIKELY(callFrame->argumentCount() < 1))
+        return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto url = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
@@ -158,51 +163,7 @@ static inline JSC::EncodedJSValue constructJSDOMURL1(JSGlobalObject* lexicalGlob
     RETURN_IF_EXCEPTION(throwScope, {});
     return JSValue::encode(jsValue);
 }
-
-static inline JSC::EncodedJSValue constructJSDOMURL2(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
-{
-    VM& vm = lexicalGlobalObject->vm();
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    auto* castedThis = jsCast<JSDOMURLDOMConstructor*>(callFrame->jsCallee());
-    ASSERT(castedThis);
-    EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    auto url = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
-    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-    EnsureStillAliveScope argument1 = callFrame->uncheckedArgument(1);
-    auto base = convert<IDLInterface<DOMURL>>(*lexicalGlobalObject, argument1.value(), [](JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope) { throwArgumentTypeError(lexicalGlobalObject, scope, 1, "base", "URL", nullptr, "DOMURL"); });
-    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-    auto object = DOMURL::create(WTFMove(url), *base);
-    if constexpr (IsExceptionOr<decltype(object)>)
-        RETURN_IF_EXCEPTION(throwScope, {});
-    static_assert(TypeOrExceptionOrUnderlyingType<decltype(object)>::isRef);
-    auto jsValue = toJSNewlyCreated<IDLInterface<DOMURL>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, WTFMove(object));
-    if constexpr (IsExceptionOr<decltype(object)>)
-        RETURN_IF_EXCEPTION(throwScope, {});
-    setSubclassStructureIfNeeded<DOMURL>(lexicalGlobalObject, callFrame, asObject(jsValue));
-    RETURN_IF_EXCEPTION(throwScope, {});
-    return JSValue::encode(jsValue);
-}
-
-template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMURLDOMConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
-{
-    VM& vm = lexicalGlobalObject->vm();
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    UNUSED_PARAM(throwScope);
-    size_t argsCount = std::min<size_t>(2, callFrame->argumentCount());
-    if (argsCount == 1) {
-        RELEASE_AND_RETURN(throwScope, (constructJSDOMURL1(lexicalGlobalObject, callFrame)));
-    }
-    if (argsCount == 2) {
-        JSValue distinguishingArg = callFrame->uncheckedArgument(1);
-        if (distinguishingArg.isUndefined())
-            RELEASE_AND_RETURN(throwScope, (constructJSDOMURL1(lexicalGlobalObject, callFrame)));
-        if (distinguishingArg.isObject() && asObject(distinguishingArg)->inherits<JSDOMURL>())
-            RELEASE_AND_RETURN(throwScope, (constructJSDOMURL2(lexicalGlobalObject, callFrame)));
-        RELEASE_AND_RETURN(throwScope, (constructJSDOMURL1(lexicalGlobalObject, callFrame)));
-    }
-    return argsCount < 1 ? throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject)) : throwVMTypeError(lexicalGlobalObject, throwScope);
-}
-JSC_ANNOTATE_HOST_FUNCTION(JSDOMURLConstructorConstruct, JSDOMURLDOMConstructor::construct);
+JSC_ANNOTATE_HOST_FUNCTION(JSDOMURLDOMConstructorConstruct, JSDOMURLDOMConstructor::construct);
 
 template<> const ClassInfo JSDOMURLDOMConstructor::s_info = { "URL"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDOMURLDOMConstructor) };
 
@@ -220,24 +181,36 @@ template<> void JSDOMURLDOMConstructor::initializeProperties(VM& vm, JSDOMGlobal
     putDirect(vm, vm.propertyNames->name, nameString, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontEnum);
     putDirect(vm, vm.propertyNames->prototype, JSDOMURL::prototype(vm, globalObject), JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete);
     reifyStaticProperties(vm, JSDOMURL::info(), JSDOMURLConstructorTableValues, *this);
+    // if (!((&globalObject)->inherits<JSDOMWindowBase>() || (&globalObject)->inherits<JSDedicatedWorkerGlobalScope>() || (&globalObject)->inherits<JSSharedWorkerGlobalScope>())) {
+    //     auto propertyName = Identifier::fromString(vm, "createObjectURL"_s);
+    //     VM::DeletePropertyModeScope scope(vm, VM::DeletePropertyMode::IgnoreConfigurable);
+    //     DeletePropertySlot slot;
+    //     JSObject::deleteProperty(this, &globalObject, propertyName, slot);
+    // }
+    // if (!((&globalObject)->inherits<JSDOMWindowBase>() || (&globalObject)->inherits<JSDedicatedWorkerGlobalScope>() || (&globalObject)->inherits<JSSharedWorkerGlobalScope>())) {
+    //     auto propertyName = Identifier::fromString(vm, "revokeObjectURL"_s);
+    //     VM::DeletePropertyModeScope scope(vm, VM::DeletePropertyMode::IgnoreConfigurable);
+    //     DeletePropertySlot slot;
+    //     JSObject::deleteProperty(this, &globalObject, propertyName, slot);
+    // }
 }
 
 /* Hash table for prototype */
 
 static const HashTableValue JSDOMURLPrototypeTableValues[] = {
-    { "constructor"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURLConstructor, 0 } },
-    { "href"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_href, setJSDOMURL_href } },
-    { "origin"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_origin, 0 } },
-    { "protocol"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_protocol, setJSDOMURL_protocol } },
-    { "username"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_username, setJSDOMURL_username } },
-    { "password"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_password, setJSDOMURL_password } },
-    { "host"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_host, setJSDOMURL_host } },
-    { "hostname"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_hostname, setJSDOMURL_hostname } },
-    { "port"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_port, setJSDOMURL_port } },
-    { "pathname"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_pathname, setJSDOMURL_pathname } },
-    { "hash"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_hash, setJSDOMURL_hash } },
-    { "search"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_search, setJSDOMURL_search } },
-    { "searchParams"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_searchParams, 0 } },
+    { "constructor"_s, static_cast<unsigned>(PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURLConstructor, 0 } },
+    { "href"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_href, setJSDOMURL_href } },
+    { "origin"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_origin, 0 } },
+    { "protocol"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_protocol, setJSDOMURL_protocol } },
+    { "username"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_username, setJSDOMURL_username } },
+    { "password"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_password, setJSDOMURL_password } },
+    { "host"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_host, setJSDOMURL_host } },
+    { "hostname"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_hostname, setJSDOMURL_hostname } },
+    { "port"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_port, setJSDOMURL_port } },
+    { "pathname"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_pathname, setJSDOMURL_pathname } },
+    { "hash"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_hash, setJSDOMURL_hash } },
+    { "search"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_search, setJSDOMURL_search } },
+    { "searchParams"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsDOMURL_searchParams, 0 } },
     { "toJSON"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsDOMURLPrototypeFunction_toJSON, 0 } },
     { "toString"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsDOMURLPrototypeFunction_toString, 0 } },
 };
@@ -258,13 +231,7 @@ JSDOMURL::JSDOMURL(Structure* structure, JSDOMGlobalObject& globalObject, Ref<DO
 {
 }
 
-void JSDOMURL::finishCreation(VM& vm)
-{
-    Base::finishCreation(vm);
-    ASSERT(inherits(info()));
-
-    // static_assert(!std::is_base_of<ActiveDOMObject, DOMURL>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
-}
+// static_assert(!std::is_base_of<ActiveDOMObject, DOMURL>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
 
 JSObject* JSDOMURL::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {
@@ -289,14 +256,14 @@ void JSDOMURL::destroy(JSC::JSCell* cell)
     thisObject->JSDOMURL::~JSDOMURL();
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURLConstructor, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURLConstructor, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName))
 {
-    VM& vm = JSC::getVM(lexicalGlobalObject);
+    auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto* prototype = jsDynamicCast<JSDOMURLPrototype*>(JSValue::decode(thisValue));
     if (UNLIKELY(!prototype))
         return throwVMTypeError(lexicalGlobalObject, throwScope);
-    return JSValue::encode(JSDOMURL::getConstructor(JSC::getVM(lexicalGlobalObject), prototype->globalObject()));
+    return JSValue::encode(JSDOMURL::getConstructor(vm, prototype->globalObject()));
 }
 
 static inline JSValue jsDOMURL_hrefGetter(JSGlobalObject& lexicalGlobalObject, JSDOMURL& thisObject)
@@ -307,7 +274,7 @@ static inline JSValue jsDOMURL_hrefGetter(JSGlobalObject& lexicalGlobalObject, J
     RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.href())));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_href, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_href, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_hrefGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
@@ -315,6 +282,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_href, (JSGlobalObject * lexicalGlobalObject, J
 static inline bool setJSDOMURL_hrefSetter(JSGlobalObject& lexicalGlobalObject, JSDOMURL& thisObject, JSValue value)
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
@@ -325,7 +293,7 @@ static inline bool setJSDOMURL_hrefSetter(JSGlobalObject& lexicalGlobalObject, J
     return true;
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_href, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_href, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::set<setJSDOMURL_hrefSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
@@ -338,7 +306,7 @@ static inline JSValue jsDOMURL_originGetter(JSGlobalObject& lexicalGlobalObject,
     RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.origin())));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_origin, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_origin, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_originGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
@@ -351,7 +319,7 @@ static inline JSValue jsDOMURL_protocolGetter(JSGlobalObject& lexicalGlobalObjec
     RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.protocol())));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_protocol, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_protocol, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_protocolGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
@@ -359,6 +327,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_protocol, (JSGlobalObject * lexicalGlobalObjec
 static inline bool setJSDOMURL_protocolSetter(JSGlobalObject& lexicalGlobalObject, JSDOMURL& thisObject, JSValue value)
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
@@ -369,7 +338,7 @@ static inline bool setJSDOMURL_protocolSetter(JSGlobalObject& lexicalGlobalObjec
     return true;
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_protocol, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_protocol, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::set<setJSDOMURL_protocolSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
@@ -382,7 +351,7 @@ static inline JSValue jsDOMURL_usernameGetter(JSGlobalObject& lexicalGlobalObjec
     RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.username())));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_username, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_username, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_usernameGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
@@ -390,6 +359,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_username, (JSGlobalObject * lexicalGlobalObjec
 static inline bool setJSDOMURL_usernameSetter(JSGlobalObject& lexicalGlobalObject, JSDOMURL& thisObject, JSValue value)
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
@@ -400,7 +370,7 @@ static inline bool setJSDOMURL_usernameSetter(JSGlobalObject& lexicalGlobalObjec
     return true;
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_username, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_username, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::set<setJSDOMURL_usernameSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
@@ -413,7 +383,7 @@ static inline JSValue jsDOMURL_passwordGetter(JSGlobalObject& lexicalGlobalObjec
     RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.password())));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_password, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_password, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_passwordGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
@@ -421,6 +391,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_password, (JSGlobalObject * lexicalGlobalObjec
 static inline bool setJSDOMURL_passwordSetter(JSGlobalObject& lexicalGlobalObject, JSDOMURL& thisObject, JSValue value)
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
@@ -431,7 +402,7 @@ static inline bool setJSDOMURL_passwordSetter(JSGlobalObject& lexicalGlobalObjec
     return true;
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_password, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_password, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::set<setJSDOMURL_passwordSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
@@ -444,7 +415,7 @@ static inline JSValue jsDOMURL_hostGetter(JSGlobalObject& lexicalGlobalObject, J
     RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.host())));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_host, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_host, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_hostGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
@@ -452,6 +423,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_host, (JSGlobalObject * lexicalGlobalObject, J
 static inline bool setJSDOMURL_hostSetter(JSGlobalObject& lexicalGlobalObject, JSDOMURL& thisObject, JSValue value)
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
@@ -462,7 +434,7 @@ static inline bool setJSDOMURL_hostSetter(JSGlobalObject& lexicalGlobalObject, J
     return true;
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_host, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_host, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::set<setJSDOMURL_hostSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
@@ -475,7 +447,7 @@ static inline JSValue jsDOMURL_hostnameGetter(JSGlobalObject& lexicalGlobalObjec
     RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.hostname())));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_hostname, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_hostname, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_hostnameGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
@@ -483,6 +455,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_hostname, (JSGlobalObject * lexicalGlobalObjec
 static inline bool setJSDOMURL_hostnameSetter(JSGlobalObject& lexicalGlobalObject, JSDOMURL& thisObject, JSValue value)
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
@@ -493,7 +466,7 @@ static inline bool setJSDOMURL_hostnameSetter(JSGlobalObject& lexicalGlobalObjec
     return true;
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_hostname, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_hostname, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::set<setJSDOMURL_hostnameSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
@@ -506,7 +479,7 @@ static inline JSValue jsDOMURL_portGetter(JSGlobalObject& lexicalGlobalObject, J
     RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.port())));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_port, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_port, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_portGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
@@ -514,6 +487,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_port, (JSGlobalObject * lexicalGlobalObject, J
 static inline bool setJSDOMURL_portSetter(JSGlobalObject& lexicalGlobalObject, JSDOMURL& thisObject, JSValue value)
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
@@ -524,7 +498,7 @@ static inline bool setJSDOMURL_portSetter(JSGlobalObject& lexicalGlobalObject, J
     return true;
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_port, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_port, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::set<setJSDOMURL_portSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
@@ -537,7 +511,7 @@ static inline JSValue jsDOMURL_pathnameGetter(JSGlobalObject& lexicalGlobalObjec
     RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.pathname())));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_pathname, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_pathname, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_pathnameGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
@@ -545,6 +519,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_pathname, (JSGlobalObject * lexicalGlobalObjec
 static inline bool setJSDOMURL_pathnameSetter(JSGlobalObject& lexicalGlobalObject, JSDOMURL& thisObject, JSValue value)
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
@@ -555,7 +530,7 @@ static inline bool setJSDOMURL_pathnameSetter(JSGlobalObject& lexicalGlobalObjec
     return true;
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_pathname, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_pathname, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::set<setJSDOMURL_pathnameSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
@@ -568,7 +543,7 @@ static inline JSValue jsDOMURL_hashGetter(JSGlobalObject& lexicalGlobalObject, J
     RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.hash())));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_hash, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_hash, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_hashGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
@@ -576,6 +551,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_hash, (JSGlobalObject * lexicalGlobalObject, J
 static inline bool setJSDOMURL_hashSetter(JSGlobalObject& lexicalGlobalObject, JSDOMURL& thisObject, JSValue value)
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
@@ -586,7 +562,7 @@ static inline bool setJSDOMURL_hashSetter(JSGlobalObject& lexicalGlobalObject, J
     return true;
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_hash, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_hash, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::set<setJSDOMURL_hashSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
@@ -599,7 +575,7 @@ static inline JSValue jsDOMURL_searchGetter(JSGlobalObject& lexicalGlobalObject,
     RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.search())));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_search, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_search, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_searchGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
 }
@@ -607,6 +583,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_search, (JSGlobalObject * lexicalGlobalObject,
 static inline bool setJSDOMURL_searchSetter(JSGlobalObject& lexicalGlobalObject, JSDOMURL& thisObject, JSValue value)
 {
     auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
@@ -617,7 +594,7 @@ static inline bool setJSDOMURL_searchSetter(JSGlobalObject& lexicalGlobalObject,
     return true;
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_search, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_SETTER(setJSDOMURL_search, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::set<setJSDOMURL_searchSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
@@ -635,9 +612,53 @@ static inline JSValue jsDOMURL_searchParamsGetter(JSGlobalObject& lexicalGlobalO
     return result;
 }
 
-JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_searchParams, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+JSC_DEFINE_CUSTOM_GETTER(jsDOMURL_searchParams, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
     return IDLAttribute<JSDOMURL>::get<jsDOMURL_searchParamsGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline JSC::EncodedJSValue jsDOMURLConstructorFunction_parseBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
+    if (UNLIKELY(callFrame->argumentCount() < 1))
+        return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
+    EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
+    auto url = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
+    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
+    EnsureStillAliveScope argument1 = callFrame->argument(1);
+    auto base = argument1.value().isUndefined() ? String() : convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
+    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLNullable<IDLInterface<DOMURL>>>(*lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(lexicalGlobalObject), throwScope, DOMURL::parse(WTFMove(url), WTFMove(base)))));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsDOMURLConstructorFunction_parse, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return IDLOperation<JSDOMURL>::callStatic<jsDOMURLConstructorFunction_parseBody>(*lexicalGlobalObject, *callFrame, "parse");
+}
+
+static inline JSC::EncodedJSValue jsDOMURLConstructorFunction_canParseBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
+    if (UNLIKELY(callFrame->argumentCount() < 1))
+        return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
+    EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
+    auto url = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
+    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
+    EnsureStillAliveScope argument1 = callFrame->argument(1);
+    auto base = argument1.value().isUndefined() ? String() : convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
+    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLBoolean>(*lexicalGlobalObject, throwScope, DOMURL::canParse(WTFMove(url), WTFMove(base)))));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsDOMURLConstructorFunction_canParse, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return IDLOperation<JSDOMURL>::callStatic<jsDOMURLConstructorFunction_canParseBody>(*lexicalGlobalObject, *callFrame, "canParse");
 }
 
 static inline JSC::EncodedJSValue jsDOMURLPrototypeFunction_toJSONBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSDOMURL>::ClassParameter castedThis)
@@ -659,8 +680,8 @@ static inline JSC::EncodedJSValue jsDOMURLConstructorFunction_createObjectURL1Bo
 {
     // auto& vm = JSC::getVM(lexicalGlobalObject);
     // auto throwScope = DECLARE_THROW_SCOPE(vm);
-    // UNUSED_PARAM(throwScope);
-    // UNUSED_PARAM(callFrame);
+    UNUSED_PARAM(lexicalGlobalObject);
+    UNUSED_PARAM(callFrame);
     // auto* context = jsCast<JSDOMGlobalObject*>(lexicalGlobalObject)->scriptExecutionContext();
     // if (UNLIKELY(!context))
     return JSValue::encode(jsUndefined());
@@ -674,8 +695,8 @@ static inline JSC::EncodedJSValue jsDOMURLConstructorFunction_revokeObjectURLBod
 {
     // auto& vm = JSC::getVM(lexicalGlobalObject);
     // auto throwScope = DECLARE_THROW_SCOPE(vm);
-    // UNUSED_PARAM(throwScope);
-    // UNUSED_PARAM(callFrame);
+    UNUSED_PARAM(lexicalGlobalObject);
+    UNUSED_PARAM(callFrame);
     // if (UNLIKELY(callFrame->argumentCount() < 1))
     //     return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     // auto* context = jsCast<JSDOMGlobalObject*>(lexicalGlobalObject)->scriptExecutionContext();
@@ -692,70 +713,31 @@ JSC_DEFINE_HOST_FUNCTION(jsDOMURLConstructorFunction_revokeObjectURL, (JSGlobalO
     return IDLOperation<JSDOMURL>::callStatic<jsDOMURLConstructorFunction_revokeObjectURLBody>(*lexicalGlobalObject, *callFrame, "revokeObjectURL");
 }
 
-static inline JSC::EncodedJSValue jsDOMURLConstructorFunction_canParseBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+void JSDOMURL::finishCreation(JSC::VM& vm)
 {
-    auto& vm = JSC::getVM(lexicalGlobalObject);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-
-    if (UNLIKELY(callFrame->argumentCount() < 1))
-        return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
-
-    EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    auto url = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
-    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-
-    EnsureStillAliveScope argument1 = callFrame->argument(1);
-    String base;
-    if (!argument1.value().isUndefinedOrNull()) {
-        base = convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
-        RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-    }
-
-    return JSValue::encode(jsBoolean(DOMURL::canParse(url, base)));
+    Base::finishCreation(vm);
+    ASSERT(inherits(info()));
 }
-
-JSC_DEFINE_HOST_FUNCTION(jsDOMURLConstructorFunction_canParse, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
-{
-    return IDLOperation<JSDOMURL>::callStatic<jsDOMURLConstructorFunction_canParseBody>(*lexicalGlobalObject, *callFrame, "canParse");
-}
-
-#if ENABLE(MEDIA_SOURCE)
-static inline JSC::EncodedJSValue jsDOMURLConstructorFunction_createObjectURL2Body(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
-{
-    // auto& vm = JSC::getVM(lexicalGlobalObject);
-    // auto throwScope = DECLARE_THROW_SCOPE(vm);
-    // UNUSED_PARAM(throwScope);
-    // UNUSED_PARAM(callFrame);
-    // auto* context = jsCast<JSDOMGlobalObject*>(lexicalGlobalObject)->scriptExecutionContext();
-    // if (UNLIKELY(!context))
-    return JSValue::encode(jsUndefined());
-    // EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    // auto source = convert<IDLInterface<MediaSource>>(*lexicalGlobalObject, argument0.value(), [](JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope) { throwArgumentTypeError(lexicalGlobalObject, scope, 0, "source", "URL", "createObjectURL", "MediaSource"); });
-    // RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-    // RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WebCore::DOMURLMediaSource::createObjectURL(*context, *source))));
-}
-
-#endif
 
 static inline JSC::EncodedJSValue jsDOMURLConstructorFunction_createObjectURLOverloadDispatcher(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
 {
-    return JSValue::encode(jsUndefined());
-
-    //     auto& vm = JSC::getVM(lexicalGlobalObject);
-    //     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    // UNUSED_PARAM(throwScope);
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
-    //     size_t argsCount = std::min<size_t>(1, callFrame->argumentCount());
-    //     if (argsCount == 1) {
-    //         JSValue distinguishingArg = callFrame->uncheckedArgument(0);
-    //         if (distinguishingArg.isObject() && asObject(distinguishingArg)->inherits<JSBlob>())
-    //             RELEASE_AND_RETURN(throwScope, (jsDOMURLConstructorFunction_createObjectURL1Body(lexicalGlobalObject, callFrame)));
-    // #if ENABLE(MEDIA_SOURCE)
-    //         if (distinguishingArg.isObject() && asObject(distinguishingArg)->inherits<JSMediaSource>())
-    //             RELEASE_AND_RETURN(throwScope, (jsDOMURLConstructorFunction_createObjectURL2Body(lexicalGlobalObject, callFrame)));
-    // #endif
-    //     }
-    //     return argsCount < 1 ? throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject)) : throwVMTypeError(lexicalGlobalObject, throwScope);
+    size_t argsCount = std::min<size_t>(1, callFrame->argumentCount());
+    if (argsCount == 1) {
+        JSValue distinguishingArg = callFrame->uncheckedArgument(0);
+        if (distinguishingArg.isObject()) {
+            return JSValue::encode(jsUndefined());
+        }
+        //         if (distinguishingArg.isObject() && asObject(distinguishingArg)->inherits<JSBlob>())
+        //             RELEASE_AND_RETURN(throwScope, (jsDOMURLConstructorFunction_createObjectURL1Body(lexicalGlobalObject, callFrame)));
+        // #if ENABLE(MEDIA_SOURCE)
+        //         if (distinguishingArg.isObject() && asObject(distinguishingArg)->inherits<JSMediaSource>())
+        //             RELEASE_AND_RETURN(throwScope, (jsDOMURLConstructorFunction_createObjectURL2Body(lexicalGlobalObject, callFrame)));
+    }
+    return argsCount < 1 ? throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject)) : throwVMTypeError(lexicalGlobalObject, throwScope);
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsDOMURLConstructorFunction_createObjectURL, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -803,8 +785,8 @@ void JSDOMURL::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
     auto* thisObject = jsCast<JSDOMURL*>(cell);
     analyzer.setWrappedObjectForCell(cell, &thisObject->wrapped());
-    // if (thisObject->scriptExecutionContext())
-    //     analyzer.setLabelForCell(cell, "url " + thisObject->scriptExecutionContext()->url().string());
+    if (thisObject->scriptExecutionContext())
+        analyzer.setLabelForCell(cell, "url "_s + thisObject->scriptExecutionContext()->url().string());
     Base::analyzeHeap(cell, analyzer);
 }
 
@@ -867,11 +849,10 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
     return wrap(lexicalGlobalObject, globalObject, impl);
 }
 
-DOMURL* JSDOMURL::toWrapped(JSC::VM& vm, JSC::JSValue value)
+DOMURL* JSDOMURL::toWrapped(JSC::VM&, JSC::JSValue value)
 {
     if (auto* wrapper = jsDynamicCast<JSDOMURL*>(value))
         return &wrapper->wrapped();
     return nullptr;
 }
-
 }

--- a/test/js/node/url/url.test.ts
+++ b/test/js/node/url/url.test.ts
@@ -77,5 +77,5 @@ it("URL constructor throws ERR_MISSING_ARGS", () => {
   }
 
   // @ts-expect-error
-  expect(err?.code ).toEqual("ERR_MISSING_ARGS");
-}) 
+  expect(err?.code).toEqual("ERR_MISSING_ARGS");
+});

--- a/test/js/node/url/url.test.ts
+++ b/test/js/node/url/url.test.ts
@@ -66,3 +66,16 @@ describe("Url.prototype.parse", () => {
     });
   });
 });
+
+it("URL constructor throws ERR_MISSING_ARGS", () => {
+  var err;
+  try {
+    // @ts-expect-error
+    new URL();
+  } catch (e) {
+    err = e;
+  }
+
+  // @ts-expect-error
+  expect(err?.code ).toEqual("ERR_MISSING_ARGS");
+}) 


### PR DESCRIPTION
### What does this PR do?

- Re-sync `URL` from WebKit, which should 1/2 the size of the JS `URL` object in memory
- Sets `ERR_MISSING_ARGS` everywhere we throw createNotEnoughArguments

5%-ish perf improvement to `new URL`
<img width="777" alt="image" src="https://github.com/oven-sh/bun/assets/709451/186d1a0f-cc47-43c9-8047-03cdbea23397">


### How did you verify your code works?

There is a test