### PR TITLE
docs: additional notes for watch flag

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -67,6 +67,7 @@ $ bun --watch run index.tsx
 {% callout %}
 **Note** — When using `bun run`, put Bun flags like `--watch` immediately after `bun`.
 
+
 ```bash
 $ bun --watch run dev # ✔️ do this
 $ bun run dev --watch # ❌ don't do this
@@ -74,6 +75,26 @@ $ bun run dev --watch # ❌ don't do this
 
 Flags that occur at the end of the command will be ignored and passed through to the `"dev"` script itself.
 {% /callout %}
+
+Keep in mind that when using `bun start` or `bun run` to run a package script, direct use of the `--watch` flag will generally be ignored, seeing as package scripts specify command line operations of their own. To use watch with a package script, add the flag to the script itself. For example:
+
+{% callout %}
+In your package.json file:
+
+```json
+{
+  "scripts": {
+    "dev": "bun --watch run index.ts"
+  }
+}
+```
+
+Then on the command line:
+
+```bash
+$ bun run dev # ✔️ the script takes care of the watch flag
+$ bun --watch run dev # ❌ use of the watch flag here is not picked up by the script
+```
 
 ## Run a `package.json` script
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -67,7 +67,6 @@ $ bun --watch run index.tsx
 {% callout %}
 **Note** — When using `bun run`, put Bun flags like `--watch` immediately after `bun`.
 
-
 ```bash
 $ bun --watch run dev # ✔️ do this
 $ bun run dev --watch # ❌ don't do this
@@ -95,6 +94,7 @@ Then on the command line:
 $ bun run dev # ✔️ the script takes care of the watch flag
 $ bun --watch run dev # ❌ use of the watch flag here is not picked up by the script
 ```
+{% /callout %}
 
 ## Run a `package.json` script
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
