### PR TITLE
Update http2 NotImplementedErrors to report issue 8823

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1267,21 +1267,21 @@ function connect(url: string | URL, options?: Http2ConnectOptions, listener?: Fu
 }
 
 function createServer() {
-  throwNotImplemented("node:http2 createServer", 887);
+  throwNotImplemented("node:http2 createServer", 8823);
 }
 function createSecureServer() {
-  throwNotImplemented("node:http2 createSecureServer", 887);
+  throwNotImplemented("node:http2 createSecureServer", 8823);
 }
 function getDefaultSettings() {
   // return default settings
   return getUnpackedSettings();
 }
 function Http2ServerRequest() {
-  throwNotImplemented("node:http2 Http2ServerRequest", 887);
+  throwNotImplemented("node:http2 Http2ServerRequest", 8823);
 }
 Http2ServerRequest.prototype = {};
 function Http2ServerResponse() {
-  throwNotImplemented("node:http2 Http2ServerResponse", 887);
+  throwNotImplemented("node:http2 Http2ServerResponse", 8823);
 }
 Http2ServerResponse.prototype = {};
 


### PR DESCRIPTION
### What does this PR do?

Update the issue reported by missing node:http2 server components from #887 to #8823 

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
