### PR TITLE
meta: ci: dont linkify list of failing files

### DIFF
--- a/packages/bun-internal-test/src/runner.node.mjs
+++ b/packages/bun-internal-test/src/runner.node.mjs
@@ -419,16 +419,10 @@ function linkToGH(linkTo) {
   return `https://github.com/oven-sh/bun/blob/${git_sha}/${linkTo}`;
 }
 
-function sectionLink(linkTo) {
-  return "#" + linkTo.replace(/[^a-zA-Z0-9_-]/g, "").toLowerCase();
-}
-
 failing_tests.sort((a, b) => a.path.localeCompare(b.path));
 passing_tests.sort((a, b) => a.localeCompare(b));
 
-const failingTestDisplay = failing_tests
-  .map(({ path, reason }) => `- [\`${path}\`](${sectionLink(path)})${reason ? ` ${reason}` : ""}`)
-  .join("\n");
+const failingTestDisplay = failing_tests.map(({ path, reason }) => `- \`${path}\` ${reason}`).join("\n");
 
 // const passingTestDisplay = passing_tests.map(path => `- \`${path}\``).join("\n");
 


### PR DESCRIPTION
these ids easily overlap on the summary page and needlessly set the page hash when viewed in the PR comment, and are easy to click on when trying to copy/paste the path in order to investigate