### PR TITLE
fix(windows): `bun create` with github repo and finding package.json

### DIFF
--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -378,7 +378,7 @@ pub const CreateCommand = struct {
                 progress.refresh();
 
                 var pluckers: [1]Archive.Plucker = if (!create_options.skip_package_json)
-                    [1]Archive.Plucker{try Archive.Plucker.init("package.json", 2048, ctx.allocator)}
+                    [1]Archive.Plucker{try Archive.Plucker.init(comptime strings.literal(bun.OSPathChar, "package.json"), 2048, ctx.allocator)}
                 else
                     [1]Archive.Plucker{undefined};
 

--- a/src/libarchive/libarchive.zig
+++ b/src/libarchive/libarchive.zig
@@ -376,10 +376,10 @@ pub const Archive = struct {
         filename_hash: u64 = 0,
         found: bool = false,
         fd: FileDescriptorType = .zero,
-        pub fn init(filepath: string, estimated_size: usize, allocator: std.mem.Allocator) !Plucker {
+        pub fn init(filepath: bun.OSPathSlice, estimated_size: usize, allocator: std.mem.Allocator) !Plucker {
             return Plucker{
                 .contents = try MutableString.init(allocator, estimated_size),
-                .filename_hash = bun.hash(filepath),
+                .filename_hash = bun.hash(std.mem.sliceAsBytes(filepath)),
                 .fd = .zero,
                 .found = false,
             };

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync } from "bun";
 import { afterEach, beforeEach, expect, it, describe } from "bun:test";
 import { bunExe, bunEnv as env } from "harness";
-import { mkdtemp, realpath, rm, mkdir, stat } from "fs/promises";
+import { mkdtemp, realpath, rm, mkdir, stat, exists } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -100,3 +100,23 @@ it("should create template from local folder", async () => {
   const dirStat = await stat(`${x_dir}/${testTemplate}`);
   expect(dirStat.isDirectory()).toBe(true);
 });
+
+for (const repo of ["https://github.com/dylan-conway/create-test", "github.com/dylan-conway/create-test"]) {
+  it(`should create and install github template from ${repo}`, async () => {
+    const { stderr, stdout, exited } = spawn({
+      cmd: [bunExe(), "create", repo],
+      cwd: x_dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const err = await Bun.readableStreamToText(stderr);
+    expect(err).not.toContain("error:");
+    const out = await Bun.readableStreamToText(stdout);
+    expect(out).toContain("Success! dylan-conway/create-test loaded into create-test");
+    expect(await exists(join(x_dir, "create-test", "node_modules", "jquery"))).toBe(true);
+
+    expect(await exited).toBe(0);
+  });
+}


### PR DESCRIPTION
### What does this PR do?
Removes `unreachable` from reachable errors.

Fixes bug finding package.json from bun create template.

fixes #10183 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
manually and added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
