### PR TITLE
Support asymmetric matchers with equals in expect.extend

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -4977,7 +4977,7 @@ pub const ExpectMatcherContext = struct {
             return .zero;
         }
         const args = arguments.slice();
-        return JSValue.jsBoolean(args[0].deepEquals(args[1], globalObject));
+        return JSValue.jsBoolean(args[0].jestDeepEquals(args[1], globalObject));
     }
 };
 

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -47,6 +47,9 @@ expect.extend({
 
     return { message, pass };
   },
+  _toCustomEqual(actual, expected) {
+    return { pass: this.equals(actual, expected) };
+  },
 
   // this matcher has not been defined through declaration merging, but expect.extends should allow it anyways,
   // type-enforcing the generic signature
@@ -332,4 +335,15 @@ it("should propagate errors from calling .toString() on the message callback val
   expect(() => expect("abc").not._toHaveMessageThatThrows("def")).toThrow(
     "i have successfully propagated the error message!",
   );
+});
+
+it("should support asymmetric matchers", () => {
+  expect(1)._toCustomEqual(expect.anything());
+  expect(1)._toCustomEqual(expect.any(Number));
+  expect({ a: "test" })._toCustomEqual({ a: expect.any(String) });
+  expect(() => expect(1)._toCustomEqual(expect.any(String))).toThrow();
+
+  expect(1).not._toCustomEqual(expect.any(String));
+  expect({ a: "test" }).not._toCustomEqual({ a: expect.any(Number) });
+  expect(() => expect(1).not._toCustomEqual(expect.any(Number))).toThrow();
 });

--- a/test/js/bun/test/expect-extend.types.d.ts
+++ b/test/js/bun/test/expect-extend.types.d.ts
@@ -8,6 +8,7 @@ interface CustomMatchersForTest {
   _toBeDivisibleBy(value: number): any;
   _toBeSymbol(value: Symbol): any;
   _toBeWithinRange(floor: number, ceiling: number): any;
+  _toCustomEqual(value: any): any;
   _shouldNotError(): any;
   _toFailWithoutMessage(): any;
   _toBeOne(): any;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fix: #10537
Support asymmetric matchers with equals in `expect.extend`.
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Run tests

```bash
bun run build
./build/bun-debug test test/js/bun/test/expect-extend.test.js
```

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

This is my first PR in the Bun repository, I am also new to using zig so there may be some things missing.