### PR TITLE
Switch to `quick_exit`

### DIFF
--- a/src/Global.zig
+++ b/src/Global.zig
@@ -99,6 +99,9 @@ pub fn exit(code: u8) noreturn {
 }
 
 pub fn exitWide(code: u32) noreturn {
+    if (comptime Environment.isMac) {
+        std.c.exit(@bitCast(code));
+    }
     bun.C.quick_exit(@bitCast(code));
 }
 

--- a/src/Global.zig
+++ b/src/Global.zig
@@ -99,7 +99,7 @@ pub fn exit(code: u8) noreturn {
 }
 
 pub fn exitWide(code: u32) noreturn {
-    std.c.exit(@bitCast(code));
+    bun.C.quick_exit(@bitCast(code));
 }
 
 pub fn raiseIgnoringPanicHandler(sig: anytype) noreturn {

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -545,7 +545,11 @@ extern "C" void bun_initialize_process()
     Bun__setCTRLHandler(1);
 #endif
 
+#if OS(DARWIN)
     atexit(Bun__onExit);
+#else
+    at_quick_exit(Bun__onExit);
+#endif
 }
 
 #if OS(WINDOWS)

--- a/src/darwin_c.zig
+++ b/src/darwin_c.zig
@@ -801,7 +801,3 @@ pub const RENAME_NOFOLLOW_ANY = 0x00000010;
 
 // int renameatx_np(int fromfd, const char *from, int tofd, const char *to, unsigned int flags);
 pub extern "c" fn renameatx_np(fromfd: c_int, from: ?[*:0]const u8, tofd: c_int, to: ?[*:0]const u8, flags: c_uint) c_int;
-
-pub fn quick_exit(code: c_int) noreturn {
-    std.c.exit(code);
-}

--- a/src/darwin_c.zig
+++ b/src/darwin_c.zig
@@ -801,3 +801,7 @@ pub const RENAME_NOFOLLOW_ANY = 0x00000010;
 
 // int renameatx_np(int fromfd, const char *from, int tofd, const char *to, unsigned int flags);
 pub extern "c" fn renameatx_np(fromfd: c_int, from: ?[*:0]const u8, tofd: c_int, to: ?[*:0]const u8, flags: c_uint) c_int;
+
+pub fn quick_exit(code: c_int) noreturn {
+    std.c.exit(code);
+}

--- a/src/linux_c.zig
+++ b/src/linux_c.zig
@@ -674,3 +674,5 @@ pub extern "C" fn sys_pwritev2(
 pub const RENAME_NOREPLACE = 1 << 0;
 pub const RENAME_EXCHANGE = 1 << 1;
 pub const RENAME_WHITEOUT = 1 << 2;
+
+pub extern "C" fn quick_exit(code: c_int) noreturn;

--- a/src/main.zig
+++ b/src/main.zig
@@ -49,4 +49,5 @@ pub fn main() void {
     }
 
     bun.CLI.Cli.start(bun.default_allocator);
+    bun.Global.exit(0);
 }

--- a/src/windows_c.zig
+++ b/src/windows_c.zig
@@ -1431,3 +1431,5 @@ pub fn deleteOpenedFile(fd: bun.FileDescriptor) Maybe(void) {
 }
 
 pub extern fn windows_enable_stdio_inheritance() void;
+
+pub extern "c" fn quick_exit(code: c_int) noreturn;


### PR DESCRIPTION
### What does this PR do?
Prevents global destructors from triggering while still allowing us to use exit handlers. `quick_exit` is not implemented on macos, we probably will want some kind of global thread termination function in the future.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
let's see what CI says
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
