### PR TITLE
fix `which` when bin or PATH is rlly long

### DIFF
--- a/src/which.zig
+++ b/src/which.zig
@@ -3,6 +3,7 @@ const bun = @import("root").bun;
 const PosixToWinNormalizer = bun.path.PosixToWinNormalizer;
 
 fn isValid(buf: *bun.PathBuffer, segment: []const u8, bin: []const u8) ?u16 {
+    if (segment.len + 1 + bin.len > bun.MAX_PATH_BYTES) return null;
     bun.copy(u8, buf, segment);
     buf[segment.len] = std.fs.path.sep;
     bun.copy(u8, buf[segment.len + 1 ..], bin);
@@ -15,6 +16,7 @@ fn isValid(buf: *bun.PathBuffer, segment: []const u8, bin: []const u8) ?u16 {
 // Like /usr/bin/which but without needing to exec a child process
 // Remember to resolve the symlink if necessary
 pub fn which(buf: *bun.PathBuffer, path: []const u8, cwd: []const u8, bin: []const u8) ?[:0]const u8 {
+    if (bin.len > bun.MAX_PATH_BYTES) return null;
     bun.Output.scoped(.which, true)("path={s} cwd={s} bin={s}", .{ path, cwd, bin });
 
     if (bun.Environment.os == .windows) {

--- a/test/js/bun/shell/commands/which.test.ts
+++ b/test/js/bun/shell/commands/which.test.ts
@@ -1,0 +1,12 @@
+import { $ } from "bun";
+import { test, expect } from "bun:test";
+
+test("which rlly long", async () => {
+  const longstr = "a".repeat(100000);
+  expect(async () => await $`${longstr}`.throws(true)).toThrow();
+});
+
+test("which PATH rlly long", async () => {
+  const longstr = "a".repeat(100000);
+  expect(async () => await $`PATH=${longstr} slkdfjlsdkfj`.throws(true)).toThrow();
+});

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -29,6 +29,11 @@ function writeFixture(path: string) {
   fs.chmodSync(script_name, "755");
 }
 
+test("which rlly long", async () => {
+  const longstr = "a".repeat(100000);
+  expect(() => which(longstr)).toThrow("bin path is too long");
+});
+
 if (isWindows) {
   test("which", () => {
     expect(which("cmd")).toBe("C:\\Windows\\system32\\cmd.exe");


### PR DESCRIPTION
### What does this PR do?

We were using `bun.copy` to copy bin or path segment into a path buffer, but not checking that it would actually fit inside the path buffer, causing a crash on windows or undefined behavior elsewhere

An example:
```typescript
const rlly_long_str = "lol".repeat(10000000)
await Bun.$`${rlly_long_str}` // shell will use which to see if rlly_long_str is bin in PATH
```

I made the `bun.which` function return null in this case, maybe it is more correct to change the function signature and return `bun.C.E.NAMETOOLONG`?

Fixes #11203

### How did you verify your code works?

added tests
