### PR TITLE
Alias util.debug to util.debuglog

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -285,6 +285,7 @@ export default Object.assign(cjs_exports, {
   formatWithOptions,
   stripVTControlCharacters,
   deprecate,
+  debug: debuglog,
   debuglog,
   _extend,
   inspect,


### PR DESCRIPTION
### What does this PR do?

Alias `util.debug` to `util.debuglog`.
Apparently `util.debug` is just an alias of `util.debuglog` as mentioned in the [Node Documentation](https://nodejs.org/api/util.html#utildebugsection)

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

N/A

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->


