### PR TITLE
fix flaky jwt test

### DIFF
--- a/test/js/third_party/jsonwebtoken/issue_147.test.js
+++ b/test/js/third_party/jsonwebtoken/issue_147.test.js
@@ -5,6 +5,8 @@ describe("issue 147 - signing with a sealed payload", function () {
   it("should put the expiration claim", function () {
     var token = jwt.sign(Object.seal({ foo: 123 }), "123", { expiresIn: 1000 });
     var result = jwt.verify(token, "123");
-    expect(result.exp).toBeCloseTo(Math.floor(Date.now() / 1000) + 1000, 0);
+    const expected = Math.floor(Date.now() / 1000) + 1000;
+    // check that the expiration is within 1 second of the expected value
+    expect(result.exp).toBeWithin(expected - 1, expected + 2);
   });
 });


### PR DESCRIPTION
### What does this PR do?
`issue_147.test.js` is flaky on windows because it checks for exact equality to a time value. This change relaxes the check to within +-1 second instead.

### How did you verify your code works?
manually run the test 100'000 times and check that it doesn't fail.
