### PR TITLE
fix wrong truncation on `fs.writeFileSync` with fd argument

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5474,7 +5474,9 @@ pub const NodeFS = struct {
             }
         } else {
             // https://github.com/oven-sh/bun/issues/2931
-            if ((@intFromEnum(args.flag) & std.os.O.APPEND) == 0) {
+            // https://github.com/oven-sh/bun/issues/10222
+            // only truncate if we're not appending and writing to a path
+            if ((@intFromEnum(args.flag) & std.os.O.APPEND) == 0 and args.file != .fd) {
                 _ = ftruncateSync(.{ .fd = fd, .len = @as(JSC.WebCore.Blob.SizeType, @truncate(written)) });
             }
         }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2971,3 +2971,13 @@ describe.if(isWindows)("windows path handling", () => {
     });
   }
 });
+
+it("using writeFile on an fd does not truncate it", () => {
+  const temp = tmpdir();
+  const fd = fs.openSync(join(temp, "file.txt"), "w+");
+  fs.writeFileSync(fd, "x");
+  fs.writeFileSync(fd, "x");
+  // fs.close(fd);
+  const content = fs.readFileSync(join(temp, "file.txt"), "utf8");
+  expect(content).toBe("xx");
+})

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2980,4 +2980,4 @@ it("using writeFile on an fd does not truncate it", () => {
   fs.closeSync(fd);
   const content = fs.readFileSync(join(temp, "file.txt"), "utf8");
   expect(content).toBe("xx");
-})
+});

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2977,7 +2977,7 @@ it("using writeFile on an fd does not truncate it", () => {
   const fd = fs.openSync(join(temp, "file.txt"), "w+");
   fs.writeFileSync(fd, "x");
   fs.writeFileSync(fd, "x");
-  // fs.close(fd);
+  fs.closeSync(fd);
   const content = fs.readFileSync(join(temp, "file.txt"), "utf8");
   expect(content).toBe("xx");
 })


### PR DESCRIPTION
### What does this PR do?
Makes it so that using `writeFile` and `writeFileSync` with a file descriptor as an argument doesn't truncate the file after every write.

Fixes #10219
Fixes #10222

### How did you verify your code works?
Added a test
