### PR TITLE
increase test timeout time for sourcemap tests

### DIFF
--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1515,7 +1515,12 @@ export function itBundled(
   if (opts.todo && !FILTER) {
     it.todo(id, () => expectBundled(id, opts as any));
   } else {
-    it(id, () => expectBundled(id, opts as any));
+    it(
+      id,
+      () => expectBundled(id, opts as any),
+      // sourcemap code is slow
+      opts.snapshotSourceMap ? 20_000 : undefined,
+    );
   }
   return ref;
 }


### PR DESCRIPTION
### What does this PR do?

While adding `@parcel/source-map` to replace the other source-map package, I found an NAPI bug in Bun. I will work to fixing that, but in interest of fixing CI, I have increased the timeout of these tests.
