### PR TITLE
feat: add canary to crash handler message

### DIFF
--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -616,8 +616,9 @@ else
     "x64";
 
 const metadata_version_line = std.fmt.comptimePrint(
-    "Bun v{s} {s} {s}{s}\n",
+    "Bun {s}v{s} {s} {s}{s}\n",
     .{
+        if (bun.Environment.is_canary) "Canary " else "",
         Global.package_json_version_with_sha,
         bun.Environment.os.displayString(),
         arch_display_string,


### PR DESCRIPTION
### What does this PR do?

make it easier to identify people's screenshots of Bun crashing to determine if it's from a canary build or not.

<img width="788" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/a38fe373-19e7-477e-8f9b-8880d303f474">
