### PR TITLE
fix(node:os): `cpus` bugfix

### DIFF
--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -83,11 +83,10 @@ pub const OS = struct {
         if (std.fs.openFileAbsolute("/proc/stat", .{})) |file| {
             defer file.close();
 
-            file_buf.ensureTotalCapacity(try file.getEndPos());
-            file_buf.items.len = try file.readAll(file_buf.items);
+            const read = try bun.sys.File.from(file).readToEndWithArrayList(&file_buf).unwrap();
             defer file_buf.clearRetainingCapacity();
+            const contents = file_buf.items[0..read];
 
-            const contents = file_buf.items;
             var line_iter = std.mem.tokenizeScalar(u8, contents, '\n');
 
             // Skip the first line (aggregate of all CPUs)
@@ -126,11 +125,10 @@ pub const OS = struct {
         if (std.fs.openFileAbsolute("/proc/cpuinfo", .{})) |file| {
             defer file.close();
 
-            file_buf.ensureTotalCapacity(try file.getEndPos());
-            file_buf.items.len = try file.readAll(file_buf.items);
+            const read = try bun.sys.File.from(file).readToEndWithArrayList(&file_buf).unwrap();
             defer file_buf.clearRetainingCapacity();
+            const contents = file_buf.items[0..read];
 
-            const contents = file_buf.items;
             var line_iter = std.mem.tokenizeScalar(u8, contents, '\n');
 
             const key_processor = "processor\t: ";
@@ -178,11 +176,11 @@ pub const OS = struct {
             if (std.fs.openFileAbsolute(path, .{})) |file| {
                 defer file.close();
 
-                file_buf.ensureTotalCapacity(try file.getEndPos());
-                file_buf.items.len = try file.readAll(file_buf.items);
+                const read = try bun.sys.File.from(file).readToEndWithArrayList(&file_buf).unwrap();
                 defer file_buf.clearRetainingCapacity();
+                const contents = file_buf.items[0..read];
 
-                const digits = std.mem.trim(u8, file_buf.items, " \n");
+                const digits = std.mem.trim(u8, contents, " \n");
                 const speed = (std.fmt.parseInt(u64, digits, 10) catch 0) / 1000;
 
                 cpu.put(globalThis, JSC.ZigString.static("speed"), JSC.JSValue.jsNumber(speed));

--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -8,7 +8,6 @@ const JSC = bun.JSC;
 const Environment = bun.Environment;
 const Global = bun.Global;
 const is_bindgen: bool = std.meta.globalOption("bindgen", bool) orelse false;
-const heap_allocator = bun.default_allocator;
 
 const libuv = bun.windows.libuv;
 pub const OS = struct {
@@ -76,7 +75,8 @@ pub const OS = struct {
         const values = JSC.JSValue.createEmptyArray(globalThis, 0);
         var num_cpus: u32 = 0;
 
-        var file_buf = std.ArrayList(u8).init(bun.default_allocator);
+        var stack_fallback = std.heap.stackFallback(1024 * 8, bun.default_allocator);
+        var file_buf = std.ArrayList(u8).init(stack_fallback.get());
         defer file_buf.deinit();
 
         // Read /proc/stat to get number of CPUs and times

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -463,7 +463,7 @@ pub fn handleRootError(err: anyerror, error_return_trace: ?*std.builtin.StackTra
                 if (limit.cur > 0 and limit.cur < (8192 * 2)) {
                     Output.prettyError(
                         \\
-                        \\<r><red>error<r>: An unknown error ocurred, possibly due to low max file descriptors <d>(<red>Unexpected<r><d>)<r>
+                        \\<r><red>error<r>: An unknown error occurred, possibly due to low max file descriptors <d>(<red>Unexpected<r><d>)<r>
                         \\
                         \\<d>Current limit: {d}<r>
                         \\
@@ -508,14 +508,14 @@ pub fn handleRootError(err: anyerror, error_return_trace: ?*std.builtin.StackTra
                     }
                 } else {
                     Output.errGeneric(
-                        "An unknown error ocurred <d>(<red>{s}<r><d>)<r>",
+                        "An unknown error occurred <d>(<red>{s}<r><d>)<r>",
                         .{@errorName(err)},
                     );
                     show_trace = true;
                 }
             } else {
                 Output.errGeneric(
-                    \\An unknown error ocurred <d>(<red>{s}<r><d>)<r>
+                    \\An unknown error occurred <d>(<red>{s}<r><d>)<r>
                 ,
                     .{@errorName(err)},
                 );
@@ -544,7 +544,7 @@ pub fn handleRootError(err: anyerror, error_return_trace: ?*std.builtin.StackTra
                 if (bun.Environment.isDebug)
                     "'main' returned <red>error.{s}<r>"
                 else
-                    "An internal error ocurred (<red>{s}<r>)",
+                    "An internal error occurred (<red>{s}<r>)",
                 .{@errorName(err)},
             );
             show_trace = true;


### PR DESCRIPTION
### What does this PR do?
Code was assuming line lengths were not longer than `1024 * 8` bytes. Removed `std.io.Reader`

fixes #10877 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
