### PR TITLE
Bun.CryptoHasher: fix byteLength and add test

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3216,7 +3216,8 @@ declare module "bun" {
      *
      * @param hashInto `TypedArray` to write the hash into. Faster than creating a new one each time
      */
-    digest(hashInto?: NodeJS.TypedArray): NodeJS.TypedArray;
+    digest(): Buffer;
+    digest(hashInto: NodeJS.TypedArray): NodeJS.TypedArray;
 
     /**
      * Run the hash over the given data
@@ -3225,10 +3226,11 @@ declare module "bun" {
      *
      * @param hashInto `TypedArray` to write the hash into. Faster than creating a new one each time
      */
+    static hash(algorithm: SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer): Buffer;
     static hash(
       algorithm: SupportedCryptoAlgorithms,
       input: Bun.BlobOrStringOrBuffer,
-      hashInto?: NodeJS.TypedArray,
+      hashInto: NodeJS.TypedArray,
     ): NodeJS.TypedArray;
 
     /**

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -2340,7 +2340,10 @@ pub const Crypto = struct {
             this: *CryptoHasher,
             _: *JSC.JSGlobalObject,
         ) callconv(.C) JSC.JSValue {
-            return JSC.JSValue.jsNumber(@as(u16, @truncate(this.evp.size())));
+            return JSC.JSValue.jsNumber(switch (this.*) {
+                .evp => |*inner| inner.size(),
+                .zig => |*inner| inner.digest_length,
+            });
         }
 
         pub fn getAlgorithm(

--- a/test/js/node/crypto/crypto.test.ts
+++ b/test/js/node/crypto/crypto.test.ts
@@ -52,10 +52,32 @@ describe("CryptoHasher", () => {
     shake256: "369771bb2cb9d2b04c1d54cca487e372d9f187f73f7ba3f65b95c8ee7798c527",
   } as const;
 
+  const expectedBitLength = {
+    blake2b256: 256,
+    blake2b512: 512,
+    md4: 128,
+    md5: 128,
+    ripemd160: 160,
+    sha1: 160,
+    sha224: 224,
+    sha256: 256,
+    sha384: 384,
+    sha512: 512,
+    "sha512-224": 224,
+    "sha512-256": 256,
+    "sha3-224": 224,
+    "sha3-256": 256,
+    "sha3-384": 384,
+    "sha3-512": 512,
+    shake128: 128,
+    shake256: 256,
+  } as const;
+
   for (const algorithm of CryptoHasher.algorithms) {
     it(`new CryptoHasher ${algorithm}`, () => {
       var hasher = new CryptoHasher(algorithm);
       expect(hasher.algorithm).toEqual(algorithm);
+      expect(hasher.byteLength).toEqual(expectedBitLength[algorithm] / 8);
       hasher.update("hello world");
       expect(hasher.digest("hex")).toEqual(expected[algorithm]);
     });


### PR DESCRIPTION
fixes crash when calling `.byteLength` on zig algorithms