### PR TITLE
chore: fix the build scripts again

### DIFF
--- a/scripts/build-libarchive.ps1
+++ b/scripts/build-libarchive.ps1
@@ -6,7 +6,7 @@ try {
   Set-Location (mkdir -Force build)
 
   Run cmake @CMAKE_FLAGS -DBUILD_SHARED_LIBS=OFF -DENABLE_TEST=OFF -DENABLE_INSTALL=OFF -DENABLE_WERROR=0 -DENABLE_ICONV=0 -DENABLE_LibGCC=0 -DENABLE_LZMA=0 -DENABLE_LZ4=0 -DENABLE_LIBXML2=0 -DENABLE_LIBB2=0 -DENABLE_OPENSSL=0 -DENABLE_CAT=0 ..
-  Run cmake  --build . --clean-first --config Release
+  Run cmake  --build . --clean-first --config Release --verbose
 
   Copy-Item libarchive\archive_static.lib $BUN_DEPS_OUT_DIR\archive.lib
   Write-Host "-> archive.lib"

--- a/scripts/build-tinycc.ps1
+++ b/scripts/build-tinycc.ps1
@@ -23,7 +23,7 @@ try {
   $Baseline = $env:BUN_DEV_ENV_SET -eq "Baseline=True"
 
   # TODO: -MT
-  Run clang-cl @($env:CFLAGS -split ' ') libtcc.c -o tcc.obj "-DTCC_TARGET_PE" "-DTCC_TARGET_X86_64" "-O2" "-W2" "-Zi" "-MD" "-GS-" "-c"
+  Run clang-cl @($env:CFLAGS -split ' ') libtcc.c -o tcc.obj "-DTCC_TARGET_PE" "-DTCC_TARGET_X86_64" "-O2" "-W2" "-Zi" "-MD" "-GS-" "-c" "-D_CRT_SECURE_NO_WARNINGS"
   Run lib "tcc.obj" "-OUT:tcc.lib"
 
   Copy-Item tcc.obj $BUN_DEPS_OUT_DIR/tcc.lib

--- a/scripts/build-tinycc.ps1
+++ b/scripts/build-tinycc.ps1
@@ -23,7 +23,7 @@ try {
   $Baseline = $env:BUN_DEV_ENV_SET -eq "Baseline=True"
 
   # TODO: -MT
-  Run clang-cl @($env:CFLAGS -split ' ') libtcc.c -o tcc.obj "-DTCC_TARGET_PE" "-DTCC_TARGET_X86_64" "-O2" "-W2" "-Zi" "-MD" "-GS-" "-c" "-D_CRT_SECURE_NO_WARNINGS"
+  Run clang-cl @($env:CFLAGS -split ' ') libtcc.c -o tcc.obj "-DTCC_TARGET_PE" "-DTCC_TARGET_X86_64" "-O2" "-W2" "-Zi" "-MD" "-GS-" "-c"
   Run lib "tcc.obj" "-OUT:tcc.lib"
 
   Copy-Item tcc.obj $BUN_DEPS_OUT_DIR/tcc.lib

--- a/scripts/env.ps1
+++ b/scripts/env.ps1
@@ -50,18 +50,18 @@ $CFLAGS = '/O2'
 $CXXFLAGS = '/O2'
 # $CXXFLAGS = '/O2 /MT'
 
-if ($Baseline) {
-  $CFLAGS += ' -march=nehalem'
-  $CXXFLAGS += ' -march=nehalem'
-}
+$CPU_NAME = if ($Baseline) { "nehalem" } else { "haswell" };
+
+$CFLAGS += " -march=${CPU_NAME}"
+$CXXFLAGS += " -march=${CPU_NAME}"
 
 $CMAKE_FLAGS = @(
   "-GNinja",
   "-DCMAKE_BUILD_TYPE=Release",
   "-DCMAKE_C_COMPILER=$CC",
   "-DCMAKE_CXX_COMPILER=$CXX",
-  "-DCMAKE_C_FLAGS=`"$CFLAGS`"",
-  "-DCMAKE_CXX_FLAGS=`"$CXXFLAGS`""
+  "-DCMAKE_C_FLAGS=$CFLAGS",
+  "-DCMAKE_CXX_FLAGS=$CXXFLAGS"
 )
 $env:CC = "clang-cl"
 $env:CXX = "clang-cl"
@@ -86,9 +86,10 @@ function Run() {
   $command = $args[0]
   $commandArgs = @()
   if ($args.Count -gt 1) {
-    $commandArgs = $args[1..($args.Count - 1)]
+    $commandArgs = @($args[1..($args.Count - 1)] | % {$_})
   }
 
+  write-host "> $command $commandArgs"
   & $command $commandArgs
   $result = $LASTEXITCODE
 


### PR DESCRIPTION
did you know clang-cl doesnt error when given the argument "/O2 -march=nehalem" (one argument with a space), nor does it apply the argument.

did you know the SDE emulator when set into nehalem mode doesnt work.

did you know powershell and arrays and string coersions are very silly