### PR TITLE
Prefer `import.meta.path` in http server guide

### DIFF
--- a/docs/guides/http/server.md
+++ b/docs/guides/http/server.md
@@ -18,7 +18,7 @@ const server = Bun.serve({
     if (path === "/abc") return Response.redirect("/source", 301);
 
     // send back a file (in this case, *this* file)
-    if (path === "/source") return new Response(Bun.file(import.meta.file));
+    if (path === "/source") return new Response(Bun.file(import.meta.path));
 
     // respond with JSON
     if (path === "/api") return Response.json({ some: "buns", for: "you" });


### PR DESCRIPTION
This means the code will work if copy/pasted into a file in a subfolder - see discussion on #8732

### What does this PR do?

Updates docs

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
