### PR TITLE
fix potential integer overflow

### DIFF
--- a/src/glob.zig
+++ b/src/glob.zig
@@ -2171,10 +2171,10 @@ pub fn detectGlobSyntax(potential_pattern: []const u8) bool {
             if (std.mem.indexOfScalar(u8, slice, token)) |idx| {
                 // Check for even number of backslashes preceding the
                 // token to know that it's not escaped
-                var i: usize = idx -| 1;
+                var i = idx;
                 var backslash_count: u16 = 0;
 
-                while (i >= 0 and potential_pattern[i] == '\\') : (i -= 1) {
+                while (i > 0 and potential_pattern[i - 1] == '\\') : (i -= 1) {
                     backslash_count += 1;
                 }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8253,7 +8253,6 @@ pub const PackageManager = struct {
         clap.parseParam("--trust                               Add to trustedDependencies in the project's package.json and install the package(s)") catch unreachable,
         clap.parseParam("-g, --global                          Install globally") catch unreachable,
         clap.parseParam("--cwd <STR>                           Set a specific cwd") catch unreachable,
-        clap.parseParam("--latest                              Update packages to their latest versions") catch unreachable,
         clap.parseParam("--backend <STR>                       Platform-specific optimizations for installing dependencies. " ++ platform_specific_backend_label) catch unreachable,
         clap.parseParam("--link-native-bins <STR>...           Link \"bin\" from a matching platform-specific \"optionalDependencies\" instead. Default: esbuild, turbo") catch unreachable,
         clap.parseParam("--concurrent-scripts <NUM>            Maximum number of concurrent jobs for lifecycle scripts (default 5)") catch unreachable,
@@ -8270,6 +8269,7 @@ pub const PackageManager = struct {
     };
 
     pub const update_params = install_params_ ++ [_]ParamType{
+        clap.parseParam("--latest                              Update packages to their latest versions") catch unreachable,
         clap.parseParam("<POS> ...                         \"name\" of packages to update") catch unreachable,
     };
 
@@ -8389,6 +8389,12 @@ pub const PackageManager = struct {
                         \\<b>Examples:<r>
                         \\  <d>Update all dependencies:<r>
                         \\  <b><green>bun update<r>
+                        \\
+                        \\  <d>Update all dependencies to latest:<r>
+                        \\  <b><green>bun update --latest<r>
+                        \\
+                        \\  <d>Update specific packages:<r>
+                        \\  <b><green>bun update zod jquery@3<r>
                         \\
                         \\Full documentation is available at <magenta>https://bun.sh/docs/cli/update<r>
                     ;
@@ -8605,7 +8611,9 @@ pub const PackageManager = struct {
                 };
             }
 
-            cli.latest = args.flag("--latest");
+            if (comptime subcommand == .update) {
+                cli.latest = args.flag("--latest");
+            }
 
             const specified_backend: ?PackageInstall.Method = brk: {
                 if (args.option("--backend")) |backend_| {

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1572,7 +1572,7 @@ pub const Printer = struct {
                     }
 
                     try writer.print(
-                        comptime Output.prettyFmt(" <r><b>{s}<r><d>@<b>{}<r>", enable_ansi_colors),
+                        comptime Output.prettyFmt(" <r><b>{s}<r><d>@<b>{}<r>\n", enable_ansi_colors),
                         .{
                             package_name,
                             resolved[package_id].fmt(string_buf, .auto),

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -778,6 +778,16 @@ pub fn clean(
     return old.cleanWithLogger(manager, updates, &log, exact_versions, log_level);
 }
 
+/// Is this a direct dependency of the workspace root package.json?
+pub fn isWorkspaceRootDependency(this: *Lockfile, id: DependencyID) bool {
+    return this.packages.items(.dependencies)[0].contains(id);
+}
+
+/// Is this a direct dependency of the workspace the install is taking place in?
+pub fn isRootDependency(this: *Lockfile, manager: *PackageManager, id: DependencyID) bool {
+    return this.packages.items(.dependencies)[manager.root_package_id.get(this, manager.workspace_name_hash)].contains(id);
+}
+
 pub fn cleanWithLogger(
     old: *Lockfile,
     manager: *PackageManager,
@@ -922,7 +932,7 @@ pub fn cleanWithLogger(
 
         // updates might be applied to the root package.json or one
         // of the workspace package.json files.
-        const workspace_package_id = manager.root_package_id.get(manager);
+        const workspace_package_id = manager.root_package_id.get(new, manager.workspace_name_hash);
 
         const dep_list = slice.items(.dependencies)[workspace_package_id];
         const res_list = slice.items(.resolutions)[workspace_package_id];


### PR DESCRIPTION
### What does this PR do?
This fixes a possible integer overflow followed by accessing memory out of bounds.

Also:
- adds a missing newline between packages in the install summary
- updates `bun update` help text
- prevents using stale lockfile after cleaning

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Manually

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
