### PR TITLE
test: use resource disposal to ensure servers shutdown even if tests fail

### DIFF
--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -106,7 +106,7 @@ describe("bundler", () => {
         );
 
         const port = 0;
-        const server = Bun.serve({
+        using server = Bun.serve({
           port,
           async fetch(req) {
             return new Response(await renderToReadableStream(<App />), headers);
@@ -115,7 +115,6 @@ describe("bundler", () => {
         const res = await fetch(server.url);
         if (res.status !== 200) throw "status error";
         console.log(await res.text());
-        server.stop(true);
       `,
     },
     run: {

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -1,5 +1,3 @@
-import assert from "assert";
-import dedent from "dedent";
 import { ESBUILD, itBundled, testForFile } from "./expectBundled";
 var { describe, test, expect } = testForFile(import.meta.path);
 
@@ -28,7 +26,7 @@ describe("bundler", () => {
         );
 
         const port = 42001;
-        const server = Bun.serve({
+        using server = Bun.serve({
           port,
           async fetch(req) {
             return new Response(await renderToReadableStream(<App />), headers);
@@ -37,7 +35,6 @@ describe("bundler", () => {
         const res = await fetch("http://localhost:" + port);
         if (res.status !== 200) throw "status error";
         console.log(await res.text());
-        server.stop();
       `,
     },
     run: {

--- a/test/cli/install/bun-install-pathname-trailing-slash.test.ts
+++ b/test/cli/install/bun-install-pathname-trailing-slash.test.ts
@@ -12,7 +12,7 @@ beforeEach(() => {
 test("custom registry doesn't have multiple trailing slashes in pathname", async () => {
   const urls: string[] = [];
 
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     async fetch(req) {
       urls.push(req.url);
@@ -48,7 +48,6 @@ registry = "http://${hostname}:${port}/prefixed-route/"
     stdin: "ignore",
   });
 
-  server.stop(true);
   expect(urls.length).toBe(1);
   expect(urls).toEqual([`http://${hostname}:${port}/prefixed-route/react`]);
 });

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -15,7 +15,6 @@ beforeEach(async () => {
 });
 
 it("two invalid arguments, should display error message and suggest command", async () => {
-  console.log(run_dir, exe_name);
   const { stderr } = spawn({
     cmd: [join(run_dir, exe_name), "upgrade", "bun-types", "--dev"],
     cwd: run_dir,
@@ -93,7 +92,7 @@ it("two valid argument, should succeed", async () => {
 });
 
 it("zero arguments, should succeed", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     tls: {
       cert: "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAKLdQVPy90jjMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTkwMjAzMTQ0OTM1WhcNMjAwMjAzMTQ0OTM1WjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEA7i7IIEdICTiSTVx+ma6xHxOtcbd6wGW3nkxlCkJ1UuV8NmY5ovMsGnGD\nhJJtUQ2j5ig5BcJUf3tezqCNW4tKnSOgSISfEAKvpn2BPvaFq3yx2Yjz0ruvcGKp\nDMZBXmB/AAtGyN/UFXzkrcfppmLHJTaBYGG6KnmU43gPkSDy4iw46CJFUOupc51A\nFIz7RsE7mbT1plCM8e75gfqaZSn2k+Wmy+8n1HGyYHhVISRVvPqkS7gVLSVEdTea\nUtKP1Vx/818/HDWk3oIvDVWI9CFH73elNxBkMH5zArSNIBTehdnehyAevjY4RaC/\nkK8rslO3e4EtJ9SnA4swOjCiqAIQEwIDAQABo1AwTjAdBgNVHQ4EFgQUv5rc9Smm\n9c4YnNf3hR49t4rH4yswHwYDVR0jBBgwFoAUv5rc9Smm9c4YnNf3hR49t4rH4ysw\nDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEATcL9CAAXg0u//eYUAlQa\nL+l8yKHS1rsq1sdmx7pvsmfZ2g8ONQGfSF3TkzkI2OOnCBokeqAYuyT8awfdNUtE\nEHOihv4ZzhK2YZVuy0fHX2d4cCFeQpdxno7aN6B37qtsLIRZxkD8PU60Dfu9ea5F\nDDynnD0TUabna6a0iGn77yD8GPhjaJMOz3gMYjQFqsKL252isDVHEDbpVxIzxPmN\nw1+WK8zRNdunAcHikeoKCuAPvlZ83gDQHp07dYdbuZvHwGj0nfxBLc9qt90XsBtC\n4IYR7c/bcLMmKXYf0qoQ4OzngsnPI5M+v9QEHvYWaKVwFY4CTcSNJEwfXw+BAeO5\nOA==\n-----END CERTIFICATE-----",
       key: "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDuLsggR0gJOJJN\nXH6ZrrEfE61xt3rAZbeeTGUKQnVS5Xw2Zjmi8ywacYOEkm1RDaPmKDkFwlR/e17O\noI1bi0qdI6BIhJ8QAq+mfYE+9oWrfLHZiPPSu69wYqkMxkFeYH8AC0bI39QVfOSt\nx+mmYsclNoFgYboqeZTjeA+RIPLiLDjoIkVQ66lznUAUjPtGwTuZtPWmUIzx7vmB\n+pplKfaT5abL7yfUcbJgeFUhJFW8+qRLuBUtJUR1N5pS0o/VXH/zXz8cNaTegi8N\nVYj0IUfvd6U3EGQwfnMCtI0gFN6F2d6HIB6+NjhFoL+QryuyU7d7gS0n1KcDizA6\nMKKoAhATAgMBAAECggEAd5g/3o1MK20fcP7PhsVDpHIR9faGCVNJto9vcI5cMMqP\n6xS7PgnSDFkRC6EmiLtLn8Z0k2K3YOeGfEP7lorDZVG9KoyE/doLbpK4MfBAwBG1\nj6AHpbmd5tVzQrnNmuDjBBelbDmPWVbD0EqAFI6mphXPMqD/hFJWIz1mu52Kt2s6\n++MkdqLO0ORDNhKmzu6SADQEcJ9Suhcmv8nccMmwCsIQAUrfg3qOyqU4//8QB8ZM\njosO3gMUesihVeuF5XpptFjrAliPgw9uIG0aQkhVbf/17qy0XRi8dkqXj3efxEDp\n1LSqZjBFiqJlFchbz19clwavMF/FhxHpKIhhmkkRSQKBgQD9blaWSg/2AGNhRfpX\nYq+6yKUkUD4jL7pmX1BVca6dXqILWtHl2afWeUorgv2QaK1/MJDH9Gz9Gu58hJb3\nymdeAISwPyHp8euyLIfiXSAi+ibKXkxkl1KQSweBM2oucnLsNne6Iv6QmXPpXtro\nnTMoGQDS7HVRy1on5NQLMPbUBQKBgQDwmN+um8F3CW6ZV1ZljJm7BFAgNyJ7m/5Q\nYUcOO5rFbNsHexStrx/h8jYnpdpIVlxACjh1xIyJ3lOCSAWfBWCS6KpgeO1Y484k\nEYhGjoUsKNQia8UWVt+uWnwjVSDhQjy5/pSH9xyFrUfDg8JnSlhsy0oC0C/PBjxn\nhxmADSLnNwKBgQD2A51USVMTKC9Q50BsgeU6+bmt9aNMPvHAnPf76d5q78l4IlKt\nwMs33QgOExuYirUZSgjRwknmrbUi9QckRbxwOSqVeMOwOWLm1GmYaXRf39u2CTI5\nV9gTMHJ5jnKd4gYDnaA99eiOcBhgS+9PbgKSAyuUlWwR2ciL/4uDzaVeDQKBgDym\nvRSeTRn99bSQMMZuuD5N6wkD/RxeCbEnpKrw2aZVN63eGCtkj0v9LCu4gptjseOu\n7+a4Qplqw3B/SXN5/otqPbEOKv8Shl/PT6RBv06PiFKZClkEU2T3iH27sws2EGru\nw3C3GaiVMxcVewdg1YOvh5vH8ZVlxApxIzuFlDvnAoGAN5w+gukxd5QnP/7hcLDZ\nF+vesAykJX71AuqFXB4Wh/qFY92CSm7ImexWA/L9z461+NKeJwb64Nc53z59oA10\n/3o2OcIe44kddZXQVP6KTZBd7ySVhbtOiK3/pCy+BQRsrC7d71W914DxNWadwZ+a\njtwwKjDzmPwdIXDSQarCx0U=\n-----END PRIVATE KEY-----",
@@ -170,7 +169,6 @@ it("zero arguments, should succeed", async () => {
     },
   });
 
-  server.stop();
   closeTempDirHandle();
 
   // Should not contain error message

--- a/test/js/bun/eventsource/eventsource.test.ts
+++ b/test/js/bun/eventsource/eventsource.test.ts
@@ -43,7 +43,7 @@
 //   pathname: string,
 //   callback: (evtSource: EventSource, done: (err?: unknown) => void) => void,
 // ) {
-//   const server = Bun.serve({
+//   using server = Bun.serve({
 //     port: 0,
 //     fetch(req) {
 //       if (new URL(req.url).pathname === "/stream") {
@@ -70,7 +70,6 @@
 //     });
 //   } catch (err) {
 //     evtSource?.close();
-//     server.stop(true);
 //     done(err);
 //   }
 // }

--- a/test/js/bun/http/async-iterator-stream.test.ts
+++ b/test/js/bun/http/async-iterator-stream.test.ts
@@ -4,7 +4,7 @@ import { bunExe, bunEnv } from "harness";
 
 describe("Streaming body via", () => {
   test("async generator function", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
 
       async fetch(req) {
@@ -25,7 +25,6 @@ describe("Streaming body via", () => {
 
     expect(Buffer.concat(chunks).toString()).toBe("Hello, world!!");
     expect(chunks).toHaveLength(2);
-    server.stop(true);
   });
 
   test("async generator function throws an error but continues to send the headers", async () => {
@@ -58,7 +57,7 @@ describe("Streaming body via", () => {
 
   test("async generator aborted doesn't crash", async () => {
     var aborter = new AbortController();
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
 
       async fetch(req) {
@@ -81,13 +80,11 @@ describe("Streaming body via", () => {
     } catch (e) {
       expect(e).toBeInstanceOf(DOMException);
       expect(e.name).toBe("AbortError");
-    } finally {
-      server.stop(true);
     }
   });
 
   test("[Symbol.asyncIterator]", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
 
       async fetch(req) {
@@ -114,11 +111,10 @@ describe("Streaming body via", () => {
 
     expect(Buffer.concat(chunks).toString()).toBe("my string goes here\nmy buffer goes here\nend!\n!");
     expect(chunks).toHaveLength(2);
-    server.stop(true);
   });
 
   test("[Symbol.asyncIterator] with a custom iterator", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
 
       async fetch(req) {
@@ -151,7 +147,6 @@ describe("Streaming body via", () => {
     expect(Buffer.concat(chunks).toString()).toBe("Hello, world!");
     // TODO:
     // expect(chunks).toHaveLength(2);
-    server.stop(true);
   });
 
   test("yield", async () => {

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "bun:test";
 
 // https://github.com/oven-sh/bun/issues/9180
 test("weird headers", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     development: false,
     fetch(req) {
@@ -17,7 +17,7 @@ test("weird headers", async () => {
     },
   });
 
-  try {
+  {
     for (let i = 0; i < 255; i++) {
       const headers = new Headers();
       const name = "X-" + String.fromCharCode(i);
@@ -32,7 +32,5 @@ test("weird headers", async () => {
       });
       expect(res.headers.get(name)).toBe("1");
     }
-  } finally {
-    server.stop(true);
   }
 });

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 describe("Server", () => {
   test("normlizes incoming request URLs", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       fetch(request) {
         return new Response(request.url, {
           headers: {
@@ -81,22 +81,19 @@ describe("Server", () => {
       await promise;
     }
 
-    server.stop(true);
     expect(received).toEqual(expected);
   });
 
   test("should not allow Bun.serve without first argument being a object", () => {
     expect(() => {
       //@ts-ignore
-      const server = Bun.serve();
-      server.stop(true);
+      using server = Bun.serve();
     }).toThrow("Bun.serve expects an object");
 
     [undefined, null, 1, "string", true, false, Symbol("symbol")].forEach(value => {
       expect(() => {
         //@ts-ignore
-        const server = Bun.serve(value);
-        server.stop(true);
+        using server = Bun.serve(value);
       }).toThrow("Bun.serve expects an object");
     });
   });
@@ -104,7 +101,7 @@ describe("Server", () => {
   test("should not allow Bun.serve with invalid tls option", () => {
     [1, "string", true, Symbol("symbol"), false].forEach(value => {
       expect(() => {
-        const server = Bun.serve({
+        using server = Bun.serve({
           //@ts-ignore
           tls: value,
           fetch() {
@@ -112,7 +109,6 @@ describe("Server", () => {
           },
           port: 0,
         });
-        server.stop(true);
       }).toThrow("tls option expects an object");
     });
   });
@@ -120,7 +116,7 @@ describe("Server", () => {
   test("should allow Bun.serve using null or undefined tls option", () => {
     [null, undefined].forEach(value => {
       expect(() => {
-        const server = Bun.serve({
+        using server = Bun.serve({
           //@ts-ignore
           tls: value,
           fetch() {
@@ -128,13 +124,12 @@ describe("Server", () => {
           },
           port: 0,
         });
-        server.stop(true);
       }).not.toThrow("tls option expects an object");
     });
   });
 
   test("returns active port when initializing server with 0 port", () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       fetch() {
         return new Response("Hello");
       },
@@ -143,11 +138,10 @@ describe("Server", () => {
 
     expect(server.port).not.toBe(0);
     expect(server.port).toBeDefined();
-    server.stop(true);
   });
 
   test("allows connecting to server", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       fetch() {
         return new Response("Hello");
       },
@@ -156,12 +150,11 @@ describe("Server", () => {
 
     const response = await fetch(`http://${server.hostname}:${server.port}`);
     expect(await response.text()).toBe("Hello");
-    server.stop(true);
   });
 
   test("allows listen on IPV6", async () => {
     {
-      const server = Bun.serve({
+      using server = Bun.serve({
         hostname: "[::1]",
         fetch() {
           return new Response("Hello");
@@ -171,11 +164,10 @@ describe("Server", () => {
 
       expect(server.port).not.toBe(0);
       expect(server.port).toBeDefined();
-      server.stop(true);
     }
 
     {
-      const server = Bun.serve({
+      using server = Bun.serve({
         hostname: "::1",
         fetch() {
           return new Response("Hello");
@@ -185,7 +177,6 @@ describe("Server", () => {
 
       expect(server.port).not.toBe(0);
       expect(server.port).toBeDefined();
-      server.stop(true);
     }
   });
 
@@ -193,7 +184,7 @@ describe("Server", () => {
     {
       let signalOnServer = false;
       const abortController = new AbortController();
-      const server = Bun.serve({
+      using server = Bun.serve({
         async fetch(req) {
           req.signal.addEventListener("abort", () => {
             signalOnServer = true;
@@ -209,7 +200,6 @@ describe("Server", () => {
         await fetch(`http://${server.hostname}:${server.port}`, { signal: abortController.signal });
       } catch {}
       expect(signalOnServer).toBe(true);
-      server.stop(true);
     }
   });
 
@@ -218,7 +208,7 @@ describe("Server", () => {
       const abortController = new AbortController();
 
       let signalOnServer = false;
-      const server = Bun.serve({
+      using server = Bun.serve({
         async fetch(req) {
           req.signal.addEventListener("abort", () => {
             signalOnServer = true;
@@ -232,7 +222,6 @@ describe("Server", () => {
         await fetch(`http://${server.hostname}:${server.port}`, { signal: abortController.signal });
       } catch {}
       expect(signalOnServer).toBe(false);
-      server.stop(true);
     }
   });
 
@@ -241,7 +230,7 @@ describe("Server", () => {
       let signalOnServer = false;
       const abortController = new AbortController();
 
-      const server = Bun.serve({
+      using server = Bun.serve({
         async fetch(req) {
           req.signal.addEventListener("abort", () => {
             signalOnServer = true;
@@ -278,43 +267,38 @@ describe("Server", () => {
       } catch {}
       await Bun.sleep(10);
       expect(signalOnServer).toBe(true);
-      server.stop(true);
     }
   });
 
   test("server.fetch should work with a string", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       fetch(req) {
         return new Response("Hello World!");
       },
     });
-    try {
+    {
       const url = `http://${server.hostname}:${server.port}/`;
       const response = await server.fetch(url);
       expect(await response.text()).toBe("Hello World!");
       expect(response.status).toBe(200);
       expect(response.url).toBe(url);
-    } finally {
-      server.stop(true);
     }
   });
 
   test("server.fetch should work with a Request object", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       fetch(req) {
         return new Response("Hello World!");
       },
     });
-    try {
+    {
       const url = `http://${server.hostname}:${server.port}/`;
       const response = await server.fetch(new Request(url));
       expect(await response.text()).toBe("Hello World!");
       expect(response.status).toBe(200);
       expect(response.url).toBe(url);
-    } finally {
-      server.stop(true);
     }
   });
   test("abort signal on server with stream", async () => {
@@ -322,7 +306,7 @@ describe("Server", () => {
       let signalOnServer = false;
       const abortController = new AbortController();
 
-      const server = Bun.serve({
+      using server = Bun.serve({
         async fetch(req) {
           req.signal.addEventListener("abort", () => {
             signalOnServer = true;
@@ -358,7 +342,6 @@ describe("Server", () => {
       } catch {}
       await Bun.sleep(10);
       expect(signalOnServer).toBe(true);
-      server.stop(true);
     }
   });
 
@@ -385,7 +368,7 @@ describe("Server", () => {
   });
 
   test("handshake failures should not impact future connections", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       tls: {
         cert: "-----BEGIN CERTIFICATE-----\nMIIDrzCCApegAwIBAgIUHaenuNcUAu0tjDZGpc7fK4EX78gwDQYJKoZIhvcNAQEL\nBQAwaTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRYwFAYDVQQHDA1TYW4gRnJh\nbmNpc2NvMQ0wCwYDVQQKDARPdmVuMREwDwYDVQQLDAhUZWFtIEJ1bjETMBEGA1UE\nAwwKc2VydmVyLWJ1bjAeFw0yMzA5MDYyMzI3MzRaFw0yNTA5MDUyMzI3MzRaMGkx\nCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNj\nbzENMAsGA1UECgwET3ZlbjERMA8GA1UECwwIVGVhbSBCdW4xEzARBgNVBAMMCnNl\ncnZlci1idW4wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC+7odzr3yI\nYewRNRGIubF5hzT7Bym2dDab4yhaKf5drL+rcA0J15BM8QJ9iSmL1ovg7x35Q2MB\nKw3rl/Yyy3aJS8whZTUze522El72iZbdNbS+oH6GxB2gcZB6hmUehPjHIUH4icwP\ndwVUeR6fB7vkfDddLXe0Tb4qsO1EK8H0mr5PiQSXfj39Yc1QHY7/gZ/xeSrt/6yn\n0oH9HbjF2XLSL2j6cQPKEayartHN0SwzwLi0eWSzcziVPSQV7c6Lg9UuIHbKlgOF\nzDpcp1p1lRqv2yrT25im/dS6oy9XX+p7EfZxqeqpXX2fr5WKxgnzxI3sW93PG8FU\nIDHtnUsoHX3RAgMBAAGjTzBNMCwGA1UdEQQlMCOCCWxvY2FsaG9zdIcEfwAAAYcQ\nAAAAAAAAAAAAAAAAAAAAATAdBgNVHQ4EFgQUF3y/su4J/8ScpK+rM2LwTct6EQow\nDQYJKoZIhvcNAQELBQADggEBAGWGWp59Bmrk3Gt0bidFLEbvlOgGPWCT9ZrJUjgc\nhY44E+/t4gIBdoKOSwxo1tjtz7WsC2IYReLTXh1vTsgEitk0Bf4y7P40+pBwwZwK\naeIF9+PC6ZoAkXGFRoyEalaPVQDBg/DPOMRG9OH0lKfen9OGkZxmmjRLJzbyfAhU\noI/hExIjV8vehcvaJXmkfybJDYOYkN4BCNqPQHNf87ZNdFCb9Zgxwp/Ou+47J5k4\n5plQ+K7trfKXG3ABMbOJXNt1b0sH8jnpAsyHY4DLEQqxKYADbXsr3YX/yy6c0eOo\nX2bHGD1+zGsb7lGyNyoZrCZ0233glrEM4UxmvldBcWwOWfk=\n-----END CERTIFICATE-----\n",
         key: "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC+7odzr3yIYewR\nNRGIubF5hzT7Bym2dDab4yhaKf5drL+rcA0J15BM8QJ9iSmL1ovg7x35Q2MBKw3r\nl/Yyy3aJS8whZTUze522El72iZbdNbS+oH6GxB2gcZB6hmUehPjHIUH4icwPdwVU\neR6fB7vkfDddLXe0Tb4qsO1EK8H0mr5PiQSXfj39Yc1QHY7/gZ/xeSrt/6yn0oH9\nHbjF2XLSL2j6cQPKEayartHN0SwzwLi0eWSzcziVPSQV7c6Lg9UuIHbKlgOFzDpc\np1p1lRqv2yrT25im/dS6oy9XX+p7EfZxqeqpXX2fr5WKxgnzxI3sW93PG8FUIDHt\nnUsoHX3RAgMBAAECggEAAckMqkn+ER3c7YMsKRLc5bUE9ELe+ftUwfA6G+oXVorn\nE+uWCXGdNqI+TOZkQpurQBWn9IzTwv19QY+H740cxo0ozZVSPE4v4czIilv9XlVw\n3YCNa2uMxeqp76WMbz1xEhaFEgn6ASTVf3hxYJYKM0ljhPX8Vb8wWwlLONxr4w4X\nOnQAB5QE7i7LVRsQIpWKnGsALePeQjzhzUZDhz0UnTyGU6GfC+V+hN3RkC34A8oK\njR3/Wsjahev0Rpb+9Pbu3SgTrZTtQ+srlRrEsDG0wVqxkIk9ueSMOHlEtQ7zYZsk\nlX59Bb8LHNGQD5o+H1EDaC6OCsgzUAAJtDRZsPiZEQKBgQDs+YtVsc9RDMoC0x2y\nlVnP6IUDXt+2UXndZfJI3YS+wsfxiEkgK7G3AhjgB+C+DKEJzptVxP+212hHnXgr\n1gfW/x4g7OWBu4IxFmZ2J/Ojor+prhHJdCvD0VqnMzauzqLTe92aexiexXQGm+WW\nwRl3YZLmkft3rzs3ZPhc1G2X9QKBgQDOQq3rrxcvxSYaDZAb+6B/H7ZE4natMCiz\nLx/cWT8n+/CrJI2v3kDfdPl9yyXIOGrsqFgR3uhiUJnz+oeZFFHfYpslb8KvimHx\nKI+qcVDcprmYyXj2Lrf3fvj4pKorc+8TgOBDUpXIFhFDyM+0DmHLfq+7UqvjU9Hs\nkjER7baQ7QKBgQDTh508jU/FxWi9RL4Jnw9gaunwrEt9bxUc79dp+3J25V+c1k6Q\nDPDBr3mM4PtYKeXF30sBMKwiBf3rj0CpwI+W9ntqYIwtVbdNIfWsGtV8h9YWHG98\nJ9q5HLOS9EAnogPuS27walj7wL1k+NvjydJ1of+DGWQi3aQ6OkMIegap0QKBgBlR\nzCHLa5A8plG6an9U4z3Xubs5BZJ6//QHC+Uzu3IAFmob4Zy+Lr5/kITlpCyw6EdG\n3xDKiUJQXKW7kluzR92hMCRnVMHRvfYpoYEtydxcRxo/WS73SzQBjTSQmicdYzLE\ntkLtZ1+ZfeMRSpXy0gR198KKAnm0d2eQBqAJy0h9AoGBAM80zkd+LehBKq87Zoh7\ndtREVWslRD1C5HvFcAxYxBybcKzVpL89jIRGKB8SoZkF7edzhqvVzAMP0FFsEgCh\naClYGtO+uo+B91+5v2CCqowRJUGfbFOtCuSPR7+B3LDK8pkjK2SQ0mFPUfRA5z0z\nNVWtC0EYNBTRkqhYtqr3ZpUc\n-----END PRIVATE KEY-----\n",
@@ -405,11 +388,9 @@ describe("Server", () => {
       expect(err.code).toBe("ConnectionClosed");
     }
 
-    try {
+    {
       const result = await fetch(`https://${url}`, { tls: { rejectUnauthorized: false } }).then(res => res.text());
       expect(result).toBe("Hello");
-    } finally {
-      server.stop(true);
     }
   });
 
@@ -435,7 +416,7 @@ test("unref keeps process alive for ongoing connections", async () => {
 });
 
 test("Bun does not crash when given invalid config", async () => {
-  const server1 = Bun.serve({
+  await using server1 = Bun.serve({
     fetch(request, server) {
       //
       throw new Error("Should not be called");
@@ -476,6 +457,4 @@ test("Bun does not crash when given invalid config", async () => {
       Bun.serve(options as any);
     }).toThrow();
   }
-
-  server1.stop();
 });

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -7,7 +7,7 @@ test("uploads roundtrip", async () => {
   const body = Bun.file(import.meta.dir + "/fetch.js.txt");
   const bodyText = await body.text();
 
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     development: false,
     async fetch(req) {
@@ -30,8 +30,6 @@ test("uploads roundtrip", async () => {
   expect(res.headers.get("Content-Type")).toBe("text/plain;charset=utf-8");
   const resText = await res.text();
   expect(resText).toBe(bodyText);
-
-  server.stop(true);
 });
 
 // https://github.com/oven-sh/bun/issues/3969
@@ -40,7 +38,7 @@ test("formData uploads roundtrip, with a call to .body", async () => {
   const body = new FormData();
   body.append("file", file, "fetch.js.txt");
 
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     development: false,
     async fetch(req) {
@@ -63,8 +61,6 @@ test("formData uploads roundtrip, with a call to .body", async () => {
   res.body;
   const resData = await res.formData();
   expect(await (resData.get("file") as Blob).arrayBuffer()).toEqual(await file.arrayBuffer());
-
-  server.stop(true);
 });
 
 test("req.formData throws error when stream is in use", async () => {
@@ -72,7 +68,7 @@ test("req.formData throws error when stream is in use", async () => {
   const body = new FormData();
   body.append("file", file, "fetch.js.txt");
   var pass = false;
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     development: false,
     error(fail) {
@@ -101,7 +97,6 @@ test("req.formData throws error when stream is in use", async () => {
   // but it does for Response
   expect(await res.text()).toBe("pass");
   expect(pass).toBe(true);
-  server.stop(true);
 });
 
 test("formData uploads roundtrip, without a call to .body", async () => {
@@ -109,7 +104,7 @@ test("formData uploads roundtrip, without a call to .body", async () => {
   const body = new FormData();
   body.append("file", file, "fetch.js.txt");
 
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     development: false,
     async fetch(req) {
@@ -129,8 +124,6 @@ test("formData uploads roundtrip, without a call to .body", async () => {
   expect(res.headers.get("Content-Type")).toStartWith("multipart/form-data; boundary=");
   const resData = await res.formData();
   expect(await (resData.get("file") as Blob).arrayBuffer()).toEqual(await file.arrayBuffer());
-
-  server.stop(true);
 });
 
 test("uploads roundtrip with sendfile()", async () => {
@@ -140,7 +133,7 @@ test("uploads roundtrip with sendfile()", async () => {
 
   const path = join(tmpdir(), "huge.txt");
   require("fs").writeFileSync(path, hugeTxt);
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     development: false,
     maxRequestBodySize: hugeTxt.byteLength * 2,
@@ -160,7 +153,6 @@ test("uploads roundtrip with sendfile()", async () => {
 
   expect(resp.status).toBe(200);
   expect(await resp.text()).toBe(hash);
-  server.stop(true);
 }, 10_000);
 
 test("missing file throws the expected error", async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1120,7 +1120,7 @@ it("request body and signal life cycle", async () => {
       },
     };
 
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       async fetch(req) {
         return new Response(await renderToReadableStream(app_jsx), headers);
@@ -1143,7 +1143,6 @@ it("request body and signal life cycle", async () => {
     }
     await Bun.sleep(10);
     expect(true).toBe(true);
-    server.stop(true);
   }
 }, 30_000);
 
@@ -1151,7 +1150,7 @@ it("propagates content-type from a Bun.file()'s file path in fetch()", async () 
   const body = Bun.file(import.meta.dir + "/fetch.js.txt");
   const bodyText = await body.text();
 
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     development: false,
     async fetch(req) {
@@ -1173,12 +1172,10 @@ it("propagates content-type from a Bun.file()'s file path in fetch()", async () 
 
   // but it does for Response
   expect(res.headers.get("Content-Type")).toBe("text/plain;charset=utf-8");
-
-  server.stop(true);
 });
 
 it("does propagate type for Blob", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     development: false,
     async fetch(req) {
@@ -1195,13 +1192,11 @@ it("does propagate type for Blob", async () => {
   });
   expect(res.status).toBe(200);
   expect(res.headers.get("Content-Type")).toBe("text/plain;charset=utf-8");
-
-  server.stop(true);
 });
 
 it("unix socket connection in Bun.serve", async () => {
   const unix = join(tmpdir(), "bun." + Date.now() + ((Math.random() * 32) | 0).toString(16) + ".sock");
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     unix,
 
@@ -1228,13 +1223,12 @@ it("unix socket connection in Bun.serve", async () => {
   await promise;
   expect(Buffer.concat(received).toString()).toEndWith("\r\n\r\nhey");
   connection.end();
-  server.stop(true);
 });
 
 it("unix socket connection throws an error on a bad domain without crashing", async () => {
   const unix = "/i/don/tevent/exist/because/the/directory/is/invalid/yes.sock";
   expect(() => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       unix,
 
@@ -1247,7 +1241,7 @@ it("unix socket connection throws an error on a bad domain without crashing", as
 });
 
 it("#5859 text", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     development: false,
     async fetch(req) {
@@ -1261,11 +1255,10 @@ it("#5859 text", async () => {
   });
 
   expect(await response.text()).toBe("�");
-  await server.stop(true);
 });
 
 it("#5859 json", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     async fetch(req) {
       try {
@@ -1285,7 +1278,6 @@ it("#5859 json", async () => {
 
   expect(response.ok).toBeFalse();
   expect(await response.text()).toBe("FAIL");
-  await server.stop(true);
 });
 
 it("#5859 arrayBuffer", async () => {
@@ -1294,7 +1286,7 @@ it("#5859 arrayBuffer", async () => {
 });
 
 it("server.requestIP (v4)", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     fetch(req, server) {
       return Response.json(server.requestIP(req));
@@ -1308,11 +1300,10 @@ it("server.requestIP (v4)", async () => {
     family: "IPv4",
     port: expect.any(Number),
   });
-  server.stop(true);
 });
 
 it("server.requestIP (v6)", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     fetch(req, server) {
       return Response.json(server.requestIP(req));
@@ -1326,12 +1317,11 @@ it("server.requestIP (v6)", async () => {
     family: "IPv6",
     port: expect.any(Number),
   });
-  server.stop(true);
 });
 
 it("server.requestIP (unix)", async () => {
   const unix = "/tmp/bun-serve.sock";
-  const server = Bun.serve({
+  using server = Bun.serve({
     unix,
     fetch(req, server) {
       return Response.json(server.requestIP(req));
@@ -1354,11 +1344,10 @@ it("server.requestIP (unix)", async () => {
   await promise;
   expect(Buffer.concat(received).toString()).toEndWith("\r\n\r\nnull");
   connection.end();
-  server.stop(true);
 });
 
 it("should response with HTTP 413 when request body is larger than maxRequestBodySize, issue#6031", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     maxRequestBodySize: 10,
     fetch(req, server) {
@@ -1381,8 +1370,6 @@ it("should response with HTTP 413 when request body is larger than maxRequestBod
     });
     expect(resp.status).toBe(413);
   }
-
-  server.stop(true);
 });
 
 it("should support promise returned from error", async () => {
@@ -1433,7 +1420,7 @@ it("should support promise returned from error", async () => {
 if (process.platform === "linux")
   it("should use correct error when using a root range port(#7187)", () => {
     expect(() => {
-      const server = Bun.serve({
+      using server = Bun.serve({
         port: 1003,
         fetch(req) {
           return new Response("request answered");

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -273,14 +273,14 @@ it("should allow large amounts of data to be sent and received", async () => {
 }, 60_000);
 
 it("it should not crash when getting a ReferenceError on client socket open", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 8080,
     hostname: "localhost",
     fetch() {
       return new Response("Hello World");
     },
   });
-  try {
+  {
     const { resolve, reject, promise } = Promise.withResolvers();
     let client: Socket<undefined> | null = null;
     const timeout = setTimeout(() => {
@@ -310,20 +310,18 @@ it("it should not crash when getting a ReferenceError on client socket open", as
 
     const result: any = await promise;
     expect(result?.message).toBe("Can't find variable: bytes");
-  } finally {
-    server.stop(true);
   }
 });
 
 it("it should not crash when returning a Error on client socket open", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 8080,
     hostname: "localhost",
     fetch() {
       return new Response("Hello World");
     },
   });
-  try {
+  {
     const { resolve, reject, promise } = Promise.withResolvers();
     let client: Socket<undefined> | null = null;
     const timeout = setTimeout(() => {
@@ -352,7 +350,5 @@ it("it should not crash when returning a Error on client socket open", async () 
 
     const result: any = await promise;
     expect(result?.message).toBe("CustomError");
-  } finally {
-    server.stop(true);
   }
 });

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -469,7 +469,7 @@ describe("errors", () => {
     Three Act Tragedy
     Death in the Clouds`;
 
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       fetch(req, server) {
         server.stop();

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -702,8 +702,8 @@ describe("should not hang", () => {
 });
 
 it("#3480", async () => {
-  try {
-    var server = Bun.serve({
+  {
+    using server = Bun.serve({
       port: 0,
       fetch: (req, res) => {
         Bun.spawnSync(["node", "-e", "console.log('1')"], {});
@@ -714,8 +714,6 @@ it("#3480", async () => {
     const response = await fetch("http://" + server.hostname + ":" + server.port);
     expect(await response.text()).toBe("Hello world!");
     expect(response.ok);
-  } finally {
-    server!.stop(true);
   }
 });
 

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -253,7 +253,7 @@ describe("async context passes through", () => {
     await s.run("value", async () => {
       expect(s.getStore()).toBe("value");
 
-      const server = Bun.serve({
+      using server = Bun.serve({
         port: 0,
         fetch(request, server) {
           return new Response(s.getStore()!);
@@ -440,12 +440,11 @@ describe("async context passes through", () => {
   test("Websocket Server", async () => {
     const s = new AsyncLocalStorage<string>();
     let values_server: string[] = [];
-    let resolve: () => void;
-    const promise = new Promise<void>(r => (resolve = r));
+    const { promise, resolve } = Promise.withResolvers();
     await s.run("value", async () => {
       expect(s.getStore()).toBe("value");
 
-      const server = Bun.serve({
+      using server = Bun.serve({
         port: 0,
         fetch(request, server) {
           if (server.upgrade(request)) return null as any;
@@ -472,20 +471,19 @@ describe("async context passes through", () => {
       ws.addEventListener("close", () => {
         resolve();
       });
+      await promise;
     });
     expect(s.getStore()).toBe(undefined);
-    await promise;
     expect(values_server).toEqual(["open:value", "message:value", "close:value"]);
   });
   test.todo("WebSocket client", async () => {
     const s = new AsyncLocalStorage<string>();
     let values_client: string[] = [];
-    let resolve: () => void;
-    const promise = new Promise<void>(r => (resolve = r));
+    const { promise, resolve } = Promise.withResolvers();
     await s.run("value", async () => {
       expect(s.getStore()).toBe("value");
 
-      const server = Bun.serve({
+      using server = Bun.serve({
         port: 0,
         fetch(request, server) {
           if (server.upgrade(request)) return null as any;

--- a/test/js/node/http/node-fetch-cjs.test.js
+++ b/test/js/node/http/node-fetch-cjs.test.js
@@ -1,6 +1,7 @@
 const fetch = require("node-fetch");
 
 test("require('node-fetch') fetches", async () => {
+  // can't use `using`. see https://github.com/oven-sh/bun/issues/11100
   const server = Bun.serve({
     port: 0,
     fetch(req, server) {

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -34,7 +34,7 @@ for (const [impl, name] of [
   [vercelFetch.default(fetch), "@vercel/fetch.default"],
 ]) {
   test(name + " fetches", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       fetch(req, server) {
         server.stop();
@@ -42,12 +42,11 @@ for (const [impl, name] of [
       },
     });
     expect(await impl("http://" + server.hostname + ":" + server.port)).toBeInstanceOf(globalThis.Response);
-    server.stop(true);
   });
 }
 
 test("node-fetch uses node streams instead of web streams", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     async fetch(req, server) {
       const body = await req.text();
@@ -56,7 +55,7 @@ test("node-fetch uses node streams instead of web streams", async () => {
     },
   });
 
-  try {
+  {
     const result = await fetch2("http://" + server.hostname + ":" + server.port, {
       body: new stream.Readable({
         read() {
@@ -79,7 +78,5 @@ test("node-fetch uses node streams instead of web streams", async () => {
       chunks.push(chunk);
     }
     expect(Buffer.concat(chunks).toString()).toBe("hello world");
-  } finally {
-    server.stop(true);
   }
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1835,7 +1835,7 @@ it("destroy should end download", async () => {
   // just simulate some file that will take forever to download
   const payload = Buffer.from("X".repeat(16 * 1024));
 
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     async fetch(req) {
       let running = true;
@@ -1848,8 +1848,7 @@ it("destroy should end download", async () => {
       });
     },
   });
-
-  try {
+  {
     let chunks = 0;
 
     const { promise, resolve } = Promise.withResolvers();
@@ -1866,8 +1865,6 @@ it("destroy should end download", async () => {
     req.destroy();
     await Bun.sleep(200);
     expect(chunks).toBeLessThanOrEqual(3);
-  } finally {
-    server.stop(true);
   }
 });
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -558,7 +558,7 @@ describe("Client Basics", () => {
   });
   it("should fail to connect over HTTP/1.1", async () => {
     const tls = TLS_CERT;
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
       tls: {
@@ -575,8 +575,6 @@ describe("Client Basics", () => {
       expect("unreachable").toBe(true);
     } catch (err) {
       expect(err.code).toBe("ERR_HTTP2_ERROR");
-    } finally {
-      server.stop();
     }
   });
   it("works with Duplex", async () => {

--- a/test/js/node/tls/fetch-tls-cert.test.ts
+++ b/test/js/node/tls/fetch-tls-cert.test.ts
@@ -1,7 +1,4 @@
 import { expect, it } from "bun:test";
-import tls from "tls";
-import type { Server, TLSSocket } from "node:tls";
-import type { AddressInfo } from "node:net";
 import { join } from "path";
 import { readFileSync } from "fs";
 
@@ -33,9 +30,8 @@ function checkServerIdentity(hostname: string, cert: any) {
 }
 
 async function connect(options: any) {
-  let server: ReturnType<Bun.serve> | null = null;
-  try {
-    server = Bun.serve({
+  {
+    using server = Bun.serve({
       tls: options.server,
       port: 0,
       fetch(req) {
@@ -49,8 +45,6 @@ async function connect(options: any) {
     if (result !== "Hello World!") {
       throw new Error("Unexpected response from server");
     }
-  } finally {
-    server?.stop(true);
   }
 }
 it.todo("complete cert chains sent to peer.", async () => {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1,6 +1,7 @@
 import tls, { TLSSocket, connect, checkServerIdentity, createServer, Server } from "tls";
 import { join } from "path";
 import { AddressInfo } from "ws";
+import { it, expect } from "bun:test";
 
 const symbolConnectOptions = Symbol.for("::buntlsconnectoptions::");
 
@@ -42,7 +43,7 @@ const COMMON_CERT = {
 };
 
 it("Bun.serve() should work with tls and Bun.file()", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     fetch() {
       return new Response(Bun.file(join(import.meta.dir, "fixtures/index.html")));
@@ -54,11 +55,10 @@ it("Bun.serve() should work with tls and Bun.file()", async () => {
   });
   const res = await fetch(`https://${server.hostname}:${server.port}/`, { tls: { rejectUnauthorized: false } });
   expect(await res.text()).toBe("<h1>HELLO</h1>");
-  server.stop();
 });
 
 it("should have peer certificate when using self asign certificate", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     tls: {
       cert: COMMON_CERT.cert,
       key: COMMON_CERT.key,
@@ -121,7 +121,6 @@ it("should have peer certificate when using self asign certificate", async () =>
     expect(cert.serialNumber).toBe("A2DD4153F2F748E3");
     expect(cert.raw).toBeInstanceOf(Buffer);
   } finally {
-    server.stop();
     socket.end();
   }
 });

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -6,9 +6,6 @@ import { expect, it, describe } from "bun:test";
 import tls from "node:tls";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { reject, set } from "lodash";
-import { resolve } from "bun";
-import { ca } from "js/third_party/grpc-js/common";
 import { AddressInfo } from "node:net";
 
 function loadPEM(filename: string) {
@@ -366,9 +363,8 @@ describe("Bun.serve SNI", () => {
     });
   }
   it("single SNI", async () => {
-    let server: ReturnType<typeof Bun.serve> | null = null;
-    try {
-      server = Bun.serve({
+    {
+      using server = Bun.serve({
         port: 0,
         tls: {
           ...SNIContexts["asterisk.test.com"],
@@ -395,11 +391,9 @@ describe("Bun.serve SNI", () => {
         });
         expect(client).toBe(false);
       }
-    } finally {
-      server?.stop(true);
     }
-    try {
-      server = Bun.serve({
+    {
+      using server = Bun.serve({
         port: 0,
         tls: {
           ...goodSecureContext,
@@ -426,14 +420,11 @@ describe("Bun.serve SNI", () => {
         });
         expect(client).toBe(true);
       }
-    } finally {
-      server.stop(true);
     }
   });
   it("multiple SNI", async () => {
-    let server: ReturnType<typeof Bun.serve> | null = null;
-    try {
-      server = Bun.serve({
+    {
+      using server = Bun.serve({
         port: 0,
         tls: [
           serverOptions,
@@ -491,8 +482,6 @@ describe("Bun.serve SNI", () => {
           port: server.port,
         }),
       ).toBe(true);
-    } finally {
-      server?.stop(true);
     }
   });
 });

--- a/test/js/web/abort/abort.signal.ts
+++ b/test/js/web/abort/abort.signal.ts
@@ -1,6 +1,6 @@
 import type { Server } from "bun";
 
-const server = Bun.serve({
+using server = Bun.serve({
   port: 0,
   async fetch() {
     const signal = AbortSignal.timeout(1);
@@ -19,6 +19,5 @@ const responses: Response[] = [];
 for (let i = 0; i < 10; i++) {
   responses.push(await fetch(url));
 }
-server.stop(true);
 // we fail if any of the requests succeeded
 process.exit(responses.every(res => res.status === 500) ? 0 : 1);

--- a/test/js/web/fetch/body-stream-excess.test.ts
+++ b/test/js/web/fetch/body-stream-excess.test.ts
@@ -90,11 +90,10 @@ describe("http response does not include an extraneous terminating 0\\r\\n\\r\\n
   ];
   for (let i = 0; i < scenarios.length; i++) {
     test("scenario " + i, async () => {
-      const server = Bun.serve(scenarios[i]);
+      using server = Bun.serve(scenarios[i]);
       const { stdout, stderr } = await $`curl ${server.url} --verbose`.quiet();
       expect(stdout.toString()).toBe("hello");
       expect(stderr.toString()).toContain("left intact");
-      server.stop(true);
     });
   }
 });

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -3,7 +3,7 @@ import { it, expect } from "bun:test";
 import { gcTick } from "harness";
 
 it("fetch() with a buffered gzip response works (one chunk)", async () => {
-  var server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
 
     async fetch(req) {
@@ -29,11 +29,10 @@ it("fetch() with a buffered gzip response works (one chunk)", async () => {
     expect(second.equals(clone)).toBe(true);
   })();
   gcTick(true);
-  server.stop();
 });
 
 it("fetch() with a redirect that returns a buffered gzip response works (one chunk)", async () => {
-  var server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
 
     async fetch(req) {
@@ -54,11 +53,10 @@ it("fetch() with a redirect that returns a buffered gzip response works (one chu
   expect(
     new Buffer(arrayBuffer).equals(new Buffer(await Bun.file(import.meta.dir + "/fixture.html").arrayBuffer())),
   ).toBe(true);
-  server.stop();
 });
 
 it("fetch() with a protocol-relative redirect that returns a buffered gzip response works (one chunk)", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
 
     async fetch(req, server) {
@@ -82,12 +80,10 @@ it("fetch() with a protocol-relative redirect that returns a buffered gzip respo
   expect(
     new Buffer(arrayBuffer).equals(new Buffer(await Bun.file(import.meta.dir + "/fixture.html").arrayBuffer())),
   ).toBe(true);
-
-  server.stop();
 });
 
 it("fetch() with a gzip response works (one chunk, streamed, with a delay)", async () => {
-  var server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
 
     fetch(req) {
@@ -118,7 +114,6 @@ it("fetch() with a gzip response works (one chunk, streamed, with a delay)", asy
   expect(
     new Buffer(arrayBuffer).equals(new Buffer(await Bun.file(import.meta.dir + "/fixture.html").arrayBuffer())),
   ).toBe(true);
-  server.stop();
 });
 
 it("fetch() with a gzip response works (multiple chunks, TCP server)", async done => {

--- a/test/js/web/fetch/fetch-leak.test.js
+++ b/test/js/web/fetch/fetch-leak.test.js
@@ -6,7 +6,7 @@ describe("fetch doesn't leak", () => {
   test("fixture #1", async () => {
     const body = new Blob(["some body in here!".repeat(100)]);
     var count = 0;
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
 
       fetch(req) {
@@ -27,7 +27,6 @@ describe("fetch doesn't leak", () => {
     });
 
     const exitCode = await proc.exited;
-    server.stop(true);
     expect(exitCode).toBe(0);
     expect(count).toBe(200);
   });
@@ -60,7 +59,7 @@ describe("fetch doesn't leak", () => {
       serveOptions.tls = COMMON_CERT;
     }
 
-    const server = Bun.serve(serveOptions);
+    using server = Bun.serve(serveOptions);
 
     const env = {
       ...bunEnv,
@@ -84,7 +83,6 @@ describe("fetch doesn't leak", () => {
     });
 
     const exitCode = await proc.exited;
-    server.stop(true);
     expect(exitCode).toBe(0);
   }
 

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -30,9 +30,8 @@ const empty = Buffer.alloc(0);
 describe("fetch() with streaming", () => {
   [-1, 0, 20, 50, 100].forEach(timeout => {
     it(`should be able to fail properly when reading from readable stream with timeout ${timeout}`, async () => {
-      let server: Server | null = null;
-      try {
-        server = Bun.serve({
+      {
+        using server = Bun.serve({
           port: 0,
           async fetch(req) {
             return new Response(
@@ -77,16 +76,13 @@ describe("fetch() with streaming", () => {
             expect(err.message).toBe("The operation timed out.");
           }
         }
-      } finally {
-        server?.stop();
       }
     });
   });
 
   it(`should be locked after start buffering`, async () => {
-    let server: Server | null = null;
-    try {
-      server = Bun.serve({
+    {
+      using server = Bun.serve({
         port: 0,
         fetch(req) {
           return new Response(
@@ -124,8 +120,6 @@ describe("fetch() with streaming", () => {
         if (err.name !== "TypeError") throw err;
         expect(err.message).toBe("ReadableStream is locked");
       }
-    } finally {
-      server?.stop();
     }
   });
 
@@ -177,9 +171,8 @@ describe("fetch() with streaming", () => {
   });
 
   it("can deflate with and without headers #4478", async () => {
-    let server: Server | null = null;
-    try {
-      server = Bun.serve({
+    {
+      using server = Bun.serve({
         port: 0,
         fetch(req) {
           if (req.url.endsWith("/with_headers")) {
@@ -205,8 +198,6 @@ describe("fetch() with streaming", () => {
       const url = `http://${server.hostname}:${server.port}/`;
       expect(await fetch(`${url}with_headers`).then(res => res.text())).toBe("Hello, World");
       expect(await fetch(url).then(res => res.text())).toBe("Hello, World");
-    } finally {
-      server?.stop();
     }
   });
 
@@ -257,10 +248,9 @@ describe("fetch() with streaming", () => {
   }
 
   it("stream still works after response get out of scope", async () => {
-    let server: Server | null = null;
-    try {
+    {
       const content = "Hello, world!\n".repeat(5);
-      server = Bun.serve({
+      using server = Bun.serve({
         port: 0,
         fetch(req) {
           return new Response(
@@ -313,16 +303,13 @@ describe("fetch() with streaming", () => {
       gcTick(false);
       expect(buffer.toString("utf8")).toBe(content);
       expect(parts).toBeGreaterThan(1);
-    } finally {
-      server?.stop();
     }
   });
 
   it("response inspected size should reflect stream state", async () => {
-    let server: Server | null = null;
-    try {
+    {
       const content = "Bun!\n".repeat(4);
-      server = Bun.serve({
+      using server = Bun.serve({
         port: 0,
         fetch(req) {
           return new Response(
@@ -380,16 +367,13 @@ describe("fetch() with streaming", () => {
       }
 
       gcTick(false);
-    } finally {
-      server?.stop();
     }
   });
 
   it("can handle multiple simultaneos requests", async () => {
-    let server: Server | null = null;
-    try {
+    {
       const content = "Hello, world!\n".repeat(5);
-      server = Bun.serve({
+      using server = Bun.serve({
         port: 0,
         fetch(req) {
           return new Response(
@@ -447,16 +431,13 @@ describe("fetch() with streaming", () => {
       }
 
       await Promise.all([doRequest(), doRequest(), doRequest(), doRequest(), doRequest(), doRequest()]);
-    } finally {
-      server?.stop();
     }
   });
 
   it(`can handle transforms`, async () => {
-    let server: Server | null = null;
-    try {
+    {
       const content = "Hello, world!\n".repeat(5);
-      server = Bun.serve({
+      using server = Bun.serve({
         port: 0,
         fetch(req) {
           return new Response(
@@ -514,15 +495,12 @@ describe("fetch() with streaming", () => {
 
       gcTick(false);
       expect(result).toBe(content.toUpperCase());
-    } finally {
-      server?.stop();
     }
   });
 
   it(`can handle gz images`, async () => {
-    let server: Server | null = null;
-    try {
-      server = Bun.serve({
+    {
+      using server = Bun.serve({
         port: 0,
         fetch(req) {
           const data = fixtures["fixture.png.gz"];
@@ -554,18 +532,14 @@ describe("fetch() with streaming", () => {
 
       gcTick(false);
       expect(buffer).toEqual(fixtures["fixture.png"]);
-    } finally {
-      server?.stop();
     }
   });
 
   it(`can proxy fetch with Bun.serve`, async () => {
-    let server: Server | null = null;
-    let server_original: Server | null = null;
-    try {
+    {
       const content = "a".repeat(64 * 1024);
 
-      server_original = Bun.serve({
+      using server_original = Bun.serve({
         port: 0,
         fetch(req) {
           return new Response(
@@ -599,7 +573,7 @@ describe("fetch() with streaming", () => {
         },
       });
 
-      server = Bun.serve({
+      using server = Bun.serve({
         port: 0,
         async fetch(req) {
           const response = await fetch(`http://${server_original.hostname}:${server_original.port}`, {});
@@ -635,9 +609,6 @@ describe("fetch() with streaming", () => {
       gcTick(false);
       expect(buffer.toString("utf8")).toBe(content);
       expect(parts).toBeGreaterThanOrEqual(1);
-    } finally {
-      server?.stop();
-      server_original?.stop();
     }
   });
   const matrix = [
@@ -652,14 +623,13 @@ describe("fetch() with streaming", () => {
     for (let j = 0; j < matrix.length; j++) {
       const fixtureb = matrix[j];
       it(`can handle fixture ${fixture.name} x ${fixtureb.name}`, async () => {
-        let server: Server | null = null;
-        try {
+        {
           //@ts-ignore
           const data = fixture.data;
           //@ts-ignore
           const data_b = fixtureb.data;
           const content = Buffer.concat([data, data_b]);
-          server = Bun.serve({
+          using server = Bun.serve({
             port: 0,
             fetch(req) {
               return new Response(
@@ -699,8 +669,6 @@ describe("fetch() with streaming", () => {
           }
           gcTick(false);
           expect(buffer).toEqual(content);
-        } finally {
-          server?.stop();
         }
       });
     }
@@ -733,10 +701,9 @@ describe("fetch() with streaming", () => {
     const test = skip ? it.skip : it;
 
     test(`with invalid utf8 with ${compression} compression`, async () => {
-      let server: Server | null = null;
-      try {
+      {
         const content = Buffer.concat([invalid, Buffer.from("Hello, world!\n".repeat(5), "utf8"), invalid]);
-        server = Bun.serve({
+        using server = Bun.serve({
           port: 0,
           fetch(req) {
             return new Response(
@@ -790,16 +757,13 @@ describe("fetch() with streaming", () => {
 
         gcTick(false);
         expect(buffer).toEqual(content);
-      } finally {
-        server?.stop();
       }
     });
 
     test(`chunked response works (single chunk) with ${compression} compression`, async () => {
-      let server: Server | null = null;
-      try {
+      {
         const content = "Hello, world!\n".repeat(5);
-        server = Bun.serve({
+        using server = Bun.serve({
           port: 0,
           fetch(req) {
             return new Response(
@@ -850,16 +814,13 @@ describe("fetch() with streaming", () => {
         gcTick(false);
         expect(buffer.toString("utf8")).toBe(content);
         expect(parts).toBe(1);
-      } finally {
-        server?.stop();
       }
     });
 
     test(`chunked response works (multiple chunks) with ${compression} compression`, async () => {
-      let server: Server | null = null;
-      try {
+      {
         const content = "Hello, world!\n".repeat(5);
-        server = Bun.serve({
+        using server = Bun.serve({
           port: 0,
           fetch(req) {
             return new Response(
@@ -921,17 +882,13 @@ describe("fetch() with streaming", () => {
         gcTick(false);
         expect(buffer.toString("utf8")).toBe(content);
         expect(parts).toBeGreaterThan(1);
-      } finally {
-        server?.stop();
       }
     });
 
     test(`Content-Length response works (single part) with ${compression} compression`, async () => {
-      let server: Server | null = null;
-      try {
+      {
         const content = "a".repeat(1024);
-
-        server = Bun.serve({
+        using server = Bun.serve({
           port: 0,
           fetch(req) {
             return new Response(compress(compression, Buffer.from(content)), {
@@ -971,17 +928,13 @@ describe("fetch() with streaming", () => {
         gcTick(false);
         expect(buffer.toString("utf8")).toBe(content);
         expect(parts).toBe(1);
-      } finally {
-        server?.stop();
       }
     });
 
     test(`Content-Length response works (multiple parts) with ${compression} compression`, async () => {
-      let server: Server | null = null;
-      try {
+      {
         const content = "a".repeat(64 * 1024);
-
-        server = Bun.serve({
+        using server = Bun.serve({
           port: 0,
           fetch(req) {
             return new Response(compress(compression, Buffer.from(content)), {
@@ -1021,19 +974,14 @@ describe("fetch() with streaming", () => {
         gcTick(false);
         expect(buffer.toString("utf8")).toBe(content);
         expect(parts).toBeGreaterThan(1);
-      } finally {
-        server?.stop();
       }
     });
 
     test(`Extra data should be ignored on streaming (multiple chunks, TCP server) with ${compression} compression`, async () => {
-      let server: TCPSocketListener<any> | null = null;
-
-      try {
+      {
         const parts = 5;
         const content = "Hello".repeat(parts);
-
-        server = Bun.listen({
+        using server = Bun.listen({
           port: 0,
           hostname: "0.0.0.0",
           socket: {
@@ -1100,19 +1048,14 @@ describe("fetch() with streaming", () => {
 
         gcTick(false);
         expect(buffer.toString("utf8")).toBe(content);
-      } finally {
-        server?.stop(true);
       }
     });
 
     test(`Missing data should timeout on streaming (multiple chunks, TCP server) with ${compression} compression`, async () => {
-      let server: TCPSocketListener<any> | null = null;
-
-      try {
+      {
         const parts = 5;
         const content = "Hello".repeat(parts);
-
-        server = Bun.listen({
+        using server = Bun.listen({
           port: 0,
           hostname: "0.0.0.0",
           socket: {
@@ -1183,19 +1126,15 @@ describe("fetch() with streaming", () => {
         } catch (err) {
           expect((err as Error).name).toBe("TimeoutError");
         }
-      } finally {
-        server?.stop(true);
       }
     });
 
     if (compression !== "no") {
       test(`can handle corrupted ${compression} compression`, async () => {
-        let server: TCPSocketListener<any> | null = null;
-
-        try {
+        {
           const parts = 5;
           const content = "Hello".repeat(parts);
-          server = Bun.listen({
+          using server = Bun.listen({
             port: 0,
             hostname: "0.0.0.0",
             socket: {
@@ -1271,20 +1210,16 @@ describe("fetch() with streaming", () => {
           } catch (err) {
             expect((err as Error).name).toBe("ZlibError");
           }
-        } finally {
-          server?.stop(true);
         }
       });
     }
 
     test(`can handle socket close with ${compression} compression`, async () => {
-      let server: TCPSocketListener<any> | null = null;
-
-      try {
+      {
         const parts = 5;
         const content = "Hello".repeat(parts);
         const { promise, resolve: resolveSocket } = Promise.withResolvers<Socket>();
-        server = Bun.listen({
+        using server = Bun.listen({
           port: 0,
           hostname: "0.0.0.0",
           socket: {
@@ -1366,8 +1301,6 @@ describe("fetch() with streaming", () => {
         } catch (err) {
           expect((err as Error).name).toBe("ConnectionClosed");
         }
-      } finally {
-        server?.stop(true);
       }
     });
   }

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -1668,6 +1668,21 @@ it("same-origin status code 302 should not strip headers", async () => {
 });
 
 describe("should handle relative location in the redirect, issue#5635", () => {
+  let server: Server;
+  beforeAll(async () => {
+    server = Bun.serve({
+      port: 0,
+      async fetch(request: Request) {
+        return new Response("Not Found", {
+          status: 404,
+        });
+      },
+    });
+  });
+  afterAll(() => {
+    server.stop(true);
+  });
+
   it.each([
     ["/a/b", "/c", "/c"],
     ["/a/b", "c", "/a/c"],
@@ -1685,14 +1700,6 @@ describe("should handle relative location in the redirect, issue#5635", () => {
     ["/a/b/", "../c/d", "/a/c/d"],
     ["/a/b/", "../../../c", "/c"],
   ])("('%s', '%s')", async (pathname, location, expected) => {
-    using server = Bun.serve({
-      port: 0,
-      async fetch(request: Request) {
-        return new Response("Not Found", {
-          status: 404,
-        });
-      },
-    });
     server.reload({
       async fetch(request: Request) {
         const url = new URL(request.url);

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -20,18 +20,14 @@ const CERT_EXPIRED: TLSOptions = {
 };
 
 async function createServer(cert: TLSOptions, callback: (port: number) => Promise<any>) {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     tls: cert,
     fetch() {
       return new Response("Hello World");
     },
   });
-  try {
-    await callback(server.port);
-  } finally {
-    server.stop(true);
-  }
+  await callback(server.port);
 }
 
 it("can handle multiple requests with non native checkServerIdentity", async () => {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -300,7 +300,7 @@ describe("FormData", () => {
   });
 
   it("file upload on HTTP server (receive)", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       development: false,
       async fetch(req) {
@@ -320,11 +320,10 @@ describe("FormData", () => {
     const res = await fetch(reqBody);
     const body = await res.text();
     expect(body).toBe("baz");
-    server.stop(true);
   });
 
   it("file send on HTTP server (receive)", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       development: false,
       async fetch(req) {
@@ -344,7 +343,6 @@ describe("FormData", () => {
     const res = await fetch(reqBody);
     const body = await res.formData();
     expect(await (body.get("foo") as Blob).text()).toBe("baz");
-    server.stop(true);
   });
   type FetchReqArgs = [request: Request, init?: RequestInit];
   type FetchURLArgs = [url: string | URL | Request, init?: FetchRequestInit];
@@ -361,7 +359,7 @@ describe("FormData", () => {
         describe("headers: " + Bun.inspect(headers).replaceAll(/([\n ])/gim, ""), () => {
           it("send on HTTP server with FormData & Blob (roundtrip)", async () => {
             let contentType = "";
-            const server = Bun.serve({
+            using server = Bun.serve({
               port: 0,
               development: false,
               async fetch(req) {
@@ -388,12 +386,11 @@ describe("FormData", () => {
             const body = await res.formData();
             expect(await (body.get("foo") as Blob).text()).toBe("baz");
             expect(body.get("bar")).toBe("baz");
-            server.stop(true);
           });
 
           it("send on HTTP server with FormData & Bun.file (roundtrip)", async () => {
             let contentType = "";
-            const server = Bun.serve({
+            using server = Bun.serve({
               port: 0,
               development: false,
               async fetch(req) {
@@ -424,13 +421,11 @@ describe("FormData", () => {
             expect(contentType).toContain("multipart/form-data");
             expect(body.get("bar")).toBe("baz");
             expect(contentType).toContain("multipart/form-data");
-
-            server.stop(true);
           });
 
           it("send on HTTP server with FormData (roundtrip)", async () => {
             let contentType = "";
-            const server = Bun.serve({
+            using server = Bun.serve({
               port: 0,
               development: false,
               async fetch(req) {
@@ -459,7 +454,6 @@ describe("FormData", () => {
             expect(contentType).toContain("multipart/form-data");
             expect(body.get("foo")).toBe("boop");
             expect(body.get("bar")).toBe("baz");
-            server.stop(true);
           });
         });
       }

--- a/test/js/web/request/request-subclass.test.ts
+++ b/test/js/web/request/request-subclass.test.ts
@@ -28,7 +28,7 @@ test("fetch() calls request.method & request.url getters on subclass", async () 
     }
   }
 
-  const server = Bun.serve({
+  using server = Bun.serve({
     fetch(req) {
       return new Response(req.method, { headers: req.headers });
     },
@@ -41,7 +41,6 @@ test("fetch() calls request.method & request.url getters on subclass", async () 
   const response = await fetch(request);
   expect(await response.text()).toBe("POST");
   expect(response.headers.get("X-My-Header")).toBe("123");
-  server.stop(true);
 });
 
 test("fetch() with subclass containing invalid HTTP headers throws without crashing", async () => {

--- a/test/js/web/timers/setImmediate2.test.ts
+++ b/test/js/web/timers/setImmediate2.test.ts
@@ -4,10 +4,10 @@ test("setImmediate doesn't block the event loop", async () => {
   const incomingTimestamps = [];
   var hasResponded = false;
   var expectedTime = "";
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     async fetch(req) {
-      await new Promise(resolve => setTimeout(resolve, 50).unref());
+      await new Promise(resolve => setTimeout(resolve, 1500).unref());
       function queuey() {
         incomingTimestamps.push(Date.now());
         if (!hasResponded) setImmediate(queuey);
@@ -20,5 +20,4 @@ test("setImmediate doesn't block the event loop", async () => {
   const resp = await fetch(`http://${server.hostname}:${server.port}/`);
   expect(await resp.text()).toBe(expectedTime);
   hasResponded = true;
-  server.stop(true);
 });

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -13,7 +13,7 @@ const COMMON_CERT = {
 };
 describe("WebSocket", () => {
   it("should connect", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       fetch(req, server) {
         if (server.upgrade(req)) {
@@ -39,7 +39,6 @@ describe("WebSocket", () => {
     });
     ws.close();
     await closed;
-    server.stop(true);
     Bun.gc(true);
   });
 
@@ -59,7 +58,7 @@ describe("WebSocket", () => {
   });
 
   it("should connect many times over https", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       tls: COMMON_CERT,
       fetch(req, server) {
@@ -76,7 +75,7 @@ describe("WebSocket", () => {
         open(ws) {},
       },
     });
-    try {
+    {
       for (let i = 0; i < 1000; i++) {
         const ws = new WebSocket(server.url.href, { tls: { rejectUnauthorized: false } });
         await new Promise((resolve, reject) => {
@@ -91,13 +90,11 @@ describe("WebSocket", () => {
         await closed;
       }
       Bun.gc(true);
-    } finally {
-      server.stop(true);
     }
   });
 
   it("rejectUnauthorized should reject self-sign certs when true/default", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       tls: COMMON_CERT,
       fetch(req, server) {
@@ -119,7 +116,7 @@ describe("WebSocket", () => {
       },
     });
 
-    try {
+    {
       function testClient(client) {
         const { promise, resolve, reject } = Promise.withResolvers();
         let messages = [];
@@ -153,13 +150,11 @@ describe("WebSocket", () => {
         expect(result.code).toBe(1015);
         expect(result.reason).toBe("TLS handshake failed");
       }
-    } finally {
-      server.stop(true);
     }
   });
 
   it("rejectUnauthorized should NOT reject self-sign certs when false", async () => {
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       tls: COMMON_CERT,
       fetch(req, server) {
@@ -181,7 +176,7 @@ describe("WebSocket", () => {
       },
     });
 
-    try {
+    {
       function testClient(client) {
         const { promise, resolve, reject } = Promise.withResolvers();
         let messages = [];
@@ -206,8 +201,6 @@ describe("WebSocket", () => {
         expect(["Hello from Bun!", "Hello from client!"]).toEqual(messages);
         expect(result.code).toBe(1000);
       }
-    } finally {
-      server.stop(true);
     }
   });
 
@@ -218,7 +211,7 @@ describe("WebSocket", () => {
       passphrase: "123123123",
     };
 
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       tls: UNTRUSTED_CERT,
       fetch(req, server) {
@@ -240,7 +233,7 @@ describe("WebSocket", () => {
       },
     });
 
-    try {
+    {
       function testClient(client) {
         const { promise, resolve, reject } = Promise.withResolvers();
         let messages = [];
@@ -264,8 +257,6 @@ describe("WebSocket", () => {
         expect(result.code).toBe(1015);
         expect(result.reason).toBe("TLS handshake failed");
       }
-    } finally {
-      server.stop(true);
     }
   });
 
@@ -501,7 +492,7 @@ it("should report failing websocket connection in onerror and onclose for connec
 describe("websocket in subprocess", () => {
   it("should exit", async () => {
     let messageReceived = false;
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       fetch(req, server) {
         if (server.upgrade(req)) {
@@ -531,7 +522,6 @@ describe("websocket in subprocess", () => {
 
     expect(await subprocess.exited).toBe(0);
     expect(messageReceived).toBe(true);
-    server.stop(true);
   });
 
   it("should exit after killed", async () => {
@@ -565,7 +555,7 @@ describe("websocket in subprocess", () => {
   it("should exit after timeout", async () => {
     let messageReceived = false;
     let start = 0;
-    const server = Bun.serve({
+    using server = Bun.serve({
       port: 0,
       fetch(req, server) {
         if (server.upgrade(req)) {
@@ -597,7 +587,6 @@ describe("websocket in subprocess", () => {
 
     expect(await subprocess.exited).toBe(0);
     expect(messageReceived).toBe(true);
-    server.stop(true);
   });
 
   it("should exit after server stop and 0 messages", async () => {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -39,9 +39,8 @@ describe("HTMLRewriter", () => {
   it("HTMLRewriter: async replacement using fetch + Bun.serve", async () => {
     await gcTick();
     let content;
-    let server;
-    try {
-      server = Bun.serve({
+    {
+      using server = Bun.serve({
         port: 0,
         fetch(req) {
           return new HTMLRewriter()
@@ -59,8 +58,6 @@ describe("HTMLRewriter", () => {
       const url = `http://localhost:${server.port}`;
       expect(await fetch(url).then(res => res.text())).toBe(`<div>${content}</div>`);
       await gcTick();
-    } finally {
-      server.stop();
     }
   });
 


### PR DESCRIPTION
`expect()` throws if given a non-passing value so many tests forget to cleanup or are wrapped in `try`/`finally`. with `using` they don't have to.