### PR TITLE
fix(win): do not allow exitcode==1 and signalCode to be set at once

### DIFF
--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -573,13 +573,16 @@ pub const Status = union(enum) {
             },
         }
 
-        if (signal) |sig| {
+        if (exit_code != null) {
             return .{
-                .signaled = @enumFromInt(sig),
+                .exited = .{
+                    .code = exit_code.?,
+                    .signal = @enumFromInt(signal orelse 0),
+                },
             };
-        } else if (exit_code) |exit| {
+        } else if (signal != null) {
             return .{
-                .exited = .{ .code = exit, .signal = @enumFromInt(0) },
+                .signaled = @enumFromInt(signal.?),
             };
         }
 

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -385,19 +385,19 @@ pub const Process = struct {
 
         bun.windows.libuv.log("Process.onExit({d}) code: {d}, signal: {?}", .{ process.pid, exit_code, signal_code });
 
-        if (exit_code >= 0) {
-            this.close();
-            this.onExit(
-                .{
-                    .exited = .{ .code = exit_code, .signal = signal_code orelse @enumFromInt(0) },
-                },
-                &rusage,
-            );
-        } else if (signal_code) |sig| {
+        if (signal_code) |sig| {
             this.close();
 
             this.onExit(
                 .{ .signaled = sig },
+                &rusage,
+            );
+        } else if (exit_code >= 0) {
+            this.close();
+            this.onExit(
+                .{
+                    .exited = .{ .code = exit_code, .signal = @enumFromInt(0) },
+                },
                 &rusage,
             );
         } else {
@@ -573,13 +573,13 @@ pub const Status = union(enum) {
             },
         }
 
-        if (exit_code != null) {
+        if (signal) |sig| {
             return .{
-                .exited = .{ .code = exit_code.?, .signal = @enumFromInt(signal orelse 0) },
+                .signaled = @enumFromInt(sig),
             };
-        } else if (signal != null) {
+        } else if (exit_code) |exit| {
             return .{
-                .signaled = @enumFromInt(signal.?),
+                .exited = .{ .code = exit, .signal = @enumFromInt(0) },
             };
         }
 

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -309,9 +309,6 @@ pub const RunCommand = struct {
 
         if (!use_system_shell) {
             if (!silent) {
-                if (Environment.isDebug) {
-                    Output.prettyError("[bun shell] ", .{});
-                }
                 Output.prettyErrorln("<r><d><magenta>$<r> <d><b>{s}<r>", .{combined_script});
                 Output.flush();
             }

--- a/test/js/bun/spawn/spawn-kill-signal.test.ts
+++ b/test/js/bun/spawn/spawn-kill-signal.test.ts
@@ -22,7 +22,7 @@ describe("subprocess.kill", () => {
           proc.kill(...input);
 
           await promise;
-          expect(proc.exitCode).toBe(isWindows ? 1 : null);
+          expect(proc.exitCode).toBe(null);
           expect(proc.signalCode).toBe(key as any);
         });
       }
@@ -45,7 +45,7 @@ describe("subprocess.kill", () => {
 
         await promise;
 
-        expect(proc.exitCode).toBe(isWindows ? 1 : null);
+        expect(proc.exitCode).toBe(null);
         expect(proc.signalCode).toBe("SIGTERM");
       });
     }

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -545,11 +545,9 @@ describe("websocket in subprocess", () => {
 
     subprocess.kill();
 
-    if (isWindows) {
-      expect(await subprocess.exited).toBe(1);
-    } else {
-      expect(await subprocess.exited).toBe(143);
-    }
+    expect(await subprocess.exited).toBe(143); // 128 + 15 (SIGTERM)
+    expect(subprocess.exitCode).toBe(null);
+    expect(subprocess.signalCode).toBe("SIGTERM");
   });
 
   it("should exit with invalid url", async () => {


### PR DESCRIPTION
### What does this PR do?

Fix failing test case on windows by ensuring a signal does not have an exit code. this matches the posix test output on windows.