### PR TITLE
fix 10474

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -3399,8 +3399,9 @@ pub const Parser = struct {
                     decls[0] = .{
                         .binding = p.b(B.Identifier{ .ref = p.dirname_ref }, logger.Loc.Empty),
                         .value = p.newExpr(
-                            // TODO: test UTF-8 file paths
-                            E.String.init(p.source.path.name.dir),
+                            E.UTF8String{
+                                .data = p.source.path.name.dir,
+                            },
                             logger.Loc.Empty,
                         ),
                     };
@@ -3410,7 +3411,9 @@ pub const Parser = struct {
                     decls[@as(usize, @intFromBool(uses_dirname))] = .{
                         .binding = p.b(B.Identifier{ .ref = p.filename_ref }, logger.Loc.Empty),
                         .value = p.newExpr(
-                            E.String.init(p.source.path.text),
+                            E.UTF8String{
+                                .data = p.source.path.text,
+                            },
                             logger.Loc.Empty,
                         ),
                     };

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -63,4 +63,23 @@ describe("bun build", () => {
     });
     expect(exitCode).toBe(0);
   });
+
+  test("__dirname and __filename are printed correctly", () => {
+    const baseDir = `${tmpdir()}/bun-build-dirname-filename-${Date.now()}`;
+    fs.mkdirSync(baseDir, { recursive: true });
+    fs.mkdirSync(path.join(baseDir, "我")), { recursive: true };
+    fs.writeFileSync(path.join(baseDir, "我", "我.ts"), "console.log(__dirname); console.log(__filename);");
+    const { exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), "build", path.join(baseDir, "我/我.ts"), "--compile", "--outfile", path.join(baseDir, "exe.exe")],
+      env: bunEnv,
+      cwd: baseDir,
+    });
+    expect(exitCode).toBe(0);
+
+    const { stdout, stderr } = Bun.spawnSync({
+      cmd: [path.join(baseDir, "exe.exe")],
+    });
+    expect(stdout.toString()).toContain(path.join(baseDir, "我"));
+    expect(stdout.toString()).toContain(path.join(baseDir, "我", "我.ts"));
+  });
 });

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -79,7 +79,7 @@ describe("bun build", () => {
     const { stdout, stderr } = Bun.spawnSync({
       cmd: [path.join(baseDir, "exe.exe")],
     });
-    expect(stdout.toString()).toContain(path.join(baseDir, "我"));
-    expect(stdout.toString()).toContain(path.join(baseDir, "我", "我.ts"));
+    expect(stdout.toString()).toContain(path.join(baseDir, "我") + "\n");
+    expect(stdout.toString()).toContain(path.join(baseDir, "我", "我.ts") + "\n");
   });
 });


### PR DESCRIPTION
### What does this PR do?
fixes #10474 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
