### PR TITLE
fix(http2) fix aborted behavior

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -1726,7 +1726,7 @@ pub const H2FrameParser = struct {
         if (stream.signal) |_signal| {
             return JSC.JSValue.jsBoolean(_signal.aborted());
         }
-        return JSC.JSValue.jsBoolean(true);
+        return JSC.JSValue.jsBoolean(stream.rstCode == @intFromEnum(ErrorCode.CANCEL));
     }
     pub fn getStreamState(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(.C) JSValue {
         JSC.markBinding(@src());

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -663,7 +663,6 @@ function emitStreamErrorNT(self, streams, streamId, error, destroy) {
     stream.emit("error", error_instance);
     if (destroy) stream.destroy(error_instance);
   }
-  self.emit("streamError", error_instance);
 }
 
 function emitAbortedNT(self, streams, streamId, error) {
@@ -678,7 +677,6 @@ function emitAbortedNT(self, streams, streamId, error) {
     stream.emit("aborted", error);
     stream.emit("error", error_instance);
   }
-  self.emit("streamError", error_instance);
 }
 class ClientHttp2Session extends Http2Session {
   /// close indicates that we called closed
@@ -726,7 +724,6 @@ class ClientHttp2Session extends Http2Session {
         }
         stream.rstCode = error;
         stream.emit("error", error_instance);
-        self.emit("streamError", error_instance);
       } else {
         process.nextTick(emitStreamErrorNT, self, self.#streams, streamId, error);
       }
@@ -842,7 +839,6 @@ class ClientHttp2Session extends Http2Session {
         stream.rstCode = constants.NGHTTP2_CANCEL;
         stream.emit("aborted", error);
         stream.emit("error", error_instance);
-        self.emit("streamError", error_instance);
       } else {
         process.nextTick(emitAbortedNT, self, self.#streams, streamId, error);
       }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -678,6 +678,8 @@ function emitAbortedNT(self, streams, streamId, error) {
     stream.rstCode = constants.NGHTTP2_CANCEL;
     stream.emit("aborted");
     stream.destroy();
+    stream.emit("end");
+    stream.emit("close");
   }
 }
 class ClientHttp2Session extends Http2Session {
@@ -842,6 +844,8 @@ class ClientHttp2Session extends Http2Session {
         stream.rstCode = constants.NGHTTP2_CANCEL;
         stream.emit("aborted");
         stream.destroy();
+        stream.emit("end");
+        stream.emit("close");
       } else {
         process.nextTick(emitAbortedNT, self, self.#streams, streamId, error);
       }


### PR DESCRIPTION
### What does this PR do?
`streamError` event is not a thing, so we should not emit it, when aborted should not emit `error`.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
Updated tests
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
