### PR TITLE
docs: Add guide for deploying a Bun app to Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ bun upgrade --canary
   - [Build an HTTP server using StricJS and Bun](https://bun.sh/guides/ecosystem/stric)
   - [Containerize a Bun application with Docker](https://bun.sh/guides/ecosystem/docker)
   - [Create a Discord bot](https://bun.sh/guides/ecosystem/discordjs)
+  - [Deploy a Bun application on Render](https://bun.sh/guides/ecosystem/render)
   - [Read and write data to MongoDB using Mongoose and Bun](https://bun.sh/guides/ecosystem/mongoose)
   - [Run Bun as a daemon with PM2](https://bun.sh/guides/ecosystem/pm2)
   - [Run Bun as a daemon with systemd](https://bun.sh/guides/ecosystem/systemd)

--- a/docs/guides/ecosystem/render.md
+++ b/docs/guides/ecosystem/render.md
@@ -4,7 +4,7 @@ name: Deploy a Bun application on Render
 
 [Render](https://render.com/) is a cloud platform that lets you flexibly build, deploy, and scale your apps.
 
-It offers features like auto deploys from GitHub, a global CDN, private networks, automatic HTTPS setup, and managed PostgreSQL and Redis instances.
+It offers features like auto deploys from GitHub, a global CDN, private networks, automatic HTTPS setup, and managed PostgreSQL and Redis.
 
 Render supports Bun natively. You can deploy Bun apps as web services, background workers, cron jobs, and more.
 

--- a/docs/guides/ecosystem/render.md
+++ b/docs/guides/ecosystem/render.md
@@ -72,6 +72,6 @@ In the Render UI, provide the following values during web service creation:
 
 ---
 
-That's it! Your web service will be live at its `onrender.com` URL as soon as the build finishes.
+That's it! Your web service will be live at its assigned `onrender.com` URL as soon as the build finishes.
 
-Visit the URL to see the "Hello world!" message.
+You can view the [deploy logs](https://docs.render.com/logging#logs-for-an-individual-deploy-or-job) for details. Refer to [Render's documentation](https://docs.render.com/deploys) for a complete overview of deploying on Render.

--- a/docs/guides/ecosystem/render.md
+++ b/docs/guides/ecosystem/render.md
@@ -1,0 +1,77 @@
+---
+name: Deploy a Bun application on Render
+---
+
+[Render](https://render.com/) is a cloud platform that lets you flexibly build, deploy, and scale your apps.
+
+It offers features like auto deploys from GitHub, a global CDN, private networks, automatic HTTPS setup, and managed PostgreSQL and Redis instances.
+
+Render supports Bun natively. You can deploy Bun apps as web services, background workers, cron jobs, and more.
+
+---
+
+As an example, let's deploy a simple Express HTTP server to Render.
+
+---
+
+Create a new GitHub repo named `myapp`. Git clone it locally.
+
+```bash
+git clone git@github.com:my-github-username/myapp.git
+cd myapp
+```
+
+---
+
+Add the Express library.
+
+```bash
+bun add express
+```
+
+---
+Define a simple server with Express:
+
+```app.ts
+import express from "express";
+
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.get("/", (req, res) => {
+  res.send("Hello World!");
+});
+
+app.listen(port, () => {
+  console.log(`Listening on port ${port}...`);
+});
+```
+
+---
+Commit your changes and push to GitHub.
+
+```bash
+git add app.ts bun.lockb package.json
+git commit -m "Create simple Express app"
+git push origin main
+```
+
+---
+
+In your [Render Dashboard](https://dashboard.render.com/), click `New` > `Web Service` and connect your `myapp` repo.
+
+---
+
+In the Render UI, provide the following values during web service creation:
+
+|             |           |
+| ----------- | --------- |
+| **Runtime** | `Node` |
+| **Build Command** | `bun install` |
+| **Start Command** | `bun app.js` |
+
+---
+
+That's it! Your web service will be live at its `onrender.com` URL as soon as the build finishes.
+
+Visit the URL to see the "Hello world!" message.


### PR DESCRIPTION
### What does this PR do?

Adds a guide that shows how to deploy a Bun app on Render.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
Manually tested by following the instructions