### PR TITLE
fix(napi): check `result` arguments in some functions

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -624,10 +624,12 @@ extern "C" napi_status napi_delete_property(napi_env env, napi_value object,
 
     auto keyProp = toJS(key);
     auto scope = DECLARE_CATCH_SCOPE(vm);
-    if (result) {
-        *result = toNapi(target->deleteProperty(globalObject, JSC::PropertyName(keyProp.toPropertyKey(globalObject))));
-    }
+    auto deleteResult = target->deleteProperty(globalObject, keyProp.toPropertyKey(globalObject));
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);
+
+    if (LIKELY(result)) {
+        *result = toNapi(deleteResult);
+    }
 
     scope.clearException();
     return napi_ok;
@@ -1161,7 +1163,7 @@ napi_define_properties(napi_env env, napi_value object, size_t property_count,
 {
     NAPI_PREMABLE
 
-    if (property_count > 0 && !properties) {
+    if (UNLIKELY(property_count > 0 && !properties)) {
         return napi_invalid_arg;
     }
 
@@ -1289,7 +1291,7 @@ extern "C" napi_status napi_reference_unref(napi_env env, napi_ref ref,
     NAPI_PREMABLE
     NapiRef* napiRef = toJS(ref);
     napiRef->unref();
-    if (result) {
+    if (LIKELY(result)) {
         *result = napiRef->refCount;
     }
     return napi_ok;
@@ -1323,7 +1325,7 @@ extern "C" napi_status napi_reference_ref(napi_env env, napi_ref ref,
     NAPI_PREMABLE
     NapiRef* napiRef = toJS(ref);
     napiRef->ref();
-    if (result) {
+    if (LIKELY(result)) {
         *result = napiRef->refCount;
     }
     return napi_ok;

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -530,7 +530,7 @@ extern "C" napi_status napi_has_property(napi_env env, napi_value object,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -558,7 +558,7 @@ extern "C" napi_status napi_get_date_value(napi_env env, napi_value value, doubl
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -586,7 +586,7 @@ extern "C" napi_status napi_get_property(napi_env env, napi_value object,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -637,7 +637,7 @@ extern "C" napi_status napi_has_own_property(napi_env env, napi_value object,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -739,7 +739,7 @@ extern "C" napi_status napi_has_named_property(napi_env env, napi_value object,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -766,7 +766,7 @@ extern "C" napi_status napi_get_named_property(napi_env env, napi_value object,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1051,7 +1051,7 @@ extern "C" napi_status napi_create_function(napi_env env, const char* utf8name,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1216,7 +1216,7 @@ extern "C" napi_status napi_create_reference(napi_env env, napi_value value,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1302,7 +1302,7 @@ extern "C" napi_status napi_get_reference_value(napi_env env, napi_ref ref,
     napi_value* result)
 {
     NAPI_PREMABLE
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
     NapiRef* napiRef = toJS(ref);
@@ -1350,7 +1350,7 @@ extern "C" napi_status napi_is_detached_arraybuffer(napi_env env,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1409,7 +1409,7 @@ extern "C" napi_status napi_is_exception_pending(napi_env env, bool* result)
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1422,7 +1422,7 @@ extern "C" napi_status napi_get_and_clear_last_exception(napi_env env,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1564,7 +1564,7 @@ extern "C" napi_status napi_create_error(napi_env env, napi_value code,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1649,7 +1649,7 @@ extern "C" napi_status napi_get_global(napi_env env, napi_value* result)
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1664,7 +1664,7 @@ extern "C" napi_status napi_create_range_error(napi_env env, napi_value code,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1715,7 +1715,7 @@ extern "C" napi_status napi_create_dataview(napi_env env, size_t length,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1731,12 +1731,8 @@ extern "C" napi_status napi_create_dataview(napi_env env, size_t length,
     auto dataView = JSC::DataView::create(arraybufferValue->impl(), byte_offset, length);
 
     *result = reinterpret_cast<napi_value>(dataView->wrap(globalObject, globalObject));
-    *result = reinterpret_cast<napi_value>(dataView->wrap(globalObject, globalObject));
-}
-*result = reinterpret_cast<napi_value>(dataView->wrap(globalObject, globalObject));
-}
 
-return napi_ok;
+    return napi_ok;
 }
 
 namespace Zig {
@@ -1853,7 +1849,7 @@ extern "C" napi_status napi_get_all_property_names(
 {
     NAPI_PREMABLE;
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1886,7 +1882,7 @@ napi_get_last_error_info(napi_env env, const napi_extended_error_info** result)
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1926,7 +1922,7 @@ extern "C" napi_status napi_define_class(napi_env env,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -1984,7 +1980,7 @@ extern "C" napi_status napi_get_property_names(napi_env env, napi_value object,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -2178,7 +2174,7 @@ extern "C" napi_status napi_get_element(napi_env env, napi_value objectValue,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 
@@ -2487,7 +2483,7 @@ extern "C" napi_status napi_create_bigint_words(napi_env env,
 {
     NAPI_PREMABLE
 
-    if (!result) {
+    if (UNLIKELY(!result)) {
         return napi_invalid_arg;
     }
 

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -1396,7 +1396,7 @@ extern "C" napi_status napi_adjust_external_memory(napi_env env,
 {
     NAPI_PREMABLE
 
-    if (!adjusted_value) {
+    if (UNLIKELY(!adjusted_value)) {
         return napi_invalid_arg;
     }
 
@@ -2209,7 +2209,7 @@ extern "C" napi_status napi_delete_element(napi_env env, napi_value objectValue,
     JSObject* object = jsValue.getObject();
 
     auto scope = DECLARE_THROW_SCOPE(object->vm());
-    if (result) {
+    if (LIKELY(result)) {
         *result = JSObject::deletePropertyByIndex(object, toJS(env), index);
     }
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -530,6 +530,10 @@ extern "C" napi_status napi_has_property(napi_env env, napi_value object,
 {
     NAPI_PREMABLE
 
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     if (UNLIKELY(!object || !env)) {
         return napi_invalid_arg;
     }
@@ -554,6 +558,10 @@ extern "C" napi_status napi_get_date_value(napi_env env, napi_value value, doubl
 {
     NAPI_PREMABLE
 
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     if (UNLIKELY(!env)) {
         return napi_invalid_arg;
     }
@@ -568,9 +576,7 @@ extern "C" napi_status napi_get_date_value(napi_env env, napi_value value, doubl
         return napi_date_expected;
     }
 
-    if (result) {
-        *result = date->internalNumber();
-    }
+    *result = date->internalNumber();
 
     return napi_ok;
 }
@@ -579,6 +585,10 @@ extern "C" napi_status napi_get_property(napi_env env, napi_value object,
     napi_value key, napi_value* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
 
     auto globalObject = toJS(env);
     auto& vm = globalObject->vm();
@@ -614,7 +624,9 @@ extern "C" napi_status napi_delete_property(napi_env env, napi_value object,
 
     auto keyProp = toJS(key);
     auto scope = DECLARE_CATCH_SCOPE(vm);
-    *result = toNapi(target->deleteProperty(globalObject, JSC::PropertyName(keyProp.toPropertyKey(globalObject))));
+    if (result) {
+        *result = toNapi(target->deleteProperty(globalObject, JSC::PropertyName(keyProp.toPropertyKey(globalObject))));
+    }
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);
 
     scope.clearException();
@@ -624,6 +636,10 @@ extern "C" napi_status napi_has_own_property(napi_env env, napi_value object,
     napi_value key, bool* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
 
     auto globalObject = toJS(env);
     auto& vm = globalObject->vm();
@@ -723,6 +739,10 @@ extern "C" napi_status napi_has_named_property(napi_env env, napi_value object,
 {
     NAPI_PREMABLE
 
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     auto globalObject = toJS(env);
     auto& vm = globalObject->vm();
 
@@ -745,6 +765,10 @@ extern "C" napi_status napi_get_named_property(napi_env env, napi_value object,
     napi_value* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
 
     auto globalObject = toJS(env);
     auto& vm = globalObject->vm();
@@ -1027,6 +1051,10 @@ extern "C" napi_status napi_create_function(napi_env env, const char* utf8name,
 {
     NAPI_PREMABLE
 
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = globalObject->vm();
     auto name = WTF::String();
@@ -1038,9 +1066,7 @@ extern "C" napi_status napi_create_function(napi_env env, const char* utf8name,
     auto method = reinterpret_cast<Zig::FFIFunction>(cb);
     auto* function = NAPIFunction::create(vm, globalObject, length, name, method, data);
 
-    if (result != nullptr) {
-        *result = toNapi(JSC::JSValue(function));
-    }
+    *result = toNapi(JSC::JSValue(function));
 
     return napi_ok;
 }
@@ -1133,6 +1159,12 @@ extern "C" napi_status
 napi_define_properties(napi_env env, napi_value object, size_t property_count,
     const napi_property_descriptor* properties)
 {
+    NAPI_PREMABLE
+
+    if (property_count > 0 && !properties) {
+        return napi_invalid_arg;
+    }
+
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = globalObject->vm();
 
@@ -1183,6 +1215,11 @@ extern "C" napi_status napi_create_reference(napi_env env, napi_value value,
     napi_ref* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     JSC::JSValue val = toJS(value);
 
     if (!val || !val.isObject()) {
@@ -1252,7 +1289,9 @@ extern "C" napi_status napi_reference_unref(napi_env env, napi_ref ref,
     NAPI_PREMABLE
     NapiRef* napiRef = toJS(ref);
     napiRef->unref();
-    *result = napiRef->refCount;
+    if (result) {
+        *result = napiRef->refCount;
+    }
     return napi_ok;
 }
 
@@ -1263,6 +1302,9 @@ extern "C" napi_status napi_get_reference_value(napi_env env, napi_ref ref,
     napi_value* result)
 {
     NAPI_PREMABLE
+    if (!result) {
+        return napi_invalid_arg;
+    }
     NapiRef* napiRef = toJS(ref);
     *result = toNapi(napiRef->value());
 
@@ -1281,7 +1323,9 @@ extern "C" napi_status napi_reference_ref(napi_env env, napi_ref ref,
     NAPI_PREMABLE
     NapiRef* napiRef = toJS(ref);
     napiRef->ref();
-    *result = napiRef->refCount;
+    if (result) {
+        *result = napiRef->refCount;
+    }
     return napi_ok;
 }
 
@@ -1305,6 +1349,10 @@ extern "C" napi_status napi_is_detached_arraybuffer(napi_env env,
     bool* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
 
     JSC::JSArrayBuffer* jsArrayBuffer = JSC::jsDynamicCast<JSC::JSArrayBuffer*>(toJS(arraybuffer));
     if (UNLIKELY(!jsArrayBuffer)) {
@@ -1345,6 +1393,11 @@ extern "C" napi_status napi_adjust_external_memory(napi_env env,
     int64_t* adjusted_value)
 {
     NAPI_PREMABLE
+
+    if (!adjusted_value) {
+        return napi_invalid_arg;
+    }
+
     if (change_in_bytes > 0) {
         toJS(env)->vm().heap.deprecatedReportExtraMemory(change_in_bytes);
     }
@@ -1355,6 +1408,11 @@ extern "C" napi_status napi_adjust_external_memory(napi_env env,
 extern "C" napi_status napi_is_exception_pending(napi_env env, bool* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     auto globalObject = toJS(env);
     *result = globalObject->vm().exceptionForInspection() != nullptr;
     return napi_ok;
@@ -1363,6 +1421,11 @@ extern "C" napi_status napi_get_and_clear_last_exception(napi_env env,
     napi_value* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     auto globalObject = toJS(env);
     *result = toNapi(JSC::JSValue(globalObject->vm().lastException()));
     globalObject->vm().clearLastException();
@@ -1500,6 +1563,11 @@ extern "C" napi_status napi_create_error(napi_env env, napi_value code,
     napi_value* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = globalObject->vm();
 
@@ -1581,6 +1649,10 @@ extern "C" napi_status napi_get_global(napi_env env, napi_value* result)
 {
     NAPI_PREMABLE
 
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     Zig::GlobalObject* globalObject = toJS(env);
     *result = reinterpret_cast<napi_value>(globalObject->globalThis());
     return napi_ok;
@@ -1591,6 +1663,11 @@ extern "C" napi_status napi_create_range_error(napi_env env, napi_value code,
     napi_value* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     Zig::GlobalObject* globalObject = toJS(env);
 
     JSC::EncodedJSValue encodedCode = reinterpret_cast<JSC::EncodedJSValue>(code);
@@ -1637,6 +1714,11 @@ extern "C" napi_status napi_create_dataview(napi_env env, size_t length,
     napi_value* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -1648,11 +1730,13 @@ extern "C" napi_status napi_create_dataview(napi_env env, size_t length,
     }
     auto dataView = JSC::DataView::create(arraybufferValue->impl(), byte_offset, length);
 
-    if (result != nullptr) {
-        *result = reinterpret_cast<napi_value>(dataView->wrap(globalObject, globalObject));
-    }
+    *result = reinterpret_cast<napi_value>(dataView->wrap(globalObject, globalObject));
+    *result = reinterpret_cast<napi_value>(dataView->wrap(globalObject, globalObject));
+}
+*result = reinterpret_cast<napi_value>(dataView->wrap(globalObject, globalObject));
+}
 
-    return napi_ok;
+return napi_ok;
 }
 
 namespace Zig {
@@ -1767,6 +1851,12 @@ extern "C" napi_status napi_get_all_property_names(
     napi_key_filter key_filter, napi_key_conversion key_conversion,
     napi_value* result)
 {
+    NAPI_PREMABLE;
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     DontEnumPropertiesMode jsc_key_mode = key_mode == napi_key_include_prototypes ? DontEnumPropertiesMode::Include : DontEnumPropertiesMode::Exclude;
     PropertyNameMode jsc_property_mode = PropertyNameMode::StringsAndSymbols;
     if (key_filter == napi_key_skip_symbols) {
@@ -1795,6 +1885,11 @@ extern "C" napi_status
 napi_get_last_error_info(napi_env env, const napi_extended_error_info** result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     auto globalObject = toJS(env);
     JSC::VM& vm = globalObject->vm();
     auto lastException = vm.lastException();
@@ -1830,6 +1925,10 @@ extern "C" napi_status napi_define_class(napi_env env,
     napi_value* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
 
     if (utf8name == nullptr) {
         return napi_invalid_arg;
@@ -1884,6 +1983,11 @@ extern "C" napi_status napi_get_property_names(napi_env env, napi_value object,
     napi_value* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = globalObject->vm();
 
@@ -2074,6 +2178,10 @@ extern "C" napi_status napi_get_element(napi_env env, napi_value objectValue,
 {
     NAPI_PREMABLE
 
+    if (!result) {
+        return napi_invalid_arg;
+    }
+
     JSValue jsValue = toJS(objectValue);
     if (UNLIKELY(!env || !jsValue || !jsValue.isObject())) {
         return napi_invalid_arg;
@@ -2085,9 +2193,7 @@ extern "C" napi_status napi_get_element(napi_env env, napi_value objectValue,
     JSValue element = object->getIndex(toJS(env), index);
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);
 
-    if (result) {
-        *result = toNapi(element);
-    }
+    *result = toNapi(element);
 
     return napi_ok;
 }
@@ -2105,7 +2211,9 @@ extern "C" napi_status napi_delete_element(napi_env env, napi_value objectValue,
     JSObject* object = jsValue.getObject();
 
     auto scope = DECLARE_THROW_SCOPE(object->vm());
-    *result = JSObject::deletePropertyByIndex(object, toJS(env), index);
+    if (result) {
+        *result = JSObject::deletePropertyByIndex(object, toJS(env), index);
+    }
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);
 
     return napi_ok;
@@ -2378,6 +2486,10 @@ extern "C" napi_status napi_create_bigint_words(napi_env env,
     napi_value* result)
 {
     NAPI_PREMABLE
+
+    if (!result) {
+        return napi_invalid_arg;
+    }
 
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = globalObject->vm();

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -762,7 +762,7 @@ pub export fn napi_make_callback(env: napi_env, _: *anyopaque, recv: napi_value,
             &.{},
     );
 
-    if (result) |*result_| {
+    if (result) |result_| {
         result_.* = res;
     }
 
@@ -937,13 +937,13 @@ pub export fn napi_get_dataview_info(env: napi_env, dataview: napi_value, bytele
         bytelength.?.* = array_buffer.byte_len;
 
     if (data != null)
-        data.* = array_buffer.ptr;
+        data.?.* = array_buffer.ptr;
 
     if (arraybuffer != null)
-        arraybuffer.* = JSValue.c(JSC.C.JSObjectGetTypedArrayBuffer(env.ref(), dataview.asObjectRef(), null));
+        arraybuffer.?.* = JSValue.c(JSC.C.JSObjectGetTypedArrayBuffer(env.ref(), dataview.asObjectRef(), null));
 
     if (byte_offset != null)
-        byte_offset.* = array_buffer.offset;
+        byte_offset.?.* = array_buffer.offset;
 
     return .ok;
 }

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -205,24 +205,36 @@ pub const napi_type_tag = extern struct {
     upper: u64,
 };
 pub extern fn napi_get_last_error_info(env: napi_env, result: [*c][*c]const napi_extended_error_info) napi_status;
-pub export fn napi_get_undefined(_: napi_env, result: *napi_value) napi_status {
+pub export fn napi_get_undefined(_: napi_env, result_: ?*napi_value) napi_status {
     log("napi_get_undefined", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSValue.jsUndefined();
     return .ok;
 }
-pub export fn napi_get_null(_: napi_env, result: *napi_value) napi_status {
+pub export fn napi_get_null(_: napi_env, result_: ?*napi_value) napi_status {
     log("napi_get_null", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSValue.jsNull();
     return .ok;
 }
 pub extern fn napi_get_global(env: napi_env, result: *napi_value) napi_status;
-pub export fn napi_get_boolean(_: napi_env, value: bool, result: *napi_value) napi_status {
+pub export fn napi_get_boolean(_: napi_env, value: bool, result_: ?*napi_value) napi_status {
     log("napi_get_boolean", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSValue.jsBoolean(value);
     return .ok;
 }
-pub export fn napi_create_array(env: napi_env, result: *napi_value) napi_status {
+pub export fn napi_create_array(env: napi_env, result_: ?*napi_value) napi_status {
     log("napi_create_array", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSValue.createEmptyArray(env, 0);
     return .ok;
 }
@@ -233,8 +245,12 @@ const prefilled_undefined_args_array: [128]JSC.JSValue = brk: {
     }
     break :brk args;
 };
-pub export fn napi_create_array_with_length(env: napi_env, length: usize, result: *napi_value) napi_status {
+pub export fn napi_create_array_with_length(env: napi_env, length: usize, result_: ?*napi_value) napi_status {
     log("napi_create_array_with_length", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
+
     const len = @as(u32, @intCast(length));
 
     const array = JSC.JSValue.createEmptyArray(env, len);
@@ -250,18 +266,27 @@ pub export fn napi_create_array_with_length(env: napi_env, length: usize, result
     return .ok;
 }
 pub extern fn napi_create_double(_: napi_env, value: f64, result: *napi_value) napi_status;
-pub export fn napi_create_int32(_: napi_env, value: i32, result: *napi_value) napi_status {
+pub export fn napi_create_int32(_: napi_env, value: i32, result_: ?*napi_value) napi_status {
     log("napi_create_int32", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSValue.jsNumber(value);
     return .ok;
 }
-pub export fn napi_create_uint32(_: napi_env, value: u32, result: *napi_value) napi_status {
+pub export fn napi_create_uint32(_: napi_env, value: u32, result_: ?*napi_value) napi_status {
     log("napi_create_uint32", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSValue.jsNumber(value);
     return .ok;
 }
-pub export fn napi_create_int64(_: napi_env, value: i64, result: *napi_value) napi_status {
+pub export fn napi_create_int64(_: napi_env, value: i64, result_: ?*napi_value) napi_status {
     log("napi_create_int64", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSValue.jsNumber(value);
     return .ok;
 }
@@ -369,32 +394,44 @@ pub extern fn napi_create_type_error(env: napi_env, code: napi_value, msg: napi_
 pub extern fn napi_create_range_error(env: napi_env, code: napi_value, msg: napi_value, result: *napi_value) napi_status;
 pub extern fn napi_typeof(env: napi_env, value: napi_value, result: *napi_valuetype) napi_status;
 pub extern fn napi_get_value_double(env: napi_env, value: napi_value, result: *f64) napi_status;
-pub export fn napi_get_value_int32(_: napi_env, value: napi_value, result: *i32) napi_status {
+pub export fn napi_get_value_int32(_: napi_env, value: napi_value, result_: ?*i32) napi_status {
     log("napi_get_value_int32", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     if (!value.isNumber()) {
         return .number_expected;
     }
     result.* = value.to(i32);
     return .ok;
 }
-pub export fn napi_get_value_uint32(_: napi_env, value: napi_value, result: *u32) napi_status {
+pub export fn napi_get_value_uint32(_: napi_env, value: napi_value, result_: ?*u32) napi_status {
     log("napi_get_value_uint32", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     if (!value.isNumber()) {
         return .number_expected;
     }
     result.* = value.to(u32);
     return .ok;
 }
-pub export fn napi_get_value_int64(_: napi_env, value: napi_value, result: *i64) napi_status {
+pub export fn napi_get_value_int64(_: napi_env, value: napi_value, result_: ?*i64) napi_status {
     log("napi_get_value_int64", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     if (!value.isNumber()) {
         return .number_expected;
     }
     result.* = value.to(i64);
     return .ok;
 }
-pub export fn napi_get_value_bool(_: napi_env, value: napi_value, result: *bool) napi_status {
+pub export fn napi_get_value_bool(_: napi_env, value: napi_value, result_: ?*bool) napi_status {
     log("napi_get_value_bool", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
 
     result.* = value.to(bool);
     return .ok;
@@ -509,23 +546,35 @@ pub export fn napi_get_value_string_utf16(env: napi_env, value: napi_value, buf_
 
     return .ok;
 }
-pub export fn napi_coerce_to_bool(env: napi_env, value: napi_value, result: *napi_value) napi_status {
+pub export fn napi_coerce_to_bool(env: napi_env, value: napi_value, result_: ?*napi_value) napi_status {
     log("napi_coerce_to_bool", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSValue.jsBoolean(value.coerce(bool, env));
     return .ok;
 }
-pub export fn napi_coerce_to_number(env: napi_env, value: napi_value, result: *napi_value) napi_status {
+pub export fn napi_coerce_to_number(env: napi_env, value: napi_value, result_: ?*napi_value) napi_status {
     log("napi_coerce_to_number", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSC.JSValue.jsNumber(JSC.C.JSValueToNumber(env.ref(), value.asObjectRef(), TODO_EXCEPTION));
     return .ok;
 }
-pub export fn napi_coerce_to_object(env: napi_env, value: napi_value, result: *napi_value) napi_status {
+pub export fn napi_coerce_to_object(env: napi_env, value: napi_value, result_: ?*napi_value) napi_status {
     log("napi_coerce_to_object", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSValue.c(JSC.C.JSValueToObject(env.ref(), value.asObjectRef(), TODO_EXCEPTION));
     return .ok;
 }
-pub export fn napi_get_prototype(env: napi_env, object: napi_value, result: *napi_value) napi_status {
+pub export fn napi_get_prototype(env: napi_env, object: napi_value, result_: ?*napi_value) napi_status {
     log("napi_get_prototype", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     if (!object.isObject()) {
         return .object_expected;
     }
@@ -552,8 +601,12 @@ pub export fn napi_set_element(env: napi_env, object: napi_value, index: c_uint,
     JSC.C.JSObjectSetPropertyAtIndex(env.ref(), object.asObjectRef(), index, value.asObjectRef(), TODO_EXCEPTION);
     return .ok;
 }
-pub export fn napi_has_element(env: napi_env, object: napi_value, index: c_uint, result: *bool) napi_status {
+pub export fn napi_has_element(env: napi_env, object: napi_value, index: c_uint, result_: ?*bool) napi_status {
     log("napi_has_element", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
+
     if (!object.jsType().isIndexable()) {
         return .array_expected;
     }
@@ -564,13 +617,20 @@ pub export fn napi_has_element(env: napi_env, object: napi_value, index: c_uint,
 pub extern fn napi_get_element(env: napi_env, object: napi_value, index: u32, result: *napi_value) napi_status;
 pub extern fn napi_delete_element(env: napi_env, object: napi_value, index: u32, result: *napi_value) napi_status;
 pub extern fn napi_define_properties(env: napi_env, object: napi_value, property_count: usize, properties: [*c]const napi_property_descriptor) napi_status;
-pub export fn napi_is_array(_: napi_env, value: napi_value, result: *bool) napi_status {
+pub export fn napi_is_array(_: napi_env, value: napi_value, result_: ?*bool) napi_status {
     log("napi_is_array", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = value.jsType().isArray();
     return .ok;
 }
-pub export fn napi_get_array_length(env: napi_env, value: napi_value, result: [*c]u32) napi_status {
+pub export fn napi_get_array_length(env: napi_env, value: napi_value, result_: [*c]u32) napi_status {
     log("napi_get_array_length", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
+
     if (!value.jsType().isArray()) {
         return .array_expected;
     }
@@ -578,20 +638,27 @@ pub export fn napi_get_array_length(env: napi_env, value: napi_value, result: [*
     result.* = @as(u32, @truncate(value.getLength(env)));
     return .ok;
 }
-pub export fn napi_strict_equals(env: napi_env, lhs: napi_value, rhs: napi_value, result: *bool) napi_status {
+pub export fn napi_strict_equals(env: napi_env, lhs: napi_value, rhs: napi_value, result_: ?*bool) napi_status {
     log("napi_strict_equals", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     // there is some nuance with NaN here i'm not sure about
     result.* = lhs.isSameValue(rhs, env);
     return .ok;
 }
 pub extern fn napi_call_function(env: napi_env, recv: napi_value, func: napi_value, argc: usize, argv: [*c]const napi_value, result: *napi_value) napi_status;
-pub export fn napi_new_instance(env: napi_env, constructor: napi_value, argc: usize, argv: [*c]const napi_value, result: *napi_value) napi_status {
+pub export fn napi_new_instance(env: napi_env, constructor: napi_value, argc: usize, argv: [*c]const napi_value, result_: ?*napi_value) napi_status {
     log("napi_new_instance", .{});
     JSC.markBinding(@src());
 
     if (argc > 0 and argv == null) {
         return invalidArg();
     }
+
+    const result = result_ orelse {
+        return invalidArg();
+    };
 
     var exception = [_]JSC.C.JSValueRef{null};
     result.* = JSValue.c(
@@ -612,8 +679,11 @@ pub export fn napi_new_instance(env: napi_env, constructor: napi_value, argc: us
 
     return .ok;
 }
-pub export fn napi_instanceof(env: napi_env, object: napi_value, constructor: napi_value, result: *bool) napi_status {
+pub export fn napi_instanceof(env: napi_env, object: napi_value, constructor: napi_value, result_: ?*bool) napi_status {
     log("napi_instanceof", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     // TODO: does this throw object_expected in node?
     result.* = object.isObject() and object.isInstanceOf(env, constructor);
     return .ok;
@@ -645,8 +715,11 @@ pub extern fn napi_get_reference_value_internal(ref: *Ref) JSC.JSValue;
 
 // JSC scans the stack
 // we don't need this
-pub export fn napi_open_handle_scope(env: napi_env, result: *napi_handle_scope) napi_status {
+pub export fn napi_open_handle_scope(env: napi_env, result_: ?*napi_handle_scope) napi_status {
     log("napi_open_handle_scope", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = env;
     return .ok;
 }
@@ -671,7 +744,7 @@ pub export fn napi_async_destroy(_: napi_env, _: *anyopaque) napi_status {
 }
 
 // this is just a regular function call
-pub export fn napi_make_callback(env: napi_env, _: *anyopaque, recv: napi_value, func: napi_value, arg_count: usize, args: ?[*]const napi_value, result: *napi_value) napi_status {
+pub export fn napi_make_callback(env: napi_env, _: *anyopaque, recv: napi_value, func: napi_value, arg_count: usize, args: ?[*]const napi_value, result: ?*napi_value) napi_status {
     log("napi_make_callback", .{});
     if (func.isEmptyOrUndefinedOrNull() or !func.isCallable(env.vm())) {
         return .function_expected;
@@ -688,7 +761,10 @@ pub export fn napi_make_callback(env: napi_env, _: *anyopaque, recv: napi_value,
         else
             &.{},
     );
-    result.* = res;
+
+    if (result) |*result_| {
+        result_.* = res;
+    }
 
     // TODO: this is likely incorrect
     if (res.isAnyError()) {
@@ -716,8 +792,11 @@ fn notImplementedYet(comptime name: []const u8) void {
 }
 
 // JSC stack scanning will handle this
-pub export fn napi_open_escapable_handle_scope(env: napi_env, handle: *napi_escapable_handle_scope) napi_status {
+pub export fn napi_open_escapable_handle_scope(env: napi_env, handle_: ?*napi_escapable_handle_scope) napi_status {
     log("napi_open_escapable_handle_scope", .{});
+    const handle = handle_ orelse {
+        return invalidArg();
+    };
     handle.* = env;
     return .ok;
 }
@@ -725,8 +804,11 @@ pub export fn napi_close_escapable_handle_scope(_: napi_env, _: napi_escapable_h
     log("napi_close_escapable_handle_scope", .{});
     return .ok;
 }
-pub export fn napi_escape_handle(_: napi_env, _: napi_escapable_handle_scope, value: napi_value, result: *napi_value) napi_status {
+pub export fn napi_escape_handle(_: napi_env, _: napi_escapable_handle_scope, value: napi_value, result_: ?*napi_value) napi_status {
     log("napi_escape_handle", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     value.ensureStillAlive();
     result.* = value;
     return .ok;
@@ -762,8 +844,11 @@ pub export fn napi_is_error(_: napi_env, value: napi_value, result: *bool) napi_
 }
 pub extern fn napi_is_exception_pending(env: napi_env, result: *bool) napi_status;
 pub extern fn napi_get_and_clear_last_exception(env: napi_env, result: *napi_value) napi_status;
-pub export fn napi_is_arraybuffer(_: napi_env, value: napi_value, result: *bool) napi_status {
+pub export fn napi_is_arraybuffer(_: napi_env, value: napi_value, result_: ?*bool) napi_status {
     log("napi_is_arraybuffer", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = !value.isNumber() and value.jsTypeLoose() == .ArrayBuffer;
     return .ok;
 }
@@ -787,8 +872,11 @@ pub export fn napi_is_typedarray(_: napi_env, value: napi_value, result: ?*bool)
         result.?.* = value.jsTypeLoose().isTypedArray();
     return if (result != null) .ok else invalidArg();
 }
-pub export fn napi_create_typedarray(env: napi_env, @"type": napi_typedarray_type, length: usize, arraybuffer: napi_value, byte_offset: usize, result: *napi_value) napi_status {
+pub export fn napi_create_typedarray(env: napi_env, @"type": napi_typedarray_type, length: usize, arraybuffer: napi_value, byte_offset: usize, result_: ?*napi_value) napi_status {
     log("napi_create_typedarray", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSValue.c(
         JSC.C.JSObjectMakeTypedArrayWithArrayBufferAndOffset(
             env.ref(),
@@ -834,28 +922,47 @@ pub export fn napi_get_typedarray_info(
     return .ok;
 }
 pub extern fn napi_create_dataview(env: napi_env, length: usize, arraybuffer: napi_value, byte_offset: usize, result: *napi_value) napi_status;
-pub export fn napi_is_dataview(_: napi_env, value: napi_value, result: *bool) napi_status {
+pub export fn napi_is_dataview(_: napi_env, value: napi_value, result_: ?*bool) napi_status {
     log("napi_is_dataview", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = !value.isEmptyOrUndefinedOrNull() and value.jsTypeLoose() == .DataView;
     return .ok;
 }
-pub export fn napi_get_dataview_info(env: napi_env, dataview: napi_value, bytelength: *usize, data: *?[*]u8, arraybuffer: *napi_value, byte_offset: *usize) napi_status {
+pub export fn napi_get_dataview_info(env: napi_env, dataview: napi_value, bytelength: ?*usize, data: ?*[*]u8, arraybuffer: ?*napi_value, byte_offset: ?*usize) napi_status {
     log("napi_get_dataview_info", .{});
     const array_buffer = dataview.asArrayBuffer(env) orelse return .object_expected;
-    bytelength.* = array_buffer.byte_len;
-    data.* = array_buffer.ptr;
+    if (bytelength != null)
+        bytelength.?.* = array_buffer.byte_len;
 
-    arraybuffer.* = JSValue.c(JSC.C.JSObjectGetTypedArrayBuffer(env.ref(), dataview.asObjectRef(), null));
-    byte_offset.* = array_buffer.offset;
+    if (data != null)
+        data.* = array_buffer.ptr;
+
+    if (arraybuffer != null)
+        arraybuffer.* = JSValue.c(JSC.C.JSObjectGetTypedArrayBuffer(env.ref(), dataview.asObjectRef(), null));
+
+    if (byte_offset != null)
+        byte_offset.* = array_buffer.offset;
+
     return .ok;
 }
-pub export fn napi_get_version(_: napi_env, result: *u32) napi_status {
+pub export fn napi_get_version(_: napi_env, result_: ?*u32) napi_status {
     log("napi_get_version", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = NAPI_VERSION;
     return .ok;
 }
-pub export fn napi_create_promise(env: napi_env, deferred: *napi_deferred, promise: *napi_value) napi_status {
+pub export fn napi_create_promise(env: napi_env, deferred_: ?*napi_deferred, promise_: ?*napi_value) napi_status {
     log("napi_create_promise", .{});
+    const deferred = deferred_ orelse {
+        return invalidArg();
+    };
+    const promise = promise_ orelse {
+        return invalidArg();
+    };
     deferred.* = bun.default_allocator.create(JSC.JSPromise.Strong) catch @panic("failed to allocate napi_deferred");
     deferred.*.* = JSC.JSPromise.Strong.init(env);
     promise.* = deferred.*.get().asValue(env);
@@ -877,8 +984,12 @@ pub export fn napi_reject_deferred(env: napi_env, deferred: napi_deferred, rejec
     bun.default_allocator.destroy(deferred);
     return .ok;
 }
-pub export fn napi_is_promise(_: napi_env, value: napi_value, is_promise: *bool) napi_status {
+pub export fn napi_is_promise(_: napi_env, value: napi_value, is_promise_: ?*bool) napi_status {
     log("napi_is_promise", .{});
+    const is_promise = is_promise_ orelse {
+        return invalidArg();
+    };
+
     if (value.isEmptyOrUndefinedOrNull()) {
         is_promise.* = false;
         return .ok;
@@ -889,39 +1000,57 @@ pub export fn napi_is_promise(_: napi_env, value: napi_value, is_promise: *bool)
 }
 pub extern fn napi_run_script(env: napi_env, script: napi_value, result: *napi_value) napi_status;
 pub extern fn napi_adjust_external_memory(env: napi_env, change_in_bytes: i64, adjusted_value: [*c]i64) napi_status;
-pub export fn napi_create_date(env: napi_env, time: f64, result: *napi_value) napi_status {
+pub export fn napi_create_date(env: napi_env, time: f64, result_: ?*napi_value) napi_status {
     log("napi_create_date", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     var args = [_]JSC.C.JSValueRef{JSC.JSValue.jsNumber(time).asObjectRef()};
     result.* = JSValue.c(JSC.C.JSObjectMakeDate(env.ref(), 1, &args, TODO_EXCEPTION));
     return .ok;
 }
-pub export fn napi_is_date(_: napi_env, value: napi_value, is_date: *bool) napi_status {
+pub export fn napi_is_date(_: napi_env, value: napi_value, is_date_: ?*bool) napi_status {
     log("napi_is_date", .{});
+    const is_date = is_date_ orelse {
+        return invalidArg();
+    };
     is_date.* = value.jsTypeLoose() == .JSDate;
     return .ok;
 }
 pub extern fn napi_get_date_value(env: napi_env, value: napi_value, result: *f64) napi_status;
 pub extern fn napi_add_finalizer(env: napi_env, js_object: napi_value, native_object: ?*anyopaque, finalize_cb: napi_finalize, finalize_hint: ?*anyopaque, result: *Ref) napi_status;
-pub export fn napi_create_bigint_int64(env: napi_env, value: i64, result: *napi_value) napi_status {
+pub export fn napi_create_bigint_int64(env: napi_env, value: i64, result_: ?*napi_value) napi_status {
     log("napi_create_bigint_int64", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSC.JSValue.fromInt64NoTruncate(env, value);
     return .ok;
 }
-pub export fn napi_create_bigint_uint64(env: napi_env, value: u64, result: *napi_value) napi_status {
+pub export fn napi_create_bigint_uint64(env: napi_env, value: u64, result_: ?*napi_value) napi_status {
     log("napi_create_bigint_uint64", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = JSC.JSValue.fromUInt64NoTruncate(env, value);
     return .ok;
 }
 pub extern fn napi_create_bigint_words(env: napi_env, sign_bit: c_int, word_count: usize, words: [*c]const u64, result: *napi_value) napi_status;
 // TODO: lossless
-pub export fn napi_get_value_bigint_int64(_: napi_env, value: napi_value, result: *i64, _: *bool) napi_status {
+pub export fn napi_get_value_bigint_int64(_: napi_env, value: napi_value, result_: ?*i64, _: *bool) napi_status {
     log("napi_get_value_bigint_int64", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = value.toInt64();
     return .ok;
 }
 // TODO: lossless
-pub export fn napi_get_value_bigint_uint64(_: napi_env, value: napi_value, result: *u64, _: *bool) napi_status {
+pub export fn napi_get_value_bigint_uint64(_: napi_env, value: napi_value, result_: ?*u64, _: *bool) napi_status {
     log("napi_get_value_bigint_uint64", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = value.toUInt64NoTruncate();
     return .ok;
 }
@@ -1100,8 +1229,11 @@ pub export fn napi_create_buffer(env: napi_env, length: usize, data: ?**anyopaqu
     return .ok;
 }
 pub extern fn napi_create_external_buffer(env: napi_env, length: usize, data: ?*anyopaque, finalize_cb: napi_finalize, finalize_hint: ?*anyopaque, result: *napi_value) napi_status;
-pub export fn napi_create_buffer_copy(env: napi_env, length: usize, data: [*]u8, result_data: ?*?*anyopaque, result: *napi_value) napi_status {
+pub export fn napi_create_buffer_copy(env: napi_env, length: usize, data: [*]u8, result_data: ?*?*anyopaque, result_: ?*napi_value) napi_status {
     log("napi_create_buffer_copy: {d}", .{length});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     var buffer = JSC.JSValue.createBufferFromLength(env, length);
     if (buffer.asArrayBuffer(env)) |array_buf| {
         if (length > 0) {
@@ -1116,8 +1248,11 @@ pub export fn napi_create_buffer_copy(env: napi_env, length: usize, data: [*]u8,
 
     return .ok;
 }
-pub export fn napi_is_buffer(env: napi_env, value: napi_value, result: *bool) napi_status {
+pub export fn napi_is_buffer(env: napi_env, value: napi_value, result_: ?*bool) napi_status {
     log("napi_is_buffer", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = value.isBuffer(env);
     return .ok;
 }
@@ -1150,28 +1285,40 @@ pub export fn napi_create_async_work(
     execute: napi_async_execute_callback,
     complete: napi_async_complete_callback,
     data: ?*anyopaque,
-    result: **napi_async_work,
+    result_: ?**napi_async_work,
 ) napi_status {
     log("napi_create_async_work", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
     result.* = napi_async_work.create(env, execute, complete, data) catch {
         return genericFailure();
     };
     return .ok;
 }
-pub export fn napi_delete_async_work(env: napi_env, work: *napi_async_work) napi_status {
+pub export fn napi_delete_async_work(env: napi_env, work_: ?*napi_async_work) napi_status {
     log("napi_delete_async_work", .{});
+    const work = work_ orelse {
+        return invalidArg();
+    };
     bun.assert(env == work.global);
     work.deinit();
     return .ok;
 }
-pub export fn napi_queue_async_work(env: napi_env, work: *napi_async_work) napi_status {
+pub export fn napi_queue_async_work(env: napi_env, work_: ?*napi_async_work) napi_status {
     log("napi_queue_async_work", .{});
+    const work = work_ orelse {
+        return invalidArg();
+    };
     bun.assert(env == work.global);
     work.schedule();
     return .ok;
 }
-pub export fn napi_cancel_async_work(env: napi_env, work: *napi_async_work) napi_status {
+pub export fn napi_cancel_async_work(env: napi_env, work_: ?*napi_async_work) napi_status {
     log("napi_cancel_async_work", .{});
+    const work = work_ orelse {
+        return invalidArg();
+    };
     bun.assert(env == work.global);
     if (work.cancel()) {
         return .ok;
@@ -1179,13 +1326,19 @@ pub export fn napi_cancel_async_work(env: napi_env, work: *napi_async_work) napi
 
     return napi_status.generic_failure;
 }
-pub export fn napi_get_node_version(_: napi_env, version: **const napi_node_version) napi_status {
+pub export fn napi_get_node_version(_: napi_env, version_: ?**const napi_node_version) napi_status {
     log("napi_get_node_version", .{});
+    const version = version_ orelse {
+        return invalidArg();
+    };
     version.* = &napi_node_version.global;
     return .ok;
 }
-pub export fn napi_get_uv_event_loop(env: napi_env, loop: **JSC.EventLoop) napi_status {
+pub export fn napi_get_uv_event_loop(env: napi_env, loop_: ?**JSC.EventLoop) napi_status {
     log("napi_get_uv_event_loop", .{});
+    const loop = loop_ orelse {
+        return invalidArg();
+    };
     if (bun.Environment.isWindows) {
         loop.* = @ptrCast(@alignCast(env.bunVM().uvLoop()));
     } else {
@@ -1445,9 +1598,13 @@ pub export fn napi_create_threadsafe_function(
     thread_finalize_cb: napi_finalize,
     context: ?*anyopaque,
     call_js_cb: ?napi_threadsafe_function_call_js,
-    result: *napi_threadsafe_function,
+    result_: ?*napi_threadsafe_function,
 ) napi_status {
     log("napi_create_threadsafe_function", .{});
+    const result = result_ orelse {
+        return invalidArg();
+    };
+
     if (call_js_cb == null and (func.isEmptyOrUndefinedOrNull() or !func.isCallable(env.vm()))) {
         return napi_status.function_expected;
     }


### PR DESCRIPTION
### What does this PR do?
this matches the behavior in node
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
