### PR TITLE
Fix sloppily written test

### DIFF
--- a/packages/bun-internal-test/src/runner.node.mjs
+++ b/packages/bun-internal-test/src/runner.node.mjs
@@ -48,6 +48,23 @@ uncygwinTempDir();
 const cwd = resolve(fileURLToPath(import.meta.url), "../../../../");
 process.chdir(cwd);
 
+function makeRunningBunInstallInWrongDirectoryFailInCI() {
+  const paths = [join(cwd, "package.json"), join(cwd, "test", "package.json")];
+
+  for (const current of paths) {
+    const inputPackageJSON = JSON.parse(readFileSync(current, "utf-8"));
+    inputPackageJSON.scripts ??= {};
+    inputPackageJSON.scripts.prepublish =
+      inputPackageJSON.scripts.preinstall =
+      inputPackageJSON.scripts.postinstall =
+      inputPackageJSON.scripts.install =
+        `echo "Ran bun install in the wrong directory. This is a bug in your test. Please fix your test." && exit 42`;
+    writeFileSync(current, JSON.stringify(inputPackageJSON, null, 2));
+  }
+}
+
+makeRunningBunInstallInWrongDirectoryFailInCI();
+
 const ci = !!process.env["GITHUB_ACTIONS"];
 const enableProgressBar = false;
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -13,6 +13,7 @@ export const isLinux = process.platform === "linux";
 export const isPosix = isMacOS || isLinux;
 export const isWindows = process.platform === "win32";
 export const isIntelMacOS = isMacOS && process.arch === "x64";
+export const isBunCI = !!process.env.BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING;
 
 export const bunEnv: NodeJS.ProcessEnv = {
   ...process.env,


### PR DESCRIPTION
### What does this PR do?

Fix sloppily written test (cc @nektro):
- It did not set the current working directory, so it installed `"stripe"` into the bun repository instead of the temporary test folder
- It did not check the exit code of `bun install`
- It only happened to work due to auto-install picking a globally-installed version of stripe.
- `String.raw` usage is unnecessary
- It unnecessarily used the node test harness instead of `bun:test`

This also:
- Make running `bun install` in `/package.json` or `test/package.json` from inside a test fail so that we don't run `bun install` in the wrong directory again in a test

### How did you verify your code works?

Ran the stripe test locally