### PR TITLE
Update platform.ts to fix isWindowsAVX2 implementation.

### DIFF
--- a/packages/bun-release/src/platform.ts
+++ b/packages/bun-release/src/platform.ts
@@ -111,7 +111,7 @@ function isWindowsAVX2(): boolean {
       spawn("powershell", [
         "-c",
         `(Add-Type -MemberDefinition '[DllImport("kernel32.dll")] public static extern bool IsProcessorFeaturePresent(int ProcessorFeature);' -Name 'Kernel32' -Namespace 'Win32' -PassThru)::IsProcessorFeaturePresent(40);`,
-      ]).stdout == "True"
+      ]).stdout.trim() === "True"
     );
   } catch (error) {
     debug("isWindowsAVX2 failed", error);


### PR DESCRIPTION
The isWindowsAVX2 function is not working as expected due to the stdout endwith `\r\n`. So the simple `stdout == "True"` will never true.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I tested the following code on my windows, and it works for me.

```ts
// windows-avx2-test.mts
import child_process from "child_process";
import { debug } from "console";

export function spawn(
  cmd: string,
  args: string[],
  options: child_process.SpawnOptions = {},
): {
  exitCode: number;
  stdout: string;
  stderr: string;
} {
  debug("spawn", [cmd, ...args].join(" "));
  const { status, stdout, stderr } = child_process.spawnSync(cmd, args, {
    stdio: "pipe",
    encoding: "utf-8",
    ...options,
  });
  return {
    exitCode: status ?? 1,
    stdout,
    stderr,
  };
}

function isWindowsAVX2(): boolean {
  try {
    const stdout = spawn("powershell", [
        "-c",
        `(Add-Type -MemberDefinition '[DllImport("kernel32.dll")] public static extern bool IsProcessorFeaturePresent(int ProcessorFeature);' -Name 'Kernel32' -Namespace 'Win32' -PassThru)::IsProcessorFeaturePresent(40);`,
    ]).stdout;
    const encoder = new TextEncoder(); 
    console.info(`stdout bytes: ${encoder.encode(stdout)}, True bytes: ${encoder.encode("True")}`)
    return stdout.trim() === "True"
  } catch (error) {
    debug("isWindowsAVX2 failed", error);
    return false;
  }
}

console.info(isWindowsAVX2())
```

```
Liu.D.H  playground   5.389s  09:59 > tsx windows-avx2-test.mts
spawn powershell -c (Add-Type -MemberDefinition '[DllImport("kernel32.dll")] public static extern bool IsProcessorFeaturePresent(int ProcessorFeature);' -Name 'Kernel32' -Namespace 'Win32' -PassThru)::IsProcessorFeaturePresent(40);
stdout bytes: 84,114,117,101,13,10, True bytes: 84,114,117,101
true

Liu.D.H  playground   5.729s  10:03 >
```

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
