### PR TITLE
docs: bun upgrade --stable flag in installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -162,7 +162,7 @@ The canary build is useful for testing new features and bug fixes before they're
 [View canary build](https://github.com/oven-sh/bun/releases/tag/canary)
 
 {% callout %}
-**Note** — To switch back to a stable release from canary, run `bun upgrade` again with no flags.
+**Note** — To switch back to a stable release from canary, run `bun upgrade --stable`.
 {% /callout %}
 
 ## Installing older versions of Bun


### PR DESCRIPTION
### What does this PR do?

It seems that the way to downgrade from a canary build has changed. It used to be just `bun upgrade`, but now it's `bun upgrade --stable`.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes