### PR TITLE
Print bun version on unhandled errors

### DIFF
--- a/src/Global.zig
+++ b/src/Global.zig
@@ -50,6 +50,14 @@ else
 
 pub const os_name = Environment.os.nameString();
 
+// Bun v1.0.0 (Linux x64 baseline)
+// Bun v1.0.0-debug (Linux x64)
+// Bun v1.0.0-canary.0+44e09bb7f (Linux x64)
+pub const unhandled_error_bun_version_string = "Bun v" ++
+    (if (Environment.is_canary) package_json_version_with_revision else package_json_version) ++
+    " (" ++ Environment.os.displayString() ++ " " ++ arch_name ++
+    (if (Environment.baseline) " baseline)" else ")");
+
 pub const arch_name = if (Environment.isX64)
     "x64"
 else if (Environment.isX86)

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -181,6 +181,9 @@ static JSValue constructVersions(VM& vm, JSObject* processObject)
 #endif
     object->putDirect(vm, JSC::Identifier::fromString(vm, "napi"_s), JSValue(JSC::jsString(vm, makeString("9"_s))), 0);
 
+    object->putDirect(vm, JSC::Identifier::fromString(vm, "icu"_s), JSValue(JSC::jsString(vm, makeString(U_ICU_VERSION))), 0);
+    object->putDirect(vm, JSC::Identifier::fromString(vm, "unicode"_s), JSValue(JSC::jsString(vm, makeString(U_UNICODE_VERSION))), 0);
+
     object->putDirect(vm, JSC::Identifier::fromString(vm, "modules"_s),
         JSC::JSValue(JSC::jsString(vm, makeAtomString("115"))));
 

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -282,6 +282,13 @@ pub const Run = struct {
                 } else {
                     vm.exit_handler.exit_code = 1;
                     vm.onExit();
+
+                    if (run.any_unhandled) {
+                        Output.prettyErrorln(
+                            "\n<r><d>{s}<r>",
+                            .{Global.unhandled_error_bun_version_string},
+                        );
+                    }
                     Global.exit(1);
                 }
             }
@@ -307,6 +314,12 @@ pub const Run = struct {
             } else {
                 vm.exit_handler.exit_code = 1;
                 vm.onExit();
+                if (run.any_unhandled) {
+                    Output.prettyErrorln(
+                        "\n<r><d>{s}<r>",
+                        .{Global.unhandled_error_bun_version_string},
+                    );
+                }
                 Global.exit(1);
             }
         }
@@ -403,6 +416,11 @@ pub const Run = struct {
         vm.global.handleRejectedPromises();
         if (this.any_unhandled and this.vm.exit_handler.exit_code == 0) {
             this.vm.exit_handler.exit_code = 1;
+
+            Output.prettyErrorln(
+                "\n<r><d>{s}<r>",
+                .{Global.unhandled_error_bun_version_string},
+            );
         }
         const exit_code = this.vm.exit_handler.exit_code;
 

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -285,7 +285,7 @@ pub const Run = struct {
 
                     if (run.any_unhandled) {
                         Output.prettyErrorln(
-                            "\n<r><d>{s}<r>",
+                            "<r>\n<d>{s}<r>",
                             .{Global.unhandled_error_bun_version_string},
                         );
                     }
@@ -316,7 +316,7 @@ pub const Run = struct {
                 vm.onExit();
                 if (run.any_unhandled) {
                     Output.prettyErrorln(
-                        "\n<r><d>{s}<r>",
+                        "<r>\n<d>{s}<r>",
                         .{Global.unhandled_error_bun_version_string},
                     );
                 }
@@ -418,7 +418,7 @@ pub const Run = struct {
             this.vm.exit_handler.exit_code = 1;
 
             Output.prettyErrorln(
-                "\n<r><d>{s}<r>",
+                "<r>\n<d>{s}<r>",
                 .{Global.unhandled_error_bun_version_string},
             );
         }

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1293,7 +1293,6 @@ for (const [key, blob] of build.outputs) {
             let error;
             const lines = stderr!
               .toUnixString()
-              .replace(/Bun v.*?\)$/gm, "")
               .split("\n")
               // remove `Bun v1.0.0...` line
               .slice(0, -2)

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1293,6 +1293,7 @@ for (const [key, blob] of build.outputs) {
             let error;
             const lines = stderr!
               .toUnixString()
+              .replace(/Bun v.*?\)$/gm, "")
               .split("\n")
               // remove `Bun v1.0.0...` line
               .slice(0, -2)

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1294,6 +1294,8 @@ for (const [key, blob] of build.outputs) {
             const lines = stderr!
               .toUnixString()
               .split("\n")
+              // remove `Bun v1.0.0...` line
+              .slice(0, -2)
               .filter(Boolean)
               .map(x => x.trim())
               .reverse();

--- a/test/js/bun/util/__snapshots__/reportError.test.ts.snap
+++ b/test/js/bun/util/__snapshots__/reportError.test.ts.snap
@@ -22,7 +22,5 @@ error
 error
 error
 error
-
-Bun v1.1.7-debug (macOS arm64)
 "
 `;

--- a/test/js/bun/util/__snapshots__/reportError.test.ts.snap
+++ b/test/js/bun/util/__snapshots__/reportError.test.ts.snap
@@ -22,5 +22,7 @@ error
 error
 error
 error
+
+Bun v1.1.7-debug (macOS arm64)
 "
 `;

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -14,6 +14,9 @@ test("reportError", () => {
       BUN_JSC_showPrivateScriptsInStackTraces: "0",
     },
   });
-  const output = stderr.toString().replaceAll(cwd, "").replaceAll("\\", "/");
+  let output = stderr.toString().replaceAll(cwd, "").replaceAll("\\", "/");
+  // remove bun version from output
+  output = output.split("\n").slice(0, -2).join("\n");
+
   expect(output).toMatchSnapshot();
 });


### PR DESCRIPTION
example:

<img width="387" alt="Screenshot 2024-05-01 at 10 47 08 PM" src="https://github.com/oven-sh/bun/assets/35280289/6cc692d5-5592-41f7-8fbd-7c77604cdf58">

debug example:

<img width="404" alt="Screenshot 2024-05-01 at 10 44 47 PM" src="https://github.com/oven-sh/bun/assets/35280289/43ca7408-cf8d-4fd0-b574-0a635c3d69ce">

canary example:

<img width="405" alt="Screenshot 2024-05-01 at 10 36 22 PM" src="https://github.com/oven-sh/bun/assets/35280289/e36e745b-3d9e-44e3-8fe7-4be94d354f83">


---
Also adds `icu` and `unicode` to `process.versions`, fixes #10765 

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
