### PR TITLE
ci: make bun-install-registry.test.ts less flaky on windows

### DIFF
--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -4925,6 +4925,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         expect(proc.resourceUsage()?.cpuTime.total).toBeLessThan(750_000);
       });
 
+      // https://github.com/oven-sh/bun/issues/11252
       test.todoIf(isWindows)(
         "bun pm trust",
         async () => {

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -4925,7 +4925,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         expect(proc.resourceUsage()?.cpuTime.total).toBeLessThan(750_000);
       });
 
-      test(
+      test.todoIf(isWindows)(
         "bun pm trust",
         async () => {
           const dep = isWindows ? "uses-what-bin-slow-window" : "uses-what-bin-slow";


### PR DESCRIPTION
pulled out of https://github.com/oven-sh/bun/pull/10882

tracked in https://github.com/oven-sh/bun/issues/11252