### PR TITLE
Tilde expansion

### DIFF
--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -889,7 +889,7 @@ pub const Interpreter = struct {
                 const static_str = if (comptime bun.Environment.isWindows) EnvStr.initSlice("USERPROFILE") else EnvStr.initSlice("HOME");
                 break :brk self.shell_env.get(static_str) orelse self.export_env.get(static_str);
             };
-            return env_var orelse EnvStr.initSlice("unknown");
+            return env_var orelse EnvStr.initSlice("");
         }
 
         pub fn writeFailingErrorFmt(

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -2169,8 +2169,16 @@ pub const LexError = struct {
     /// Allocated with lexer arena
     msg: []const u8,
 };
-pub const LEX_JS_OBJREF_PREFIX = &[_]u8{8} ++ "__bun_";
-pub const LEX_JS_STRING_PREFIX = &[_]u8{8} ++ "__bunstr_";
+
+/// A special char used to denote the beginning of a special token
+/// used for substituting JS variables into the script string.
+///
+/// \b (decimal value of 8) is deliberately chosen so that it is not
+/// easy for the user to accidentally use this char in their script.
+///
+const SPECIAL_JS_CHAR = 8;
+pub const LEX_JS_OBJREF_PREFIX = &[_]u8{SPECIAL_JS_CHAR} ++ "__bun_";
+pub const LEX_JS_STRING_PREFIX = &[_]u8{SPECIAL_JS_CHAR} ++ "__bunstr_";
 
 pub fn NewLexer(comptime encoding: StringEncoding) type {
     const Chars = ShellCharIter(encoding);
@@ -2310,7 +2318,7 @@ pub fn NewLexer(comptime encoding: StringEncoding) type {
 
                 // Special token to denote substituted JS variables
                 // we use 8 or \b which is a non printable char
-                if (char == 8) {
+                if (char == SPECIAL_JS_CHAR) {
                     if (self.looksLikeJSStringRef()) {
                         if (self.eatJSStringRef()) |bunstr| {
                             try self.break_word(false);

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -352,6 +352,32 @@ describe("bunshell", () => {
     expect(stdout.toString()).toEqual(`noice\n`);
   });
 
+  describe("tilde_expansion", () => {
+    describe("with paths", async () => {
+      TestBuilder.command`echo ~/Documents`.stdout(`${process.env.HOME}/Documents\n`).runAsTest("normal");
+      TestBuilder.command`echo ~/Do"cu"me"nts"`.stdout(`${process.env.HOME}/Documents\n`).runAsTest("compound word");
+      TestBuilder.command`echo ~/LOL hi hello`.stdout(`${process.env.HOME}/LOL hi hello\n`).runAsTest("multiple words");
+    });
+
+    describe("normal", async () => {
+      TestBuilder.command`echo ~`.stdout(`${process.env.HOME}\n`).runAsTest("lone tilde");
+      TestBuilder.command`echo ~~`.stdout(`~~\n`).runAsTest("double tilde");
+      TestBuilder.command`echo ~ hi hello`.stdout(`${process.env.HOME} hi hello\n`).runAsTest("multiple words");
+    });
+
+    TestBuilder.command`HOME="" USERPROFILE="" && echo ~ && echo ~/Documents`
+      .stdout("\n/Documents\n")
+      .runAsTest("empty $HOME or $USERPROFILE");
+
+    describe("modified $HOME or $USERPROFILE", async () => {
+      TestBuilder.command`HOME=lmao USERPROFILE=lmao && echo ~`.stdout("lmao\n").runAsTest("1");
+
+      TestBuilder.command`HOME=lmao USERPROFILE=lmao && echo ~ && echo ~/Documents`
+        .stdout("lmao\nlmao/Documents\n")
+        .runAsTest("2");
+    });
+  });
+
   // Ported from GNU bash "quote.tests"
   // https://github.com/bminor/bash/blob/f3b6bd19457e260b65d11f2712ec3da56cef463f/tests/quote.tests#L1
   // Some backtick tests are skipped, because of insane behavior:


### PR DESCRIPTION
### What does this PR do?

This adds basic support for [tilde expansion](https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_06_01) in Bun shell. 

"Basic" means that tilde is expanded in two scenarios:

```bash
# lone tilde expands to $HOME
echo ~

# tilde + path expands to $HOME/$PATH
echo ~/Documents
```

Also, this changes how JS strings/objects are substituted into the shell script. It now uses a non-printable char as a special token to denote a substituted JS string/object (it was previously using a tilde).

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
