### PR TITLE
add `[Symbol.dispose]` in some bun apis

### DIFF
--- a/src/bun.js/api/BunObject.classes.ts
+++ b/src/bun.js/api/BunObject.classes.ts
@@ -96,6 +96,10 @@ export default [
         fn: "kill",
         length: 1,
       },
+      "@@asyncDispose": {
+        fn: "asyncDispose",
+        length: 1,
+      },
 
       killed: {
         getter: "getKilled",

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -574,6 +574,25 @@ pub const Subprocess = struct {
         return this.stdout.toJS(globalThis, this.hasExited());
     }
 
+    pub fn asyncDispose(
+        this: *Subprocess,
+        global: *JSGlobalObject,
+        call_frame: *JSC.CallFrame,
+    ) callconv(.C) JSValue {
+        _ = call_frame; // dispose accepts no arguments
+
+        switch (this.tryKill(9)) {
+            .result => {},
+            .err => |err| {
+                // Signal 9 should always be fine, but just in case that somehow fails.
+                global.throwValue(err.toJSC(global));
+                return .zero;
+            },
+        }
+
+        return this.getExited(global);
+    }
+
     pub fn kill(
         this: *Subprocess,
         globalThis: *JSGlobalObject,

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -581,7 +581,14 @@ pub const Subprocess = struct {
     ) callconv(.C) JSValue {
         _ = call_frame; // dispose accepts no arguments
 
-        switch (this.tryKill(9)) {
+        // unref self and streams so that this disposed process will not prevent
+        // the process from exiting causing a hang
+        this.unref();
+        this.stdin.unref();
+        this.stdout.unref();
+        this.stderr.unref();
+
+        switch (this.tryKill(SignalCode.default)) {
             .result => {},
             .err => |err| {
                 // Signal 9 should always be fine, but just in case that somehow fails.

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -577,7 +577,7 @@ pub const Subprocess = struct {
     pub fn asyncDispose(
         this: *Subprocess,
         global: *JSGlobalObject,
-        call_frame: *JSC.CallFrame,
+        _: *JSC.CallFrame,
     ) callconv(.C) JSValue {
         if (this.process.hasExited()) {
            // rely on GC to clean everything up in this case

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -583,7 +583,6 @@ pub const Subprocess = struct {
 
         // unref self and streams so that this disposed process will not prevent
         // the process from exiting causing a hang
-        this.unref();
         this.stdin.unref();
         this.stdout.unref();
         this.stderr.unref();

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -580,8 +580,8 @@ pub const Subprocess = struct {
         _: *JSC.CallFrame,
     ) callconv(.C) JSValue {
         if (this.process.hasExited()) {
-           // rely on GC to clean everything up in this case
-           return .undefined;
+            // rely on GC to clean everything up in this case
+            return .undefined;
         }
 
         // unref streams so that this disposed process will not prevent

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -579,7 +579,10 @@ pub const Subprocess = struct {
         global: *JSGlobalObject,
         call_frame: *JSC.CallFrame,
     ) callconv(.C) JSValue {
-        _ = call_frame; // dispose accepts no arguments
+        if (this.process.hasExited()) {
+           // rely on GC to clean everything up in this case
+           return .undefined;
+        }
 
         // unref streams so that this disposed process will not prevent
         // the process from exiting causing a hang

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -581,7 +581,7 @@ pub const Subprocess = struct {
     ) callconv(.C) JSValue {
         _ = call_frame; // dispose accepts no arguments
 
-        // unref self and streams so that this disposed process will not prevent
+        // unref streams so that this disposed process will not prevent
         // the process from exiting causing a hang
         this.stdin.unref();
         this.stdout.unref();

--- a/src/bun.js/api/server.classes.ts
+++ b/src/bun.js/api/server.classes.ts
@@ -20,6 +20,10 @@ function generate(name) {
         fn: "doReload",
         length: 2,
       },
+      "@@dispose": {
+        fn: "dispose",
+        length: 0,
+      },
       stop: {
         fn: "doStop",
         length: 1,

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5119,6 +5119,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
         } = .{},
 
         pub const doStop = JSC.wrapInstanceMethod(ThisServer, "stopFromJS", false);
+        pub const dispose = JSC.wrapInstanceMethod(ThisServer, "disposeFromJS", false);
         pub const doUpgrade = JSC.wrapInstanceMethod(ThisServer, "onUpgrade", false);
         pub const doPublish = JSC.wrapInstanceMethod(ThisServer, "publish", false);
         pub const doReload = onReload;
@@ -5539,6 +5540,16 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 JSC.C.JSValueUnprotect(this.globalThis, this.thisObject.asObjectRef());
                 this.thisObject = JSC.JSValue.jsUndefined();
                 this.stop(abrupt);
+            }
+
+            return JSC.JSValue.jsUndefined();
+        }
+
+        pub fn disposeFromJS(this: *ThisServer) JSC.JSValue {
+            if (this.listener != null) {
+                JSC.C.JSValueUnprotect(this.globalThis, this.thisObject.asObjectRef());
+                this.thisObject = JSC.JSValue.jsUndefined();
+                this.stop(true);
             }
 
             return JSC.JSValue.jsUndefined();

--- a/src/bun.js/api/sockets.classes.ts
+++ b/src/bun.js/api/sockets.classes.ts
@@ -111,6 +111,11 @@ function generate(ssl) {
         length: 0,
       },
 
+      "@@dispose": {
+        fn: "shutdown",
+        length: 0,
+      },
+
       shutdown: {
         fn: "shutdown",
         length: 1,
@@ -181,6 +186,10 @@ export default [
         fn: "stop",
         length: 1,
       },
+      "@@dispose": {
+        fn: "stop",
+        length: 0,
+      },
 
       ref: {
         fn: "ref",
@@ -236,6 +245,10 @@ export default [
         length: 3,
       },
       close: {
+        fn: "close",
+        length: 0,
+      },
+      "@@dispose": {
         fn: "close",
         length: 0,
       },

--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -106,6 +106,10 @@ class JSCallback {
       closeCallback(ctx);
     }
   }
+
+  [Symbol.dispose]() {
+    this.close();
+  }
 }
 
 class CString extends String {

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -995,6 +995,12 @@ class ChildProcess extends EventEmitter {
   pid;
   channel;
 
+  [Symbol.dispose]() {
+    if (!this.killed) {
+      this.kill();
+    }
+  }
+
   get killed() {
     if (this.#handle == null) return false;
   }
@@ -1310,7 +1316,7 @@ class ChildProcess extends EventEmitter {
     this.#handle.disconnect();
   }
 
-  kill(sig) {
+  kill(sig?) {
     const signal = sig === 0 ? sig : convertToValidSignal(sig === undefined ? "SIGTERM" : sig);
 
     if (this.#handle) {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1513,3 +1513,18 @@ it("should resolve pending promise if requested ended with pending read", async 
     },
   );
 });
+
+it("should work with dispose keyword", async () => {
+  let url: string;
+  {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("OK");
+      },
+    });
+    url = server.url;
+    expect((await fetch(url)).status).toBe(200);
+  }
+  expect(fetch(url)).rejects.toThrow();
+});

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -795,5 +795,5 @@ it("dispose keyword works", async () => {
   await Bun.sleep(0);
   expect(captured.killed).toBe(true);
   expect(captured.exitCode).toBe(null);
-  expect(captured.signalCode).toBe("SIGKILL");
+  expect(captured.signalCode).toBe("SIGTERM");
 });

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -782,3 +782,18 @@ describe("close handling", () => {
     }
   }
 });
+
+it("dispose keyword works", async () => {
+  let captured;
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", "await Bun.sleep(100000)"],
+    });
+    captured = proc;
+    await Bun.sleep(100);
+  }
+  await Bun.sleep(0);
+  expect(captured.killed).toBe(true);
+  expect(captured.exitCode).toBe(null);
+  expect(captured.signalCode).toBe("SIGKILL");
+});


### PR DESCRIPTION
```ts
{
  using server = Bun.serve({
    port: 0,
    fetch() {
      return new Response("OK");
    },
  });
  
  // do something with server
}

// the server is closed as `server` is out of scope.
```

- Bun.spawn
- Bun.serve
- Bun.listen
- Bun.connect
- JSCallback
