### PR TITLE
fix 10556

### DIFF
--- a/src/defines.zig
+++ b/src/defines.zig
@@ -62,6 +62,7 @@ pub const DefineData = struct {
             .value = b.value,
             .can_be_removed_if_unused = a.can_be_removed_if_unused,
             .call_can_be_unwrapped_if_unused = a.call_can_be_unwrapped_if_unused,
+            .original_name = b.original_name,
         };
     }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9250,7 +9250,7 @@ pub const PackageManager = struct {
                 },
                 else => {
                     if (comptime Environment.allow_assert) {
-                        @panic("bad");
+                        @panic("Internal assertion failure: unexpected resolution tag");
                     }
                     this.incrementTreeInstallCount(this.current_tree_id, !is_pending_package_install, log_level);
                     return;

--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -8,6 +8,7 @@ describe("Bun.Transpiler", () => {
       "process.env.NODE_ENV": JSON.stringify("development"),
       user_undefined: "undefined",
       user_nested: "location.origin",
+      "hello.earth": "hello.mars",
     },
     macro: {
       react: {
@@ -1939,6 +1940,7 @@ console.log(resolve.length)
       expectPrinted_(`export default !user_undefined;`, `export default true`);
 
       expectPrinted_(`export default user_nested;`, `export default location.origin`);
+      expectPrinted_("hello.earth('hi')", 'hello.mars("hi")');
     });
 
     it("jsx symbol should work", () => {

--- a/test/transpiler/transpiler.test.js
+++ b/test/transpiler/transpiler.test.js
@@ -9,6 +9,7 @@ describe("Bun.Transpiler", () => {
       user_undefined: "undefined",
       user_nested: "location.origin",
       "hello.earth": "hello.mars",
+      "Math.log": "console.error",
     },
     macro: {
       react: {
@@ -1941,6 +1942,7 @@ console.log(resolve.length)
 
       expectPrinted_(`export default user_nested;`, `export default location.origin`);
       expectPrinted_("hello.earth('hi')", 'hello.mars("hi")');
+      expectPrinted_("Math.log('hi')", 'console.error("hi")');
     });
 
     it("jsx symbol should work", () => {


### PR DESCRIPTION
### What does this PR do?
If a dot define matches with a global define, make sure the replacement name is merged with the existing one.

fixes #10556 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
