### PR TITLE
Make Windows command line argument parsing more robust

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2091,8 +2091,46 @@ pub const Stat = if (Environment.isWindows) windows.libuv.uv_stat_t else std.os.
 
 pub var argv: [][:0]const u8 = &[_][:0]const u8{};
 
+extern "c" fn CommandLineToArgvW([*:0]u16, *c_int) ?[*][*:0]u16;
+
 pub fn initArgv(allocator: std.mem.Allocator) !void {
-    argv = try std.process.argsAlloc(allocator);
+    if (comptime !Environment.isWindows) {
+        argv = try std.process.argsAlloc(allocator);
+    } else {
+        // Zig's implementation of `std.process.argsAlloc()`on Windows platforms
+        // is not reliable, specifically the way it splits the command line string.
+        //
+        // For example, an arg like "foo\nbar" will be
+        // erroneously split into two arguments: "foo" and "bar".
+        //
+        // To work around this, we can simply call the Windows API functions
+        // that do this for us.
+        //
+        // Updates in Zig v0.12 related to Windows cmd line parsing may fix this,
+        // see (here: https://ziglang.org/download/0.12.0/release-notes.html#Windows-Command-Line-Argument-Parsing),
+        // so this may only need to be a temporary workaround.
+        const cmdline_ptr = std.os.windows.kernel32.GetCommandLineW();
+        var length: c_int = 0;
+        const argvu16_ptr = CommandLineToArgvW(cmdline_ptr, &length) orelse {
+            switch (sys.getErrno({})) {
+                // may be returned if can't alloc enough space for the str
+                .NOMEM => return error.OutOfMemory,
+                // may be returned if it's invalid
+                .INVAL => return error.InvalidArgument,
+                // TODO: anything else?
+                else => return error.Unknown,
+            }
+        };
+        const argvu16 = argvu16_ptr[0..@intCast(length)];
+        var out_argv = try allocator.alloc([:0]u8, @intCast(length));
+        for (argvu16, 0..) |argraw, i| {
+            const arg = std.mem.span(argraw);
+            // Invalid surrogates are not allowed in the command line string so
+            // WTF-8 is not necessary
+            out_argv[i] = try strings.toUTF8AllocZ(allocator, arg);
+        }
+        argv = out_argv;
+    }
 }
 
 pub const posix = struct {

--- a/src/string_builder.zig
+++ b/src/string_builder.zig
@@ -42,6 +42,16 @@ pub fn deinit(this: *StringBuilder, allocator: Allocator) void {
     allocator.free(this.ptr.?[0..this.cap]);
 }
 
+pub fn count16(this: *StringBuilder, slice: []const u16) void {
+    const result = bun.simdutf.length.utf8.from.utf16.le(slice);
+    this.cap += result;
+}
+
+pub fn count16Z(this: *StringBuilder, slice: [:0]const u16) void {
+    const result = bun.simdutf.length.utf8.from.utf16.le(slice);
+    this.cap += result + 1;
+}
+
 pub fn append16(this: *StringBuilder, slice: []const u16) ?[:0]u8 {
     var buf = this.writable();
     const result = bun.simdutf.convert.utf16.to.utf8.with_errors.le(slice, buf);

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -91,10 +91,10 @@ pub extern "kernel32" fn SetFileValidData(
     validDataLength: c_longlong,
 ) callconv(windows.WINAPI) win32.BOOL;
 
-pub extern fn CommandLineToArgvW(
+pub extern "kernel32" fn CommandLineToArgvW(
     lpCmdLine: win32.LPCWSTR,
     pNumArgs: *c_int,
-) callconv(windows.WINAPI) [*]win32.LPWSTR;
+) callconv(windows.WINAPI) ?[*]win32.LPWSTR;
 
 pub extern fn GetFileType(
     hFile: win32.HANDLE,

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -94,7 +94,7 @@ pub extern "kernel32" fn SetFileValidData(
 pub extern fn CommandLineToArgvW(
     lpCmdLine: win32.LPCWSTR,
     pNumArgs: *c_int,
-) [*]win32.LPWSTR;
+) callconv(windows.WINAPI) [*]win32.LPWSTR;
 
 pub extern fn GetFileType(
     hFile: win32.HANDLE,


### PR DESCRIPTION
### What does this PR do?

This fixes a failing test in bunshell.test.ts related to some discrepancies in Windows command line argument parsing

Specifically the problem is that `std.process.argsAlloc()` was incorrectly splitting the command line string into argv

The fix is just to use the Windows API functions that do this

Note that Zig 0.12 shipped with command line arg parsing fixes, which _may_ fix this, so this serves more as a temporary
work around

### How did you verify your code works?


- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)