### PR TITLE
update crash handler

### DIFF
--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -33,7 +33,7 @@ const debug = std.debug;
 pub const enable = true;
 
 /// Override with BUN_CRASH_REPORT_URL enviroment variable.
-const default_report_base_url = "https://bun.report/";
+const default_report_base_url = "https://bun.report";
 
 /// Only print the `Bun has crashed` message once. Once this is true, control
 /// flow is not returned to the main application.
@@ -583,7 +583,7 @@ pub fn reportBaseUrl() []const u8 {
     return static.base_url orelse {
         const computed = computed: {
             if (bun.getenvZ("BUN_CRASH_REPORT_URL")) |url| {
-                break :computed url;
+                break :computed bun.strings.withoutTrailingSlash(url);
             }
             break :computed default_report_base_url;
         };

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -1339,7 +1339,10 @@ pub fn dumpStackTrace(trace: std.builtin.StackTrace) void {
     // order to get the demangled stack traces.
     var name_bytes: [1024]u8 = undefined;
     for (trace.instruction_addresses[0..trace.index]) |addr| {
-        const line = StackLine.fromAddress(addr, &name_bytes) orelse continue;
+        const line = StackLine.fromAddress(addr, &name_bytes) orelse {
+            stderr.print("- ??? at 0x{X}\n", .{addr}) catch break;
+            continue;
+        };
         stderr.print("- {}\n", .{line}) catch break;
     }
     const program = switch (bun.Environment.os) {


### PR DESCRIPTION
### What does this PR do?
format lines when the trace is unknown
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
