### PR TITLE
linter: ergonomics and new rules

### DIFF
--- a/packages/bun-internal-test/src/banned.json
+++ b/packages/bun-internal-test/src/banned.json
@@ -1,4 +1,5 @@
 {
   "std.debug.assert": "Use bun.assert instead",
+  "@import(\"root\").bun.": "Only import 'bun' once",
   "": ""
 }

--- a/packages/bun-internal-test/src/banned.json
+++ b/packages/bun-internal-test/src/banned.json
@@ -1,5 +1,6 @@
 {
   "std.debug.assert": "Use bun.assert instead",
   "@import(\"root\").bun.": "Only import 'bun' once",
+  "std.mem.indexOfAny": "Use bun.strings.indexAny or bun.strings.indexAnyComptime",
   "": ""
 }

--- a/packages/bun-internal-test/src/banned.json
+++ b/packages/bun-internal-test/src/banned.json
@@ -1,3 +1,4 @@
 {
-  "std.debug.assert": "Use bun.assert instead"
+  "std.debug.assert": "Use bun.assert instead",
+  "": ""
 }

--- a/packages/bun-internal-test/src/banned.json
+++ b/packages/bun-internal-test/src/banned.json
@@ -2,5 +2,6 @@
   "std.debug.assert": "Use bun.assert instead",
   "@import(\"root\").bun.": "Only import 'bun' once",
   "std.mem.indexOfAny": "Use bun.strings.indexAny or bun.strings.indexAnyComptime",
+  "std.debug.print": "Don't let this be committed",
   "": ""
 }

--- a/packages/bun-internal-test/src/linter.ts
+++ b/packages/bun-internal-test/src/linter.ts
@@ -19,7 +19,9 @@ for (const [banned, suggestion] of Object.entries(BANNED)) {
   if (banned.length === 0) continue;
   // Run git grep to find occurrences of std.debug.assert in .zig files
   // .nothrow() is here since git will exit with non-zero if no matches are found.
-  let stdout = await $`git grep -n -F "${banned}" "src/**/**.zig"`.nothrow().text();
+  let stdout = await $`git grep -n -F "${banned}" "src/**/**.zig" | grep -v -F '//' | grep -v -F bench`
+    .nothrow()
+    .text();
 
   stdout = stdout.trim();
   if (stdout.length === 0) continue;

--- a/packages/bun-internal-test/src/linter.ts
+++ b/packages/bun-internal-test/src/linter.ts
@@ -18,7 +18,8 @@ const write = (text: string) => {
 for (const [banned, suggestion] of Object.entries(BANNED)) {
   if (banned.length === 0) continue;
   // Run git grep to find occurrences of std.debug.assert in .zig files
-  let stdout = await $`git grep -n "${banned}" "src/**/**.zig"`.text();
+  // .nothrow() is here since git will exit with non-zero if no matches are found.
+  let stdout = await $`git grep -n -F "${banned}" "src/**/**.zig"`.nothrow().text();
 
   stdout = stdout.trim();
   if (stdout.length === 0) continue;

--- a/packages/bun-internal-test/src/linter.ts
+++ b/packages/bun-internal-test/src/linter.ts
@@ -16,6 +16,7 @@ const write = (text: string) => {
   report += text;
 };
 for (const [banned, suggestion] of Object.entries(BANNED)) {
+  if (banned.length === 0) continue;
   // Run git grep to find occurrences of std.debug.assert in .zig files
   let stdout = await $`git grep -n "${banned}" "src/**/**.zig"`.text();
 

--- a/src/bun.js/bindings/bindings-generator.zig
+++ b/src/bun.js/bindings/bindings-generator.zig
@@ -3,12 +3,12 @@ const Exports = @import("exports.zig");
 const HeaderGen = @import("./header-gen.zig").HeaderGen;
 const std = @import("std");
 const builtin = @import("builtin");
+const bun = @import("root").bun;
 const io = std.io;
 const fs = std.fs;
 const process = std.process;
 const ChildProcess = std.ChildProcess;
 const Progress = std.Progress;
-const print = std.debug.print;
 const mem = std.mem;
 const testing = std.testing;
 const Allocator = std.mem.Allocator;
@@ -20,7 +20,7 @@ const JSC = bun.JSC;
 const Classes = JSC.GlobalClasses;
 
 pub fn main() anyerror!void {
-    var allocator = std.heap.c_allocator;
+    const allocator = std.heap.c_allocator;
     const src: std.builtin.SourceLocation = @src();
     const src_path = comptime bun.Environment.base_path ++ std.fs.path.dirname(src.file).?;
     {
@@ -46,16 +46,16 @@ pub fn main() anyerror!void {
         inline while (i < Classes.len) : (i += 1) {
             const Class = Classes[i];
             const paths = [_][]const u8{ src_path, Class.name ++ ".generated.h" };
-            var headerFilePath = try std.fs.path.join(
+            const headerFilePath = try std.fs.path.join(
                 allocator,
                 &paths,
             );
-            var implFilePath = try std.fs.path.join(
+            const implFilePath = try std.fs.path.join(
                 allocator,
                 &[_][]const u8{ std.fs.path.dirname(src.file) orelse return error.BadPath, Class.name ++ ".generated.cpp" },
             );
             var headerFile = try std.fs.createFileAbsolute(headerFilePath, .{});
-            var header_writer = headerFile.writer();
+            const header_writer = headerFile.writer();
             var implFile = try std.fs.createFileAbsolute(implFilePath, .{});
             try Class.@"generateC++Header"(header_writer);
             try Class.@"generateC++Class"(implFile.writer());

--- a/src/bun.js/unbounded_queue.zig
+++ b/src/bun.js/unbounded_queue.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const bun = @import("root").bun;
 
 const os = std.os;
 const mem = std.mem;
@@ -7,7 +8,7 @@ const atomic = std.atomic;
 const builtin = std.builtin;
 const testing = std.testing;
 
-const assert = @import("root").bun.assert;
+const assert = bun.assert;
 
 const mpsc = @This();
 

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -331,8 +331,7 @@ pub const BunxCommand = struct {
                 else => ":",
             };
 
-            const has_banned_char = std.mem.indexOfAny(u8, update_request.name, banned_path_chars) != null or
-                std.mem.indexOfAny(u8, display_version, banned_path_chars) != null;
+            const has_banned_char = bun.strings.indexAnyComptime(update_request.name, banned_path_chars) != null or bun.strings.indexAnyComptime(display_version, banned_path_chars) != null;
 
             break :brk try if (has_banned_char)
                 // This branch gets hit usually when a URL is requested as the package

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -154,7 +154,8 @@ pub const UpgradeCheckerThread = struct {
     fn run(env_loader: *DotEnv.Loader) void {
         _run(env_loader) catch |err| {
             if (Environment.isDebug) {
-                std.debug.print("\n[UpgradeChecker] ERROR: {s}\n", .{@errorName(err)});
+                Output.prettyError("\n[UpgradeChecker] ERROR: {s}\n", .{@errorName(err)});
+                Output.flush();
             }
         };
     }

--- a/src/deps/diffz/DiffMatchPatch.zig
+++ b/src/deps/diffz/DiffMatchPatch.zig
@@ -1398,7 +1398,7 @@ fn diffCommonOverlap(text1_in: []const u8, text2_in: []const u8) usize {
 }
 
 // pub fn main() void {
-//     var arena = @import("root").bun.ArenaAllocator.init(std.heap.page_allocator);
+//     var arena = bun.ArenaAllocator.init(std.heap.page_allocator);
 //     defer arena.deinit();
 
 //     var bruh = default.diff(arena.allocator(), "Hello World.", "Goodbye World.", true);
@@ -1406,7 +1406,7 @@ fn diffCommonOverlap(text1_in: []const u8, text2_in: []const u8) usize {
 // }
 
 // test {
-//     var arena = @import("root").bun.ArenaAllocator.init(testing.allocator);
+//     var arena = bun.ArenaAllocator.init(testing.allocator);
 //     defer arena.deinit();
 
 //     var bruh = try default.diff(arena.allocator(), "Hello World.", "Goodbye World.", true);
@@ -1455,7 +1455,7 @@ test diffCommonOverlap {
 }
 
 test diffHalfMatch {
-    var arena = @import("root").bun.ArenaAllocator.init(testing.allocator);
+    var arena = bun.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
 
     var one_timeout = DiffMatchPatch{};
@@ -1549,7 +1549,7 @@ test diffHalfMatch {
 }
 
 test diffLinesToChars {
-    var arena = @import("root").bun.ArenaAllocator.init(testing.allocator);
+    var arena = bun.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
 
     // Convert lines down to characters.
@@ -1611,7 +1611,7 @@ test diffLinesToChars {
 }
 
 test diffCharsToLines {
-    var arena = @import("root").bun.ArenaAllocator.init(testing.allocator);
+    var arena = bun.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
 
     try testing.expect((Diff.init(.equal, "a")).eql(Diff.init(.equal, "a")));
@@ -1640,7 +1640,7 @@ test diffCharsToLines {
 }
 
 test diffCleanupMerge {
-    var arena = @import("root").bun.ArenaAllocator.init(testing.allocator);
+    var arena = bun.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
 
     // Cleanup a messy diff.
@@ -1828,7 +1828,7 @@ test diffCleanupMerge {
 }
 
 test diffCleanupSemanticLossless {
-    var arena = @import("root").bun.ArenaAllocator.init(testing.allocator);
+    var arena = bun.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
 
     var diffs = DiffList{};
@@ -1953,7 +1953,7 @@ fn rebuildtexts(allocator: std.mem.Allocator, diffs: DiffList) ![2][]const u8 {
 }
 
 test diffBisect {
-    var arena = @import("root").bun.ArenaAllocator.init(talloc);
+    var arena = bun.ArenaAllocator.init(talloc);
     defer arena.deinit();
 
     // Normal.
@@ -1987,7 +1987,7 @@ test diffBisect {
 
 const talloc = testing.allocator;
 test diff {
-    var arena = @import("root").bun.ArenaAllocator.init(talloc);
+    var arena = bun.ArenaAllocator.init(talloc);
     defer arena.deinit();
 
     // Perform a trivial diff.
@@ -2094,7 +2094,7 @@ test diff {
 }
 
 test diffCleanupSemantic {
-    var arena = @import("root").bun.ArenaAllocator.init(talloc);
+    var arena = bun.ArenaAllocator.init(talloc);
     defer arena.deinit();
 
     // Cleanup semantically trivial equalities.

--- a/src/deps/picohttp.zig
+++ b/src/deps/picohttp.zig
@@ -229,22 +229,4 @@ pub const Headers = struct {
     }
 };
 
-test "pico_http: parse headers" {
-    const HEADERS = "Date: Mon, 22 Mar 2021 08:15:54 GMT\r\n" ++
-        "Content-Type: text/html; charset=utf-8\r\n" ++
-        "Content-Length: 9593\r\n" ++
-        "Connection: keep-alive\r\n" ++
-        "Server: gunicorn/19.9.0\r\n" ++
-        "Access-Control-Allow-Origin: *\r\n" ++
-        "Access-Control-Allow-Credentials: true\r\n" ++
-        "\r\n";
-
-    var headers: [32]Header = undefined;
-
-    const result = try Headers.parse(HEADERS, &headers);
-    for (result.headers) |header| {
-        std.debug.print("{}\n", .{header});
-    }
-}
-
 pub usingnamespace c;

--- a/src/deps/picohttp.zig
+++ b/src/deps/picohttp.zig
@@ -199,30 +199,6 @@ pub const Response = struct {
     }
 };
 
-test "pico_http: parse response" {
-    const RES = "HTTP/1.1 200 OK\r\n" ++
-        "Date: Mon, 22 Mar 2021 08:15:54 GMT\r\n" ++
-        "Content-Type: text/html; charset=utf-8\r\n" ++
-        "Content-Length: 9593\r\n" ++
-        "Connection: keep-alive\r\n" ++
-        "Server: gunicorn/19.9.0\r\n" ++
-        "Access-Control-Allow-Origin: *\r\n" ++
-        "Access-Control-Allow-Credentials: true\r\n" ++
-        "\r\n";
-
-    var headers: [32]Header = undefined;
-
-    const res = try Response.parse(RES, &headers);
-
-    std.debug.print("Minor Version: {}\n", .{res.minor_version});
-    std.debug.print("Status Code: {}\n", .{res.status_code});
-    std.debug.print("Status: {s}\n", .{res.status});
-
-    for (res.headers) |header| {
-        std.debug.print("{}\n", .{header});
-    }
-}
-
 pub const Headers = struct {
     headers: []const Header,
 

--- a/src/deps/zig-clap/clap.zig
+++ b/src/deps/zig-clap/clap.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const bun = @import("root").bun;
 
 const debug = std.debug;
 const heap = std.heap;
@@ -251,7 +252,7 @@ fn testDiag(diag: Diagnostic, err: anyerror, expected: []const u8) void {
 
 pub fn Args(comptime Id: type, comptime params: []const Param(Id)) type {
     return struct {
-        arena: @import("root").bun.ArenaAllocator,
+        arena: bun.ArenaAllocator,
         clap: ComptimeClap(Id, params),
         exe_arg: ?[]const u8,
 
@@ -484,7 +485,7 @@ pub fn simpleHelp(
         if (desc_text.len == 0) continue;
 
         // create a string with spaces_len spaces
-        const default_allocator = @import("root").bun.default_allocator;
+        const default_allocator = bun.default_allocator;
 
         const flags_len = if (param.names.long) |l| l.len else 0;
         const num_spaces_after = max_spacing - flags_len;

--- a/src/deps/zig-clap/clap/args.zig
+++ b/src/deps/zig-clap/clap/args.zig
@@ -49,7 +49,7 @@ const bun = @import("root").bun;
 pub const OsIterator = struct {
     const Error = process.ArgIterator.InitError;
 
-    arena: @import("root").bun.ArenaAllocator,
+    arena: bun.ArenaAllocator,
     remain: [][:0]const u8,
 
     /// The executable path (this is the first argument passed to the program)
@@ -59,7 +59,7 @@ pub const OsIterator = struct {
 
     pub fn init(allocator: mem.Allocator) OsIterator {
         var res = OsIterator{
-            .arena = @import("root").bun.ArenaAllocator.init(allocator),
+            .arena = bun.ArenaAllocator.init(allocator),
             .exe_arg = undefined,
             .remain = bun.argv(),
         };
@@ -90,12 +90,12 @@ pub const ShellIterator = struct {
         QuoteNotClosed,
     } || mem.Allocator.Error;
 
-    arena: @import("root").bun.ArenaAllocator,
+    arena: bun.ArenaAllocator,
     str: []const u8,
 
     pub fn init(allocator: mem.Allocator, str: []const u8) ShellIterator {
         return .{
-            .arena = @import("root").bun.ArenaAllocator.init(allocator),
+            .arena = bun.ArenaAllocator.init(allocator),
             .str = str,
         };
     }

--- a/src/deps/zig-clap/clap/streaming.zig
+++ b/src/deps/zig-clap/clap/streaming.zig
@@ -1,7 +1,8 @@
 const builtin = @import("builtin");
 const clap = @import("../clap.zig");
 const std = @import("std");
-const Output = @import("root").bun.Output;
+const bun = @import("root").bun;
+const Output = bun.Output;
 
 const args = clap.args;
 const debug = std.debug;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8861,15 +8861,15 @@ pub const PackageManager = struct {
                 LifecycleScriptSubprocess.alive_count.load(.Monotonic) < this.manager.options.max_concurrent_lifecycle_scripts;
         }
 
-        pub fn printTreeDeps(this: *PackageInstaller) void {
-            for (this.tree_ids_to_trees_the_id_depends_on, 0..) |deps, j| {
-                std.debug.print("tree #{d:3}: ", .{j});
-                for (0..this.lockfile.buffers.trees.items.len) |tree_id| {
-                    std.debug.print("{d} ", .{@intFromBool(deps.isSet(tree_id))});
-                }
-                std.debug.print("\n", .{});
-            }
-        }
+        // pub fn printTreeDeps(this: *PackageInstaller) void {
+        //     for (this.tree_ids_to_trees_the_id_depends_on, 0..) |deps, j| {
+        //         std.debug.print("tree #{d:3}: ", .{j});
+        //         for (0..this.lockfile.buffers.trees.items.len) |tree_id| {
+        //             std.debug.print("{d} ", .{@intFromBool(deps.isSet(tree_id))});
+        //         }
+        //         std.debug.print("\n", .{});
+        //     }
+        // }
 
         pub fn deinit(this: *PackageInstaller) void {
             const allocator = this.manager.allocator;

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1450,7 +1450,7 @@ pub const Printer = struct {
                             needs_comma = false;
                         }
                         const version_name = dependency_version.literal.slice(string_buf);
-                        const needs_quote = always_needs_quote or std.mem.indexOfAny(u8, version_name, " |\t-/!") != null or strings.hasPrefixComptime(version_name, "npm:");
+                        const needs_quote = always_needs_quote or bun.strings.indexAnyComptime(version_name, " |\t-/!") != null or strings.hasPrefixComptime(version_name, "npm:");
 
                         if (needs_quote) {
                             try writer.writeByte('"');

--- a/src/io/fifo.zig
+++ b/src/io/fifo.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
-const assert = @import("root").bun.assert;
+const bun = @import("root").bun;
+const assert = bun.assert;
 
 /// An intrusive first in/first out linked list.
 /// The element type T must have a field called "next" of type ?*T

--- a/src/io/heap.zig
+++ b/src/io/heap.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
-const assert = @import("root").bun.assert;
+const bun = @import("root").bun;
+const assert = bun.assert;
 
 /// An intrusive heap implementation backed by a pairing heap[1] implementation.
 ///

--- a/src/io/time.zig
+++ b/src/io/time.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
-const assert = @import("root").bun.assert;
+const bun = @import("root").bun;
+const assert = bun.assert;
 const is_darwin = @import("builtin").target.isDarwin();
 
 pub const Time = struct {

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -569,11 +569,10 @@ fn windowsVolumeNameLenT(comptime T: type, path: []const T) struct { usize, usiz
                 }
             }
         } else {
-            // TODO(dylan-conway): use strings.indexOfAny instead of std
-            if (std.mem.indexOfAny(T, path[3..], comptime strings.literal(T, "/\\"))) |idx| {
+            if (bun.strings.indexAnyComptimeT(T, path[3..], comptime strings.literal(T, "/\\"))) |idx| {
                 // TODO: handle input "//abc//def" should be picked up as a unc path
                 if (path.len > idx + 4 and !Platform.windows.isSeparatorT(T, path[idx + 4])) {
-                    if (std.mem.indexOfAny(T, path[idx + 4 ..], comptime strings.literal(T, "/\\"))) |idx2| {
+                    if (bun.strings.indexAnyComptimeT(T, path[idx + 4 ..], comptime strings.literal(T, "/\\"))) |idx2| {
                         return .{ idx + idx2 + 4, idx + 3 };
                     } else {
                         return .{ path.len, idx + 3 };
@@ -623,15 +622,9 @@ pub fn windowsFilesystemRootT(comptime T: type, path: []const T) []const T {
         !Platform.windows.isSeparatorT(T, path[2]) and
         path[2] != '.')
     {
-        if (comptime T == u8) {
-            if (strings.indexOfAny(path[3..], "/\\")) |idx| {
-                // TODO: handle input "//abc//def" should be picked up as a unc path
-                return path[0 .. idx + 4];
-            }
-        } else {
-            if (std.mem.indexOfAny(T, path[3..], "/\\")) |idx| {
-                return path[0 .. idx + 4];
-            }
+        if (bun.strings.indexAnyComptimeT(T, path[3..], "/\\")) |idx| {
+            // TODO: handle input "//abc//def" should be picked up as a unc path
+            return path[0 .. idx + 4];
         }
     }
     if (isSepAnyT(T, path[0])) return path[0..1];

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -2910,10 +2910,7 @@ pub const Interpreter = struct {
             parent: ParentPtr,
             io: IO,
         ) *Binary {
-            var binary = interpreter.allocator.create(Binary) catch |err| {
-                std.debug.print("Ruh roh: {any}\n", .{err});
-                @panic("Ruh roh");
-            };
+            var binary = interpreter.allocator.create(Binary) catch |err| std.debug.panic("Ruh roh: {any}\n", .{err});
             binary.node = node;
             binary.base = .{ .kind = .binary, .interpreter = interpreter, .shell = shell_state };
             binary.parent = parent;
@@ -4350,10 +4347,7 @@ pub const Interpreter = struct {
             parent: ParentPtr,
             io: IO,
         ) *Cmd {
-            var cmd = interpreter.allocator.create(Cmd) catch |err| {
-                std.debug.print("Ruh roh: {any}\n", .{err});
-                @panic("Ruh roh");
-            };
+            var cmd = interpreter.allocator.create(Cmd) catch |err| std.debug.panic("Ruh roh: {any}\n", .{err});
             cmd.* = .{
                 .base = .{ .kind = .cmd, .interpreter = interpreter, .shell = shell_state },
                 .node = node,
@@ -10916,10 +10910,7 @@ pub fn StatePtrUnion(comptime TypesValue: anytype) type {
         }
 
         fn unknownTag(tag: Ptr.TagInt) void {
-            if (comptime bun.Environment.allow_assert) {
-                std.debug.print("Bad tag: {d}\n", .{tag});
-                @panic("Bad tag");
-            }
+            if (bun.Environment.allow_assert) std.debug.panic("Bad tag: {d}\n", .{tag});
         }
 
         fn tagInt(this: @This()) Ptr.TagInt {

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -2105,19 +2105,19 @@ pub const Token = union(TokenTag) {
         };
     }
 
-    pub fn debug(self: Token, buf: []const u8) void {
-        switch (self) {
-            .Var => |txt| {
-                std.debug.print("(var) {s}\n", .{buf[txt.start..txt.end]});
-            },
-            .Text => |txt| {
-                std.debug.print("(txt) {s}\n", .{buf[txt.start..txt.end]});
-            },
-            else => {
-                std.debug.print("{s}\n", .{@tagName(self)});
-            },
-        }
-    }
+    // pub fn debug(self: Token, buf: []const u8) void {
+    //     switch (self) {
+    //         .Var => |txt| {
+    //             std.debug.print("(var) {s}\n", .{buf[txt.start..txt.end]});
+    //         },
+    //         .Text => |txt| {
+    //             std.debug.print("(txt) {s}\n", .{buf[txt.start..txt.end]});
+    //         },
+    //         else => {
+    //             std.debug.print("{s}\n", .{@tagName(self)});
+    //         },
+    //     }
+    // }
 };
 
 pub const LexerAscii = NewLexer(.ascii);
@@ -3254,13 +3254,13 @@ pub fn NewLexer(comptime encoding: StringEncoding) type {
             return self.chars.read_char();
         }
 
-        fn debug_tokens(self: *const @This()) void {
-            std.debug.print("Tokens: \n", .{});
-            for (self.tokens.items, 0..) |tok, i| {
-                std.debug.print("{d}: ", .{i});
-                tok.debug(self.strpool.items[0..self.strpool.items.len]);
-            }
-        }
+        // fn debug_tokens(self: *const @This()) void {
+        //     std.debug.print("Tokens: \n", .{});
+        //     for (self.tokens.items, 0..) |tok, i| {
+        //         std.debug.print("{d}: ", .{i});
+        //         tok.debug(self.strpool.items[0..self.strpool.items.len]);
+        //     }
+        // }
     };
 }
 

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -225,6 +225,15 @@ pub inline fn indexAnyComptime(target: string, comptime chars: string) ?usize {
     return null;
 }
 
+pub inline fn indexAnyComptimeT(comptime T: type, target: []const T, comptime chars: []const T) ?usize {
+    for (target, 0..) |parent, i| {
+        inline for (chars) |char| {
+            if (char == parent) return i;
+        }
+    }
+    return null;
+}
+
 pub inline fn indexEqualAny(in: anytype, target: string) ?usize {
     for (in, 0..) |str, i| if (eqlLong(str, target, true)) return i;
     return null;


### PR DESCRIPTION
catching `std.mem.indexOfAny` found many cases that could use `bun.strings.indexAnyComptime` instead