### PR TITLE
fix(install): bug with dist-tags and workspaces with versions

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -3744,9 +3744,9 @@ pub const PackageManager = struct {
 
         switch (version.tag) {
             .npm, .dist_tag => {
-                const workspace_path = if (this.lockfile.workspace_paths.count() > 0) this.lockfile.workspace_paths.get(name_hash) else null;
                 resolve_from_workspace: {
                     if (version.tag == .npm) {
+                        const workspace_path = if (this.lockfile.workspace_paths.count() > 0) this.lockfile.workspace_paths.get(name_hash) else null;
                         const workspace_version = this.lockfile.workspace_versions.get(name_hash);
                         const buf = this.lockfile.buffers.string_bytes.items;
                         if ((workspace_version != null and version.value.npm.version.satisfies(workspace_version.?, buf, buf)) or
@@ -3771,24 +3771,6 @@ pub const PackageManager = struct {
                                 }
                             }
                         }
-                    } else {
-                        // dist_tag will match any workspace version, even missing ones
-                        if (workspace_path != null and !this.lockfile.workspace_versions.contains(name_hash)) {
-                            const root_package = this.lockfile.rootPackage() orelse break :resolve_from_workspace;
-                            const root_dependencies = root_package.dependencies.get(this.lockfile.buffers.dependencies.items);
-                            const root_resolutions = root_package.resolutions.get(this.lockfile.buffers.resolutions.items);
-
-                            for (root_dependencies, root_resolutions) |root_dep, workspace_package_id| {
-                                if (workspace_package_id != invalid_package_id and root_dep.version.tag == .workspace and root_dep.name_hash == name_hash) {
-                                    // make sure verifyResolutions sees this resolution as a valid package id
-                                    successFn(this, dependency_id, workspace_package_id);
-                                    return .{
-                                        .package = this.lockfile.packages.get(workspace_package_id),
-                                        .is_first_time = false,
-                                    };
-                                }
-                            }
-                        }
                     }
                 }
 
@@ -3798,10 +3780,39 @@ pub const PackageManager = struct {
                     .dist_tag => manifest.findByDistTag(this.lockfile.str(&version.value.dist_tag.tag)),
                     .npm => manifest.findBestVersion(version.value.npm.version, this.lockfile.buffers.string_bytes.items),
                     else => unreachable,
-                } orelse return if (behavior.isPeer()) null else switch (version.tag) {
-                    .npm => error.NoMatchingVersion,
-                    .dist_tag => error.DistTagNotFound,
-                    else => unreachable,
+                } orelse {
+                    resolve_workspace_from_dist_tag: {
+                        // choose a workspace for a dist_tag only if a version was not found
+                        if (version.tag == .dist_tag) {
+                            const workspace_path = if (this.lockfile.workspace_paths.count() > 0) this.lockfile.workspace_paths.get(name_hash) else null;
+                            if (workspace_path != null) {
+                                const root_package = this.lockfile.rootPackage() orelse break :resolve_workspace_from_dist_tag;
+                                const root_dependencies = root_package.dependencies.get(this.lockfile.buffers.dependencies.items);
+                                const root_resolutions = root_package.resolutions.get(this.lockfile.buffers.resolutions.items);
+
+                                for (root_dependencies, root_resolutions) |root_dep, workspace_package_id| {
+                                    if (workspace_package_id != invalid_package_id and root_dep.version.tag == .workspace and root_dep.name_hash == name_hash) {
+                                        // make sure verifyResolutions sees this resolution as a valid package id
+                                        successFn(this, dependency_id, workspace_package_id);
+                                        return .{
+                                            .package = this.lockfile.packages.get(workspace_package_id),
+                                            .is_first_time = false,
+                                        };
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if (behavior.isPeer()) {
+                        return null;
+                    }
+
+                    return switch (version.tag) {
+                        .npm => error.NoMatchingVersion,
+                        .dist_tag => error.DistTagNotFound,
+                        else => unreachable,
+                    };
                 };
 
                 return try this.getOrPutResolvedPackageWithFindResult(

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -3773,7 +3773,7 @@ pub const PackageManager = struct {
                         }
                     } else {
                         // dist_tag will match any workspace version, even missing ones
-                        if (workspace_path != null) {
+                        if (workspace_path != null and !this.lockfile.workspace_versions.contains(name_hash)) {
                             const root_package = this.lockfile.rootPackage() orelse break :resolve_from_workspace;
                             const root_dependencies = root_package.dependencies.get(this.lockfile.buffers.dependencies.items);
                             const root_resolutions = root_package.resolutions.get(this.lockfile.buffers.resolutions.items);

--- a/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
@@ -1209,3 +1209,99 @@ exports[`dependency on workspace without version in package.json: version: *+bui
   }
 }"
 `;
+
+exports[`dependency on same name as workspace and dist-tag: with version 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "13e05e9c7522649464f47891db2c094497e8827d4a1f6784db8ef6c066211846",
+  "package_index": {
+    "lodash": [
+      1,
+      3
+    ],
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "latest",
+          "dist_tag": {
+            "name": "lodash",
+            "tag": "lodash"
+          },
+          "resolved_id": 3,
+          "behavior": "normal | workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 3,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "npm 4.17.21",
+      "dependencies": {},
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0",
+    "15298228331728003776": "4.17.21"
+  }
+}"
+`;

--- a/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
@@ -160,166 +160,6 @@ exports[`dependency on workspace without version in package.json: version: *.*.*
 }"
 `;
 
-exports[`dependency on workspace without version in package.json: version: latest 1`] = `
-"{
-  "format": "v2",
-  "meta_hash": "1e2d5fa6591f007aa6674495d1022868fc3b60325c4a1555315ca0e16ef31c4e",
-  "package_index": {
-    "lodash": 1,
-    "foo": 0,
-    "bar": 2
-  },
-  "packages": [
-    {
-      "id": 0,
-      "name": "foo",
-      "name_hash": "14841791273925386894",
-      "resolution": "root ",
-      "dependencies": {
-        "bar": {
-          "literal": "packages/bar",
-          "workspace": "packages/bar",
-          "resolved_id": 2,
-          "behavior": "workspace"
-        },
-        "lodash": {
-          "literal": "packages/mono",
-          "workspace": "packages/mono",
-          "resolved_id": 1,
-          "behavior": "workspace"
-        }
-      },
-      "integrity": null,
-      "man_dir": "",
-      "origin": "local",
-      "bin": null,
-      "scripts": {}
-    },
-    {
-      "id": 1,
-      "name": "lodash",
-      "name_hash": "15298228331728003776",
-      "resolution": "workspace workspace:packages/mono",
-      "dependencies": {},
-      "integrity": null,
-      "man_dir": "",
-      "origin": "npm",
-      "bin": null,
-      "scripts": {}
-    },
-    {
-      "id": 2,
-      "name": "bar",
-      "name_hash": "11592711315645265694",
-      "resolution": "workspace workspace:packages/bar",
-      "dependencies": {
-        "lodash": {
-          "literal": "latest",
-          "dist_tag": {
-            "name": "lodash",
-            "tag": "lodash"
-          },
-          "resolved_id": 1,
-          "behavior": "normal | workspace"
-        }
-      },
-      "integrity": null,
-      "man_dir": "",
-      "origin": "npm",
-      "bin": null,
-      "scripts": {}
-    }
-  ],
-  "workspace_paths": {
-    "11592711315645265694": "packages/bar",
-    "15298228331728003776": "packages/mono"
-  },
-  "workspace_versions": {
-    "11592711315645265694": "1.0.0"
-  }
-}"
-`;
-
-exports[`dependency on workspace without version in package.json: version:  1`] = `
-"{
-  "format": "v2",
-  "meta_hash": "1e2d5fa6591f007aa6674495d1022868fc3b60325c4a1555315ca0e16ef31c4e",
-  "package_index": {
-    "lodash": 1,
-    "foo": 0,
-    "bar": 2
-  },
-  "packages": [
-    {
-      "id": 0,
-      "name": "foo",
-      "name_hash": "14841791273925386894",
-      "resolution": "root ",
-      "dependencies": {
-        "bar": {
-          "literal": "packages/bar",
-          "workspace": "packages/bar",
-          "resolved_id": 2,
-          "behavior": "workspace"
-        },
-        "lodash": {
-          "literal": "packages/mono",
-          "workspace": "packages/mono",
-          "resolved_id": 1,
-          "behavior": "workspace"
-        }
-      },
-      "integrity": null,
-      "man_dir": "",
-      "origin": "local",
-      "bin": null,
-      "scripts": {}
-    },
-    {
-      "id": 1,
-      "name": "lodash",
-      "name_hash": "15298228331728003776",
-      "resolution": "workspace workspace:packages/mono",
-      "dependencies": {},
-      "integrity": null,
-      "man_dir": "",
-      "origin": "npm",
-      "bin": null,
-      "scripts": {}
-    },
-    {
-      "id": 2,
-      "name": "bar",
-      "name_hash": "11592711315645265694",
-      "resolution": "workspace workspace:packages/bar",
-      "dependencies": {
-        "lodash": {
-          "literal": "",
-          "dist_tag": {
-            "name": "lodash",
-            "tag": "lodash"
-          },
-          "resolved_id": 1,
-          "behavior": "normal | workspace"
-        }
-      },
-      "integrity": null,
-      "man_dir": "",
-      "origin": "npm",
-      "bin": null,
-      "scripts": {}
-    }
-  ],
-  "workspace_paths": {
-    "11592711315645265694": "packages/bar",
-    "15298228331728003776": "packages/mono"
-  },
-  "workspace_versions": {
-    "11592711315645265694": "1.0.0"
-  }
-}"
-`;
-
 exports[`dependency on workspace without version in package.json: version: =* 1`] = `
 "{
   "format": "v2",
@@ -1176,6 +1016,196 @@ exports[`dependency on workspace without version in package.json: version: *+bui
           "npm": {
             "name": "lodash",
             "version": ">=0.0.0"
+          },
+          "resolved_id": 3,
+          "behavior": "normal | workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 3,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "npm 4.17.21",
+      "dependencies": {},
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version: latest 1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "13e05e9c7522649464f47891db2c094497e8827d4a1f6784db8ef6c066211846",
+  "package_index": {
+    "lodash": [
+      1,
+      3
+    ],
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "latest",
+          "dist_tag": {
+            "name": "lodash",
+            "tag": "lodash"
+          },
+          "resolved_id": 3,
+          "behavior": "normal | workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 3,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "npm 4.17.21",
+      "dependencies": {},
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    }
+  ],
+  "workspace_paths": {
+    "11592711315645265694": "packages/bar",
+    "15298228331728003776": "packages/mono"
+  },
+  "workspace_versions": {
+    "11592711315645265694": "1.0.0"
+  }
+}"
+`;
+
+exports[`dependency on workspace without version in package.json: version:  1`] = `
+"{
+  "format": "v2",
+  "meta_hash": "13e05e9c7522649464f47891db2c094497e8827d4a1f6784db8ef6c066211846",
+  "package_index": {
+    "lodash": [
+      1,
+      3
+    ],
+    "foo": 0,
+    "bar": 2
+  },
+  "packages": [
+    {
+      "id": 0,
+      "name": "foo",
+      "name_hash": "14841791273925386894",
+      "resolution": "root ",
+      "dependencies": {
+        "bar": {
+          "literal": "packages/bar",
+          "workspace": "packages/bar",
+          "resolved_id": 2,
+          "behavior": "workspace"
+        },
+        "lodash": {
+          "literal": "packages/mono",
+          "workspace": "packages/mono",
+          "resolved_id": 1,
+          "behavior": "workspace"
+        }
+      },
+      "integrity": null,
+      "man_dir": "",
+      "origin": "local",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 1,
+      "name": "lodash",
+      "name_hash": "15298228331728003776",
+      "resolution": "workspace workspace:packages/mono",
+      "dependencies": {},
+      "integrity": null,
+      "man_dir": "",
+      "origin": "npm",
+      "bin": null,
+      "scripts": {}
+    },
+    {
+      "id": 2,
+      "name": "bar",
+      "name_hash": "11592711315645265694",
+      "resolution": "workspace workspace:packages/bar",
+      "dependencies": {
+        "lodash": {
+          "literal": "",
+          "dist_tag": {
+            "name": "lodash",
+            "tag": "lodash"
           },
           "resolved_id": 3,
           "behavior": "normal | workspace"

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -44,8 +44,24 @@ test("dependency on workspace without version in package.json", () => {
 
   mkdirSync(join(packageDir, "packages", "bar"), { recursive: true });
 
-  const shouldWork: string[] = ["*", "*.*.*", "latest", "", "=*", "kjwoehcojrgjoj", "*.1.*", "*-pre"];
-  const shouldNotWork: string[] = ["1", "1.*", "1.1.*", "1.1.1", "*-pre+build", "*+build"];
+  const shouldWork: string[] = [
+    "*",
+    "*.*.*",
+    "=*",
+    "kjwoehcojrgjoj", // dist-tag does not exist, should choose local workspace
+    "*.1.*",
+    "*-pre",
+  ];
+  const shouldNotWork: string[] = [
+    "1",
+    "1.*",
+    "1.1.*",
+    "1.1.1",
+    "*-pre+build",
+    "*+build",
+    "latest", // dist-tag exists, should choose package from npm
+    "",
+  ];
 
   for (const version of shouldWork) {
     writeFileSync(


### PR DESCRIPTION
### What does this PR do?
Fixes a regression from #10913 . A dist tag should be able to resolve to a workspace if a version isn't found for the dist tag. 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
