### PR TITLE
fix some `child_process` tests

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -364,13 +364,17 @@ function execFile(file, args, options, callback) {
             encodedLength += actualLen;
 
             if (encodedLength > maxBuffer) {
-              let combined = ArrayPrototypeJoin.$call(array, "") + chunk;
+              const joined = ArrayPrototypeJoin.$call(array, "");
+              let combined = joined + chunk;
               combined = StringPrototypeSlice.$call(combined, 0, maxBuffer);
-              array = [combined];
+              array.length = 1;
+              array[0] = combined;
               ex = ERR_CHILD_PROCESS_STDIO_MAXBUFFER(kind);
               kill();
             } else {
-              array = [ArrayPrototypeJoin.$call(array, "") + chunk];
+              const val = ArrayPrototypeJoin.$call(array, "") + chunk;
+              array.length = 1;
+              array[0] = val;
             }
           } else {
             $arrayPush(array, chunk);


### PR DESCRIPTION
### What does this PR do?
Fixes how we handle `maxBuffer` in `node:child_process`.

### How did you verify your code works?
Tests now pass consistently on macos and linux (unrelated issues on windows persist)
