### PR TITLE
Introduce `bun.dns.prefetch` API

### DIFF
--- a/bench/snippets/dns-prefetch.mjs
+++ b/bench/snippets/dns-prefetch.mjs
@@ -9,7 +9,7 @@
 // To clear your DNS cache on Windows:
 //   ipconfig /flushdns
 //
-const url = new URL(process.argv.length > 2 ? process.argv.at(-1) : "https://bun.sh"); 
+const url = new URL(process.argv.length > 2 ? process.argv.at(-1) : "https://bun.sh");
 const hostname = url.hostname;
 const port = url.port ? parseInt(url.port, 10) : url.protocol === "https:" ? 443 : 80;
 

--- a/bench/snippets/dns-prefetch.mjs
+++ b/bench/snippets/dns-prefetch.mjs
@@ -32,3 +32,7 @@ await Promise.all(promises);
 
 const end = performance.now();
 console.log("fetch() took", (end - start) | 0, "ms");
+
+if (typeof globalThis.Bun?.dns?.getCacheStats === "function") {
+  console.log("DNS cache stats", Bun.dns.getCacheStats());
+}

--- a/bench/snippets/dns-prefetch.mjs
+++ b/bench/snippets/dns-prefetch.mjs
@@ -1,0 +1,34 @@
+// For maximum effect, make sure to clear your DNS cache before running this
+//
+// To clear your DNS cache on macOS:
+//   sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+//
+// To clear your DNS cache on Linux:
+//   sudo systemd-resolve --flush-caches && sudo killall -HUP systemd-resolved
+//
+// To clear your DNS cache on Windows:
+//   ipconfig /flushdns
+//
+const url = new URL(process.argv.length > 2 ? process.argv.at(-1) : "https://bun.sh"); 
+const hostname = url.hostname;
+const port = url.port ? parseInt(url.port, 10) : url.protocol === "https:" ? 443 : 80;
+
+if (typeof globalThis.Bun?.dns?.prefetch === "function") {
+  Bun.dns.prefetch(hostname, port);
+}
+
+// Delay one second to make sure the DNS prefetch has time to run
+await new Promise(resolve => setTimeout(resolve, 1000));
+
+const start = performance.now();
+const promises = [];
+
+// Now let's fetch 20 times to see if the DNS prefetch has worked
+for (let i = 0; i < 20; i++) {
+  promises.push(fetch(url, { redirect: "manual", method: "HEAD" }));
+}
+
+await Promise.all(promises);
+
+const end = performance.now();
+console.log("fetch() took", (end - start) | 0, "ms");

--- a/docs/api/dns.md
+++ b/docs/api/dns.md
@@ -8,34 +8,83 @@ console.log(addrs);
 // => [{ address: "172.67.161.226", family: 4, ttl: 0 }, ...]
 ```
 
-<!--
-## `Bun.dns` - lookup a domain
-`Bun.dns` includes utilities to make DNS requests, similar to `node:dns`. As of Bun v0.5.0, the only implemented function is `dns.lookup`, though more will be implemented soon.
-You can lookup the IP addresses of a hostname by using `dns.lookup`.
-```ts
-import { dns } from "bun";
-const [{ address }] = await dns.lookup("example.com");
-console.log(address); // "93.184.216.34"
-```
-If you need to limit IP addresses to either IPv4 or IPv6, you can specify the `family` as an option.
-```ts
-import { dns } from "bun";
-const [{ address }] = await dns.lookup("example.com", { family: 6 });
-console.log(address); // "2606:2800:220:1:248:1893:25c8:1946"
-```
-Bun supports three backends for DNS resolution:
-- `c-ares` - This is the default on Linux, and it uses the [c-ares](https://c-ares.org/) library to perform DNS resolution.
-- `system` - Uses the system's non-blocking DNS resolver, if available. Otherwise, falls back to `getaddrinfo`. This is the default on macOS, and the same as `getaddrinfo` on Linux.
-- `getaddrinfo` - Uses the POSIX standard `getaddrinfo` function, which may cause performance issues under concurrent load.
+## DNS caching in Bun
 
-You can choose a particular backend by specifying `backend` as an option.
+In Bun v1.1.9, we added support for DNS caching. This cache is used by `bun install`, `fetch()`, `node:http` (client), `Bun.connect`, `node:net`, and `node:tls` to make repeated connections to the same hosts faster. 
+
+At the time of writing, we cache up to 255 entries for a maximum of 30 seconds (each). If any connections to a host fail, we remove the entry from the cache. When multiple connections are made to the same host simultaneously, DNS lookups are deduplicated to avoid making multiple requests for the same host.
+
+### `dns.prefetch`
+
+{% callout %}
+**🚧** — This API is experimental and may change in the future.
+{% /callout %}
+
+To prefetch a DNS entry, you can use the `dns.prefetch` API. This API is useful when you know you'll need to connect to a host in the soon and want to avoid the initial DNS lookup.
+
 ```ts
-import { dns } from "bun";
-const [{ address, ttl }] = await dns.lookup("example.com", {
-  backend: "c-ares"
-});
-console.log(address); // "93.184.216.34"
-console.log(ttl); // 21237
+dns.prefetch(hostname: string, port: number): void;
 ```
-Note: the `ttl` property is only accurate when the `backend` is c-ares. Otherwise, `ttl` will be `0`.
-This was added in Bun v0.5.0. -->
+
+Here's an example:
+
+```ts
+import {dns} from "bun";
+
+dns.prefetch("bun.sh", 443);
+//
+// ... sometime later ...
+await fetch("https://bun.sh");
+```
+
+### `dns.getCacheStats()`
+
+{% callout %}
+**🚧** — This API is experimental and may change in the future.
+{% /callout %}
+
+To get the current cache stats, you can use the `dns.getCacheStats` API. 
+
+This API returns an object with the following properties:
+
+```ts
+{
+  // Cache hits 
+  cacheHitsCompleted: number;
+  cacheHitsInflight: number;
+  cacheMisses: number;
+  // Number of items in the DNS cache
+  size: number;
+
+  // Number of times a connection failed
+  errors: number;
+
+  // Number of times a connection was requested at all (including cache hits and misses)
+  totalCount: number;
+}
+```
+
+Example:
+
+```ts
+import {dns} from "bun";
+
+const stats = dns.getCacheStats();
+console.log(stats);
+// => { cacheHitsCompleted: 0, cacheHitsInflight: 0, cacheMisses: 0, size: 0, errors: 0, totalCount: 0 }
+```
+
+### Configuring DNS cache TTL
+
+Bun defaults to 30 seconds for the TTL of DNS cache entries. To change this, you can set the envionrment variable `$BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS`. For example, to set the TTL to 5 seconds:
+
+```sh
+BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS=5 bun run my-script.ts
+```
+
+#### Why is 30 seconds the default?
+
+Unfortunately, the system API underneath (`getaddrinfo`) does not provide a way to get the TTL of a DNS entry. This means we have to pick a number arbitrarily. We chose 30 seconds because it's long enough to see the benefits of caching, and short enough to be unlikely to cause issues if a DNS entry changes. [Amazon Web Services recommends 5 seconds](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/jvm-ttl-dns.html) for the Java Virtual Machine, however the JVM defaults to cache indefinitely. 
+
+
+

--- a/docs/api/dns.md
+++ b/docs/api/dns.md
@@ -14,6 +14,20 @@ In Bun v1.1.9, we added support for DNS caching. This cache is used by `bun inst
 
 At the time of writing, we cache up to 255 entries for a maximum of 30 seconds (each). If any connections to a host fail, we remove the entry from the cache. When multiple connections are made to the same host simultaneously, DNS lookups are deduplicated to avoid making multiple requests for the same host.
 
+### When should I prefetch a DNS entry?
+
+Web browsers expose [`<link rel="dns-prefetch">`](https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch) to allow developers to prefetch DNS entries. This is useful when you know you'll need to connect to a host in the near future and want to avoid the initial DNS lookup.
+
+In Bun, you can use the `dns.prefetch` API to achieve the same effect. 
+
+```ts
+import {dns} from "bun";
+
+dns.prefetch("my.database-host.com", 5432);
+```
+
+An example where you might want to use this is a database driver. When your application first starts up, you can prefetch the DNS entry for the database host so that by the time it finishes loading everything, the DNS query to resolve the database host may already be completed.
+
 ### `dns.prefetch`
 
 {% callout %}

--- a/docs/api/dns.md
+++ b/docs/api/dns.md
@@ -10,9 +10,18 @@ console.log(addrs);
 
 ## DNS caching in Bun
 
-In Bun v1.1.9, we added support for DNS caching. This cache is used by `bun install`, `fetch()`, `node:http` (client), `Bun.connect`, `node:net`, and `node:tls` to make repeated connections to the same hosts faster. 
+In Bun v1.1.9, we added support for DNS caching. This cache makes repeated connections to the same hosts faster. 
 
 At the time of writing, we cache up to 255 entries for a maximum of 30 seconds (each). If any connections to a host fail, we remove the entry from the cache. When multiple connections are made to the same host simultaneously, DNS lookups are deduplicated to avoid making multiple requests for the same host.
+
+This cache is automatically used by;
+
+- `bun install`
+- `fetch()`
+- `node:http` (client)
+- `Bun.connect`
+- `node:net`
+- `node:tls`
 
 ### When should I prefetch a DNS entry?
 

--- a/docs/api/dns.md
+++ b/docs/api/dns.md
@@ -43,7 +43,7 @@ An example where you might want to use this is a database driver. When your appl
 **🚧** — This API is experimental and may change in the future.
 {% /callout %}
 
-To prefetch a DNS entry, you can use the `dns.prefetch` API. This API is useful when you know you'll need to connect to a host in the soon and want to avoid the initial DNS lookup.
+To prefetch a DNS entry, you can use the `dns.prefetch` API. This API is useful when you know you'll need to connect to a host soon and want to avoid the initial DNS lookup.
 
 ```ts
 dns.prefetch(hostname: string, port: number): void;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -998,6 +998,42 @@ declare module "bun" {
         backend?: "libc" | "c-ares" | "system" | "getaddrinfo";
       },
     ): Promise<DNSLookup[]>;
+
+    /**
+     *
+     * **Experimental API**
+     *
+     * Prefetch a hostname and port.
+     *
+     * This will be used by fetch() and Bun.connect() to avoid DNS lookups.
+     *
+     * @param hostname The hostname to prefetch
+     * @param port The port to prefetch
+     *
+     * @example
+     * ```js
+     * import { dns } from 'bun';
+     * dns.prefetch('example.com', 443);
+     * // ... something expensive
+     * await fetch('https://example.com');
+     * ```
+     */
+    prefetch(hostname: string, port: number): void;
+
+    /**
+     * **Experimental API**
+     */
+    getCacheStats(): {
+      /**
+       * The number of times a cached DNS entry that was already resolved was used.
+       */
+      cacheHitsCompleted: number;
+      cacheHitsInflight: number;
+      cacheMisses: number;
+      size: number;
+      errors: number;
+      totalCount: number;
+    };
   };
 
   interface DNSLookup {

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -17,6 +17,7 @@
 
 #include "libusockets.h"
 #include "internal/internal.h"
+#include <netdb.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -344,12 +345,57 @@ struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_sock
     return ls;
 }
 
-struct us_connecting_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_t *context, const char *host, int port, int options, int socket_ext_size) {
+
+struct us_socket_t* us_socket_context_connect_resolved_dns(struct us_socket_context_t *context, void* request, int options, int socket_ext_size) {
+    struct addrinfo_result *result = Bun__addrinfo_getRequestResult(request);
+    if (result->error) {
+        errno = result->error;
+        Bun__addrinfo_freeRequest(request, 1);
+        return NULL;
+    }
+
+    LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(result->info, options);
+    if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
+        int err = errno;
+        Bun__addrinfo_freeRequest(request, err);
+        return NULL;
+    }
+
+    Bun__addrinfo_freeRequest(request, 0);
+    bsd_socket_nodelay(connect_socket_fd, 1);
+
+    /* Connect sockets are semi-sockets just like listen sockets */
+    struct us_poll_t *p = us_create_poll(context->loop, 0, sizeof(struct us_socket_t) + socket_ext_size);
+    us_poll_init(p, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
+    us_poll_start(p, context->loop, LIBUS_SOCKET_WRITABLE);
+
+    struct us_socket_t *socket = (struct us_socket_t *) p;
+
+    /* Link it into context so that timeout fires properly */
+    socket->context = context;
+    socket->timeout = 255;
+    socket->long_timeout = 255;
+    socket->low_prio_state = 0;
+    socket->connect_state = NULL;
+    us_internal_socket_context_link_socket(context, socket);
+
+    return socket;
+}
+
+struct us_connecting_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_t *context, const char *host, int port, int options, int socket_ext_size, int* is_connecting) {
 #ifndef LIBUS_NO_SSL
-    if (ssl) {
-        return us_internal_ssl_socket_context_connect((struct us_internal_ssl_socket_context_t *) context, host, port, options, socket_ext_size);
+    if (ssl == 1) {
+        return us_internal_ssl_socket_context_connect((struct us_internal_ssl_socket_context_t *) context, host, port, options, socket_ext_size, is_connecting);
     }
 #endif
+
+    struct us_loop_t* loop = us_socket_context_loop(ssl, context);
+
+    void* ptr;
+    if (Bun__addrinfo_get(loop, host, port, &ptr) == 0) {
+        *is_connecting = 1;
+        return (struct us_connecting_socket_t *) us_socket_context_connect_resolved_dns(context, ptr, options, socket_ext_size);
+    }
 
     struct us_connecting_socket_t *c = us_calloc(1, sizeof(struct us_connecting_socket_t) + socket_ext_size);
     c->socket_ext_size = socket_ext_size;
@@ -360,13 +406,13 @@ struct us_connecting_socket_t *us_socket_context_connect(int ssl, struct us_sock
     c->long_timeout = 255;
     c->pending_resolve_callback = 1;
 
-    Bun__addrinfo_get(host, port, c);
-
 #ifdef _WIN32
-    context->loop->uv_loop->active_handles++;
+    loop->uv_loop->active_handles++;
 #else
-    context->loop->num_polls++;
+    loop->num_polls++;
 #endif
+
+    Bun__addrinfo_set(ptr, c);
 
     return c;
 }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -17,7 +17,6 @@
 
 #include "libusockets.h"
 #include "internal/internal.h"
-#include <netdb.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -393,6 +392,8 @@ struct us_connecting_socket_t *us_socket_context_connect(int ssl, struct us_sock
 
     void* ptr;
     if (Bun__addrinfo_get(loop, host, port, &ptr) == 0) {
+        // Fast-path: it's already cached.
+        // Avoid the connection logic.
         *is_connecting = 1;
         return (struct us_connecting_socket_t *) us_socket_context_connect_resolved_dns(context, ptr, options, socket_ext_size);
     }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -648,6 +648,17 @@ void us_socket_context_on_connect_error(int ssl, struct us_socket_context_t *con
     context->on_connect_error = on_connect_error;
 }
 
+void us_socket_context_on_socket_connect_error(int ssl, struct us_socket_context_t *context, struct us_socket_t *(*on_connect_error)(struct us_socket_t *s, int code)) {
+#ifndef LIBUS_NO_SSL
+    if (ssl) {
+        us_internal_ssl_socket_context_on_socket_connect_error((struct us_internal_ssl_socket_context_t *) context, (struct us_internal_ssl_socket_t * (*)(struct us_internal_ssl_socket_t *, int)) on_connect_error);
+        return;
+    }
+#endif
+    
+    context->on_socket_connect_error = on_connect_error;
+}
+
 void *us_socket_context_ext(int ssl, struct us_socket_context_t *context) {
 #ifndef LIBUS_NO_SSL
     if (ssl) {

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1518,11 +1518,11 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(
 // TODO does this need more changes?
 struct us_connecting_socket_t *us_internal_ssl_socket_context_connect(
     struct us_internal_ssl_socket_context_t *context, const char *host,
-    int port, int options, int socket_ext_size) {
+    int port, int options, int socket_ext_size, int* is_connected) {
   return us_socket_context_connect(
-      0, &context->sc, host, port, options,
+      2, &context->sc, host, port, options,
       sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) +
-          socket_ext_size);
+          socket_ext_size, is_connected);
 }
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect_unix(

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -80,7 +80,8 @@ struct addrinfo_result {
     int error;
 };
 
-extern void Bun__addrinfo_get(const char* host, int port, struct us_connecting_socket_t *s);
+extern int Bun__addrinfo_get(struct us_loop_t* loop, const char* host, int port, void** ptr);
+extern int Bun__addrinfo_set(void* ptr, struct us_connecting_socket_t* socket); 
 extern void Bun__addrinfo_freeRequest(void* addrinfo_req, int error);
 extern struct addrinfo_result *Bun__addrinfo_getRequestResult(void* addrinfo_req);
 
@@ -350,7 +351,7 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(
 
 struct us_connecting_socket_t *us_internal_ssl_socket_context_connect(
     struct us_internal_ssl_socket_context_t *context, const char *host,
-    int port, int options, int socket_ext_size);
+    int port, int options, int socket_ext_size, int* is_resolved);
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect_unix(
     struct us_internal_ssl_socket_context_t *context, const char *server_path,

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -243,7 +243,9 @@ struct us_socket_context_t {
   struct us_socket_t *(*on_socket_long_timeout)(struct us_socket_t *);
   struct us_socket_t *(*on_end)(struct us_socket_t *);
   struct us_connecting_socket_t *(*on_connect_error)(struct us_connecting_socket_t *, int code);
+  struct us_socket_t *(*on_socket_connect_error)(struct us_socket_t *, int code);
   int (*is_low_prio)(struct us_socket_t *);
+  
 };
 
 /* Internal SSL interface */
@@ -339,6 +341,11 @@ void us_internal_ssl_socket_context_on_end(
 void us_internal_ssl_socket_context_on_connect_error(
     struct us_internal_ssl_socket_context_t *context,
     struct us_internal_ssl_socket_t *(*on_connect_error)(
+        struct us_internal_ssl_socket_t *s, int code));
+
+void us_internal_ssl_socket_context_on_socket_connect_error(
+        struct us_internal_ssl_socket_context_t *context,
+    struct us_internal_ssl_socket_t *(*on_socket_connect_error)(
         struct us_internal_ssl_socket_t *s, int code));
 
 struct us_listen_socket_t *us_internal_ssl_socket_context_listen(

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -269,7 +269,7 @@ void us_listen_socket_close(int ssl, struct us_listen_socket_t *ls);
 
 /* Land in on_open or on_connection_error or return null or return socket */
 struct us_connecting_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_t *context,
-    const char *host, int port, int options, int socket_ext_size);
+    const char *host, int port, int options, int socket_ext_size, int *is_connecting);
 
 struct us_socket_t *us_socket_context_connect_unix(int ssl, struct us_socket_context_t *context,
     const char *server_path, size_t pathlen, int options, int socket_ext_size);

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -181,6 +181,7 @@ struct us_socket_events_t {
     struct us_socket_t *(*on_long_timeout)(struct us_socket_t *);
     struct us_socket_t *(*on_end)(struct us_socket_t *);
     struct us_connecting_socket_t *(*on_connect_error)(struct us_connecting_socket_t *, int code);
+    struct us_socket_t *(*on_connecting_socket_error)(struct us_socket_t *, int code);
     void (*on_handshake)(struct us_socket_t*, int success, struct us_bun_verify_error_t verify_error, void* custom_data);
 };
 
@@ -245,6 +246,8 @@ void us_socket_context_on_long_timeout(int ssl, struct us_socket_context_t *cont
 /* This one is only used for when a connecting socket fails in a late stage. */
 void us_socket_context_on_connect_error(int ssl, struct us_socket_context_t *context,
     struct us_connecting_socket_t *(*on_connect_error)(struct us_connecting_socket_t *s, int code));
+void us_socket_context_on_socket_connect_error(int ssl, struct us_socket_context_t *context,
+    struct us_socket_t *(*on_connect_error)(struct us_socket_t *s, int code));
 
 void us_socket_context_on_handshake(int ssl, struct us_socket_context_t *context, void (*on_handshake)(struct us_socket_t *, int success, struct us_bun_verify_error_t verify_error, void* custom_data), void* custom_data);
 

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -285,8 +285,10 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
                     if (c) {
                         /* Emit error, close without emitting on_close */
                         s->context->on_connect_error(s->connect_state, error);
+                        us_connecting_socket_close(c->ssl, c);
                     } else {
                         s->context->on_socket_connect_error(s, error);
+                        // close is called by the caller
                     }
                     
                     s = NULL;

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -281,9 +281,14 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
 
                 /* It is perfectly possible to come here with an error */
                 if (error) {
-                    /* Emit error, close without emitting on_close */
-                    s->context->on_connect_error(s->connect_state, error);
-                    us_connecting_socket_close(0, s->connect_state);
+                    struct us_connecting_socket_t *c = s->connect_state; 
+                    if (c) {
+                        /* Emit error, close without emitting on_close */
+                        s->context->on_connect_error(s->connect_state, error);
+                    } else {
+                        s->context->on_socket_connect_error(s, error);
+                    }
+                    
                     s = NULL;
                 } else {
                     /* All sockets poll for readable */

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -282,13 +282,21 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
                 /* It is perfectly possible to come here with an error */
                 if (error) {
                     struct us_connecting_socket_t *c = s->connect_state; 
+
+                    /* Emit error, close without emitting on_close */
+
+                    /* There are two possible states here: 
+                        1. It's a us_connecting_socket_t*. DNS resolution failed, or a connection failed. 
+                        2. It's a us_socket_t* 
+
+                       We differentiate between these two cases by checking if the connect_state is null.
+                    */
                     if (c) {
-                        /* Emit error, close without emitting on_close */
                         s->context->on_connect_error(s->connect_state, error);
                         us_connecting_socket_close(c->ssl, c);
                     } else {
                         s->context->on_socket_connect_error(s, error);
-                        // close is called by the caller
+                        // It's expected that close is called by the caller
                     }
                     
                     s = NULL;

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -191,7 +191,10 @@ struct us_socket_t *us_socket_close(int ssl, struct us_socket_t *s, int code, vo
         /* Any socket with prev = context is marked as closed */
         s->prev = (struct us_socket_t *) s->context;
 
-        return s->context->on_close(s, code, reason);
+        if (!(s->p.state.poll_type & POLL_TYPE_SEMI_SOCKET)) {
+            return s->context->on_close(s, code, reason);
+        }
+        
     }
     return s;
 }

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -191,7 +191,7 @@ struct us_socket_t *us_socket_close(int ssl, struct us_socket_t *s, int code, vo
         /* Any socket with prev = context is marked as closed */
         s->prev = (struct us_socket_t *) s->context;
 
-        if (!(s->p.state.poll_type & POLL_TYPE_SEMI_SOCKET)) {
+        if (!(us_internal_poll_type(&s->p) & POLL_TYPE_SEMI_SOCKET)) {
             return s->context->on_close(s, code, reason);
         }
         

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1331,8 +1331,7 @@ pub const InternalDNS = struct {
         // However, we're almost out of time to use 32 bit timestamps for anything
         // So we set the epoch to January 1st, 2024 instead.
         pub fn getCacheTimestamp() u32 {
-            const now = bun.getRoughTickCountMs();
-            return @truncate(now / 1000);
+            return @truncate(bun.getRoughTickCountMs());
         }
 
         fn isNearlyFull(this: *This) bool {

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1354,7 +1354,7 @@ pub const InternalDNS = struct {
             // equivalent of swapRemove
             for (0..len) |i| {
                 if (this.cache[i] == entry) {
-                    this.deleteEntryAt(i, len);
+                    this.deleteEntryAt(len, i);
                     return;
                 }
             }

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1170,6 +1170,32 @@ pub const GlobalData = struct {
 
 pub const InternalDNS = struct {
     const log = Output.scoped(.dns, true);
+
+    var __max_dns_time_to_live_seconds: ?u32 = null;
+    pub fn getMaxDNSTimeToLiveSeconds() u32 {
+        // Amazon Web Services recommends 5 seconds: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/jvm-ttl-dns.html
+        const default_max_dns_time_to_live_seconds = 30;
+
+        // This is racy, but it's okay because the number won't be invalid, just stale.
+        return __max_dns_time_to_live_seconds orelse {
+            if (bun.getenvZ("BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS")) |string_value| {
+                const value = std.fmt.parseInt(i64, string_value, 10) catch {
+                    __max_dns_time_to_live_seconds = default_max_dns_time_to_live_seconds;
+                    return default_max_dns_time_to_live_seconds;
+                };
+                if (value < 0) {
+                    __max_dns_time_to_live_seconds = std.math.maxInt(u32);
+                } else {
+                    __max_dns_time_to_live_seconds = @truncate(@as(u64, @intCast(value)));
+                }
+                return __max_dns_time_to_live_seconds.?;
+            }
+
+            __max_dns_time_to_live_seconds = default_max_dns_time_to_live_seconds;
+            return default_max_dns_time_to_live_seconds;
+        };
+    }
+
     pub const Request = struct {
         const Key = struct {
             host: ?[:0]const u8,
@@ -1178,10 +1204,7 @@ pub const InternalDNS = struct {
 
             pub fn init(name: ?[:0]const u8, port: u16) @This() {
                 const hash = if (name) |n| brk: {
-                    var hasher = std.hash.Wyhash.init(0);
-                    hasher.update(n);
-                    const hash = hasher.final();
-                    break :brk hash;
+                    break :brk bun.hash(n);
                 } else 0;
                 return .{
                     .host = name,
@@ -1224,13 +1247,37 @@ pub const InternalDNS = struct {
         key: Key,
         result: ?Result = null,
 
-        notify: std.ArrayListUnmanaged(*bun.uws.ConnectingSocket) = .{},
-        // number of sockets that have a reference to result or are waiting for the result
-        // while this is non-zero, this entry cannot be freed
-        refcount: usize = 0,
+        notify: std.ArrayListUnmanaged(DNSRequestOwner) = .{},
+
+        /// number of sockets that have a reference to result or are waiting for the result
+        /// while this is non-zero, this entry cannot be freed
+        refcount: u32 = 0,
+
+        /// Seconds since the epoch when this request was created.
+        /// Not a precise timestamp.
+        created_at: u32 = std.math.maxInt(u32),
+
+        lock: bun.Lock = bun.Lock.init(),
+
         valid: bool = true,
 
         libinfo: if (Environment.isMac) MacAsyncDNS else void = if (Environment.isMac) .{} else {},
+
+        pub fn isExpired(this: *Request, timestamp_to_store: *u32) bool {
+            if (this.refcount > 0 or this.result == null) {
+                return false;
+            }
+
+            const now = GlobalCache.getCacheTimestamp();
+            timestamp_to_store.* = now;
+
+            if (now -| this.created_at > getMaxDNSTimeToLiveSeconds()) {
+                this.valid = false;
+                return true;
+            }
+
+            return false;
+        }
 
         pub fn deinit(this: *@This()) void {
             bun.assert(this.notify.items.len == 0);
@@ -1263,18 +1310,43 @@ pub const InternalDNS = struct {
         fn get(
             this: *This,
             key: Request.Key,
+            timestamp_to_store: *u32,
         ) ?*Request {
-            for (this.cache[0..this.len]) |entry| {
+            const len = this.len;
+            for (this.cache[0..len], 0..) |entry, i| {
                 if (entry.key.hash == key.hash and entry.key.port == key.port and entry.valid) {
+                    if (entry.isExpired(timestamp_to_store)) {
+                        log("get: expired entry", .{});
+                        this.deleteEntryAt(len, i);
+                        return null;
+                    }
+
                     return entry;
                 }
             }
             return null;
         }
 
+        // To preserve memory, we use a 32 bit timestamp
+        // However, we're almost out of time to use 32 bit timestamps for anything
+        // So we set the epoch to January 1st, 2024 instead.
+        pub fn getCacheTimestamp() u32 {
+            const now = bun.getRoughTimestampMillis();
+            // Excited for the bug report: "if i set my system clock to before 2024, the dns cache stops working!"
+            const january_1st_2024_ms = 1704067200000;
+            const relative_now = now -| january_1st_2024_ms;
+            return @truncate(relative_now / 1000);
+        }
+
         fn isNearlyFull(this: *This) bool {
             // 80% full (value is kind of arbitrary)
-            return this.len * 5 >= this.cache.len * 4;
+            return @atomicLoad(usize, &this.len, .Monotonic) * 5 >= this.cache.len * 4;
+        }
+
+        fn deleteEntryAt(this: *This, len: usize, i: usize) void {
+            this.cache[i] = this.cache[len - 1];
+            this.len -= 1;
+            dns_cache_size = len - 1;
         }
 
         fn remove(this: *This, entry: *Request) void {
@@ -1282,9 +1354,7 @@ pub const InternalDNS = struct {
             // equivalent of swapRemove
             for (0..len) |i| {
                 if (this.cache[i] == entry) {
-                    this.cache[i] = this.cache[len - 1];
-                    this.len -= 1;
-                    dns_cache_size = len - 1;
+                    this.deleteEntryAt(i, len);
                     return;
                 }
             }
@@ -1328,19 +1398,48 @@ pub const InternalDNS = struct {
     extern fn us_internal_dns_callback(socket: *bun.uws.ConnectingSocket, req: *Request) void;
     extern fn us_internal_dns_callback_threadsafe(socket: *bun.uws.ConnectingSocket, req: *Request) void;
 
+    pub const DNSRequestOwner = union(enum) {
+        socket: *bun.uws.ConnectingSocket,
+        prefetch: *bun.uws.Loop,
+
+        pub fn notifyThreadsafe(this: DNSRequestOwner, req: *Request) void {
+            switch (this) {
+                .socket => |socket| us_internal_dns_callback_threadsafe(socket, req),
+                .prefetch => freeaddrinfo(req, 0),
+            }
+        }
+
+        pub fn notify(this: DNSRequestOwner, req: *Request) void {
+            switch (this) {
+                .prefetch => freeaddrinfo(req, 0),
+                .socket => us_internal_dns_callback(this.socket, req),
+            }
+        }
+
+        pub fn loop(this: DNSRequestOwner) *bun.uws.Loop {
+            return switch (this) {
+                .prefetch => this.prefetch,
+                .socket => bun.uws.us_connecting_socket_get_loop(this.socket),
+            };
+        }
+    };
+
     fn afterResult(req: *Request, info: ?*std.c.addrinfo, err: c_int) void {
-        // need to acquire the global cache lock to ensure that the notify list is not modified while we are iterating over it
-        global_cache.lock.lock();
-        defer global_cache.lock.unlock();
+        // Only lock while
+        req.lock.lock();
 
         req.result = .{
             .info = info,
             .err = err,
         };
-        for (req.notify.items) |socket| {
-            us_internal_dns_callback_threadsafe(socket, req);
+        var notify = req.notify;
+        defer notify.deinit(bun.default_allocator);
+        req.notify = .{};
+        req.lock.unlock();
+
+        for (notify.items) |query| {
+            query.notifyThreadsafe(req);
         }
-        req.notify.clearAndFree(bun.default_allocator);
     }
 
     fn workPoolCallback(req: *Request) void {
@@ -1382,9 +1481,9 @@ pub const InternalDNS = struct {
         }
     }
 
-    pub fn lookupLibinfo(req: *Request, socket: *bun.uws.ConnectingSocket) bool {
+    pub fn lookupLibinfo(req: *Request, owner: DNSRequestOwner) bool {
         const getaddrinfo_async_start_ = LibInfo.getaddrinfo_async_start() orelse return false;
-        const loop = bun.uws.us_connecting_socket_get_loop(socket).internal_loop_data.getParent();
+        const loop = owner.loop().internal_loop_data.getParent();
 
         var port_buf: [128]u8 = undefined;
         const port = std.fmt.bufPrintIntToSlice(&port_buf, req.key.port, 10, .lower, .{});
@@ -1437,44 +1536,43 @@ pub const InternalDNS = struct {
     var dns_cache_errors: usize = 0;
     var getaddrinfo_calls: usize = 0;
 
-    pub fn createDNSCacheStatsObject(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) callconv(.C) JSC.JSValue {
-        const object = JSC.JSValue.createEmptyObject(globalObject, 7);
-        object.put(globalObject, JSC.ZigString.static("cache_hits_completed"), JSC.JSValue.jsNumber(@atomicLoad(usize, &dns_cache_hits_completed, .Monotonic)));
-        object.put(globalObject, JSC.ZigString.static("cache_hits_inflight"), JSC.JSValue.jsNumber(@atomicLoad(usize, &dns_cache_hits_inflight, .Monotonic)));
+    pub fn getDNSCacheStats(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) callconv(.C) JSC.JSValue {
+        const object = JSC.JSValue.createEmptyObject(globalObject, 6);
+        object.put(globalObject, JSC.ZigString.static("cacheHitsCompleted"), JSC.JSValue.jsNumber(@atomicLoad(usize, &dns_cache_hits_completed, .Monotonic)));
+        object.put(globalObject, JSC.ZigString.static("cacheHitsInflight"), JSC.JSValue.jsNumber(@atomicLoad(usize, &dns_cache_hits_inflight, .Monotonic)));
+        object.put(globalObject, JSC.ZigString.static("cacheMisses"), JSC.JSValue.jsNumber(@atomicLoad(usize, &dns_cache_misses, .Monotonic)));
         object.put(globalObject, JSC.ZigString.static("size"), JSC.JSValue.jsNumber(@atomicLoad(usize, &dns_cache_size, .Monotonic)));
-        object.put(globalObject, JSC.ZigString.static("cache_misses"), JSC.JSValue.jsNumber(@atomicLoad(usize, &dns_cache_misses, .Monotonic)));
         object.put(globalObject, JSC.ZigString.static("errors"), JSC.JSValue.jsNumber(@atomicLoad(usize, &dns_cache_errors, .Monotonic)));
-        object.put(globalObject, JSC.ZigString.static("getaddrinfo"), JSC.JSValue.jsNumber(@atomicLoad(usize, &getaddrinfo_calls, .Monotonic)));
+        object.put(globalObject, JSC.ZigString.static("totalCount"), JSC.JSValue.jsNumber(@atomicLoad(usize, &getaddrinfo_calls, .Monotonic)));
         return object;
     }
 
-    pub fn getDNSCacheStats(globalObject: *JSC.JSGlobalObject) callconv(.C) JSC.JSValue {
-        return JSC.JSFunction.create(globalObject, "createDNSCacheStatsObject", createDNSCacheStatsObject, 0, .{});
-    }
-
-    fn getaddrinfo(_host: ?[*:0]const u8, port: u16, socket: *bun.uws.ConnectingSocket) callconv(.C) void {
-        const host: ?[:0]const u8 = std.mem.span(_host);
+    pub fn getaddrinfo(host: ?[:0]const u8, port: u16, query: DNSRequestOwner) void {
         const key = Request.Key.init(host, port);
-
         global_cache.lock.lock();
         getaddrinfo_calls += 1;
+        var timestamp_to_store: u32 = 0;
         // is there a cache hit?
         if (!bun.getRuntimeFeatureFlag("BUN_FEATURE_FLAG_DISABLE_DNS_CACHE")) {
-            if (global_cache.get(key)) |entry| {
+            if (global_cache.get(key, &timestamp_to_store)) |entry| {
+                entry.lock.lock();
                 if (entry.result != null) {
                     log("getaddrinfo({s}:{d}) = cache hit", .{ host orelse "", port });
                     // result is already available, we can notify the socket immediately
                     entry.refcount += 1;
                     dns_cache_hits_completed += 1;
                     global_cache.lock.unlock();
-                    us_internal_dns_callback(socket, entry);
+                    entry.lock.unlock();
+                    query.notify(entry);
                     return;
                 } else {
                     log("getaddrinfo({s}:{d}) = cache hit (inflight)", .{ host orelse "", port });
+
                     // add this socket to the list of sockets to be notified when the request is resolved
-                    entry.notify.append(bun.default_allocator, socket) catch bun.outOfMemory();
+                    entry.notify.append(bun.default_allocator, query) catch bun.outOfMemory();
                     entry.refcount += 1;
                     dns_cache_hits_inflight += 1;
+                    entry.lock.unlock();
                     global_cache.lock.unlock();
                     return;
                 }
@@ -1486,8 +1584,11 @@ pub const InternalDNS = struct {
         req.* = .{
             .key = key.toOwned(),
             .refcount = 1,
+
+            // Seconds since when this request was created
+            .created_at = if (timestamp_to_store == 0) GlobalCache.getCacheTimestamp() else timestamp_to_store,
         };
-        req.notify.append(bun.default_allocator, socket) catch bun.outOfMemory();
+        req.notify.append(bun.default_allocator, query) catch bun.outOfMemory();
         _ = global_cache.tryPush(req);
         dns_cache_misses += 1;
         dns_cache_size = global_cache.len;
@@ -1496,7 +1597,7 @@ pub const InternalDNS = struct {
         // doesn't work yet
         if (comptime Environment.isMac) {
             if (!bun.getRuntimeFeatureFlag("BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO")) {
-                const res = lookupLibinfo(req, socket);
+                const res = lookupLibinfo(req, query);
                 log("getaddrinfo({s}:{d}) = cache miss (libinfo)", .{ host orelse "", port });
                 if (res) return;
                 // if we were not able to use libinfo, we fall back to the work pool
@@ -1508,16 +1609,71 @@ pub const InternalDNS = struct {
         bun.JSC.WorkPool.go(bun.default_allocator, *Request, req, workPoolCallback) catch bun.outOfMemory();
     }
 
+    pub fn prefetchFromJS(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) JSC.JSValue {
+        const arguments = callframe.arguments(2).slice();
+
+        if (arguments.len < 1) {
+            globalThis.throwNotEnoughArguments("prefetch", 1, arguments.len);
+            return .zero;
+        }
+
+        const hostname_or_url = arguments[0];
+
+        var hostname_slice = JSC.ZigString.Slice.empty;
+        defer hostname_slice.deinit();
+        var port: u16 = 0;
+
+        if (hostname_or_url.isString()) {
+            hostname_slice = hostname_or_url.toSlice(globalThis, bun.default_allocator);
+
+            if (arguments.len > 1 and arguments[1].isAnyInt()) {
+                const portI = arguments[1].coerce(i32, globalThis);
+                if (portI < 0 or portI > 65535) {
+                    globalThis.throwInvalidArguments("port must be between 0 and 65535", .{});
+                    return .zero;
+                }
+                port = @intCast(portI);
+            } else {
+                globalThis.throwInvalidArguments("port must be an integer", .{});
+                return .zero;
+            }
+        } else {
+            globalThis.throwInvalidArguments("hostname must be a string", .{});
+            return .zero;
+        }
+
+        const hostname_z = bun.default_allocator.dupeZ(u8, hostname_slice.slice()) catch {
+            globalThis.throwOutOfMemory();
+            return .zero;
+        };
+        defer bun.default_allocator.free(hostname_z);
+
+        prefetch(JSC.VirtualMachine.get().uwsLoop(), hostname_z, port);
+        return .undefined;
+    }
+
+    pub fn prefetch(loop: *bun.uws.Loop, hostname: ?[:0]const u8, port: u16) void {
+        getaddrinfo(hostname, port, .{ .prefetch = loop });
+    }
+
+    fn us_getaddrinfo(_host: ?[*:0]const u8, port: u16, socket: *bun.uws.ConnectingSocket) callconv(.C) void {
+        const host: ?[:0]const u8 = std.mem.span(_host);
+        getaddrinfo(host, port, .{ .socket = socket });
+    }
+
     fn freeaddrinfo(req: *Request, err: c_int) callconv(.C) void {
-        global_cache.lock.lock();
-        defer global_cache.lock.unlock();
+        req.lock.lock();
+        defer req.lock.unlock();
 
         req.valid = err == 0;
         dns_cache_errors += @as(usize, @intFromBool(err != 0));
 
         req.refcount -= 1;
         if (req.refcount == 0 and (global_cache.isNearlyFull() or !req.valid)) {
+            global_cache.lock.lock();
             log("cache --", .{});
+
+            defer global_cache.lock.unlock();
             global_cache.remove(req);
             req.deinit();
         }
@@ -1531,7 +1687,7 @@ pub const InternalDNS = struct {
 pub const InternalDNSRequest = InternalDNS.Request;
 
 comptime {
-    @export(InternalDNS.getaddrinfo, .{
+    @export(InternalDNS.us_getaddrinfo, .{
         .name = "Bun__addrinfo_get",
     });
     @export(InternalDNS.freeaddrinfo, .{
@@ -2911,7 +3067,14 @@ pub const DNSResolver = struct {
                 .name = "Bun__DNSResolver__lookupService",
             },
         );
+        @export(
+            InternalDNS.prefetchFromJS,
+            .{
+                .name = "Bun__DNSResolver__prefetch",
+            },
+        );
+        @export(InternalDNS.getDNSCacheStats, .{
+            .name = "Bun__DNSResolver__getCacheStats",
+        });
     }
 };
-
-pub const getDNSCacheStats = InternalDNS.getDNSCacheStats;

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1331,11 +1331,8 @@ pub const InternalDNS = struct {
         // However, we're almost out of time to use 32 bit timestamps for anything
         // So we set the epoch to January 1st, 2024 instead.
         pub fn getCacheTimestamp() u32 {
-            const now = bun.getRoughTimestampMillis();
-            // Excited for the bug report: "if i set my system clock to before 2024, the dns cache stops working!"
-            const january_1st_2024_ms = 1704067200000;
-            const relative_now = now -| january_1st_2024_ms;
-            return @truncate(relative_now / 1000);
+            const now = bun.getRoughTickCountMs();
+            return @truncate(now / 1000);
         }
 
         fn isNearlyFull(this: *This) bool {

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1322,9 +1322,7 @@ pub const InternalDNS = struct {
                 if (entry.key.hash == key.hash and entry.key.port == key.port and entry.valid) {
                     if (entry.isExpired(timestamp_to_store)) {
                         log("get: expired entry", .{});
-                        if (this.deleteEntryAt(len, i)) |deleted| {
-                            deleted.deinit();
-                        }
+                        entry.deinit();
                         len = this.len;
                         continue;
                     }

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1322,6 +1322,7 @@ pub const InternalDNS = struct {
                 if (entry.key.hash == key.hash and entry.key.port == key.port and entry.valid) {
                     if (entry.isExpired(timestamp_to_store)) {
                         log("get: expired entry", .{});
+                        _ = this.deleteEntryAt(len, i);
                         entry.deinit();
                         len = this.len;
                         continue;

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -275,20 +275,22 @@ static JSValue constructBunShell(VM& vm, JSObject* bunObject)
     return bunShell;
 }
 
-extern "C" EncodedJSValue Bun__DNSResolver__lookup(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__resolve(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__resolveSrv(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__resolveTxt(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__resolveSoa(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__resolveNaptr(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__resolveMx(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__resolveCaa(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__resolveNs(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__resolvePtr(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__resolveCname(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__getServers(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__reverse(JSGlobalObject*, JSC::CallFrame*);
-extern "C" EncodedJSValue Bun__DNSResolver__lookupService(JSGlobalObject*, JSC::CallFrame*);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__lookup);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__resolve);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__resolveSrv);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__resolveTxt);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__resolveSoa);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__resolveNaptr);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__resolveMx);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__resolveCaa);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__resolveNs);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__resolvePtr);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__resolveCname);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__getServers);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__reverse);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__lookupService);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__prefetch);
+extern "C" JSC_DECLARE_HOST_FUNCTION(Bun__DNSResolver__getCacheStats);
 
 static JSValue constructDNSObject(VM& vm, JSObject* bunObject)
 {
@@ -321,6 +323,10 @@ static JSValue constructDNSObject(VM& vm, JSObject* bunObject)
     dnsObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "reverse"_s), 2, Bun__DNSResolver__reverse, ImplementationVisibility::Public, NoIntrinsic,
         JSC::PropertyAttribute::DontDelete | 0);
     dnsObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "lookupService"_s), 2, Bun__DNSResolver__lookupService, ImplementationVisibility::Public, NoIntrinsic,
+        JSC::PropertyAttribute::DontDelete | 0);
+    dnsObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "prefetch"_s), 2, Bun__DNSResolver__prefetch, ImplementationVisibility::Public, NoIntrinsic,
+        JSC::PropertyAttribute::DontDelete | 0);
+    dnsObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "getCacheStats"_s), 0, Bun__DNSResolver__getCacheStats, ImplementationVisibility::Public, NoIntrinsic,
         JSC::PropertyAttribute::DontDelete | 0);
     return dnsObject;
 }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3219,7 +3219,7 @@ pub const dns = @import("./dns.zig");
 /// When you don't need a super accurate timestamp, this is a fast way to get one.
 ///
 /// Requesting the current time frequently is somewhat expensive. So we can use a rough timestamp
-pub fn getRoughTimestampMillis() u64 {
+pub fn getRoughTickCountMs() u64 {
     if (comptime Environment.isMac) {
         // https://opensource.apple.com/source/xnu/xnu-2782.30.5/libsyscall/wrappers/mach_approximate_time.c.auto.html
         // https://opensource.apple.com/source/Libc/Libc-1158.1.2/gen/clock_gettime.c.auto.html
@@ -3227,8 +3227,8 @@ pub fn getRoughTimestampMillis() u64 {
             pub extern "C" fn clock_gettime_nsec_np(i32) u64;
         }.clock_gettime_nsec_np;
         // time.h
-        const CLOCK_MONOTONIC_RAW_APPROX = 5;
-        return clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW_APPROX) *| std.time.ns_per_ms;
+        const CLOCK_UPTIME_RAW_APPROX = 9;
+        return clock_gettime_nsec_np(CLOCK_UPTIME_RAW_APPROX) *| std.time.ns_per_ms;
     }
 
     if (comptime Environment.isLinux) {

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3218,7 +3218,9 @@ pub const dns = @import("./dns.zig");
 
 /// When you don't need a super accurate timestamp, this is a fast way to get one.
 ///
-/// Requesting the current time frequently is somewhat expensive. So we can use a rough timestamp
+/// Requesting the current time frequently is somewhat expensive. So we can use a rough timestamp.
+///
+/// This timestamp doesn't easily correlate to a specific time. It's only useful relative to other calls.
 pub fn getRoughTickCountMs() u64 {
     if (comptime Environment.isMac) {
         // https://opensource.apple.com/source/xnu/xnu-2782.30.5/libsyscall/wrappers/mach_approximate_time.c.auto.html

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3222,13 +3222,11 @@ pub const dns = @import("./dns.zig");
 pub fn getRoughTickCountMs() u64 {
     if (comptime Environment.isMac) {
         // https://opensource.apple.com/source/xnu/xnu-2782.30.5/libsyscall/wrappers/mach_approximate_time.c.auto.html
-        // https://opensource.apple.com/source/Libc/Libc-1158.1.2/gen/clock_gettime.c.auto.html
-        const clock_gettime_nsec_np = struct {
-            pub extern "C" fn clock_gettime_nsec_np(i32) u64;
-        }.clock_gettime_nsec_np;
-        // time.h
-        const CLOCK_UPTIME_RAW_APPROX = 9;
-        return clock_gettime_nsec_np(CLOCK_UPTIME_RAW_APPROX) *| std.time.ns_per_ms;
+        const mach_continuous_approximate_time = struct {
+            pub extern "C" fn mach_continuous_approximate_time() u64;
+        }.mach_continuous_approximate_time;
+
+        return mach_continuous_approximate_time() *| std.time.ns_per_ms;
     }
 
     if (comptime Environment.isLinux) {

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3226,7 +3226,7 @@ pub fn getRoughTickCountMs() u64 {
             pub extern "C" fn mach_continuous_approximate_time() u64;
         }.mach_continuous_approximate_time;
 
-        return mach_continuous_approximate_time() *| std.time.ns_per_ms;
+        return mach_continuous_approximate_time() / std.time.ns_per_ms;
     }
 
     if (comptime Environment.isLinux) {

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -256,8 +256,16 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 }
                 pub fn on_connect_error(socket: *Socket, code: i32) callconv(.C) ?*Socket {
                     Fields.onConnectError(
-                        getValue(socket),
+                        TLSSocket.from(socket).ext(ContextType).*,
                         TLSSocket.from(socket),
+                        code,
+                    );
+                    return socket;
+                }
+                pub fn on_connect_error_connecting_socket(socket: *ConnectingSocket, code: i32) callconv(.C) ?*ConnectingSocket {
+                    Fields.onConnectError(
+                        @as(*align(alignment) ContextType, @ptrCast(@alignCast(us_connecting_socket_ext(1, socket)))).*,
+                        TLSSocket.fromConnecting(socket),
                         code,
                     );
                     return socket;
@@ -281,6 +289,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .on_writable = SocketHandler.on_writable,
                 .on_timeout = SocketHandler.on_timeout,
                 .on_connect_error = SocketHandler.on_connect_error,
+                .on_connect_error_connecting_socket = SocketHandler.on_connect_error_connecting_socket,
                 .on_end = SocketHandler.on_end,
                 .on_handshake = SocketHandler.on_handshake,
                 .on_long_timeout = SocketHandler.on_long_timeout,
@@ -783,7 +792,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     );
                     return socket;
                 }
-                pub fn on_connect_error(socket: *ConnectingSocket, code: i32) callconv(.C) ?*ConnectingSocket {
+                pub fn on_connect_error_connecting_socket(socket: *ConnectingSocket, code: i32) callconv(.C) ?*ConnectingSocket {
                     const val = if (comptime ContextType == anyopaque)
                         us_connecting_socket_ext(comptime ssl_int, socket)
                     else if (comptime deref_)
@@ -793,6 +802,20 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     Fields.onConnectError(
                         val,
                         SocketHandlerType.fromConnecting(socket),
+                        code,
+                    );
+                    return socket;
+                }
+                pub fn on_connect_error(socket: *Socket, code: i32) callconv(.C) ?*Socket {
+                    const val = if (comptime ContextType == anyopaque)
+                        us_socket_ext(comptime ssl_int, socket)
+                    else if (comptime deref_)
+                        SocketHandlerType.from(socket).ext(ContextType).*
+                    else
+                        SocketHandlerType.from(socket).ext(ContextType);
+                    Fields.onConnectError(
+                        val,
+                        SocketHandlerType.from(socket),
                         code,
                     );
                     return socket;
@@ -819,8 +842,10 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 us_socket_context_on_writable(ssl_int, ctx, SocketHandler.on_writable);
             if (comptime @hasDecl(Type, "onTimeout") and @typeInfo(@TypeOf(Type.onTimeout)) != .Null)
                 us_socket_context_on_timeout(ssl_int, ctx, SocketHandler.on_timeout);
-            if (comptime @hasDecl(Type, "onConnectError") and @typeInfo(@TypeOf(Type.onConnectError)) != .Null)
-                us_socket_context_on_connect_error(ssl_int, ctx, SocketHandler.on_connect_error);
+            if (comptime @hasDecl(Type, "onConnectError") and @typeInfo(@TypeOf(Type.onConnectError)) != .Null) {
+                us_socket_context_on_socket_connect_error(ssl_int, ctx, SocketHandler.on_connect_error);
+                us_socket_context_on_connect_error(ssl_int, ctx, SocketHandler.on_connect_error_connecting_socket);
+            }
             if (comptime @hasDecl(Type, "onEnd") and @typeInfo(@TypeOf(Type.onEnd)) != .Null)
                 us_socket_context_on_end(ssl_int, ctx, SocketHandler.on_end);
             if (comptime @hasDecl(Type, "onHandshake") and @typeInfo(@TypeOf(Type.onHandshake)) != .Null)
@@ -906,7 +931,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     );
                     return socket;
                 }
-                pub fn on_connect_error(socket: *ConnectingSocket, code: i32) callconv(.C) ?*ConnectingSocket {
+                pub fn on_connect_error_connecting_socket(socket: *ConnectingSocket, code: i32) callconv(.C) ?*ConnectingSocket {
                     const val = if (comptime ContextType == anyopaque)
                         us_connecting_socket_ext(comptime ssl_int, socket)
                     else if (comptime deref_)
@@ -916,6 +941,20 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     Fields.onConnectError(
                         val,
                         ThisSocket.fromConnecting(socket),
+                        code,
+                    );
+                    return socket;
+                }
+                pub fn on_connect_error(socket: *Socket, code: i32) callconv(.C) ?*Socket {
+                    const val = if (comptime ContextType == anyopaque)
+                        us_socket_ext(comptime ssl_int, socket)
+                    else if (comptime deref_)
+                        ThisSocket.from(socket).ext(ContextType).*
+                    else
+                        ThisSocket.from(socket).ext(ContextType);
+                    Fields.onConnectError(
+                        val,
+                        ThisSocket.from(socket),
                         code,
                     );
                     return socket;
@@ -942,8 +981,10 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 us_socket_context_on_writable(ssl_int, ctx, SocketHandler.on_writable);
             if (comptime @hasDecl(Type, "onTimeout") and @typeInfo(@TypeOf(Type.onTimeout)) != .Null)
                 us_socket_context_on_timeout(ssl_int, ctx, SocketHandler.on_timeout);
-            if (comptime @hasDecl(Type, "onConnectError") and @typeInfo(@TypeOf(Type.onConnectError)) != .Null)
-                us_socket_context_on_connect_error(ssl_int, ctx, SocketHandler.on_connect_error);
+            if (comptime @hasDecl(Type, "onConnectError") and @typeInfo(@TypeOf(Type.onConnectError)) != .Null) {
+                us_socket_context_on_socket_connect_error(ssl_int, ctx, SocketHandler.on_connect_error);
+                us_socket_context_on_connect_error(ssl_int, ctx, SocketHandler.on_connect_error_connecting_socket);
+            }
             if (comptime @hasDecl(Type, "onEnd") and @typeInfo(@TypeOf(Type.onEnd)) != .Null)
                 us_socket_context_on_end(ssl_int, ctx, SocketHandler.on_end);
             if (comptime @hasDecl(Type, "onHandshake") and @typeInfo(@TypeOf(Type.onHandshake)) != .Null)
@@ -1063,6 +1104,9 @@ pub const SocketContext = opaque {
             fn connect_error(socket: *ConnectingSocket, _: i32) callconv(.C) ?*ConnectingSocket {
                 return socket;
             }
+            fn socket_connect_error(socket: *Socket, _: i32) callconv(.C) ?*Socket {
+                return socket;
+            }
             fn end(socket: *Socket) callconv(.C) ?*Socket {
                 return socket;
             }
@@ -1077,6 +1121,7 @@ pub const SocketContext = opaque {
         us_socket_context_on_writable(ssl_int, ctx, DummyCallbacks.writable);
         us_socket_context_on_timeout(ssl_int, ctx, DummyCallbacks.timeout);
         us_socket_context_on_connect_error(ssl_int, ctx, DummyCallbacks.connect_error);
+        us_socket_context_on_socket_connect_error(ssl_int, ctx, DummyCallbacks.socket_connect_error);
         us_socket_context_on_end(ssl_int, ctx, DummyCallbacks.end);
         us_socket_context_on_handshake(ssl_int, ctx, DummyCallbacks.handshake, null);
         us_socket_context_on_long_timeout(ssl_int, ctx, DummyCallbacks.long_timeout);
@@ -1343,6 +1388,7 @@ pub const us_socket_events_t = extern struct {
     on_long_timeout: ?*const fn (*Socket) callconv(.C) ?*Socket = null,
     on_end: ?*const fn (*Socket) callconv(.C) ?*Socket = null,
     on_connect_error: ?*const fn (*Socket, i32) callconv(.C) ?*Socket = null,
+    on_connect_error_connecting_socket: ?*const fn (*ConnectingSocket, i32) callconv(.C) ?*ConnectingSocket = null,
     on_handshake: ?*const fn (*Socket, i32, us_bun_verify_error_t, ?*anyopaque) callconv(.C) void = null,
 };
 
@@ -1367,6 +1413,7 @@ extern fn us_socket_context_on_handshake(ssl: i32, context: ?*SocketContext, on_
 extern fn us_socket_context_on_timeout(ssl: i32, context: ?*SocketContext, on_timeout: *const fn (*Socket) callconv(.C) ?*Socket) void;
 extern fn us_socket_context_on_long_timeout(ssl: i32, context: ?*SocketContext, on_timeout: *const fn (*Socket) callconv(.C) ?*Socket) void;
 extern fn us_socket_context_on_connect_error(ssl: i32, context: ?*SocketContext, on_connect_error: *const fn (*ConnectingSocket, i32) callconv(.C) ?*ConnectingSocket) void;
+extern fn us_socket_context_on_socket_connect_error(ssl: i32, context: ?*SocketContext, on_connect_error: *const fn (*Socket, i32) callconv(.C) ?*Socket) void;
 extern fn us_socket_context_on_end(ssl: i32, context: ?*SocketContext, on_end: *const fn (*Socket) callconv(.C) ?*Socket) void;
 extern fn us_socket_context_ext(ssl: i32, context: ?*SocketContext) ?*anyopaque;
 

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -952,6 +952,12 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                         ThisSocket.from(socket).ext(ContextType).*
                     else
                         ThisSocket.from(socket).ext(ContextType);
+
+                    // We close immediately in this case
+                    // uSockets doesn't know if this is a TLS socket or not.
+                    // So we have to do that logic in here.
+                    ThisSocket.from(socket).close(0, null);
+
                     Fields.onConnectError(
                         val,
                         ThisSocket.from(socket),

--- a/src/dns.zig
+++ b/src/dns.zig
@@ -436,3 +436,5 @@ pub fn addrInfoToJSArray(
 
     return array;
 }
+
+pub const internal = bun.JSC.DNS.InternalDNS;

--- a/src/http.zig
+++ b/src/http.zig
@@ -832,7 +832,11 @@ pub const HTTPThread = struct {
                 start_time = std.time.nanoTimestamp();
             }
             Output.flush();
-            this.loop.tickOnce(this);
+
+            this.loop.loop.inc();
+            this.loop.loop.tick();
+            this.loop.loop.dec();
+
             // this.loop.run();
             if (comptime Environment.isDebug) {
                 const end = std.time.nanoTimestamp();

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -55,12 +55,3 @@ export const nativeFrameForTesting: (callback: () => void) => void = $cpp(
   "CallSite.cpp",
   "createNativeFrameForTesting",
 );
-
-export const dnsCacheStats = $zig("dns_resolver.zig", "getDNSCacheStats") as () => {
-  hits_completed: number;
-  hits_inflight: number;
-  size: number;
-  misses: number;
-  errors: number;
-  getaddrinfo: number;
-};

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -1,0 +1,35 @@
+import { dns } from "bun";
+import { describe, expect, it } from "bun:test";
+
+describe("dns.prefetch", () => {
+  it("should prefetch", async () => {
+    const currentStats = dns.getCacheStats();
+    dns.prefetch("example.com", 80);
+    await Bun.sleep(32);
+
+    // Must set keepalive: false to ensure it doesn't reuse the socket.
+    await fetch("http://example.com", { method: "HEAD", redirect: "manual", keepalive: false });
+    const newStats = dns.getCacheStats();
+    expect(currentStats).not.toEqual(newStats);
+    if (
+      newStats.cacheHitsCompleted > currentStats.cacheHitsCompleted ||
+      newStats.cacheHitsInflight > currentStats.cacheHitsInflight
+    ) {
+      expect().pass();
+    } else {
+      expect().fail("dns.prefetch should have prefetched");
+    }
+
+    // Must set keepalive: false to ensure it doesn't reuse the socket.
+    await fetch("http://example.com", { method: "HEAD", redirect: "manual", keepalive: false });
+    const newStats2 = dns.getCacheStats();
+    // Ensure it's cached.
+    expect(newStats2.cacheHitsCompleted).toBeGreaterThan(currentStats.cacheHitsCompleted);
+
+    dns.prefetch("example.com", 443);
+    await Bun.sleep(32);
+
+    // Verify the cache key includes the port number.
+    expect(dns.getCacheStats().cacheMisses).toBeGreaterThan(currentStats.cacheMisses);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

This adds the `bun.dns.prefetch` API.

```ts
import {dns} from "bun";

dns.prefetch("bun.sh", 443);
//
// ... sometime later ...
await fetch("https://bun.sh");
```

Like `<link rel="dns-prefetch">` in browsers, the intended usecase is to amortize the cost of DNS lookups you know you'll make soon.

This also sets the DNS cache to have a TTL of 30 seconds. For reference, the Java Virtual Machine has no TTL set and [AWS recommends 5 seconds](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/jvm-ttl-dns.html).

This also introduces a `dns.getCacheStats()` API which exposes information about the DNS cache.

This also adds documentation.

This also makes `bun install` prefetch the DNS query. 

### How did you verify your code works?

There is a test