### PR TITLE
fix(stream): flush enqueued entries on every pull on direct streams

### DIFF
--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -889,10 +889,8 @@ export function onPullDirectStream(controller) {
     return promiseToReturn;
   }
 
-  // not done, but they called flush()
-  if (deferFlush === 1) {
-    $onFlushDirectStream.$call(controller);
-  }
+  // coalesce all enqueued entries during $pull() and flush them
+  $onFlushDirectStream.$call(controller);
 
   return promiseToReturn;
 }

--- a/test/js/bun/stream/direct-readable-stream-suspense.test.tsx
+++ b/test/js/bun/stream/direct-readable-stream-suspense.test.tsx
@@ -1,0 +1,54 @@
+import { Suspense } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it } from "bun:test";
+
+if (!import.meta.resolveSync("react-dom/server").endsWith("server.bun.js")) {
+  throw new Error("react-dom/server is not the correct version:\n  " + import.meta.resolveSync("react-dom/server"));
+}
+
+describe("ReactDOM", () => {
+  it("should properly chunk Suspense boundaries", async () => {
+    const A = async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      return <div>hi</div>;
+    };
+
+    const B = async () => {
+      return (
+        // @ts-ignore
+        <Suspense fallback={<div>loading</div>}>
+          {/* @ts-ignore */}
+          <A />
+        </Suspense>
+      );
+    };
+    // @ts-ignore
+    const stream = await renderToReadableStream(<B />);
+
+    let text = "";
+    let numChunks = 0;
+    for await (const chunk of stream) {
+      text += new TextDecoder().decode(chunk);
+      numChunks++;
+    }
+
+    expect(text).toBe(
+      `<!--$?--><template id="B:0"></template><div>loading</div><!--/$--><div hidden id="S:0"><div>hi</div></div><script>$RC=function(b,c,e){c=document.getElementById(c);c.parentNode.removeChild(c);var a=document.getElementById(b);if(a){b=a.previousSibling;if(e)b.data="$!",a.setAttribute("data-dgst",e);else{e=b.parentNode;a=b.nextSibling;var f=0;do{if(a&&8===a.nodeType){var d=a.data;if("/$"===d)if(0===f)break;else f--;else"$"!==d&&"$?"!==d&&"$!"!==d||f++}d=a.nextSibling;e.removeChild(a);a=d}while(a);for(;c.firstChild;)e.insertBefore(c.firstChild,a);b.data="$"}b._reactRetry&&b._reactRetry()}};$RC("B:0","S:0")</script>`,
+    );
+    expect(numChunks).toBeGreaterThan(1);
+  });
+});
+const A = async () => {
+  await new Promise(resolve => setImmediate(resolve));
+  return <div>hi</div>;
+};
+
+const B = async () => {
+  return (
+    // @ts-ignore
+    <Suspense fallback={<div>loading</div>}>
+      {/* @ts-ignore */}
+      <A />
+    </Suspense>
+  );
+};


### PR DESCRIPTION
### What does this PR do?

Direct streams only flush their enqueued entries either 1) on close or 2) when the ReadableStreamController requests a flush. Libraries such as `react-dom/server` assume entries enqueued during a ReadableStreamController.pull() are flushed at times other than when the stream is closed.

To remedy this, we flush all enqueued entries in a direct stream at the end of a pull() invocation.

Fixes #7321.
Fixes #5664.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
