### PR TITLE
Speculative fix for alignment crash in directory iterator on Windows

### DIFF
--- a/src/bun.js/node/dir_iterator.zig
+++ b/src/bun.js/node/dir_iterator.zig
@@ -218,7 +218,7 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
                         var io: w.IO_STATUS_BLOCK = undefined;
                         if (self.first) {
                             // > Any bytes inserted for alignment SHOULD be set to zero, and the receiver MUST ignore them
-                            @memset(self.buf, 0);
+                            @memset(&self.buf, 0);
                         }
 
                         const rc = w.ntdll.NtQueryDirectoryFile(

--- a/src/bun.js/node/dir_iterator.zig
+++ b/src/bun.js/node/dir_iterator.zig
@@ -185,6 +185,8 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
         },
         .windows => struct {
             const FILE_DIRECTORY_INFORMATION = std.os.windows.FILE_DIRECTORY_INFORMATION;
+            // While the official api docs guarantee FILE_BOTH_DIR_INFORMATION to be aligned properly
+            // this may not always be the case (e.g. due to faulty VM/Sandboxing tools)
             const FILE_DIRECTORY_INFORMATION_PTR = *align(2) FILE_DIRECTORY_INFORMATION;
             dir: Dir,
 


### PR DESCRIPTION
### What does this PR do?

We've received about 16 crash reports for an alignment issue in the directory iterator code

So let's loosen the alignment requirements here and see if it goes away

> This structure must be aligned on a LONGLONG (8-byte) boundary. If a buffer contains two or more of these structures, the NextEntryOffset value in each entry, except the last, falls on an 8-byte boundary.

See also: https://github.com/ziglang/zig/pull/17958

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
