### PR TITLE
fix: never create more than one stdin tty

### DIFF
--- a/src/bun.js/bindings/ProcessBindingTTYWrap.cpp
+++ b/src/bun.js/bindings/ProcessBindingTTYWrap.cpp
@@ -29,7 +29,7 @@
 
 #if OS(WINDOWS)
 
-extern "C" int Source__setRawModeStdin(uv_loop_t* loop, bool raw);
+extern "C" int Source__setRawModeStdin(bool raw);
 
 namespace UV {
 
@@ -198,9 +198,8 @@ JSC_DEFINE_HOST_FUNCTION(jsTTYSetMode, (JSC::JSGlobalObject * globalObject, Call
     bool raw = flag.asBoolean();
 
     Zig::GlobalObject* global = jsCast<Zig::GlobalObject*>(globalObject);
-    uv_loop_t* loop = global->uvLoop();
 
-    return Source__setRawModeStdin(loop, raw);
+    return Source__setRawModeStdin(raw);
 #else
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/src/bun.js/bindings/ProcessBindingTTYWrap.cpp
+++ b/src/bun.js/bindings/ProcessBindingTTYWrap.cpp
@@ -29,6 +29,8 @@
 
 #if OS(WINDOWS)
 
+extern "C" int Source__setRawModeStdin(uv_loop_t* loop, bool raw);
+
 namespace UV {
 
 class TTY {
@@ -49,18 +51,6 @@ public:
     }
 };
 
-}
-
-static uv_tty_t* getSharedHandle(int fd, uv_loop_t* loop)
-{
-    static thread_local uv_tty_t* sharedHandle = nullptr;
-
-    if (!sharedHandle) {
-        sharedHandle = new uv_tty_t;
-        memset(sharedHandle, 0, sizeof(uv_tty_t));
-        uv_tty_init(loop, sharedHandle, fd, 0);
-    }
-    return sharedHandle;
 }
 
 #endif
@@ -203,7 +193,14 @@ extern "C" int Bun__ttySetMode(int fd, int mode);
 JSC_DEFINE_HOST_FUNCTION(jsTTYSetMode, (JSC::JSGlobalObject * globalObject, CallFrame* callFrame))
 {
 #if OS(WINDOWS)
-    RELEASE_ASSERT_NOT_REACHED();
+    ASSERT(callFrame->argumentCount() == 1);
+    auto flag = callFrame->argument(0);
+    bool raw = flag.asBoolean();
+
+    Zig::GlobalObject* global = jsCast<Zig::GlobalObject*>(globalObject);
+    uv_loop_t* loop = global->uvLoop();
+
+    return Source__setRawModeStdin(loop, raw);
 #else
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -487,6 +487,10 @@ pub fn WindowsPipeReader(
                         pipe.close(onPipeClose);
                     },
                     .tty => |tty| {
+                        if (Source.stdin_tty == tty) {
+                            Source.stdin_tty = null;
+                        }
+
                         tty.data = tty;
                         tty.close(onTTYClose);
                     },

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -487,8 +487,9 @@ pub fn WindowsPipeReader(
                         pipe.close(onPipeClose);
                     },
                     .tty => |tty| {
-                        if (Source.stdin_tty == tty) {
-                            Source.stdin_tty = null;
+                        if (tty == &Source.stdin_tty) {
+                            Source.stdin_tty = undefined;
+                            Source.stdin_tty_init = false;
                         }
 
                         tty.data = tty;


### PR DESCRIPTION
### What does this PR do?

Multiple `uv_tty_t`s were created, and keypress events were not routed correctly.

This resolves some raw mode issues on Windows

Fixes #10217
Fixes #9944
Fixes #9870
