### PR TITLE
Rewrite some tests so they don't use GitHub annotations

### DIFF
--- a/test/js/bun/http/async-iterator-throws.fixture.js
+++ b/test/js/bun/http/async-iterator-throws.fixture.js
@@ -1,0 +1,18 @@
+const server = Bun.serve({
+  port: 0,
+
+  async fetch(req) {
+    return new Response(
+      async function* () {
+        throw new Error("Oops");
+      },
+      {
+        headers: {
+          "X-Hey": "123",
+        },
+      },
+    );
+  },
+});
+
+process.send(`${server.url}`);

--- a/test/js/bun/http/bun-serve.fixture.js
+++ b/test/js/bun/http/bun-serve.fixture.js
@@ -1,0 +1,35 @@
+import { serve, sleep } from "bun";
+
+const server = serve({
+  port: 0,
+
+  fetch(request) {
+    const { url } = request;
+    const { pathname } = new URL(url);
+    throw new Error(pathname);
+  },
+
+  async error(cause) {
+    const { message } = cause;
+
+    if (message === "/async-fulfilled") {
+      return new Response("Async fulfilled");
+    }
+
+    if (message === "/async-rejected") {
+      throw new Error("Async rejected");
+    }
+
+    if (message === "/async-pending") {
+      await sleep(1);
+      return new Response("Async pending");
+    }
+
+    if (message === "/async-rejected-pending") {
+      await sleep(1);
+      throw new Error("Async rejected pending");
+    }
+  },
+});
+
+process.send(`${server.url}`);

--- a/test/js/bun/http/readable-stream-throws.fixture.js
+++ b/test/js/bun/http/readable-stream-throws.fixture.js
@@ -1,0 +1,32 @@
+const server = Bun.serve({
+  port: 0,
+
+  error(err) {
+    return new Response("Failed", { status: 555 });
+  },
+
+  async fetch(request) {
+    const { pathname } = new URL(request.url);
+    return new Response(
+      new ReadableStream({
+        pull(controller) {
+          if (pathname === "/write") {
+            controller.enqueue("Hello, ");
+            controller.enqueue("world!");
+            controller.close();
+          }
+          throw new Error("Oops");
+        },
+        cancel(reason) {},
+      }),
+      {
+        status: 402,
+        headers: {
+          "X-Hey": "123",
+        },
+      },
+    );
+  },
+});
+
+process.send(`${server.url}`);

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1,5 +1,5 @@
 import { file, gc, Serve, serve, Server } from "bun";
-import { afterEach, describe, it, expect, afterAll } from "bun:test";
+import { afterEach, describe, it, expect, afterAll, mock } from "bun:test";
 import { readFileSync, writeFileSync } from "fs";
 import { join, resolve } from "path";
 import { bunExe, bunEnv, dumpStats } from "harness";
@@ -300,97 +300,64 @@ it("request.url should be based on the Host header", async () => {
 describe("streaming", () => {
   describe("error handler", () => {
     it("throw on pull renders headers, does not call error handler", async () => {
-      var pass = true;
-      await runTest(
-        {
-          error(e) {
-            pass = false;
-            return new Response("FAIL!", { status: 555 });
-          },
-          fetch(req) {
-            return new Response(
-              new ReadableStream({
-                pull(controller) {
-                  throw new Error("TestPassed");
-                },
-                cancel(reason) {},
-              }),
-              {
-                status: 402,
-                headers: {
-                  "I-AM": "A-TEAPOT",
-                },
-              },
-            );
-          },
-        },
-        async server => {
-          const response = await fetch(server.url.origin);
-          expect(response.status).toBe(402);
-          expect(response.headers.get("I-AM")).toBe("A-TEAPOT");
-          expect(await response.text()).toBe("");
-          expect(pass).toBe(true);
-        },
-      );
+      let subprocess;
+
+      afterAll(() => {
+        subprocess?.kill();
+      });
+
+      const onMessage = mock(async url => {
+        const response = await fetch(url);
+        expect(response.status).toBe(402);
+        expect(response.headers.get("X-Hey")).toBe("123");
+        expect(response.text()).resolves.toBe("");
+        subprocess.kill();
+      });
+
+      subprocess = Bun.spawn({
+        cwd: import.meta.dirname,
+        cmd: [bunExe(), "readable-stream-throws.fixture.js"],
+        env: bunEnv,
+        stdout: "ignore",
+        stderr: "pipe",
+        ipc: onMessage,
+      });
+
+      let [exitCode, stderr] = await Promise.all([subprocess.exited, new Response(subprocess.stderr).text()]);
+      expect(exitCode).toBeInteger();
+      expect(stderr).toContain("error: Oops");
+      expect(onMessage).toHaveBeenCalled();
     });
 
-    describe("throw on pull after writing should not call the error handler", () => {
-      async function execute(options: ResponseInit) {
-        var pass = true;
-        await runTest(
-          {
-            error(e) {
-              pass = false;
-              return new Response("FAIL", { status: 555 });
-            },
-            fetch(req) {
-              const stream = new ReadableStream({
-                async pull(controller) {
-                  controller.enqueue("PASS");
-                  controller.close();
-                  throw new Error("FAIL");
-                },
-              });
-              const r = new Response(stream, options);
-              return r;
-            },
-          },
-          async server => {
-            const response = await fetch(server.url.origin);
-            // connection terminated
-            expect(await response.text()).toBe("");
-            expect(response.status).toBe(options.status ?? 200);
-            expect(pass).toBe(true);
-          },
-        );
-      }
+    it("throw on pull after writing should not call the error handler", async () => {
+      let subprocess;
 
-      it("with headers", async () => {
-        await execute({
-          headers: {
-            "X-A": "123",
-          },
-        });
+      afterAll(() => {
+        subprocess?.kill();
       });
 
-      it("with headers and status", async () => {
-        await execute({
-          status: 204,
-          headers: {
-            "X-A": "123",
-          },
-        });
+      const onMessage = mock(async href => {
+        const url = new URL("write", href);
+        const response = await fetch(url);
+        expect(response.status).toBe(402);
+        expect(response.headers.get("X-Hey")).toBe("123");
+        expect(response.text()).resolves.toBe("");
+        subprocess.kill();
       });
 
-      it("with status", async () => {
-        await execute({
-          status: 204,
-        });
+      subprocess = Bun.spawn({
+        cwd: import.meta.dirname,
+        cmd: [bunExe(), "readable-stream-throws.fixture.js"],
+        env: bunEnv,
+        stdout: "ignore",
+        stderr: "pipe",
+        ipc: onMessage,
       });
 
-      it("with empty object", async () => {
-        await execute({});
-      });
+      let [exitCode, stderr] = await Promise.all([subprocess.exited, new Response(subprocess.stderr).text()]);
+      expect(exitCode).toBeInteger();
+      expect(stderr).toContain("error: Oops");
+      expect(onMessage).toHaveBeenCalled();
     });
   });
 
@@ -1419,55 +1386,48 @@ it("should response with HTTP 413 when request body is larger than maxRequestBod
 });
 
 it("should support promise returned from error", async () => {
-  const server = Bun.serve({
-    port: 0,
-    fetch(req) {
-      throw new Error(req.url);
-    },
-    async error(e) {
-      if (e.message.endsWith("/async-fulfilled")) {
-        return new Response("OK");
-      }
+  const { promise, resolve } = Promise.withResolvers<string>();
 
-      if (e.message.endsWith("/async-rejected")) {
-        throw new Error("");
-      }
-
-      if (e.message.endsWith("/async-rejected-pending")) {
-        await Bun.sleep(100);
-        throw new Error("");
-      }
-
-      if (e.message.endsWith("/async-pending")) {
-        await Bun.sleep(100);
-        return new Response("OK");
-      }
+  const subprocess = Bun.spawn({
+    cwd: import.meta.dirname,
+    cmd: [bunExe(), "bun-serve.fixture.js"],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+    ipc(message) {
+      resolve(message);
     },
   });
 
+  afterAll(() => {
+    subprocess.kill();
+  });
+
+  const url = new URL(await promise);
+
   {
-    const resp = await fetch(`${server.url.origin}/async-fulfilled`);
+    const resp = await fetch(new URL("async-fulfilled", url));
     expect(resp.status).toBe(200);
-    expect(await resp.text()).toBe("OK");
+    expect(resp.text()).resolves.toBe("Async fulfilled");
   }
 
   {
-    const resp = await fetch(`${server.url.origin}/async-pending`);
-    expect(resp.status).toBe(200);
-    expect(await resp.text()).toBe("OK");
-  }
-
-  {
-    const resp = await fetch(`${server.url.origin}/async-rejected`);
+    const resp = await fetch(new URL("async-rejected", url));
     expect(resp.status).toBe(500);
   }
 
   {
-    const resp = await fetch(`${server.url.origin}/async-rejected-pending`);
+    const resp = await fetch(new URL("async-pending", url));
+    expect(resp.status).toBe(200);
+    expect(resp.text()).resolves.toBe("Async pending");
+  }
+
+  {
+    const resp = await fetch(new URL("async-rejected-pending", url));
     expect(resp.status).toBe(500);
   }
 
-  server.stop(true);
+  subprocess.kill();
 });
 
 if (process.platform === "linux")


### PR DESCRIPTION
### What does this PR do?

Theses tests caused annoying Github annotations. They were re-written to be a subprocess instead.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
