### PR TITLE
fix flaky `bun-create.test.ts` with git templates

### DIFF
--- a/docs/cli/bun-create.md
+++ b/docs/cli/bun-create.md
@@ -207,8 +207,8 @@ After cloning a template, `bun create` will automatically remove the `"bun-creat
 
 ---
 
-- `GITHUB_ACCESS_TOKEN`
-- This lets `bun create` work with private repositories or if you get rate-limited
+- `GITHUB_TOKEN` (or `GITHUB_ACCESS_TOKEN`)
+- This lets `bun create` work with private repositories or if you get rate-limited. `GITHUB_TOKEN` is chosen over `GITHUB_ACCESS_TOKEN` if both exist.
 
 {% /table %}
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2206,7 +2206,7 @@ pub const Command = struct {
                         \\  <b><green>bun create<r> <blue>\<username/repo\><r> <cyan>[...flags]<r> <blue>[dest]<r>
                         \\
                         \\<b>Environment variables:<r>
-                        \\  <cyan>GITHUB_ACCESS_TOKEN<r>      <d>Supply a token to download code from GitHub with a higher rate limit<r>
+                        \\  <cyan>GITHUB_TOKEN<r>             <d>Supply a token to download code from GitHub with a higher rate limit<r>
                         \\  <cyan>GITHUB_API_DOMAIN<r>        <d>Configure custom/enterprise GitHub domain. Default "api.github.com".<r>
                         \\  <cyan>NPM_CLIENT<r>               <d>Absolute path to the npm client executable<r>
                     ;

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1851,7 +1851,7 @@ pub const Example = struct {
         var header_entries: Headers.Entries = .{};
         var headers_buf: string = "";
 
-        if (env_loader.map.get("GITHUB_ACCESS_TOKEN")) |access_token| {
+        if (env_loader.map.get("GITHUB_TOKEN") orelse env_loader.map.get("GITHUB_ACCESS_TOKEN")) |access_token| {
             if (access_token.len > 0) {
                 headers_buf = try std.fmt.allocPrint(ctx.allocator, "AuthorizationBearer {s}", .{access_token});
                 try header_entries.append(

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -213,17 +213,17 @@ pub const UpgradeCommand = struct {
 
         if (env_loader.map.get("GITHUB_TOKEN") orelse env_loader.map.get("GITHUB_ACCESS_TOKEN")) |access_token| {
             if (access_token.len > 0) {
-                headers_buf = try std.fmt.allocPrint(allocator, default_github_headers ++ "Access-TokenBearer {s}", .{access_token});
+                headers_buf = try std.fmt.allocPrint(allocator, default_github_headers ++ "AuthorizationBearer {s}", .{access_token});
                 try header_entries.append(
                     allocator,
                     Headers.Kv{
                         .name = Api.StringPointer{
-                            .offset = accept.value.length + accept.value.offset,
-                            .length = @as(u32, @intCast("Access-Token".len)),
+                            .offset = accept.value.offset + accept.value.length,
+                            .length = @as(u32, @intCast("Authorization".len)),
                         },
                         .value = Api.StringPointer{
-                            .offset = @as(u32, @intCast(accept.value.length + accept.value.offset + "Access-Token".len)),
-                            .length = @as(u32, @intCast(access_token.len)),
+                            .offset = @as(u32, @intCast(accept.value.offset + accept.value.length + "Authorization".len)),
+                            .length = @as(u32, @intCast("Bearer ".len + access_token.len)),
                         },
                     },
                 );

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -211,7 +211,7 @@ pub const UpgradeCommand = struct {
             ),
         );
 
-        if (env_loader.map.get("GITHUB_ACCESS_TOKEN")) |access_token| {
+        if (env_loader.map.get("GITHUB_TOKEN") orelse env_loader.map.get("GITHUB_ACCESS_TOKEN")) |access_token| {
             if (access_token.len > 0) {
                 headers_buf = try std.fmt.allocPrint(allocator, default_github_headers ++ "Access-TokenBearer {s}", .{access_token});
                 try header_entries.append(


### PR DESCRIPTION
### What does this PR do?
checks for both `GITHUB_TOKEN` and `GITHUB_ACCESS_TOKEN` in `bun create` and `bun upgrade`
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
