### PR TITLE
fix hang when spawning many processes

### DIFF
--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -261,11 +261,14 @@ pub const Process = struct {
                         if (err_.getErrno() == .SRCH) {
                             break :brk Status.from(pid, &PosixSpawn.wait4(
                                 pid,
-                                // normally we would use WNOHANG to avoid blocking the event loop
-                                // however, there seems to be a race condition where the operating system
+                                // Normally we would use WNOHANG to avoid blocking the event loop.
+                                // However, there seems to be a race condition where the operating system
                                 // tells us that the process has already exited (ESRCH) but the waitpid
                                 // call with WNOHANG doesn't return the status yet.
                                 // As a workaround, we use 0 to block the event loop until the status is available.
+                                // This should be fine because the process has already exited, so the data
+                                // should become available basically immediately. Also, testing has shown that this
+                                // occurs extremely rarely and only under high load.
                                 0,
                                 &rusage_result,
                             ));

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -261,7 +261,12 @@ pub const Process = struct {
                         if (err_.getErrno() == .SRCH) {
                             break :brk Status.from(pid, &PosixSpawn.wait4(
                                 pid,
-                                if (this.sync) 0 else std.os.W.NOHANG,
+                                // normally we would use WNOHANG to avoid blocking the event loop
+                                // however, there seems to be a race condition where the operating system
+                                // tells us that the process has already exited (ESRCH) but the waitpid
+                                // call with WNOHANG doesn't return the status yet.
+                                // As a workaround, we use 0 to block the event loop until the status is available.
+                                0,
                                 &rusage_result,
                             ));
                         }


### PR DESCRIPTION
### What does this PR do?
Fixes flaky test failure on macos in `spawn.test.ts` when spawning many processes.

### How did you verify your code works?
tests now work consistently
