### PR TITLE
fix flaky jsonwebtoken tests

### DIFF
--- a/test/js/third_party/jsonwebtoken/claim-iat.test.js
+++ b/test/js/third_party/jsonwebtoken/claim-iat.test.js
@@ -15,7 +15,7 @@ function signWithIssueAt(issueAt, options, callback) {
   const opts = Object.assign({ algorithm: "HS256" }, options);
   // async calls require a truthy secret
   // see: https://github.com/brianloveswords/node-jws/issues/62
-  testUtils.signJWTHelper(payload, "secret", opts, callback);
+  testUtils.signJWTHelperWithoutAddingTimestamp(payload, "secret", opts, callback);
 }
 
 function verifyWithIssueAt(token, maxAge, options, secret, callback) {
@@ -38,7 +38,7 @@ describe("issue at", function () {
 
     // undefined needs special treatment because {} is not the same as {iat: undefined}
     it("should error with iat of undefined", function (done) {
-      testUtils.signJWTHelper({ iat: undefined }, "secret", { algorithm: "HS256" }, err => {
+      testUtils.signJWTHelperWithoutAddingTimestamp({ iat: undefined }, "secret", { algorithm: "HS256" }, err => {
         testUtils.asyncCheck(done, () => {
           expect(err).toBeInstanceOf(Error);
           expect(err.message).toEqual('"iat" should be a number of seconds');

--- a/test/js/third_party/jsonwebtoken/test-utils.js
+++ b/test/js/third_party/jsonwebtoken/test-utils.js
@@ -116,11 +116,14 @@ function verifyJWTHelper(jwtString, secretOrPrivateKey, options, callback) {
  * @param {function(err, token):void} callback
  */
 function signJWTHelper(payload, secretOrPrivateKey, options, callback) {
-  jwt.sign(payload, secretOrPrivateKey, options, (err, asyncSigned) => {
+  // make sure they are created with the same timestamp
+  // https://github.com/auth0/node-jsonwebtoken/blob/bc28861f1fa981ed9c009e29c044a19760a0b128/sign.js#L185
+  const timestamp = Math.floor(Date.now() / 1000);
+  jwt.sign({ ...payload, iat: timestamp }, secretOrPrivateKey, options, (err, asyncSigned) => {
     let error;
     let syncSigned;
     try {
-      syncSigned = jwt.sign(payload, secretOrPrivateKey, options);
+      syncSigned = jwt.sign({ ...payload, iat: timestamp }, secretOrPrivateKey, options);
     } catch (err) {
       error = err;
     }

--- a/test/js/third_party/jsonwebtoken/test-utils.js
+++ b/test/js/third_party/jsonwebtoken/test-utils.js
@@ -119,11 +119,39 @@ function signJWTHelper(payload, secretOrPrivateKey, options, callback) {
   // make sure they are created with the same timestamp
   // https://github.com/auth0/node-jsonwebtoken/blob/bc28861f1fa981ed9c009e29c044a19760a0b128/sign.js#L185
   const timestamp = Math.floor(Date.now() / 1000);
-  jwt.sign({ ...payload, iat: timestamp }, secretOrPrivateKey, options, (err, asyncSigned) => {
+  if (typeof payload === "object" && !Buffer.isBuffer(payload) && !payload.iat) {
+    payload = { ...payload, iat: timestamp };
+  }
+  jwt.sign(payload, secretOrPrivateKey, options, (err, asyncSigned) => {
     let error;
     let syncSigned;
     try {
-      syncSigned = jwt.sign({ ...payload, iat: timestamp }, secretOrPrivateKey, options);
+      syncSigned = jwt.sign(payload, secretOrPrivateKey, options);
+    } catch (err) {
+      error = err;
+    }
+    try {
+      expectError(error, err);
+      if (error) {
+        callback(err);
+      } else {
+        expect(syncSigned).toEqual(asyncSigned);
+        callback(null, syncSigned);
+      }
+    } catch (err) {
+      callback(err);
+    }
+  });
+}
+
+// Same as above but won't automatically set the iat field. When we implement fake timers,
+// we can delete this function and use the one above with a fake timer.
+function signJWTHelperWithoutAddingTimestamp(payload, secretOrPrivateKey, options, callback) {
+  jwt.sign(payload, secretOrPrivateKey, options, (err, asyncSigned) => {
+    let error;
+    let syncSigned;
+    try {
+      syncSigned = jwt.sign(payload, secretOrPrivateKey, options);
     } catch (err) {
       error = err;
     }
@@ -147,5 +175,6 @@ export default {
   asyncCheck,
   base64UrlEncode,
   signJWTHelper,
+  signJWTHelperWithoutAddingTimestamp,
   verifyJWTHelper,
 };


### PR DESCRIPTION
### What does this PR do?
Uses the same timestamp for both
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
