### PR TITLE
correctly handle `--cwd` flag

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -412,20 +412,10 @@ pub const Arguments = struct {
             cwd = brk: {
                 var outbuf: [bun.MAX_PATH_BYTES]u8 = undefined;
                 const out = bun.path.joinAbs(try bun.getcwd(&outbuf), .loose, cwd_);
-
-                // On POSIX, we don't actually call chdir() on the path
-                //
-                // On Windows, we do change the current directory.
-                // Not all system calls on Windows support passing a dirfd (and libuv entirely doesn't)
-                // So we have to do it the real way
-                if (comptime Environment.isWindows) {
-                    var wbuf: bun.WPathBuffer = undefined;
-                    bun.sys.chdir(bun.strings.toWPathNormalized(&wbuf, out)).unwrap() catch |err| {
-                        Output.prettyErrorln("{}\n", .{err});
-                        Global.exit(1);
-                    };
-                }
-
+                bun.sys.chdir(out).unwrap() catch |err| {
+                    Output.prettyErrorln("{}\n", .{err});
+                    Global.exit(1);
+                };
                 break :brk try allocator.dupe(u8, out);
             };
         } else {

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -1,7 +1,7 @@
 import { file, spawn, spawnSync } from "bun";
 import { afterEach, beforeEach, expect, it, describe } from "bun:test";
 import { bunEnv, bunExe, bunEnv as env, isWindows } from "harness";
-import { mkdtemp, realpath, rm, writeFile, exists } from "fs/promises";
+import { mkdtemp, realpath, rm, writeFile, exists, mkdir } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { readdirSorted } from "./dummy.registry";
@@ -419,3 +419,29 @@ import { prueba } from "pruebadfasdfasdkafasdyuif.js";
   // The exit code will not be 1 if it panics.
   expect(await exited).toBe(1);
 });
+
+
+it("should show the correct working directory when run with --cwd", async() => {
+  await mkdir(join(run_dir, "subdir"));
+  await writeFile(
+    join(run_dir, "subdir", "test.js"),
+    `
+    console.log(process.cwd());
+  `,
+  );
+  const res = Bun.spawn({
+    cmd: [bunExe(), "run", "--cwd", "subdir", "test.js"],
+    cwd: run_dir,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      BUN_INSTALL_CACHE_DIR: join(run_dir, ".cache"),
+    },
+  });
+
+  // The exit code will not be 1 if it panics.
+  expect(await res.exited).toBe(0);
+  expect(await Bun.readableStreamToText(res.stdout)).toMatch(/subdir/);
+})

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -420,8 +420,7 @@ import { prueba } from "pruebadfasdfasdkafasdyuif.js";
   expect(await exited).toBe(1);
 });
 
-
-it("should show the correct working directory when run with --cwd", async() => {
+it("should show the correct working directory when run with --cwd", async () => {
   await mkdir(join(run_dir, "subdir"));
   await writeFile(
     join(run_dir, "subdir", "test.js"),
@@ -444,4 +443,4 @@ it("should show the correct working directory when run with --cwd", async() => {
   // The exit code will not be 1 if it panics.
   expect(await res.exited).toBe(0);
   expect(await Bun.readableStreamToText(res.stdout)).toMatch(/subdir/);
-})
+});


### PR DESCRIPTION
### What does this PR do?
Makes the process actually change working directory when passed the `--cwd` flag, as reflected in `process.cwd()`

Fixes #8167

### How did you verify your code works?
Added a test to `bun-run.test.ts`