### PR TITLE
fix(install): workspaces without versions

### DIFF
--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -1242,32 +1242,27 @@ pub const Behavior = packed struct(u8) {
     }
 
     pub fn format(self: Behavior, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-        const fields = std.meta.fields(Behavior);
-        var num_fields: u8 = 0;
-        inline for (fields) |f| {
-            if (f.type == bool and @field(self, f.name)) {
-                num_fields += 1;
+        const fields = .{
+            "normal",
+            "optional",
+            "dev",
+            "peer",
+            "workspace",
+        };
+
+        var first = true;
+        inline for (fields) |field| {
+            if (@field(self, field)) {
+                if (!first) {
+                    try writer.writeAll(" | ");
+                }
+                try writer.writeAll(field);
+                first = false;
             }
         }
-        switch (num_fields) {
-            0 => try writer.writeAll("Behavior.uninitialized"),
-            1 => {
-                inline for (fields) |f| {
-                    if (f.type == bool and @field(self, f.name)) {
-                        try writer.writeAll("Behavior." ++ f.name);
-                        break;
-                    }
-                }
-            },
-            else => {
-                try writer.writeAll("Behavior{");
-                inline for (fields) |f| {
-                    if (f.type == bool and @field(self, f.name)) {
-                        try writer.writeAll(" " ++ f.name);
-                    }
-                }
-                try writer.writeAll(" }");
-            },
+
+        if (first) {
+            try writer.writeAll("-");
         }
     }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -3747,29 +3747,27 @@ pub const PackageManager = struct {
                 const workspace_path = if (this.lockfile.workspace_paths.count() > 0) this.lockfile.workspace_paths.get(name_hash) else null;
                 resolve_from_workspace: {
                     if (version.tag == .npm) {
-                        if (this.lockfile.workspace_versions.count() > 0) {
-                            const workspace_version = this.lockfile.workspace_versions.get(name_hash);
-                            const buf = this.lockfile.buffers.string_bytes.items;
-                            if ((workspace_version != null and version.value.npm.version.satisfies(workspace_version.?, buf, buf)) or
+                        const workspace_version = this.lockfile.workspace_versions.get(name_hash);
+                        const buf = this.lockfile.buffers.string_bytes.items;
+                        if ((workspace_version != null and version.value.npm.version.satisfies(workspace_version.?, buf, buf)) or
 
-                                // https://github.com/oven-sh/bun/pull/10899#issuecomment-2099609419
-                                // if the workspace doesn't have a version, it can still be used if
-                                // dependency version is wildcard
-                                (workspace_path != null and version.value.npm.version.@"is *"()))
-                            {
-                                const root_package = this.lockfile.rootPackage() orelse break :resolve_from_workspace;
-                                const root_dependencies = root_package.dependencies.get(this.lockfile.buffers.dependencies.items);
-                                const root_resolutions = root_package.resolutions.get(this.lockfile.buffers.resolutions.items);
+                            // https://github.com/oven-sh/bun/pull/10899#issuecomment-2099609419
+                            // if the workspace doesn't have a version, it can still be used if
+                            // dependency version is wildcard
+                            (workspace_path != null and version.value.npm.version.@"is *"()))
+                        {
+                            const root_package = this.lockfile.rootPackage() orelse break :resolve_from_workspace;
+                            const root_dependencies = root_package.dependencies.get(this.lockfile.buffers.dependencies.items);
+                            const root_resolutions = root_package.resolutions.get(this.lockfile.buffers.resolutions.items);
 
-                                for (root_dependencies, root_resolutions) |root_dep, workspace_package_id| {
-                                    if (workspace_package_id != invalid_package_id and root_dep.version.tag == .workspace and root_dep.name_hash == name_hash) {
-                                        // make sure verifyResolutions sees this resolution as a valid package id
-                                        successFn(this, dependency_id, workspace_package_id);
-                                        return .{
-                                            .package = this.lockfile.packages.get(workspace_package_id),
-                                            .is_first_time = false,
-                                        };
-                                    }
+                            for (root_dependencies, root_resolutions) |root_dep, workspace_package_id| {
+                                if (workspace_package_id != invalid_package_id and root_dep.version.tag == .workspace and root_dep.name_hash == name_hash) {
+                                    // make sure verifyResolutions sees this resolution as a valid package id
+                                    successFn(this, dependency_id, workspace_package_id);
+                                    return .{
+                                        .package = this.lockfile.packages.get(workspace_package_id),
+                                        .is_first_time = false,
+                                    };
                                 }
                             }
                         }
@@ -3843,7 +3841,7 @@ pub const PackageManager = struct {
             },
             .workspace => {
                 // package name hash should be used to find workspace path from map
-                const workspace_path_raw: *const String = this.lockfile.workspace_paths.getPtr(@truncate(name_hash)) orelse &version.value.workspace;
+                const workspace_path_raw: *const String = this.lockfile.workspace_paths.getPtr(name_hash) orelse &version.value.workspace;
                 const workspace_path = this.lockfile.str(workspace_path_raw);
                 var buf2: bun.PathBuffer = undefined;
                 const workspace_path_u8 = if (std.fs.path.isAbsolute(workspace_path)) workspace_path else blk: {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -3744,11 +3744,19 @@ pub const PackageManager = struct {
 
         switch (version.tag) {
             .npm, .dist_tag => {
-                if (version.tag == .npm) {
-                    if (this.lockfile.workspace_versions.count() > 0) resolve_from_workspace: {
-                        if (this.lockfile.workspace_versions.get(name_hash)) |workspace_version| {
+                const workspace_path = if (this.lockfile.workspace_paths.count() > 0) this.lockfile.workspace_paths.get(name_hash) else null;
+                resolve_from_workspace: {
+                    if (version.tag == .npm) {
+                        if (this.lockfile.workspace_versions.count() > 0) {
+                            const workspace_version = this.lockfile.workspace_versions.get(name_hash);
                             const buf = this.lockfile.buffers.string_bytes.items;
-                            if (version.value.npm.version.satisfies(workspace_version, buf, buf)) {
+                            if ((workspace_version != null and version.value.npm.version.satisfies(workspace_version.?, buf, buf)) or
+
+                                // https://github.com/oven-sh/bun/pull/10899#issuecomment-2099609419
+                                // if the workspace doesn't have a version, it can still be used if
+                                // dependency version is wildcard
+                                (workspace_path != null and version.value.npm.version.@"is *"()))
+                            {
                                 const root_package = this.lockfile.rootPackage() orelse break :resolve_from_workspace;
                                 const root_dependencies = root_package.dependencies.get(this.lockfile.buffers.dependencies.items);
                                 const root_resolutions = root_package.resolutions.get(this.lockfile.buffers.resolutions.items);
@@ -3762,6 +3770,24 @@ pub const PackageManager = struct {
                                             .is_first_time = false,
                                         };
                                     }
+                                }
+                            }
+                        }
+                    } else {
+                        // dist_tag will match any workspace version, even missing ones
+                        if (workspace_path != null) {
+                            const root_package = this.lockfile.rootPackage() orelse break :resolve_from_workspace;
+                            const root_dependencies = root_package.dependencies.get(this.lockfile.buffers.dependencies.items);
+                            const root_resolutions = root_package.resolutions.get(this.lockfile.buffers.resolutions.items);
+
+                            for (root_dependencies, root_resolutions) |root_dep, workspace_package_id| {
+                                if (workspace_package_id != invalid_package_id and root_dep.version.tag == .workspace and root_dep.name_hash == name_hash) {
+                                    // make sure verifyResolutions sees this resolution as a valid package id
+                                    successFn(this, dependency_id, workspace_package_id);
+                                    return .{
+                                        .package = this.lockfile.packages.get(workspace_package_id),
+                                        .is_first_time = false,
+                                    };
                                 }
                             }
                         }

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -6100,7 +6100,7 @@ pub fn jsonStringify(this: *const Lockfile, w: anytype) !void {
             if (pkg.resolution.tag == .uninitialized) {
                 try w.write(null);
             } else {
-                const b = try std.fmt.bufPrint(&buf, "{s} {s}", .{ @tagName(pkg.resolution.tag), pkg.resolution.fmt(sb, .auto) });
+                const b = try std.fmt.bufPrint(&buf, "{s} {s}", .{ @tagName(pkg.resolution.tag), pkg.resolution.fmt(sb, .posix) });
                 try w.write(b);
             }
 

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -3639,10 +3639,14 @@ pub const Package = extern struct {
                 // if relative is empty, we are linking the package to itself
                 dependency_version.value.folder = string_builder.append(String, if (relative.len == 0) "." else relative);
             },
-            .npm => if (comptime tag != null)
-                unreachable
-            else if (workspace_version) |ver| {
-                if (dependency_version.value.npm.version.satisfies(ver, buf, buf)) {
+            .npm => {
+                if (comptime tag != null) bun.assert(false);
+                const npm = dependency_version.value.npm;
+                if ((workspace_version != null and npm.version.satisfies(workspace_version.?, buf, buf)) or
+
+                    // no version in workspace package.json
+                    (workspace_path != null and npm.version.isSingleWildcard()))
+                {
                     for (package_dependencies[0..dependencies_count]) |dep| {
                         // `dependencies` & `workspaces` defined within the same `package.json`
                         if (dep.version.tag == .workspace and dep.name_hash == name_hash) {

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -4588,7 +4588,7 @@ pub const Package = extern struct {
         }
 
         total_dependencies_count = 0;
-        const in_workspace = lockfile.workspace_paths.contains(@as(u32, @truncate(package.name_hash)));
+        const in_workspace = lockfile.workspace_paths.contains(package.name_hash);
 
         inline for (dependency_groups) |group| {
             if (group.behavior.isWorkspace()) {

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1759,8 +1759,8 @@ pub fn getPackageID(
                 return id;
             }
 
-            if (npm_version) |range| {
-                if (range.satisfies(resolutions[id].value.npm.version, buf, buf)) return id;
+            if (resolutions[id].tag == .npm and npm_version != null) {
+                if (npm_version.?.satisfies(resolutions[id].value.npm.version, buf, buf)) return id;
             }
         },
         .PackageIDMultiple => |ids| {
@@ -1771,8 +1771,8 @@ pub fn getPackageID(
                     return id;
                 }
 
-                if (npm_version) |range| {
-                    if (range.satisfies(resolutions[id].value.npm.version, buf, buf)) return id;
+                if (resolutions[id].tag == .npm and npm_version != null) {
+                    if (npm_version.?.satisfies(resolutions[id].value.npm.version, buf, buf)) return id;
                 }
             }
         },

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -3643,36 +3643,9 @@ pub const Package = extern struct {
                 // if relative is empty, we are linking the package to itself
                 dependency_version.value.folder = string_builder.append(String, if (relative.len == 0) "." else relative);
             },
-            .dist_tag => {
-                if (workspace_path != null) {
-                    for (package_dependencies[0..dependencies_count]) |dep| {
-                        if (dep.version.tag == .workspace and dep.name_hash == name_hash) {
-                            return null;
-                        }
-                    }
-
-                    const path = workspace_path.?.sliced(buf);
-                    if (Dependency.parseWithTag(
-                        allocator,
-                        external_alias.value,
-                        external_alias.hash,
-                        path.slice,
-                        .workspace,
-                        &path,
-                        log,
-                    )) |dep| {
-                        dependency_version = dep;
-                    }
-                }
-            },
             .npm => {
                 const npm = dependency_version.value.npm;
-                if (workspace_version != null and
-                    (npm.version.satisfies(workspace_version.?, buf, buf) or
-
-                    // no version in workspace package.json
-                    (workspace_path != null and npm.version.@"is *"())))
-                {
+                if (workspace_version != null and npm.version.satisfies(workspace_version.?, buf, buf)) {
                     for (package_dependencies[0..dependencies_count]) |dep| {
                         // `dependencies` & `workspaces` defined within the same `package.json`
                         if (dep.version.tag == .workspace and dep.name_hash == name_hash) {

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -3623,6 +3623,10 @@ pub const Package = extern struct {
             }
         }
 
+        if (comptime tag != null) {
+            bun.assert(dependency_version.tag != .npm and dependency_version.tag != .dist_tag);
+        }
+
         switch (dependency_version.tag) {
             .folder => {
                 const relative = Path.relative(
@@ -3640,7 +3644,6 @@ pub const Package = extern struct {
                 dependency_version.value.folder = string_builder.append(String, if (relative.len == 0) "." else relative);
             },
             .dist_tag => {
-                if (comptime tag != null) bun.assert(false);
                 if (workspace_path != null) {
                     for (package_dependencies[0..dependencies_count]) |dep| {
                         if (dep.version.tag == .workspace and dep.name_hash == name_hash) {
@@ -3663,12 +3666,12 @@ pub const Package = extern struct {
                 }
             },
             .npm => {
-                if (comptime tag != null) bun.assert(false);
                 const npm = dependency_version.value.npm;
-                if ((workspace_version != null and npm.version.satisfies(workspace_version.?, buf, buf)) or
+                if (workspace_version != null and
+                    (npm.version.satisfies(workspace_version.?, buf, buf) or
 
                     // no version in workspace package.json
-                    (workspace_path != null and npm.version.@"is *"()))
+                    (workspace_path != null and npm.version.@"is *"())))
                 {
                     for (package_dependencies[0..dependencies_count]) |dep| {
                         // `dependencies` & `workspaces` defined within the same `package.json`

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -3668,7 +3668,7 @@ pub const Package = extern struct {
                 if ((workspace_version != null and npm.version.satisfies(workspace_version.?, buf, buf)) or
 
                     // no version in workspace package.json
-                    (workspace_path != null and npm.version.isSingleWildcard()))
+                    (workspace_path != null and npm.version.@"is *"()))
                 {
                     for (package_dependencies[0..dependencies_count]) |dep| {
                         // `dependencies` & `workspaces` defined within the same `package.json`

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -1279,6 +1279,18 @@ pub const Range = struct {
     left: Comparator = .{},
     right: Comparator = .{},
 
+    pub fn format(this: Range, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+        if (this.left.op == .unset and this.right.op == .unset) {
+            return;
+        }
+
+        if (this.right.op == .unset) {
+            try std.fmt.format(writer, "{}", .{this.left});
+        } else {
+            try std.fmt.format(writer, "{} {}", .{ this.left, this.right });
+        }
+    }
+
     /// *
     /// >= 0.0.0
     /// >= 0
@@ -1369,12 +1381,59 @@ pub const Range = struct {
         return lhs.left.eql(rhs.left) and lhs.right.eql(rhs.right);
     }
 
+    pub const Formatter = struct {
+        buffer: []const u8,
+        range: *const Range,
+
+        pub fn format(this: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+            if (this.range.left.op == Op.unset and this.range.right.op == Op.unset) {
+                return;
+            }
+
+            if (this.range.right.op == .unset) {
+                try std.fmt.format(writer, "{}", .{this.range.left.fmt(this.buffer)});
+            } else {
+                try std.fmt.format(writer, "{} {}", .{ this.range.left.fmt(this.buffer), this.range.right.fmt(this.buffer) });
+            }
+        }
+    };
+
+    pub fn fmt(this: *const Range, buf: []const u8) @This().Formatter {
+        return .{ .buffer = buf, .range = this };
+    }
+
     pub const Comparator = struct {
         op: Op = .unset,
         version: Version = .{},
 
         pub inline fn eql(lhs: Comparator, rhs: Comparator) bool {
             return lhs.op == rhs.op and lhs.version.eql(rhs.version);
+        }
+
+        pub const Formatter = struct {
+            buffer: []const u8,
+            comparator: *const Comparator,
+
+            pub fn format(this: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+                if (this.comparator.op == Op.unset) {
+                    return;
+                }
+
+                switch (this.comparator.op) {
+                    .unset => unreachable, // see above,
+                    .eql => try writer.writeAll("=="),
+                    .lt => try writer.writeAll("<"),
+                    .lte => try writer.writeAll("<="),
+                    .gt => try writer.writeAll(">"),
+                    .gte => try writer.writeAll(">="),
+                }
+
+                try std.fmt.format(writer, "{}", .{this.comparator.version.fmt(this.buffer)});
+            }
+        };
+
+        pub fn fmt(this: *const Comparator, buf: []const u8) @This().Formatter {
+            return .{ .buffer = buf, .comparator = this };
         }
 
         pub fn satisfies(
@@ -1473,6 +1532,27 @@ pub const Query = struct {
     // AND
     next: ?*Query = null,
 
+    const Formatter = struct {
+        query: *const Query,
+        buffer: []const u8,
+        pub fn format(formatter: Formatter, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+            const this = formatter.query;
+
+            if (this.next) |ptr| {
+                if (ptr.range.hasLeft() or ptr.range.hasRight()) {
+                    try std.fmt.format(writer, "{} && {}", .{ this.range.fmt(formatter.buffer), ptr.range.fmt(formatter.buffer) });
+                    return;
+                }
+            }
+
+            try std.fmt.format(writer, "{}", .{this.range.fmt(formatter.buffer)});
+        }
+    };
+
+    pub fn fmt(this: *const Query, buf: []const u8) @This().Formatter {
+        return .{ .query = this, .buffer = buf };
+    }
+
     /// Linked-list of Queries OR'd together
     /// "^1 || ^2"
     /// ----|-----
@@ -1483,6 +1563,24 @@ pub const Query = struct {
 
         // OR
         next: ?*List = null,
+
+        const Formatter = struct {
+            list: *const List,
+            buffer: []const u8,
+            pub fn format(formatter: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+                const this = formatter.list;
+
+                if (this.next) |ptr| {
+                    try std.fmt.format(writer, "{} || {}", .{ this.head.fmt(formatter.buffer), ptr.fmt(formatter.buffer) });
+                } else {
+                    try std.fmt.format(writer, "{}", .{this.head.fmt(formatter.buffer)});
+                }
+            }
+        };
+
+        pub fn fmt(this: *const List, buf: []const u8) @This().Formatter {
+            return .{ .list = this, .buffer = buf };
+        }
 
         pub fn satisfies(list: *const List, version: Version, list_buf: string, version_buf: string) bool {
             return list.head.satisfies(
@@ -1557,6 +1655,44 @@ pub const Query = struct {
             pub const pre = 1;
             pub const build = 0;
         };
+
+        const Formatter = struct {
+            group: *const Group,
+            pub fn format(formatter: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+                const this = formatter.group;
+
+                if (this.tail == null and this.head.tail == null and !this.head.head.range.hasLeft()) {
+                    return;
+                }
+
+                if (this.tail == null and this.head.tail == null) {
+                    try std.fmt.format(writer, "{}", .{this.head.fmt(this.input)});
+                    return;
+                }
+
+                var list = &this.head;
+                while (list.next) |next| {
+                    try std.fmt.format(writer, "{} && ", .{list.fmt(this.input)});
+                    list = next;
+                }
+
+                try std.fmt.format(writer, "{}", .{list.fmt(this.input)});
+            }
+        };
+
+        pub fn fmt(this: *const Group) @This().Formatter {
+            return .{ .group = this };
+        }
+
+        pub fn jsonStringify(this: *const Group, writer: anytype) !void {
+            const temp = try std.fmt.allocPrint(bun.default_allocator, "{}", .{this.fmt()});
+            defer bun.default_allocator.free(temp);
+            try std.json.encodeJsonString(temp, .{}, writer);
+        }
+
+        pub fn format(this: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+            try this.fmt().format("", .{}, writer);
+        }
 
         pub fn deinit(this: *Group) void {
             var list = this.head;

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -1609,6 +1609,19 @@ pub const Query = struct {
             return this.head.next == null and this.head.head.next == null and !this.head.head.range.hasRight() and this.head.head.range.left.op == .eql;
         }
 
+        pub fn isSingleWildcard(this: *const Group) bool {
+            const left = this.head.head.range.left;
+            return this.head.head.range.right.op == .unset and
+                left.op == .gte and
+                left.version.patch == 0 and
+                left.version.minor == 0 and
+                left.version.major == 0 and
+                left.version.tag.pre.isEmpty() and
+                left.version.tag.build.isEmpty() and
+                this.head.next == null and
+                this.head.head.next == null;
+        }
+
         pub inline fn eql(lhs: Group, rhs: Group) bool {
             return lhs.head.eql(&rhs.head);
         }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -44,6 +44,10 @@ export const upgrade_test_helpers = $zig("upgrade_command.zig", "upgrade_js_bind
   closeTempDirHandle: () => void;
 };
 
+export const install_test_helpers = $zig("install.zig", "bun_install_js_bindings.generate") as {
+  printLockfileAsJSON: (cwd: string) => string;
+};
+
 export const nativeFrameForTesting: (callback: () => void) => void = $cpp(
   "CallSite.cpp",
   "createNativeFrameForTesting",

--- a/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
@@ -60,7 +60,7 @@ exports[`dependency on workspace without version in package.json: version: * 1`]
             "version": ">=0.0.0"
           },
           "resolved_id": 1,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -140,7 +140,7 @@ exports[`dependency on workspace without version in package.json: version: *.*.*
             "version": ">=0.0.0"
           },
           "resolved_id": 1,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -220,7 +220,7 @@ exports[`dependency on workspace without version in package.json: version: lates
             "tag": "lodash"
           },
           "resolved_id": 1,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -300,7 +300,7 @@ exports[`dependency on workspace without version in package.json: version:  1`] 
             "tag": "lodash"
           },
           "resolved_id": 1,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -380,7 +380,7 @@ exports[`dependency on workspace without version in package.json: version: =* 1`
             "version": ">=0.0.0"
           },
           "resolved_id": 1,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -460,7 +460,7 @@ exports[`dependency on workspace without version in package.json: version: kjwoe
             "tag": "lodash"
           },
           "resolved_id": 1,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -540,7 +540,7 @@ exports[`dependency on workspace without version in package.json: version: *.1.*
             "version": ">=0.0.0"
           },
           "resolved_id": 1,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -620,7 +620,7 @@ exports[`dependency on workspace without version in package.json: version: *-pre
             "version": ">=0.0.0"
           },
           "resolved_id": 1,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -703,7 +703,7 @@ exports[`dependency on workspace without version in package.json: version: 1 1`]
             "version": "<2.0.0 >=1.0.0"
           },
           "resolved_id": 3,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -798,7 +798,7 @@ exports[`dependency on workspace without version in package.json: version: 1.* 1
             "version": "<2.0.0 >=1.0.0"
           },
           "resolved_id": 3,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -893,7 +893,7 @@ exports[`dependency on workspace without version in package.json: version: 1.1.*
             "version": "<1.2.0 >=1.1.0"
           },
           "resolved_id": 3,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -988,7 +988,7 @@ exports[`dependency on workspace without version in package.json: version: 1.1.1
             "version": "==1.1.1"
           },
           "resolved_id": 3,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -1083,7 +1083,7 @@ exports[`dependency on workspace without version in package.json: version: *-pre
             "version": ">=0.0.0"
           },
           "resolved_id": 3,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,
@@ -1178,7 +1178,7 @@ exports[`dependency on workspace without version in package.json: version: *+bui
             "version": ">=0.0.0"
           },
           "resolved_id": 3,
-          "behavior": "normal"
+          "behavior": "normal | workspace"
         }
       },
       "integrity": null,

--- a/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
@@ -1,0 +1,1211 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dependency on workspace without version in package.json: version: * 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "1e2d5fa6591f007aa6674495d1022868fc3b60325c4a1555315ca0e16ef31c4e",
+  "package_index": {
+    "lodash": 1,
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "*",
+          "npm": {
+            "name": "lodash",
+            "version": ">=0.0.0"
+          },
+          "resolved_id": 1,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: *.*.* 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "1e2d5fa6591f007aa6674495d1022868fc3b60325c4a1555315ca0e16ef31c4e",
+  "package_index": {
+    "lodash": 1,
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "*.*.*",
+          "npm": {
+            "name": "lodash",
+            "version": ">=0.0.0"
+          },
+          "resolved_id": 1,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: latest 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "1e2d5fa6591f007aa6674495d1022868fc3b60325c4a1555315ca0e16ef31c4e",
+  "package_index": {
+    "lodash": 1,
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "latest",
+          "dist_tag": {
+            "name": "lodash",
+            "tag": "lodash"
+          },
+          "resolved_id": 1,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version:  1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "1e2d5fa6591f007aa6674495d1022868fc3b60325c4a1555315ca0e16ef31c4e",
+  "package_index": {
+    "lodash": 1,
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "",
+          "dist_tag": {
+            "name": "lodash",
+            "tag": "lodash"
+          },
+          "resolved_id": 1,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: =* 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "1e2d5fa6591f007aa6674495d1022868fc3b60325c4a1555315ca0e16ef31c4e",
+  "package_index": {
+    "lodash": 1,
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "=*",
+          "npm": {
+            "name": "lodash",
+            "version": ">=0.0.0"
+          },
+          "resolved_id": 1,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: kjwoehcojrgjoj 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "1e2d5fa6591f007aa6674495d1022868fc3b60325c4a1555315ca0e16ef31c4e",
+  "package_index": {
+    "lodash": 1,
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "kjwoehcojrgjoj",
+          "dist_tag": {
+            "name": "lodash",
+            "tag": "lodash"
+          },
+          "resolved_id": 1,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: *.1.* 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "1e2d5fa6591f007aa6674495d1022868fc3b60325c4a1555315ca0e16ef31c4e",
+  "package_index": {
+    "lodash": 1,
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "*.1.*",
+          "npm": {
+            "name": "lodash",
+            "version": ">=0.0.0"
+          },
+          "resolved_id": 1,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: *-pre 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "1e2d5fa6591f007aa6674495d1022868fc3b60325c4a1555315ca0e16ef31c4e",
+  "package_index": {
+    "lodash": 1,
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "*-pre",
+          "npm": {
+            "name": "lodash",
+            "version": ">=0.0.0"
+          },
+          "resolved_id": 1,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: 1 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "56c714bc8ac0cdbf731de74d216134f3ce156ab45adda065fa84e4b2ce349f4b",
+  "package_index": {
+    "lodash": [
+      1,
+      3
+    ],
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "1",
+          "npm": {
+            "name": "lodash",
+            "version": "<2.0.0 >=1.0.0"
+          },
+          "resolved_id": 3,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 3,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "npm 1.3.1",
+      "dependencies": {},
+      "integrity": "sha512-F7AB8u+6d00CCgnbjWzq9fFLpzOMCgq6mPjOW4+8+dYbrnc0obRrC+IHctzfZ1KKTQxX0xo/punrlpOWcf4gpw==",
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: 1.* 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "56c714bc8ac0cdbf731de74d216134f3ce156ab45adda065fa84e4b2ce349f4b",
+  "package_index": {
+    "lodash": [
+      1,
+      3
+    ],
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "1.*",
+          "npm": {
+            "name": "lodash",
+            "version": "<2.0.0 >=1.0.0"
+          },
+          "resolved_id": 3,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 3,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "npm 1.3.1",
+      "dependencies": {},
+      "integrity": "sha512-F7AB8u+6d00CCgnbjWzq9fFLpzOMCgq6mPjOW4+8+dYbrnc0obRrC+IHctzfZ1KKTQxX0xo/punrlpOWcf4gpw==",
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: 1.1.* 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "56ec928a6d5f1d18236abc348bc711d6cfd08ca0a068bfc9fda24e7b22bed046",
+  "package_index": {
+    "lodash": [
+      1,
+      3
+    ],
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "1.1.*",
+          "npm": {
+            "name": "lodash",
+            "version": "<1.2.0 >=1.1.0"
+          },
+          "resolved_id": 3,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 3,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "npm 1.1.1",
+      "dependencies": {},
+      "integrity": "sha512-SFeNKyKPh4kvYv0yd95fwLKw4JXM45PJLsPRdA8v7/q0lBzFeK6XS8xJTl6mlhb8PbAzioMkHli1W/1g0y4XQQ==",
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: 1.1.1 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "56ec928a6d5f1d18236abc348bc711d6cfd08ca0a068bfc9fda24e7b22bed046",
+  "package_index": {
+    "lodash": [
+      1,
+      3
+    ],
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "1.1.1",
+          "npm": {
+            "name": "lodash",
+            "version": "==1.1.1"
+          },
+          "resolved_id": 3,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 3,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "npm 1.1.1",
+      "dependencies": {},
+      "integrity": "sha512-SFeNKyKPh4kvYv0yd95fwLKw4JXM45PJLsPRdA8v7/q0lBzFeK6XS8xJTl6mlhb8PbAzioMkHli1W/1g0y4XQQ==",
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: *-pre+build 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "13e05e9c7522649464f47891db2c094497e8827d4a1f6784db8ef6c066211846",
+  "package_index": {
+    "lodash": [
+      1,
+      3
+    ],
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "*-pre+build",
+          "npm": {
+            "name": "lodash",
+            "version": ">=0.0.0"
+          },
+          "resolved_id": 3,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 3,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "npm 4.17.21",
+      "dependencies": {},
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: *+build 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "13e05e9c7522649464f47891db2c094497e8827d4a1f6784db8ef6c066211846",
+  "package_index": {
+    "lodash": [
+      1,
+      3
+    ],
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "*+build",
+          "npm": {
+            "name": "lodash",
+            "version": ">=0.0.0"
+          },
+          "resolved_id": 3,
+          "behavior": "normal"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 3,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "npm 4.17.21",
+      "dependencies": {},
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -3,6 +3,8 @@ import { bunExe, bunEnv as env, tmpdirSync } from "harness";
 import { join } from "path";
 import { writeFileSync, mkdirSync, rmSync } from "fs";
 import { beforeEach, test, expect } from "bun:test";
+import { install_test_helpers } from "bun:internal-for-testing";
+const { printLockfileAsJSON } = install_test_helpers;
 
 var testCounter: number = 0;
 
@@ -84,6 +86,8 @@ test("dependency on workspace without version in package.json", () => {
 
     expect(exitCode).toBe(0);
 
+    expect(printLockfileAsJSON(packageDir)).toMatchSnapshot(`version: ${version}`);
+
     rmSync(join(packageDir, "node_modules"), { recursive: true, force: true });
     rmSync(join(packageDir, "bun.lockb"), { recursive: true, force: true });
   }
@@ -123,6 +127,8 @@ test("dependency on workspace without version in package.json", () => {
     ]);
 
     expect(exitCode).toBe(0);
+
+    expect(printLockfileAsJSON(packageDir)).toMatchSnapshot(`version: ${version}`);
 
     rmSync(join(packageDir, "node_modules"), { recursive: true, force: true });
     rmSync(join(packageDir, "packages", "bar", "node_modules"), { recursive: true, force: true });

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -42,8 +42,8 @@ test("dependency on workspace without version in package.json", () => {
 
   mkdirSync(join(packageDir, "packages", "bar"), { recursive: true });
 
-  const shouldWork: string[] = ["*", "*.*.*", "latest", "", "=*", "kjwoehcojrgjoj", "*.1.*"];
-  const shouldNotWork: string[] = ["1", "1.*", "1.1.*", "1.1.1"];
+  const shouldWork: string[] = ["*", "*.*.*", "latest", "", "=*", "kjwoehcojrgjoj", "*.1.*", "*-pre"];
+  const shouldNotWork: string[] = ["1", "1.*", "1.1.*", "1.1.1", "*-pre+build", "*+build"];
 
   for (const version of shouldWork) {
     writeFileSync(

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -67,6 +67,8 @@ test("dependency on workspace without version in package.json", () => {
       env,
     });
 
+    expect(printLockfileAsJSON(packageDir)).toMatchSnapshot(`version: ${version}`);
+
     const err = stderr.toString();
 
     expect(err).toContain("Saved lockfile");
@@ -85,8 +87,6 @@ test("dependency on workspace without version in package.json", () => {
     ]);
 
     expect(exitCode).toBe(0);
-
-    expect(printLockfileAsJSON(packageDir)).toMatchSnapshot(`version: ${version}`);
 
     rmSync(join(packageDir, "node_modules"), { recursive: true, force: true });
     rmSync(join(packageDir, "bun.lockb"), { recursive: true, force: true });
@@ -114,6 +114,8 @@ test("dependency on workspace without version in package.json", () => {
       env,
     });
 
+    expect(printLockfileAsJSON(packageDir)).toMatchSnapshot(`version: ${version}`);
+
     const err = stderr.toString();
     expect(err).toContain("Saved lockfile");
 
@@ -127,8 +129,6 @@ test("dependency on workspace without version in package.json", () => {
     ]);
 
     expect(exitCode).toBe(0);
-
-    expect(printLockfileAsJSON(packageDir)).toMatchSnapshot(`version: ${version}`);
 
     rmSync(join(packageDir, "node_modules"), { recursive: true, force: true });
     rmSync(join(packageDir, "packages", "bar", "node_modules"), { recursive: true, force: true });

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1,0 +1,117 @@
+import { spawnSync } from "bun";
+import { bunExe, bunEnv as env, toBeValidBin, toHaveBins, tmpdirSync } from "harness";
+import { join, s } from "path";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { beforeEach, test, expect } from "bun:test";
+
+var testCounter: number = 0;
+
+// not necessary, but verdaccio will be added to this file in the near future
+var port: number = 4873;
+var packageDir: string;
+
+beforeEach(() => {
+  packageDir = tmpdirSync("bun-workspaces-" + testCounter++ + "-");
+  env.BUN_INSTALL_CACHE_DIR = join(packageDir, ".bun-cache");
+  env.BUN_TMPDIR = env.TMPDIR = env.TEMP = join(packageDir, ".bun-tmp");
+  writeFileSync(
+    join(packageDir, "bunfig.toml"),
+    `
+[install]
+cache = false
+registry = "http://localhost:${port}/"
+`,
+  );
+});
+
+test("dependency on workspace without version in package.json", () => {
+  writeFileSync(
+    join(packageDir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      workspaces: ["packages/*"],
+    }),
+  );
+
+  mkdirSync(join(packageDir, "packages", "mono"), { recursive: true });
+  writeFileSync(
+    join(packageDir, "packages", "mono", "package.json"),
+    JSON.stringify({
+      name: "mono",
+    }),
+  );
+
+  mkdirSync(join(packageDir, "packages", "bar"), { recursive: true });
+
+  const shouldWork: string[] = ["*", "*.*.*", "latest", "", "=*", "kjwoehcojrgjoj", "*.1.*"];
+  const shouldNotWork: string[] = ["1", "1.1.*", "1.1.*", "1.1.1"];
+
+  for (const version of shouldWork) {
+    writeFileSync(
+      join(packageDir, "packages", "bar", "package.json"),
+      JSON.stringify({
+        name: "bar",
+        version: "1.0.0",
+        dependencies: {
+          mono: version,
+        },
+      }),
+    );
+
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stderr: "pipe",
+      stdout: "pipe",
+      env,
+    });
+
+    const err = stderr.toString();
+
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(err).not.toContain("warn:");
+    expect(err).not.toContain("panic:");
+    expect(err).not.toContain("failed");
+
+    const out = stdout.toString();
+    expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+      "",
+      " + bar@workspace:packages/bar",
+      " + mono@workspace:packages/mono",
+      "",
+      " 2 packages installed",
+    ]);
+
+    expect(exitCode).toBe(0);
+
+    rmSync(join(packageDir, "node_modules"), { recursive: true, force: true });
+    rmSync(join(packageDir, "bun.lockb"), { recursive: true, force: true });
+  }
+
+  for (const version of shouldNotWork) {
+    writeFileSync(
+      join(packageDir, "packages", "bar", "package.json"),
+      JSON.stringify({
+        name: "bar",
+        version: "1.0.0",
+        dependencies: {
+          mono: version,
+        },
+      }),
+    );
+
+    const { stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stderr: "pipe",
+      stdout: "pipe",
+      env,
+    });
+
+    const err = stderr.toString();
+    expect(err).toContain("failed to resolve");
+    expect(err).not.toContain("Saved lockfile");
+    expect(exitCode).toBe(1);
+  }
+});

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -59,23 +59,15 @@ test("dependency on workspace without version in package.json", () => {
       }),
     );
 
-    const { stdout, stderr, exitCode } = spawnSync({
+    const { stdout, exitCode } = spawnSync({
       cmd: [bunExe(), "install"],
       cwd: packageDir,
-      stderr: "pipe",
+      stderr: "inherit",
       stdout: "pipe",
       env,
     });
 
     expect(printLockfileAsJSON(packageDir)).toMatchSnapshot(`version: ${version}`);
-
-    const err = stderr.toString();
-
-    expect(err).toContain("Saved lockfile");
-    expect(err).not.toContain("error:");
-    expect(err).not.toContain("warn:");
-    expect(err).not.toContain("panic:");
-    expect(err).not.toContain("failed");
 
     const out = stdout.toString();
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
@@ -106,18 +98,15 @@ test("dependency on workspace without version in package.json", () => {
       }),
     );
 
-    const { stderr, exitCode, stdout } = spawnSync({
+    const { exitCode, stdout } = spawnSync({
       cmd: [bunExe(), "install"],
       cwd: packageDir,
-      stderr: "pipe",
+      stderr: "inherit",
       stdout: "pipe",
       env,
     });
 
     expect(printLockfileAsJSON(packageDir)).toMatchSnapshot(`version: ${version}`);
-
-    const err = stderr.toString();
-    expect(err).toContain("Saved lockfile");
 
     const out = stdout.toString();
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([


### PR DESCRIPTION
### What does this PR do?
This fixes workspaces dependencies with missing versions in their package.json

fixes comment https://github.com/oven-sh/bun/pull/10899#issuecomment-2099609419
fixes #7433 

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added some tests with different version strings

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
