### PR TITLE
fix(install): re-link workspaces if necessary

### DIFF
--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -1780,7 +1780,7 @@ describe("workspaces", async () => {
       "installed what-bin@1.5.0 with binaries:",
       " - what-bin",
       "",
-      "2 packages installed",
+      "1 package installed",
     ]);
     expect(await exited).toBe(0);
     expect(await file(join(packageDir, "foo", "package.json")).json()).toEqual({
@@ -1907,11 +1907,9 @@ describe("workspaces", async () => {
     out = await Bun.readableStreamToText(stdout);
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       "",
-      "+ bar@workspace:packages/bar",
-      "",
       "installed no-deps@2.0.0",
       "",
-      "4 packages installed",
+      "1 package installed",
     ]);
     expect(await exited).toBe(0);
     expect(await file(join(packageDir, "package.json")).json()).toEqual({
@@ -1935,11 +1933,9 @@ describe("workspaces", async () => {
     out = await Bun.readableStreamToText(stdout);
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       "",
-      "+ pkg5@workspace:packages/pkg5",
-      "",
       "installed two-range-deps@1.0.0",
       "",
-      "6 packages installed",
+      "3 packages installed",
     ]);
     expect(await exited).toBe(0);
     expect(await file(join(packageDir, "packages", "boba", "package.json")).json()).toEqual({
@@ -1972,11 +1968,9 @@ describe("workspaces", async () => {
     out = await Bun.readableStreamToText(stdout);
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       "",
-      "+ pkg5@workspace:packages/pkg5",
-      "",
       "installed bar@0.0.7",
       "",
-      "4 packages installed",
+      "1 package installed",
     ]);
     expect(await exited).toBe(0);
     expect(await file(join(packageDir, "packages", "boba", "package.json")).json()).toEqual({
@@ -2120,9 +2114,7 @@ describe("workspaces", async () => {
         expect(err).not.toContain("error:");
         expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
           "",
-          `+ pkg2@workspace:packages/pkg2`,
-          "",
-          "2 packages installed",
+          "Checked 2 installs across 3 packages (no changes)",
         ]);
         expect(await exited).toBe(0);
 
@@ -2167,9 +2159,7 @@ describe("workspaces", async () => {
         expect(err).not.toContain("error:");
         expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
           "",
-          `+ pkg2@workspace:packages/pkg2`,
-          "",
-          "2 packages installed",
+          "Checked 2 installs across 3 packages (no changes)",
         ]);
         expect(await exited).toBe(0);
       });
@@ -2244,7 +2234,10 @@ describe("workspaces", async () => {
       expect(err).not.toContain("Duplicate dependency");
       expect(err).not.toContain('workspace dependency "workspace-1" not found');
       expect(err).not.toContain("error:");
-      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual(["", "1 package installed"]);
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        "",
+        "Checked 1 install across 2 packages (no changes)",
+      ]);
       expect(await exited).toBe(0);
       expect(await file(join(packageDir, "node_modules", "workspace-1", "package.json")).json()).toEqual({
         name: "workspace-1",
@@ -2298,9 +2291,7 @@ describe("workspaces", async () => {
       expect(err).not.toContain("error:");
       expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
         "",
-        `+ workspace-1@workspace:packages/workspace-1`,
-        "",
-        "1 package installed",
+        "Checked 1 install across 2 packages (no changes)",
       ]);
       expect(await exited).toBe(0);
       expect(await file(join(packageDir, "node_modules", "workspace-1", "package.json")).json()).toEqual({


### PR DESCRIPTION
### What does this PR do?
Currently bun will re-link workspaces with each install because it's comparing the workspace relative path to the version in the package.json. Instead, it should compare the known workspace version to the one read from disk.

Also we should allow workspaces to not have versions when verifying.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
updated tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
