### PR TITLE
Fix an ambiguous redirect in bun bash-completions

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -39,7 +39,7 @@ _read_scripts_in_package_json() {
         [[ "${COMP_WORDS[${line}]}" == "--cwd" ]] && working_dir="${COMP_WORDS[$((line + 1))]}";
     done
 
-    [[ -f "${working_dir}/package.json" ]] && package_json=$(<${working_dir}/package.json);
+    [[ -f "${working_dir}/package.json" ]] && package_json=$(<"${working_dir}/package.json");
 
     [[ "${package_json}" =~ "\"scripts\""[[:space:]]*":"[[:space:]]*\{(.*)\} ]] && {
         local package_json_compreply;


### PR DESCRIPTION
### What does this PR do?

This fixes an ambiguous redirect (Due to missing double quotes around a variable) in bash completions that result in broken completions inside a js project with package.json

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Changing the same line in bash completions of local bun install fixes this warning. 
