### PR TITLE
Remove `expect.extend` from list of missing features in migrate-from-jest.md

### DIFF
--- a/docs/guides/test/migrate-from-jest.md
+++ b/docs/guides/test/migrate-from-jest.md
@@ -30,7 +30,6 @@ Bun implements the vast majority of Jest's matchers, but compatibility isn't 100
 
 Some notable missing features:
 
-- `expect.extend()`
 - `expect().toMatchInlineSnapshot()`
 - `expect().toHaveReturned()`
 


### PR DESCRIPTION
### What does this PR do?

Removes `expect.extend` from the list of missing features in migrate-from-jest.md. Support for `expect.extend` was added in #7319.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
