### PR TITLE
Removed ambiguous quotes in utils.md

### DIFF
--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -251,11 +251,11 @@ Bun.deepEquals(new Foo(), { a: 1 }, true); // false
 
 Escapes the following characters from an input string:
 
-- `"` becomes `"&quot;"`
-- `&` becomes `"&amp;"`
-- `'` becomes `"&#x27;"`
-- `<` becomes `"&lt;"`
-- `>` becomes `"&gt;"`
+- `"` becomes `&quot;`
+- `&` becomes `&amp;`
+- `'` becomes `&#x27;`
+- `<` becomes `&lt;`
+- `>` becomes `&gt;`
 
 This function is optimized for large input. On an M1X, it processes 480 MB/s -
 20 GB/s, depending on how much data is being escaped and whether there is non-ascii


### PR DESCRIPTION
### What does this PR do?

![image](https://github.com/oven-sh/bun/assets/95184938/c3ce44f0-1168-4b2a-8777-3340fe127305)

The double quotes are ambiguous and redundant imo: it’s not clear if they’re included in the return value of the `escapeHTML` function or if they are only used for delimiting the return value.
Additionally, the inline codeblock is already used for delimiting the return value.

Because of this, I removed the double quotes `"`.