### PR TITLE
docs: fix invalid links to other pages

### DIFF
--- a/docs/bundler/loaders.md
+++ b/docs/bundler/loaders.md
@@ -175,7 +175,7 @@ In the bundler, `.node` files are handled using the [`file`](#file) loader.
 
 **SQLite loader**. `with { "type": "sqlite" }` import attribute
 
-In the runtime and bundler, SQLite databases can be directly imported. This will load the database using [`bun:sqlite`](/docs/api/sqlite.md).
+In the runtime and bundler, SQLite databases can be directly imported. This will load the database using [`bun:sqlite`](/docs/api/sqlite).
 
 ```ts
 import db from "./my.db" with { type: "sqlite" };

--- a/docs/cli/filter.md
+++ b/docs/cli/filter.md
@@ -39,7 +39,7 @@ Path patterns are specified by starting the pattern with `./`, and will select a
 
 ## Workspaces
 
-Filters respect your [workspace configuration](/docs/install/workspaces.md): If you have a `package.json` file that specifies which packages are part of the workspace,
+Filters respect your [workspace configuration](/docs/install/workspaces): If you have a `package.json` file that specifies which packages are part of the workspace,
 `--filter` will be restricted to only these packages. Also, in a workspace you can use `--filter` to run scripts in packages that are located anywhere in the workspace:
 
 ```bash

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -162,7 +162,7 @@ bun run --filter 'ba*' <script>
 ```
 will execute `<script>` in both `bar` and `baz`, but not in `foo`.
 
-Find more details in the docs page for [filter](/docs/cli/filter.md).
+Find more details in the docs page for [filter](/docs/cli/filter).
 
 ## `bun run -` to pipe code from stdin
 

--- a/docs/install/workspaces.md
+++ b/docs/install/workspaces.md
@@ -61,7 +61,7 @@ Workspaces have a couple major benefits.
 
 - **Code can be split into logical parts.** If one package relies on another, you can simply add it as a dependency in `package.json`. If package `b` depends on `a`, `bun install` will install your local `packages/a` directory into `node_modules` instead of downloading it from the npm registry.
 - **Dependencies can be de-duplicated.** If `a` and `b` share a common dependency, it will be _hoisted_ to the root `node_modules` directory. This reduces redundant disk usage and minimizes "dependency hell" issues associated with having multiple versions of a package installed simultaneously.
-- **Run scripts in multiple pacakges.** You can use the [`--filter` flag](/docs/cli/filter.md) to easily run `package.json` scripts in multiple packages in your workspace.
+- **Run scripts in multiple pacakges.** You can use the [`--filter` flag](/docs/cli/filter) to easily run `package.json` scripts in multiple packages in your workspace.
 
 {% callout %}
 ⚡️ **Speed** — Installs are fast, even for big monorepos. Bun installs the [Remix](https://github.com/remix-run/remix) monorepo in about `500ms` on Linux.


### PR DESCRIPTION
### What does this PR do?

- [x] Documentation
- [ ] Code changes

A few documentation links to other pages are defined with the `.md` extension which produces invalid links.

Simply removing the `.md` extension seems to fix the issue.

### How did you verify your code works?

Couldn't verify it as there is no documentation on how to deploy documentation but looking at other valid links, I'm pretty confident it will fix it.