### PR TITLE
ci: make test/js/bun/shell/commands/rm.test.ts less flaky

### DIFF
--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -991,7 +991,7 @@ pub const ModuleLoader = struct {
 
             pub fn pollModules(this: *Queue) void {
                 var pm = this.vm().packageManager();
-                if (pm.pending_tasks.load(.Monotonic) > 0) return;
+                if (pm.pendingTaskCount() > 0) return;
 
                 var modules: []AsyncModule = this.map.items;
                 var i: usize = 0;

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -4,7 +4,7 @@
  *
  * This code is licensed under the MIT License: https://opensource.org/licenses/MIT
  */
-import { tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { describe, test, afterAll, beforeAll, expect } from "bun:test";
 import { $ } from "bun";
 import path from "path";
@@ -18,14 +18,19 @@ const fileExists = async (path: string): Promise<boolean> =>
 
 $.nothrow();
 
-const BUN = process.argv0;
 const DEV_NULL = process.platform === "win32" ? "NUL" : "/dev/null";
 
 describe("bunshell rm", () => {
-  TestBuilder.command`echo ${packagejson()} > package.json; ${BUN} install &> ${DEV_NULL}; rm -rf node_modules/`
+  TestBuilder.command`echo ${packagejson()} > package.json; ${bunExe()} install; rm -rf node_modules/`
     .ensureTempDir()
     .doesNotExist("node_modules")
-    .timeout(10 * 1000)
+    .env({
+      ...bunEnv,
+      BUN_CONFIG_MAX_HTTP_REQUESTS: "8",
+    })
+    .stdout(undefined)
+    .stderr(undefined)
+    .timeout(20 * 1000)
     .runAsTest("node_modules");
 
   test("force", async () => {

--- a/test/js/bun/shell/test_builder.ts
+++ b/test/js/bun/shell/test_builder.ts
@@ -20,8 +20,8 @@ export function createTestBuilder(path: string) {
   class TestBuilder {
     _testName: string | undefined = undefined;
 
-    expected_stdout: string | ((stdout: string, tempdir: string) => void) = "";
-    expected_stderr: string | ((stderr: string, tempdir: string) => void) | { contains: string } = "";
+    expected_stdout: string | ((stdout: string, tempdir: string) => void) | undefined = "";
+    expected_stderr: string | ((stderr: string, tempdir: string) => void) | { contains: string } | undefined = "";
     expected_exit_code: number | ((code: number) => void) = 0;
     expected_error: ShellError | string | boolean | undefined = undefined;
     file_equals: { [filename: string]: string | (() => string | Promise<string>) } = {};
@@ -135,12 +135,12 @@ export function createTestBuilder(path: string) {
      *
      * @param expected - can either be a string or a function which itself calls `expect()`
      */
-    stdout(expected: string | ((stdout: string, tempDir: string) => void)): this {
+    stdout(expected?: string | ((stdout: string, tempDir: string) => void)): this {
       this.expected_stdout = expected;
       return this;
     }
 
-    stderr(expected: string | ((stderr: string, tempDir: string) => void)): this {
+    stderr(expected?: string | ((stderr: string, tempDir: string) => void)): this {
       this.expected_stderr = expected;
       return this;
     }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": [".", "../packages/bun-types/index.d.ts", "./testing-internals.d.ts"],
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "module": "ESNext",
     "target": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
typical times for the node_modules test range from 2713.78ms to 9518.02ms

slightly increasing the timeout length and lowering the parallelism should make this much less flaky to network conditions