### PR TITLE
Update documentation for the `[dir]` option when customizing bundler `naming`

### DIFF
--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -792,7 +792,7 @@ The names and locations of the generated files can be customized with the `namin
 - `[name]` - The name of the entrypoint file, without the extension.
 - `[ext]` - The extension of the generated bundle.
 - `[hash]` - A hash of the bundle contents.
-- `[dir]` - The relative path from the build root to the parent directory of the file.
+- `[dir]` - The relative path from the project root to the parent directory of the source file.
 
 For example:
 


### PR DESCRIPTION
### What does this PR do?

After working through some issues with Dave and the bundler, I realized the documentation around `naming`'s `[dir]` option was confusing. So I'm attempting to correct that while my thoughts are still fresh.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes