### PR TITLE
Fix Linux spawn issue

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -2156,8 +2156,7 @@ pub const Subprocess = struct {
 
         if (comptime is_sync) {
             switch (subprocess.process.watchOrReap()) {
-                .result => {
-                },
+                .result => {},
                 .err => {
                     subprocess.process.wait(true);
                 },

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -2107,7 +2107,7 @@ pub const Subprocess = struct {
         var send_exit_notification = false;
 
         if (comptime !is_sync) {
-            switch (subprocess.process.watch(jsc_vm)) {
+            switch (subprocess.process.watch()) {
                 .result => {},
                 .err => {
                     send_exit_notification = true;
@@ -2150,7 +2150,7 @@ pub const Subprocess = struct {
         }
 
         if (comptime is_sync) {
-            switch (subprocess.process.watch(jsc_vm)) {
+            switch (subprocess.process.watch()) {
                 .result => {},
                 .err => {
                     subprocess.process.wait(true);

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -240,7 +240,13 @@ pub const LifecycleScriptSubprocess = struct {
         this.process = process;
         process.setExitHandler(this);
 
-        try process.watch(event_loop).unwrap();
+        switch (process.watchOrReap()) {
+            .err => |err| {
+                if (!process.hasExited())
+                    process.onExit(.{ .err = err }, &std.mem.zeroes(bun.spawn.Rusage));
+            },
+            .result => {},
+        }
     }
 
     pub fn printOutput(this: *LifecycleScriptSubprocess) void {

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -889,7 +889,7 @@ pub const ShellSubprocess = struct {
         var send_exit_notification = false;
 
         if (comptime !is_sync) {
-            switch (subprocess.process.watch(event_loop)) {
+            switch (subprocess.process.watch()) {
                 .result => {},
                 .err => {
                     send_exit_notification = true;


### PR DESCRIPTION
### What does this PR do?

This makes the error handling code for spawning processes work better in cases where a seccomp filter is used to block pidfd_open 

Fixes https://github.com/oven-sh/bun/issues/10490 (likely)

Might help with https://github.com/oven-sh/bun/issues/10018
Might help with https://github.com/oven-sh/bun/issues/9924


### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
