### PR TITLE
fix: don't crash when seeing -1 in code cov

### DIFF
--- a/src/sourcemap/CodeCoverage.zig
+++ b/src/sourcemap/CodeCoverage.zig
@@ -21,6 +21,7 @@ const prettyFmt = Output.prettyFmt;
 /// bitsets are simple and bitsets are relatively fast to construct and query
 ///
 pub const CodeCoverageReport = struct {
+    
     source_url: bun.JSC.ZigString.Slice,
     executable_lines: Bitset,
     lines_which_have_executed: Bitset,
@@ -394,6 +395,8 @@ pub const ByteRangeMapping = struct {
             executable_lines = try Bitset.initEmpty(allocator, line_count);
             lines_which_have_executed = try Bitset.initEmpty(allocator, line_count);
             for (blocks, 0..) |block, i| {
+                if (block.endOffset < 0) continue; // does not map to anything
+
                 const min: usize = @intCast(@min(block.startOffset, block.endOffset));
                 const max: usize = @intCast(@max(block.startOffset, block.endOffset));
                 var min_line: u32 = std.math.maxInt(u32);
@@ -473,6 +476,8 @@ pub const ByteRangeMapping = struct {
             lines_which_have_executed = try Bitset.initEmpty(allocator, line_count);
 
             for (blocks, 0..) |block, i| {
+                if (block.endOffset < 0) continue; // does not map to anything
+
                 const min: usize = @intCast(@min(block.startOffset, block.endOffset));
                 const max: usize = @intCast(@max(block.startOffset, block.endOffset));
                 var min_line: u32 = std.math.maxInt(u32);

--- a/src/sourcemap/CodeCoverage.zig
+++ b/src/sourcemap/CodeCoverage.zig
@@ -21,7 +21,6 @@ const prettyFmt = Output.prettyFmt;
 /// bitsets are simple and bitsets are relatively fast to construct and query
 ///
 pub const CodeCoverageReport = struct {
-    
     source_url: bun.JSC.ZigString.Slice,
     executable_lines: Bitset,
     lines_which_have_executed: Bitset,

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -13,12 +13,8 @@ test("coverage crash", () => {
     env: {
       ...bunEnv,
     },
+    stdio: ["inherit", "inherit", "inherit"],
   });
-  try {
-    expect(result.exitCode).toBe(0);
-    expect(result.signalCode).toBeUndefined();
-  } catch (e) {
-    console.log("Err: ", result.stderr.toString("utf8"));
-    throw e;
-  }
+  expect(result.exitCode).toBe(0);
+  expect(result.signalCode).toBeUndefined();
 });

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test";
+import { tempDirWithFiles, bunExe, bunEnv } from "harness";
+import path from "path";
+
+test("coverage crash", () => {
+  const dir = tempDirWithFiles("cov", {
+    "demo.test.ts": `class Y {
+  #hello
+}`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage"], {
+    cwd: dir,
+    env: {
+      ...bunEnv,
+    },
+  });
+  try {
+    expect(result.exitCode).toBe(0);
+    expect(result.signalCode).toBeUndefined();
+  } catch (e) {
+    console.log("Err: ", result.stderr.toString("utf8"));
+    throw e;
+  }
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #10836
Fixes #10621
Fixes #10395
Fixes #9681
Fixes #10501

Does not fix already existing cases where code coverage reports less than 100% of functions when 100% of the lines are executed.