### PR TITLE
Fix bun.fish completions

### DIFF
--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -53,7 +53,7 @@ function __bun_complete_bins_scripts --inherit-variable bun_builtin_cmds_without
     # Scripts have descriptions appended with a tab separator.
     # Strip off descriptions for the purposes of subcommand testing.
     set -l scripts (__fish__get_bun_scripts)
-    if __fish_seen_subcommand_from $(string split \t -f 1 -- $scripts)
+    if __fish_seen_subcommand_from (string split \t -f 1 -- $scripts)
         return
     end
     # Emit scripts.


### PR DESCRIPTION
$( is not supported in fish

Before this fix, the fish completion crashes after `bun <tab>` with
```
~/.config/fish/completions/bun.fish (line 56): $(...) is not supported. In fish, please use '(string)'.                 
    if __fish_seen_subcommand_from $(string split \t -f 1 -- $scripts)                                                                 
                                   ^                                                                                                   
from sourcing file ~/.config/fish/completions/bun.fish
```