### PR TITLE
fix child-process-exec test on windows

### DIFF
--- a/test/js/node/child_process/child-process-exec.test.ts
+++ b/test/js/node/child_process/child-process-exec.test.ts
@@ -1,17 +1,34 @@
 import { test, expect, describe } from "bun:test";
-import { bunExe } from "harness";
+import { bunExe, isWindows } from "harness";
 import { exec } from "node:child_process";
+
+const SIZE = 262145;
 
 // https://github.com/oven-sh/bun/issues/5319
 describe("child_process.exec", () => {
+  const shell = Bun.which(isWindows ? "powershell" : "bash");
+
   describe.each(["stdout", "stderr"])("%s", io => {
-    const script = io === "stdout" ? `printf '=%.0s' {1..262145}` : `printf '=%.0s' {1..262145} 1>&2`;
+    let script;
+    if (isWindows) {
+      if (io === "stdout") {
+        script = `[Console]::Out.Write.Invoke('=' * ${SIZE})`
+      } else {
+        script = `[Console]::Error.Write.Invoke('=' * ${SIZE})`
+      }
+    } else {
+      if (io === "stdout") {
+        script = `printf '=%.0s' {1..${SIZE}}`;
+      } else {
+        script = `printf '=%.0s' {1..${SIZE}} 1>&2`;
+      }
+    }
 
     test("no encoding", async () => {
       const { resolve, reject, promise } = Promise.withResolvers();
       exec(
         script,
-        { maxBuffer: 1024 * 1024 * 10, encoding: "buffer", shell: Bun.which("bash") },
+        { maxBuffer: 1024 * 1024 * 10, encoding: "buffer", shell },
         (err, stdout, stderr) => {
           if (err) {
             reject(err);
@@ -23,14 +40,14 @@ describe("child_process.exec", () => {
       const { stdout, stderr } = await promise;
       const out = io === "stdout" ? stdout : stderr;
       const other = io === "stdout" ? stderr : stdout;
-      expect(out).toHaveLength(262145);
+      expect(out).toHaveLength(SIZE);
       expect(out).toBeInstanceOf(Buffer);
       expect(other).toEqual(Buffer.alloc(0));
     });
 
     test("Infinity maxBuffer", async () => {
       const { resolve, reject, promise } = Promise.withResolvers();
-      exec(script, { maxBuffer: Infinity, shell: Bun.which("bash") }, (err, stdout, stderr) => {
+      exec(script, { maxBuffer: Infinity, shell }, (err, stdout, stderr) => {
         if (err) {
           reject(err);
         } else {
@@ -40,13 +57,13 @@ describe("child_process.exec", () => {
       const { stdout, stderr } = await promise;
       const out = io === "stdout" ? stdout : stderr;
       const other = io === "stdout" ? stderr : stdout;
-      expect(out).toHaveLength(262145);
+      expect(out).toHaveLength(SIZE);
       expect(other).toBe("");
     });
 
     test("large output", async () => {
       const { resolve, reject, promise } = Promise.withResolvers();
-      exec(script, { maxBuffer: 1024 * 1024 * 10, shell: Bun.which("bash") }, (err, stdout, stderr) => {
+      exec(script, { maxBuffer: 1024 * 1024 * 10, shell }, (err, stdout, stderr) => {
         if (err) {
           reject(err);
         } else {
@@ -56,13 +73,13 @@ describe("child_process.exec", () => {
       const { stdout, stderr } = await promise;
       const out = io === "stdout" ? stdout : stderr;
       const other = io === "stdout" ? stderr : stdout;
-      expect(out).toHaveLength(262145);
+      expect(out).toHaveLength(SIZE);
       expect(other).toBe("");
     });
 
     test("exceeding maxBuffer should throw", async () => {
       const { resolve, reject, promise } = Promise.withResolvers();
-      exec(script, { maxBuffer: 1024 * 100, shell: Bun.which("bash") }, (err, stdout, stderr) => {
+      exec(script, { maxBuffer: 1024 * 100, shell }, (err, stdout, stderr) => {
         resolve({ stdout, stderr, err });
       });
       const { stdout, stderr, err } = await promise;
@@ -76,7 +93,7 @@ describe("child_process.exec", () => {
 
     test("exceeding maxBuffer should truncate output length", async () => {
       const { resolve, reject, promise } = Promise.withResolvers();
-      exec(script, { maxBuffer: 1024 * 255 - 1, shell: Bun.which("bash") }, (err, stdout, stderr) => {
+      exec(script, { maxBuffer: 1024 * 255 - 1, shell }, (err, stdout, stderr) => {
         resolve({ stdout, stderr, err });
       });
       const { stdout, stderr, err } = await promise;

--- a/test/js/node/child_process/child-process-exec.test.ts
+++ b/test/js/node/child_process/child-process-exec.test.ts
@@ -12,9 +12,9 @@ describe("child_process.exec", () => {
     let script;
     if (isWindows) {
       if (io === "stdout") {
-        script = `[Console]::Out.Write.Invoke('=' * ${SIZE})`
+        script = `[Console]::Out.Write.Invoke('=' * ${SIZE})`;
       } else {
-        script = `[Console]::Error.Write.Invoke('=' * ${SIZE})`
+        script = `[Console]::Error.Write.Invoke('=' * ${SIZE})`;
       }
     } else {
       if (io === "stdout") {
@@ -26,17 +26,13 @@ describe("child_process.exec", () => {
 
     test("no encoding", async () => {
       const { resolve, reject, promise } = Promise.withResolvers();
-      exec(
-        script,
-        { maxBuffer: 1024 * 1024 * 10, encoding: "buffer", shell },
-        (err, stdout, stderr) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve({ stdout, stderr });
-          }
-        },
-      );
+      exec(script, { maxBuffer: 1024 * 1024 * 10, encoding: "buffer", shell }, (err, stdout, stderr) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ stdout, stderr });
+        }
+      });
       const { stdout, stderr } = await promise;
       const out = io === "stdout" ? stdout : stderr;
       const other = io === "stdout" ? stderr : stdout;


### PR DESCRIPTION
### What does this PR do?
Fixes the `child-process-exec` test on windows by adding a powershell alternative to the bash scripts.

### How did you verify your code works?
Tests now pass (note that two of the remaining failing tests are fixed in #10521 as the changes apply to all platforms )
