### PR TITLE
Support comments & trailing commas in require/import `package.json`

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1672,6 +1672,10 @@ pub const Path = struct {
 
     pub fn isJSONCFile(this: *const Path) bool {
         const str = this.name.filename;
+        if (strings.eqlComptime(str, "package.json")) {
+            return true;
+        }
+
         if (!(strings.hasPrefixComptime(str, "tsconfig.") or strings.hasPrefixComptime(str, "jsconfig."))) {
             return false;
         }

--- a/src/js/builtins/ImportMetaObject.ts
+++ b/src/js/builtins/ImportMetaObject.ts
@@ -149,7 +149,7 @@ export function internalRequire(this: ImportMetaObject, id) {
   }
 
   // TODO: remove this hardcoding
-  if (last5 === ".json") {
+  if (last5 === ".json" && !id.endsWith?.("package.json")) {
     var fs = (globalThis[Symbol.for("_fs")] ||= Bun.fs());
     var exports = JSON.parse(fs.readFileSync(id, "utf8"));
     $requireMap.$set(id, $createCommonJSModule(id, exports, true, undefined));

--- a/test/cli/run/require-and-import-trailing.test.ts
+++ b/test/cli/run/require-and-import-trailing.test.ts
@@ -1,0 +1,29 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+test("require() with trailing slash", () => {
+  const requireDir = tempDirWithFiles("require-trailing", {
+    "package.json": `
+    {
+      // Comments!
+      "name": "require-and-import-trailing",
+      "version": "1.0.0",
+    },`,
+  });
+
+  expect(require(requireDir + "/package.json").name).toBe("require-and-import-trailing");
+});
+
+test("import() with trailing slash", async () => {
+  const importDir = tempDirWithFiles("import-trailing", {
+    "package.json": `
+    {
+      // Comments!
+      "name": "require-and-import-trailing",
+      "version": "1.0.0",
+    },`,
+  });
+
+  expect((await import(importDir + "/package.json")).default.name).toBe("require-and-import-trailing");
+});


### PR DESCRIPTION
### What does this PR do?

Supports `require("./package.json")` and `await import("./package.json")` when the json file has comments or trailing commas

### How did you verify your code works?

There is a test