### PR TITLE
fix(sourcemaps): prevent possible integer overflow

### DIFF
--- a/src/sourcemap/sourcemap.zig
+++ b/src/sourcemap/sourcemap.zig
@@ -721,8 +721,11 @@ pub fn encodeVLQ(value: i32) VLQ {
 
     var vlq: u32 = if (value >= 0)
         @as(u32, @bitCast(value << 1))
+    else if (value != std.math.minInt(i32))
+        @as(u32, @bitCast((-value << 1) | 1))
     else
-        @as(u32, @bitCast((-value << 1) | 1));
+        // `-value` will overflow if it's a signed minInt(T)
+        return .{ .bytes = .{ 104, 103, 103, 103, 103, 103, 69, 0 }, .len = 7 };
 
     // source mappings are limited to i32
     comptime var i: usize = 0;


### PR DESCRIPTION
### What does this PR do?
`-(minInt(T))` will overflow if T is signed

This pr hardcodes what `encodeVLQ` would return if `value` is `minInt(i32)`
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
manual
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
