### PR TITLE
Use calloc when allocating loop on Windows

### DIFF
--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -145,7 +145,7 @@ struct us_loop_t *us_create_loop(void *hint,
                                  void (*post_cb)(struct us_loop_t *loop),
                                  unsigned int ext_size) {
   struct us_loop_t *loop =
-      (struct us_loop_t *)malloc(sizeof(struct us_loop_t) + ext_size);
+      (struct us_loop_t *)calloc(1, sizeof(struct us_loop_t) + ext_size);
 
   loop->uv_loop = hint ? hint : uv_loop_new();
   loop->is_default = hint != 0;


### PR DESCRIPTION
### What does this PR do?

Use calloc when allocating loop on Windows

We do this on Linux & Darwin. It has caught bugs. I wonder if it will on Windows.

### How did you verify your code works?

CI