### PR TITLE
Fix bug with errname not allowing double numbers as ints

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -2610,12 +2610,12 @@ JSC_DEFINE_CUSTOM_SETTER(setProcessDebugPort,
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue value = JSValue::decode(encodedValue);
 
-    if (!value.isInt32()) {
+    if (!value.isInt32AsAnyInt()) {
         throwRangeError(globalObject, scope, "debugPort must be 0 or in range 1024 to 65535"_s);
         return false;
     }
 
-    int port = value.asInt32();
+    int port = value.toInt32(globalObject);
 
     if (port != 0) {
         if (port < 1024 || port > 65535) {

--- a/src/bun.js/bindings/ProcessBindingUV.cpp
+++ b/src/bun.js/bindings/ProcessBindingUV.cpp
@@ -1,4 +1,7 @@
 #include "ProcessBindingUV.h"
+#include "JavaScriptCore/ArrayAllocationProfile.h"
+#include "JavaScriptCore/JSCJSValue.h"
+#include "JavaScriptCore/ThrowScope.h"
 #include "ZigGlobalObject.h"
 #include "JavaScriptCore/ObjectConstructor.h"
 #include "JavaScriptCore/JSMap.h"
@@ -98,14 +101,17 @@ namespace ProcessBindingUV {
 
 JSC_DEFINE_HOST_FUNCTION(jsErrname, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    auto arg0 = callFrame->argument(0);
     auto& vm = globalObject->vm();
+    auto arg0 = callFrame->argument(0);
 
-    // Node.js will actualy crash here, lol.
-    if (!arg0.isInt32())
-        return JSValue::encode(jsString(vm, makeString("Unknown system error "_s, arg0.toWTFString(globalObject))));
+    // Node.js crashes here:
+    // However, we should ensure this function never throws
+    // That's why we do not call toPrimitive here or throw on invalid input.
+    if (UNLIKELY(!arg0.isInt32AsAnyInt())) {
+        return JSValue::encode(jsString(vm, String("Unknown system error"_s)));
+    }
 
-    auto err = arg0.asInt32();
+    auto err = arg0.toInt32(globalObject);
     switch (err) {
 #define CASE(name, value, desc) \
     case value:                 \
@@ -113,9 +119,12 @@ JSC_DEFINE_HOST_FUNCTION(jsErrname, (JSGlobalObject * globalObject, JSC::CallFra
 
         BUN_UV_ERRNO_MAP(CASE)
 #undef CASE
+    default: {
+        break;
+    }
     }
 
-    return JSValue::encode(jsString(vm, makeString("Unknown system error "_s, String::number(err))));
+    return JSValue::encode(jsString(vm, String("Unknown system error"_s)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsGetErrorMap, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -123,12 +132,12 @@ JSC_DEFINE_HOST_FUNCTION(jsGetErrorMap, (JSGlobalObject * globalObject, JSC::Cal
     auto& vm = globalObject->vm();
     auto map = JSC::JSMap::create(vm, globalObject->mapStructure());
 
-#define PUT_PROPERTY(name, value, desc)                                             \
-    {                                                                               \
-        auto arr = JSC::constructEmptyArray(globalObject, nullptr, 2);              \
-        arr->putDirectIndex(globalObject, 0, JSC::jsString(vm, String(#name##_s))); \
-        arr->putDirectIndex(globalObject, 1, JSC::jsString(vm, String(desc##_s)));  \
-        map->set(globalObject, JSC::jsNumber(value), arr);                          \
+#define PUT_PROPERTY(name, value, desc)                                                                           \
+    {                                                                                                             \
+        auto arr = JSC::constructEmptyArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), 2); \
+        arr->putDirectIndex(globalObject, 0, JSC::jsString(vm, String(#name##_s)));                               \
+        arr->putDirectIndex(globalObject, 1, JSC::jsString(vm, String(desc##_s)));                                \
+        map->set(globalObject, JSC::jsNumber(value), arr);                                                        \
     }
 
     BUN_UV_ERRNO_MAP(PUT_PROPERTY)
@@ -140,7 +149,7 @@ JSC_DEFINE_HOST_FUNCTION(jsGetErrorMap, (JSGlobalObject * globalObject, JSC::Cal
 JSObject* create(VM& vm, JSGlobalObject* globalObject)
 {
     auto bindingObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
-
+    EnsureStillAliveScope ensureStillAlive(bindingObject);
     bindingObject->putDirect(vm, JSC::Identifier::fromString(vm, "errname"_s), JSC::JSFunction::create(vm, globalObject, 1, "errname"_s, jsErrname, ImplementationVisibility::Public));
 
 #define PUT_PROPERTY(name, value, desc) \

--- a/src/bun.js/bindings/ProcessBindingUV.cpp
+++ b/src/bun.js/bindings/ProcessBindingUV.cpp
@@ -124,7 +124,7 @@ JSC_DEFINE_HOST_FUNCTION(jsErrname, (JSGlobalObject * globalObject, JSC::CallFra
     }
     }
 
-    return JSValue::encode(jsString(vm, String("Unknown system error"_s)));
+    return JSValue::encode(jsString(vm, makeString("Unknown system error: "_s, err)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsGetErrorMap, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/test/js/node/process-binding.test.ts
+++ b/test/js/node/process-binding.test.ts
@@ -17,7 +17,11 @@ describe("process.binding", () => {
     expect(uv).toHaveProperty("errname");
     expect(uv).toHaveProperty("UV_EACCES");
     expect(uv.errname(-4)).toBe("EINTR");
-    expect(uv.errname(5)).toBe("Unknown system error 5");
+    // force the number to be represented as a double
+    expect(uv.errname(Number("-5.9") + 1.9)).toBe("EINTR");
+    expect(uv.errname(-4)).toBe("EINTR");
+
+    expect(uv.errname(5)).toBe("Unknown system error");
 
     const map = uv.getErrorMap();
     expect(map).toBeDefined();

--- a/test/js/node/process-binding.test.ts
+++ b/test/js/node/process-binding.test.ts
@@ -21,7 +21,7 @@ describe("process.binding", () => {
     expect(uv.errname(Number("-5.9") + 1.9)).toBe("EINTR");
     expect(uv.errname(-4)).toBe("EINTR");
 
-    expect(uv.errname(5)).toBe("Unknown system error");
+    expect(uv.errname(5)).toBe("Unknown system error: 5");
 
     const map = uv.getErrorMap();
     expect(map).toBeDefined();


### PR DESCRIPTION
### What does this PR do?

`errname` is in the stack trace here: https://github.com/oven-sh/bun/issues/11014

I suspect the stacktrace is wrong due to some bug in our stack trace code (cc @paperdave) but noticed a couple things in `process.binding("uv")` nonetheless

### How did you verify your code works?

Test