### PR TITLE
Deflake fs.watchFile tests

### DIFF
--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -19,11 +19,14 @@ const testDir = tempDirWithFiles("watch", {
 describe("fs.watchFile", () => {
   test("zeroed stats if does not exist", async () => {
     let entries: any = [];
+    let { promise, resolve } = Promise.withResolvers<void>();
     fs.watchFile(path.join(testDir, "does-not-exist"), (curr, prev) => {
       entries.push([curr, prev]);
+      resolve();
+      resolve = () => {};
     });
 
-    await Bun.sleep(35);
+    await promise;
 
     fs.unwatchFile(path.join(testDir, "does-not-exist"));
 
@@ -34,16 +37,19 @@ describe("fs.watchFile", () => {
     expect(entries[0][1].mtimeMs).toBe(0);
   });
   test("it watches a file", async () => {
+    let { promise, resolve } = Promise.withResolvers<void>();
     let entries: any = [];
     fs.watchFile(path.join(testDir, "watch.txt"), { interval: 50 }, (curr, prev) => {
       entries.push([curr, prev]);
+      resolve();
+      resolve = () => {};
     });
     let increment = 0;
     const interval = repeat(() => {
       increment++;
       fs.writeFileSync(path.join(testDir, "watch.txt"), "hello" + increment);
     });
-    await Bun.sleep(300);
+    await promise;
     clearInterval(interval);
 
     fs.unwatchFile(path.join(testDir, "watch.txt"));
@@ -56,8 +62,11 @@ describe("fs.watchFile", () => {
   });
   test("unicode file name", async () => {
     let entries: any = [];
+    let { promise, resolve } = Promise.withResolvers<void>();
     fs.watchFile(path.join(testDir, encodingFileName), { interval: 50 }, (curr, prev) => {
       entries.push([curr, prev]);
+      resolve();
+      resolve = () => {};
     });
 
     let increment = 0;
@@ -65,7 +74,7 @@ describe("fs.watchFile", () => {
       increment++;
       fs.writeFileSync(path.join(testDir, encodingFileName), "hello" + increment);
     });
-    await Bun.sleep(300);
+    await promise;
     clearInterval(interval);
 
     fs.unwatchFile(path.join(testDir, encodingFileName));
@@ -79,8 +88,11 @@ describe("fs.watchFile", () => {
 
   test("bigint stats", async () => {
     let entries: any = [];
+    let { promise, resolve } = Promise.withResolvers<void>();
     fs.watchFile(path.join(testDir, encodingFileName), { interval: 50, bigint: true }, (curr, prev) => {
       entries.push([curr, prev]);
+      resolve();
+      resolve = () => {};
     });
 
     let increment = 0;
@@ -88,7 +100,7 @@ describe("fs.watchFile", () => {
       increment++;
       fs.writeFileSync(path.join(testDir, encodingFileName), "hello" + increment);
     });
-    await Bun.sleep(300);
+    await promise;
     clearInterval(interval);
 
     fs.unwatchFile(path.join(testDir, encodingFileName));


### PR DESCRIPTION
### What does this PR do?

Deflake fs.watchFile tests

If they fail now, then they something is actually broken instead of a timer issue

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
