### PR TITLE
fix(windows spawn): use cmd to call batch scripts

### DIFF
--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1521,7 +1521,7 @@ pub fn spawnProcessWindows(
         const args_slice = std.mem.span(args);
         args = try allocator.allocSentinel(?[*:0]const u8, args_slice.len + 2, null);
         args[0..2].* = .{ file, "/c" };
-        args[2] = std.fmt.allocPrintZ(allocator, "\"{?s}\"", .{args_slice[0]});
+        args[2] = try std.fmt.allocPrintZ(allocator, "\"{?s}\"", .{args_slice[0]});
         @memcpy(args[3..], args_slice[1..]);
     }
 

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1515,7 +1515,7 @@ pub fn spawnProcessWindows(
     var args = argv;
     var force_verbatim_arguments = false;
     const extension = std.fs.path.extension(std.mem.sliceTo(file, 0));
-    if (bun.strings.eqlComptime(extension, ".cmd") or bun.strings.eqlComptime(extension, ".bat")) {
+    if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(extension, ".cmd") or bun.strings.eqlCaseInsensitiveASCIIICheckLength(extension, ".bat")) {
         force_verbatim_arguments = true;
         file = "cmd.exe";
         const args_slice = std.mem.span(args);

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -833,6 +833,11 @@ ${temp_dir}`
       .stdout("complex > command; $(execute)\n")
       .runAsTest("complex_mixed_special_chars");
   });
+
+  test("spaces in path and args", async () => {
+    const fields = "name scripts";
+    expect(async () => { await $`npm pkg get ${fields}` }).not.toThrow();
+  });
 });
 
 describe("deno_task", () => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
fixes #11328
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests 

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

based on https://github.com/nodejs/node/issues/7367#issuecomment-1277495127

not 100% sure about this, so count on your expertise