### PR TITLE
Fix typo in workspaces docs "pacakges"

### DIFF
--- a/docs/install/workspaces.md
+++ b/docs/install/workspaces.md
@@ -61,7 +61,7 @@ Workspaces have a couple major benefits.
 
 - **Code can be split into logical parts.** If one package relies on another, you can simply add it as a dependency in `package.json`. If package `b` depends on `a`, `bun install` will install your local `packages/a` directory into `node_modules` instead of downloading it from the npm registry.
 - **Dependencies can be de-duplicated.** If `a` and `b` share a common dependency, it will be _hoisted_ to the root `node_modules` directory. This reduces redundant disk usage and minimizes "dependency hell" issues associated with having multiple versions of a package installed simultaneously.
-- **Run scripts in multiple pacakges.** You can use the [`--filter` flag](/docs/cli/filter) to easily run `package.json` scripts in multiple packages in your workspace.
+- **Run scripts in multiple packages.** You can use the [`--filter` flag](/docs/cli/filter) to easily run `package.json` scripts in multiple packages in your workspace.
 
 {% callout %}
 ⚡️ **Speed** — Installs are fast, even for big monorepos. Bun installs the [Remix](https://github.com/remix-run/remix) monorepo in about `500ms` on Linux.


### PR DESCRIPTION
### What does this PR do?

There is a typo in the [workspaces docs](https://bun.sh/docs/install/workspaces), where it says "pacakges" instead of packages.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
