### PR TITLE
fix: typo in the comment

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -718,7 +718,7 @@ pub const TypeScript = struct {
                 return false;
             }
 
-            // If we have a 'yield' keyword, and we're in the [yield] context, then 'yield' is
+            // If we have an 'await' keyword, and we're in the [await] context, then 'await' is
             // considered a keyword and is not an identifier.
             if (p.fn_or_arrow_data_parse.allow_await != .allow_ident and strings.eqlComptime(p.lexer.identifier, "await")) {
                 return false;


### PR DESCRIPTION
Comment for "yield" was also used for "await" stuff. I know this is a small typo fix kind of PR, but had to do that.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

This PR fixed typo in the comment in the code.

