### PR TITLE
docs: Correct command line of package upgrading with Scoop

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -144,7 +144,7 @@ $ bun upgrade
 {% callout %}
 **Homebrew users** — To avoid conflicts with Homebrew, use `brew upgrade bun` instead.
 
-**Scoop users** — To avoid conflicts with Scoop, use `scoop upgrade bun` instead.
+**Scoop users** — To avoid conflicts with Scoop, use `scoop update bun` instead.
 
 **proto users** - Use `proto install bun --pin` instead.
 {% /callout %}


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

Scoop users should use `update` for package upgrading.

```
> scoop upgrade bun
WARN  scoop: 'upgrade' isn't a scoop command. See 'scoop help'.

> scoop update bun
bun: 1.1.10 (latest version)
Latest versions for all apps are installed! For more information try 'scoop status'
```
