### PR TITLE
Use error handling callback in more places, emit 1015 when WSS TLS handshaking fails, micro-optimize ServerWebSocket, fix bug in util.inspect exceptions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -121,6 +121,9 @@
     "**/*.xcscheme": true,
     "**/*.xcodeproj": true,
     "**/*.i": true,
+
+    // uws WebSocket.cpp conflicts with webcore WebSocket.cpp
+    "packages/bun-uws/fuzzing": true,
   },
   "files.associations": {
     "*.idl": "cpp",

--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2017,7 +2017,9 @@ pub const Formatter = struct {
                     &is_exception,
                 );
                 if (is_exception) {
-                    JSC.VirtualMachine.get().onError(this.globalThis, result);
+                    // Previously, this printed [native code]
+                    // TODO: in the future, should this throw when in Bun.inspect?
+                    writer.print("[custom formatter threw an exception]", .{});
                     return;
                 }
                 // Strings are printed directly, otherwise we recurse. It is possible to end up in an infinite loop.

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -3685,7 +3685,7 @@ pub const Timer = struct {
             }
 
             var this = args.ptr[1].asPtr(CallbackJob);
-            globalThis.bunVM().onUnhandledError(globalThis, args.ptr[0]);
+            globalThis.bunVM().onError(globalThis, args.ptr[0]);
             this.deinit();
             return JSValue.jsUndefined();
         }
@@ -3787,7 +3787,7 @@ pub const Timer = struct {
             }
 
             if (result.isAnyError()) {
-                vm.onUnhandledError(globalThis, result);
+                vm.onError(globalThis, result);
                 this.deinit();
                 return;
             }
@@ -3796,7 +3796,7 @@ pub const Timer = struct {
                 switch (promise.status(globalThis.vm())) {
                     .Rejected => {
                         this.deinit();
-                        vm.onUnhandledError(globalThis, promise.result(globalThis.vm()));
+                        vm.onError(globalThis, promise.result(globalThis.vm()));
                     },
                     .Fulfilled => {
                         this.deinit();
@@ -5265,7 +5265,7 @@ pub const EnvironmentVariables = struct {
 };
 
 export fn Bun__reportError(globalObject: *JSGlobalObject, err: JSC.JSValue) void {
-    JSC.VirtualMachine.runErrorHandlerWithDedupe(globalObject.bunVM(), err, null);
+    JSC.VirtualMachine.get().onError(globalObject, err);
 }
 
 comptime {

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -236,14 +236,14 @@ const Handlers = struct {
         const onError = this.onError;
         if (onError == .zero) {
             if (err.len > 0)
-                this.vm.onUnhandledError(this.globalObject, err[0]);
+                this.vm.onError(this.globalObject, err[0]);
 
             return false;
         }
 
         const result = onError.callWithThis(this.globalObject, thisValue, err);
         if (result.isAnyError()) {
-            this.vm.onUnhandledError(this.globalObject, result);
+            this.vm.onError(this.globalObject, result);
         }
 
         return true;

--- a/src/bun.js/api/bun/udp_socket.zig
+++ b/src/bun.js/api/bun/udp_socket.zig
@@ -355,14 +355,14 @@ pub const UDPSocket = struct {
 
         if (callback == .zero) {
             if (err.len > 0)
-                vm.onUnhandledError(globalThis, err[0]);
+                vm.onError(globalThis, err[0]);
 
             return false;
         }
 
         const result = callback.callWithThis(globalThis, thisValue, err);
         if (result.isAnyError()) {
-            vm.onUnhandledError(globalThis, result);
+            vm.onError(globalThis, result);
         }
 
         return true;

--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -897,7 +897,7 @@ fn HandlerCallback(
                     this.global.bunVM().waitForPromise(promise);
                     const fail = promise.status(this.global.vm()) == .Rejected;
                     if (fail) {
-                        this.global.bunVM().runErrorHandler(promise.result(this.global.vm()), null);
+                        this.global.bunVM().onError(this.global, promise.result(this.global.vm()));
                     }
                     return fail;
                 }

--- a/src/bun.js/bindings/UtilInspect.cpp
+++ b/src/bun.js/bindings/UtilInspect.cpp
@@ -3,10 +3,6 @@
 #include "JavaScriptCore/JSObject.h"
 #include "JavaScriptCore/JSFunction.h"
 #include "JavaScriptCore/JSString.h"
-#include "JavaScriptCore/JSValue.h"
-#include "JavaScriptCore/Identifier.h"
-#include "JavaScriptCore/Structure.h"
-
 #include "JavaScriptCore/JSCJSValue.h"
 #include "JavaScriptCore/JSGlobalObject.h"
 #include "ZigGlobalObject.h"

--- a/src/bun.js/bindings/UtilInspect.cpp
+++ b/src/bun.js/bindings/UtilInspect.cpp
@@ -1,0 +1,75 @@
+#include "root.h"
+#include "headers.h"
+#include "JavaScriptCore/JSObject.h"
+#include "JavaScriptCore/JSFunction.h"
+#include "JavaScriptCore/JSString.h"
+#include "JavaScriptCore/JSValue.h"
+#include "JavaScriptCore/Identifier.h"
+#include "JavaScriptCore/Structure.h"
+
+#include "JavaScriptCore/JSCJSValue.h"
+#include "JavaScriptCore/JSGlobalObject.h"
+#include "ZigGlobalObject.h"
+#include "JavaScriptCore/ObjectConstructor.h"
+
+namespace Bun {
+
+using namespace JSC;
+
+Structure* createUtilInspectOptionsStructure(VM& vm, JSC::JSGlobalObject* globalObject)
+{
+    Structure* structure = globalObject->structureCache().emptyObjectStructureForPrototype(globalObject, globalObject->objectPrototype(), 3);
+    PropertyOffset offset;
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "stylize"_s), 0, offset);
+    RELEASE_ASSERT(offset == 0);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "depth"_s), 0, offset);
+    RELEASE_ASSERT(offset == 1);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "colors"_s), 0, offset);
+    RELEASE_ASSERT(offset == 2);
+    return structure;
+}
+
+JSObject* createInspectOptionsObject(VM& vm, Zig::GlobalObject* globalObject, unsigned max_depth, bool colors)
+{
+    JSFunction* stylizeFn = colors ? globalObject->utilInspectStylizeColorFunction() : globalObject->utilInspectStylizeNoColorFunction();
+    JSObject* options = JSC::constructEmptyObject(vm, globalObject->utilInspectOptionsStructure());
+    options->putDirectOffset(vm, 0, stylizeFn);
+    options->putDirectOffset(vm, 1, jsNumber(max_depth));
+    options->putDirectOffset(vm, 2, jsBoolean(colors));
+    return options;
+}
+
+extern "C" JSC::EncodedJSValue JSC__JSValue__callCustomInspectFunction(
+    Zig::GlobalObject* globalObject,
+    JSC::JSGlobalObject* lexicalGlobalObject,
+    JSC__JSValue encodedFunctionValue,
+    JSC__JSValue encodedThisValue,
+    unsigned depth,
+    unsigned max_depth,
+    bool colors,
+    bool* is_exception)
+{
+    JSValue functionToCall = JSValue::decode(encodedFunctionValue);
+    JSValue thisValue = JSValue::decode(encodedThisValue);
+    JSC::VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* options = Bun::createInspectOptionsObject(vm, globalObject, max_depth, colors);
+
+    JSFunction* inspectFn = globalObject->utilInspectFunction();
+    auto callData = JSC::getCallData(functionToCall);
+    MarkedArgumentBuffer arguments;
+    arguments.append(jsNumber(depth));
+    arguments.append(options);
+    arguments.append(inspectFn);
+
+    auto inspectRet = JSC::call(lexicalGlobalObject, functionToCall, callData, thisValue, arguments);
+    if (auto exe = scope.exception()) {
+        *is_exception = true;
+        scope.clearException();
+        return JSValue::encode(exe);
+    }
+    RELEASE_AND_RETURN(scope, JSValue::encode(inspectRet));
+}
+
+}

--- a/src/bun.js/bindings/UtilInspect.h
+++ b/src/bun.js/bindings/UtilInspect.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace Bun {
+
+JSC::Structure* createUtilInspectOptionsStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject);
+
+}

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -145,6 +145,7 @@
 #include "webcrypto/JSSubtleCrypto.h"
 #include "ZigGeneratedClasses.h"
 #include "ZigSourceProvider.h"
+#include "UtilInspect.h"
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include "JavaScriptCore/RemoteInspectorServer.h"
@@ -2568,14 +2569,19 @@ void GlobalObject::finishCreation(VM& vm)
             init.set(jsCast<JSFunction*>(nodeUtilValue.getObject()->getIfPropertyExists(init.owner, Identifier::fromString(init.vm, "inspect"_s))));
         });
 
+    m_utilInspectOptionsStructure.initLater(
+        [](const Initializer<Structure>& init) {
+            init.set(Bun::createUtilInspectOptionsStructure(init.vm, init.owner));
+        });
+
     m_utilInspectStylizeColorFunction.initLater(
         [](const Initializer<JSFunction>& init) {
+            JSC::MarkedArgumentBuffer args;
+            args.append(jsCast<Zig::GlobalObject*>(init.owner)->utilInspectFunction());
+
             auto scope = DECLARE_THROW_SCOPE(init.vm);
             JSC::JSFunction* getStylize = JSC::JSFunction::create(init.vm, utilInspectGetStylizeWithColorCodeGenerator(init.vm), init.owner);
             // RETURN_IF_EXCEPTION(scope, {});
-
-            JSC::MarkedArgumentBuffer args;
-            args.append(jsCast<Zig::GlobalObject*>(init.owner)->utilInspectFunction());
 
             JSC::CallData callData = JSC::getCallData(getStylize);
 
@@ -3421,6 +3427,7 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_subtleCryptoObject.visit(visitor);
     thisObject->m_testMatcherUtilsObject.visit(visitor);
     thisObject->m_utilInspectFunction.visit(visitor);
+    thisObject->m_utilInspectOptionsStructure.visit(visitor);
     thisObject->m_utilInspectStylizeColorFunction.visit(visitor);
     thisObject->m_utilInspectStylizeNoColorFunction.visit(visitor);
     thisObject->m_vmModuleContextMap.visit(visitor);

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -253,6 +253,7 @@ public:
     JSC::JSFunction* performMicrotaskFunction() const { return m_performMicrotaskFunction.getInitializedOnMainThread(this); }
     JSC::JSFunction* performMicrotaskVariadicFunction() const { return m_performMicrotaskVariadicFunction.getInitializedOnMainThread(this); }
 
+    JSC::Structure* utilInspectOptionsStructure() const { return m_utilInspectOptionsStructure.getInitializedOnMainThread(this); }
     JSC::JSFunction* utilInspectFunction() const { return m_utilInspectFunction.getInitializedOnMainThread(this); }
     JSC::JSFunction* utilInspectStylizeColorFunction() const { return m_utilInspectStylizeColorFunction.getInitializedOnMainThread(this); }
     JSC::JSFunction* utilInspectStylizeNoColorFunction() const { return m_utilInspectStylizeNoColorFunction.getInitializedOnMainThread(this); }
@@ -534,6 +535,7 @@ public:
     LazyProperty<JSGlobalObject, JSFunction> m_nativeMicrotaskTrampoline;
     LazyProperty<JSGlobalObject, JSFunction> m_performMicrotaskVariadicFunction;
     LazyProperty<JSGlobalObject, JSFunction> m_utilInspectFunction;
+    LazyProperty<JSGlobalObject, Structure> m_utilInspectOptionsStructure;
     LazyProperty<JSGlobalObject, JSFunction> m_utilInspectStylizeColorFunction;
     LazyProperty<JSGlobalObject, JSFunction> m_utilInspectStylizeNoColorFunction;
     LazyProperty<JSGlobalObject, JSFunction> m_emitReadableNextTickFunction;

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4844,42 +4844,6 @@ static JSC::Identifier builtinNameMap(JSC::JSGlobalObject* globalObject, unsigne
     }
 }
 
-extern "C" JSC::EncodedJSValue JSC__JSValue__callCustomInspectFunction(
-    JSC::JSGlobalObject* lexicalGlobalObject,
-    JSC__JSValue encodedFunctionValue,
-    JSC__JSValue encodedThisValue,
-    unsigned depth,
-    unsigned max_depth,
-    bool colors)
-{
-    auto* globalObject = jsCast<Zig::GlobalObject*>(lexicalGlobalObject);
-    JSValue functionToCall = JSValue::decode(encodedFunctionValue);
-    JSValue thisValue = JSValue::decode(encodedThisValue);
-    JSC::VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSFunction* inspectFn = globalObject->utilInspectFunction();
-    JSFunction* stylizeFn = colors ? globalObject->utilInspectStylizeColorFunction() : globalObject->utilInspectStylizeNoColorFunction();
-
-    JSObject* options = JSC::constructEmptyObject(globalObject);
-    options->putDirect(vm, Identifier::fromString(vm, "stylize"_s), stylizeFn);
-    options->putDirect(vm, Identifier::fromString(vm, "depth"_s), jsNumber(max_depth));
-    options->putDirect(vm, Identifier::fromString(vm, "colors"_s), jsBoolean(colors));
-
-    auto callData = JSC::getCallData(functionToCall);
-    MarkedArgumentBuffer arguments;
-    arguments.append(jsNumber(depth));
-    arguments.append(options);
-    arguments.append(inspectFn);
-
-    auto inspectRet = JSC::call(globalObject, functionToCall, callData, thisValue, arguments);
-    if (auto exe = scope.exception()) {
-        scope.clearException();
-        return JSValue::encode(exe);
-    }
-    RELEASE_AND_RETURN(scope, JSValue::encode(inspectRet));
-}
-
 JSC__JSValue JSC__JSValue__fastGetDirect_(JSC__JSValue JSValue0, JSC__JSGlobalObject* globalObject, unsigned char arg2)
 {
     JSC::JSValue value = JSC::JSValue::decode(JSValue0);

--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -260,19 +260,6 @@ ExceptionOr<void> WebSocket::connect(const String& url, const String& protocol)
     return connect(url, Vector<String> { 1, protocol }, std::nullopt);
 }
 
-void WebSocket::failAsynchronously()
-{
-    // queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [this] {
-    // We must block this connection. Instead of throwing an exception, we indicate this
-    // using the error event. But since this code executes as part of the WebSocket's
-    // constructor, we have to wait until the constructor has completed before firing the
-    // event; otherwise, users can't connect to the event.
-    this->dispatchErrorEventIfNeeded();
-    // this->();
-    // this->stop();
-    // });
-}
-
 static String resourceName(const URL& url)
 {
     auto path = url.path();
@@ -304,7 +291,6 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     m_url = URL { url };
 
     ASSERT(scriptExecutionContext());
-    auto& context = *scriptExecutionContext();
 
     if (!m_url.isValid()) {
         // context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, );
@@ -440,16 +426,15 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     headerNames.clear();
 
     if (this->m_upgradeClient == nullptr) {
-        // context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, );
         m_state = CLOSED;
-
-        context.postTask([this, protectedThis = Ref { *this }](ScriptExecutionContext& context) {
-            ASSERT(scriptExecutionContext());
-            protectedThis->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
-            protectedThis->dispatchEvent(Event::create(eventNames().closeEvent, Event::CanBubble::No, Event::IsCancelable::No));
-            protectedThis->decPendingActivityCount();
-        });
-
+        if (auto* context = scriptExecutionContext()) {
+            context->postTask([this, protectedThis = Ref { *this }](ScriptExecutionContext& context) {
+                ASSERT(scriptExecutionContext());
+                protectedThis->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
+                protectedThis->dispatchEvent(CloseEvent::create(false, 1006, "Failed to connect"_s));
+                protectedThis->decPendingActivityCount();
+            });
+        }
         return {};
     }
 
@@ -1158,15 +1143,19 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
     // });
 }
 
-void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason)
+void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason, bool isConnectionError)
 {
     // LOG(Network, "WebSocket %p didReceiveErrorMessage()", this);
     // queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [this, reason = WTFMove(reason)] {
     if (m_state == CLOSED)
         return;
+    const bool wasConnecting = m_state == CONNECTING;
     m_state = CLOSED;
     if (auto* context = scriptExecutionContext()) {
         this->incPendingActivityCount();
+        if (wasConnecting && isConnectionError) {
+            dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        }
         // https://html.spec.whatwg.org/multipage/web-sockets.html#feedback-from-the-protocol:concept-websocket-closed, we should synchronously fire a close event.
         dispatchEvent(CloseEvent::create(wasClean == CleanStatus::Clean, code, reason));
         this->decPendingActivityCount();
@@ -1236,29 +1225,6 @@ void WebSocket::didClose(unsigned unhandledBufferedAmount, unsigned short code, 
 
     // m_pendingActivity = nullptr;
     // });
-}
-
-// void WebSocket::didUpgradeURL()
-// {
-//     ASSERT(m_url.protocolIs("ws"));
-//     m_url.setProtocol("wss");
-// }
-
-void WebSocket::dispatchErrorEventIfNeeded()
-{
-    if (m_dispatchedErrorEvent)
-        return;
-
-    m_dispatchedErrorEvent = true;
-
-    if (auto* context = scriptExecutionContext()) {
-        this->incPendingActivityCount();
-        context->postTask([this, protectedThis = Ref { *this }](ScriptExecutionContext& context) {
-            ASSERT(scriptExecutionContext());
-            protectedThis->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
-            protectedThis->decPendingActivityCount();
-        });
-    }
 }
 
 void WebSocket::didConnect(us_socket_t* socket, char* bufferedData, size_t bufferedDataSize)
@@ -1379,7 +1345,7 @@ void WebSocket::didFailWithErrorCode(int32_t code)
     // failed_to_connect
     case 15: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Failed to connect");
-        didReceiveClose(CleanStatus::NotClean, 1006, message);
+        didReceiveClose(CleanStatus::NotClean, 1006, message, true);
         break;
     }
     // headers_too_large
@@ -1447,6 +1413,12 @@ void WebSocket::didFailWithErrorCode(int32_t code)
     case 26: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Server sent invalid UTF8");
         didReceiveClose(CleanStatus::NotClean, 1003, message);
+        break;
+    }
+    // tls_handshake_failed
+    case 27: {
+        static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("TLS handshake failed");
+        didReceiveClose(CleanStatus::NotClean, 1015, message);
         break;
     }
     }

--- a/src/bun.js/bindings/webcore/WebSocket.h
+++ b/src/bun.js/bindings/webcore/WebSocket.h
@@ -179,27 +179,17 @@ private:
     explicit WebSocket(ScriptExecutionContext&);
     explicit WebSocket(ScriptExecutionContext&, const String& url);
 
-    void dispatchErrorEventIfNeeded();
-
-    // void contextDestroyed() final;
-    // void suspend(ReasonForSuspension) final;
-    // void resume() final;
-    // void stop() final;
-    // const char* activeDOMObjectName() const final;
-
     EventTargetInterface eventTargetInterface() const final;
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    void didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason);
+    void didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason, bool isConnectionError = false);
     void didUpdateBufferedAmount(unsigned bufferedAmount);
     void didStartClosingHandshake();
 
     void sendWebSocketString(const String& message, const Opcode opcode);
     void sendWebSocketData(const char* data, size_t length, const Opcode opcode);
-
-    void failAsynchronously();
 
     enum class BinaryType { Blob,
         ArrayBuffer,

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -850,7 +850,7 @@ pub const EventLoop = struct {
         const result = callback.callWithThis(globalObject, thisValue, arguments);
 
         if (result.toError()) |err| {
-            this.virtual_machine.onUnhandledError(globalObject, err);
+            this.virtual_machine.onError(globalObject, err);
         }
     }
 

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -351,7 +351,7 @@ pub export fn Bun__reportUnhandledError(globalObject: *JSGlobalObject, value: JS
     // This JSGlobalObject might not be the main script execution context
     // See the crash in https://github.com/oven-sh/bun/issues/9778
     const jsc_vm = JSC.VirtualMachine.get();
-    jsc_vm.onUnhandledError(globalObject, value);
+    jsc_vm.onError(globalObject, value);
     return JSC.JSValue.jsUndefined();
 }
 
@@ -379,7 +379,7 @@ pub export fn Bun__handleRejectedPromise(global: *JSGlobalObject, promise: *JSC.
     if (result == .zero)
         return;
 
-    jsc_vm.onUnhandledError(global, result);
+    jsc_vm.onError(global, result);
     jsc_vm.autoGarbageCollect();
 }
 
@@ -825,7 +825,7 @@ pub const VirtualMachine = struct {
         }
     }
 
-    pub fn onUnhandledError(this: *JSC.VirtualMachine, globalObject: *JSC.JSGlobalObject, value: JSC.JSValue) void {
+    pub fn onError(this: *JSC.VirtualMachine, globalObject: *JSC.JSGlobalObject, value: JSC.JSValue) void {
         this.unhandled_error_counter += 1;
         this.onUnhandledRejection(this, globalObject, value);
     }
@@ -2614,7 +2614,7 @@ pub const VirtualMachine = struct {
 
     pub fn reportUncaughtException(globalObject: *JSGlobalObject, exception: *JSC.Exception) JSValue {
         var jsc_vm = globalObject.bunVM();
-        jsc_vm.onUnhandledError(globalObject, exception.value());
+        jsc_vm.onError(globalObject, exception.value());
         return JSC.JSValue.jsUndefined();
     }
 

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -385,7 +385,7 @@ pub const StatWatcher = struct {
 
         const vm = this.globalThis.bunVM();
         if (result.isAnyError()) {
-            vm.onUnhandledError(this.globalThis, result);
+            vm.onError(this.globalThis, result);
         }
 
         vm.rareData().nodeFSStatWatcherScheduler(vm).append(this);
@@ -421,7 +421,7 @@ pub const StatWatcher = struct {
         );
         if (result.isAnyError()) {
             const vm = this.globalThis.bunVM();
-            vm.onUnhandledError(this.globalThis, result);
+            vm.onError(this.globalThis, result);
         }
     }
 

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -606,7 +606,7 @@ pub const FSWatcher = struct {
         );
 
         if (err.toError()) |value| {
-            JSC.VirtualMachine.get().runErrorHandler(value, null);
+            JSC.VirtualMachine.get().onError(globalObject, value);
         }
     }
 

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -4183,7 +4183,7 @@ pub const Expect = struct {
                 .Fulfilled => {},
                 .Rejected => {
                     // TODO throw the actual rejection error
-                    globalObject.bunVM().runErrorHandler(result, null);
+                    JSC.VirtualMachine.get().onError(globalObject, result);
                     globalObject.throw("Matcher `{s}` returned a promise that rejected", .{matcher_name});
                     return false;
                 },

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -4182,8 +4182,8 @@ pub const Expect = struct {
                 .Pending => unreachable,
                 .Fulfilled => {},
                 .Rejected => {
-                    // TODO throw the actual rejection error
-                    JSC.VirtualMachine.get().onError(globalObject, result);
+                    // TODO: rewrite this code to use .then() instead of blocking the event loop
+                    JSC.VirtualMachine.get().runErrorHandler(result, null);
                     globalObject.throw("Matcher `{s}` returned a promise that rejected", .{matcher_name});
                     return false;
                 },
@@ -4319,7 +4319,9 @@ pub const Expect = struct {
         for (0..args_count) |i| matcher_args.appendAssumeCapacity(args_ptr[i]);
 
         // call the matcher, which will throw a js exception when failed
-        _ = executeCustomMatcher(globalObject, matcher_name, matcher_fn, matcher_args.items, expect.flags, false);
+        if (!executeCustomMatcher(globalObject, matcher_name, matcher_fn, matcher_args.items, expect.flags, false) or globalObject.hasException()) {
+            return .zero;
+        }
 
         return thisValue;
     }

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -602,7 +602,7 @@ pub const TestScope = struct {
         debug("onReject", .{});
         const arguments = callframe.arguments(2);
         const err = arguments.ptr[0];
-        globalThis.bunVM().onUnhandledError(globalThis, err);
+        globalThis.bunVM().onError(globalThis, err);
         var task: *TestRunnerTask = arguments.ptr[1].asPromisePtr(TestRunnerTask);
         task.handleResult(.{ .fail = expect.active_test_expectation_counter.actual }, .promise);
         globalThis.bunVM().autoGarbageCollect();
@@ -637,7 +637,7 @@ pub const TestScope = struct {
                     task.handleResult(.{ .pass = expect.active_test_expectation_counter.actual }, .callback);
                 } else {
                     debug("done(err)", .{});
-                    globalThis.bunVM().onUnhandledError(globalThis, err);
+                    globalThis.bunVM().onError(globalThis, err);
                     task.handleResult(.{ .fail = expect.active_test_expectation_counter.actual }, .callback);
                 }
             } else {
@@ -696,7 +696,7 @@ pub const TestScope = struct {
         initial_value = callJSFunctionForTestRunner(vm, vm.global, this.func, this.func_arg);
 
         if (initial_value.isAnyError()) {
-            vm.onUnhandledError(vm.global, initial_value);
+            vm.onError(vm.global, initial_value);
 
             if (this.tag == .todo) {
                 return .{ .todo = {} };
@@ -719,7 +719,7 @@ pub const TestScope = struct {
             }
             switch (promise.status(vm.global.vm())) {
                 .Rejected => {
-                    vm.onUnhandledError(vm.global, promise.result(vm.global.vm()));
+                    vm.onError(vm.global, promise.result(vm.global.vm()));
 
                     if (this.tag == .todo) {
                         return .{ .todo = {} };
@@ -893,7 +893,7 @@ pub const DescribeScope = struct {
             if (args.len > 0) {
                 const err = args.ptr[0];
                 if (!err.isEmptyOrUndefinedOrNull()) {
-                    ctx.bunVM().onUnhandledError(ctx.bunVM().global, err);
+                    ctx.bunVM().onError(ctx.bunVM().global, err);
                 }
             }
             scope.done = true;
@@ -1090,12 +1090,12 @@ pub const DescribeScope = struct {
                 switch (prom.status(globalObject.ptr().vm())) {
                     JSPromise.Status.Fulfilled => {},
                     else => {
-                        globalObject.bunVM().onUnhandledError(globalObject, prom.result(globalObject.ptr().vm()));
+                        globalObject.bunVM().onError(globalObject, prom.result(globalObject.ptr().vm()));
                         return .undefined;
                     },
                 }
             } else if (result.toError()) |err| {
-                globalObject.bunVM().onUnhandledError(globalObject, err);
+                globalObject.bunVM().onError(globalObject, err);
                 return .undefined;
             }
         }
@@ -1123,7 +1123,7 @@ pub const DescribeScope = struct {
 
         if (this.shouldEvaluateScope()) {
             if (this.runCallback(globalObject, .beforeAll)) |err| {
-                globalObject.bunVM().onUnhandledError(globalObject, err);
+                globalObject.bunVM().onError(globalObject, err);
                 while (i < end) {
                     Jest.runner.?.reportFailure(i + this.test_id_start, source.path.text, tests[i].label, 0, 0, this);
                     i += 1;
@@ -1168,7 +1168,7 @@ pub const DescribeScope = struct {
 
         if (!skipped) {
             if (this.runCallback(globalThis, .afterEach)) |err| {
-                globalThis.bunVM().onUnhandledError(globalThis, err);
+                globalThis.bunVM().onError(globalThis, err);
             }
         }
 
@@ -1180,7 +1180,7 @@ pub const DescribeScope = struct {
             // Run the afterAll callbacks, in reverse order
             // unless there were no tests for this scope
             if (this.execCallback(globalThis, .afterAll)) |err| {
-                globalThis.bunVM().onUnhandledError(globalThis, err);
+                globalThis.bunVM().onError(globalThis, err);
             }
         }
 
@@ -1327,7 +1327,7 @@ pub const TestRunnerTask = struct {
             const label = test_.label;
 
             if (this.describe.runCallback(globalThis, .beforeEach)) |err| {
-                jsc_vm.onUnhandledError(globalThis, err);
+                jsc_vm.onError(globalThis, err);
                 Jest.runner.?.reportFailure(test_id, this.source_file_path, label, 0, 0, this.describe);
                 return false;
             }
@@ -1429,7 +1429,7 @@ pub const TestRunnerTask = struct {
 
         if (comptime from == .timeout) {
             const err = this.globalThis.createErrorInstance("Test {} timed out after {d}ms", .{ bun.fmt.quote(test_.label), test_.timeout_millis });
-            this.globalThis.bunVM().onUnhandledError(this.globalThis, err);
+            this.globalThis.bunVM().onError(this.globalThis, err);
         }
 
         processTestResult(this, this.globalThis, result, test_, test_id, describe);

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -272,7 +272,7 @@ pub const WebWorker = struct {
         };
 
         if (promise.status(vm.global.vm()) == .Rejected) {
-            vm.onUnhandledError(vm.global, promise.result(vm.global.vm()));
+            vm.onError(vm.global, promise.result(vm.global.vm()));
 
             vm.exit_handler.exit_code = 1;
             this.exitAndDeinit();

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -274,7 +274,7 @@ pub const Run = struct {
 
         if (vm.loadEntryPoint(this.entry_path)) |promise| {
             if (promise.status(vm.global.vm()) == .Rejected) {
-                vm.runErrorHandler(promise.result(vm.global.vm()), null);
+                vm.onError(vm.global, promise.result(vm.global.vm()));
 
                 if (vm.hot_reload != .none) {
                     vm.eventLoop().tick();
@@ -325,7 +325,7 @@ pub const Run = struct {
             if (this.vm.isWatcherEnabled()) {
                 var prev_promise = this.vm.pending_internal_promise;
                 if (prev_promise.status(vm.global.vm()) == .Rejected) {
-                    vm.onUnhandledError(this.vm.global, this.vm.pending_internal_promise.result(vm.global.vm()));
+                    vm.onError(this.vm.global, this.vm.pending_internal_promise.result(vm.global.vm()));
                 }
 
                 while (true) {
@@ -335,7 +335,7 @@ pub const Run = struct {
                         // Report exceptions in hot-reloaded modules
                         if (this.vm.pending_internal_promise.status(vm.global.vm()) == .Rejected and prev_promise != this.vm.pending_internal_promise) {
                             prev_promise = this.vm.pending_internal_promise;
-                            vm.onUnhandledError(this.vm.global, this.vm.pending_internal_promise.result(vm.global.vm()));
+                            vm.onError(this.vm.global, this.vm.pending_internal_promise.result(vm.global.vm()));
                             continue;
                         }
 
@@ -346,7 +346,7 @@ pub const Run = struct {
 
                     if (this.vm.pending_internal_promise.status(vm.global.vm()) == .Rejected and prev_promise != this.vm.pending_internal_promise) {
                         prev_promise = this.vm.pending_internal_promise;
-                        vm.onUnhandledError(this.vm.global, this.vm.pending_internal_promise.result(vm.global.vm()));
+                        vm.onError(this.vm.global, this.vm.pending_internal_promise.result(vm.global.vm()));
                     }
 
                     vm.eventLoop().tickPossiblyForever();
@@ -354,7 +354,7 @@ pub const Run = struct {
 
                 if (this.vm.pending_internal_promise.status(vm.global.vm()) == .Rejected and prev_promise != this.vm.pending_internal_promise) {
                     prev_promise = this.vm.pending_internal_promise;
-                    vm.onUnhandledError(this.vm.global, this.vm.pending_internal_promise.result(vm.global.vm()));
+                    vm.onError(this.vm.global, this.vm.pending_internal_promise.result(vm.global.vm()));
                 }
             } else {
                 while (vm.isEventLoopAlive()) {

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1042,7 +1042,7 @@ pub const TestCommand = struct {
 
             switch (promise.status(vm.global.vm())) {
                 .Rejected => {
-                    vm.onUnhandledError(vm.global, promise.result(vm.global.vm()));
+                    vm.onError(vm.global, promise.result(vm.global.vm()));
                     reporter.summary.fail += 1;
 
                     if (reporter.jest.bail == reporter.summary.fail) {
@@ -1127,7 +1127,7 @@ pub const TestCommand = struct {
         if (is_last) {
             if (jest.Jest.runner != null) {
                 if (jest.DescribeScope.runGlobalCallbacks(vm.global, .afterAll)) |err| {
-                    vm.onUnhandledError(vm.global, err);
+                    vm.onError(vm.global, err);
                 }
             }
         }

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -7039,7 +7039,7 @@ pub const Macro = struct {
         var loaded_result = try vm.loadMacroEntryPoint(input_specifier, function_name, specifier, hash);
 
         if (loaded_result.status(vm.global.vm()) == JSC.JSPromise.Status.Rejected) {
-            vm.runErrorHandler(loaded_result.result(vm.global.vm()), null);
+            vm.onError(vm.global, loaded_result.result(vm.global.vm()));
             vm.disableMacroMode();
             return error.MacroLoadError;
         }
@@ -7150,7 +7150,7 @@ pub const Macro = struct {
             ) MacroError!Expr {
                 switch (comptime tag) {
                     .Error => {
-                        this.macro.vm.runErrorHandler(value, null);
+                        this.macro.vm.onError(this.global, value);
                         return this.caller;
                     },
                     .Undefined => if (this.is_top_level)
@@ -7177,7 +7177,7 @@ pub const Macro = struct {
                                 blob_ = resp.*;
                                 blob_.?.allocator = null;
                             } else if (value.as(JSC.ResolveMessage) != null or value.as(JSC.BuildMessage) != null) {
-                                this.macro.vm.runErrorHandler(value, null);
+                                this.macro.vm.onError(this.global, value);
                                 return error.MacroFailed;
                             }
                         }
@@ -7353,7 +7353,7 @@ pub const Macro = struct {
                         }
 
                         if (rejected or promise_result.isError() or promise_result.isAggregateError(this.global) or promise_result.isException(this.global.vm())) {
-                            this.macro.vm.runErrorHandler(promise_result, null);
+                            this.macro.vm.onError(this.global, promise_result);
                             return error.MacroFailed;
                         }
                         this.is_top_level = false;

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1352,7 +1352,7 @@ pub const ThreadSafeFunction = struct {
                 }
                 const err = js_function.call(this.env, &.{});
                 if (err.isAnyError()) {
-                    this.env.bunVM().onUnhandledError(this.env, err);
+                    this.env.bunVM().onError(this.env, err);
                 }
             },
             .c => |cb| {

--- a/test/js/bun/util/__snapshots__/reportError.test.ts.snap
+++ b/test/js/bun/util/__snapshots__/reportError.test.ts.snap
@@ -11,6 +11,7 @@ error: null
 error: 123
 error: Infinity
 error: NaN
+error: NaN
 error
 error
 error

--- a/test/js/node/util/bun-inspect.test.ts
+++ b/test/js/node/util/bun-inspect.test.ts
@@ -2,14 +2,13 @@ import { describe, it, expect } from "bun:test";
 
 describe("Bun.inspect", () => {
   it("reports error instead of [native code]", () => {
-    // This works because expect(()=> {}).toThrow creates an error handling scope
-    expect(() =>
+    expect(
       Bun.inspect({
         [Symbol.for("nodejs.util.inspect.custom")]() {
           throw new Error("custom inspect");
         },
       }),
-    ).toThrow("custom inspect");
+    ).toBe("[custom formatter threw an exception]");
   });
 
   it("depth < 0 throws", () => {

--- a/test/js/node/util/bun-inspect.test.ts
+++ b/test/js/node/util/bun-inspect.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect } from "bun:test";
 
 describe("Bun.inspect", () => {
+  it("reports error instead of [native code]", () => {
+    // This works because expect(()=> {}).toThrow creates an error handling scope
+    expect(() =>
+      Bun.inspect({
+        [Symbol.for("nodejs.util.inspect.custom")]() {
+          throw new Error("custom inspect");
+        },
+      }),
+    ).toThrow("custom inspect");
+  });
+
   it("depth < 0 throws", () => {
     expect(() => Bun.inspect({}, { depth: -1 })).toThrow();
     expect(() => Bun.inspect({}, { depth: -13210 })).toThrow();

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -141,8 +141,8 @@ describe("WebSocket", () => {
         const client = WebSocket(url);
         const { result, messages } = await testClient(client);
         expect(["Hello from Bun!", "Hello from client!"]).not.toEqual(messages);
-        expect(result.code).toBe(1006);
-        expect(result.reason).toBe("Failed to connect");
+        expect(result.code).toBe(1015);
+        expect(result.reason).toBe("TLS handshake failed");
       }
 
       {
@@ -150,8 +150,8 @@ describe("WebSocket", () => {
         const client = WebSocket(url, { tls: { rejectUnauthorized: true } });
         const { result, messages } = await testClient(client);
         expect(["Hello from Bun!", "Hello from client!"]).not.toEqual(messages);
-        expect(result.code).toBe(1006);
-        expect(result.reason).toBe("Failed to connect");
+        expect(result.code).toBe(1015);
+        expect(result.reason).toBe("TLS handshake failed");
       }
     } finally {
       server.stop(true);
@@ -261,8 +261,8 @@ describe("WebSocket", () => {
         const client = WebSocket(url);
         const { result, messages } = await testClient(client);
         expect(["Hello from Bun!", "Hello from client!"]).not.toEqual(messages);
-        expect(result.code).toBe(1006);
-        expect(result.reason).toBe("Failed to connect");
+        expect(result.code).toBe(1015);
+        expect(result.reason).toBe("TLS handshake failed");
       }
     } finally {
       server.stop(true);
@@ -464,34 +464,38 @@ describe("WebSocket", () => {
     gc(true);
   });
 
-  it("should report failing websocket construction to onerror/onclose", async () => {
-    let did_report_error = false;
-    let did_report_close = false;
+  // If this test fails locally, check that ATT DNS error assist is disabled
+  // or, make sure that your DNS server is pointed to a DNS server that does not mitm your requests
+  it("should report failing websocket connection in onerror and onclose for DNS resolution error", async () => {
+    const url = `ws://aposdkpaosdkpasodk.com`;
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const { promise: promise2, resolve: resolve2, reject: reject2 } = Promise.withResolvers();
 
-    try {
-      const url = `wss://some-random-domain.smth`;
-      await new Promise((resolve, reject) => {
-        const ws = new WebSocket(url, {});
-        let timeout = setTimeout(() => {
-          reject.call();
-        }, 500);
-
-        ws.onclose = () => {
-          did_report_close = true;
-          clearTimeout(timeout);
-          resolve.call();
-        };
-
-        ws.onerror = () => {
-          did_report_error = true;
-        };
-      });
-    } finally {
-    }
-
-    expect(did_report_error).toBe(true);
-    expect(did_report_close).toBe(true);
+    const ws = new WebSocket(url, {});
+    ws.onopen = () => reject(new Error("should not be called"));
+    ws.onmessage = () => reject(new Error("should not be called"));
+    ws.onerror = () => {
+      resolve();
+    };
+    ws.onclose = () => resolve2();
+    await Promise.all([promise, promise2]);
   });
+});
+
+// We want to test that the `onConnectError` callback gets called.
+it("should report failing websocket connection in onerror and onclose for connection refused", async () => {
+  const url = `ws://localhost:65412`;
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const { promise: promise2, resolve: resolve2, reject: reject2 } = Promise.withResolvers();
+
+  const ws = new WebSocket(url, {});
+  ws.onopen = () => reject(new Error("should not be called"));
+  ws.onmessage = () => reject(new Error("should not be called"));
+  ws.onerror = () => {
+    resolve();
+  };
+  ws.onclose = () => resolve2();
+  await Promise.all([promise, promise2]);
 });
 
 describe("websocket in subprocess", () => {


### PR DESCRIPTION
### What does this PR do?

- Prepare for #5091 by swapping almost all usages of `vm.runErrorHandler` to `vm.onError` which calls the currently registered error handler instead of the global one. This may cause test failures, we will see.
- Shrink `ServerWebSocket` struct size from 28 bytes -> 24 bytes, which should slightly improve performance (rounding to alignment it was probably 32 bytes before)
- Micro-optimize console.log on objects which implement util.inspect.custom by caching the structure. This was barely measurable, might not be worth it
- Fixes a bug where throwing while logging a custom inspect would print `[native code]` because it was not correctly checking for exceptions
- This adds a test for `onConnectError` and fixes a double free there. Fixes #10619. 
- `WebSocket` now emits close code 1015 for TLS handshaking failure (cc @cirospaciari). Browsers do not do this. But on a server, this is useful information (image from the websocket spec).
<img width="1367" alt="image" src="https://github.com/oven-sh/bun/assets/709451/75cee40b-d089-4151-be24-bbbd00ef8a36">

Along the way, noticed a bug with unhandled errors. We seem to continue executing in cases where we should not continue executing. I think it's simple to fix, but it is very much a breaking change until we do #5091


### How did you verify your code works?

There are tests