### PR TITLE
bypass getaddrinfo for ip addresses

### DIFF
--- a/test/js/bun/net/socket-leak-fixture.js
+++ b/test/js/bun/net/socket-leak-fixture.js
@@ -3,7 +3,7 @@ import { expect } from "bun:test";
 
 const server = Bun.listen({
   port: 0,
-  hostname: "localhost",
+  hostname: "127.0.0.1",
   socket: {
     open(socket) {
       socket.end();

--- a/test/js/bun/net/socket-leak-fixture.js
+++ b/test/js/bun/net/socket-leak-fixture.js
@@ -3,7 +3,7 @@ import { expect } from "bun:test";
 
 const server = Bun.listen({
   port: 0,
-  hostname: "127.0.0.1",
+  hostname: "localhost",
   socket: {
     open(socket) {
       socket.end();


### PR DESCRIPTION
### What does this PR do?
This PR makes it so that when we try to open a new TCP connection, we attempt to parse `host` with `inet_pton`. If we succeed, we use the resulting ip address and bypass `getaddrinfo` entirely.

### How did you verify your code works?
A test (it's hard to test for this specifically)