### PR TITLE
Make receiving data over TCP faster on Windows

### DIFF
--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -338,7 +338,13 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
 
                 do {
                     const struct us_loop_t* loop = s->context->loop;
-                    int length = bsd_recv(us_poll_fd(&s->p), loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING, LIBUS_RECV_BUFFER_LENGTH, MSG_DONTWAIT);
+                    #ifdef _WIN32
+                      const int recv_flags = MSG_PUSH_IMMEDIATE;
+                    #else
+                      const int recv_flags = MSG_DONTWAIT | MSG_NOSIGNAL;
+                    #endif
+
+                    int length = bsd_recv(us_poll_fd(&s->p), loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING, LIBUS_RECV_BUFFER_LENGTH, recv_flags);
 
                     if (length > 0) {
                         s = s->context->on_data(s, loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING, length);


### PR DESCRIPTION
### What does this PR do?

Windows has a secret 0.5s delay when the TCP PUSH bit is not set by the sender

http://smallvoid.com/article/winnt-tcp-push-flag.html

### How did you verify your code works?

Before, `bun upgrade` seemed to take a really long time waiting for 0.5s & doing nothing

now it does not