### PR TITLE
node:fs.fdatasync: include fd in Error when thrown

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -4186,8 +4186,7 @@ pub const NodeFS = struct {
         if (Environment.isWindows) {
             return Syscall.fdatasync(args.fd);
         }
-        return Maybe(Return.Fdatasync).errnoSys(system.fdatasync(args.fd.int()), .fdatasync) orelse
-            Maybe(Return.Fdatasync).success;
+        return Maybe(Return.Fdatasync).errnoSysFd(system.fdatasync(args.fd.int()), .fdatasync, args.fd) orelse Maybe(Return.Fdatasync).success;
     }
 
     pub fn fstat(_: *NodeFS, args: Arguments.Fstat, comptime _: Flavor) Maybe(Return.Fstat) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3019,3 +3019,14 @@ it("existsSync should never throw ENAMETOOLONG", () => {
 it("promises exists should never throw ENAMETOOLONG", async () => {
   expect(await _promises.exists(new Array(16).fill(new Array(64).fill("a")).join("/"))).toBeFalse();
 });
+
+it("promises.fdatasync with a bad fd should include that in the error thrown", async () => {
+  try {
+    await _promises.fdatasync(500);
+  } catch (e) {
+    expect(typeof e.fd).toBe("number");
+    expect(e.fd).toBe(500);
+    return;
+  }
+  expect.unreachable();
+});


### PR DESCRIPTION
many others do, but this one did not