### PR TITLE
Try deflaking child process test again

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -316,15 +316,19 @@ function execFile(file, args, options, callback) {
   function errorHandler(e) {
     ex = e;
 
-    if (child.stdout) child.stdout.destroy();
-    if (child.stderr) child.stderr.destroy();
+    const { stdout, stderr } = child;
+
+    if (stdout) stdout.destroy();
+    if (stderr) stderr.destroy();
 
     exitHandler();
   }
 
   function kill() {
-    if (child.stdout) child.stdout.destroy();
-    if (child.stderr) child.stderr.destroy();
+    const { stdout, stderr } = child;
+
+    if (stdout) stdout.destroy();
+    if (stderr) stderr.destroy();
 
     killed = true;
     try {
@@ -337,8 +341,8 @@ function execFile(file, args, options, callback) {
 
   if (options.timeout > 0) {
     timeoutId = setTimeout(function delayedKill() {
-      timeoutId && kill();
       timeoutId = null;
+      kill();
     }, options.timeout).unref();
   }
 
@@ -1001,20 +1005,13 @@ class ChildProcess extends EventEmitter {
   spawnargs;
   pid;
   channel;
+  killed = false;
 
   [Symbol.dispose]() {
     if (!this.killed) {
       this.kill();
     }
   }
-
-  get killed() {
-    if (this.#handle == null) return false;
-  }
-
-  // constructor(options) {
-  //   super(options);
-  // }
 
   #handleOnExit(exitCode, signalCode, err) {
     if (signalCode) {
@@ -1339,15 +1336,23 @@ class ChildProcess extends EventEmitter {
   kill(sig?) {
     const signal = sig === 0 ? sig : convertToValidSignal(sig === undefined ? "SIGTERM" : sig);
 
-    if (this.#handle) {
-      this.#handle.kill(signal);
+    const handle = this.#handle;
+    if (handle) {
+      if (handle.killed) {
+        this.killed = true;
+        return true;
+      }
+
+      try {
+        handle.kill(signal);
+        this.killed = true;
+        return true;
+      } catch (e) {
+        this.emit("error", e);
+      }
     }
 
-    // TODO: Figure out how to make this conform to the Node spec...
-    // The problem is that the handle does not report killed until the process exits
-    // So we can't return whether or not the process was killed because Bun.spawn seems to handle this async instead of sync like Node does
-    // return this.#handle?.killed ?? true;
-    return true;
+    return false;
   }
 
   #maybeClose() {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
