### PR TITLE
fix(windows): check for `bunx` without exe extension

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1235,14 +1235,14 @@ pub const Command = struct {
 
     pub fn isBunX(argv0: []const u8) bool {
         if (Environment.isWindows) {
-            return strings.endsWithComptime(argv0, "bunx.exe");
+            return strings.endsWithComptime(argv0, "bunx.exe") or strings.endsWithComptime(argv0, "bunx");
         }
         return strings.endsWithComptime(argv0, "bunx");
     }
 
     pub fn isNode(argv0: []const u8) bool {
         if (Environment.isWindows) {
-            return strings.endsWithComptime(argv0, "node.exe");
+            return strings.endsWithComptime(argv0, "node.exe") or strings.endsWithComptime(argv0, "node");
         }
         return strings.endsWithComptime(argv0, "node");
     }


### PR DESCRIPTION
### What does this PR do?
In command prompt, argv0 is the first argument without changes. Most of the time it will just be `bun` without an extension. In powershell it becomes an absolute path to the executable: `<absolute path>/bun.exe`.

from https://learn.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-getcommandlinew

> Note  The name of the executable in the command line that the operating system provides to a process is not necessarily identical to that in the command line that the calling process gives to the [CreateProcess](https://learn.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa) function. The operating system may prepend a fully qualified path to an executable name that is provided without a fully qualified path.


fixes #10355 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
