### PR TITLE
Fix passing stdout/stderr from Bun.spawn -> Bun.serve()'s Response

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -190,7 +190,7 @@ $ iex "& {$(irm https://bun.sh/install.ps1)} -Version 1.1.6"
 
 To download Bun binaries directly, you can visit the [releases page](https://github.com/oven-sh/bun/releases) page on GitHub.
 
-For convenience, here are the direct download links for the latest version:
+For convenience, here are download links for the latest version:
 
 - [`bun-linux-x64.zip`](https://github.com/oven-sh/bun/releases/latest/download/bun-linux-x64.zip)
 - [`bun-linux-x64-baseline.zip`](https://github.com/oven-sh/bun/releases/latest/download/bun-linux-x64-baseline.zip)

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2823,10 +2823,13 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                             .Invalid => {
                                 this.readable_stream_ref.deinit();
                             },
-                            // toBlobIfPossible should've caught this
-                            .Blob, .File => unreachable,
-
-                            .JavaScript, .Direct => {
+                            // toBlobIfPossible will typically convert .Blob streams, or .File streams into a Blob object, but cannot always.
+                            .Blob,
+                            .File,
+                            // These are the common scenario:
+                            .JavaScript,
+                            .Direct,
+                            => {
                                 if (this.resp) |resp| {
                                     var pair = StreamPair{ .stream = stream, .this = this };
                                     resp.runCorkedWithType(*StreamPair, doRenderStream, &pair);

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -269,7 +269,7 @@ export function randomPort(): number {
 }
 
 expect.extend({
-  toRun(cmds: string[]) {
+  toRun(cmds: string[], optionalStdout?: string) {
     const result = Bun.spawnSync({
       cmd: [bunExe(), ...cmds],
       env: bunEnv,
@@ -280,6 +280,14 @@ expect.extend({
       return {
         pass: false,
         message: () => `Command ${cmds.join(" ")} failed:` + "\n" + result.stdout.toString("utf-8"),
+      };
+    }
+
+    if (optionalStdout) {
+      return {
+        pass: result.stdout.toString("utf-8") === optionalStdout,
+        message: () =>
+          `Expected ${cmds.join(" ")} to output ${optionalStdout} but got ${result.stdout.toString("utf-8")}`,
       };
     }
 

--- a/test/js/bun/spawn/spawn-stream-http-fixture.js
+++ b/test/js/bun/spawn/spawn-stream-http-fixture.js
@@ -1,0 +1,20 @@
+import { spawn, serve } from "bun";
+
+const server = serve({
+  port: 0,
+  async fetch(req) {
+    const { stdout } = spawn({
+      cmd: [process.execPath, "--eval", 'console.write("hello world")'],
+      env: process.env,
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
+
+    return new Response(stdout);
+  },
+});
+
+const response = await fetch(server.url);
+console.write(await response.text());
+server.stop(true);

--- a/test/js/bun/spawn/spawn-stream-serve.test.ts
+++ b/test/js/bun/spawn/spawn-stream-serve.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "bun:test";
+import "harness";
+import { fileURLToPath } from "url";
+
+test("Subprocess stdout can be used in Bun.serve()", async () => {
+  expect([fileURLToPath(import.meta.resolve("./spawn-stream-http-fixture.js"))]).toRun("hello world");
+});


### PR DESCRIPTION
### What does this PR do?

This makes it so Bun.spawn().stdout can be used in `new Response(stdout)` within Bun.serve()

```ts
import { spawn, serve } from "bun";

const server = serve({
  port: 0,
  async fetch(req) {
    const { stdout } = spawn({
      cmd: [process.execPath, "--eval", 'console.write("hello world")'],
      env: process.env,
      stdout: "pipe",
      stderr: "inherit",
      stdin: "ignore",
    });

    return new Response(stdout);
  },
});

const response = await fetch(server.url);
console.write(await response.text());
server.stop(true);
```

We assumed `toBlobIfPossible` would always be able to convert pipes into Blob, but that may not always be the case

### How did you verify your code works?

There is a test