### PR TITLE
fix 10610

### DIFF
--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -579,7 +579,7 @@ extern "C" void JSC__JSValue__putBunString(
     JSC::JSObject* target = JSC::JSValue::decode(encodedTarget).getObject();
     JSC::JSValue value = JSC::JSValue::decode(encodedValue);
     auto& vm = global->vm();
-    WTF::String str = key->toWTFString();
+    WTF::String str = key->tag == BunStringTag::Empty ? WTF::String(""_s) : key->toWTFString();
     Identifier id = Identifier::fromString(vm, str);
     target->putDirect(vm, id, value, 0);
 }

--- a/src/bun.js/bindings/JSPropertyIterator.zig
+++ b/src/bun.js/bindings/JSPropertyIterator.zig
@@ -59,7 +59,7 @@ pub fn JSPropertyIterator(comptime options: JSPropertyIteratorOptions) type {
             if (comptime options.include_value) {
                 const current = Bun__JSPropertyIterator__getNameAndValue(this.impl, this.globalObject, this.object, &name, i);
                 if (current.isEmpty()) {
-                    return null;
+                    return this.next();
                 }
                 current.ensureStillAlive();
                 this.value = current;
@@ -68,12 +68,12 @@ pub fn JSPropertyIterator(comptime options: JSPropertyIteratorOptions) type {
             }
 
             if (name.tag == .Dead) {
-                return null;
+                return this.next();
             }
 
             if (comptime options.skip_empty_name) {
                 if (name.isEmpty()) {
-                    return null;
+                    return this.next();
                 }
             }
 

--- a/src/bun.js/bindings/JSPropertyIterator.zig
+++ b/src/bun.js/bindings/JSPropertyIterator.zig
@@ -49,6 +49,7 @@ pub fn JSPropertyIterator(comptime options: JSPropertyIteratorOptions) type {
         pub fn next(this: *@This()) ?bun.String {
             const i: usize = this.iter_i;
             if (i >= this.len) {
+                this.i = this.iter_i;
                 return null;
             }
 

--- a/src/bun.js/bindings/JSWrappingFunction.cpp
+++ b/src/bun.js/bindings/JSWrappingFunction.cpp
@@ -27,7 +27,7 @@ JS_EXPORT_PRIVATE JSWrappingFunction* JSWrappingFunction::create(
     JSC::JSFunction* wrappedFn = jsCast<JSC::JSFunction*>(wrappedFnValue.asCell());
     ASSERT(wrappedFn != nullptr);
 
-    auto nameStr = symbolName->toWTFString();
+    auto nameStr = symbolName->tag == BunStringTag::Empty ? WTF::String(""_s) : symbolName->toWTFString();
     auto name = Identifier::fromString(vm, nameStr);
     NativeExecutable* executable = vm.getHostFunction(functionPointer, ImplementationVisibility::Public, nullptr, nameStr);
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3262,7 +3262,7 @@ extern "C" void JSC__JSValue__putMayBeIndex(JSC__JSValue target, JSC__JSGlobalOb
     JSC::VM& vm = globalObject->vm();
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
 
-    WTF::String keyStr = key->toWTFString();
+    WTF::String keyStr = key->tag == BunStringTag::Empty ? WTF::String(""_s) : key->toWTFString();
     JSC::Identifier identifier = JSC::Identifier::fromString(vm, keyStr);
 
     JSC::JSObject* object = JSC::JSValue::decode(target).asCell()->getObject();
@@ -3591,7 +3591,8 @@ extern "C" JSC__JSValue JSC__JSValue__getIfPropertyExistsImplString(JSC__JSValue
 
     JSC::VM& vm = globalObject->vm();
     JSC::JSObject* object = value.getObject();
-    auto identifier = JSC::Identifier::fromString(vm, propertyName->toWTFString(BunString::ZeroCopy));
+    WTF::String propertyNameString = propertyName->tag == BunStringTag::Empty ? WTF::String(""_s) : propertyName->toWTFString(BunString::ZeroCopy);
+    auto identifier = JSC::Identifier::fromString(vm, propertyNameString);
     auto property = JSC::PropertyName(identifier);
 
     return JSC::JSValue::encode(object->getIfPropertyExists(globalObject, property));
@@ -3601,7 +3602,8 @@ extern "C" JSC__JSValue JSC__JSValue__getOwn(JSC__JSValue JSValue0, JSC__JSGloba
 {
     VM& vm = globalObject->vm();
     JSValue value = JSC::JSValue::decode(JSValue0);
-    auto identifier = JSC::Identifier::fromString(vm, propertyName->toWTFString(BunString::ZeroCopy));
+    WTF::String propertyNameString = propertyName->tag == BunStringTag::Empty ? WTF::String(""_s) : propertyName->toWTFString(BunString::ZeroCopy);
+    auto identifier = JSC::Identifier::fromString(vm, propertyNameString);
     auto property = JSC::PropertyName(identifier);
     PropertySlot slot(value, PropertySlot::InternalMethodType::GetOwnProperty);
     if (value.getOwnPropertySlot(globalObject, property, slot)) {

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -4042,7 +4042,7 @@ pub const Expect = struct {
         const matchers_to_register = args[0];
         {
             var iter = JSC.JSPropertyIterator(.{
-                .skip_empty_name = true,
+                .skip_empty_name = false,
                 .include_value = true,
             }).init(globalObject, matchers_to_register);
             defer iter.deinit();

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -24,6 +24,9 @@ expect.extend({
 
     return { message, pass: 42 };
   },
+  [""](actual, expected) {
+    return { pass: actual === expected };
+  },
   _toBeDivisibleBy(actual, expected) {
     const pass = typeof actual === "number" && actual % expected === 0;
     const message = pass
@@ -116,6 +119,10 @@ it("is ok if there is no message specified", () => {
   });
 
   expect(() => expect(true)._toFailWithoutMessage())._toThrowErrorMatchingSnapshot();
+});
+
+it("works with empty matcher name", () => {
+  expect(1)[""](1);
 });
 
 it("exposes an equality function to custom matchers", () => {

--- a/test/js/bun/test/expect-extend.types.d.ts
+++ b/test/js/bun/test/expect-extend.types.d.ts
@@ -14,6 +14,7 @@ interface CustomMatchersForTest {
   _toAllowOverridingExistingMatcher(): any;
   _toCustomA(): any;
   _toCustomB(): any;
+  [""](value: any): any;
 
   _toThrowErrorMatchingSnapshot(): any; // TODO: remove when implemented
   _toHaveMessageThatThrows(a: any): any;

--- a/test/transpiler/macro-test.test.ts
+++ b/test/transpiler/macro-test.test.ts
@@ -14,6 +14,16 @@ test("ascii string", () => {
   expect(identity("abc")).toBe("abc");
 });
 
+test("type coercion", () => {
+  expect(identity({ a: 1 })).toEqual({ a: 1 });
+  expect(identity([1, 2, 3])).toEqual([1, 2, 3]);
+  expect(identity(undefined)).toBe(undefined);
+  expect(identity(null)).toBe(null);
+  expect(identity(1.5)).toBe(1.5);
+  expect(identity(1)).toBe(1);
+  expect(identity(true)).toBe(true);
+});
+
 test("escaping", () => {
   expect(identity("\\")).toBe("\\");
   expect(identity("\f")).toBe("\f");


### PR DESCRIPTION
### What does this PR do?
fixes #10610 

Also fixes properties with empty string keys in `expect.extends({ ... })`. This was a bug because the keys were skipped, and if one was found, it would skip the remaining keys in the object.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
