### PR TITLE
fix(node:path): toNamespacedPath bugfix

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -4766,7 +4766,7 @@ pub const Path = struct {
             buf[3] = CHAR_BACKWARD_SLASH;
             return MaybeSlice(T){ .result = buf[0..bufSize] };
         }
-        return MaybeSlice(T){ .result = path };
+        return MaybeSlice(T){ .result = resolvedPath };
     }
 
     pub inline fn toNamespacedPathWindowsJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, path: []const T, buf: []T, buf2: []T) JSC.JSValue {

--- a/test/js/node/path/to-namespaced-path.test.js
+++ b/test/js/node/path/to-namespaced-path.test.js
@@ -61,7 +61,9 @@ describe("path.toNamespacedPath", () => {
     assert.strictEqual(path.win32.toNamespacedPath("C:/foo"), "\\\\?\\C:\\foo");
     assert.strictEqual(path.win32.toNamespacedPath("\\\\foo\\bar"), "\\\\?\\UNC\\foo\\bar\\");
     assert.strictEqual(path.win32.toNamespacedPath("//foo//bar"), "\\\\?\\UNC\\foo\\bar\\");
-    assert.strictEqual(path.win32.toNamespacedPath("\\\\?\\foo"), "\\\\?\\foo");
+    assert.strictEqual(path.win32.toNamespacedPath("\\\\?\\foo\\"), "\\\\?\\foo\\");
+    assert.strictEqual(path.win32.toNamespacedPath("\\\\?\\foo"), "\\\\?\\foo\\");
+    assert.strictEqual(path.win32.toNamespacedPath("\\\\?\\c:\\Windows/System"), "\\\\?\\c:\\Windows\\System");
     assert.strictEqual(path.win32.toNamespacedPath(null), null);
     assert.strictEqual(path.win32.toNamespacedPath(true), true);
     assert.strictEqual(path.win32.toNamespacedPath(1), 1);


### PR DESCRIPTION
### What does this PR do?
Same fix as https://github.com/nodejs/node/pull/52915, thanks @huseyinacacak-janea! Bun's implementation of `toNamespacedPath` is the same code adapted to zig, so the same bug existed.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
