### PR TITLE
`console.table` bugfix

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -360,15 +360,15 @@ const TablePrinter = struct {
                     const column: *Column = brk: {
                         const col_str = String.init(col_key);
 
-                        // Need to ref this string because JSPropertyIterator
-                        // uses `toString` instead of `toStringRef` for property names
-                        col_str.ref();
-
                         for (columns.items[1..]) |*col| {
                             if (col.name.eql(col_str)) {
                                 break :brk col;
                             }
                         }
+
+                        // Need to ref this string because JSPropertyIterator
+                        // uses `toString` instead of `toStringRef` for property names
+                        col_str.ref();
 
                         try columns.append(.{ .name = col_str });
 

--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -359,6 +359,11 @@ const TablePrinter = struct {
                     // find or create the column for the property
                     const column: *Column = brk: {
                         const col_str = String.init(col_key);
+
+                        // Need to ref this string because JSPropertyIterator
+                        // uses `toString` instead of `toStringRef` for property names
+                        col_str.ref();
+
                         for (columns.items[1..]) |*col| {
                             if (col.name.eql(col_str)) {
                                 break :brk col;

--- a/test/js/bun/console/console-table-repeat-50.ts
+++ b/test/js/bun/console/console-table-repeat-50.ts
@@ -1,0 +1,3 @@
+for (let i = 0; i < 50; i++) {
+  console.table([{ n: 8 }]);
+}

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -222,12 +222,13 @@ test("console.table repeat 50", () => {
 │ 0 │ 8 │
 └───┴───┘
 `;
-  const { stdout } = spawnSync({
+  const { stdout, stderr } = spawnSync({
     cmd: [bunExe(), `${import.meta.dir}/console-table-repeat-50.ts`],
     stdout: "pipe",
-    stderr: "inherit",
+    stderr: "pipe",
     env: bunEnv,
   });
 
   expect(stdout.toString()).toBe(expected.repeat(50));
+  expect(stderr.toString()).toBe("");
 });

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -214,3 +214,20 @@ test.skip("console.table character widths", () => {
 
   console.log(actualOutput);
 });
+
+test("console.table repeat 50", () => {
+  const expected = `┌───┬───┐
+│   │ n │
+├───┼───┤
+│ 0 │ 8 │
+└───┴───┘
+`;
+  const { stdout } = spawnSync({
+    cmd: [bunExe(), `${import.meta.dir}/console-table-repeat-50.ts`],
+    stdout: "pipe",
+    stderr: "inherit",
+    env: bunEnv,
+  });
+
+  expect(stdout.toString()).toBe(expected.repeat(50));
+});


### PR DESCRIPTION
### What does this PR do?
ref strings coming from property iterator. `deref` is called on them after printing the table. The original issue would fail after about 5 iterations because the name strings would `deref` to 0.

fixes #10791 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
