### PR TITLE
fix out of bounds error for bun install

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -10771,20 +10771,6 @@ pub const PackageManager = struct {
                             }
                         }
 
-                        if (manager.summary.overrides_changed and all_name_hashes.len > 0) {
-                            for (manager.lockfile.buffers.dependencies.items, 0..) |*dependency, dependency_i| {
-                                if (std.mem.indexOfScalar(PackageNameHash, all_name_hashes, dependency.name_hash)) |_| {
-                                    manager.lockfile.buffers.resolutions.items[dependency_i] = invalid_package_id;
-                                    try manager.enqueueDependencyWithMain(
-                                        @truncate(dependency_i),
-                                        dependency,
-                                        manager.lockfile.buffers.resolutions.items[dependency_i],
-                                        false,
-                                    );
-                                }
-                            }
-                        }
-
                         manager.lockfile.packages.items(.scripts)[0] = maybe_root.scripts.clone(
                             lockfile.buffers.string_bytes.items,
                             *Lockfile.StringBuilder,
@@ -10817,6 +10803,20 @@ pub const PackageManager = struct {
                         }
 
                         builder.clamp();
+
+                        if (manager.summary.overrides_changed and all_name_hashes.len > 0) {
+                            for (manager.lockfile.buffers.dependencies.items, 0..) |*dependency, dependency_i| {
+                                if (std.mem.indexOfScalar(PackageNameHash, all_name_hashes, dependency.name_hash)) |_| {
+                                    manager.lockfile.buffers.resolutions.items[dependency_i] = invalid_package_id;
+                                    try manager.enqueueDependencyWithMain(
+                                        @truncate(dependency_i),
+                                        dependency,
+                                        manager.lockfile.buffers.resolutions.items[dependency_i],
+                                        false,
+                                    );
+                                }
+                            }
+                        }
 
                         // Split this into two passes because the below may allocate memory or invalidate pointers
                         if (manager.summary.add > 0 or manager.summary.update > 0) {

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2092,7 +2092,11 @@ pub const StringBuilder = struct {
     }
 
     pub fn clamp(this: *StringBuilder) void {
-        if (comptime Environment.allow_assert) assert(this.cap >= this.len);
+        if (comptime Environment.allow_assert) {
+            assert(this.cap >= this.len);
+            // assert that no other builder was allocated while this builder was being used
+            assert(this.lockfile.buffers.string_bytes.items.len == this.off + this.cap);
+        }
 
         const excess = this.cap - this.len;
 


### PR DESCRIPTION
### What does this PR do?
In short - we were creating string builders for the lockfile while string builders already existed. When the first string builder later truncated the buffer, it actually truncated a different part from what it expected.

### How did you verify your code works?
Not really sure how to write a test for this, the repro was using the entire bun repo package.json 😅 