### PR TITLE
Correctly handle duplicate column names in sqlite joins

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -257,8 +257,6 @@ void us_internal_on_ssl_handshake(
 struct us_internal_ssl_socket_t *
 us_internal_ssl_socket_close(struct us_internal_ssl_socket_t *s, int code,
                              void *reason) {
-  struct us_internal_ssl_socket_context_t *context =
-      (struct us_internal_ssl_socket_context_t *)us_socket_context(0, &s->s);
 
   if (s->handshake_state != HANDSHAKE_COMPLETED) {
     // if we have some pending handshake we cancel it and try to check the

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -506,12 +506,12 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
 
             // When joining multiple tables, the same column names can appear multiple times
             // columnNames de-dupes property names internally
-            // We can't have two properties with the same name, so we use columnOffsets to track this.
-            int preCount = columnNames->size();
+            // We can't have two properties with the same name, so we use validColumns to track this.
+            auto preCount = columnNames->size();
             columnNames->add(
                 Identifier::fromString(vm, WTF::String::fromUTF8({name, len}))
             );
-            int curCount = columnNames->size();
+            auto curCount = columnNames->size();
 
             if (preCount != curCount) {
                 castedThis->validColumns.set(i);
@@ -541,7 +541,6 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
                 castedThis->columnNames->vm(),
                 castedThis->columnNames->propertyNameMode(),
                 castedThis->columnNames->privateSymbolMode()));
-            // castedThis->columnOffsets = 0;
             castedThis->validColumns.clearAll();
         }
     }
@@ -585,9 +584,9 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
             }
         }
 
-        int preCount = castedThis->columnNames->size();
+        auto preCount = castedThis->columnNames->size();
         castedThis->columnNames->add(key);
-        int curCount = castedThis->columnNames->size();
+        auto curCount = castedThis->columnNames->size();
 
         // only put the property if it's not a duplicate
         if (preCount != curCount) {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -797,7 +797,7 @@ it("issue#6597", () => {
   db.close();
 });
 
-it.only("issue#6597 with many columns", () => {
+it("issue#6597 with many columns", () => {
   // better-sqlite3 returns the last value of duplicate fields
   const db = new Database(":memory:");
   const count = 100;

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -883,11 +883,12 @@ it("close() should NOT throw an error if the database is in use", () => {
 
 it("should dispose AND throw an error if the database is in use", () => {
   expect(() => {
+    let prepared;
     {
       using db = new Database(":memory:");
       db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
       db.exec("INSERT INTO foo (name) VALUES ('foo')");
-      var prepared = db.prepare("SELECT * FROM foo");
+      prepared = db.prepare("SELECT * FROM foo");
     }
   }).toThrow("database is locked");
 });
@@ -903,8 +904,8 @@ it("should dispose", () => {
 });
 
 it("can continue to use existing statements after database has been GC'd", async () => {
-  var called = false;
-  var registry = new FinalizationRegistry(() => {
+  let called = false;
+  const registry = new FinalizationRegistry(() => {
     called = true;
   });
   function leakTheStatement() {
@@ -939,10 +940,11 @@ it("statements should be disposable", () => {
 
 it("query should work if the cached statement was finalized", () => {
   {
+    let prevQuery;
     using db = new Database("mydb.sqlite");
     {
       using query = db.query("select 'Hello world' as message;");
-      var prevQuery = query;
+      prevQuery = query;
       query.get();
     }
     {


### PR DESCRIPTION
### What does this PR do?
Makes it so that, when duplicate columns occur in an sqlite select statement, the last occurrence of the column is chosen.

Closes: #6597 
Closes: #7147

### How did you verify your code works?
New tests in sqlite.test.ts