### PR TITLE
[bun:test] Implement `beforeEachFile` and `afterEachFile` hooks

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -267,6 +267,14 @@ declare module "bun:test" {
    * @param fn the function to run
    */
   export function beforeEach(fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void)): void;
+
+  /**
+   *
+   * Run a function before each file. Equivalent to `beforeAll` except that it runs before each file instead of each test.
+   *
+   * @param fn the function to run
+   */
+  export function beforeEachFile(fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void)): void;
   /**
    * Runs a function, once, after all the tests.
    *
@@ -293,6 +301,14 @@ declare module "bun:test" {
    * @param fn the function to run
    */
   export function afterEach(fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void)): void;
+
+  /**
+   *
+   * Run a function after each file. Equivalent to `afterAll` except that it runs before each file instead of each test.
+   *
+   * @param fn the function to run
+   */
+  export function afterEachFile(fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void)): void;
   export interface TestOptions {
     /**
      * Sets the timeout for the test in milliseconds.


### PR DESCRIPTION
### What does this PR do?

This adds support for adding a function to call before each test file runs and after each test file runs:

In a preload script:
```js
import {beforeEachFile, afterEachFile} from 'bun:test';

beforeEachFile(() => {
  resetDatabase();
});
```

In a test:
```ts
import {test, expect} from 'bun:test';

test("signup user in database", async () => {
  doSomething();
});
```



When switching to`bun:test` from vitest or jest, there currently is no equivalent to [`setupFiles`](https://vitest.dev/config/#setupfiles). This adds an alternative .



### How did you verify your code works?

WIP. Needs automated tests.