### PR TITLE
Add powershell completer (#8939)

### DIFF
--- a/completions/bun.ps1
+++ b/completions/bun.ps1
@@ -1,0 +1,226 @@
+<#
+.SYNOPSIS
+  This is a PowerShell script that provides tab completion for the Bun CLI.
+
+.DESCRIPTION
+  This script will be installed into a users ~/.bun directory as bun.completion.ps1 by `bun completions`.
+  Users can source it in their PowerShell profile e.g. `. ~/.bun/bun.completion.ps1` to enable tab completion for the Bun CLI.
+
+.NOTES
+  Subcommands are defined in this script and where possible use `bun getcompletes` to provide dynamic auto-complete.
+  Subcommand argument completion uses `--help` on subcommands as required, so it's not as full featured as the bash completion script but it will stay in sync with args as bun is updated.
+  To provide more advanced auto-complete requires re-implementation of the bun arguments parsing in PowerShell, which is not feasible.
+  Ideally the `bun getcompletes` command could be extended to provide more completions then the shell completers can rely on it.
+#>
+
+# Pattern used to extract flags from `bun --help` output
+$script:BunHelpFlagPattern = "^\s+(?<Alias>-[\w]+)?,?\s+(?<LongName>--[-\w]+)?\s+(?<Description>.+?)$"
+# Global arguments are cached in memory after the first load
+$script:BunGlobalArguments = $null
+# Subcommands are manually defined because `bun getcompletes` doesn't provide info on them
+$script:BunSubCommands = @(
+  @{
+    Name        = "run"
+    Description = "Execute a file with Bun or run a package.json script"
+    Completers  = @(
+      {
+        # Get scripts runnable from package json via `bun getcompletes z`
+        param (
+          [string] $WordToComplete
+        )
+        $env:MAX_DESCRIPTION_LEN = 250
+        return & bun getcompletes z | Where-Object { $_ -like "$WordToComplete*" } | Foreach-Object {
+          $script = $_.Split("`t")
+          [System.Management.Automation.CompletionResult]::new($script[0], $script[0], 'ParameterValue', $script[1])
+        }
+      },
+      {
+        # Get bins runnable via `bun getcompletes b`
+        param (
+          [string] $WordToComplete
+        )
+        return & bun getcompletes b | Where-Object { $_ -like "$WordToComplete*" } | Foreach-Object {
+          [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+        }
+      },
+      {
+        # Get javascript files runnable via `bun getcompletes j`
+        param (
+          [string] $WordToComplete
+        )
+        return & bun getcompletes j | Where-Object { $_ -like "$WordToComplete*" } | ForEach-Object {
+          [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+        }
+      }
+    )
+  },
+  @{
+    Name        = "test"
+    Description = "Run unit tests with Bun"
+  },
+  @{
+    Name        = "x"
+    Description = "Execute a package binary (CLI), installing if needed (bunx)"
+  },
+  @{
+    Name        = "repl"
+    Description = "Start a REPL session with Bun"
+  },
+  @{
+    Name        = "exec"
+    Description = "Run a shell script directly with Bun"
+  },
+  @{
+    Name        = "install"
+    Alias       = "i"
+    Description = "Install dependencies for a package.json (bun i)"
+  },
+  @{
+    Name        = "add"
+    Alias       = "a"
+    Description = "Add a dependency to package.json (bun a)"
+    Completers  = @(
+      {
+        # Get frequently installed packages via `bun getcompletes a`
+        param (
+          [string] $WordToComplete
+        )
+        Write-Debug "Completing package names for $WordToComplete"
+        return & bun getcompletes a "$WordToComplete" | Foreach-Object {
+          Write-Debug "Completing package $_"
+          [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+        }
+      }
+    )
+  },
+  @{
+    Name        = "remove"
+    Alias       = "rm"
+    Description = "Remove a dependency from package.json (bun rm)"
+    Completers  = @(
+      {
+        # Remove dependencies from package.json, this is not available in getcompletes
+        param (
+          [string] $WordToComplete
+        )
+        if (Test-Path "package.json") {
+          $packageJson = Get-Content "package.json" -Raw | ConvertFrom-Json
+          $packageJson.dependencies.PSObject.Properties.Name | Where-Object { $_ -like "$WordToComplete*" } | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+          }
+        }
+      }
+    )
+  },
+  @{
+    Name        = "update"
+    Description = "Update outdated dependencies"
+  },
+  @{
+    Name        = "link"
+    Description = "Register or link a local npm package"
+  },
+  @{
+    Name        = "unlink"
+    Description = "Unregister a local npm package"
+  },
+  @{
+    Name        = "pm"
+    Description = "Additional package management utilities"
+  },
+  @{
+    Name        = "build"
+    Description = "Bundle TypeScript & JavaScript into a single file"
+  },
+  @{
+    Name        = "init"
+    Description = "Start an empty Bun project from a blank template"
+  },
+  @{
+    Name        = "create"
+    Alias       = "c"
+    Description = "Create a new project from a template (bun c)"
+  },
+  @{
+    Name        = "upgrade"
+    Description = "Upgrade to latest version of Bun."
+  }
+)
+
+function Get-BunSubCommandCompletions {
+  param (
+    [string] $SubCommandName,
+    [System.Management.Automation.Language.CommandAst] $CommandAst,
+    [string] $WordToComplete
+  )
+
+  $subCommandCompletions = @()
+
+  $subCommand = $script:BunSubCommands | Where-Object { $_.Name -eq $SubCommandName -or $_.Alias -eq $SubCommandName }
+
+  if ($null -eq $subCommand -and $CommandAst.CommandElements.Count -le 2) {
+    # Get the subcommand name completions
+    $script:BunSubCommands | Where-Object { $_.Name -like "$WordToComplete*" } | ForEach-Object {
+      $subCommandCompletions += [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Description)
+    }
+  } elseif ($subCommand -and ($CommandAst.CommandElements.Count -gt 2 -or [string]::IsNullOrWhiteSpace($WordToComplete))) {
+    # Invoke all dynamic completers for the subcommand
+    $subCommandCompletions += $subCommand.Completers | ForEach-Object {
+      $_.Invoke($WordToComplete)
+    }
+
+    # Get all arguments exposed in help with regex capture https://regex101.com/r/lTzfLB/1
+    & bun $SubCommandName --help *>&1 | Select-String $script:BunHelpFlagPattern | ForEach-Object {
+
+      $alias = $_.Matches.Groups | Where-Object { $_.Name -eq 'Alias' } | Select-Object -ExpandProperty Value
+      $name = $_.Matches.Groups | Where-Object { $_.Name -eq 'LongName' } | Select-Object -ExpandProperty Value
+      $description = $_.Matches.Groups | Where-Object { $_.Name -eq 'Description' } | Select-Object -ExpandProperty Value
+
+      if (($null -ne $name -and $name -like "$WordToComplete*") -or ($null -ne $alias -and $alias -like "$WordToComplete*")) {
+        $completionName = if (-not [string]::IsNullOrWhiteSpace($name)) { $name } else { $alias }
+        $subCommandCompletions += [System.Management.Automation.CompletionResult]::new($completionName, $completionName, 'ParameterValue', $description)
+      }
+    }
+  }
+
+  return $subCommandCompletions
+}
+
+function Get-BunGlobalArgumentCompletions {
+  param (
+    [string] $WordToComplete
+  )
+
+  # These don't change often, keep them in memory after the first load
+  if ($null -eq $script:BunGlobalArguments) {
+    $script:BunGlobalArguments = @()
+    & bun --help *>&1 | Select-String $script:BunHelpFlagPattern | ForEach-Object {
+
+      $alias = $_.Matches.Groups | Where-Object { $_.Name -eq 'Alias' } | Select-Object -ExpandProperty Value
+      $name = $_.Matches.Groups | Where-Object { $_.Name -eq 'LongName' } | Select-Object -ExpandProperty Value
+      $description = $_.Matches.Groups | Where-Object { $_.Name -eq 'Description' } | Select-Object -ExpandProperty Value
+
+      $completionName = if (-not [string]::IsNullOrWhiteSpace($name)) { $name } else { $alias }
+      $script:BunGlobalArguments += [System.Management.Automation.CompletionResult]::new($completionName, $completionName, 'ParameterValue', $description)
+    }
+  }
+
+  return $script:BunGlobalArguments | Where-Object { $_.Name -like "$WordToComplete*" } | ForEach-Object {
+    [CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Description)
+  }
+}
+
+Register-ArgumentCompleter -Native -CommandName "bun" -ScriptBlock {
+  param(
+    [string] $WordToComplete,
+    [System.Management.Automation.Language.CommandAst] $CommandAst,
+    [int] $CursorPosition
+  )
+
+  $subCommandName = if ($CommandAst.CommandElements.Count -ge 2) { $CommandAst.CommandElements[1].Extent.Text.Trim() } else { $null }
+
+  $completions = @()
+  $completions += Get-BunSubCommandCompletions -SubCommandName $subCommandName -CommandAst $CommandAst -WordToComplete $WordToComplete
+  $completions += Get-BunGlobalArgumentCompletions -WordToComplete $WordToComplete
+  return $completions | Select-Object * -Unique | Foreach-Object { [System.Management.Automation.CompletionResult]::new($_.CompletionText, $_.ListItemText, $_.ResultType, $_.ToolTip) }
+}

--- a/root.zig
+++ b/root.zig
@@ -17,6 +17,7 @@ pub const completions = struct {
     pub const bash = @embedFile("./completions/bun.bash");
     pub const zsh = @embedFile("./completions/bun.zsh");
     pub const fish = @embedFile("./completions/bun.fish");
+    pub const pwsh = @embedFile("./completions/bun.ps1");
 };
 
 pub const JavaScriptCore = @import("./src/jsc.zig");

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1094,9 +1094,6 @@ pub const RunCommand = struct {
                                 bun.copy(u8, path_buf[dir_slice.len..], base);
                                 path_buf[dir_slice.len + base.len] = 0;
                                 const slice = path_buf[0 .. dir_slice.len + base.len :0];
-                                if (Environment.isWindows) {
-                                    @panic("TODO");
-                                }
                                 if (!(bun.sys.isExecutableFilePath(slice))) continue;
                                 // we need to dupe because the string pay point to a pointer that only exists in the current scope
                                 _ = try results.getOrPut(this_bundler.fs.filename_store.append(@TypeOf(base), base) catch continue);

--- a/src/cli/shell_completions.zig
+++ b/src/cli/shell_completions.zig
@@ -20,12 +20,14 @@ pub const Shell = enum {
     const bash_completions = @import("root").completions.bash;
     const zsh_completions = @import("root").completions.zsh;
     const fish_completions = @import("root").completions.fish;
+    const pwsh_completions = @import("root").completions.pwsh;
 
     pub fn completions(this: Shell) []const u8 {
         return switch (this) {
             .bash => bun.asByteSlice(bash_completions),
             .zsh => bun.asByteSlice(zsh_completions),
             .fish => bun.asByteSlice(fish_completions),
+            .pwsh => bun.asByteSlice(pwsh_completions),
             else => "",
         };
     }

--- a/src/cli/uninstall.ps1
+++ b/src/cli/uninstall.ps1
@@ -82,6 +82,14 @@ try {
   exit 1
 }
 
+# Remove autocomplete loader from user's PROFILE, Do not fail if an error happens here
+try {
+  $profileContent = Get-Content $PROFILE.CurrentUserCurrentHost -Raw -ErrorAction SilentlyContinue
+  if ($profileContent | Select-String -SimpleMatch "bun.completion.ps1" -Quiet) {
+    $profileContent -replace "^.+bun\.completion\.ps1.+$", "" | Set-Content -Path $PROFILE.CurrentUserCurrentHost
+  }
+} catch {}
+
 # Delete some tempdir files. Do not fail if an error happens here
 try {
   Remove-Item "${Temp}\bun-*" -Recurse -Force

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2233,27 +2233,14 @@ pub fn isExecutableFileOSPath(path: bun.OSPathSliceZ) bool {
         // Rationale: `GetBinaryTypeW` does not work on .cmd files.
         // Windows does not have executable permission like posix does, instead we
         // can just look at the file extension to determine executable status.
-        @compileError("Do not use isExecutableFilePath on Windows");
-
-        // var out: windows.DWORD = 0;
-        // const rc = kernel32.GetBinaryTypeW(path, &out);
-
-        // const result = if (rc == windows.FALSE)
-        //     false
-        // else switch (out) {
-        //     kernel32.SCS_32BIT_BINARY,
-        //     kernel32.SCS_64BIT_BINARY,
-        //     kernel32.SCS_DOS_BINARY,
-        //     kernel32.SCS_OS216_BINARY,
-        //     kernel32.SCS_PIF_BINARY,
-        //     kernel32.SCS_POSIX_BINARY,
-        //     => true,
-        //     else => false,
-        // };
-
-        // log("GetBinaryTypeW({}) = {d}. isExecutable={}", .{ bun.fmt.utf16(path), out, result });
-
-        // return result;
+        const stringPath = bun.String.createFromOSPath(path);
+        if (stringPath.asUTF8()) |utf8Path| {
+            const windowsExecutableExtensions = [_][]const u8{ ".exe", ".cmd", ".bat" };
+            const extension = std.fs.path.extension(utf8Path);
+            return bun.strings.containsAny(windowsExecutableExtensions, extension);
+        } else {
+            return false;
+        }
     }
 
     @compileError("TODO: isExecutablePath");


### PR DESCRIPTION
### What does this PR do?

This adds completions for PowerShell. It should work back to PowerShell v5 and cross platform.  
Rather than add hard coded completions it pulls available args from the bun help.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Built and installed on Windows for now, the idea needs fleshing out which is why this is a draft.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
