### PR TITLE
feat(cli): Adding an ignore workspace option

### DIFF
--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -2879,6 +2879,9 @@ pub const Api = struct {
         /// concurrent_scripts
         concurrent_scripts: ?u32 = null,
 
+        /// ignore_workspace
+        ignore_workspace: ?bool = null,
+
         pub fn decode(reader: anytype) anyerror!BunInstall {
             var this = std.mem.zeroes(BunInstall);
 

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -506,6 +506,12 @@ pub const Bunfig = struct {
                             }
                         }
                     }
+
+                    if (_bun.get("ignoreWorkspace")) |optional| {
+                        if (optional.asBool()) |ignore_workspace| {
+                            install.ignore_workspace = ignore_workspace;
+                        }
+                    }
                 }
 
                 if (json.get("run")) |run_expr| {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2224,7 +2224,7 @@ pub const Command = struct {
                     Output.flush();
                 },
                 Command.Tag.HelpCommand => {
-                    HelpCommand.printWithReason(.explicit);
+                    HelpCommand.printWithReason(.explicit, show_all_flags);
                 },
                 Command.Tag.UpgradeCommand => {
                     const intro_text =
@@ -2283,7 +2283,7 @@ pub const Command = struct {
                     Output.flush();
                 },
                 else => {
-                    HelpCommand.printWithReason(.explicit);
+                    HelpCommand.printWithReason(.explicit, show_all_flags);
                 },
             }
         }
@@ -2329,13 +2329,6 @@ pub const Command = struct {
 
         pub const uses_global_options: std.EnumArray(Tag, bool) = std.EnumArray(Tag, bool).initDefault(true, .{
             .CreateCommand = false,
-            .InstallCommand = false,
-            .AddCommand = false,
-            .RemoveCommand = false,
-            .UpdateCommand = false,
-            .PackageManagerCommand = false,
-            .LinkCommand = false,
-            .UnlinkCommand = false,
             .BunxCommand = false,
         });
     };

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -266,6 +266,7 @@ pub const Arguments = struct {
         };
 
         defer config_file.close();
+
         const contents = config_file.readToEndAlloc(allocator, std.math.maxInt(usize)) catch |err| {
             if (auto_loaded) return;
             Output.prettyErrorln("<r><red>error<r>: {s} reading config \"{s}\"", .{
@@ -286,6 +287,7 @@ pub const Arguments = struct {
             ctx.log.level = original_level;
         }
         ctx.log.level = logger.Log.Level.warn;
+
         try Bunfig.parse(allocator, logger.Source.initPathString(bun.asByteSlice(config_path), contents), ctx, cmd);
     }
 
@@ -297,7 +299,18 @@ pub const Arguments = struct {
 
         return null;
     }
+
     pub fn loadConfig(allocator: std.mem.Allocator, user_config_path_: ?string, ctx: Command.Context, comptime cmd: Command.Tag) !void {
+        return loadConfig_(allocator, user_config_path_, ctx, cmd, false);
+    }
+
+    pub fn loadConfig_(
+        allocator: std.mem.Allocator,
+        user_config_path_: ?string,
+        ctx: Command.Context,
+        comptime cmd: Command.Tag,
+        override_absolute_working_dir: ?bool,
+    ) !void {
         var config_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
         if (comptime cmd.readGlobalConfig()) {
             if (!ctx.has_loaded_global_config) {
@@ -310,7 +323,6 @@ pub const Arguments = struct {
         }
 
         var config_path_: []const u8 = user_config_path_ orelse "";
-
         var auto_loaded: bool = false;
         if (config_path_.len == 0 and (user_config_path_ != null or
             Command.Tag.always_loads_config.get(cmd) or
@@ -334,7 +346,7 @@ pub const Arguments = struct {
             config_buf[config_path_.len] = 0;
             config_path = config_buf[0..config_path_.len :0];
         } else {
-            if (ctx.args.absolute_working_dir == null) {
+            if ((override_absolute_working_dir orelse false) or ctx.args.absolute_working_dir == null) {
                 var secondbuf: [bun.MAX_PATH_BYTES]u8 = undefined;
                 const cwd = bun.getcwd(&secondbuf) catch return;
 
@@ -348,6 +360,7 @@ pub const Arguments = struct {
                 &parts,
                 .auto,
             );
+
             config_buf[config_path_.len] = 0;
             config_path = config_buf[0..config_path_.len :0];
         }
@@ -1447,6 +1460,7 @@ pub const Command = struct {
             },
             .InstallCommand => {
                 if (comptime bun.fast_debug_build_mode and bun.fast_debug_build_cmd != .InstallCommand) unreachable;
+
                 const ctx = try Command.init(allocator, log, .InstallCommand);
 
                 try InstallCommand.exec(ctx);
@@ -2330,6 +2344,13 @@ pub const Command = struct {
         pub const uses_global_options: std.EnumArray(Tag, bool) = std.EnumArray(Tag, bool).initDefault(true, .{
             .CreateCommand = false,
             .BunxCommand = false,
+            .InstallCommand = false,
+            .AddCommand = false,
+            .RemoveCommand = false,
+            .UpdateCommand = false,
+            .PackageManagerCommand = false,
+            .LinkCommand = false,
+            .UnlinkCommand = false,
         });
     };
 };

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6083,6 +6083,7 @@ it("should install dependencies in root package of workspace", async () => {
       workspaces: ["moo"],
     }),
   );
+
   await mkdir(join(package_dir, "moo"));
   const moo_package = JSON.stringify({
     name: "moo",
@@ -6105,6 +6106,7 @@ it("should install dependencies in root package of workspace", async () => {
   expect(err).toContain("Saved lockfile");
   expect(stdout).toBeDefined();
   const out = await new Response(stdout).text();
+
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     "",
     " + moo@workspace:moo",
@@ -6123,6 +6125,79 @@ it("should install dependencies in root package of workspace", async () => {
   expect(await readdirSorted(join(package_dir, "node_modules", "moo"))).toEqual(["package.json"]);
   expect(await file(join(package_dir, "node_modules", "moo", "package.json")).text()).toEqual(moo_package);
   await access(join(package_dir, "bun.lockb"));
+});
+
+it("should ignore workspaces when installing a package inside a workspace with bunfig", async () => {
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "Foo",
+      version: "0.0.1",
+      workspaces: ["bar", "packages/*"],
+    }),
+  );
+
+  const barPath = join(package_dir, "bar");
+  await mkdir(barPath);
+  await writeFile(
+    join(package_dir, "bar", "package.json"),
+    JSON.stringify({
+      name: "Bar",
+      version: "0.0.2",
+    }),
+  );
+
+  await mkdir(join(package_dir, "packages", "nominally-scoped"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "nominally-scoped", "package.json"),
+    JSON.stringify({
+      name: "@org/nominally-scoped",
+      version: "0.1.4",
+    }),
+  );
+
+  await mkdir(join(package_dir, "packages", "second-asterisk"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "second-asterisk", "package.json"),
+    JSON.stringify({
+      name: "AsteriskTheSecond",
+      version: "0.1.4",
+    }),
+  );
+
+  await mkdir(join(package_dir, "packages", "asterisk"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "asterisk", "package.json"),
+    JSON.stringify({
+      name: "Asterisk",
+      version: "0.0.4",
+    }),
+  );
+
+  await writeFile(
+    join(package_dir, "bar", "bunfig.toml"),
+    `${await file(join(package_dir, "bunfig.toml")).text()}
+ignoreWorkspace=true
+`,
+  );
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: barPath,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr).toBeDefined();
+  const err = await new Response(stderr).text();
+  expect(err).not.toContain("Saved lockfile");
+  expect(stdout).toBeDefined();
+  const out = await new Response(stdout).text();
+  expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*/, "").split(/\r?\n/)).toEqual(["done", ""]);
+  expect(await exited).toBe(0);
+  expect(requested).toBe(0);
+  expect(async () => await readdirSorted(join(package_dir, "node_modules"))).toThrow("No such file or directory");
 });
 
 it("should install dependencies in root package of workspace (*)", async () => {
@@ -7139,8 +7214,6 @@ it("should handle installing workspaces with multiple glob patterns", async () =
     },
   });
 
-  console.log("TEMPDIR", package_dir);
-
   const { stdout, stderr } = await Bun.$`${bunExe()} install`.env(env).cwd(package_dir).throws(true);
   const err1 = stderr.toString();
   expect(err1).toContain("Saved lockfile");
@@ -7209,7 +7282,6 @@ it.todo("should handle installing workspaces with absolute glob patterns", async
       },
     },
   });
-  console.log("TEMP DIR", package_dir);
 
   const { stdout, stderr } = await Bun.$`${bunExe()} install`.env(env).cwd(package_dir).throws(true);
   const err1 = stderr.toString();

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1005,6 +1005,72 @@ it("should ignore peerDependencies within workspaces", async () => {
   await access(join(package_dir, "bun.lockb"));
 });
 
+it("should ignore workspaces when installing a package inside a workspace", async () => {
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "Foo",
+      version: "0.0.1",
+      workspaces: ["bar", "packages/*"],
+    }),
+  );
+
+  const barPath = join(package_dir, "bar");
+  await mkdir(barPath);
+  await writeFile(
+    join(package_dir, "bar", "package.json"),
+    JSON.stringify({
+      name: "Bar",
+      version: "0.0.2",
+    }),
+  );
+
+  await mkdir(join(package_dir, "packages", "nominally-scoped"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "nominally-scoped", "package.json"),
+    JSON.stringify({
+      name: "@org/nominally-scoped",
+      version: "0.1.4",
+    }),
+  );
+
+  await mkdir(join(package_dir, "packages", "second-asterisk"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "second-asterisk", "package.json"),
+    JSON.stringify({
+      name: "AsteriskTheSecond",
+      version: "0.1.4",
+    }),
+  );
+
+  await mkdir(join(package_dir, "packages", "asterisk"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "asterisk", "package.json"),
+    JSON.stringify({
+      name: "Asterisk",
+      version: "0.0.4",
+    }),
+  );
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--ignore-workspace"],
+    cwd: barPath,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(stderr).toBeDefined();
+  const err = await new Response(stderr).text();
+  expect(err).not.toContain("Saved lockfile");
+  expect(stdout).toBeDefined();
+  const out = await new Response(stdout).text();
+  expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*/, "").split(/\r?\n/)).toEqual(["done", ""]);
+  expect(await exited).toBe(0);
+  expect(requested).toBe(0);
+  expect(async () => await readdirSorted(join(package_dir, "node_modules"))).toThrow("No such file or directory");
+});
+
 it("should handle installing the same peerDependency with different versions", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));


### PR DESCRIPTION
### What does this PR do?

The point of this PR is to add way to ignore the workspace when being in the case of an `InstallCommand`. 
For the context, we have a CLI in our monorepo that is developed with Bun, but we want it to be able to be independent from the monorepo. Since `1.1.7`, it'll automatically detect the workspace and go through all the process of installing the workspace dependencies.

This PR adds a new flag `--ignore-workspace` to bun `InstallCommand`. When set, it won't go through the workspace detection and run everything for the current package. It also adds the `ignoreWorkspace` option in the `bunfig.toml` so you don't have to pass the flag every time.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
