### PR TITLE
Fix DNS lookup not draining microtasks

### DIFF
--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -2098,12 +2098,29 @@ pub const JSPromise = extern struct {
             this.swap().reject(globalThis, val);
         }
 
+        /// Like `reject`, except it drains microtasks at the end of the current event loop iteration.
+        pub fn rejectTask(this: *Strong, globalThis: *JSC.JSGlobalObject, val: JSC.JSValue) void {
+            const loop = JSC.VirtualMachine.get().eventLoop();
+            loop.enter();
+            defer loop.exit();
+
+            this.reject(globalThis, val);
+        }
+
         pub fn rejectOnNextTick(this: *Strong, globalThis: *JSC.JSGlobalObject, val: JSC.JSValue) void {
             this.swap().rejectOnNextTick(globalThis, val);
         }
 
         pub fn resolve(this: *Strong, globalThis: *JSC.JSGlobalObject, val: JSC.JSValue) void {
             this.swap().resolve(globalThis, val);
+        }
+
+        /// Like `resolve`, except it drains microtasks at the end of the current event loop iteration.
+        pub fn resolveTask(this: *Strong, globalThis: *JSC.JSGlobalObject, val: JSC.JSValue) void {
+            const loop = JSC.VirtualMachine.get().eventLoop();
+            loop.enter();
+            defer loop.exit();
+            this.resolve(globalThis, val);
         }
 
         pub fn resolveOnNextTick(this: *Strong, globalThis: *JSC.JSGlobalObject, val: JSC.JSValue) void {

--- a/test/js/node/dns/dns-fixture.js
+++ b/test/js/node/dns/dns-fixture.js
@@ -1,0 +1,9 @@
+// This tests that the dns.lookup function keeps the process alive when it's called
+const dns = require("dns");
+
+process.exitCode = 42;
+
+dns.lookup("google.com", (err, address, family) => {
+  console.log("Worked");
+  process.exit(0);
+});

--- a/test/js/node/dns/dns-lookup-keepalive.test.ts
+++ b/test/js/node/dns/dns-lookup-keepalive.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test, it } from "bun:test";
+import "harness";
+import { bunExe } from "harness";
+import { join } from "path";
+
+test("expect dns.lookup to keep the process alive", () => {
+  expect([join(import.meta.dir, "dns-fixture.js")]).toRun();
+});


### PR DESCRIPTION
### What does this PR do?

Fix DNS lookup not draining microtasks

Previously, this code would hang on macOS:

```js
const dns = require("dns");

dns.lookup("google.com", (err, address, family) => {
  process.exit(0);
});
```

### How did you verify your code works?

there is a test