### PR TITLE
test: unify how all files create a temp directory

### DIFF
--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import { tmpdir } from "node:os";
@@ -54,7 +54,7 @@ describe("bun build", () => {
   });
 
   test("works with utf8 bom", () => {
-    const tmp = fs.mkdtempSync(path.join(tmpdir(), "bun-build-utf8-bom-"));
+    const tmp = tmpdirSync();
     const src = path.join(tmp, "index.js");
     fs.writeFileSync(src, '\ufeffconsole.log("hello world");', { encoding: "utf8" });
     const { exitCode } = Bun.spawnSync({

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,14 +1,13 @@
 import { spawn } from "bun";
 import { beforeAll, beforeEach, expect, it } from "bun:test";
-import { bunExe, bunEnv, tempDirWithFiles, bunRun, bunRunAsScript } from "harness";
+import { bunExe, bunEnv, tmpdirSync } from "harness";
 import { cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync, copyFileSync } from "fs";
 import { join } from "path";
-import { tmpdir } from "os";
 
 let hotRunnerRoot: string = "",
   cwd = "";
 beforeEach(() => {
-  const hotPath = join(tmpdir(), "bun-hot-test-" + (Date.now() | 0) + "_" + Math.random().toString(36).slice(2));
+  const hotPath = tmpdirSync();
   hotRunnerRoot = join(hotPath, "hot-runner-root.js");
   rmSync(hotPath, { recursive: true, force: true });
   cpSync(import.meta.dir, hotPath, { recursive: true, force: true });

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -1,10 +1,10 @@
 import fs from "fs";
 import path from "path";
-import os from "os";
-import { bunExe, bunEnv } from "harness";
+import { bunExe, bunEnv, tmpdirSync } from "harness";
+import { test, expect } from "bun:test";
 
 test("bun init works", () => {
-  const temp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bun-init-X")));
+  const temp = tmpdirSync();
 
   const out = Bun.spawnSync({
     cmd: [bunExe(), "init", "-y"],
@@ -40,7 +40,7 @@ test("bun init works", () => {
 }, 30_000);
 
 test("bun init with piped cli", () => {
-  const temp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bun-init-X")));
+  const temp = tmpdirSync();
 
   const out = Bun.spawnSync({
     cmd: [bunExe(), "init"],

--- a/test/cli/install/bad-workspace.test.ts
+++ b/test/cli/install/bad-workspace.test.ts
@@ -1,14 +1,12 @@
 import { spawnSync } from "bun";
-import { afterEach, beforeEach, expect, test } from "bun:test";
-import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "fs";
-import { bunExe, bunEnv } from "harness";
-import { join } from "path";
-import { tmpdir } from "os";
+import { beforeEach, expect, test } from "bun:test";
+import { writeFileSync } from "fs";
+import { bunExe, bunEnv, tmpdirSync } from "harness";
 
 let cwd: string;
 
 beforeEach(() => {
-  cwd = mkdtempSync(join(realpathSync(tmpdir()), "bad-workspace.test"));
+  cwd = tmpdirSync();
 });
 
 test("bad workspace path", () => {

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1762,7 +1762,7 @@ async function installRedirectsToAdd(saveFlagFirst: boolean) {
     " 1 package installed",
   ]);
   expect(await exited).toBe(0);
-  expect(await file(join(package_dir, "package.json")).text()).toInclude("bun-add.test");
+  expect(await file(join(package_dir, "package.json")).text()).toInclude("bun.test.");
 }
 
 it("should add dependency alongside peerDependencies", async () => {

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1,9 +1,8 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { bunExe, bunEnv as env, toHaveBins, toBeValidBin, toBeWorkspaceLink, ospath } from "harness";
-import { access, mkdir, mkdtemp, readlink, realpath, rm, writeFile, copyFile, appendFile } from "fs/promises";
+import { bunExe, bunEnv as env, toHaveBins, toBeValidBin, toBeWorkspaceLink,  tmpdirSync } from "harness";
+import { access, mkdir, readlink, rm, writeFile, copyFile, appendFile } from "fs/promises";
 import { join, relative } from "path";
-import { tmpdir } from "os";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -33,7 +32,7 @@ beforeAll(() => {
 });
 
 beforeEach(async () => {
-  add_dir = await mkdtemp(join(await realpath(tmpdir()), "bun-add.test"));
+  add_dir = tmpdirSync();
   await dummyBeforeEach();
 });
 afterEach(async () => {

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { bunExe, bunEnv as env, toHaveBins, toBeValidBin, toBeWorkspaceLink,  tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, toHaveBins, toBeValidBin, toBeWorkspaceLink, tmpdirSync } from "harness";
 import { access, mkdir, readlink, rm, writeFile, copyFile, appendFile } from "fs/promises";
 import { join, relative } from "path";
 import {

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -7,7 +7,7 @@ import { join } from "path";
 let x_dir: string;
 
 beforeEach(async () => {
-  x_dir = tmpdirSync("bun-create.test");
+  x_dir = tmpdirSync();
 });
 
 describe("should not crash", async () => {

--- a/test/cli/install/bun-install-pathname-trailing-slash.test.ts
+++ b/test/cli/install/bun-install-pathname-trailing-slash.test.ts
@@ -1,13 +1,11 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
-import { mkdtempSync, realpathSync, rmSync } from "fs";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
-import { tmpdir } from "os";
 import { join } from "path";
 
 let package_dir: string;
 
 beforeEach(() => {
-  package_dir = tmpdirSync("bun-install-path");
+  package_dir = tmpdirSync();
 });
 
 // https://github.com/oven-sh/bun/issues/2462

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -1,9 +1,8 @@
 import { spawn, file } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { bunExe, bunEnv as env, toBeValidBin, toHaveBins } from "harness";
-import { access, mkdtemp, readlink, realpath, rm, writeFile, mkdir } from "fs/promises";
-import { basename, join, sep, dirname } from "path";
-import { tmpdir } from "os";
+import { bunExe, bunEnv as env, tmpdirSync, toBeValidBin, toHaveBins } from "harness";
+import { access, writeFile, mkdir } from "fs/promises";
+import { basename, join } from "path";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -24,7 +23,7 @@ expect.extend({
 });
 
 beforeEach(async () => {
-  link_dir = await mkdtemp(join(await realpath(tmpdir()), "bun-link.test"));
+  link_dir = tmpdirSync();
   await dummyBeforeEach();
 });
 afterEach(async () => {

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,6 +1,6 @@
 import { hash, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { bunEnv, bunExe, bunEnv as env } from "harness";
+import { bunEnv, bunExe, bunEnv as env, tmpdirSync } from "harness";
 import { mkdir, writeFile, exists } from "fs/promises";
 import { join } from "path";
 import {
@@ -371,7 +371,7 @@ it("should remove all cache", async () => {
 
 import { tmpdir } from "os";
 it("bun pm migrate", async () => {
-  const test_dir = join(tmpdir(), "contoso-test" + Math.random().toString(36).slice(2));
+  const test_dir = tmpdirSync();
 
   cpSync(join(import.meta.dir, "migration/contoso-test"), test_dir, { recursive: true });
 

--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -1,7 +1,6 @@
-import { bunExe, bunEnv as env } from "harness";
-import { mkdir, mkdtemp, realpath, rm, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, tmpdirSync } from "harness";
+import { mkdir, writeFile } from "fs/promises";
 import { join, relative } from "path";
-import { tmpdir } from "os";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
 import { dummyAfterAll, dummyAfterEach, dummyBeforeAll, dummyBeforeEach, package_dir } from "./dummy.registry";
 import { spawn } from "bun";
@@ -13,7 +12,7 @@ afterAll(dummyAfterAll);
 let remove_dir: string;
 
 beforeEach(async () => {
-  remove_dir = await mkdtemp(join(await realpath(tmpdir()), "bun-remove.test"));
+  remove_dir = tmpdirSync();
   await dummyBeforeEach();
 });
 

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -1,17 +1,14 @@
 import { file, spawn, spawnSync } from "bun";
 import { afterEach, beforeEach, expect, it, describe } from "bun:test";
-import { bunEnv, bunExe, bunEnv as env, isWindows } from "harness";
-import { mkdtemp, realpath, rm, writeFile, exists, mkdir } from "fs/promises";
-import { tmpdir } from "os";
+import { bunEnv, bunExe, bunEnv as env, isWindows, tmpdirSync } from "harness";
+import { rm, writeFile, exists, mkdir } from "fs/promises";
 import { join } from "path";
 import { readdirSorted } from "./dummy.registry";
 
 let run_dir: string;
 
 beforeEach(async () => {
-  run_dir = await realpath(
-    await mkdtemp(join(tmpdir(), "bun-run.test." + Math.trunc(Math.random() * 9999999).toString(32))),
-  );
+  run_dir = tmpdirSync();
 });
 
 for (let withRun of [false, true]) {

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -1,8 +1,6 @@
 import { spawn, spawnSync } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { bunExe, bunEnv as env } from "harness";
-import { mkdtemp, realpath, readFile } from "fs/promises";
-import { tmpdir } from "os";
+import { bunExe, bunEnv as env, tmpdirSync } from "harness";
 import { join } from "path";
 import { copyFileSync } from "js/node/fs/export-star-from";
 import { upgrade_test_helpers } from "bun:internal-for-testing";
@@ -12,9 +10,7 @@ let run_dir: string;
 let exe_name: string = "bun-debug" + (process.platform === "win32" ? ".exe" : "");
 
 beforeEach(async () => {
-  run_dir = await realpath(
-    await mkdtemp(join(tmpdir(), "bun-upgrade.test." + Math.trunc(Math.random() * 9999999).toString(32))),
-  );
+  run_dir = tmpdirSync();
   copyFileSync(bunExe(), join(run_dir, exe_name));
 });
 

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -15,7 +15,7 @@ var port: number = 4873;
 var packageDir: string;
 
 beforeEach(() => {
-  packageDir = tmpdirSync("bun-workspaces-" + testCounter++ + "-");
+  packageDir = tmpdirSync();
   env.BUN_INSTALL_CACHE_DIR = join(packageDir, ".bun-cache");
   env.BUN_TMPDIR = env.TMPDIR = env.TEMP = join(packageDir, ".bun-tmp");
   writeFileSync(

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { afterEach, beforeEach, expect, it } from "bun:test";
-import { bunExe, bunEnv, isWindows } from "harness";
-import { mkdtemp, realpath, writeFile, rm } from "fs/promises";
+import { bunExe, bunEnv, isWindows, tmpdirSync } from "harness";
+import { writeFile, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { readdirSorted } from "./dummy.registry";
@@ -29,9 +29,9 @@ beforeEach(async () => {
     }
   });
 
-  install_cache_dir = await mkdtemp(join(tmpdir(), "bun-install-cache-" + Math.random().toString(36).slice(2)));
-  current_tmpdir = await realpath(await mkdtemp(join(tmpdir(), "bun-x-tmpdir" + Math.random().toString(36).slice(2))));
-  x_dir = await realpath(await mkdtemp(join(tmpdir(), "bun-x.test" + Math.random().toString(36).slice(2))));
+  install_cache_dir = tmpdirSync();
+  current_tmpdir = tmpdirSync();
+  x_dir = tmpdirSync();
 
   env.TEMP = current_tmpdir;
   env.BUN_TMPDIR = env.TMPDIR = current_tmpdir;

--- a/test/cli/install/dummy.registry.ts
+++ b/test/cli/install/dummy.registry.ts
@@ -21,7 +21,6 @@ type Pkg = {
 };
 let handler: Handler;
 let server: Server;
-let testCounter = 0;
 export let package_dir: string;
 export let requested: number;
 export let root_url: string;
@@ -98,7 +97,7 @@ export function dummyAfterAll() {
 }
 
 let packageDirGetter: () => string = () => {
-  return tmpdirSync("bun-install-test-" + testCounter++ + "--");
+  return tmpdirSync();
 };
 export async function dummyBeforeEach() {
   resetHandler();

--- a/test/cli/install/migration/complex-workspace.test.ts
+++ b/test/cli/install/migration/complex-workspace.test.ts
@@ -1,11 +1,9 @@
 import fs from "fs";
 import path from "path";
 import { test, expect, describe, beforeAll } from "bun:test";
-import { bunEnv, bunExe } from "harness";
-import { tmpdir } from "os";
-import { join } from "path";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 
-let cwd = join(tmpdir(), "complex-workspace-test" + Math.random().toString(36).slice(2, 8));
+let cwd = tmpdirSync();
 
 function validate(packageName: string, version: string, realPackageName?: string) {
   test(`${packageName} is ${realPackageName ? `${realPackageName}@${version}` : version}`, () => {

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -1,27 +1,10 @@
 import fs from "fs";
-import { test, expect, beforeAll, afterAll } from "bun:test";
-import { bunEnv, bunExe } from "harness";
-import { join, sep } from "path";
-import { mkdtempSync } from "js/node/fs/export-star-from";
-import { tmpdir } from "os";
-
-const ROOT_TEMP_DIR = join(tmpdir(), "migrate", sep);
-
-beforeAll(() => {
-  // if the test was stopped early
-  fs.rmSync(ROOT_TEMP_DIR, { recursive: true, force: true });
-  fs.mkdirSync(ROOT_TEMP_DIR);
-});
-
-afterAll(() => {
-  fs.rmSync(ROOT_TEMP_DIR, {
-    recursive: true,
-    force: true,
-  });
-});
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { join } from "path";
 
 function testMigration(lockfile: string) {
-  const testDir = mkdtempSync(ROOT_TEMP_DIR);
+  const testDir = tmpdirSync();
 
   fs.writeFileSync(
     join(testDir, "package.json"),
@@ -58,7 +41,7 @@ test("migrate from npm lockfile v2 during `bun add`", () => {
 
 // Currently this upgrades svelte :(
 test.todo("migrate workspace from npm during `bun add`", async () => {
-  const testDir = mkdtempSync(ROOT_TEMP_DIR);
+  const testDir = tmpdirSync();
 
   fs.cpSync(join(import.meta.dir, "add-while-migrate-workspace"), testDir, { recursive: true });
 
@@ -77,7 +60,7 @@ test.todo("migrate workspace from npm during `bun add`", async () => {
 });
 
 test("migrate from npm lockfile that is missing `resolved` properties", async () => {
-  const testDir = mkdtempSync(ROOT_TEMP_DIR);
+  const testDir = tmpdirSync();
 
   fs.cpSync(join(import.meta.dir, "missing-resolved-properties"), testDir, { recursive: true });
 

--- a/test/cli/install/overrides.test.ts
+++ b/test/cli/install/overrides.test.ts
@@ -1,8 +1,7 @@
-import { mkdtempSync } from "fs";
 import { join } from "path";
-import { tmpdir } from "os";
 import { readFileSync, writeFileSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { test, expect } from "bun:test";
 
 function install(cwd: string, args: string[]) {
   const exec = Bun.spawnSync({
@@ -51,7 +50,7 @@ function ensureLockfileDoesntChangeOnBunI(cwd: string) {
 }
 
 test("overrides affect your own packages", async () => {
-  const tmp = mkdtempSync(join(tmpdir(), "bun-pm-test"));
+  const tmp = tmpdirSync();
   writeFileSync(
     join(tmp, "package.json"),
     JSON.stringify({
@@ -67,7 +66,7 @@ test("overrides affect your own packages", async () => {
 });
 
 test("overrides affects all dependencies", async () => {
-  const tmp = mkdtempSync(join(tmpdir(), "bun-pm-test"));
+  const tmp = tmpdirSync();
   writeFileSync(
     join(tmp, "package.json"),
     JSON.stringify({
@@ -84,7 +83,7 @@ test("overrides affects all dependencies", async () => {
 });
 
 test("overrides being set later affects all dependencies", async () => {
-  const tmp = mkdtempSync(join(tmpdir(), "bun-pm-test"));
+  const tmp = tmpdirSync();
   writeFileSync(
     join(tmp, "package.json"),
     JSON.stringify({
@@ -112,7 +111,7 @@ test("overrides being set later affects all dependencies", async () => {
 });
 
 test("overrides to npm specifier", async () => {
-  const tmp = mkdtempSync(join(tmpdir(), "bun-pm-test"));
+  const tmp = tmpdirSync();
   writeFileSync(
     join(tmp, "package.json"),
     JSON.stringify({
@@ -137,7 +136,7 @@ test("overrides to npm specifier", async () => {
 });
 
 test("changing overrides makes the lockfile changed, prevent frozen install", async () => {
-  const tmp = mkdtempSync(join(tmpdir(), "bun-pm-test"));
+  const tmp = tmpdirSync();
   writeFileSync(
     join(tmp, "package.json"),
     JSON.stringify({
@@ -163,7 +162,7 @@ test("changing overrides makes the lockfile changed, prevent frozen install", as
 });
 
 test("overrides reset when removed", async () => {
-  const tmp = mkdtempSync(join(tmpdir(), "bun-pm-test"));
+  const tmp = tmpdirSync();
   writeFileSync(
     join(tmp, "package.json"),
     JSON.stringify({

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -11,10 +11,8 @@ import {
   toMatchNodeModulesAt,
 } from "harness";
 import { join, sep } from "path";
-import { mkdtempSync, realpathSync } from "fs";
 import { rm, writeFile, mkdir, exists, cp } from "fs/promises";
 import { readdirSorted } from "../dummy.registry";
-import { tmpdir } from "os";
 import { fork, ChildProcess } from "child_process";
 import { beforeAll, afterAll, beforeEach, afterEach, test, expect, describe } from "bun:test";
 import { install_test_helpers } from "bun:internal-for-testing";
@@ -53,7 +51,7 @@ afterAll(() => {
 });
 
 beforeEach(async () => {
-  packageDir = tmpdirSync("bun-install-registry-" + testCounter++ + "-");
+  packageDir = tmpdirSync();
   env.BUN_INSTALL_CACHE_DIR = join(packageDir, ".bun-cache");
   env.BUN_TMPDIR = env.TMPDIR = env.TEMP = join(packageDir, ".bun-tmp");
   await writeFile(

--- a/test/cli/install/registry/bun-install-windowsshim.test.ts
+++ b/test/cli/install/registry/bun-install-windowsshim.test.ts
@@ -1,9 +1,8 @@
 import { spawn } from "bun";
-import { bunExe, bunEnv as env, isWindows, mergeWindowEnvs } from "harness";
+import { bunExe, bunEnv as env, isWindows, mergeWindowEnvs, tmpdirSync } from "harness";
 import { join } from "path";
-import { copyFileSync, mkdirSync, mkdtempSync, realpathSync } from "fs";
+import { copyFileSync, mkdirSync } from "fs";
 import { writeFile } from "fs/promises";
-import { tmpdir } from "os";
 import { test, expect, describe } from "bun:test";
 
 // This test is to verify that BinLinkingShim.zig creates correct shim files as
@@ -12,7 +11,7 @@ import { test, expect, describe } from "bun:test";
 describe("windows bin linking shim should work", async () => {
   if (!isWindows) return;
 
-  const packageDir = mkdtempSync(join(realpathSync(tmpdir()), "bun-install-windowsshim-"));
+  const packageDir = tmpdirSync();
   const port = 4873;
 
   await writeFile(

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -1,11 +1,10 @@
 import { expect, test } from "bun:test";
-import { mkdirSync, realpathSync } from "fs";
-import { bunEnv, bunExe } from "harness";
-import { tmpdir } from "os";
+import { mkdirSync } from "fs";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { join } from "path";
 
 test("running a commonjs module works", async () => {
-  const dir = join(realpathSync(tmpdir()), "bun-run-test1");
+  const dir = tmpdirSync();
   mkdirSync(dir, { recursive: true });
   await Bun.write(join(dir, "index1.js"), "module.exports = 1; console.log('hello world');");
   let { stdout } = Bun.spawnSync({

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -1,7 +1,7 @@
 import { SpawnOptions, Subprocess, SyncSubprocess } from "bun";
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { writeFileSync, rmSync } from "fs";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join, sep, posix } from "path";
 
@@ -48,7 +48,7 @@ for (const flag of ["-e", "--print"]) {
 
 describe("--print for cjs/esm", () => {
   test("eval result between esm imports", async () => {
-    let cwd = mkdtempSync(join(tmpdir(), "bun-run-eval-test-"));
+    let cwd = tmpdirSync();
     writeFileSync(join(cwd, "foo.js"), "'foo'");
     writeFileSync(join(cwd, "bar.js"), "'bar'");
     let { stdout, stderr, exitCode } = Bun.spawnSync({

--- a/test/cli/run/run-extensionless.test.ts
+++ b/test/cli/run/run-extensionless.test.ts
@@ -1,12 +1,11 @@
 import { expect, test } from "bun:test";
-import { mkdirSync, realpathSync } from "fs";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { mkdirSync } from "fs";
+import { bunEnv, bunExe, isWindows, tmpdirSync } from "harness";
 import { writeFileSync } from "fs";
-import { tmpdir } from "os";
 import { join } from "path";
 
 test("running extensionless file works", async () => {
-  const dir = join(realpathSync(tmpdir()), "bun-run-test1");
+  const dir = tmpdirSync();
   mkdirSync(dir, { recursive: true });
   await Bun.write(join(dir, "cool"), "const x: Test = 2; console.log('hello world');");
   let { stdout } = Bun.spawnSync({
@@ -18,7 +17,7 @@ test("running extensionless file works", async () => {
 });
 
 test.skipIf(isWindows)("running shebang typescript file works", async () => {
-  const dir = join(realpathSync(tmpdir()), "bun-run-test2");
+  const dir = tmpdirSync();
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, "cool"), `#!${bunExe()}\nconst x: Test = 2; console.log('hello world');`, { mode: 0o777 });
 

--- a/test/cli/run/run-shell.test.ts
+++ b/test/cli/run/run-shell.test.ts
@@ -1,11 +1,10 @@
 import { expect, test } from "bun:test";
-import { mkdirSync, realpathSync } from "fs";
-import { bunEnv, bunExe } from "harness";
-import { tmpdir } from "os";
+import { mkdirSync } from "fs";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { join } from "path";
 
 test("running a shell script works", async () => {
-  const dir = join(realpathSync(tmpdir()), "bun-run-shell");
+  const dir = tmpdirSync();
   mkdirSync(dir, { recursive: true });
   await Bun.write(join(dir, "something.sh"), "echo wah");
   let { stdout, stderr } = Bun.spawnSync({

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -1,7 +1,7 @@
 import { Subprocess } from "bun";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { realpathSync, chmodSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun } from "harness";
+import { bunEnv, bunExe, bunRun, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -50,7 +50,7 @@ beforeEach(() => {
     removeCache();
   }
 
-  temp_dir = join(tmpdir(), `bun-test-transpiler-cache-${Date.now()}-` + (Math.random() * 81023).toString(36).slice(2));
+  temp_dir = tmpdirSync();
   mkdirSync(temp_dir, { recursive: true });
   temp_dir = realpathSync(temp_dir);
   cache_dir = join(temp_dir, ".cache");

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,9 +1,9 @@
 import { join, resolve, dirname } from "node:path";
 import { tmpdir } from "node:os";
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { spawnSync } from "bun";
 import { describe, test, expect } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { bunExe, bunEnv, tmpdirSync } from "harness";
 
 describe("bun test", () => {
   test("can provide no arguments", () => {
@@ -889,7 +889,7 @@ describe("bun test", () => {
 });
 
 function createTest(input?: string | (string | { filename: string; contents: string })[], filename?: string): string {
-  const cwd = mkdtempSync(join(tmpdir(), "bun-test-"));
+  const cwd = tmpdirSync();
   const inputs = Array.isArray(input) ? input : [input ?? ""];
   for (const input of inputs) {
     const contents = typeof input === "string" ? input : input.contents;

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -2,14 +2,13 @@ import { it, expect, afterEach } from "bun:test";
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
-import { bunExe, bunEnv } from "harness";
+import { writeFileSync, rmSync } from "node:fs";
+import { bunExe, bunEnv, tmpdirSync } from "harness";
 
 let watchee: Subprocess;
 
 it("should watch files", async () => {
-  const cwd = mkdtempSync(join(tmpdir(), "bun-test-"));
+  const cwd = tmpdirSync();
   const path = join(cwd, "watchee.js");
 
   const updateFile = (i: number) => {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -761,5 +761,5 @@ export function mergeWindowEnvs(envs: Record<string, string | undefined>[]) {
 }
 
 export function tmpdirSync(pattern: string = "bun.test.") {
-  return fs.mkdtempSync(join(fs.realpathSync(os.tmpdir()), "bun.test."));
+  return fs.mkdtempSync(join(fs.realpathSync(os.tmpdir()), pattern));
 }

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -760,6 +760,6 @@ export function mergeWindowEnvs(envs: Record<string, string | undefined>[]) {
   return flat;
 }
 
-export function tmpdirSync() {
+export function tmpdirSync(pattern: string = "bun.test.") {
   return fs.mkdtempSync(join(fs.realpathSync(os.tmpdir()), "bun.test."));
 }

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -760,6 +760,6 @@ export function mergeWindowEnvs(envs: Record<string, string | undefined>[]) {
   return flat;
 }
 
-export function tmpdirSync(pattern: string) {
-  return fs.mkdtempSync(join(fs.realpathSync(os.tmpdir()), pattern));
+export function tmpdirSync() {
+  return fs.mkdtempSync(join(fs.realpathSync(os.tmpdir()), "bun.test."));
 }

--- a/test/integration/esbuild/esbuild.test.ts
+++ b/test/integration/esbuild/esbuild.test.ts
@@ -1,14 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { rm, writeFile, mkdir, exists, cp } from "fs/promises";
-import { bunExe, bunEnv as env } from "harness";
-import { mkdtempSync, realpathSync } from "fs";
-import { tmpdir } from "os";
+import { rm, writeFile, cp } from "fs/promises";
+import { bunExe, bunEnv as env, tmpdirSync } from "harness";
 import { join } from "path";
 import { spawn } from "bun";
 
 describe("esbuild integration test", () => {
   test("install and use esbuild", async () => {
-    const packageDir = mkdtempSync(join(realpathSync(tmpdir()), "bun-esbuild-test-"));
+    const packageDir = tmpdirSync();
 
     await writeFile(
       join(packageDir, "package.json"),
@@ -50,7 +48,7 @@ describe("esbuild integration test", () => {
   });
 
   test("install and use estrella", async () => {
-    const packageDir = mkdtempSync(join(realpathSync(tmpdir()), "bun-ebuild-estrella-test-"));
+    const packageDir = tmpdirSync();
 
     await writeFile(
       join(packageDir, "package.json"),

--- a/test/integration/next-pages/test/dev-server-ssr-100.test.ts
+++ b/test/integration/next-pages/test/dev-server-ssr-100.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, toMatchNodeModulesAt } from "../../../harness";
+import { bunEnv, bunExe, tmpdirSync, toMatchNodeModulesAt } from "../../../harness";
 import { Subprocess } from "bun";
 import { copyFileSync, rmSync } from "fs";
 import { join } from "path";
@@ -8,11 +8,9 @@ import { cp, rm } from "fs/promises";
 import { install_test_helpers } from "bun:internal-for-testing";
 const { parseLockfile } = install_test_helpers;
 
-import { tmpdir } from "node:os";
-
 expect.extend({ toMatchNodeModulesAt });
 
-let root = join(tmpdir(), "ssr" + Math.random().toString(36).slice(2, 4) + "-" + Date.now().toString(36).slice(2, 4));
+let root = tmpdirSync();
 
 beforeAll(async () => {
   await rm(root, { recursive: true, force: true });

--- a/test/integration/next-pages/test/dev-server.test.ts
+++ b/test/integration/next-pages/test/dev-server.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { bunEnv, bunExe, toMatchNodeModulesAt } from "../../../harness";
+import { bunEnv, bunExe, tmpdirSync, toMatchNodeModulesAt } from "../../../harness";
 import { Subprocess } from "bun";
 import { copyFileSync } from "fs";
 import { join } from "path";
@@ -8,11 +8,9 @@ import { cp, rm } from "fs/promises";
 import { install_test_helpers } from "bun:internal-for-testing";
 const { parseLockfile } = install_test_helpers;
 
-import { tmpdir } from "node:os";
-
 expect.extend({ toMatchNodeModulesAt });
 
-let root = join(tmpdir(), "next-pages" + Math.random().toString(36).slice(2) + "-" + Date.now().toString(36));
+let root = tmpdirSync();
 
 beforeAll(async () => {
   await rm(root, { recursive: true, force: true });

--- a/test/integration/next-pages/test/next-build.test.ts
+++ b/test/integration/next-pages/test/next-build.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, toMatchNodeModulesAt } from "../../../harness";
-import { copyFileSync, cpSync, mkdtempSync, readFileSync, rmSync, symlinkSync, promises as fs } from "fs";
-import { tmpdir } from "os";
+import { bunEnv, bunExe, tmpdirSync, toMatchNodeModulesAt } from "../../../harness";
+import { copyFileSync, cpSync, readFileSync, rmSync, promises as fs } from "fs";
 import { join } from "path";
 import { cp } from "fs/promises";
 import { install_test_helpers } from "bun:internal-for-testing";
@@ -12,7 +11,7 @@ expect.extend({ toMatchNodeModulesAt });
 const root = join(import.meta.dir, "../");
 
 async function tempDirToBuildIn() {
-  const dir = mkdtempSync(join(tmpdir(), "bun-next-build-"));
+  const dir = tmpdirSync();
   const copy = [
     ".eslintrc.json",
     "bun.lockb",

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -25,7 +25,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import fg from "fast-glob";
 import * as path from "path";
 import { tempFixturesDir, createTempDirectoryWithBrokenSymlinks, prepareEntries } from "./util";
-import { tempDirWithFiles } from "harness";
+import { tempDirWithFiles, tmpdirSync } from "harness";
 import * as os from "node:os";
 import * as fs from "node:fs";
 
@@ -313,8 +313,7 @@ describe("fast-glob e2e tests", async () => {
   let absolute_pattern_dir: string = "";
   // beforeAll(() => {
   tempFixturesDir();
-  const tmp = os.tmpdir();
-  absolute_pattern_dir = fs.mkdtempSync(path.join(tmp, "absolute_patterns"));
+  absolute_pattern_dir = tmpdirSync();
   // add some more directories so patterns like ../**/* don't break
   absolute_pattern_dir = path.join(absolute_pattern_dir, "ooga/booga");
   fs.mkdirSync(absolute_pattern_dir, { recursive: true })!;
@@ -590,14 +589,9 @@ describe("literal fast path", async () => {
   });
 });
 
-function makeTmpdir(): string {
-  const tmp = os.tmpdir();
-  return fs.mkdtempSync(path.join(tmp, "test_builder"));
-}
-
 describe("trailing directory separator", async () => {
   test("matches directories absolute", async () => {
-    const tmpdir = makeTmpdir();
+    const tmpdir = tmpdirSync();
     const files = [`${tmpdir}${path.sep}bunx-foo`, `${tmpdir}${path.sep}bunx-bar`, `${tmpdir}${path.sep}bunx-baz`];
     await Bun.$`touch ${files[0]}; touch ${files[1]}; mkdir ${files[2]}`;
     const glob = new Glob(`${path.join(tmpdir, "bunx-*")}${path.sep}`);
@@ -606,7 +600,7 @@ describe("trailing directory separator", async () => {
   });
 
   test("matches directories relative", async () => {
-    const tmpdir = makeTmpdir();
+    const tmpdir = tmpdirSync();
     const files = [`bunx-foo`, `bunx-bar`, `bunx-baz`];
     await Bun.$`touch ${files[0]}; touch ${files[1]}; mkdir ${files[2]}`.cwd(tmpdir);
     const glob = new Glob(`bunx-*/`);
@@ -617,7 +611,7 @@ describe("trailing directory separator", async () => {
 
 describe("absolute path pattern", async () => {
   test("works *", async () => {
-    const tmpdir = makeTmpdir();
+    const tmpdir = tmpdirSync();
     const files = [`${tmpdir}${path.sep}bunx-foo`, `${tmpdir}${path.sep}bunx-bar`, `${tmpdir}${path.sep}bunx-baz`];
     await Bun.$`touch ${files[0]}; touch ${files[1]}; mkdir ${files[2]}`;
     const glob = new Glob(`${path.join(tmpdir, "bunx-*")}`);
@@ -626,7 +620,7 @@ describe("absolute path pattern", async () => {
   });
 
   test("works **/", async () => {
-    const tmpdir = makeTmpdir();
+    const tmpdir = tmpdirSync();
     const files = [
       `${tmpdir}${path.sep}bunx-foo`,
       `${tmpdir}${path.sep}bunx-bar`,
@@ -642,7 +636,7 @@ describe("absolute path pattern", async () => {
   });
 
   test("works **", async () => {
-    const tmpdir = makeTmpdir();
+    const tmpdir = tmpdirSync();
     const files = [
       `${tmpdir}${path.sep}bunx-foo`,
       `${tmpdir}${path.sep}bunx-bar`,
@@ -664,7 +658,7 @@ describe("absolute path pattern", async () => {
   });
 
   test("doesn't exist, file pattern", async () => {
-    const tmpdir = makeTmpdir();
+    const tmpdir = tmpdirSync();
     await Bun.$`mkdir -p hello/friends; touch hello/friends/lol.json; echo ${tmpdir}`.cwd(tmpdir);
     const glob = new Glob(`${tmpdir}/hello/friends/nice.json`);
     console.log(Array.from(glob.scanSync({ cwd: tmpdir })));

--- a/test/js/bun/glob/util.ts
+++ b/test/js/bun/glob/util.ts
@@ -1,10 +1,10 @@
-import { mkdtempSync, symlinkSync } from "fs";
+import { symlinkSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdirSync } from "harness";
 
 export function createTempDirectoryWithBrokenSymlinks() {
   // Create a temporary directory
-  const tempDir = mkdtempSync(path.join(os.tmpdir(), "fixtures_symlink_"));
+  const tempDir = tmpdirSync();
 
   // Define broken symlink targets (non-existent paths)
   const brokenTargets = ["non_existent_file.txt", "non_existent_dir"];

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -1,15 +1,15 @@
 import { describe, test, expect } from "bun:test";
 import { file, serve } from "bun";
 import type { NetworkInterfaceInfo } from "node:os";
-import { tmpdir, networkInterfaces } from "node:os";
-import { mkdtempSync } from "node:fs";
+import { networkInterfaces } from "node:os";
 import { join } from "node:path";
+import { tmpdirSync } from "harness";
 
 const networks = Object.values(networkInterfaces()).flat() as NetworkInterfaceInfo[];
 const hasIPv4 = networks.some(({ family }) => family === "IPv4");
 const hasIPv6 = networks.some(({ family }) => family === "IPv6");
 
-const unix = join(mkdtempSync(join(tmpdir(), "bun-serve-")), "unix.sock");
+const unix = join(tmpdirSync(), "unix.sock");
 const tls = {
   cert: file(new URL("./fixtures/cert.pem", import.meta.url)),
   key: file(new URL("./fixtures/cert.key", import.meta.url)),

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -6,9 +6,8 @@
  */
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, realpath, rm, stat } from "fs/promises";
-import { bunEnv, bunExe, runWithErrorPromise, tempDirWithFiles } from "harness";
-import { tmpdir } from "os";
+import { mkdir, rm, stat } from "fs/promises";
+import { bunEnv, bunExe, runWithErrorPromise, tempDirWithFiles, tmpdirSync } from "harness";
 import { join, sep } from "path";
 import { createTestBuilder, sortedShellOutput } from "./util";
 const TestBuilder = createTestBuilder(import.meta.path);
@@ -21,7 +20,7 @@ let temp_dir: string;
 const temp_files = ["foo.txt", "lmao.ts"];
 beforeAll(async () => {
   $.nothrow();
-  temp_dir = await mkdtemp(join(await realpath(tmpdir()), "bun-add.test"));
+  temp_dir = tmpdirSync();
   await mkdir(temp_dir, { recursive: true });
 
   for (const file of temp_files) {

--- a/test/js/bun/shell/test_builder.ts
+++ b/test/js/bun/shell/test_builder.ts
@@ -4,7 +4,6 @@ import { ShellPromise, ShellExpression } from "bun";
 import { join } from "node:path";
 import * as os from "node:os";
 import * as fs from "node:fs";
-import { tmpdirSync } from "harness";
 // import { bunExe } from "harness";
 
 export function createTestBuilder(path: string) {
@@ -188,7 +187,8 @@ export function createTestBuilder(path: string) {
     }
 
     static tmpdir(): string {
-      return tmpdirSync();
+      const tmp = os.tmpdir();
+      return fs.mkdtempSync(join(tmp, "test_builder"));
     }
 
     setTempdir(tempdir: string): this {

--- a/test/js/bun/shell/test_builder.ts
+++ b/test/js/bun/shell/test_builder.ts
@@ -4,6 +4,7 @@ import { ShellPromise, ShellExpression } from "bun";
 import { join } from "node:path";
 import * as os from "node:os";
 import * as fs from "node:fs";
+import { tmpdirSync } from "harness";
 // import { bunExe } from "harness";
 
 export function createTestBuilder(path: string) {
@@ -187,8 +188,7 @@ export function createTestBuilder(path: string) {
     }
 
     static tmpdir(): string {
-      const tmp = os.tmpdir();
-      return fs.mkdtempSync(join(tmp, "test_builder"));
+      return tmpdirSync();
     }
 
     setTempdir(tempdir: string): this {

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1,16 +1,22 @@
 import { ArrayBufferSink, readableStreamToText, spawn, spawnSync, write } from "bun";
 import { beforeAll, describe, expect, it } from "bun:test";
 import { closeSync, fstatSync, openSync } from "fs";
-import { gcTick as _gcTick, bunEnv, bunExe, isLinux, isMacOS, isPosix, isWindows, withoutAggressiveGC } from "harness";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import {
+  gcTick as _gcTick,
+  bunEnv,
+  bunExe,
+  isMacOS,
+  isPosix,
+  isWindows,
+  tmpdirSync,
+  withoutAggressiveGC,
+} from "harness";
+import { rmSync, writeFileSync } from "node:fs";
 import path from "path";
 let tmp;
 
 beforeAll(() => {
-  tmp = path.join(tmpdir(), "bun-spawn-" + Date.now().toString(32)) + path.sep;
-  rmSync(tmp, { force: true, recursive: true });
-  mkdirSync(tmp, { recursive: true });
+  tmp = tmpdirSync();
 });
 
 function createHugeString() {

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -1,11 +1,9 @@
 import fs from "fs";
-import { bunExe } from "harness";
-import { tmpdir } from "os";
-
+import { bunExe, tmpdirSync } from "harness";
 import { it, test, expect, describe } from "bun:test";
 
 test("it will create a snapshot file and directory if they don't exist", () => {
-  const tempDir = tmpdir() + "/new-snapshot";
+  const tempDir = tmpdirSync();
   fs.rmSync(tempDir, { force: true, recursive: true });
   fs.mkdirSync(tempDir, { recursive: true });
 

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -2,8 +2,8 @@
 import { spawn, spawnSync } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { mkdirSync, realpathSync, rmSync, writeFileSync, copyFileSync } from "fs";
-import { mkdtemp, rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe } from "harness";
+import { rm, writeFile } from "fs/promises";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join, dirname } from "path";
 
@@ -27,7 +27,7 @@ it("shouldn't crash when async test runner callback throws", async () => {
   })
 `;
 
-  const test_dir = await mkdtemp(join(tmp, "test"));
+  const test_dir = tmpdirSync();
   try {
     await writeFile(join(test_dir, "bad.test.js"), code);
     const { stdout, stderr, exited } = spawn({
@@ -259,7 +259,7 @@ test("test async exceptions fail tests", () => {
   });
 
   `;
-  const dir = join(tmp, "test-throwing-bun");
+  const dir = tmpdirSync();
   const filepath = join(dir, "test-throwing-eventemitter.test.js");
   rmSync(filepath, {
     force: true,
@@ -289,7 +289,7 @@ test("test async exceptions fail tests", () => {
 });
 
 it("should return non-zero exit code for invalid syntax", async () => {
-  const test_dir = await mkdtemp(join(tmp, "test"));
+  const test_dir = tmpdirSync();
   try {
     await writeFile(join(test_dir, "bad.test.js"), "!!!");
     const { stdout, stderr, exited } = spawn({
@@ -314,7 +314,7 @@ it("should return non-zero exit code for invalid syntax", async () => {
 });
 
 it("invalid syntax counts towards bail", async () => {
-  const test_dir = await mkdtemp(join(tmp, "test"));
+  const test_dir = tmpdirSync();
   try {
     await writeFile(join(test_dir, "bad1.test.js"), "!!!");
     await writeFile(join(test_dir, "bad2.test.js"), "!!!");
@@ -616,7 +616,7 @@ it("skip() and skipIf()", () => {
 });
 
 it("should run beforeAll() & afterAll() even without tests", async () => {
-  const test_dir = await mkdtemp(join(tmp, "test-hooks-empty"));
+  const test_dir = tmpdirSync();
   try {
     await writeFile(
       join(test_dir, "empty.test.js"),

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,8 +1,6 @@
-import { ArrayBufferSink } from "bun";
 import { describe, expect, it } from "bun:test";
-import { isWindows } from "harness";
+import { isWindows, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 describe("FileSink", () => {
@@ -45,7 +43,7 @@ describe("FileSink", () => {
   });
 
   function getPath(label: string) {
-    const path = join(tmpdir(), `bun-test-${Bun.hash(label).toString(10)}.${(Math.random() * 1_000_000) | 0}.txt`);
+    const path = join(tmpdirSync(), `${Bun.hash(label).toString(10)}.txt`);
     try {
       require("fs").unlinkSync(path);
     } catch (e) {}
@@ -56,7 +54,7 @@ describe("FileSink", () => {
   var decoder = new TextDecoder();
 
   function getFd(label: string, byteLength = 0) {
-    const path = join(tmpdir(), `bun-test-${Bun.hash(label).toString(10)}.${(Math.random() * 1_000_000) | 0}.txt`);
+    const path = join(tmpdirSync(), `${Bun.hash(label).toString(10)}.txt`);
     try {
       require("fs").unlinkSync(path);
     } catch (e) {}

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -1,9 +1,8 @@
 import { FileSystemRouter } from "bun";
 import { it, expect } from "bun:test";
-import path, { dirname, resolve } from "path";
-import fs, { mkdirSync, realpathSync, rmSync } from "fs";
-import { tmpdir } from "os";
-const tempdir = realpathSync(tmpdir()) + "/";
+import path, { dirname } from "path";
+import fs, { mkdirSync, rmSync } from "fs";
+import { tmpdirSync } from "harness";
 
 function createTree(basedir: string, paths: string[]) {
   for (const end of paths) {
@@ -17,7 +16,7 @@ function createTree(basedir: string, paths: string[]) {
 }
 var count = 0;
 function make(files: string[]) {
-  const dir = (tempdir + `fs-router-test-${count++}`).replace(/\\/g, "/");
+  const dir = tmpdirSync();
   rmSync(dir, {
     recursive: true,
     force: true,

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -5,7 +5,7 @@ import { rmSync, chmodSync, mkdirSync, realpathSync } from "node:fs";
 import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
 import { rmdirSync } from "js/node/fs/export-star-from";
-import { isIntelMacOS, isWindows, tempDirWithFiles } from "harness";
+import { isIntelMacOS, isWindows, tempDirWithFiles, tmpdirSync } from "harness";
 import { w } from "vitest/dist/types-2b1c412e.js";
 
 $.nothrow();
@@ -51,7 +51,7 @@ if (isWindows) {
       }
     }
 
-    let basedir = join(tmpdir(), "which-test-" + Math.random().toString(36).slice(2));
+    let basedir = tmpdirSync();
 
     rmSync(basedir, { recursive: true, force: true });
     mkdirSync(basedir, { recursive: true });

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -382,7 +382,7 @@ it("should call close and exit before process exits", async () => {
 });
 
 it("it accepts stdio passthrough", async () => {
-  const package_dir = tmpdirSync("bun-node-child_process");
+  const package_dir = tmpdirSync();
 
   await fs.promises.writeFile(
     path.join(package_dir, "package.json"),

--- a/test/js/node/crypto/crypto.test.ts
+++ b/test/js/node/crypto/crypto.test.ts
@@ -200,7 +200,7 @@ describe("crypto.createSign()/.verifySign()", () => {
 });
 
 it("should send cipher events in the right order", async () => {
-  const package_dir = tmpdirSync("bun-test-node-stream");
+  const package_dir = tmpdirSync();
   const fixture_path = path.join(package_dir, "fixture.js");
 
   await Bun.write(

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import { dirname, resolve, relative } from "node:path";
 import { promisify } from "node:util";
-import { bunEnv, bunExe, gc, getMaxFD, isIntelMacOS, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, gc, getMaxFD, isIntelMacOS, isWindows, tempDirWithFiles, tmpdirSync } from "harness";
 import { isAscii } from "node:buffer";
 import fs, {
   closeSync,
@@ -253,7 +253,7 @@ it("Dirent.name setter", () => {
 });
 
 it("writeFileSync should correctly resolve ../..", () => {
-  const base = join(tmpdir(), `fs-test-${Math.random().toString(36).slice(2)}`);
+  const base = tmpdirSync();
   const path = join(base, "foo", "bar");
   mkdirSync(path, { recursive: true });
   const cwd = process.cwd();
@@ -264,7 +264,7 @@ it("writeFileSync should correctly resolve ../..", () => {
 });
 
 it("writeFileSync in append should not truncate the file", () => {
-  const path = join(tmpdir(), "writeFileSync-should-not-append-" + (Date.now() * 10000).toString(16));
+  const path = join(tmpdirSync(), "should-not-append.txt");
   var str = "";
   writeFileSync(path, "---BEGIN---");
   str += "---BEGIN---";
@@ -286,7 +286,7 @@ it("await readdir #3931", async () => {
 });
 
 it("writeFileSync NOT in append SHOULD truncate the file", () => {
-  const path = join(tmpdir(), "writeFileSync-should-not-append-" + (Date.now() * 10000).toString(16));
+  const path = join(tmpdirSync(), "should-not-append.txt");
 
   for (let options of [{ flag: "w" }, { flag: undefined }, {}, undefined]) {
     writeFileSync(path, "---BEGIN---", options);
@@ -482,9 +482,7 @@ it("readdirSync on import.meta.dir", () => {
 });
 
 it("promises.readdir on a large folder", async () => {
-  const huge = join(tmpdir(), "huge-folder-" + Math.random().toString(32));
-  rmSync(huge, { force: true, recursive: true });
-  mkdirSync(huge, { recursive: true });
+  const huge = tmpdirSync();
   for (let i = 0; i < 128; i++) {
     writeFileSync(join(huge, "file-" + i), "");
   }
@@ -819,9 +817,7 @@ it("promises.readFile with buffer as file path", async () => {
 });
 
 it("promises.readdir on a large folder withFileTypes", async () => {
-  const huge = join(tmpdir(), "huge-folder-" + Math.random().toString(32));
-  rmSync(huge, { force: true, recursive: true });
-  mkdirSync(huge, { recursive: true });
+  const huge = tmpdirSync();
   let withFileTypes = { withFileTypes: true } as const;
   for (let i = 0; i < 128; i++) {
     writeFileSync(join(huge, "file-" + i), "");
@@ -954,14 +950,12 @@ it("readdirSync on import.meta.dir with trailing slash", () => {
 });
 
 it("readdirSync works on empty directories", () => {
-  const path = `${tmpdir()}/fs-test-empty-dir-${(Math.random() * 100000 + 100).toString(32)}`;
-  mkdirSync(path, { recursive: true });
+  const path = tmpdirSync();
   expect(readdirSync(path).length).toBe(0);
 });
 
 it("readdirSync works on directories with under 32 files", () => {
-  const path = `${tmpdir()}/fs-test-one-dir-${(Math.random() * 100000 + 100).toString(32)}`;
-  mkdirSync(path, { recursive: true });
+  const path = tmpdirSync();
   writeFileSync(`${path}/a`, "a");
   const results = readdirSync(path);
   expect(results.length).toBe(1);
@@ -1263,13 +1257,13 @@ describe("readFile", () => {
 
 describe("writeFileSync", () => {
   it("works", () => {
-    const path = `${tmpdir()}/${Date.now()}.writeFileSync.txt`;
+    const path = `${tmpdirSync()}/writeFileSync.txt`;
     writeFileSync(path, "File written successfully", "utf8");
 
     expect(readFileSync(path, "utf8")).toBe("File written successfully");
   });
   it("write file with mode, issue #3740", () => {
-    const path = `${tmpdir()}/${Date.now()}.writeFileSyncWithMode.txt`;
+    const path = `${tmpdirSync()}/writeFileSyncWithMode.txt`;
     writeFileSync(path, "bun", { mode: 33188 });
     const stat = fs.statSync(path);
     expect(stat.mode).toBe(isWindows ? 33206 : 33188);
@@ -1279,7 +1273,7 @@ describe("writeFileSync", () => {
       70, 105, 108, 101, 32, 119, 114, 105, 116, 116, 101, 110, 32, 115, 117, 99, 99, 101, 115, 115, 102, 117, 108, 108,
       121,
     ]);
-    const path = `${tmpdir()}/${Date.now()}.blob.writeFileSync.txt`;
+    const path = `${tmpdirSync()}/blob.writeFileSync.txt`;
     writeFileSync(path, buffer);
     const out = readFileSync(path);
 
@@ -1292,7 +1286,7 @@ describe("writeFileSync", () => {
       70, 105, 108, 101, 32, 119, 114, 105, 116, 116, 101, 110, 32, 115, 117, 99, 99, 101, 115, 115, 102, 117, 108, 108,
       121,
     ]);
-    const path = `${tmpdir()}/${Date.now()}.blob2.writeFileSync.txt`;
+    const path = `${tmpdirSync()}/blob2.writeFileSync.txt`;
     writeFileSync(path, buffer);
     const out = readFileSync(path);
 
@@ -1335,7 +1329,7 @@ describe("lstat", () => {
   });
 
   it("symlink metadata is correct", () => {
-    const link = join(tmpdir(), `fs-stream.link${Math.random().toString(32)}.js`);
+    const link = join(tmpdirSync(), `fs-stream.link.js`);
     symlinkSync(join(import.meta.dir, "fs-stream.js"), link);
     const linkStats = lstatSync(link);
     expect(linkStats.isSymbolicLink()).toBe(true);
@@ -1349,7 +1343,7 @@ describe("lstat", () => {
 });
 
 it("symlink", () => {
-  const actual = join(tmpdir(), Math.random().toString(32) + "-fs-symlink.txt");
+  const actual = join(tmpdirSync(), "fs-symlink.txt");
   try {
     unlinkSync(actual);
   } catch (e) {}
@@ -1360,7 +1354,7 @@ it("symlink", () => {
 });
 
 it("readlink", () => {
-  const actual = join(tmpdir(), Math.random().toString(32) + "-fs-readlink.txt");
+  const actual = join(tmpdirSync(), "fs-readlink.txt");
   try {
     unlinkSync(actual);
   } catch (e) {}
@@ -1371,7 +1365,7 @@ it("readlink", () => {
 });
 
 it.if(isWindows)("symlink on windows with forward slashes", async () => {
-  const r = join(tmpdir(), Math.random().toString(32));
+  const r = tmpdirSync();
   await fs.promises.rm(join(r, "files/2024"), { recursive: true, force: true });
   await fs.promises.mkdir(join(r, "files/2024"), { recursive: true });
   await fs.promises.writeFile(join(r, "files/2024/123.txt"), "text");
@@ -1380,7 +1374,7 @@ it.if(isWindows)("symlink on windows with forward slashes", async () => {
 });
 
 it("realpath async", async () => {
-  const actual = join(tmpdir(), Math.random().toString(32) + "-fs-realpath.txt");
+  const actual = join(tmpdirSync(), "fs-realpath.txt");
   try {
     unlinkSync(actual);
   } catch (e) {}
@@ -1453,7 +1447,7 @@ describe("stat", () => {
 
   it("stat returns ENOENT", () => {
     try {
-      statSync("${tmpdir()}/doesntexist");
+      statSync(`${tmpdir()}/doesntexist`);
       throw "statSync should throw";
     } catch (e: any) {
       expect(e.code).toBe("ENOENT");

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1,12 +1,10 @@
 import { ServerWebSocket, TCPSocket, Socket as _BunSocket, TCPSocketListener } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { connect, isIP, isIPv4, isIPv6, Socket, createConnection, Server } from "net";
-import { realpathSync, mkdtempSync } from "fs";
-import { tmpdir } from "os";
 import { join } from "path";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 
-const socket_domain = mkdtempSync(join(realpathSync(tmpdir()), "node-net"));
+const socket_domain = tmpdirSync();
 
 it("should support net.isIP()", () => {
   expect(isIP("::1")).toBe(6);

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -533,7 +533,7 @@ it("#9242.10 PassThrough has constructor", () => {
 });
 
 it("should send Readable events in the right order", async () => {
-  const package_dir = tmpdirSync("bun-test-node-stream");
+  const package_dir = tmpdirSync();
   const fixture_path = join(package_dir, "fixture.js");
 
   await Bun.write(

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -153,7 +153,7 @@ describe("zlib.brotli", () => {
   });
 
   it("fully works as a stream.Transform", async () => {
-    const x_dir = tmpdirSync("bun.test.");
+    const x_dir = tmpdirSync();
     const out_path_c = resolve(x_dir, "this.js.br");
     const out_path_d = resolve(x_dir, "this.js");
 

--- a/test/js/third_party/st.test.ts
+++ b/test/js/third_party/st.test.ts
@@ -5,7 +5,7 @@ const { describe, expect, it, beforeAll, afterAll, createDoneDotAll } = createTe
 import * as path from "node:path";
 
 it("works", async () => {
-  const package_dir = tmpdirSync("bun-test-");
+  const package_dir = tmpdirSync();
 
   let { stdout, stderr, exited } = Bun.spawn({
     cmd: [bunExe(), "add", "st@3.0.0"],

--- a/test/js/third_party/stripe.test.ts
+++ b/test/js/third_party/stripe.test.ts
@@ -5,7 +5,7 @@ import { createTest } from "node-harness";
 const { describe, expect, it, beforeAll, afterAll, createDoneDotAll } = createTest(import.meta.path);
 
 it.skipIf(!process.env.TEST_INFO_STRIPE)("should be able to query a charge", async () => {
-  const package_dir = tmpdirSync("bun-test-");
+  const package_dir = tmpdirSync();
 
   await Bun.write(
     path.join(package_dir, "package.json"),

--- a/test/js/web/abort/abort.test.ts
+++ b/test/js/web/abort/abort.test.ts
@@ -1,15 +1,15 @@
 import { describe, test, expect } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { bunExe, bunEnv, tmpdirSync } from "harness";
 import { writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
 describe("AbortSignal", () => {
   test("spawn test", async () => {
-    const fileName = `/abort-${Date.now()}.test.ts`;
+    const fileName = `/abort.test.ts`;
     const testFileContents = await Bun.file(join(import.meta.dir, "abort.ts")).arrayBuffer();
 
-    writeFileSync(join(tmpdir(), fileName), testFileContents, "utf8");
+    writeFileSync(join(tmpdirSync(), fileName), testFileContents, "utf8");
     const { stderr } = Bun.spawnSync({
       cmd: [bunExe(), "test", fileName],
       env: bunEnv,

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -1,14 +1,13 @@
 import { AnyFunction, serve, ServeOptions, Server, sleep, TCPSocketListener } from "bun";
 import { afterAll, afterEach, beforeAll, describe, expect, it, beforeEach } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { mkfifo } from "mkfifo";
-import { tmpdir } from "os";
 import { gzipSync } from "zlib";
 import { join } from "path";
-import { gc, withoutAggressiveGC, gcTick, isWindows } from "harness";
+import { gc, withoutAggressiveGC, gcTick, isWindows, tmpdirSync } from "harness";
 import net from "net";
 
-const tmp_dir = mkdtempSync(join(realpathSync(tmpdir()), "fetch.test"));
+const tmp_dir = tmpdirSync();
 
 const fixture = readFileSync(join(import.meta.dir, "fetch.js.txt"), "utf8").replaceAll("\r\n", "\n");
 

--- a/test/js/web/fetch/fetch.unix.test.ts
+++ b/test/js/web/fetch/fetch.unix.test.ts
@@ -1,11 +1,10 @@
 import { serve, ServeOptions, Server } from "bun";
 import { afterAll, afterEach, expect, it } from "bun:test";
-import { mkdtempSync, realpathSync, rmSync } from "fs";
-import { tmpdir } from "os";
+import { rmSync } from "fs";
 import { join } from "path";
 import { request } from "http";
-import { isWindows } from "harness";
-const tmp_dir = join(realpathSync(tmpdir()));
+import { isWindows, tmpdirSync } from "harness";
+const tmp_dir = tmpdirSync();
 
 it("throws ENAMETOOLONG when socket path exceeds platform-specific limit", () => {
   // this must be the filename specifically, because we add a workaround for the length limit on linux

--- a/test/node.js/runner.mjs
+++ b/test/node.js/runner.mjs
@@ -140,7 +140,7 @@ async function runTests(options, filters) {
     }
 
     const { pathname: filePath } = new URL(filename, testPath);
-    const tmp = mkdtempSync(join(tmpdir(), "bun-"));
+    const tmp = tmpdirSync();
     const timestamp = Date.now();
     const {
       status: exitCode,

--- a/test/regression/issue/00631.test.ts
+++ b/test/regression/issue/00631.test.ts
@@ -1,11 +1,10 @@
 import { expect, it } from "bun:test";
-import { bunExe, bunEnv } from "../../harness.js";
-import { mkdirSync, rmSync, writeFileSync, readFileSync, mkdtempSync } from "fs";
-import { tmpdir } from "os";
+import { bunExe, bunEnv, tmpdirSync } from "../../harness.js";
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from "fs";
 import { join } from "path";
 
 it("JSON strings escaped properly", async () => {
-  const testDir = mkdtempSync(join(tmpdir(), "issue631-"));
+  const testDir = tmpdirSync();
 
   // Clean up from prior runs if necessary
   rmSync(testDir, { recursive: true, force: true });

--- a/test/regression/issue/03216.test.ts
+++ b/test/regression/issue/03216.test.ts
@@ -1,12 +1,11 @@
 // https://github.com/oven-sh/bun/issues/3216
 import { test, expect } from "bun:test";
-import { tmpdir } from "os";
-import { mkdtempSync, writeFileSync } from "fs";
+import { writeFileSync } from "fs";
 import { join } from "path";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 
 test("runtime directory caching gets invalidated", () => {
-  const tmp = mkdtempSync(join(tmpdir(), "bun-test-"));
+  const tmp = tmpdirSync();
   writeFileSync(
     join(tmp, "index.ts"),
     `const file = \`\${import.meta.dir}/temp.mjs\`;

--- a/test/regression/issue/03830.test.ts
+++ b/test/regression/issue/03830.test.ts
@@ -1,14 +1,13 @@
 import { it, expect } from "bun:test";
-import { bunEnv, bunExe } from "harness";
-import { mkdirSync, rmSync, writeFileSync, readFileSync, mkdtempSync, realpathSync } from "fs";
-import { tmpdir } from "os";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { mkdirSync, rmSync, writeFileSync, realpathSync } from "fs";
 import { join } from "path";
 
 it("macros should not lead to seg faults under any given input", async () => {
   // this test code follows the same structure as and
   // is based on the code for testing issue 4893
 
-  let testDir = mkdtempSync(join(tmpdir(), "issue3830-"));
+  let testDir = tmpdirSync();
 
   // Clean up from prior runs if necessary
   rmSync(testDir, { recursive: true, force: true });

--- a/test/regression/issue/04893.test.ts
+++ b/test/regression/issue/04893.test.ts
@@ -1,10 +1,10 @@
-import { bunEnv, bunExe } from "harness";
-import { mkdirSync, rmSync, writeFileSync, readFileSync, mkdtempSync } from "fs";
-import { tmpdir } from "os";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
+import { it, expect } from "bun:test";
 
 it("correctly handles CRLF multiline string in CRLF terminated files", async () => {
-  const testDir = mkdtempSync(join(tmpdir(), "issue4893-"));
+  const testDir = tmpdirSync();
 
   // Clean up from prior runs if necessary
   rmSync(testDir, { recursive: true, force: true });

--- a/test/regression/issue/07261.test.ts
+++ b/test/regression/issue/07261.test.ts
@@ -1,10 +1,10 @@
-import { bunEnv, bunExe } from "harness";
-import { mkdirSync, rmSync, writeFileSync, mkdtempSync } from "fs";
-import { tmpdir } from "os";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
+import { it, expect } from "bun:test";
 
 it("imports tsconfig.json with abritary keys", async () => {
-  const testDir = mkdtempSync(join(tmpdir(), "issue7261-"));
+  const testDir = tmpdirSync();
 
   // Clean up from prior runs if necessary
   rmSync(testDir, { recursive: true, force: true });

--- a/test/regression/issue/07500.test.ts
+++ b/test/regression/issue/07500.test.ts
@@ -1,9 +1,9 @@
 import { test, expect } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 test("7500 - Bun.stdin.text() doesn't read all data", async () => {
-  const filename = join(tmpdir(), "bun.test.offset." + Date.now() + ".txt");
+  const filename = join(tmpdirSync(), "bun.test.offset.txt");
   const text = "contents of file to be read with several lines of text and lots and lots and lots and lots of bytes! "
     .repeat(1000)
     .repeat(9)

--- a/test/regression/issue/08757.test.ts
+++ b/test/regression/issue/08757.test.ts
@@ -1,7 +1,6 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, symlinkSync } from "fs";
-import { tmpdir } from "os";
-import { bunRun } from "../../harness";
+import { symlinkSync } from "fs";
+import { bunRun, tmpdirSync } from "../../harness";
 
 if (process.env.IS_SUBPROCESS) {
   console.log(process.argv[1]);
@@ -14,7 +13,7 @@ if (process.env.IS_SUBPROCESS) {
 }
 
 test("absolute path to a file that is symlinked has import.meta.main", () => {
-  const root = mkdtempSync(tmpdir() + "/bun-08757-");
+  const root = tmpdirSync();
   try {
     symlinkSync(process.argv[1], root + "/main.js");
   } catch (e) {

--- a/test/transpiler/transpiler-stack-overflow.test.ts
+++ b/test/transpiler/transpiler-stack-overflow.test.ts
@@ -1,15 +1,11 @@
 import { test, expect } from "bun:test";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { join } from "path";
-import { tmpdir } from "node:os";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 
 test("long chain of expressions does not cause stack overflow", () => {
   const chain = `globalThis.a = {};` + "\n" + `globalThis.a + globalThis.a +`.repeat(1000000) + `globalThis.a` + "\n";
-  const temp_dir = join(
-    tmpdir(),
-    `bun-test-transpiler-cache-${Date.now()}-` + (Math.random() * 81023).toString(36).slice(2),
-  );
+  const temp_dir = tmpdirSync();
   mkdirSync(temp_dir, { recursive: true });
   writeFileSync(join(temp_dir, "index.js"), chain, "utf-8");
   const { exitCode } = Bun.spawnSync({


### PR DESCRIPTION
this makes clearing the bun folders in the system temp directory much easier as they all use the same naming scheme with this patch. as well as ensures all created folders are unique, rather than leaving it up to an impromptu randomness algorithm