### PR TITLE
fix spawn-kill-signal.test.ts

### DIFF
--- a/test/js/bun/spawn/spawn-kill-signal.test.ts
+++ b/test/js/bun/spawn/spawn-kill-signal.test.ts
@@ -13,7 +13,7 @@ describe("subprocess.kill", () => {
       for (let input of inputs[key as keyof typeof inputs]) {
         test(Bun.inspect(input).replaceAll("\n", "\\n"), async () => {
           const proc = Bun.spawn({
-            cmd: ["bash", "-c", "sleep infinity"],
+            cmd: ["bash", "-c", "sleep 1000"],
             stdio: ["inherit", "inherit", "inherit"],
           });
 
@@ -33,7 +33,7 @@ describe("subprocess.kill", () => {
     for (let input of fails) {
       test(Bun.inspect(input).replaceAll("\n", "\\n"), async () => {
         const proc = Bun.spawn({
-          cmd: ["bash", "-c", "sleep infinity"],
+          cmd: ["bash", "-c", "sleep 1000"],
           stdio: ["inherit", "inherit", "inherit"],
         });
 


### PR DESCRIPTION
```
48 |         expect(proc.exitCode).toBe(null);
             ^
error: expect(received).toBe(expected)

Expected: null
Received: 1
```

```
❯ bash -c 'sleep infinity'
usage: sleep seconds
```

process was exiting before it could be killed