### PR TITLE
fix(windows): build all dependencies with proper cpu target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_policy(SET CMP0091 NEW)
 cmake_policy(SET CMP0067 NEW)
 
 set(Bun_VERSION "1.1.8")
-set(WEBKIT_TAG 18eaec2ddf9062a76e911c6fbb9c469a6e442ad7)
+set(WEBKIT_TAG ad8d763e76faf64bdae185dc4fb8743135d6f53b)
 
 set(BUN_WORKDIR "${CMAKE_CURRENT_BINARY_DIR}")
 message(STATUS "Configuring Bun ${Bun_VERSION} in ${BUN_WORKDIR}")

--- a/scripts/build-tinycc.ps1
+++ b/scripts/build-tinycc.ps1
@@ -20,8 +20,10 @@ try {
   Run clang-cl -DTCC_TARGET_PE -DTCC_TARGET_X86_64 config.h -DC2STR -o c2str.exe conftest.c
   Run .\c2str.exe .\include\tccdefs.h tccdefs_.h
 
+  $Baseline = $env:BUN_DEV_ENV_SET -eq "Baseline=True"
+
   # TODO: -MT
-  Run clang-cl libtcc.c -o tcc.obj "-DTCC_TARGET_PE" "-DTCC_TARGET_X86_64" "-O2" "-W2" "-Zi" "-MD" "-GS-" "-c"
+  Run clang-cl @($env:CFLAGS -split ' ') libtcc.c -o tcc.obj "-DTCC_TARGET_PE" "-DTCC_TARGET_X86_64" "-O2" "-W2" "-Zi" "-MD" "-GS-" "-c"
   Run lib "tcc.obj" "-OUT:tcc.lib"
 
   Copy-Item tcc.obj $BUN_DEPS_OUT_DIR/tcc.lib

--- a/scripts/env.ps1
+++ b/scripts/env.ps1
@@ -1,7 +1,12 @@
 param(
-  [switch]$Baseline = $False
+  [switch]$Baseline = $false
 )
-$ErrorActionPreference = 'Stop'  # Setting strict mode, similar to 'set -euo pipefail' in bash
+
+if ($ENV:BUN_DEV_ENV_SET -eq "Baseline=True") {
+  $Baseline = $true
+}
+
+$ErrorActionPreference = 'Stop' # Setting strict mode, similar to 'set -euo pipefail' in bash
 
 # this is the environment script for building bun's dependencies
 # it sets c compiler and flags
@@ -28,6 +33,8 @@ if($Env:VSCMD_ARG_TGT_ARCH -eq "x86") {
   # Please do not try to compile Bun for 32 bit. It will not work. I promise.
   throw "Visual Studio environment is targetting 32 bit. This configuration is definetly a mistake."
 }
+
+$ENV:BUN_DEV_ENV_SET = "Baseline=$Baseline";
 
 $BUN_BASE_DIR = if ($env:BUN_BASE_DIR) { $env:BUN_BASE_DIR } else { Join-Path $ScriptDir '..' }
 $BUN_DEPS_DIR = if ($env:BUN_DEPS_DIR) { $env:BUN_DEPS_DIR } else { Join-Path $BUN_BASE_DIR 'src\deps' }

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -213,11 +213,15 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
     if (has_loaded_jsc)
         return;
     has_loaded_jsc = true;
+    printf("1: a\n");
     JSC::Config::enableRestrictedOptions();
 
     std::set_terminate([]() { Zig__GlobalObject__onCrash(); });
+    printf("1: a\n");
     WTF::initializeMainThread();
+    printf("1: b\n");
     JSC::initialize();
+    printf("1: c\n");
     {
         JSC::Options::AllowUnfinalizedAccessScope scope;
 
@@ -257,6 +261,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         }
         JSC::Options::assertOptionsAreCoherent();
     }
+    printf("1: d\n");
 }
 
 extern "C" void* Bun__getVM();

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -217,7 +217,6 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
 
     std::set_terminate([]() { Zig__GlobalObject__onCrash(); });
     WTF::initializeMainThread();
-    printf("1: b\n");
     JSC::initialize();
     {
         JSC::Options::AllowUnfinalizedAccessScope scope;

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -261,7 +261,6 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         }
         JSC::Options::assertOptionsAreCoherent();
     }
-    printf("1: d\n");
 }
 
 extern "C" void* Bun__getVM();

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -213,7 +213,6 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
     if (has_loaded_jsc)
         return;
     has_loaded_jsc = true;
-    printf("1: a\n");
     JSC::Config::enableRestrictedOptions();
 
     std::set_terminate([]() { Zig__GlobalObject__onCrash(); });

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -221,7 +221,6 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
     WTF::initializeMainThread();
     printf("1: b\n");
     JSC::initialize();
-    printf("1: c\n");
     {
         JSC::Options::AllowUnfinalizedAccessScope scope;
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -216,7 +216,6 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
     JSC::Config::enableRestrictedOptions();
 
     std::set_terminate([]() { Zig__GlobalObject__onCrash(); });
-    printf("1: a\n");
     WTF::initializeMainThread();
     printf("1: b\n");
     JSC::initialize();

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -117,7 +117,10 @@ pub fn crashHandler(
                 panic_mutex.lock();
                 defer panic_mutex.unlock();
 
-                const writer = Output.errorWriter();
+                // Use an raw unbuffered writer to stderr to avoid losing information on
+                // panic in a panic. There is also a possibility that `Output` related code
+                // is not configured correctly, so that would also mask the message.
+                const writer = std.io.getStdErr().writer();
 
                 // The format of the panic trace is slightly different in debug
                 // builds Mainly, we demangle the backtrace immediately instead
@@ -140,10 +143,17 @@ pub fn crashHandler(
 
                     writer.writeAll("=" ** 60 ++ "\n") catch std.os.abort();
                     printMetadata(writer) catch std.os.abort();
-
-                    Output.flush();
                 } else {
-                    Output.err("oh no", "multiple threads are crashing", .{});
+                    if (Output.enable_ansi_colors) {
+                        writer.writeAll(Output.prettyFmt("<red>", true)) catch std.os.abort();
+                    }
+                    writer.writeAll("oh no") catch std.os.abort();
+                    if (Output.enable_ansi_colors) {
+                        writer.writeAll(Output.prettyFmt("<r><d>: ", true)) catch std.os.abort();
+                    } else {
+                        writer.writeAll(Output.prettyFmt(": ", true)) catch std.os.abort();
+                    }
+                    writer.writeAll("multiple threads are crashing") catch std.os.abort();
                 }
 
                 if (reason != .out_of_memory or debug_trace) {
@@ -173,10 +183,12 @@ pub fn crashHandler(
                         else => @compileError("TODO"),
                     }
 
-                    Output.prettyErrorln(":<r> {}", .{reason});
+                    writer.writeAll(": ") catch std.os.abort();
+                    if (Output.enable_ansi_colors) {
+                        writer.writeAll(Output.prettyFmt("<r>", true)) catch std.os.abort();
+                    }
+                    writer.print("{}", .{reason}) catch std.os.abort();
                 }
-
-                Output.flush();
 
                 var addr_buf: [10]usize = undefined;
                 var trace_buf: std.builtin.StackTrace = undefined;
@@ -194,35 +206,39 @@ pub fn crashHandler(
                 if (debug_trace) {
                     dumpStackTrace(trace.*);
 
-                    // TODO: REMOVE
                     trace_str_buf.writer().print("{}", .{TraceString{
                         .trace = trace,
                         .reason = reason,
-                        .action = .open_issue,
+                        .action = .view_trace,
                     }}) catch std.os.abort();
                 } else {
                     if (!has_printed_message) {
                         has_printed_message = true;
+                        writer.writeAll("oh no") catch std.os.abort();
+                        if (Output.enable_ansi_colors) {
+                            writer.writeAll(Output.prettyFmt("<r><d>:<r> ", true)) catch std.os.abort();
+                        } else {
+                            writer.writeAll(Output.prettyFmt(": ", true)) catch std.os.abort();
+                        }
                         if (reason == .out_of_memory) {
-                            Output.err("oh no",
+                            writer.writeAll(
                                 \\Bun has ran out of memory.
                                 \\
                                 \\To send a redacted crash report to Bun's team,
                                 \\please file a GitHub issue using the link below:
                                 \\
                                 \\
-                            , .{});
+                            ) catch std.os.abort();
                         } else {
-                            Output.err("oh no",
+                            writer.writeAll(
                                 \\Bun has crashed. This indicates a bug in Bun, not your code.
                                 \\
                                 \\To send a redacted crash report to Bun's team,
                                 \\please file a GitHub issue using the link below:
                                 \\
                                 \\
-                            , .{});
+                            ) catch std.os.abort();
                         }
-                        Output.flush();
                     }
 
                     if (Output.enable_ansi_colors) {
@@ -247,8 +263,6 @@ pub fn crashHandler(
                 } else {
                     writer.writeAll("\n") catch std.os.abort();
                 }
-
-                Output.flush();
             }
             // Be aware that this function only lets one thread return from it.
             // This is important so that we do not try to run the following reload logic twice.

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -120,6 +120,9 @@ pub fn crashHandler(
                 // Use an raw unbuffered writer to stderr to avoid losing information on
                 // panic in a panic. There is also a possibility that `Output` related code
                 // is not configured correctly, so that would also mask the message.
+                //
+                // Output.errorWriter() is not used here because it may not be configured
+                // if the program crashes immediatly at startup.
                 const writer = std.io.getStdErr().writer();
 
                 // The format of the panic trace is slightly different in debug

--- a/src/output.zig
+++ b/src/output.zig
@@ -16,7 +16,7 @@ const SystemTimer = @import("./system_timer.zig").Timer;
 
 // These are threadlocal so we don't have stdout/stderr writing on top of each other
 threadlocal var source: Source = undefined;
-pub threadlocal var source_set: bool = false;
+threadlocal var source_set: bool = false;
 
 // These are not threadlocal so we avoid opening stdout/stderr for every thread
 var stderr_stream: Source.StreamType = undefined;

--- a/src/output.zig
+++ b/src/output.zig
@@ -16,7 +16,7 @@ const SystemTimer = @import("./system_timer.zig").Timer;
 
 // These are threadlocal so we don't have stdout/stderr writing on top of each other
 threadlocal var source: Source = undefined;
-threadlocal var source_set: bool = false;
+pub threadlocal var source_set: bool = false;
 
 // These are not threadlocal so we avoid opening stdout/stderr for every thread
 var stderr_stream: Source.StreamType = undefined;
@@ -610,6 +610,7 @@ pub fn Scoped(comptime tag: anytype, comptime disabled: bool) type {
         /// To enable all logs, set the environment variable
         ///   BUN_DEBUG_ALL=1
         pub fn log(comptime fmt: string, args: anytype) void {
+            if (!source_set) return;
             if (fmt.len == 0 or fmt[fmt.len - 1] != '\n') {
                 return log(fmt ++ "\n", args);
             }


### PR DESCRIPTION
### What does this PR do?

Fixes #10856
Fixes #10435
Fixes #10460
Fixes #10545
Fixes #10546
Fixes #10547
Fixes #10578
Fixes #10583
Fixes #10615
Fixes #10629
Fixes #10700
Fixes #10755
Fixes #10756
For #10788, this will resolve their third point.
Fixes #10790
Fixes #10798
Fixes #10841
Fixes #10853

Besides 10788, all of the above are the same exact issue report.

What went wrong is when compiling dependencies is the logic in every dependency script is
```ps1
. (Join-Path $PSScriptRoot "env.ps1")
```

This overrides the baseline state of the shell to haswell, which will unintentionally compile newer code for older cpus.

We also never even tried compiling tcc correctly. The proper flags are added.

When using SDE, I noticed a very odd failure reported in `WTF::initialize`, which names the current thread. This applies for any JS entrypoint, which is different from the mostly install-related ones above (makes sense, since `libarchive` is a notable dependency, while the js runtime in general is mostly just JSC + our own code + simdutf). I dont think the change in JSC is significant but it is definetly on the safer side to do this.
