### PR TITLE
Fix bad stack traces

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -386,7 +386,7 @@ WTF::String Bun::formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* globalObject
                 // "".test(/[a-0]/);
                 auto originalLine = WTF::OrdinalNumber::fromOneBasedInt(err->line());
 
-                ZigStackFrame remappedFrame;
+                ZigStackFrame remappedFrame = {};
                 memset(&remappedFrame, 0, sizeof(ZigStackFrame));
 
                 remappedFrame.position.line = originalLine.zeroBasedInt() + 1;
@@ -467,7 +467,7 @@ WTF::String Bun::formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* globalObject
             LineColumn lineColumn = frame.computeLineAndColumn();
             thisLine = lineColumn.line;
             thisColumn = lineColumn.column;
-            ZigStackFrame remappedFrame;
+            ZigStackFrame remappedFrame = {};
             remappedFrame.position.line = thisLine;
             remappedFrame.position.column_start = thisColumn;
 
@@ -565,6 +565,7 @@ static String computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObje
         size_t framesCount = stackTrace.size();
         ZigStackFrame remappedFrames[framesCount];
         for (int i = 0; i < framesCount; i++) {
+            remappedFrames[i] = {};
             remappedFrames[i].source_url = Bun::toString(lexicalGlobalObject, stackTrace.at(i).sourceURL());
             if (JSCStackFrame::SourcePositions* sourcePositions = stackTrace.at(i).getSourcePositions()) {
                 remappedFrames[i].position.line = sourcePositions->line.oneBasedInt();

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4326,14 +4326,15 @@ static void fromErrorInstance(ZigException* except, JSC::JSGlobalObject* global,
                 iterator.forEachFrame([&](const V8StackTraceIterator::StackFrame& frame, bool& stop) -> void {
                     ASSERT(except->stack.frames_len < frame_count);
                     auto& current = except->stack.frames_ptr[except->stack.frames_len];
+                    current = {};
 
                     String functionName = frame.functionName.toString();
                     String sourceURL = frame.sourceURL.toString();
                     current.function_name = Bun::toStringRef(functionName);
                     current.source_url = Bun::toStringRef(sourceURL);
-                    current.position.line = frame.lineNumber.zeroBasedInt();
-                    current.position.column_start = frame.columnNumber.zeroBasedInt();
-                    current.position.column_stop = frame.columnNumber.zeroBasedInt();
+                    current.position.line = frame.lineNumber.oneBasedInt();
+                    current.position.column_start = frame.columnNumber.oneBasedInt();
+                    current.position.column_stop = frame.columnNumber.oneBasedInt();
 
                     current.remapped = true;
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4332,9 +4332,9 @@ static void fromErrorInstance(ZigException* except, JSC::JSGlobalObject* global,
                     String sourceURL = frame.sourceURL.toString();
                     current.function_name = Bun::toStringRef(functionName);
                     current.source_url = Bun::toStringRef(sourceURL);
-                    current.position.line = frame.lineNumber.oneBasedInt();
-                    current.position.column_start = frame.columnNumber.oneBasedInt();
-                    current.position.column_stop = frame.columnNumber.oneBasedInt();
+                    current.position.line = frame.lineNumber.zeroBasedInt();
+                    current.position.column_start = frame.columnNumber.zeroBasedInt();
+                    current.position.column_stop = frame.columnNumber.zeroBasedInt();
 
                     current.remapped = true;
 


### PR DESCRIPTION
### What does this PR do?

This fixes stack traces pointing to the wrong line on Windows (the cause of the remaining bunshell.test.ts failure)

The problem was caused by C++ variable being declared but not initialized causing undefined memory, and also an off-by-one error because of `.zeroBasedInt()`/`.oneBasedInt()`

- [x] Code changes
