### PR TITLE
fix `requestCert` and `rejectUnauthorized` option handling

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -560,13 +560,25 @@ pub const ServerConfig = struct {
             }
 
             if (obj.getTruthy(global, "requestCert")) |request_cert| {
-                result.request_cert = if (request_cert.asBoolean()) 1 else 0;
-                any = true;
+                if (request_cert.isBoolean()) {
+                    result.request_cert = if (request_cert.asBoolean()) 1 else 0;
+                    any = true;
+                } else {
+                    global.throw("Expected requestCert to be a boolean", .{});
+                    result.deinit();
+                    return null;
+                }
             }
 
             if (obj.getTruthy(global, "rejectUnauthorized")) |reject_unauthorized| {
-                result.reject_unauthorized = if (reject_unauthorized.asBoolean()) 1 else 0;
-                any = true;
+                if (reject_unauthorized.isBoolean()) {
+                    result.reject_unauthorized = if (reject_unauthorized.asBoolean()) 1 else 0;
+                    any = true;
+                } else {
+                    global.throw("Expected rejectUnauthorized to be a boolean", .{});
+                    result.deinit();
+                    return null;
+                }
             }
 
             if (obj.getTruthy(global, "ciphers")) |ssl_ciphers| {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -732,8 +732,14 @@ pub const ServerConfig = struct {
                 }
 
                 if (obj.get(global, "lowMemoryMode")) |low_memory_mode| {
-                    result.low_memory_mode = low_memory_mode.toBoolean();
-                    any = true;
+                    if (low_memory_mode.isBoolean() or low_memory_mode.isUndefined()) {
+                        result.low_memory_mode = low_memory_mode.toBoolean();
+                        any = true;
+                    } else {
+                        global.throw("Expected lowMemoryMode to be a boolean", .{});
+                        result.deinit();
+                        return null;
+                    }
                 }
             }
 
@@ -4203,6 +4209,11 @@ pub const ServerWebSocket = struct {
             return .zero;
         }
 
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+            globalThis.throw("publish expects compress to be a boolean", .{});
+            return .zero;
+        }
+
         const compress = args.len > 1 and compress_value.toBoolean();
 
         if (message_value.isEmptyOrUndefinedOrNull()) {
@@ -4280,6 +4291,11 @@ pub const ServerWebSocket = struct {
         var topic_slice = topic_value.toSlice(globalThis, bun.default_allocator);
         defer topic_slice.deinit();
 
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+            globalThis.throw("publishText expects compress to be a boolean", .{});
+            return .zero;
+        }
+
         const compress = args.len > 1 and compress_value.toBoolean();
 
         if (message_value.isEmptyOrUndefinedOrNull() or !message_value.isString()) {
@@ -4338,6 +4354,11 @@ pub const ServerWebSocket = struct {
         defer topic_slice.deinit();
         if (topic_slice.len == 0) {
             globalThis.throw("publishBinary requires a non-empty topic", .{});
+            return .zero;
+        }
+
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+            globalThis.throw("publishBinary expects compress to be a boolean", .{});
             return .zero;
         }
 
@@ -4509,6 +4530,11 @@ pub const ServerWebSocket = struct {
         const message_value = args.ptr[0];
         const compress_value = args.ptr[1];
 
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+            globalThis.throw("send expects compress to be a boolean", .{});
+            return .zero;
+        }
+
         const compress = args.len > 1 and compress_value.toBoolean();
 
         if (message_value.isEmptyOrUndefinedOrNull()) {
@@ -4577,6 +4603,11 @@ pub const ServerWebSocket = struct {
 
         const message_value = args.ptr[0];
         const compress_value = args.ptr[1];
+
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+            globalThis.throw("sendText expects compress to be a boolean", .{});
+            return .zero;
+        }
 
         const compress = args.len > 1 and compress_value.toBoolean();
 
@@ -4656,6 +4687,11 @@ pub const ServerWebSocket = struct {
 
         const message_value = args.ptr[0];
         const compress_value = args.ptr[1];
+
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+            globalThis.throw("sendBinary expects compress to be a boolean", .{});
+            return .zero;
+        }
 
         const compress = args.len > 1 and compress_value.toBoolean();
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1482,27 +1482,45 @@ if (process.platform === "linux")
     }).toThrow("permission denied 0.0.0.0:1003");
   });
 
-it("should error properly with invalid requestCert or rejectUnauthorized", async () => {
-  expect(() => {
-    Bun.serve({
-      port: 0,
-      fetch(req) {
-        return new Response("hi");
-      },
-      tls: {
-        requestCert: "invalid",
-      },
-    });
-  }).toThrow("Expected requestCert to be a boolean");
-  expect(() => {
-    Bun.serve({
-      port: 0,
-      fetch(req) {
-        return new Response("hi");
-      },
-      tls: {
-        rejectUnauthorized: "invalid",
-      },
-    });
-  }).toThrow("Expected rejectUnauthorized to be a boolean");
+describe("should error with invalid options", async () => {
+  it("requestCert", () => {
+    expect(() => {
+      Bun.serve({
+        port: 0,
+        fetch(req) {
+          return new Response("hi");
+        },
+        tls: {
+          requestCert: "invalid",
+        },
+      });
+    }).toThrow("Expected requestCert to be a boolean");
+  });
+  it("rejectUnauthorized", () => {
+    expect(() => {
+      Bun.serve({
+        port: 0,
+        fetch(req) {
+          return new Response("hi");
+        },
+        tls: {
+          rejectUnauthorized: "invalid",
+        },
+      });
+    }).toThrow("Expected rejectUnauthorized to be a boolean");
+  });
+  it("lowMemoryMode", () => {
+    expect(() => {
+      Bun.serve({
+        port: 0,
+        fetch(req) {
+          return new Response("hi");
+        },
+        tls: {
+          rejectUnauthorized: true,
+          lowMemoryMode: "invalid",
+        },
+      });
+    }).toThrow("Expected lowMemoryMode to be a boolean");
+  });
 });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1481,3 +1481,28 @@ if (process.platform === "linux")
       });
     }).toThrow("permission denied 0.0.0.0:1003");
   });
+
+it("should error properly with invalid requestCert or rejectUnauthorized", async () => {
+  expect(() => {
+    Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response("hi");
+      },
+      tls: {
+        requestCert: "invalid",
+      },
+    });
+  }).toThrow("Expected requestCert to be a boolean");
+  expect(() => {
+    Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response("hi");
+      },
+      tls: {
+        rejectUnauthorized: "invalid",
+      },
+    });
+  }).toThrow("Expected rejectUnauthorized to be a boolean");
+});

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -308,6 +308,18 @@ describe("ServerWebSocket", () => {
       30_000,
     );
   });
+
+  test("send/sendText/sendBinary error on invalid arguments", done => ({
+    open(ws) {
+      // @ts-expect-error
+      expect(() => ws.send("hello", "world")).toThrow("send expects compress to be a boolean");
+      // @ts-expect-error
+      expect(() => ws.sendText("hello", "world")).toThrow("sendText expects compress to be a boolean");
+      // @ts-expect-error
+      expect(() => ws.sendBinary(Buffer.from("hello"), "world")).toThrow("sendBinary expects compress to be a boolean");
+      done();
+    },
+  }));
   describe("sendBinary()", () => {
     for (const { label, message, bytes } of buffers) {
       test(label, done => ({
@@ -374,6 +386,23 @@ describe("ServerWebSocket", () => {
       }));
     }
   });
+
+  test("publish/publishText/publishBinary error on invalid arguments", done => ({
+    async open(ws) {
+      // @ts-expect-error
+      expect(() => ws.publish("hello", Buffer.from("hi"), "invalid")).toThrow(
+        "publish expects compress to be a boolean",
+      );
+      // @ts-expect-error
+      expect(() => ws.publishText("hello", "hi", "invalid")).toThrow("publishText expects compress to be a boolean");
+      // @ts-expect-error
+      expect(() => ws.publishBinary("hello", Buffer.from("hi"), "invalid")).toThrow(
+        "publishBinary expects compress to be a boolean",
+      );
+      done();
+    },
+  }));
+
   describe("publishBinary()", () => {
     for (const { label, message, bytes } of buffers) {
       test(label, (done, connect) => ({


### PR DESCRIPTION
### What does this PR do?
Errors on unexpected values for `requestCert` and `rejectUnauthorized`
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
