### PR TITLE
fix high cpu usage when using bun.build

### DIFF
--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -30,8 +30,8 @@ pub const All = struct {
         .context = {},
     },
     active_timer_count: i32 = 0,
-    uv_timer: if (Environment.isWindows) uv.uv_timer_t else void =
-        if (Environment.isWindows) std.mem.zeroes(uv.uv_timer_t) else {},
+    uv_timer: if (Environment.isWindows) uv.Timer else void =
+        if (Environment.isWindows) std.mem.zeroes(uv.Timer) else {},
 
     // We split up the map here to avoid storing an extra "repeat" boolean
     maps: struct {
@@ -81,7 +81,7 @@ pub const All = struct {
         }
     }
 
-    pub fn onUVTimer(uv_timer_t: *uv.uv_timer_t) callconv(.C) void {
+    pub fn onUVTimer(uv_timer_t: *uv.Timer) callconv(.C) void {
         const all = @fieldParentPtr(All, "uv_timer", uv_timer_t);
         const vm = @fieldParentPtr(JSC.VirtualMachine, "timer", all);
         all.drainTimers(vm);

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1548,10 +1548,18 @@ pub const BundleV2 = struct {
         }
     }
 
+    pub fn timerCallback(_: *bun.windows.libuv.Timer) callconv(.C) void {}
+
     pub fn generateInNewThreadWrap(instance: *BundleThread) void {
         Output.Source.configureNamedThread("Bundler");
 
         instance.waker = bun.Async.Waker.init() catch @panic("Failed to create waker");
+
+        var timer: bun.windows.libuv.Timer = undefined;
+        if (bun.Environment.isWindows) {
+            timer.init(instance.waker.?.loop.uv_loop);
+            timer.start(std.math.maxInt(u64), std.math.maxInt(u64), &timerCallback);
+        }
 
         var has_bundled = false;
         while (true) {

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -297,7 +297,6 @@ pub const uv_tcp_accept_s = struct_uv_tcp_accept_s;
 pub const uv_tcp_s = struct_uv_tcp_s;
 pub const uv_udp_s = struct_uv_udp_s;
 pub const uv_pipe_accept_s = struct_uv_pipe_accept_s;
-pub const uv_timer_s = struct_uv_timer_s;
 pub const uv_write_s = struct_uv_write_s;
 pub const uv_tty_s = struct_uv_tty_s;
 pub const uv_poll_s = struct_uv_poll_s;
@@ -1156,8 +1155,8 @@ const union_unnamed_411 = extern union {
     fd: c_int,
     reserved: [4]?*anyopaque,
 };
-pub const uv_timer_cb = ?*const fn (*uv_timer_t) callconv(.C) void;
-pub const struct_uv_timer_s = extern struct {
+pub const uv_timer_cb = ?*const fn (*Timer) callconv(.C) void;
+pub const Timer = extern struct {
     data: ?*anyopaque,
     loop: *uv_loop_t,
     type: uv_handle_type,
@@ -1199,7 +1198,6 @@ pub const struct_uv_timer_s = extern struct {
         uv_ref(@alignCast(@ptrCast(this)));
     }
 };
-pub const uv_timer_t = struct_uv_timer_s;
 const struct_unnamed_413 = extern struct {
     overlapped: OVERLAPPED,
     queued_bytes: usize,
@@ -1262,7 +1260,7 @@ const union_unnamed_415 = extern union {
     dummy: u64,
 };
 const struct_unnamed_410 = extern struct {
-    eof_timer: [*c]uv_timer_t,
+    eof_timer: [*c]Timer,
     dummy: uv_write_t,
     ipc_remote_pid: DWORD,
     ipc_data_frame: union_unnamed_415,
@@ -2201,13 +2199,13 @@ pub extern fn uv_idle_start(idle: [*c]uv_idle_t, cb: uv_idle_cb) c_int;
 pub extern fn uv_idle_stop(idle: [*c]uv_idle_t) c_int;
 pub extern fn uv_async_init(*uv_loop_t, @"async": *uv_async_t, async_cb: uv_async_cb) c_int;
 pub extern fn uv_async_send(@"async": *uv_async_t) c_int;
-pub extern fn uv_timer_init(*uv_loop_t, handle: *uv_timer_t) c_int;
-pub extern fn uv_timer_start(handle: *uv_timer_t, cb: uv_timer_cb, timeout: u64, repeat: u64) c_int;
-pub extern fn uv_timer_stop(handle: *uv_timer_t) c_int;
-pub extern fn uv_timer_again(handle: *uv_timer_t) c_int;
-pub extern fn uv_timer_set_repeat(handle: *uv_timer_t, repeat: u64) void;
-pub extern fn uv_timer_get_repeat(handle: *const uv_timer_t) u64;
-pub extern fn uv_timer_get_due_in(handle: *const uv_timer_t) u64;
+pub extern fn uv_timer_init(*uv_loop_t, handle: *Timer) c_int;
+pub extern fn uv_timer_start(handle: *Timer, cb: uv_timer_cb, timeout: u64, repeat: u64) c_int;
+pub extern fn uv_timer_stop(handle: *Timer) c_int;
+pub extern fn uv_timer_again(handle: *Timer) c_int;
+pub extern fn uv_timer_set_repeat(handle: *Timer, repeat: u64) void;
+pub extern fn uv_timer_get_repeat(handle: *const Timer) u64;
+pub extern fn uv_timer_get_due_in(handle: *const Timer) u64;
 pub extern fn uv_getaddrinfo(loop: *uv_loop_t, req: *uv_getaddrinfo_t, getaddrinfo_cb: uv_getaddrinfo_cb, node: [*:0]const u8, service: [*:0]const u8, hints: ?*const anyopaque) ReturnCode;
 pub extern fn uv_freeaddrinfo(ai: *anyopaque) void;
 pub extern fn uv_getnameinfo(loop: *uv_loop_t, req: [*c]uv_getnameinfo_t, getnameinfo_cb: uv_getnameinfo_cb, addr: [*c]const sockaddr, flags: c_int) c_int;
@@ -2547,7 +2545,7 @@ pub const union_uv_any_handle = extern union {
     process: uv_process_t,
     stream: uv_stream_t,
     tcp: uv_tcp_t,
-    timer: uv_timer_t,
+    timer: Timer,
     tty: uv_tty_t,
     udp: uv_udp_t,
     signal: uv_signal_t,

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "path";
 import { tempDirWithFiles } from "harness";
 
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 // Because macOS (and possibly other operating systems) can return a watcher
 // before it is actually watching, we need to repeat the operation to avoid
 // a race condition.
@@ -11,9 +11,12 @@ function repeat(fn: any) {
   return interval;
 }
 const encodingFileName = `新建文夹件.txt`;
-const testDir = tempDirWithFiles("watch", {
-  "watch.txt": "hello",
-  [encodingFileName]: "hello",
+let testDir = "";
+beforeEach(() => {
+  testDir = tempDirWithFiles("watch", {
+    "watch.txt": "hello",
+    [encodingFileName]: "hello",
+  });
 });
 
 describe("fs.watchFile", () => {
@@ -55,8 +58,8 @@ describe("fs.watchFile", () => {
     fs.unwatchFile(path.join(testDir, "watch.txt"));
 
     expect(entries.length).toBeGreaterThan(0);
-
-    expect(entries[0][0].size).toBe(6);
+    console.log(entries);
+    expect(entries[0][0].size).toBeGreaterThan(5);
     expect(entries[0][1].size).toBe(5);
     expect(entries[0][0].mtimeMs).toBeGreaterThan(entries[0][1].mtimeMs);
   });
@@ -98,7 +101,7 @@ describe("fs.watchFile", () => {
     let increment = 0;
     const interval = repeat(() => {
       increment++;
-      fs.writeFileSync(path.join(testDir, encodingFileName), "hello" + increment);
+      fs.writeFileSync(path.join(testDir, encodingFileName), "hello" + "a".repeat(increment));
     });
     await promise;
     clearInterval(interval);


### PR DESCRIPTION
### What does this PR do?

Calling `bun --watch` on a file that calls bun.build will pin the bundler's thread to max.

~~This PR calls .inc() in that thread, but that doesnt fix it on it's own. To fix it, we need to make libuv actually sleep. This is done through a shared timer instead of mutating libuv's internal counters. doing this before caused subtle bugs like this.~~ Doing this caused more problems than it solved. I am reducing the scope of this PR to only fix the bundler issues.

Result:

![image](https://github.com/oven-sh/bun/assets/24465214/8ccfea7e-555d-4291-96a2-cf79886ab481)

Fixes #10967
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

Code for measuring resource usage does not work on windows. It is not trivial to write a test for this.
