### PR TITLE
Fix workers on windows taking a long time to exit

### DIFF
--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -190,9 +190,9 @@ pub const WebWorker = struct {
     fn deinit(this: *WebWorker) void {
         log("[{d}] deinit", .{this.execution_context_id});
         this.parent_poll_ref.unrefConcurrently(this.parent);
+        this.parent.event_loop_handle.?.wakeup();
         bun.default_allocator.free(this.specifier);
         bun.default_allocator.destroy(this);
-        this.parent.event_loop_handle.?.wakeup();
     }
 
     fn flushLogs(this: *WebWorker) void {

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -192,6 +192,7 @@ pub const WebWorker = struct {
         this.parent_poll_ref.unrefConcurrently(this.parent);
         bun.default_allocator.free(this.specifier);
         bun.default_allocator.destroy(this);
+        this.parent.event_loop_handle.?.wakeup();
     }
 
     fn flushLogs(this: *WebWorker) void {


### PR DESCRIPTION
### What does this PR do?
Some recent change made it so that, on windows, a worker exiting would not immediately wake up the parent event loop, which meant that the event loop would be unnecessarily kept alive until the event. This PR fixes that.

### How did you verify your code works?
The failing worker tests now pass.
