### PR TITLE
windows: fix bunx ci test

### DIFF
--- a/src/hive_array.zig
+++ b/src/hive_array.zig
@@ -92,6 +92,7 @@ pub fn HiveArray(comptime T: type, comptime capacity: u16) type {
                     return value;
                 }
 
+                new.* = true;
                 return self.allocator.create(T) catch unreachable;
             }
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1934,7 +1934,7 @@ pub const Resolver = struct {
 
                 const dir_path_for_resolution = manager.pathForResolution(resolved_package_id, resolution, bufs(.path_in_global_disk_cache)) catch |err| {
                     // if it's missing, we need to install it
-                    if (err == error.FileNotFound) {
+                    if (err == error.FileNotFound or err == error.ENOENT) {
                         switch (manager.getPreinstallState(resolved_package_id)) {
                             .done => {
                                 var path = Fs.Path.init(import_path);
@@ -4092,7 +4092,7 @@ pub const Resolver = struct {
                 ) catch |err| brk: {
                     const pretty = r.prettyPath(Path.init(tsconfigpath));
 
-                    if (err == error.ENOENT or err == error.FileNotFound) {
+                    if (err == error.FileNotFound or err == error.ENOENT) {
                         r.log.addErrorFmt(null, logger.Loc.Empty, r.allocator, "Cannot find tsconfig file {}", .{bun.fmt.QuotedFormatter{ .text = pretty }}) catch {};
                     } else if (err != error.ParseErrorAlreadyLogged and err != error.IsDir and err != error.EISDIR) {
                         r.log.addErrorFmt(null, logger.Loc.Empty, r.allocator, "Cannot read file {}: {s}", .{ bun.fmt.QuotedFormatter{ .text = pretty }, @errorName(err) }) catch {};

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -681,7 +681,7 @@ fn openDirAtWindowsNtPath(
         w.SYNCHRONIZE | w.FILE_TRAVERSE;
     const iterable_flag: u32 = if (iterable) w.FILE_LIST_DIRECTORY else 0;
     const rename_flag: u32 = if (can_rename_or_delete) w.DELETE else 0;
-    const read_only_flag: u32 = if (read_only) 0 else w.FILE_ADD_FILE | w.FILE_ADD_SUBDIRECTORY;
+    const read_only_flag: u32 = if (read_only) 0 else (w.FILE_ADD_FILE | w.FILE_ADD_SUBDIRECTORY);
     const flags: u32 = iterable_flag | base_flags | rename_flag | read_only_flag;
 
     const path_len_bytes: u16 = @truncate(path.len * 2);

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -76,11 +76,7 @@ it("should choose the tagged versions instead of the PATH versions when a tag is
       stdout: "pipe",
       stdin: "ignore",
       stderr: "inherit",
-      env: {
-        ...env,
-        // BUN_DEBUG_QUIET_LOGS: undefined,
-        // BUN_DEBUG: "/tmp/bun-debug.txt." + i,
-      },
+      env,
     });
   });
 
@@ -90,7 +86,7 @@ it("should choose the tagged versions instead of the PATH versions when a tag is
     a.substring(0, a.indexOf("\n")),
   );
   expect(outputs).toEqual(semverVersions.map(v => "SemVer " + v));
-});
+}, 35_000);
 
 it("should install and run default (latest) version", async () => {
   const { stdout, stderr, exited } = spawn({
@@ -106,7 +102,7 @@ it("should install and run default (latest) version", async () => {
   const out = await new Response(stdout).text();
   expect(out.split(/\r?\n/)).toEqual(["console.log(42);", ""]);
   expect(await exited).toBe(0);
-});
+}, 15_000);
 
 it("should install and run specified version", async () => {
   const { stdout, stderr, exited } = spawn({
@@ -122,7 +118,7 @@ it("should install and run specified version", async () => {
   const out = await new Response(stdout).text();
   expect(out.split(/\r?\n/)).toEqual(["uglify-js 3.14.1", ""]);
   expect(await exited).toBe(0);
-});
+}, 15_000);
 
 it("should output usage if no arguments are passed", async () => {
   const { stdout, stderr, exited } = spawn({
@@ -181,7 +177,7 @@ it("should work for @scoped packages", async () => {
   expect(err).not.toContain("error:");
 
   expect(out.trim()).toContain("Usage: babel [options]");
-});
+}, 15_000);
 
 it("should execute from current working directory", async () => {
   await writeFile(
@@ -206,7 +202,7 @@ console.log(
   expect(await readdirSorted(x_dir)).toEqual(["test.js"]);
   expect(out.split(/\r?\n/)).toEqual(["console.log(42);", ""]);
   expect(exitCode).toBe(0);
-});
+}, 15_000);
 
 it("should work for github repository", async () => {
   // without cache
@@ -248,7 +244,7 @@ it("should work for github repository", async () => {
   expect(err).not.toContain("error:");
   expect(out.trim()).toContain("Usage: " + (isWindows ? "cli.js" : "cowsay"));
   expect(exited).toBe(0);
-});
+}, 15_000);
 
 it("should work for github repository with committish", async () => {
   const withoutCache = spawn({
@@ -289,7 +285,7 @@ it("should work for github repository with committish", async () => {
   expect(err).not.toContain("error:");
   expect(out.trim()).toContain("hello bun!");
   expect(exited).toBe(0);
-});
+}, 15_000);
 
 it.each(["--version", "-v"])("should print the version using %s and exit", async flag => {
   const subprocess = spawn({
@@ -353,4 +349,4 @@ it("should pass --version to the package if specified", async () => {
   expect(err).not.toContain("error:");
   expect(out.trim()).not.toContain(Bun.version);
   expect(exited).toBe(0);
-});
+}, 15_000);

--- a/test/integration/esbuild/esbuild.test.ts
+++ b/test/integration/esbuild/esbuild.test.ts
@@ -7,6 +7,7 @@ import { spawn } from "bun";
 describe("esbuild integration test", () => {
   test("install and use esbuild", async () => {
     const packageDir = tmpdirSync();
+    console.log(1);
 
     await writeFile(
       join(packageDir, "package.json"),
@@ -30,6 +31,7 @@ describe("esbuild integration test", () => {
     expect(err).toContain("Saved lockfile");
     expect(out).toContain("esbuild@0.19.8");
     expect(await exited).toBe(0);
+    console.log(2);
 
     ({ stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "esbuild", "--version"],
@@ -45,10 +47,12 @@ describe("esbuild integration test", () => {
     expect(err).toBe("");
     expect(out).toContain("0.19.8");
     expect(await exited).toBe(0);
+    console.log(3);
   });
 
   test("install and use estrella", async () => {
     const packageDir = tmpdirSync();
+    console.log(1);
 
     await writeFile(
       join(packageDir, "package.json"),
@@ -72,6 +76,7 @@ describe("esbuild integration test", () => {
     expect(err).toContain("Saved lockfile");
     expect(out).toContain("estrella@1.4.1");
     expect(await exited).toBe(0);
+    console.log(2);
 
     ({ stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "estrella", "--estrella-version"],
@@ -87,6 +92,7 @@ describe("esbuild integration test", () => {
     expect(err).toBe("");
     expect(out).toContain("1.4.1");
     expect(await exited).toBe(0);
+    console.log(3);
 
     await cp(join(import.meta.dir, "build-file.js"), join(packageDir, "build-file.js"));
 
@@ -104,6 +110,7 @@ describe("esbuild integration test", () => {
     expect(err).toBe("");
     expect(out).toBe('console.log("hello"),console.log("estrella");\n');
     expect(await exited).toBe(0);
+    console.log(4);
 
     await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
     await rm(join(packageDir, "bun.lockb"), { force: true });
@@ -136,6 +143,7 @@ describe("esbuild integration test", () => {
     expect(out).toContain("estrella@1.4.1");
     expect(out).toContain("esbuild@0.19.8");
     expect(await exited).toBe(0);
+    console.log(5);
 
     ({ stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "estrella", "--estrella-version"],
@@ -151,6 +159,7 @@ describe("esbuild integration test", () => {
     expect(err).toBe("");
     expect(out).toContain("1.4.1");
     expect(await exited).toBe(0);
+    console.log(6);
 
     ({ stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "esbuild", "--version"],
@@ -166,6 +175,7 @@ describe("esbuild integration test", () => {
     expect(err).toBe("");
     expect(out).toContain("0.19.8");
     expect(await exited).toBe(0);
+    console.log(7);
 
     ({ stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "esbuild", "--version"],
@@ -180,6 +190,8 @@ describe("esbuild integration test", () => {
     out = await new Response(stdout).text();
     expect(err).toBe("");
     expect(out).toContain("0.11.23");
+    expect(await exited).toBe(0);
+    console.log(8);
 
     ({ stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "estrella", "build-file.js"],
@@ -195,5 +207,6 @@ describe("esbuild integration test", () => {
     expect(err).toBe("");
     expect(out).toBe('console.log("hello"),console.log("estrella");\n');
     expect(await exited).toBe(0);
+    console.log(9);
   });
 });


### PR DESCRIPTION
I have noticed it can sometimes rarely still fail which im looking into. but it used to fail every time consistently so I wanted to get the progress in a branch

ci logs used to be inundated with errors like:

```
error: moving "lru-cache" to cache dir failed
ENOTEMPTY: Directory not empty (NtSetInformationFile())
  From: .f7f5ffdec4e5b3bf-00000002.lru-cache
    To: lru-cache@6.0.0
```