### PR TITLE
Fixes missing argument in signal events

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -773,6 +773,7 @@ void signalHandler(uv_signal_t* signal, int signalNumber)
         String signalName = signalNumberToNameMap->get(signalNumber);
         Identifier signalNameIdentifier = Identifier::fromString(globalObject->vm(), signalName);
         MarkedArgumentBuffer args;
+        args.append(jsString(globalObject->vm(), signalNameIdentifier.string()));
         args.append(jsNumber(signalNumber));
         // TODO(@paperdave): add an ASSERT(isMainThread());
         // This should be true on posix if I understand sigaction right

--- a/test/js/node/process/process-signal-handler.fixture.js
+++ b/test/js/node/process/process-signal-handler.fixture.js
@@ -1,6 +1,20 @@
 import os from "os";
 import { raise } from "./call-raise";
 
+function checkSignal(signalName, args) {
+  if (args.length !== 2) {
+    throw new Error("Expected 2 arguments, got " + args.length);
+  }
+  if (args[0] !== signalName) {
+    throw new Error("Expected signal name " + signalName + ", got " + args[0]);
+  }
+
+  const signalNumber = os.constants.signals[signalName];
+  if (args[1] !== signalNumber) {
+    throw new Error("Expected signal number " + signalNumber + ", got " + args[1]);
+  }
+}
+
 var counter = 0;
 function done() {
   counter++;
@@ -40,10 +54,12 @@ const SIGUSR2 = os.constants.signals.SIGUSR2;
 
 switch (process.argv.at(-1)) {
   case "SIGUSR1": {
-    process.on("SIGUSR1", () => {
+    process.on("SIGUSR1", function () {
+      checkSignal("SIGUSR1", arguments);
       done();
     });
-    process.on("SIGUSR1", () => {
+    process.on("SIGUSR1", function () {
+      checkSignal("SIGUSR1", arguments);
       done();
     });
     raise(SIGUSR1);

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -417,6 +417,7 @@ describe("signal", () => {
     const child = Bun.spawn({
       cmd: [bunExe(), fixture, "SIGUSR1"],
       env: bunEnv,
+      stderr: "inherit",
     });
 
     expect(await child.exited).toBe(0);


### PR DESCRIPTION


### What does this PR do?

Fixes https://twitter.com/sahithyandev/status/1788243782011367893

`process.on("SIG123", cb)`  is supposed to emit `[signal name, signal number]`. We were only emitting `[ signal number ]`.

> SIGWINCH 28

### How did you verify your code works?

There is a test