### PR TITLE
Fix workspace packages not being found when they are moved

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -10545,20 +10545,16 @@ pub const PackageManager = struct {
                             builder,
                         );
 
-                        {
-                            // Copy over new workspace paths or update existing ones that have been changed
-                            // TODO: is this correct, what else do we need to do?
-                            var iter = lockfile.workspace_paths.iterator();
-                            while (iter.next()) |entry| {
-                                const gop = try manager.lockfile.workspace_paths.getOrPut(manager.lockfile.allocator, entry.key_ptr.*);
-                                const do_copy = !gop.found_existing or !bun.strings.eql(gop.value_ptr.slice(manager.lockfile.buffers.string_bytes.items), entry.value_ptr.slice(lockfile.buffers.string_bytes.items));
-                                if (do_copy) {
-                                    const str = entry.value_ptr.slice(lockfile.buffers.string_bytes.items);
-                                    builder.count(str);
-                                    const new_value = builder.append(String, str);
-                                    gop.value_ptr.* = new_value;
-                                }
-                            }
+                        // Copy over new workspace paths or update existing ones that have been changed
+                        // TODO: is this correct, what else do we need to do?
+                        manager.lockfile.workspace_paths.deinit(manager.lockfile.allocator);
+                        manager.lockfile.workspace_paths = try lockfile.workspace_paths.clone(manager.lockfile.allocator);
+                        const disk_lockfile_paths = manager.lockfile.workspace_paths.values();
+                        const parsed_lockfile_paths = lockfile.workspace_paths.values();
+                        for (disk_lockfile_paths, parsed_lockfile_paths) |*disk_path, parsed_path| {
+                            const str = parsed_path.slice(lockfile.buffers.string_bytes.items);
+                            builder.count(str);
+                            disk_path.* = builder.append(String, str);
                         }
 
                         builder.clamp();

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -10462,8 +10462,9 @@ pub const PackageManager = struct {
                             new_dep.count(lockfile.buffers.string_bytes.items, *Lockfile.StringBuilder, builder);
                         }
 
-                        lockfile.overrides.count(&lockfile, builder);
+                        for (lockfile.workspace_paths.values()) |path| builder.count(path.slice(lockfile.buffers.string_bytes.items));
 
+                        lockfile.overrides.count(&lockfile, builder);
                         maybe_root.scripts.count(lockfile.buffers.string_bytes.items, *Lockfile.StringBuilder, builder);
 
                         const off = @as(u32, @truncate(manager.lockfile.buffers.dependencies.items.len));
@@ -10553,10 +10554,8 @@ pub const PackageManager = struct {
                         const parsed_lockfile_paths = lockfile.workspace_paths.values();
                         for (disk_lockfile_paths, parsed_lockfile_paths) |*disk_path, parsed_path| {
                             const str = parsed_path.slice(lockfile.buffers.string_bytes.items);
-                            builder.count(str);
                             disk_path.* = builder.append(String, str);
                         }
-
                         builder.clamp();
 
                         // Split this into two passes because the below may allocate memory or invalidate pointers

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -10553,7 +10553,9 @@ pub const PackageManager = struct {
                                 const gop = try manager.lockfile.workspace_paths.getOrPut(manager.lockfile.allocator, entry.key_ptr.*);
                                 const do_copy = !gop.found_existing or !bun.strings.eql(gop.value_ptr.slice(manager.lockfile.buffers.string_bytes.items), entry.value_ptr.slice(lockfile.buffers.string_bytes.items));
                                 if (do_copy) {
-                                    const new_value = builder.append(String, entry.value_ptr.slice(lockfile.buffers.string_bytes.items));
+                                    const str = entry.value_ptr.slice(lockfile.buffers.string_bytes.items);
+                                    builder.count(str);
+                                    const new_value = builder.append(String, str);
                                     gop.value_ptr.* = new_value;
                                 }
                             }

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -276,7 +276,6 @@ it("should work when moving workspace packages", async () => {
     },
   });
 
-  console.log("Cwd", package_dir);
 
   await Bun.$`${bunExe()} i`.env(bunEnv).cwd(package_dir);
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -298,6 +298,7 @@ it("should work when moving workspace packages", async () => {
 
   mv packages/typescript-config config/
   mv packages/eslint-config config/
+  mv packages/ui config/
 
   rm -rf packages
   rm -rf apps

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -242,6 +242,7 @@ it("should work when moving workspace packages", async () => {
       private: "true",
       version: "0.0.1",
       "devDependencies": {
+        "@repo/ui": "*",
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
       },
@@ -265,6 +266,7 @@ it("should work when moving workspace packages", async () => {
       "ui": {
         "package.json": JSON.stringify({
           name: "@repo/ui",
+          version: "0.0.0",
           private: "true",
           devDependencies: {
             "@repo/eslint-config": "*",
@@ -288,6 +290,7 @@ it("should work when moving workspace packages", async () => {
     version: "0.0.1",
     workspaces: ["config/*"],
     "devDependencies": {
+      "@repo/ui": "*",
       "@repo/eslint-config": "*",
       "@repo/typescript-config": "*",
     },
@@ -298,6 +301,86 @@ it("should work when moving workspace packages", async () => {
 
   rm -rf packages
   rm -rf apps
+  `
+    .env(bunEnv)
+    .cwd(package_dir);
+
+  await Bun.$`${bunExe()} i`.env(bunEnv).cwd(package_dir);
+});
+
+it("should work when renaming a single workspace package", async () => {
+  const package_dir = tempDirWithFiles("lol", {
+    "package.json": JSON.stringify({
+      "name": "my-workspace",
+      private: "true",
+      version: "0.0.1",
+      "devDependencies": {
+        "@repo/ui": "*",
+        "@repo/eslint-config": "*",
+        "@repo/typescript-config": "*",
+      },
+      workspaces: ["packages/*"],
+    }),
+    packages: {
+      "eslint-config": {
+        "package.json": JSON.stringify({
+          name: "@repo/eslint-config",
+          "version": "0.0.0",
+          private: "true",
+        }),
+      },
+      "typescript-config": {
+        "package.json": JSON.stringify({
+          "name": "@repo/typescript-config",
+          "version": "0.0.0",
+          private: "true",
+        }),
+      },
+      "ui": {
+        "package.json": JSON.stringify({
+          name: "@repo/ui",
+          version: "0.0.0",
+          private: "true",
+          devDependencies: {
+            "@repo/eslint-config": "*",
+            "@repo/typescript-config": "*",
+          },
+        }),
+      },
+    },
+  });
+
+  console.log("Cwd", package_dir);
+
+  await Bun.$`${bunExe()} i`.env(bunEnv).cwd(package_dir);
+
+  await Bun.$/* sh */ `
+  echo ${JSON.stringify({
+    "name": "my-workspace",
+    version: "0.0.1",
+    workspaces: ["packages/*"],
+    "devDependencies": {
+      "@repo/ui": "*",
+      "@repo/eslint-config-lol": "*",
+      "@repo/typescript-config": "*",
+    },
+  })} > package.json
+
+  echo ${JSON.stringify({
+    name: "@repo/eslint-config-lol",
+    "version": "0.0.0",
+    private: "true",
+  })} > packages/eslint-config/package.json
+
+  echo ${JSON.stringify({
+    name: "@repo/ui",
+    version: "0.0.0",
+    private: "true",
+    devDependencies: {
+      "@repo/eslint-config-lol": "*",
+      "@repo/typescript-config": "*",
+    },
+  })} > packages/ui/package.json
   `
     .env(bunEnv)
     .cwd(package_dir);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -349,7 +349,6 @@ it("should work when renaming a single workspace package", async () => {
     },
   });
 
-  console.log("Cwd", package_dir);
 
   await Bun.$`${bunExe()} i`.env(bunEnv).cwd(package_dir);
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -15,7 +15,6 @@ import {
   root_url,
   setHandler,
 } from "./dummy.registry.js";
-import { version } from "yargs";
 
 expect.extend({
   toBeWorkspaceLink,


### PR DESCRIPTION
### What does this PR do?

Fixes #10833 

It looks like when we were diffing the lockfile from disk and parsed lockfile we did not update with the new workspace_paths from the newly parsed one
