### PR TITLE
allow connecting a socket again after its connection was closed

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -598,6 +598,11 @@ const Socket = (function (InternalSocket) {
       } catch (error) {
         process.nextTick(emitErrorAndCloseNextTick, this, error);
       }
+      // reset the underlying writable object when establishing a new connection
+      // this is a function on `Duplex`, originally defined on `Writable`
+      // https://github.com/nodejs/node/blob/c5cfdd48497fe9bd8dbd55fd1fca84b321f48ec1/lib/net.js#L311
+      // https://github.com/nodejs/node/blob/c5cfdd48497fe9bd8dbd55fd1fca84b321f48ec1/lib/net.js#L1126
+      this._undestroy();
       return this;
     }
 

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -35,7 +35,7 @@ it("should support net.isIPv6()", () => {
 describe("net.Socket read", () => {
   var unix_servers = 0;
   for (let [message, label] of [
-    // ["Hello World!".repeat(1024), "long message"],
+    ["Hello World!".repeat(1024), "long message"],
     ["Hello!", "short message"],
   ]) {
     describe(label, () => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1,6 +1,6 @@
 import { ServerWebSocket, TCPSocket, Socket as _BunSocket, TCPSocketListener } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { connect, isIP, isIPv4, isIPv6, Socket, createConnection } from "net";
+import { connect, isIP, isIPv4, isIPv6, Socket, createConnection, Server } from "net";
 import { realpathSync, mkdtempSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -353,6 +353,37 @@ describe("net.Socket write", () => {
       }
       socket.end();
     }),
+  );
+
+  it(
+    "should allow reconnecting after end()",
+    async () => {
+      const server = new Server(socket => socket.end());
+      const port = await new Promise(resolve => {
+        server.once("listening", () => resolve(server.address().port));
+        server.listen();
+      })
+
+      const socket = new Socket()
+      socket.on('data', data => console.log(data.toString()));
+      socket.on('error', err => console.error(err));
+
+      async function run() {
+          return new Promise((resolve, reject) => {
+              socket.once('connect', (...args) => {
+                  socket.write('script\n', (err) => {
+                      if (err) return reject(err)
+                      socket.end(() => setTimeout(resolve, 3))
+                  })
+              })
+              socket.connect(port, '127.0.0.1')
+          })
+      }
+
+      for (let i = 0; i < 10; i++) {
+          await run()
+      }
+    }
   );
 });
 

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -355,36 +355,33 @@ describe("net.Socket write", () => {
     }),
   );
 
-  it(
-    "should allow reconnecting after end()",
-    async () => {
-      const server = new Server(socket => socket.end());
-      const port = await new Promise(resolve => {
-        server.once("listening", () => resolve(server.address().port));
-        server.listen();
-      })
+  it("should allow reconnecting after end()", async () => {
+    const server = new Server(socket => socket.end());
+    const port = await new Promise(resolve => {
+      server.once("listening", () => resolve(server.address().port));
+      server.listen();
+    });
 
-      const socket = new Socket()
-      socket.on('data', data => console.log(data.toString()));
-      socket.on('error', err => console.error(err));
+    const socket = new Socket();
+    socket.on("data", data => console.log(data.toString()));
+    socket.on("error", err => console.error(err));
 
-      async function run() {
-          return new Promise((resolve, reject) => {
-              socket.once('connect', (...args) => {
-                  socket.write('script\n', (err) => {
-                      if (err) return reject(err)
-                      socket.end(() => setTimeout(resolve, 3))
-                  })
-              })
-              socket.connect(port, '127.0.0.1')
-          })
-      }
-
-      for (let i = 0; i < 10; i++) {
-          await run()
-      }
+    async function run() {
+      return new Promise((resolve, reject) => {
+        socket.once("connect", (...args) => {
+          socket.write("script\n", err => {
+            if (err) return reject(err);
+            socket.end(() => setTimeout(resolve, 3));
+          });
+        });
+        socket.connect(port, "127.0.0.1");
+      });
     }
-  );
+
+    for (let i = 0; i < 10; i++) {
+      await run();
+    }
+  });
 });
 
 it("should handle connection error", done => {


### PR DESCRIPTION
### What does this PR do?
Allows a `net.Socket` to be re-used to connect and write data to another peer after the initial connection is terminated, matching node's behavior.
Fixes #7325

### How did you verify your code works?
Added a test.
