### PR TITLE
Fix `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD` env var

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -890,7 +890,7 @@ pub const VirtualMachine = struct {
 
     pub fn reload(this: *VirtualMachine) void {
         Output.debug("Reloading...", .{});
-        const should_clear_terminal = !this.bundler.env.hasSetNoClearTerminalOnReload() and Output.enable_ansi_colors;
+        const should_clear_terminal = !this.bundler.env.hasSetNoClearTerminalOnReload(Output.enable_ansi_colors);
         if (this.hot_reload == .watch) {
             Output.flush();
             bun.reloadProcess(
@@ -3589,7 +3589,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                 this.bundler.resolver.watcher = Resolver.ResolveWatcher(*@This().Watcher, onMaybeWatchDirectory).init(this.bun_watcher.?);
             }
 
-            clear_screen = Output.enable_ansi_colors and !this.bundler.env.hasSetNoClearTerminalOnReload();
+            clear_screen = !this.bundler.env.hasSetNoClearTerminalOnReload(Output.enable_ansi_colors);
 
             reloader.getContext().start() catch @panic("Failed to start File Watcher");
         }

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -890,16 +890,17 @@ pub const VirtualMachine = struct {
 
     pub fn reload(this: *VirtualMachine) void {
         Output.debug("Reloading...", .{});
+        const should_clear_terminal = !this.bundler.env.hasSetNoClearTerminalOnReload() and Output.enable_ansi_colors;
         if (this.hot_reload == .watch) {
             Output.flush();
             bun.reloadProcess(
                 bun.default_allocator,
-                !strings.eqlComptime(this.bundler.env.get("BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD") orelse "0", "true"),
+                should_clear_terminal,
                 false,
             );
         }
 
-        if (!strings.eqlComptime(this.bundler.env.get("BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD") orelse "0", "true")) {
+        if (should_clear_terminal) {
             Output.flush();
             Output.disableBuffering();
             Output.resetTerminalAll();
@@ -3588,7 +3589,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                 this.bundler.resolver.watcher = Resolver.ResolveWatcher(*@This().Watcher, onMaybeWatchDirectory).init(this.bun_watcher.?);
             }
 
-            clear_screen = Output.enable_ansi_colors and !strings.eqlComptime(this.bundler.env.get("BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD") orelse "0", "true");
+            clear_screen = Output.enable_ansi_colors and !this.bundler.env.hasSetNoClearTerminalOnReload();
 
             reloader.getContext().start() catch @panic("Failed to start File Watcher");
         }

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -890,7 +890,7 @@ pub const VirtualMachine = struct {
 
     pub fn reload(this: *VirtualMachine) void {
         Output.debug("Reloading...", .{});
-        const should_clear_terminal = !this.bundler.env.hasSetNoClearTerminalOnReload(Output.enable_ansi_colors);
+        const should_clear_terminal = !this.bundler.env.hasSetNoClearTerminalOnReload(!Output.enable_ansi_colors);
         if (this.hot_reload == .watch) {
             Output.flush();
             bun.reloadProcess(
@@ -3589,7 +3589,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                 this.bundler.resolver.watcher = Resolver.ResolveWatcher(*@This().Watcher, onMaybeWatchDirectory).init(this.bun_watcher.?);
             }
 
-            clear_screen = !this.bundler.env.hasSetNoClearTerminalOnReload(Output.enable_ansi_colors);
+            clear_screen = !this.bundler.env.hasSetNoClearTerminalOnReload(!Output.enable_ansi_colors);
 
             reloader.getContext().start() catch @panic("Failed to start File Watcher");
         }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -170,6 +170,7 @@ pub const Arguments = struct {
     const runtime_params_ = [_]ParamType{
         clap.parseParam("--watch                           Automatically restart the process on file change") catch unreachable,
         clap.parseParam("--hot                             Enable auto reload in the Bun runtime, test runner, or bundler") catch unreachable,
+        clap.parseParam("--no-clear-screen                 Disable clearing the terminal screen on reload when --hot or --watch is enabled") catch unreachable,
         clap.parseParam("--smol                            Use less memory, but run garbage collection more often") catch unreachable,
         clap.parseParam("-r, --preload <STR>...            Import a module before other modules are loaded") catch unreachable,
         clap.parseParam("--inspect <STR>?                  Activate Bun's debugger") catch unreachable,
@@ -214,9 +215,10 @@ pub const Arguments = struct {
     const build_only_params = [_]ParamType{
         clap.parseParam("--compile                        Generate a standalone Bun executable containing your bundled code") catch unreachable,
         clap.parseParam("--watch                          Automatically restart the process on file change") catch unreachable,
+        clap.parseParam("--no-clear-screen                Disable clearing the terminal screen on reload when --watch is enabled") catch unreachable,
         clap.parseParam("--target <STR>                   The intended execution environment for the bundle. \"browser\", \"bun\" or \"node\"") catch unreachable,
         clap.parseParam("--outdir <STR>                   Default to \"dist\" if multiple files") catch unreachable,
-        clap.parseParam("--outfile <STR>                  Write to a file") catch unreachable,
+        clap.parseParam("--outfile <STR>                   Write to a file") catch unreachable,
         clap.parseParam("--sourcemap <STR>?               Build with sourcemaps - 'inline', 'external', or 'none'") catch unreachable,
         clap.parseParam("--format <STR>                   Specifies the module format to build to. Only \"esm\" is supported.") catch unreachable,
         clap.parseParam("--root <STR>                     Root directory used for multiple entry points") catch unreachable,
@@ -231,7 +233,7 @@ pub const Arguments = struct {
         clap.parseParam("--minify                         Enable all minification flags") catch unreachable,
         clap.parseParam("--minify-syntax                  Minify syntax and inline data") catch unreachable,
         clap.parseParam("--minify-whitespace              Minify whitespace") catch unreachable,
-        clap.parseParam("--minify-identifiers             Minify identifiers") catch unreachable,
+        clap.parseParam("--minify-identifiers              Minify identifiers") catch unreachable,
         clap.parseParam("--dump-environment-variables") catch unreachable,
         clap.parseParam("--conditions <STR>...            Pass custom conditions to resolve") catch unreachable,
     };
@@ -532,9 +534,15 @@ pub const Arguments = struct {
 
             if (args.flag("--hot")) {
                 ctx.debug.hot_reload = .hot;
+                if (args.flag("--no-clear-screen")) {
+                    bun.DotEnv.Loader.has_no_clear_screen_cli_flag = true;
+                }
             } else if (args.flag("--watch")) {
                 ctx.debug.hot_reload = .watch;
                 bun.auto_reload_on_crash = true;
+                if (args.flag("--no-clear-screen")) {
+                    bun.DotEnv.Loader.has_no_clear_screen_cli_flag = true;
+                }
             }
 
             if (args.option("--origin")) |origin| {
@@ -692,6 +700,10 @@ pub const Arguments = struct {
             if (args.flag("--watch")) {
                 ctx.debug.hot_reload = .watch;
                 bun.auto_reload_on_crash = true;
+
+                if (args.flag("--no-clear-screen")) {
+                    bun.DotEnv.Loader.has_no_clear_screen_cli_flag = true;
+                }
             }
 
             if (args.flag("--compile")) {

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -256,9 +256,10 @@ pub const Loader = struct {
         }
     }
 
+    pub var has_no_clear_screen_cli_flag: ?bool = null;
     /// Returns whether the `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD` env var is set to something truthy
     pub fn hasSetNoClearTerminalOnReload(this: *const Loader, default_value: bool) bool {
-        return this.getAs(bool, "BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD") orelse default_value;
+        return (has_no_clear_screen_cli_flag orelse this.getAs(bool, "BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD")) orelse default_value;
     }
 
     pub fn get(this: *const Loader, key: string) ?string {

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -257,8 +257,8 @@ pub const Loader = struct {
     }
 
     /// Returns whether the `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD` env var is set to something truthy
-    pub fn hasSetNoClearTerminalOnReload(this: *const Loader) bool {
-        return this.getAs(bool, "BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD") orelse false;
+    pub fn hasSetNoClearTerminalOnReload(this: *const Loader, default_value: bool) bool {
+        return this.getAs(bool, "BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD") orelse default_value;
     }
 
     pub fn get(this: *const Loader, key: string) ?string {

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -240,6 +240,27 @@ pub const Loader = struct {
         return true;
     }
 
+    pub fn getAs(this: *const Loader, comptime T: type, key: string) ?T {
+        const value = this.get(key) orelse return null;
+        switch (comptime T) {
+            bool => {
+                if (strings.eqlComptime(value, "")) return false;
+                if (strings.eqlComptime(value, "0")) return false;
+                if (strings.eqlComptime(value, "NO")) return false;
+                if (strings.eqlComptime(value, "OFF")) return false;
+                if (strings.eqlComptime(value, "false")) return false;
+
+                return true;
+            },
+            else => @compileError("Implement getAs for this type"),
+        }
+    }
+
+    /// Returns whether the `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD` env var is set to something truthy
+    pub fn hasSetNoClearTerminalOnReload(this: *const Loader) bool {
+        return this.getAs(bool, "BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD") orelse false;
+    }
+
     pub fn get(this: *const Loader, key: string) ?string {
         var _key = key;
         if (_key.len > 0 and _key[0] == '$') {


### PR DESCRIPTION
### What does this PR do?

Fix `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD` env var so that it handles more ways to say false. Any value which is not a falsy value makes it set to true, if it is set

For example:
- `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD=123 bun --watch src/server.ts` will disable clearing the screen
- `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD=0 bun --watch src/server.ts` will enable clearing the screen
- `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD= bun --watch src/server.ts` will enable clearing the screen

Fixes https://github.com/oven-sh/bun/issues/10725

### How did you verify your code works?

Did not test it. 