### PR TITLE
docs: Add Sentry guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ bun upgrade --canary
   - [Use Neon's Serverless Postgres with Bun](https://bun.sh/guides/ecosystem/neon-serverless-postgres)
   - [Use Prisma with Bun](https://bun.sh/guides/ecosystem/prisma)
   - [Use React and JSX](https://bun.sh/guides/ecosystem/react)
+  - [Add Sentry to a Bun app](https://bun.sh/guides/ecosystem/sentry)
 
 - HTTP 
   - [Common HTTP server usage](https://bun.sh/guides/http/server)

--- a/docs/guides/ecosystem/sentry.md
+++ b/docs/guides/ecosystem/sentry.md
@@ -1,0 +1,52 @@
+---
+name: Add Sentry to a Bun app
+---
+
+[Sentry](https://sentry.io) is a developer-first error tracking and performance monitoring platform. Sentry has a first-class SDK for Bun, `@sentry/bun`, that instruments your Bun application to automatically collect error and performance data.
+
+Don't already have an account and Sentry project established? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
+
+---
+
+To start using Sentry with Bun, first install the Sentry Bun SDK.
+
+```bash
+bun add @sentry/bun
+```
+
+---
+
+Then, initialize the Sentry SDK with your Sentry DSN in your app's entry file. You can find your DSN in your Sentry project settings.
+
+```JavaScript
+import * as Sentry from '@sentry/bun';
+
+// Ensure to call this before importing any other modules!
+Sentry.init({
+  dsn: '__SENTRY_DSN__',
+
+  // Add Performance Monitoring by setting tracesSampleRate
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+});
+```
+
+---
+
+You can verify that Sentry is working by capturing a test error:
+
+```JavaScript
+setTimeout(() => {
+  try {
+    foo();
+  } catch (e) {
+    Sentry.captureException(e);
+  }
+}, 99);
+```
+
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io/) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+
+---
+
+To learn more about Sentry and using the Sentry Bun SDK, view the [Sentry documentation](https://docs.sentry.io/platforms/javascript/guides/bun).


### PR DESCRIPTION
### What does this PR do?

Add guide for Sentry leveraging [Sentry's Bun SDK](https://docs.sentry.io/platforms/javascript/guides/bun).

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes