### PR TITLE
fix `child_process.test.ts` test case on windows

### DIFF
--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -381,45 +381,54 @@ it("should call close and exit before process exits", async () => {
   expect(data).toContain("exithHandler called");
 });
 
-it("it accepts stdio passthrough", async () => {
-  const package_dir = tmpdirSync("bun-node-child_process");
+it(
+  "it accepts stdio passthrough",
+  async () => {
+    const package_dir = tmpdirSync("bun-node-child_process");
 
-  await fs.promises.writeFile(
-    path.join(package_dir, "package.json"),
-    JSON.stringify({
-      "name": "npm-run-all-test",
-      "version": "1.0.0",
-      "type": "module",
-      "scripts": {
-        "all": "run-p echo-hello echo-world",
-        "echo-hello": "echo hello",
-        "echo-world": "echo world",
-      },
-      "devDependencies": {
-        "npm-run-all": "^4",
-      },
-    }),
-  );
+    await fs.promises.writeFile(
+      path.join(package_dir, "package.json"),
+      JSON.stringify({
+        "name": "npm-run-all-test",
+        "version": "1.0.0",
+        "type": "module",
+        "scripts": {
+          "all": "run-p echo-hello echo-world",
+          "echo-hello": "echo hello",
+          "echo-world": "echo world",
+        },
+        "devDependencies": {
+          "npm-run-all": "^4",
+        },
+      }),
+    );
 
-  let { stdout, stderr, exited } = Bun.spawn({
-    cmd: [bunExe(), "install"],
-    cwd: package_dir,
-    stdio: ["ignore", "ignore", "ignore"],
-    env: bunEnv,
-  });
-  expect(await exited).toBe(0);
+    let { stdout, stderr, exited } = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdio: ["ignore", "ignore", "ignore"],
+      env: bunEnv,
+    });
+    expect(await exited).toBe(0);
 
-  ({ stdout, stderr, exited } = Bun.spawn({
-    cmd: [bunExe(), "--bun", "run", "all"],
-    cwd: package_dir,
-    stdio: ["ignore", "pipe", "pipe"],
-    env: bunEnv,
-  }));
+    ({ stdout, stderr, exited } = Bun.spawn({
+      cmd: [bunExe(), "--bun", "run", "all"],
+      cwd: package_dir,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: bunEnv,
+    }));
 
-  expect(stderr).toBeDefined();
-  const err = await new Response(stderr).text();
-  expect(err.split("\n").map(x => x.replaceAll("[bun shell] ", ""))).toEqual(["$ run-p echo-hello echo-world", "$ echo hello", "$ echo world", ""]);
-  expect(stdout).toBeDefined();
-  const out = await new Response(stdout).text();
-  expect(out.split("\n")).toEqual(["hello", "world", ""]);
-}, { timeout: 20000 });
+    expect(stderr).toBeDefined();
+    const err = await new Response(stderr).text();
+    expect(err.split("\n").map(x => x.replaceAll("[bun shell] ", ""))).toEqual([
+      "$ run-p echo-hello echo-world",
+      "$ echo hello",
+      "$ echo world",
+      "",
+    ]);
+    expect(stdout).toBeDefined();
+    const out = await new Response(stdout).text();
+    expect(out.split("\n")).toEqual(["hello", "world", ""]);
+  },
+  { timeout: 20000 },
+);

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -418,8 +418,8 @@ it("it accepts stdio passthrough", async () => {
 
   expect(stderr).toBeDefined();
   const err = await new Response(stderr).text();
-  expect(err.split("\n")).toEqual(["$ run-p echo-hello echo-world", "$ echo hello", "$ echo world", ""]);
+  expect(err.split("\n").map(x => x.replaceAll("[bun shell] ", ""))).toEqual(["$ run-p echo-hello echo-world", "$ echo hello", "$ echo world", ""]);
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
   expect(out.split("\n")).toEqual(["hello", "world", ""]);
-});
+}, { timeout: 20000 });


### PR DESCRIPTION
### What does this PR do?
One of the tests does string comparison to shell output and disregards the fact that the bun shell prefixes output with `[bun shell]`. This PR changes the test to account for this. It also increases the timeout because the test would sometimes fail to complete in the default timeout.

### How did you verify your code works?
Test now passes
