### PR TITLE
fix(stream) fix http body-stream sending duplicate data

### DIFF
--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1758,8 +1758,10 @@ it("#10177 response.write with non-ascii latin1 should not cause duplicated char
   // 128 = small than waterMark, 256 = waterMark, 1024 = large than waterMark
   // 8Kb = small than cork buffer
   // 16Kb = cork buffer
-  // 64Kb = large than cork buffer
-  const sizes = [128, 256, 1024, 8 * 1024, 16 * 1024, 64 * 1024];
+  // 32Kb = large than cork buffer
+  const start_size = 128;
+  const increment_step = 1024;
+  const end_size = 32 * 1024;
   let expected = "";
 
   function finish(err) {
@@ -1778,7 +1780,7 @@ it("#10177 response.write with non-ascii latin1 should not cause duplicated char
       expect(port).toBeGreaterThan(0);
 
       for (const char of chars) {
-        for (const size of sizes) {
+        for (let size = start_size; size <= end_size; size += increment_step) {
           expected = char + "-".repeat(size) + "x";
 
           try {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1774,13 +1774,14 @@ it("#10177 response.write with non-ascii latin1 should not cause duplicated char
       response.end();
     })
     .listen(0, "localhost", async (err, hostname, port) => {
+      expect(err).toBeFalsy();
+      expect(port).toBeGreaterThan(0);
+
       for (const char of chars) {
         for (const size of sizes) {
           expected = char + "-".repeat(size) + "x";
 
           try {
-            expect(err).toBeFalsy();
-            expect(port).toBeGreaterThan(0);
             const url = `http://${hostname}:${port}`;
             const count = 20;
             const all = [];

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1751,7 +1751,7 @@ it("#10177 response.write with non-ascii latin1 should not cause duplicated char
   const expected = "á" + "-".repeat(254) + "x";
   const server = require("http")
     .createServer((_, response) => {
-      response.write("á" + "-".repeat(254) + "x");
+      response.write(expected);
       response.write("");
       response.end();
     })
@@ -1773,7 +1773,7 @@ it("#10177 response.write with non-ascii latin1 should not cause duplicated char
           expect(result).toBe(expected);
         }
       } finally {
-        server.close();
+        server.closeAllConnections();
         Bun.gc(true);
       }
     });


### PR DESCRIPTION
### What does this PR do?
Fix: #10177 

This PR supersedes https://github.com/oven-sh/bun/pull/10205
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Added a test
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
