### PR TITLE
Fixes #10551 Search for LLVM 17 during initial setup

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -7,8 +7,8 @@ export BUN_DEPS_DIR=${BUN_DEPS_DIR:-$BUN_BASE_DIR/src/deps/}
 export BUN_DEPS_OUT_DIR=${BUN_DEPS_OUT_DIR:-$BUN_BASE_DIR/src/deps/}
 
 # this compiler detection could be better
-export CC=${CC:-$(which clang-17 || which clang || which cc)}
-export CXX=${CXX:-$(which clang++-17 || which clang++ || which c++)}
+export CC=${CC:-$(which clang-16 || which clang || which cc)}
+export CXX=${CXX:-$(which clang++-16 || which clang++ || which c++)}
 export AR=${AR:-$(which llvm-ar || which ar)}
 export CPUS=${CPUS:-$(nproc || sysctl -n hw.ncpu || echo 1)}
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,8 +19,8 @@ LLVM_VERSION=16
 
 # this compiler detection could be better
 # it is copy pasted from ./env.sh
-CC=${CC:-$(which clang-17 || which clang || which cc)}
-CXX=${CXX:-$(which clang++-17 || which clang++ || which c++)}
+CC=${CC:-$(which clang-16 || which clang || which cc)}
+CXX=${CXX:-$(which clang++-16 || which clang++ || which c++)}
 
 test -n "$CC" || fail "missing LLVM $LLVM_VERSION (could not find clang)"
 test -n "$CXX" || fail "missing LLVM $LLVM_VERSION (could not find clang++)"


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- Update build script to not failed if LLVM - 17 isn't found. 
- Docs are updated to point for contributors 

Fixes #10551

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x ] Code changes

### How did you verify your code works?

After changes build succeedes locally. Beforehand it did not.