### PR TITLE
Optimize fish completions

### DIFF
--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -53,7 +53,6 @@ end
 set -l bun_install_boolean_flags yarn production optional development no-save dry-run force no-cache silent verbose global
 set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't install devDependencies" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
 
-set -l bun_builtin_cmds dev create help bun upgrade discord run install remove add init link unlink pm x
 set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add init pm x
 set -l bun_builtin_cmds_without_bun dev create help upgrade run discord install remove add init pm x
 set -l bun_builtin_cmds_without_create dev help bun upgrade discord run install remove add init pm x
@@ -191,4 +190,16 @@ complete -c bun \
 complete -c bun \
 	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from cache; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts);" -a 'rm' -f
 
-complete -c bun -n "__fish_use_subcommand" -a "$bun_builtin_cmds" -f
+# Add built-in subcommands with descriptions.
+complete -c bun -n "__fish_use_subcommand" -a "create" -f -d "Create a new project from a template"
+complete -c bun -n "__fish_use_subcommand" -a "build bun" --require-parameter -F -d "Transpile and bundle one or more files"
+complete -c bun -n "__fish_use_subcommand" -a "upgrade" -d "Upgrade Bun"
+complete -c bun -n "__fish_use_subcommand" -a "run" -d "Run a script or package binary"
+complete -c bun -n "__fish_use_subcommand" -a "install" -d "Install dependencies from package.json" -f
+complete -c bun -n "__fish_use_subcommand" -a "remove" -d "Remove a dependency from package.json" -f
+complete -c bun -n "__fish_use_subcommand" -a "add" -d "Add a dependency to package.json" -f
+complete -c bun -n "__fish_use_subcommand" -a "init" -d "Initialize a Bun project in this directory" -f
+complete -c bun -n "__fish_use_subcommand" -a "link" -d "Register or link a local npm package" -f
+complete -c bun -n "__fish_use_subcommand" -a "link" -d "Unregister a local npm package" -f
+complete -c bun -n "__fish_use_subcommand" -a "pm" -d "Additional package management utilities" -f
+complete -c bun -n "__fish_use_subcommand" -a "x" -d "Execute a package binary, installing if needed" -f

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -121,16 +121,19 @@ complete -c bun \
 complete -c bun \
 	-n "__fish_use_subcommand" -a 'create' -f -d 'Create a new project from a template'
 
+# Complete "next" and "react" if we've seen "create".
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_create next react; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from create;" -a 'next' -d 'new Next.js project'
+	-n "__fish_seen_subcommand_from create" -a 'next' -d 'new Next.js project'
 
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_create next react; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from create;" -a 'react' -d 'new React project'
+	-n "__fish_seen_subcommand_from create" -a 'react' -d 'new React project'
 
+# Complete "upgrade" as first subcommand.
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'upgrade' -d 'Upgrade bun to the latest version' -x
+	-n "__fish_use_subcommand" -a 'upgrade' -d 'Upgrade bun to the latest version' -x
+# Complete "-h/--help" unconditionally.
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand"  -a '--help' -d 'See all commands and flags' -x
+	-s "h" -l "help" -d 'See all commands and flags' -x
 
 complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -l "version" -s "v"  -a '--version' -d 'Bun\'s version' -x

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -156,19 +156,16 @@ complete -c bun \
 
 
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'init' -F -d 'Start an empty Bun project'
+	-n "__fish_use_subcommand" -a 'init' -F -d 'Start an empty Bun project'
 
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'install' -f -d 'Install packages from package.json'
+	-n "__fish_use_subcommand" -a 'install' -f -d 'Install packages from package.json'
 
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'add' -F -d 'Add a package to package.json'
+	-n "__fish_use_subcommand" -a 'add' -F -d 'Add a package to package.json'
 
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'remove' -F -d 'Remove a package from package.json'
-
-complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand add remove" -F
+	-n "__fish_use_subcommand" -a 'remove' -F -d 'Remove a package from package.json'
 
 
 for i in (seq (count $bun_install_boolean_flags))

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -71,24 +71,24 @@ complete -c bun \
 complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_run; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from run" -a '(__fish__get_bun_bun_js_files)' -d 'Bun.js'
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __fish_use_subcommand" -a 'run' -f -d 'Run a script or bin' 
+	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __fish_use_subcommand" -a 'run' -f -d 'Run a script or bin'
 complete -c bun \
 	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files -s 'u' -l 'origin' -r -d 'Server URL. Rewrites import paths'
 complete -c bun \
-	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files  -s 'p' -l 'port' -r -d 'Port number to start server from' 
+	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files  -s 'p' -l 'port' -r -d 'Port number to start server from'
 complete -c bun \
-	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files  -s 'd' -l 'define' -r -d 'Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:\"development\"' 
+	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files  -s 'd' -l 'define' -r -d 'Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:\"development\"'
 complete -c bun \
-	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files  -s 'e' -l 'external' -r -d 'Exclude module from transpilation (can use * wildcards). ex: -e react' 
+	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files  -s 'e' -l 'external' -r -d 'Exclude module from transpilation (can use * wildcards). ex: -e react'
 complete -c bun \
-	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files -l 'use' -r -d 'Use a framework (ex: next)' 
+	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files -l 'use' -r -d 'Use a framework (ex: next)'
 complete -c bun \
-	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files -l 'hot' -r -d 'Enable hot reloading in Bun\'s JavaScript runtime' 
-	
+	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files -l 'hot' -r -d 'Enable hot reloading in Bun\'s JavaScript runtime'
+
 complete -c bun \
 	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __fish_use_subcommand" -a 'dev' -d 'Start dev server'
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'create' -f -d 'Create a new project from a template' 
+	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'create' -f -d 'Create a new project from a template'
 
 complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_create next react; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from create;" -a 'next' -d 'new Next.js project'
@@ -97,14 +97,14 @@ complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_create next react; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from create;" -a 'react' -d 'new React project'
 
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'upgrade' -d 'Upgrade bun to the latest version' -x 
+	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'upgrade' -d 'Upgrade bun to the latest version' -x
 complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand"  -a '--help' -d 'See all commands and flags' -x
 
 complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -l "version" -s "v"  -a '--version' -d 'Bun\'s version' -x
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'discord' -d 'Open bun\'s Discord server' -x 
+	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'discord' -d 'Open bun\'s Discord server' -x
 
 
 complete -c bun \
@@ -119,21 +119,21 @@ complete -c bun \
 
 
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'init' -F -d 'Start an empty Bun project' 
+	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'init' -F -d 'Start an empty Bun project'
 
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'install' -f -d 'Install packages from package.json' 
+	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'install' -f -d 'Install packages from package.json'
 
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'add' -F -d 'Add a package to package.json' 
-	
+	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'add' -F -d 'Add a package to package.json'
+
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'remove' -F -d 'Remove a package from package.json' 
+	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'remove' -F -d 'Remove a package from package.json'
 
 complete -c bun \
 	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand add remove" -F
 
-		  
+
 for i in (seq (count $bun_install_boolean_flags))
 	complete -c bun \
 		-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from install add remove;" -l "$bun_install_boolean_flags[$i]" -d "$bun_install_boolean_flags_descriptions[$i]"
@@ -150,7 +150,7 @@ complete -c bun \
 
 complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from add;" -d 'History' -a '(__history_completions)'
-  
+
 complete -c bun \
 	-n "__fish_seen_subcommand_from pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) cache;" -a 'bin ls cache hash hash-print hash-string' -f
 

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -58,6 +58,7 @@ set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install 
 set -l bun_builtin_cmds_without_bun dev create help upgrade run discord install remove add init pm x
 set -l bun_builtin_cmds_without_create dev help bun upgrade discord run install remove add init pm x
 set -l bun_builtin_cmds_without_pm create dev help bun upgrade discord run init pm x
+set -l bun_builtin_cmds_accepting_flags create help bun upgrade discord run init link unlink pm x
 
 function __bun_complete_bins_scripts --inherit-variable bun_builtin_cmds_without_run -d "Emit bun completions for bins and scripts"
     # Do nothing if we already have a builtin subcommand,
@@ -99,18 +100,20 @@ complete -e -c bun
 # Dynamically emit scripts and binaries
 complete -c bun -f -a "(__bun_complete_bins_scripts)"
 
+# Complete flags if we have no subcommand or a flag-friendly one.
+set -l flag_applies "__fish_use_subcommand; or __fish_seen_subcommand_from $bun_builtin_cmds_accepting_flags"
 complete -c bun \
-	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files -s 'u' -l 'origin' -r -d 'Server URL. Rewrites import paths'
+	-n $flag_applies --no-files -s 'u' -l 'origin' -r -d 'Server URL. Rewrites import paths'
 complete -c bun \
-	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files  -s 'p' -l 'port' -r -d 'Port number to start server from'
+	-n $flag_applies --no-files  -s 'p' -l 'port' -r -d 'Port number to start server from'
 complete -c bun \
-	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files  -s 'd' -l 'define' -r -d 'Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:\"development\"'
+	-n $flag_applies --no-files  -s 'd' -l 'define' -r -d 'Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:\"development\"'
 complete -c bun \
-	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files  -s 'e' -l 'external' -r -d 'Exclude module from transpilation (can use * wildcards). ex: -e react'
+	-n $flag_applies --no-files  -s 'e' -l 'external' -r -d 'Exclude module from transpilation (can use * wildcards). ex: -e react'
 complete -c bun \
-	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files -l 'use' -r -d 'Use a framework (ex: next)'
+	-n $flag_applies --no-files -l 'use' -r -d 'Use a framework (ex: next)'
 complete -c bun \
-	-n "not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) install remove add;" --no-files -l 'hot' -r -d 'Enable hot reloading in Bun\'s JavaScript runtime'
+	-n $flag_applies --no-files -l 'hot' -r -d 'Enable hot reloading in Bun\'s JavaScript runtime'
 
 complete -c bun \
 	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __fish_use_subcommand" -a 'dev' -d 'Start dev server'

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -170,20 +170,20 @@ complete -c bun \
 
 for i in (seq (count $bun_install_boolean_flags))
 	complete -c bun \
-		-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from install add remove;" -l "$bun_install_boolean_flags[$i]" -d "$bun_install_boolean_flags_descriptions[$i]"
+		-n "__fish_seen_subcommand_from install add remove" -l "$bun_install_boolean_flags[$i]" -d "$bun_install_boolean_flags_descriptions[$i]"
 end
 
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from install add remove;" -l 'cwd' -d 'Change working directory'
+	-n "__fish_seen_subcommand_from install add remove" -l 'cwd' -d 'Change working directory'
 
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from install add remove;" -l 'cache-dir' -d 'Choose a cache directory (default: $HOME/.bun/install/cache)'
+	-n "__fish_seen_subcommand_from install add remove" -l 'cache-dir' -d 'Choose a cache directory (default: $HOME/.bun/install/cache)'
 
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from add;" -d 'Popular' -a '(__fish__get_bun_packages)'
+	-n "__fish_seen_subcommand_from add" -d 'Popular' -a '(__fish__get_bun_packages)'
 
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from add;" -d 'History' -a '(__history_completions)'
+	-n "__fish_seen_subcommand_from add" -d 'History' -a '(__history_completions)'
 
 complete -c bun \
 	-n "__fish_seen_subcommand_from pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) cache;" -a 'bin ls cache hash hash-print hash-string' -f
@@ -191,4 +191,4 @@ complete -c bun \
 complete -c bun \
 	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from cache; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts);" -a 'rm' -f
 
-complete -c bun -n "not __fish_seen_subcommand_from $bun_builtin_cmds (__fish__get_bun_bins) (__fish__get_bun_scripts)" -a "$bun_builtin_cmds" -f
+complete -c bun -n "__fish_use_subcommand" -a "$bun_builtin_cmds" -f

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -57,9 +57,6 @@ set -l bun_builtin_cmds dev create help bun upgrade discord run install remove a
 set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add init pm x
 set -l bun_builtin_cmds_without_bun dev create help upgrade run discord install remove add init pm x
 set -l bun_builtin_cmds_without_create dev help bun upgrade discord run install remove add init pm x
-set -l bun_builtin_cmds_without_install create dev help bun upgrade discord run remove add init pm x
-set -l bun_builtin_cmds_without_remove create dev help bun upgrade discord run install add init pm x
-set -l bun_builtin_cmds_without_add create dev help bun upgrade discord run remove install init pm x
 set -l bun_builtin_cmds_without_pm create dev help bun upgrade discord run init pm x
 
 # clear

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -32,31 +32,10 @@ function __fish__get_bun_bun_js_files
 	string split ' ' (bun getcompletes j)
 end
 
-function bun_fish_is_nth_token --description 'Test if current token is on Nth place' --argument-names n
-	set -l tokens (commandline -poc)
-	set -l tokens (string replace -r --filter '^([^-].*)' '$1' -- $tokens)
-	test (count $tokens) -eq "$n"
-end
-
-function __bun_command_count --argument-names n
-	set -l cmds (commandline -poc)
-
-	test (count cmds) -eq "$n"
-end
-
-function __bun_last_cmd --argument-names n
-	set -l cmds (commandline -poc)
-
-	test "(cmds[-1])" = "$n"
-end
-
 set -l bun_install_boolean_flags yarn production optional development no-save dry-run force no-cache silent verbose global
 set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't install devDependencies" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
 
 set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add init pm x
-set -l bun_builtin_cmds_without_bun dev create help upgrade run discord install remove add init pm x
-set -l bun_builtin_cmds_without_create dev help bun upgrade discord run install remove add init pm x
-set -l bun_builtin_cmds_without_pm create dev help bun upgrade discord run init pm x
 set -l bun_builtin_cmds_accepting_flags create help bun upgrade discord run init link unlink pm x
 
 function __bun_complete_bins_scripts --inherit-variable bun_builtin_cmds_without_run -d "Emit bun completions for bins and scripts"

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -135,21 +135,24 @@ complete -c bun \
 complete -c bun \
 	-s "h" -l "help" -d 'See all commands and flags' -x
 
+# Complete "-v/--version" if we have no subcommand.
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -l "version" -s "v"  -a '--version' -d 'Bun\'s version' -x
+	-n "not __fish_use_subcommand" -l "version" -s "v" -d 'Bun\'s version' -x
+
+# Complete additional subcommands.
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_use_subcommand" -a 'discord' -d 'Open bun\'s Discord server' -x
+	-n "__fish_use_subcommand" -a 'discord' -d 'Open bun\'s Discord server' -x
 
 
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_bun; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); __fish_use_subcommand" -a 'bun' -d 'Generate a new bundle'
+	-n "__fish_use_subcommand" -a 'bun' -d 'Generate a new bundle'
 
 
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_bun; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from bun" -F -d 'Bundle this'
+	-n "__fish_seen_subcommand_from bun" -F -d 'Bundle this'
 
 complete -c bun \
-	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_create; and not __fish_seen_subcommand_from (__fish__get_bun_bins); and not __fish_seen_subcommand_from (__fish__get_bun_scripts); and __fish_seen_subcommand_from react; or __fish_seen_subcommand_from next" -F -d "Create in directory"
+	-n "__fish_seen_subcommand_from create; and __fish_seen_subcommand_from react next" -F -d "Create in directory"
 
 
 complete -c bun \

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -115,10 +115,11 @@ complete -c bun \
 complete -c bun \
 	-n $flag_applies --no-files -l 'hot' -r -d 'Enable hot reloading in Bun\'s JavaScript runtime'
 
+# Complete dev and create as first subcommand.
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __fish_use_subcommand" -a 'dev' -d 'Start dev server'
+	-n "__fish_use_subcommand" -a 'dev' -d 'Start dev server'
 complete -c bun \
-	-n "bun_fish_is_nth_token 1; and not __fish_seen_subcommand_from $bun_builtin_cmds; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) and __bun_command_count 1 and __fish_use_subcommand" -a 'create' -f -d 'Create a new project from a template'
+	-n "__fish_use_subcommand" -a 'create' -f -d 'Create a new project from a template'
 
 complete -c bun \
 	-n "not __fish_seen_subcommand_from $bun_builtin_cmds_without_create next react; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts); and __fish_seen_subcommand_from create;" -a 'next' -d 'new Next.js project'


### PR DESCRIPTION
### What does this PR do?

See [this Jarred tweet](https://twitter.com/jarredsumner/status/1790603279044661513) for context.

It was observed that the fish shell completions for bun invokes bun too frequently. The primary reason for the completion to invoke bun, is to discover the installed package binaries and scripts, with `bun getcompletes`.

Jarred estimated ~30 invocations of bun after `bun <tab>`; with these changes there are only 2 invocations, one for `bun getcompletes b` and one for `bun getcompletes z`.

The optimizations here are:

1. Emit completions for both package binaries and scripts from a single function. This allows us to coalesce these `bun getcompletes` calls.
2. Simplify the conditionals (when completions are offered). Most completions tried to suppress themself if there were a package script or binary but I don't think this is generally necessary; most completions are just subcommands and should be offered if there is not yet a subcommand.

### How did you verify your code works?

I performed manual testing to validate that commands generally made sense. But I am not a heavy bun user so it's possible I've introduced a regression or missed an improvement, so I would appreciate more testing.

The fish completions may be loaded by running (in fish of course):

```sh
> source /path/to/bun/completions/fish.complete
```

then inside a package, try various `bun <tab>` or `bun subcommand <tab>` scenarios.