### PR TITLE
fix(bundler): more windows backslash stuff

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -569,6 +569,10 @@ pub const BundleV2 = struct {
             // TODO: outbase
             const rel = bun.path.relativePlatform(this.bundler.fs.top_level_dir, path.text, .loose, false);
             path.pretty = this.graph.allocator.dupe(u8, rel) catch @panic("Ran out of memory");
+        } else if (!path.isPrettyPathPosix()) {
+            const dup = this.graph.allocator.dupe(u8, path.pretty) catch bun.outOfMemory();
+            bun.path.platformToPosixInPlace(u8, dup);
+            path.pretty = dup;
         }
         path.assertPrettyIsValid();
 
@@ -670,7 +674,12 @@ pub const BundleV2 = struct {
             // TODO: outbase
             const rel = bun.path.relativePlatform(this.bundler.fs.top_level_dir, path.text, .loose, false);
             path.pretty = this.graph.allocator.dupe(u8, rel) catch @panic("Ran out of memory");
+        } else if (path.isPrettyPathPosix()) {
+            const dup = this.graph.allocator.dupe(u8, path.pretty) catch bun.outOfMemory();
+            bun.path.platformToPosixInPlace(u8, dup);
+            path.pretty = dup;
         }
+        path.assertPrettyIsValid();
         path.* = try path.dupeAlloc(this.graph.allocator);
         entry.value_ptr.* = source_index.get();
         this.graph.ast.append(bun.default_allocator, JSAst.empty) catch unreachable;
@@ -2010,6 +2019,10 @@ pub const BundleV2 = struct {
                 // TODO: outbase
                 const rel = bun.path.relativePlatform(this.bundler.fs.top_level_dir, path.text, .loose, false);
                 path.pretty = this.graph.allocator.dupe(u8, rel) catch bun.outOfMemory();
+            } else if (!path.isPrettyPathPosix()) {
+                const dup = this.graph.allocator.dupe(u8, path.pretty) catch bun.outOfMemory();
+                bun.path.platformToPosixInPlace(u8, dup);
+                path.pretty = dup;
             }
             path.assertPrettyIsValid();
             path.* = path.dupeAlloc(this.graph.allocator) catch @panic("Ran out of memory");

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -569,10 +569,6 @@ pub const BundleV2 = struct {
             // TODO: outbase
             const rel = bun.path.relativePlatform(this.bundler.fs.top_level_dir, path.text, .loose, false);
             path.pretty = this.graph.allocator.dupe(u8, rel) catch @panic("Ran out of memory");
-        } else if (!path.isPrettyPathPosix()) {
-            const dup = this.graph.allocator.dupe(u8, path.pretty) catch bun.outOfMemory();
-            bun.path.platformToPosixInPlace(u8, dup);
-            path.pretty = dup;
         }
         path.assertPrettyIsValid();
 
@@ -588,7 +584,7 @@ pub const BundleV2 = struct {
 
         const entry = this.graph.path_to_source_index_map.getOrPut(this.graph.allocator, path.hashKey()) catch @panic("Ran out of memory");
         if (!entry.found_existing) {
-            path.* = path.dupeAlloc(this.graph.allocator) catch @panic("Ran out of memory");
+            path.* = path.dupeAllocFixPretty(this.graph.allocator) catch @panic("Ran out of memory");
 
             // We need to parse this
             const source_index = Index.init(@as(u32, @intCast(this.graph.ast.len)));
@@ -674,13 +670,9 @@ pub const BundleV2 = struct {
             // TODO: outbase
             const rel = bun.path.relativePlatform(this.bundler.fs.top_level_dir, path.text, .loose, false);
             path.pretty = this.graph.allocator.dupe(u8, rel) catch @panic("Ran out of memory");
-        } else if (path.isPrettyPathPosix()) {
-            const dup = this.graph.allocator.dupe(u8, path.pretty) catch bun.outOfMemory();
-            bun.path.platformToPosixInPlace(u8, dup);
-            path.pretty = dup;
         }
+        path.* = try path.dupeAllocFixPretty(this.graph.allocator);
         path.assertPrettyIsValid();
-        path.* = try path.dupeAlloc(this.graph.allocator);
         entry.value_ptr.* = source_index.get();
         this.graph.ast.append(bun.default_allocator, JSAst.empty) catch unreachable;
 
@@ -2019,13 +2011,8 @@ pub const BundleV2 = struct {
                 // TODO: outbase
                 const rel = bun.path.relativePlatform(this.bundler.fs.top_level_dir, path.text, .loose, false);
                 path.pretty = this.graph.allocator.dupe(u8, rel) catch bun.outOfMemory();
-            } else if (!path.isPrettyPathPosix()) {
-                const dup = this.graph.allocator.dupe(u8, path.pretty) catch bun.outOfMemory();
-                bun.path.platformToPosixInPlace(u8, dup);
-                path.pretty = dup;
             }
-            path.assertPrettyIsValid();
-            path.* = path.dupeAlloc(this.graph.allocator) catch @panic("Ran out of memory");
+            path.* = path.dupeAllocFixPretty(this.graph.allocator) catch @panic("Ran out of memory");
 
             var secondary_path_to_copy: ?Fs.Path = null;
             if (resolve_result.path_pair.secondary) |*secondary| {
@@ -11320,6 +11307,10 @@ pub const Chunk = struct {
                             "\n//# debugId={}\n",
                             .{bun.sourcemap.DebugIDFormatter{ .id = chunk.isolated_hash }},
                         ) catch bun.outOfMemory()).len..];
+                    }
+
+                    if (remain.len > 0) {
+                        std.debug.print("Remaining Left: {} - \"{s}\"\n", .{ remain.len, total_buf[0 .. total_buf.len - remain.len] });
                     }
 
                     bun.assert(remain.len == 0);

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1798,14 +1798,14 @@ pub const Path = struct {
     pub fn dupeAllocFixPretty(this: *const Path, allocator: std.mem.Allocator) !Fs.Path {
         if (this.isPrettyPathPosix()) return this.dupeAlloc(allocator);
         comptime bun.assert(bun.Environment.isWindows);
-        var new = this;
+        var new = this.*;
         new.pretty = "";
-        new = new.dupeAlloc(allocator);
-        const pretty = allocator.dupe(u8, this.pretty);
+        new = try new.dupeAlloc(allocator);
+        const pretty = try allocator.dupe(u8, this.pretty);
         bun.path.platformToPosixInPlace(u8, pretty);
         new.pretty = pretty;
         new.assertPrettyIsValid();
-        return pretty;
+        return new;
     }
 
     pub const empty = Fs.Path.init("");

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -409,7 +409,7 @@ pub fn relativeToCommonPath(
     var out_slice: []u8 = buf[0..0];
 
     if (normalized_from.len > 0) {
-        var i: usize = @as(usize, @intCast(@intFromBool(normalized_from[0] == separator))) + 1 + last_common_separator;
+        var i: usize = @as(usize, @intCast(@intFromBool(platform.isSeparator(normalized_from[0])))) + 1 + last_common_separator;
 
         while (i <= normalized_from.len) : (i += 1) {
             if (i == normalized_from.len or (normalized_from[i] == separator and i + 1 < normalized_from.len)) {
@@ -427,13 +427,15 @@ pub fn relativeToCommonPath(
     if (normalized_to.len > last_common_separator + 1) {
         var tail = normalized_to[last_common_separator..];
         if (normalized_from.len > 0 and (last_common_separator == normalized_from.len or (last_common_separator == normalized_from.len - 1))) {
-            if (tail[0] == separator) {
+            if (platform.isSeparator(tail[0])) {
                 tail = tail[1..];
             }
         }
 
         // avoid making non-absolute paths absolute
-        const insert_leading_slash = tail[0] != separator and out_slice.len > 0 and out_slice[out_slice.len - 1] != separator;
+        const insert_leading_slash = !platform.isSeparator(tail[0]) and
+            out_slice.len > 0 and !platform.isSeparator(out_slice[out_slice.len - 1]);
+
         if (insert_leading_slash) {
             buf[out_slice.len] = separator;
             out_slice.len += 1;
@@ -496,6 +498,13 @@ pub fn relative(from: []const u8, to: []const u8) []const u8 {
 
 pub fn relativePlatform(from: []const u8, to: []const u8, comptime platform: Platform, comptime always_copy: bool) []const u8 {
     const normalized_from = if (platform.isAbsolute(from)) brk: {
+        if (platform == .loose and bun.Environment.isWindows) {
+            // we want to invoke the windows resolution behavior but end up with a
+            // string with forward slashes.
+            const normalized = normalizeStringBuf(from, relative_from_buf[1..], true, .windows, true);
+            platformToPosixInPlace(u8, normalized);
+            break :brk normalized;
+        }
         const path = normalizeStringBuf(from, relative_from_buf[1..], true, platform, true);
         if (platform == .windows) break :brk path;
         relative_from_buf[0] = platform.separator();
@@ -510,6 +519,11 @@ pub fn relativePlatform(from: []const u8, to: []const u8, comptime platform: Pla
     );
 
     const normalized_to = if (platform.isAbsolute(to)) brk: {
+        if (platform == .loose and bun.Environment.isWindows) {
+            const normalized = normalizeStringBuf(to, relative_to_buf[1..], true, .windows, true);
+            platformToPosixInPlace(u8, normalized);
+            break :brk normalized;
+        }
         const path = normalizeStringBuf(to, relative_to_buf[1..], true, platform, true);
         if (platform == .windows) break :brk path;
         relative_to_buf[0] = platform.separator();
@@ -1971,8 +1985,8 @@ pub fn pathToPosixBuf(comptime T: type, path: []const T, buf: []T) []T {
     return buf[0..path.len];
 }
 
-pub fn platformToPosixBuf(comptime T: type, path: []const T, buf: []T) []T {
-    if (std.fs.path.sep == '/') return;
+pub fn platformToPosixBuf(comptime T: type, path: []const T, buf: []T) []const T {
+    if (std.fs.path.sep == '/') return path;
     var idx: usize = 0;
     while (std.mem.indexOfScalarPos(T, path, idx, std.fs.path.sep)) |index| : (idx = index + 1) {
         @memcpy(buf[idx..index], path[idx..index]);

--- a/test/bundler/bundler_regressions.test.ts
+++ b/test/bundler/bundler_regressions.test.ts
@@ -216,4 +216,14 @@ describe("bundler", () => {
     },
     run: { stdout: "你好" },
   });
+
+  itBundled("regression/WindowsBackslashAssertion1#9974", {
+    files: {
+      "/test/entry.ts": `
+        import { loadFonts } from "../base";
+        console.log(loadFonts);
+      `,
+    },
+    entryPointsRaw: ["test/entry.ts", "--external", "*"],
+  });
 });


### PR DESCRIPTION
### What does this PR do?

on windows we become more aggressive for checking backslashes and also fixing them in pretty paths. this also changes some behavior of our relative function (not node:path) when the mode is loose, all related to slash handling.

Fixes #11300
Fixes #9974

11300 does not have a test but i manually verified that by running their framework. 9974 has a test.