### PR TITLE
fix(windows): revert thread naming code

### DIFF
--- a/src/Global.zig
+++ b/src/Global.zig
@@ -72,9 +72,8 @@ pub fn setThreadName(name: [:0]const u8) void {
     } else if (Environment.isMac) {
         _ = std.c.pthread_setname_np(name);
     } else if (Environment.isWindows) {
-        var name_buf: [1024]u16 = undefined;
-        const name_wide = bun.strings.convertUTF8toUTF16InBufferZ(&name_buf, name);
-        _ = SetThreadDescription(std.os.windows.kernel32.GetCurrentThread(), name_wide);
+        // TODO: use SetThreadDescription or NtSetInformationThread with 0x26 (ThreadNameInformation)
+        // without causing exit code 0xC0000409 (stack buffer overrun) in child process
     }
 }
 

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -682,6 +682,13 @@ pub fn handleSegfaultWindows(info: *windows.EXCEPTION_POINTERS) callconv(windows
             windows.EXCEPTION_ACCESS_VIOLATION => .{ .segmentation_fault = info.ExceptionRecord.ExceptionInformation[1] },
             windows.EXCEPTION_ILLEGAL_INSTRUCTION => .{ .illegal_instruction = info.ContextRecord.getRegs().ip },
             windows.EXCEPTION_STACK_OVERFLOW => .{ .stack_overflow = {} },
+
+            // exception used for thread naming
+            // https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2017/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2017#set-a-thread-name-by-throwing-an-exception
+            // related commit
+            // https://github.com/go-delve/delve/pull/1384
+            bun.windows.MS_VC_EXCEPTION => return bun.windows.EXCEPTION_CONTINUE_EXECUTION,
+
             else => return windows.EXCEPTION_CONTINUE_SEARCH,
         },
         null,
@@ -1330,11 +1337,11 @@ pub fn dumpStackTrace(trace: std.builtin.StackTrace) void {
     }
     // TODO: It would be reasonable, but hacky, to spawn LLVM-symbolizer here in
     // order to get the demangled stack traces.
-    var name_bytes: [1024]u8 = undefined;
-    for (trace.instruction_addresses[0..trace.index]) |addr| {
-        const line = StackLine.fromAddress(addr, &name_bytes);
-        stderr.print("- {}\n", .{line}) catch break;
-    }
+    // var name_bytes: [1024]u8 = undefined;
+    // for (trace.instruction_addresses[0..trace.index]) |addr| {
+    //     const line = StackLine.fromAddress(addr, &name_bytes);
+    //     stderr.print("- {}\n", .{line}) catch break;
+    // }
     const program = switch (bun.Environment.os) {
         .windows => "pdb-addr2line",
         else => "llvm-symbolizer",

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -1337,11 +1337,11 @@ pub fn dumpStackTrace(trace: std.builtin.StackTrace) void {
     }
     // TODO: It would be reasonable, but hacky, to spawn LLVM-symbolizer here in
     // order to get the demangled stack traces.
-    // var name_bytes: [1024]u8 = undefined;
-    // for (trace.instruction_addresses[0..trace.index]) |addr| {
-    //     const line = StackLine.fromAddress(addr, &name_bytes);
-    //     stderr.print("- {}\n", .{line}) catch break;
-    // }
+    var name_bytes: [1024]u8 = undefined;
+    for (trace.instruction_addresses[0..trace.index]) |addr| {
+        const line = StackLine.fromAddress(addr, &name_bytes) orelse continue;
+        stderr.print("- {}\n", .{line}) catch break;
+    }
     const program = switch (bun.Environment.os) {
         .windows => "pdb-addr2line",
         else => "llvm-symbolizer",

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -3524,3 +3524,6 @@ pub fn DeleteFileBun(sub_path_w: []const u16, options: DeleteFileOptions) bun.JS
 
     return .{ .result = {} };
 }
+
+pub const EXCEPTION_CONTINUE_EXECUTION = -1;
+pub const MS_VC_EXCEPTION = 0x406d1388;

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -36,7 +36,7 @@ test("module.Module works", () => {
 });
 
 test("_nodeModulePaths() works", () => {
-  const root = isWindows ? "C:\\" : "/";
+  const root = path.resolve("/");
   expect(() => {
     _nodeModulePaths();
   }).toThrow();


### PR DESCRIPTION
### What does this PR do?
Let's see test results. Ideally we don't remove `SetThreadDescription`, but for now we can format with `GetCurrentThreadID` and find a way to make it work later.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
