### PR TITLE
fix flaky udp test

### DIFF
--- a/src/bun.js/api/bun/udp_socket.zig
+++ b/src/bun.js/api/bun/udp_socket.zig
@@ -145,7 +145,11 @@ pub const UDPSocketConfig = struct {
         const port: u16 = brk: {
             if (options.getTruthy(globalThis, "port")) |value| {
                 const number = value.coerceToInt32(globalThis);
-                break :brk if (number < 1 or number > 0xffff) 0 else @intCast(number);
+                if (number < 0 or number > 0xffff) {
+                    globalThis.throwInvalidArguments("Expected \"port\" to be an integer between 0 and 65535", .{});
+                    return null;
+                }
+                break :brk @intCast(number);
             } else {
                 break :brk 0;
             }

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -265,7 +265,7 @@ export function fakeNodeRun(dir: string, file: string | string[], env?: Record<s
 }
 
 export function randomPort(): number {
-  return 1024 + Math.floor(Math.random() * 65535);
+  return 1024 + Math.floor(Math.random() * (65535 - 1024));
 }
 
 expect.extend({

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -28,7 +28,7 @@ describe("udpSocket()", () => {
   });
 
   test("can create a socket with given port", async () => {
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 30; i++) {
       const port = randomPort();
       try {
         const socket = await udpSocket({ port });

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -28,11 +28,18 @@ describe("udpSocket()", () => {
   });
 
   test("can create a socket with given port", async () => {
-    const port = randomPort();
-    const socket = await udpSocket({ port });
-    expect(socket.port).toBe(port);
-    expect(socket.address).toMatchObject({ port: socket.port });
-    socket.close();
+    for (let i = 0; i < 5; i++) {
+      const port = randomPort();
+      try {
+        const socket = await udpSocket({ port });
+        expect(socket.port).toBe(port);
+        expect(socket.address).toMatchObject({ port: socket.port });
+        socket.close();
+        break;
+      } catch (e) {
+        continue;
+      }
+    }
   });
 
   test("can create a socket with a random port", async () => {


### PR DESCRIPTION
### What does this PR do?
Makes `udpSocket` throw on invalid port and makes the `create socket with given port` test retry until it can find an unused port, hopefully eliminating flakiness.

### How did you verify your code works?
existing tests