### PR TITLE
Avoid loading `libm.so.6` as it breaks Vercel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1141,6 +1141,7 @@ if(UNIX AND NOT APPLE)
         "-Wl,--wrap=stat64"
         "-Wl,--wrap=pow"
         "-Wl,--wrap=exp"
+        "-Wl,--wrap=expf"
         "-Wl,--wrap=log"
         "-Wl,--wrap=log2"
         "-Wl,--wrap=lstat"

--- a/src/bun.js/bindings/workaround-missing-symbols.cpp
+++ b/src/bun.js/bindings/workaround-missing-symbols.cpp
@@ -182,6 +182,21 @@ extern "C" double __wrap_fmod(double x, double y)
     return __real_fmod(x, y);
 }
 
+static inline float __real_expf(float arg)
+{
+    static void* ptr = nullptr;
+    if (UNLIKELY(ptr == nullptr)) {
+        ptr = dlsym(RTLD_DEFAULT, "expf");
+    }
+
+    return ((float (*)(float))ptr)(arg);
+}
+
+extern "C" float __wrap_expf(float arg)
+{
+    return __real_expf(arg);
+}
+
 #ifndef _MKNOD_VER
 #define _MKNOD_VER 1
 #endif


### PR DESCRIPTION
### What does this PR do?

Fixes this error:
```sh
Archive:  bun-linux-x64.zip
--
04:35:54.020 | creating: bun-linux-x64/
04:35:54.782 | inflating: bun-linux-x64/bun
04:35:55.084 | bun: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by bun)

```

Adds a wrapper for `expf` to load it via `dlsym`, which avoids loading `libm.so.6` (un-breaking Vercel deployments)

```js
❯ llvm-objdump -T (which bun-1.1.6) | rg "GLIBC_2.2([0-9]+)"
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.24) quick_exit
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.25) getrandom
❯ llvm-objdump -T (which bun) | rg "GLIBC_2.2([0-9]+)"
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.24) quick_exit
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.25) getrandom
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.27) expf
```

Began in https://github.com/WebKit/WebKit/pull/28160 because `simde` uses `expf`

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
