### PR TITLE
Fix(windows) search correct path for esbuild(.exe|.cmd)

### DIFF
--- a/scripts/make-old-js.ps1
+++ b/scripts/make-old-js.ps1
@@ -3,7 +3,13 @@ $npm_client = "npm"
 # & ${npm_client} i
 
 $root = Join-Path (Split-Path -Path $MyInvocation.MyCommand.Definition -Parent) "..\"
+
+# search for .cmd or .exe 
 $esbuild = Join-Path $root "node_modules\.bin\esbuild.cmd"
+if (!(Test-Path $esbuild)) {
+    $esbuild = Join-Path $root "node_modules\.bin\esbuild.exe"
+}
+
 
 $env:NODE_ENV = "production"
 


### PR DESCRIPTION
### What does this PR do?

In my Windows build setup, I encountered an issue with the 'make-old-js.ps1' script. The script failed to launch 'esbuild.cmd' as expected, because the actual file located in the ".bin" folder is 'esbuild.exe'. In this PR, I've addressed this issue by first searching for '.cmd' file and then '.exe' if the first file is not found.

Error before fix:
![image](https://github.com/oven-sh/bun/assets/2702557/95e6c891-b81b-4cb7-9fd0-03781857e002)

"esbuild.exe" instead of "esbuild.cmd":
![image](https://github.com/oven-sh/bun/assets/2702557/a4294fb0-a2e5-4fc0-9800-7a4567ff1172)