### PR TITLE
Implement generational test isolation in `bun:test`

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -2814,12 +2814,13 @@ pub fn serve(
     globalObject: *JSC.JSGlobalObject,
     callframe: *JSC.CallFrame,
 ) callconv(.C) JSC.JSValue {
+    const vm = globalObject.bunVM();
     const arguments = callframe.arguments(2).slice();
     var config: JSC.API.ServerConfig = brk: {
         var exception_ = [1]JSC.JSValueRef{null};
         const exception = &exception_;
 
-        var args = JSC.Node.ArgumentsSlice.init(globalObject.bunVM(), arguments);
+        var args = JSC.Node.ArgumentsSlice.init(vm, arguments);
         const config_ = JSC.API.ServerConfig.fromJS(globalObject.ptr(), &args, exception);
         if (exception[0] != null) {
             globalObject.throwValue(exception_[0].?.value());
@@ -2836,7 +2837,7 @@ pub fn serve(
     var exception_value: *JSC.JSValue = undefined;
 
     if (config.allow_hot) {
-        if (globalObject.bunVM().hotMap()) |hot| {
+        if (vm.hotMap()) |hot| {
             if (config.id.len == 0) {
                 config.id = config.computeID(globalObject.allocator());
             }
@@ -2889,9 +2890,12 @@ pub fn serve(
             server.thisObject = obj;
 
             if (config.allow_hot) {
-                if (globalObject.bunVM().hotMap()) |hot| {
+                if (vm.hotMap()) |hot| {
                     hot.insert(config.id, server);
                 }
+            }
+            if (vm.resourceCleaner()) |cleaner| {
+                cleaner.add(server);
             }
             return obj;
         } else {
@@ -2910,10 +2914,14 @@ pub fn serve(
             server.thisObject = obj;
 
             if (config.allow_hot) {
-                if (globalObject.bunVM().hotMap()) |hot| {
+                if (vm.hotMap()) |hot| {
                     hot.insert(config.id, server);
                 }
             }
+            if (vm.resourceCleaner()) |cleaner| {
+                cleaner.add(server);
+            }
+
             return obj;
         }
     } else {
@@ -2933,9 +2941,12 @@ pub fn serve(
             server.thisObject = obj;
 
             if (config.allow_hot) {
-                if (globalObject.bunVM().hotMap()) |hot| {
+                if (vm.hotMap()) |hot| {
                     hot.insert(config.id, server);
                 }
+            }
+            if (vm.resourceCleaner()) |cleaner| {
+                cleaner.add(server);
             }
             return obj;
         } else {
@@ -2955,9 +2966,12 @@ pub fn serve(
             server.thisObject = obj;
 
             if (config.allow_hot) {
-                if (globalObject.bunVM().hotMap()) |hot| {
+                if (vm.hotMap()) |hot| {
                     hot.insert(config.id, server);
                 }
+            }
+            if (vm.resourceCleaner()) |cleaner| {
+                cleaner.add(server);
             }
             return obj;
         }

--- a/src/bun.js/test/TestCleanupHandler.zig
+++ b/src/bun.js/test/TestCleanupHandler.zig
@@ -54,7 +54,7 @@ const Cleanable = packed struct {
     const name = bun.meta.typeName;
 
     pub fn run(this: Cleanable, vm: *JSC.VirtualMachine) void {
-        switch (this.tag()) {
+        switch (this.ptr.tag()) {
             inline @field(Tag, name(Subprocess)),
             @field(Tag, name(TLSSocket)),
             @field(Tag, name(TCPSocket)),
@@ -65,7 +65,7 @@ const Cleanable = packed struct {
             @field(Tag, name(DebugHTTPSServer)),
             @field(Tag, name(ShellSubprocess)),
             => |tag| {
-                this.as(
+                this.ptr.as(
                     Type.typeFromTag(
                         @intFromEnum(
                             @field(

--- a/src/bun.js/test/TestCleanupHandler.zig
+++ b/src/bun.js/test/TestCleanupHandler.zig
@@ -1,0 +1,213 @@
+const std = @import("std");
+const bun = @import("root").bun;
+const default_allocator = bun.default_allocator;
+const string = bun.string;
+const MutableString = bun.MutableString;
+const strings = bun.strings;
+const Output = bun.Output;
+const jest = bun.JSC.Jest;
+const Jest = jest.Jest;
+const TestRunner = jest.TestRunner;
+const DescribeScope = jest.DescribeScope;
+const JSC = bun.JSC;
+const VirtualMachine = JSC.VirtualMachine;
+const JSGlobalObject = JSC.JSGlobalObject;
+const JSValue = JSC.JSValue;
+const JSInternalPromise = JSC.JSInternalPromise;
+const JSPromise = JSC.JSPromise;
+const JSType = JSValue.JSType;
+const JSError = JSC.JSError;
+const JSObject = JSC.JSObject;
+const CallFrame = JSC.CallFrame;
+const ZigString = JSC.ZigString;
+const Environment = bun.Environment;
+const Subprocess = bun.JSC.Subprocess;
+const TLSSocket = bun.JSC.API.TLSSocket;
+const TCPSocket = bun.JSC.API.TCPSocket;
+const Listener = bun.JSC.API.Listener;
+const HTTPServer = JSC.API.HTTPServer;
+const HTTPSServer = JSC.API.HTTPSServer;
+const DebugHTTPServer = JSC.API.DebugHTTPServer;
+const DebugHTTPSServer = JSC.API.DebugHTTPSServer;
+const ShellSubprocess = bun.shell.ShellSubprocess;
+pub const CleanableTypes = bun.TaggedPointerUnion(.{
+    Subprocess,
+    TLSSocket,
+    TCPSocket,
+    Listener,
+    HTTPServer,
+    HTTPSServer,
+    DebugHTTPServer,
+    DebugHTTPSServer,
+    ShellSubprocess,
+});
+
+pub const TestCleanupHandler = struct {
+    cleanables: std.AutoArrayHashMapUnmanaged(CleanableTypes, u32) = .{},
+    generation: u32 = 0,
+    state: State = .none,
+    current_cleanable: CleanableTypes = CleanableTypes.Null,
+
+    const State = enum {
+        none,
+        waiting,
+        running,
+    };
+
+    pub usingnamespace bun.New(@This());
+
+    pub fn add(this: *TestCleanupHandler, ptr: anytype) void {
+        _ = this.cleanables.getOrPutValue(bun.default_allocator, CleanableTypes.init(ptr), this.generation) catch bun.outOfMemory();
+    }
+
+    pub fn remove(this: *TestCleanupHandler, ptr: anytype) void {
+        const cleanable = CleanableTypes.init(ptr);
+        _ = this.cleanables.swapRemove(cleanable);
+    }
+
+    pub fn runAllAfter(this: *TestCleanupHandler, target: u32, vm: *JSC.VirtualMachine) void {
+        vm.test_cleaner = null;
+        const cleanables = this.cleanables.keys();
+        const generations = this.cleanables.values();
+        var i: usize = 0;
+        for (generations, cleanables, 0..) |gen, cleanable, idx| {
+            if (target <= gen) {
+                switch (cleanable.tag()) {
+                    inline @field(CleanableTypes.Tag, bun.meta.typeName(Subprocess)),
+                    @field(CleanableTypes.Tag, bun.meta.typeName(TLSSocket)),
+                    @field(CleanableTypes.Tag, bun.meta.typeName(TCPSocket)),
+                    @field(CleanableTypes.Tag, bun.meta.typeName(Listener)),
+                    @field(CleanableTypes.Tag, bun.meta.typeName(HTTPServer)),
+                    @field(CleanableTypes.Tag, bun.meta.typeName(HTTPSServer)),
+                    @field(CleanableTypes.Tag, bun.meta.typeName(DebugHTTPServer)),
+                    @field(CleanableTypes.Tag, bun.meta.typeName(DebugHTTPSServer)),
+                    @field(CleanableTypes.Tag, bun.meta.typeName(ShellSubprocess)),
+                    => |tag| {
+                        cleanable.as(
+                            CleanableTypes.typeFromTag(
+                                @intFromEnum(
+                                    @field(
+                                        CleanableTypes.Tag,
+                                        @tagName(tag),
+                                    ),
+                                ),
+                            ),
+                        ).onCleanup(vm);
+                    },
+                    else => {
+                        bun.assert(false);
+                    },
+                }
+            } else {
+                i = idx;
+            }
+        }
+
+        this.cleanables.shrinkRetainingCapacity(i);
+    }
+
+    pub fn runAll(this: *TestCleanupHandler, vm: *JSC.VirtualMachine) void {
+        const cleanables = this.cleanables;
+        this.cleanables = .{};
+        const ptrs = cleanables.keys();
+        for (ptrs) |cleanable| {
+            switch (cleanable.tag()) {
+                inline @field(CleanableTypes.Tag, bun.meta.typeName(Subprocess)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(TLSSocket)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(TCPSocket)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(Listener)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(HTTPServer)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(HTTPSServer)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(DebugHTTPServer)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(DebugHTTPSServer)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(ShellSubprocess)),
+                => |tag| {
+                    cleanable.as(
+                        CleanableTypes.typeFromTag(
+                            @intFromEnum(
+                                @field(
+                                    CleanableTypes.Tag,
+                                    @tagName(tag),
+                                ),
+                            ),
+                        ),
+                    ).onCleanup(vm);
+                },
+                else => {
+                    bun.assert(false);
+                },
+            }
+        }
+    }
+
+    pub fn run(this: *TestCleanupHandler, expected_generation: u32, vm: *JSC.VirtualMachine) void {
+        bun.assert(this.state != .running); // must not be re-entrant.
+        this.state = .running;
+        const cleanables = this.cleanables.keys();
+        const generations = this.cleanables.values();
+
+        var has_any_from_other_generations = false;
+        var i: usize = 0;
+        var last_i: usize = 0;
+        while (i < this.cleanables.count()) {
+            const generation = generations[i];
+            if (generation != expected_generation) {
+                has_any_from_other_generations = true;
+                i += 1;
+                last_i = i;
+                continue;
+            }
+
+            const cleanable = cleanables[i];
+
+            switch (cleanable.tag()) {
+                inline @field(CleanableTypes.Tag, bun.meta.typeName(Subprocess)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(TLSSocket)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(TCPSocket)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(Listener)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(HTTPServer)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(HTTPSServer)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(DebugHTTPServer)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(DebugHTTPSServer)),
+                @field(CleanableTypes.Tag, bun.meta.typeName(ShellSubprocess)),
+                => |tag| {
+                    this.current_cleanable = cleanable;
+                    cleanable.as(
+                        CleanableTypes.typeFromTag(
+                            @intFromEnum(
+                                @field(
+                                    CleanableTypes.Tag,
+                                    @tagName(tag),
+                                ),
+                            ),
+                        ),
+                    ).onCleanup(vm);
+                },
+                else => {
+                    bun.assert(false);
+                },
+            }
+
+            i += 1;
+        }
+
+        this.cleanables.shrinkRetainingCapacity(last_i);
+    }
+
+    pub fn beginCycle(this: *TestCleanupHandler, vm: *JSC.VirtualMachine) u32 {
+        bun.assert(this.state != .running);
+        this.state = .waiting;
+        vm.test_cleaner = this;
+        this.current_cleanable = CleanableTypes.Null;
+        return this.generation;
+    }
+
+    pub fn endCycle(this: *TestCleanupHandler, generation: u32, vm: *JSC.VirtualMachine) void {
+        vm.test_cleaner = null;
+        this.run(generation, vm);
+        this.state = .none;
+        if (generation == this.generation)
+            this.generation +%= 1;
+        this.current_cleanable = CleanableTypes.Null;
+    }
+};

--- a/src/tagged_pointer.zig
+++ b/src/tagged_pointer.zig
@@ -100,7 +100,7 @@ pub fn TaggedPointerUnion(comptime Types: anytype) type {
 
     const TagType: type = result.tag_type;
 
-    return struct {
+    return packed struct {
         pub const Tag = TagType;
         pub const TagInt = TagSize;
         pub const type_map: TypeMap(Types) = result.ty_map;

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1,5 +1,5 @@
 import { file, gc, Serve, serve, Server } from "bun";
-import { afterEach, describe, it, expect, afterAll } from "bun:test";
+import { afterEach, describe, it, expect, afterAll, beforeAll } from "bun:test";
 import { readFileSync, writeFileSync } from "fs";
 import { join, resolve } from "path";
 import { bunExe, bunEnv, dumpStats } from "harness";
@@ -19,6 +19,21 @@ afterEach(() => {
 
 const count = 200;
 let server: Server | undefined;
+beforeAll(() => {
+  try {
+    server = serve({
+      fetch() {
+        return new Response();
+      },
+      port: 0,
+    });
+  } catch (e: any) {
+    console.log("catch:", e);
+    if (e?.message !== `Failed to start server `) {
+      throw e;
+    }
+  }
+});
 
 async function runTest({ port, ...serverOptions }: Serve<any>, test: (server: Server) => Promise<void> | void) {
   if (server) {


### PR DESCRIPTION
### What does this PR do?

WIP. Towards #9243 

Adds `--isolate=lite` to `bun test`

After each `test()` ends:
- `kill()` all `Subprocess` and `Bun.$` created during the test
- Close all `Bun.serve()`, `Bun.connect()`, `Bun.listen()` created during the test

After each `.test.*` file finishes running:
- `kill()` all `Subprocess` and `Bun.$` created since the module started 
- Close all `Bun.serve()`, `Bun.connect()`, `Bun.listen()` created since the module started 

Before `bun test`'s process exits:
- `kill()` all `Subprocess` and `Bun.$`
- Close all `Bun.serve()`, `Bun.connect()`, `Bun.listen()`


##### How it works

Each test scope gets an (incremented) generation ID.  I/O resources add themselves to the list of active resources and add the current generation ID. Each time we finish a test, a module, or a test scope we run a cleanup function for each I/O resource that has a generation ID >= the current generation ID. 

TODO:
- [ ] Write tests for each type
- [ ] Store a pointer to `ActiveSpySet` in `DescribeScope` and `TestScope`, associate all mocks with these and restore all these mocks created per scope

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
