### PR TITLE
Fixes #4718

### DIFF
--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -518,7 +518,7 @@ pub const Request = struct {
             const value_type = value.jsType();
             const explicit_check = values_to_try.len == 2 and value_type == .FinalObject and values_to_try[1].jsType() == .DOMWrapper;
             if (value_type == .DOMWrapper) {
-                if (value.as(Request)) |request| {
+                if (value.asDirect(Request)) |request| {
                     if (values_to_try.len == 1) {
                         request.cloneInto(&req, globalThis.allocator(), globalThis, fields.contains(.url));
                         return req;
@@ -547,7 +547,7 @@ pub const Request = struct {
                     }
                 }
 
-                if (value.as(JSC.WebCore.Response)) |response| {
+                if (value.asDirect(JSC.WebCore.Response)) |response| {
                     if (!fields.contains(.method)) {
                         req.method = response.init.method;
                         fields.insert(.method);

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -529,7 +529,7 @@ pub const Response = struct {
             return that;
         }
 
-        pub fn init(allocator: std.mem.Allocator, ctx: *JSGlobalObject, response_init: JSC.JSValue) !?Init {
+        pub fn init(_: std.mem.Allocator, ctx: *JSGlobalObject, response_init: JSC.JSValue) !?Init {
             var result = Init{ .status_code = 200 };
 
             if (!response_init.isCell())
@@ -538,7 +538,7 @@ pub const Response = struct {
             if (response_init.jsType() == .DOMWrapper) {
                 // fast path: it's a Request object or a Response object
                 // we can skip calling JS getters
-                if (response_init.as(Request)) |req| {
+                if (response_init.asDirect(Request)) |req| {
                     if (req.headers) |headers| {
                         if (!headers.isEmpty()) {
                             result.headers = headers.cloneThis(ctx);
@@ -549,7 +549,7 @@ pub const Response = struct {
                     return result;
                 }
 
-                if (response_init.as(Response)) |resp| {
+                if (response_init.asDirect(Response)) |resp| {
                     return resp.init.clone(ctx);
                 }
             }
@@ -580,10 +580,8 @@ pub const Response = struct {
             }
 
             if (response_init.fastGet(ctx, .method)) |method_value| {
-                var method_str = method_value.toSlice(ctx, allocator);
-                defer method_str.deinit();
-                if (method_str.len > 0) {
-                    result.method = Method.which(method_str.slice()) orelse .GET;
+                if (Method.fromJS(ctx, method_value)) |method| {
+                    result.method = method;
                 }
             }
 
@@ -1755,9 +1753,25 @@ pub const Fetch = struct {
         // TODO: move this into a DRYer implementation
         // The status quo is very repetitive and very bug prone
         if (first_arg.as(Request)) |request| {
+            const can_use_fast_getters = first_arg.asDirect(Request) == request;
+            const slow_getters: ?JSC.JSValue = if (can_use_fast_getters) null else first_arg;
             request.ensureURL() catch unreachable;
 
-            if (request.url.isEmpty()) {
+            var url_str = request.url;
+            var need_to_deinit_url_str = false;
+            defer if (need_to_deinit_url_str) url_str.deref();
+
+            if (!can_use_fast_getters) {
+                if (first_arg.fastGet(globalThis, .url)) |url_value| {
+                    url_str = url_value.toBunString(globalThis);
+                    need_to_deinit_url_str = true;
+                    if (globalThis.hasException()) {
+                        return .zero;
+                    }
+                }
+            }
+
+            if (url_str.isEmpty()) {
                 const err = JSC.toTypeError(.ERR_INVALID_ARG_VALUE, fetch_error_blank_url, .{}, ctx);
                 // clean hostname if any
                 if (hostname) |host| {
@@ -1768,8 +1782,8 @@ pub const Fetch = struct {
                 return JSPromise.rejectedPromiseValue(globalThis, err);
             }
 
-            if (request.url.hasPrefixComptime("data:")) {
-                var url_slice = request.url.toUTF8WithoutRef(allocator);
+            if (url_str.hasPrefixComptime("data:")) {
+                var url_slice = url_str.toUTF8WithoutRef(allocator);
                 defer url_slice.deinit();
 
                 var data_url = DataURL.parseWithoutCheck(url_slice.slice()) catch {
@@ -1777,11 +1791,11 @@ pub const Fetch = struct {
                     return JSPromise.rejectedPromiseValue(globalThis, err);
                 };
 
-                data_url.url = request.url;
+                data_url.url = url_str;
                 return dataURLResponse(data_url, globalThis, allocator);
             }
 
-            url = ZigURL.fromString(allocator, request.url) catch {
+            url = ZigURL.fromString(allocator, url_str) catch {
                 const err = JSC.toTypeError(.ERR_INVALID_ARG_VALUE, "fetch() URL is invalid", .{}, ctx);
                 // clean hostname if any
                 if (hostname) |host| {
@@ -1799,15 +1813,17 @@ pub const Fetch = struct {
             if (!is_file_url) {
                 if (args.nextEat()) |options| {
                     if (options.isObject() or options.jsType() == .DOMWrapper) {
-                        if (options.fastGet(ctx.ptr(), .method)) |method_| {
-                            var slice_ = method_.toSlice(ctx.ptr(), allocator);
-                            defer slice_.deinit();
-                            method = Method.which(slice_.slice()) orelse .GET;
-                        } else {
+                        if (options.fastGetOrElse(ctx.ptr(), .method, slow_getters)) |method_| {
+                            method = Method.fromJS(ctx, method_) orelse .GET;
+                        } else if (can_use_fast_getters) {
                             method = request.method;
                         }
 
-                        if (options.fastGet(ctx.ptr(), .body)) |body__| {
+                        if (options.fastGetOrElse(
+                            ctx.ptr(),
+                            .body,
+                            slow_getters,
+                        )) |body__| {
                             if (Body.Value.fromJS(ctx.ptr(), body__)) |body_const| {
                                 var body_value = body_const;
                                 // TODO: buffer ReadableStream?
@@ -1826,7 +1842,7 @@ pub const Fetch = struct {
                             body = request.body.value.useAsAnyBlob();
                         }
 
-                        if (options.fastGet(ctx.ptr(), .headers)) |headers_| {
+                        if (options.fastGetOrElse(ctx.ptr(), .headers, slow_getters)) |headers_| {
                             if (headers_.as(FetchHeaders)) |headers__| {
                                 if (headers__.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
                                     if (hostname) |host| {
@@ -1954,7 +1970,11 @@ pub const Fetch = struct {
                         }
                     }
                 } else {
-                    method = request.method;
+                    if (can_use_fast_getters) {
+                        method = request.method;
+                    } else if (first_arg.fastGet(globalThis, .method)) |method_value| {
+                        method = Method.fromJS(globalThis, method_value) orelse .GET;
+                    }
 
                     if (request.body.value == .Locked) {
                         if (request.body.value.Locked.readable.get()) |stream| {
@@ -2028,9 +2048,10 @@ pub const Fetch = struct {
                 if (args.nextEat()) |options| {
                     if (options.isObject() or options.jsType() == .DOMWrapper) {
                         if (options.fastGet(ctx.ptr(), .method)) |method_| {
-                            var slice_ = method_.toSlice(ctx.ptr(), allocator);
-                            defer slice_.deinit();
-                            method = Method.which(slice_.slice()) orelse .GET;
+                            method = Method.fromJS(ctx, method_) orelse .GET;
+                            if (globalThis.hasException()) {
+                                return .zero;
+                            }
                         }
 
                         if (options.fastGet(ctx.ptr(), .body)) |body__| {

--- a/src/http/method.zig
+++ b/src/http/method.zig
@@ -48,6 +48,8 @@ pub const Method = enum {
     UNLOCK,
     UNSUBSCRIBE,
 
+    pub const fromJS = Map.fromJS;
+
     const with_body: std.enums.EnumSet(Method) = brk: {
         var values = std.enums.EnumSet(Method).initFull();
         values.remove(.HEAD);

--- a/test/js/web/request/request-subclass.test.ts
+++ b/test/js/web/request/request-subclass.test.ts
@@ -1,0 +1,35 @@
+import { test, expect, describe } from "bun:test";
+import { RequestInit } from "undici-types";
+
+// https://github.com/oven-sh/bun/issues/4718
+test("fetch() calls request.method & request.url getters on subclass", async () => {
+  class MyRequest extends Request {
+    constructor(input: string, init?: RequestInit, actual_url?: string) {
+      super(input, init);
+
+      Object.defineProperty(this, "url", {
+        get() {
+          return actual_url;
+        },
+      });
+    }
+
+    // @ts-ignore
+    get method() {
+      return "POST";
+    }
+  }
+
+  const server = Bun.serve({
+    fetch(req) {
+      return new Response(req.method);
+    },
+    port: 0,
+  });
+
+  const request = new MyRequest("https://example.com", {}, server.url.href);
+  expect(request.method).toBe("POST");
+  const response = await fetch(request);
+  expect(await response.text()).toBe("POST");
+  server.stop(true);
+});


### PR DESCRIPTION
### What does this PR do?

`fetch()`, `new Response`, `new Request` are supposed to call getters for the request & response objects. Previously, we would skip calling getters if we knew it was a `Request` or `Response` object passed. But, this is incorrect. We have to call getters if it's not exactly the same type as the native type - for example, if they have a subclass or if they override `method` or `url`. We probably also need to do this for `signal`.

To make this work, this PR adds `JSValue.asDirect` to our bindings generator which checks if the `JSValue` has the same StructureID of the corresponding native type. If it does, we can skip the getters. If it does not, we cannot skip the getters.

Fixes #4718

### How did you verify your code works?

There is a test