### PR TITLE
Added forgotten dot in utils.md

### DIFF
--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -183,7 +183,7 @@ const currentFile = import.meta.url;
 Bun.openInEditor(currentFile);
 ```
 
-You can override this via the `debug.editor` setting in your [`bunfig.toml`](/docs/runtime/bunfig)
+You can override this via the `debug.editor` setting in your [`bunfig.toml`](/docs/runtime/bunfig).
 
 ```toml-diff#bunfig.toml
 + [debug]


### PR DESCRIPTION
### What does this PR do?

Added forgotten dot in the docs: utils.md