### PR TITLE
fix(bundler): fix emitting invalid sourcemaps

### DIFF
--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -5865,7 +5865,7 @@ pub fn getSourceMapBuilder(
     return .{
         .source_map = SourceMap.Chunk.Builder.SourceMapper.init(
             opts.allocator,
-            is_bun_platform,
+            is_bun_platform and generate_source_map == .lazy,
         ),
         .cover_lines_without_mappings = true,
         .approximate_input_line_count = tree.approximate_newline_count,


### PR DESCRIPTION
This fixes an off by 24 error related to sourcemap generation.

Before you would get sourcemaps with negative line numbers.
