### PR TITLE
fix(socket) fix error in case of failure/returning a error in the open handler

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -218,9 +218,14 @@ const Handlers = struct {
                 this.unprotect();
                 // will deinit when is not wrapped or when is the TCP wrapped connection
                 if (wrapped != .tls) {
-                    if (ctx) |ctx_|
+                    if (ctx) |ctx_| {
+                        // at this point we dont care about the callback anymore because we are deiniting after this
+                        // ctx will deinit only in the next tick
+                        ctx_.cleanCallbacks(false);
                         ctx_.deinit(ssl);
+                    }
                 }
+                // clean
                 bun.default_allocator.destroy(this);
             }
         }
@@ -861,6 +866,9 @@ pub const Listener = struct {
         this.handlers.unprotect();
 
         if (this.socket_context) |ctx| {
+            // at this point we dont care about the callback anymore because we are deiniting after this
+            // ctx will deinit only in the next tick
+            if (this.ssl) ctx.cleanCallbacks(true) else ctx.cleanCallbacks(false);
             ctx.deinit(this.ssl);
         }
 

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -828,11 +828,14 @@ pub const Listener = struct {
 
         var listener = this.listener orelse return JSValue.jsUndefined();
         this.listener = null;
-        listener.close(this.ssl);
+
+        const forceClose = arguments.len > 0 and arguments.ptr[0].isBoolean() and arguments.ptr[0].toBoolean() and this.socket_context != null;
+        if (!forceClose) {
+            listener.close(this.ssl);
+        }
 
         this.poll_ref.unref(this.handlers.vm);
 
-        const forceClose = arguments.len > 0 and arguments.ptr[0].isBoolean() and arguments.ptr[0].toBoolean() and this.socket_context != null;
         if (this.handlers.active_connections == 0 or forceClose) {
             this.handlers.unprotect();
             // context deinit will close all connections

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -219,9 +219,6 @@ const Handlers = struct {
                 // will deinit when is not wrapped or when is the TCP wrapped connection
                 if (wrapped != .tls) {
                     if (ctx) |ctx_| {
-                        // at this point we dont care about the callback anymore because we are deiniting after this
-                        // ctx will deinit only in the next tick
-                        ctx_.cleanCallbacks(false);
                         ctx_.deinit(ssl);
                     }
                 }
@@ -842,7 +839,6 @@ pub const Listener = struct {
         this.poll_ref.unref(this.handlers.vm);
         if (this.handlers.active_connections == 0) {
             this.handlers.unprotect();
-            this.socket_context.?.close(this.ssl);
             this.socket_context.?.deinit(this.ssl);
             this.socket_context = null;
             this.strong_self.clear();
@@ -866,9 +862,6 @@ pub const Listener = struct {
         this.handlers.unprotect();
 
         if (this.socket_context) |ctx| {
-            // at this point we dont care about the callback anymore because we are deiniting after this
-            // ctx will deinit only in the next tick
-            if (this.ssl) ctx.cleanCallbacks(true) else ctx.cleanCallbacks(false);
             ctx.deinit(this.ssl);
         }
 

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -222,7 +222,6 @@ const Handlers = struct {
                         ctx_.deinit(ssl);
                     }
                 }
-                // clean
                 bun.default_allocator.destroy(this);
             }
         }

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -943,8 +943,6 @@ pub const SocketContext = opaque {
 
     /// closes and deinit the SocketContexts
     pub fn deinit(this: *SocketContext, ssl: bool) void {
-        // at this point we dont care about the callback anymore because we are deiniting after this
-        this.cleanCallbacks(ssl);
         this.close(ssl);
         //always deinit in next iteration
         if (ssl) {
@@ -956,6 +954,7 @@ pub const SocketContext = opaque {
 
     fn close(this: *SocketContext, ssl: bool) void {
         debug("us_socket_context_close({d})", .{@intFromPtr(this)});
+        this.cleanCallbacks(ssl);
         us_socket_context_close(@as(i32, @intFromBool(ssl)), this);
     }
 

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -954,7 +954,7 @@ pub const SocketContext = opaque {
         }
     }
 
-    pub fn close(this: *SocketContext, ssl: bool) void {
+    fn close(this: *SocketContext, ssl: bool) void {
         debug("us_socket_context_close({d})", .{@intFromPtr(this)});
         us_socket_context_close(@as(i32, @intFromBool(ssl)), this);
     }

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -893,7 +893,7 @@ pub const SocketContext = opaque {
         us_socket_context_free(@as(i32, 0), this);
     }
 
-    pub fn cleanCallbacks(ctx: *SocketContext, comptime is_ssl: bool) void {
+    pub fn cleanCallbacks(ctx: *SocketContext, is_ssl: bool) void {
         const ssl_int: i32 = @intFromBool(is_ssl);
         // replace callbacks with dummy ones
         const DummyCallbacks = struct {
@@ -943,6 +943,8 @@ pub const SocketContext = opaque {
 
     /// closes and deinit the SocketContexts
     pub fn deinit(this: *SocketContext, ssl: bool) void {
+        // at this point we dont care about the callback anymore because we are deiniting after this
+        this.cleanCallbacks(ssl);
         this.close(ssl);
         //always deinit in next iteration
         if (ssl) {

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -954,6 +954,7 @@ pub const SocketContext = opaque {
 
     fn close(this: *SocketContext, ssl: bool) void {
         debug("us_socket_context_close({d})", .{@intFromPtr(this)});
+        // we clean the callbacks to avoid UAF, we are probably deiniting after this in the next tick
         this.cleanCallbacks(ssl);
         us_socket_context_close(@as(i32, @intFromBool(ssl)), this);
     }

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -943,6 +943,8 @@ pub const SocketContext = opaque {
 
     /// closes and deinit the SocketContexts
     pub fn deinit(this: *SocketContext, ssl: bool) void {
+        // we clean the callbacks to avoid UAF because we are deiniting
+        this.cleanCallbacks(ssl);
         this.close(ssl);
         //always deinit in next iteration
         if (ssl) {
@@ -952,10 +954,8 @@ pub const SocketContext = opaque {
         }
     }
 
-    fn close(this: *SocketContext, ssl: bool) void {
+    pub fn close(this: *SocketContext, ssl: bool) void {
         debug("us_socket_context_close({d})", .{@intFromPtr(this)});
-        // we clean the callbacks to avoid UAF, we are probably deiniting after this in the next tick
-        this.cleanCallbacks(ssl);
         us_socket_context_close(@as(i32, @intFromBool(ssl)), this);
     }
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests 

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
