### PR TITLE
[bun:sqlite] Support `sqlite3_file_control`, better closing behavior, implement Disposable

### DIFF
--- a/docs/api/sqlite.md
+++ b/docs/api/sqlite.md
@@ -417,12 +417,12 @@ db.loadExtension("myext");
 To use the advanced `sqlite3_file_control` API, call `.fileControl(cmd, value)` on your `Database` instance.
 
 ```ts
-import { Database } from "bun:sqlite";
+import { Database, constants } from "bun:sqlite";
 
 const db = new Database();
 // Ensure WAL mode is NOT persistent
 // this prevents wal files from lingering after the database is closed
-db.fileControl(SQL.constants.SQLITE_FCNTL_PERSIST_WAL, 0);
+db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0);
 ```
 
 `value` can be:

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -24,7 +24,7 @@
  * | `null` | `NULL` |
  */
 declare module "bun:sqlite" {
-  export class Database {
+  export class Database implements Disposable {
     /**
      * Open or create a SQLite3 database
      *
@@ -257,7 +257,20 @@ declare module "bun:sqlite" {
      *
      * Internally, this calls `sqlite3_close_v2`.
      */
-    close(): void;
+    close(
+      /**
+       * If `true`, then the database will throw an error if it is in use
+       * @default false
+       *
+       * When true, this calls `sqlite3_close` instead of `sqlite3_close_v2`.
+       *
+       * Learn more about this in the [sqlite3 documentation](https://www.sqlite.org/c3ref/close.html).
+       *
+       * Bun will automatically call close by default when the database instance is garbage collected.
+       * In The future, Bun may default `throwOnError` to be true but for backwards compatibility, it is false by default.
+       */
+      throwOnError?: boolean,
+    ): void;
 
     /**
      * The filename passed when `new Database()` was called
@@ -303,6 +316,8 @@ declare module "bun:sqlite" {
      * @param path The path to the SQLite library
      */
     static setCustomSQLite(path: string): boolean;
+
+    [Symbol.dispose](): void;
 
     /**
      * Creates a function that always runs inside a transaction. When the
@@ -427,6 +442,17 @@ declare module "bun:sqlite" {
      * ```
      */
     static deserialize(serialized: NodeJS.TypedArray | ArrayBufferLike, isReadOnly?: boolean): Database;
+
+    /**
+     * See `sqlite3_file_control` for more information.
+     * @link https://www.sqlite.org/c3ref/file_control.html
+     */
+    fileControl(op: number, arg?: ArrayBufferView | number): number;
+    /**
+     * See `sqlite3_file_control` for more information.
+     * @link https://www.sqlite.org/c3ref/file_control.html
+     */
+    fileControl(zDbName: string, op: number, arg?: ArrayBufferView | number): number;
   }
 
   /**
@@ -455,7 +481,7 @@ declare module "bun:sqlite" {
    * // => undefined
    * ```
    */
-  export class Statement<ReturnType = unknown, ParamsType extends SQLQueryBindings[] = any[]> {
+  export class Statement<ReturnType = unknown, ParamsType extends SQLQueryBindings[] = any[]> implements Disposable {
     /**
      * Creates a new prepared statement from native code.
      *
@@ -634,6 +660,11 @@ declare module "bun:sqlite" {
     finalize(): void;
 
     /**
+     * Calls {@link finalize} if it wasn't already called.
+     */
+    [Symbol.dispose](): void;
+
+    /**
      * Return the expanded SQL string for the prepared statement.
      *
      * Internally, this calls `sqlite3_expanded_sql()` on the underlying `sqlite3_stmt`.
@@ -766,6 +797,187 @@ declare module "bun:sqlite" {
      * @constant 0x04
      */
     SQLITE_PREPARE_NO_VTAB: number;
+
+    /**
+     * @constant 1
+     */
+    SQLITE_FCNTL_LOCKSTATE: number;
+    /**
+     * @constant 2
+     */
+    SQLITE_FCNTL_GET_LOCKPROXYFILE: number;
+    /**
+     * @constant 3
+     */
+    SQLITE_FCNTL_SET_LOCKPROXYFILE: number;
+    /**
+     * @constant 4
+     */
+    SQLITE_FCNTL_LAST_ERRNO: number;
+    /**
+     * @constant 5
+     */
+    SQLITE_FCNTL_SIZE_HINT: number;
+    /**
+     * @constant 6
+     */
+    SQLITE_FCNTL_CHUNK_SIZE: number;
+    /**
+     * @constant 7
+     */
+    SQLITE_FCNTL_FILE_POINTER: number;
+    /**
+     * @constant 8
+     */
+    SQLITE_FCNTL_SYNC_OMITTED: number;
+    /**
+     * @constant 9
+     */
+    SQLITE_FCNTL_WIN32_AV_RETRY: number;
+    /**
+     * @constant 10
+     *
+     * Control whether or not the WAL is persisted
+     * Some versions of macOS configure WAL to be persistent by default.
+     *
+     * You can change this with code like the below:
+     * ```ts
+     * import { Database } from "bun:sqlite";
+     *
+     * const db = Database.open("mydb.sqlite");
+     * db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0);
+     * // enable WAL
+     * db.exec("PRAGMA journal_mode = WAL");
+     * // .. do some work
+     * db.close();
+     * ```
+     *
+     */
+    SQLITE_FCNTL_PERSIST_WAL: number;
+    /**
+     * @constant 11
+     */
+    SQLITE_FCNTL_OVERWRITE: number;
+    /**
+     * @constant 12
+     */
+    SQLITE_FCNTL_VFSNAME: number;
+    /**
+     * @constant 13
+     */
+    SQLITE_FCNTL_POWERSAFE_OVERWRITE: number;
+    /**
+     * @constant 14
+     */
+    SQLITE_FCNTL_PRAGMA: number;
+    /**
+     * @constant 15
+     */
+    SQLITE_FCNTL_BUSYHANDLER: number;
+    /**
+     * @constant 16
+     */
+    SQLITE_FCNTL_TEMPFILENAME: number;
+    /**
+     * @constant 18
+     */
+    SQLITE_FCNTL_MMAP_SIZE: number;
+    /**
+     * @constant 19
+     */
+    SQLITE_FCNTL_TRACE: number;
+    /**
+     * @constant 20
+     */
+    SQLITE_FCNTL_HAS_MOVED: number;
+    /**
+     * @constant 21
+     */
+    SQLITE_FCNTL_SYNC: number;
+    /**
+     * @constant 22
+     */
+    SQLITE_FCNTL_COMMIT_PHASETWO: number;
+    /**
+     * @constant 23
+     */
+    SQLITE_FCNTL_WIN32_SET_HANDLE: number;
+    /**
+     * @constant 24
+     */
+    SQLITE_FCNTL_WAL_BLOCK: number;
+    /**
+     * @constant 25
+     */
+    SQLITE_FCNTL_ZIPVFS: number;
+    /**
+     * @constant 26
+     */
+    SQLITE_FCNTL_RBU: number;
+    /**
+     * @constant 27
+     */
+    SQLITE_FCNTL_VFS_POINTER: number;
+    /**
+     * @constant 28
+     */
+    SQLITE_FCNTL_JOURNAL_POINTER: number;
+    /**
+     * @constant 29
+     */
+    SQLITE_FCNTL_WIN32_GET_HANDLE: number;
+    /**
+     * @constant 30
+     */
+    SQLITE_FCNTL_PDB: number;
+    /**
+     * @constant 31
+     */
+    SQLITE_FCNTL_BEGIN_ATOMIC_WRITE: number;
+    /**
+     * @constant 32
+     */
+    SQLITE_FCNTL_COMMIT_ATOMIC_WRITE: number;
+    /**
+     * @constant 33
+     */
+    SQLITE_FCNTL_ROLLBACK_ATOMIC_WRITE: number;
+    /**
+     * @constant 34
+     */
+    SQLITE_FCNTL_LOCK_TIMEOUT: number;
+    /**
+     * @constant 35
+     */
+    SQLITE_FCNTL_DATA_VERSION: number;
+    /**
+     * @constant 36
+     */
+    SQLITE_FCNTL_SIZE_LIMIT: number;
+    /**
+     * @constant 37
+     */
+    SQLITE_FCNTL_CKPT_DONE: number;
+    /**
+     * @constant 38
+     */
+    SQLITE_FCNTL_RESERVE_BYTES: number;
+    /**
+     * @constant 39
+     */
+    SQLITE_FCNTL_CKPT_START: number;
+    /**
+     * @constant 40
+     */
+    SQLITE_FCNTL_EXTERNAL_READER: number;
+    /**
+     * @constant 41
+     */
+    SQLITE_FCNTL_CKSM_FILE: number;
+    /**
+     * @constant 42
+     */
+    SQLITE_FCNTL_RESET_CACHE: number;
   };
 
   /**

--- a/src/bun.js/bindings/sqlite/lazy_sqlite3.h
+++ b/src/bun.js/bindings/sqlite/lazy_sqlite3.h
@@ -20,6 +20,8 @@ typedef int (*lazy_sqlite3_bind_parameter_index_type)(sqlite3_stmt*, const char*
 typedef int (*lazy_sqlite3_changes_type)(sqlite3*);
 typedef int (*lazy_sqlite3_clear_bindings_type)(sqlite3_stmt*);
 typedef int (*lazy_sqlite3_close_v2_type)(sqlite3*);
+typedef int (*lazy_sqlite3_close_type)(sqlite3*);
+typedef int (*lazy_sqlite3_file_control_type)(sqlite3*, const char* zDbName, int op, void* pArg);
 typedef int (*lazy_sqlite3_extended_result_codes_type)(sqlite3*, int onoff);
 typedef const void* (*lazy_sqlite3_column_blob_type)(sqlite3_stmt*, int iCol);
 typedef double (*lazy_sqlite3_column_double_type)(sqlite3_stmt*, int iCol);
@@ -100,6 +102,8 @@ static lazy_sqlite3_bind_text16_type lazy_sqlite3_bind_text16;
 static lazy_sqlite3_changes_type lazy_sqlite3_changes;
 static lazy_sqlite3_clear_bindings_type lazy_sqlite3_clear_bindings;
 static lazy_sqlite3_close_v2_type lazy_sqlite3_close_v2;
+static lazy_sqlite3_close_type lazy_sqlite3_close;
+static lazy_sqlite3_file_control_type lazy_sqlite3_file_control;
 static lazy_sqlite3_column_blob_type lazy_sqlite3_column_blob;
 static lazy_sqlite3_column_bytes_type lazy_sqlite3_column_bytes;
 static lazy_sqlite3_column_bytes16_type lazy_sqlite3_column_bytes16;
@@ -147,6 +151,8 @@ static lazy_sqlite3_memory_used_type lazy_sqlite3_memory_used;
 #define sqlite3_changes lazy_sqlite3_changes
 #define sqlite3_clear_bindings lazy_sqlite3_clear_bindings
 #define sqlite3_close_v2 lazy_sqlite3_close_v2
+#define sqlite3_close lazy_sqlite3_close
+#define sqlite3_file_control lazy_sqlite3_file_control
 #define sqlite3_column_blob lazy_sqlite3_column_blob
 #define sqlite3_column_bytes lazy_sqlite3_column_bytes
 #define sqlite3_column_count lazy_sqlite3_column_count
@@ -226,6 +232,8 @@ static int lazyLoadSQLite()
     lazy_sqlite3_changes = (lazy_sqlite3_changes_type)dlsym(sqlite3_handle, "sqlite3_changes");
     lazy_sqlite3_clear_bindings = (lazy_sqlite3_clear_bindings_type)dlsym(sqlite3_handle, "sqlite3_clear_bindings");
     lazy_sqlite3_close_v2 = (lazy_sqlite3_close_v2_type)dlsym(sqlite3_handle, "sqlite3_close_v2");
+    lazy_sqlite3_close = (lazy_sqlite3_close_type)dlsym(sqlite3_handle, "sqlite3_close");
+    lazy_sqlite3_file_control = (lazy_sqlite3_file_control_type)dlsym(sqlite3_handle, "sqlite3_file_control");
     lazy_sqlite3_column_blob = (lazy_sqlite3_column_blob_type)dlsym(sqlite3_handle, "sqlite3_column_blob");
     lazy_sqlite3_column_bytes = (lazy_sqlite3_column_bytes_type)dlsym(sqlite3_handle, "sqlite3_column_bytes");
     lazy_sqlite3_column_count = (lazy_sqlite3_column_count_type)dlsym(sqlite3_handle, "sqlite3_column_count");

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1,8 +1,8 @@
 import { expect, it, describe } from "bun:test";
 import { Database, constants, SQLiteError } from "bun:sqlite";
-import { existsSync, fstat, realpathSync, rmSync, writeFileSync } from "fs";
+import { existsSync, fstat, readdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { spawnSync } from "bun";
-import { bunExe } from "harness";
+import { bunExe, tempDirWithFiles } from "harness";
 import { tmpdir } from "os";
 import path from "path";
 
@@ -776,4 +776,105 @@ it.skipIf(
   expect(db.prepare("SELECT SIN(0.25)").all()).toEqual([{ "SIN(0.25)": 0.24740395925452294 }]);
   expect(db.prepare("SELECT SQRT(0.25)").all()).toEqual([{ "SQRT(0.25)": 0.5 }]);
   expect(db.prepare("SELECT TAN(0.25)").all()).toEqual([{ "TAN(0.25)": 0.25534192122103627 }]);
+});
+
+it("should close with WAL enabled", () => {
+  const dir = tempDirWithFiles("sqlite-wal-test", { "empty.txt": "" });
+  const file = path.join(dir, "my.db");
+  const db = new Database(file);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0);
+  db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+  db.exec("INSERT INTO foo (name) VALUES ('foo')");
+  expect(db.query("SELECT * FROM foo").all()).toEqual([{ id: 1, name: "foo" }]);
+  db.exec("PRAGMA wal_checkpoint(truncate)");
+  db.close();
+  expect(readdirSync(dir).sort()).toEqual(["empty.txt", "my.db"]);
+});
+
+it("close(true) should throw an error if the database is in use", () => {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+  db.exec("INSERT INTO foo (name) VALUES ('foo')");
+  const prepared = db.prepare("SELECT * FROM foo");
+  expect(() => db.close(true)).toThrow("database is locked");
+  prepared.finalize();
+  expect(() => db.close(true)).not.toThrow();
+});
+
+it("close() should NOT throw an error if the database is in use", () => {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+  db.exec("INSERT INTO foo (name) VALUES ('foo')");
+  const prepared = db.prepare("SELECT * FROM foo");
+  expect(() => db.close()).not.toThrow("database is locked");
+});
+
+it("should dispose AND throw an error if the database is in use", () => {
+  expect(() => {
+    {
+      using db = new Database(":memory:");
+      db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+      db.exec("INSERT INTO foo (name) VALUES ('foo')");
+      var prepared = db.prepare("SELECT * FROM foo");
+    }
+  }).toThrow("database is locked");
+});
+
+it("should dispose", () => {
+  expect(() => {
+    {
+      using db = new Database(":memory:");
+      db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+      db.exec("INSERT INTO foo (name) VALUES ('foo')");
+    }
+  }).not.toThrow();
+});
+
+it("can continue to use existing statements after database has been GC'd", async () => {
+  var called = false;
+  var registry = new FinalizationRegistry(() => {
+    called = true;
+  });
+  function leakTheStatement() {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+    db.exec("INSERT INTO foo (name) VALUES ('foo')");
+    const prepared = db.prepare("SELECT * FROM foo");
+    registry.register(db);
+    return prepared;
+  }
+
+  const stmt = leakTheStatement();
+  Bun.gc(true);
+  await Bun.sleep(1);
+  Bun.gc(true);
+  expect(stmt.all()).toEqual([{ id: 1, name: "foo" }]);
+  stmt.finalize();
+  expect(() => stmt.all()).toThrow();
+  expect(called).toBe(true);
+});
+
+it("statements should be disposable", () => {
+  {
+    using db = new Database("mydb.sqlite");
+    using query = db.query("select 'Hello world' as message;");
+    console.log(query.get()); // => { message: "Hello world" }
+  }
+});
+
+it("query should work if the cached statement was finalized", () => {
+  {
+    using db = new Database("mydb.sqlite");
+    {
+      using query = db.query("select 'Hello world' as message;");
+      var prevQuery = query;
+      query.get();
+    }
+    {
+      using query = db.query("select 'Hello world' as message;");
+      expect(() => query.get()).not.toThrow();
+    }
+    expect(() => prevQuery.get()).toThrow();
+  }
 });

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2,7 +2,7 @@ import { expect, it, describe } from "bun:test";
 import { Database, constants, SQLiteError } from "bun:sqlite";
 import { existsSync, fstat, readdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { spawnSync } from "bun";
-import { bunExe, tempDirWithFiles } from "harness";
+import { bunExe, isWindows, tempDirWithFiles } from "harness";
 import { tmpdir } from "os";
 import path from "path";
 
@@ -852,7 +852,10 @@ it("can continue to use existing statements after database has been GC'd", async
   expect(stmt.all()).toEqual([{ id: 1, name: "foo" }]);
   stmt.finalize();
   expect(() => stmt.all()).toThrow();
-  expect(called).toBe(true);
+  if (!isWindows) {
+    // on Windows, FinalizationRegistry is more flaky than on POSIX.
+    expect(called).toBe(true);
+  }
 });
 
 it("statements should be disposable", () => {


### PR DESCRIPTION
### What does this PR do?

You can now manage the lifetime of a `Database` instance in `bun:sqlite` via the `using` keyword:

```ts
import { Database } from "bun:sqlite";

{
  using db = new Database("mydb.sqlite");
  using query = db.query("select 'Hello world' as message;");
  console.log(query.get()); // => { message: "Hello world" }
}
```

`Database#fileControl` lets you use the `sqlite3_file_control` API

For example:

```ts
import { Database } from "bun:sqlite";

const db = new Database();
// Ensure WAL mode is NOT persistent
// this prevents wal files from lingering after the database is closed
db.fileControl(SQL.constants.SQLITE_FCNTL_PERSIST_WAL, 0);
```

Automatically closing databases when the `Database` object GC'd was not implemented correctly before (bun would only automatically close the database before process exit). This has now been fixed

`database.close(true)` will now throw an error if the database has any pending resources associated with it.

Fixes https://github.com/oven-sh/bun/issues/2537

### How did you verify your code works?

Tests