### PR TITLE
Fix crash in Windows PipeReader

### DIFF
--- a/packages/bun-internal-test/src/runner.node.mjs
+++ b/packages/bun-internal-test/src/runner.node.mjs
@@ -502,7 +502,8 @@ if (failing_tests.length) {
       .replace(/^::(group|endgroup|error|warning|set-output|add-matcher|remove-matcher).*$/gm, "");
 
     if (failing_output.length > 1024 * 64) {
-      failing_output = failing_output.slice(0, 1024 * 64) + `\n\n[truncated output (length: ${failing_output.length})]`;
+      failing_output =
+        failing_output.slice(0, 1024 * 64) + `\n\n[truncated output (length: ${failing_output.length})]\n`;
     }
 
     report += failing_output;

--- a/src/Global.zig
+++ b/src/Global.zig
@@ -100,12 +100,16 @@ pub fn exit(code: u8) noreturn {
 
 pub fn exitWide(code: u32) noreturn {
     if (bun.crash_handler.panicking.load(.SeqCst) != 0) {
-        // We are in a panic, so let that thread handle the exit
+        // Another thread is panicking. If we exit now, their message will be
+        // truncated. Instead, we let them handle the exit. Note that the panic
+        // handler NEVER calls this exitWide
+
         // Sleep forever without hammering the CPU
         var futex = std.atomic.Value(u32).init(0);
         while (true) std.Thread.Futex.wait(&futex, 0);
         comptime unreachable;
     }
+
     if (comptime Environment.isMac) {
         std.c.exit(@bitCast(code));
     }

--- a/src/Global.zig
+++ b/src/Global.zig
@@ -99,6 +99,13 @@ pub fn exit(code: u8) noreturn {
 }
 
 pub fn exitWide(code: u32) noreturn {
+    if (bun.crash_handler.panicking.load(.SeqCst) != 0) {
+        // We are in a panic, so let that thread handle the exit
+        // Sleep forever without hammering the CPU
+        var futex = std.atomic.Value(u32).init(0);
+        while (true) std.Thread.Futex.wait(&futex, 0);
+        comptime unreachable;
+    }
     if (comptime Environment.isMac) {
         std.c.exit(@bitCast(code));
     }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3155,3 +3155,23 @@ pub inline fn unsafeAssert(condition: bool) void {
         unreachable;
     }
 }
+
+pub fn unexpectedTag(union_value: anytype) noreturn {
+    @setCold(true);
+
+    const non_pointer = switch (@typeInfo(@TypeOf(union_value))) {
+        else => union_value,
+        .Pointer => union_value.*,
+    };
+
+    Output.panic("Unexpected tag: " ++ @typeName(@TypeOf(non_pointer)) ++ ".{s}", .{
+        @tagName(non_pointer),
+    });
+}
+
+pub fn releaseNonNull(optional: anytype) @TypeOf(optional.?) {
+    return optional orelse {
+        const name = @typeName(@TypeOf(optional.?));
+        Output.panic("Unexpected null (" ++ name ++ ")", .{});
+    };
+}

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -41,7 +41,7 @@ var has_printed_message = false;
 
 /// Non-zero whenever the program triggered a panic.
 /// The counter is incremented/decremented atomically.
-var panicking = std.atomic.Value(u8).init(0);
+pub var panicking = std.atomic.Value(u8).init(0);
 
 // Locked to avoid interleaving panic messages from multiple threads.
 var panic_mutex = std.Thread.Mutex{};
@@ -149,6 +149,10 @@ pub fn crashHandler(
                 if (reason != .out_of_memory or debug_trace) {
                     if (Output.enable_ansi_colors) {
                         writer.writeAll(Output.prettyFmt("<red>", true)) catch std.os.abort();
+                    }
+
+                    if (bun.Output.shouldLogPid()) |pid| {
+                        writer.print("process {d} ", .{pid}) catch std.os.abort();
                     }
 
                     writer.writeAll("panic") catch std.os.abort();

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -1803,7 +1803,7 @@ pub const fs_t = extern struct {
             if ((this.flags & UV_FS_CLEANEDUP) != 0) {
                 return;
             }
-            @panic("uv_fs_t was not cleaned up. it is expected to call .deinit() on the fs_t here.");
+            @panic("uv_fs_t was not cleaned up. this is either a double-use of fs_t or a missing .deinit() call");
         }
     }
 

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -1777,6 +1777,11 @@ pub const fs_t = extern struct {
     pub inline fn deinit(this: *fs_t) void {
         this.assertInitialized();
         uv_fs_req_cleanup(this);
+        if (bun.Environment.isDebug) {
+            const flags = this.flags;
+            this.* = undefined;
+            this.flags = flags;
+        }
         this.assertCleanedUp();
     }
 

--- a/src/fd.zig
+++ b/src/fd.zig
@@ -356,6 +356,14 @@ pub const FDImpl = packed struct {
             @compileError("invalid format string for FDImpl.format. must be empty like '{}'");
         }
 
+        // if (std.debug.runtime_safety) {
+        //     const undef = comptime std.mem.bytesAsValue(FDImpl, &([_]u8{0xAA} ** @sizeOf(FDImpl))).encode();
+        //     if (this.encode() == undef) {
+        //         try writer.writeAll("[garbage memory]");
+        //         return;
+        //     }
+        // }
+
         switch (env.os) {
             else => {
                 const fd = this.system();

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -396,8 +396,7 @@ pub fn WindowsPipeReader(
                     }
                     // we got some data lets get the current iov
                     const len: usize = @intCast(nread_int);
-                    const source = bun.releaseNonNull(this.source);
-                    switch (source) {
+                    switch (bun.releaseNonNull(this.source)) {
                         .file => |file| {
                             defer if (!this.flags.is_paused) {
                                 file.fs.assertCleanedUp();

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -396,9 +396,6 @@ pub fn WindowsPipeReader(
                     }
                     // we got some data lets get the current iov
                     const len: usize = @intCast(nread_int);
-                    if (this.source == null) {
-                        bun.Output.panic("oh uh {}, {d}", .{ fd, nread_int });
-                    }
                     const source = bun.releaseNonNull(this.source);
                     switch (source) {
                         .file => |file| {
@@ -418,7 +415,7 @@ pub fn WindowsPipeReader(
                             var buf = file.iov.slice();
                             return this.onRead(.{ .result = len }, buf[0..len], .progress);
                         },
-                        else => bun.unexpectedTag(source),
+                        else => |t| bun.unexpectedTag(t),
                     }
                 },
             }

--- a/src/output.zig
+++ b/src/output.zig
@@ -670,12 +670,10 @@ pub fn scoped(comptime tag: anytype, comptime disabled: bool) LogFunction {
 
 pub fn shouldLogPid() ?c_int {
     if (debug_scoped_add_pid == .unknown) {
-        // debug_scoped_add_pid = if (bun.getenvZ("BUN_DEBUG_ADD_PID")) |val|
-        //     if (bun.strings.eqlComptime(val, "1")) .{ .yes = getpid() } else .no
-        // else
-        //     .no;
-
-        debug_scoped_add_pid = .{ .yes = getpid() };
+        debug_scoped_add_pid = if (bun.getenvZ("BUN_DEBUG_ADD_PID")) |val|
+            if (bun.strings.eqlComptime(val, "1")) .{ .yes = getpid() } else .no
+        else
+            .no;
     }
 
     return switch (debug_scoped_add_pid) {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -17,15 +17,14 @@ export const isIntelMacOS = isMacOS && process.arch === "x64";
 export const bunEnv: NodeJS.ProcessEnv = {
   ...process.env,
   GITHUB_ACTIONS: "false",
-  BUN_DEBUG_ADD_PID: "1",
-  // BUN_DEBUG_QUIET_LOGS: "1",
+  BUN_DEBUG_QUIET_LOGS: "1",
   NO_COLOR: "1",
   FORCE_COLOR: undefined,
   TZ: "Etc/UTC",
   CI: "1",
-  // BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
-  // BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
-  // BUN_GARBAGE_COLLECTOR_LEVEL: process.env.BUN_GARBAGE_COLLECTOR_LEVEL || "0",
+  BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
+  BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+  BUN_GARBAGE_COLLECTOR_LEVEL: process.env.BUN_GARBAGE_COLLECTOR_LEVEL || "0",
 };
 
 if (isWindows) {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -17,14 +17,15 @@ export const isIntelMacOS = isMacOS && process.arch === "x64";
 export const bunEnv: NodeJS.ProcessEnv = {
   ...process.env,
   GITHUB_ACTIONS: "false",
-  BUN_DEBUG_QUIET_LOGS: "1",
+  BUN_DEBUG_ADD_PID: "1",
+  // BUN_DEBUG_QUIET_LOGS: "1",
   NO_COLOR: "1",
   FORCE_COLOR: undefined,
   TZ: "Etc/UTC",
   CI: "1",
-  BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
-  BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
-  BUN_GARBAGE_COLLECTOR_LEVEL: process.env.BUN_GARBAGE_COLLECTOR_LEVEL || "0",
+  // BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
+  // BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+  // BUN_GARBAGE_COLLECTOR_LEVEL: process.env.BUN_GARBAGE_COLLECTOR_LEVEL || "0",
 };
 
 if (isWindows) {

--- a/test/integration/next-pages/test/dev-server-puppeteer.ts
+++ b/test/integration/next-pages/test/dev-server-puppeteer.ts
@@ -65,8 +65,11 @@ async function main() {
   await counter_root.$eval(".dec", x => (x as HTMLElement).click());
   assert.strictEqual(await getCount(), "Count A: 1");
 
+  console.log("reloading");
+  const wait2 = waitForConsoleMessage(p, /counter a/);
   p.reload({});
-  await waitForConsoleMessage(p, /counter a/);
+  await wait2;
+  console.log("reloaded");
 
   assert.strictEqual(await p.$eval("code.font-bold", x => x.innerText), Bun.version);
 
@@ -108,6 +111,9 @@ async function main() {
 
 try {
   await main();
+} catch (e) {
+  console.error(e);
+  process.exit(1);
 } finally {
   await b?.close?.();
 }

--- a/test/integration/next-pages/test/dev-server.test.ts
+++ b/test/integration/next-pages/test/dev-server.test.ts
@@ -149,5 +149,6 @@ test.skipIf(puppeteer_unsupported)(
     // @ts-expect-error
     timeout = undefined;
   },
-  30000,
+  // debug builds are slow
+  Bun.version.endsWith("-debug") ? Infinity : 30000,
 );


### PR DESCRIPTION
### What does this PR do?

Fixes #10660, a crash impacting Next.js dev server while reading files.

To make better panics, I'm introducing two new functions:

- `unexpectedTag`, for use in a switch `else => |t| unexpectedTag`
- `releaseNonNull`, named after the method of the same name in WebKit's `Ref`. This is a release-mode safety checked version of `.?` and should be used if one is not confident 

This fixes the test locally for me, but I don't think it will fix CI as CI was running into a different test failure.