### PR TITLE
chore: upload release artifacts by hash so `bun.report` can remap them

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "setup": "./scripts/setup.sh",
+    "bump": "bun ./scripts/bump.ts",
     "build": "if [ ! -e build ]; then bun setup; fi && ninja -C build",
     "build:valgrind": "cmake . -DZIG_OPTIMIZE=Debug -DUSE_DEBUG_JSC=ON -DCMAKE_BUILD_TYPE=Debug -GNinja -Bbuild-valgrind && ninja -Cbuild-valgrind",
     "build:release": "cmake . -DCMAKE_BUILD_TYPE=Release -GNinja -Bbuild-release && ninja -Cbuild-release",

--- a/packages/bun-release/scripts/upload-s3.ts
+++ b/packages/bun-release/scripts/upload-s3.ts
@@ -1,16 +1,32 @@
 import { AwsClient } from "aws4fetch";
-import { getBuild, getRelease, getSemver } from "../src/github";
+import { getBuild, getRelease, getSemver, getSha } from "../src/github";
+
+const dryRun = process.argv.includes("--dry-run");
 
 const [tag] = process.argv.slice(2);
-const bucketUrl = new URL(`${env("AWS_BUCKET")}/`, env("AWS_ENDPOINT"));
-const aws = new AwsClient({
-  accessKeyId: env("AWS_ACCESS_KEY_ID"),
-  secretAccessKey: env("AWS_SECRET_ACCESS_KEY"),
-});
+let bucketUrl;
+let aws: AwsClient;
+try {
+  bucketUrl = new URL(`${env("AWS_BUCKET")}/`, env("AWS_ENDPOINT"));
+  aws = new AwsClient({
+    accessKeyId: env("AWS_ACCESS_KEY_ID"),
+    secretAccessKey: env("AWS_SECRET_ACCESS_KEY"),
+  });
+} catch (error) {
+  bucketUrl = new URL(`bun/`, "https://s3.amazonaws.com");
+  console.error("Failed to create S3 client:", error);
+  if (!dryRun) {
+    process.exit(1);
+  }
+  console.log("since this is a dry run, i'll allow it");
+}
 
 const latest = await getRelease();
 const release = await getRelease(tag);
-console.log("Found release:", release.tag_name);
+const full_commit_hash = await getSha(tag, "long");
+console.log("Found release:", release.tag_name, "with commit hash:", full_commit_hash);
+
+console.log("Found build:", full_commit_hash);
 
 let paths: string[];
 if (latest.tag_name === release.tag_name) {
@@ -18,13 +34,13 @@ if (latest.tag_name === release.tag_name) {
 } else if (release.tag_name === "canary") {
   try {
     const build = await getSemver("canary", await getBuild());
-    paths = ["releases/canary", `releases/${build}`];
+    paths = ["releases/canary", `releases/${build}`, `releases/${full_commit_hash}`];
   } catch (error) {
     console.warn(error);
     paths = ["releases/canary"];
   }
 } else {
-  paths = [`releases/${release.tag_name}`];
+  paths = [`releases/${release.tag_name}`, `releases/${full_commit_hash}`];
 }
 console.log("Found paths:", paths);
 
@@ -78,6 +94,10 @@ async function uploadToS3({
   };
 }): Promise<void> {
   const { href } = new URL(key, bucketUrl);
+  if (dryRun) {
+    console.log("Would upload:", key, "to", href);
+    return;
+  }
   const response = await aws.fetch(href, {
     method: "PUT",
     body,

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -1,0 +1,47 @@
+import path from "path";
+
+process.chdir(path.join(import.meta.dir, "../"));
+
+const git_branch = await Bun.$`git rev-parse --abbrev-ref HEAD`.text();
+
+if (git_branch.trim() !== "main") {
+  console.error("You must be on the main branch to run this script");
+  process.exit(1);
+}
+
+const kinds = ["major", "minor", "patch"];
+const increment = kinds.findIndex(type => process.argv[2] === type);
+if (increment === -1) {
+  console.error("Usage: bun bump <major|minor|patch>");
+  process.exit(1);
+}
+
+const cmakelists = await Bun.file("./CMakeLists.txt").text();
+
+const found_version_line = cmakelists.indexOf("set(Bun_VERSION");
+if (found_version_line === -1) {
+  throw new Error("Could not find version line in CMakeLists.txt");
+}
+
+const version = /set\(Bun_VERSION "([0-9]+\.[0-9]+\.[0-9]+)"/.exec(cmakelists);
+if (!version) {
+  throw new Error("Could not find version in CMakeLists.txt");
+}
+
+const updated_version = version[1]
+  .split(".")
+  .map((v, i) => (i === increment ? parseInt(v) + 1 : i < increment ? parseInt(v) : 0))
+  .join(".");
+
+console.log("Bumping version from %s to %s", version[1], updated_version);
+
+// remove all files from stage
+await Bun.$`git reset`;
+
+await Bun.write("./CMakeLists.txt", cmakelists.replace(version[1], updated_version));
+
+await Bun.$`git add CMakeLists.txt`;
+await Bun.$`git commit -m "Release Bun v${updated_version}"`;
+
+console.log("");
+console.log("Done.");


### PR DESCRIPTION
fixes bun.report not remapping things correctly because the wrong build of bun was uploaded. this will overwrite the canary artifact with the release artifact when it is uploaded.

Ideally, we should have CI that never builds canary on the moment we bump the version. That is not the case yet.

Also, i provided a script to bump the version.