### PR TITLE
Align arguments of `connect()` in node:tls and node:net to Node (#10854)

### DIFF
--- a/packages/bun-types/overrides.d.ts
+++ b/packages/bun-types/overrides.d.ts
@@ -61,4 +61,11 @@ declare module "tls" {
   }
 
   function connect(options: BunConnectionOptions, secureConnectListener?: () => void): TLSSocket;
+  function connect(path: string, options?: BunConnectionOptions, secureConnectListener?: () => void): TLSSocket;
+  function connect(
+    port: number,
+    host?: string,
+    options?: BunConnectionOptions,
+    secureConnectListener?: () => void,
+  ): TLSSocket;
 }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -725,8 +725,8 @@ const Socket = (function (InternalSocket) {
 
 // we gotta handle the different signatures that nodejs tls.connect accepts
 // connect(options[, callback])
-// connect(path[, options][, callback])
-// connect(port[, host][, options][, callback])
+// connect(path[, callback])
+// connect(port[, host][, callback])
 function normalizeArgs(args) {
   if (args.length === 0) {
     return [{}, null];
@@ -745,15 +745,9 @@ function normalizeArgs(args) {
     }
   }
 
-  if (args[1] !== null && typeof args[1] === "object") {
-    Object.assign(options, args[1]);
-  } else if (args[2] !== null && typeof args[2] === "object") {
-    Object.assign(options, args[2]);
-  }
+  const connectListener = typeof args[args.length - 1] === "function" ? args[args.length - 1] : null;
 
-  const callback = typeof args[args.length - 1] === "function" ? args[args.length - 1] : null;
-
-  return [options, callback];
+  return [options, connectListener];
 }
 
 function createConnection(...args) {

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -678,6 +678,12 @@ function normalizeArgs(args) {
     }
   }
 
+  if (args[1] !== null && typeof args[1] === "object") {
+    Object.assign(options, args[1]);
+  } else if (args[2] !== null && typeof args[2] === "object") {
+    Object.assign(options, args[2]);
+  }
+
   const callback = typeof args[args.length - 1] === "function" ? args[args.length - 1] : null;
 
   return [options, callback];

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -652,6 +652,18 @@ class Server extends NetServer {
   }
 }
 
+function normalizeConnectArgs(args) {
+  let [options, callback] = net._normalizeArgs(args);
+
+  if (args[1] !== null && typeof args[1] === "object") {
+    Object.assign(options, args[1]);
+  } else if (args[2] !== null && typeof args[2] === "object") {
+    Object.assign(options, args[2]);
+  }
+
+  return [options, callback];
+}
+
 function createServer(options, connectionListener) {
   return new Server(options, connectionListener);
 }
@@ -676,7 +688,7 @@ const DEFAULT_ECDH_CURVE = "auto",
     return new TLSSocket().connect(port, host, connectListener);
   },
   connect = (...args) => {
-    let [options, callback] = net._normalizeArgs(args);
+    let [options, callback] = normalizeConnectArgs(args);
     if (options.ALPNProtocols) {
       convertALPNProtocols(options.ALPNProtocols, options);
     }

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -721,7 +721,6 @@ const DEFAULT_ECDH_CURVE = "auto",
 
     // Node.js connects the socket right away if no options.socket is provided. For compatibility, I guess we should do the same.
     if (!options.socket) {
-      console.log("connecting now1");
       tlsSocket.connect(options.port, options.host, callback);
     }
 

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -393,8 +393,6 @@ describe("net.Socket write", () => {
     });
 
     const socket = new Socket();
-    socket.on("data", data => console.log(data.toString()));
-    socket.on("error", err => console.error(err));
 
     async function run() {
       return new Promise((resolve, reject) => {
@@ -418,7 +416,7 @@ it("should handle connection error", done => {
   let errored = false;
 
   // @ts-ignore
-  const socket = connect(55555, () => {
+  const socket = connect(55555, "localhost", () => {
     done(new Error("Should not have connected"));
   });
 


### PR DESCRIPTION
### What does this PR do?

The handling of arguments in Bun's implementation of `connect()` (`node:tls`) deviates from the available combinations of arguments in Node. This breaks compatibility for many packages that rely on the order of parameters in Node.

I adjusted the `connect` method to allow the same amount and order of arguments as Node.

- [X] Code changes

### How did you verify your code works?


- [X] I included a test for the new code, or existing tests cover it
- [X] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

