### PR TITLE
fix(Bun.Socket) onDrain will only be called after handshake + docs update

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -15,7 +15,7 @@
  */
 declare module "bun" {
   import type { Encoding as CryptoEncoding } from "crypto";
-
+  import type { CipherNameAndProtocol, EphemeralKeyInfo, PeerCertificate } from "tls";
   interface Env {
     NODE_ENV?: string;
     /**
@@ -3919,6 +3919,181 @@ declare module "bun" {
      * local port connected to the socket
      */
     readonly localPort: number;
+
+    /**
+     * This property is `true` if the peer certificate was signed by one of the CAs
+     * specified when creating the `Socket` instance, otherwise `false`.
+     */
+    readonly authorized: boolean;
+
+    /**
+     * String containing the selected ALPN protocol.
+     * Before a handshake has completed, this value is always null.
+     * When a handshake is completed but not ALPN protocol was selected, socket.alpnProtocol equals false.
+     */
+    readonly alpnProtocol: string | false | null;
+
+    /**
+     * Disables TLS renegotiation for this `Socket` instance. Once called, attempts
+     * to renegotiate will trigger an `error` handler on the `Socket`.
+     *
+     * There is no support for renegotiation as a server. (Attempts by clients will result in a fatal alert so that ClientHello messages cannot be used to flood a server and escape higher-level limits.)
+     */
+    disableRenegotiation(): void;
+
+    /**
+     * Keying material is used for validations to prevent different kind of attacks in
+     * network protocols, for example in the specifications of IEEE 802.1X.
+     *
+     * Example
+     *
+     * ```js
+     * const keyingMaterial = socket.exportKeyingMaterial(
+     *   128,
+     *   'client finished');
+     *
+     * /*
+     *  Example return value of keyingMaterial:
+     *  <Buffer 76 26 af 99 c5 56 8e 42 09 91 ef 9f 93 cb ad 6c 7b 65 f8 53 f1 d8 d9
+     *     12 5a 33 b8 b5 25 df 7b 37 9f e0 e2 4f b8 67 83 a3 2f cd 5d 41 42 4c 91
+     *     74 ef 2c ... 78 more bytes>
+     *
+     * ```
+     *
+     * @param length number of bytes to retrieve from keying material
+     * @param label an application specific label, typically this will be a value from the [IANA Exporter Label
+     * Registry](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#exporter-labels).
+     * @param context Optionally provide a context.
+     * @return requested bytes of the keying material
+     */
+    exportKeyingMaterial(length: number, label: string, context: Buffer): Buffer;
+
+    /**
+     * Returns the reason why the peer's certificate was not been verified. This
+     * property is set only when `socket.authorized === false`.
+     */
+    getAuthorizationError(): Error | null;
+
+    /**
+     * Returns an object representing the local certificate. The returned object has
+     * some properties corresponding to the fields of the certificate.
+     *
+     * If there is no local certificate, an empty object will be returned. If the
+     * socket has been destroyed, `null` will be returned.
+     */
+    getCertificate(): PeerCertificate | object | null;
+
+    /**
+     * Returns an object containing information on the negotiated cipher suite.
+     *
+     * For example, a TLSv1.2 protocol with AES256-SHA cipher:
+     *
+     * ```json
+     * {
+     *     "name": "AES256-SHA",
+     *     "standardName": "TLS_RSA_WITH_AES_256_CBC_SHA",
+     *     "version": "SSLv3"
+     * }
+     * ```
+     *
+     */
+    getCipher(): CipherNameAndProtocol;
+
+    /**
+     * Returns an object representing the type, name, and size of parameter of
+     * an ephemeral key exchange in `perfect forward secrecy` on a client
+     * connection. It returns an empty object when the key exchange is not
+     * ephemeral. As this is only supported on a client socket; `null` is returned
+     * if called on a server socket. The supported types are `'DH'` and `'ECDH'`. The`name` property is available only when type is `'ECDH'`.
+     *
+     * For example: `{ type: 'ECDH', name: 'prime256v1', size: 256 }`.
+     */
+    getEphemeralKeyInfo(): EphemeralKeyInfo | object | null;
+
+    /**
+     * Returns an object representing the peer's certificate. If the peer does not
+     * provide a certificate, an empty object will be returned. If the socket has been
+     * destroyed, `null` will be returned.
+     *
+     * If the full certificate chain was requested, each certificate will include an`issuerCertificate` property containing an object representing its issuer's
+     * certificate.
+     * @return A certificate object.
+     */
+    getPeerCertificate(): PeerCertificate;
+
+    /**
+     * See [SSL\_get\_shared\_sigalgs](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_shared_sigalgs.html) for more information.
+     * @since v12.11.0
+     * @return List of signature algorithms shared between the server and the client in the order of decreasing preference.
+     */
+    getSharedSigalgs(): string[];
+
+    /**
+     * As the `Finished` messages are message digests of the complete handshake
+     * (with a total of 192 bits for TLS 1.0 and more for SSL 3.0), they can
+     * be used for external authentication procedures when the authentication
+     * provided by SSL/TLS is not desired or is not enough.
+     *
+     * @return The latest `Finished` message that has been sent to the socket as part of a SSL/TLS handshake, or `undefined` if no `Finished` message has been sent yet.
+     */
+    getTLSFinishedMessage(): Buffer | undefined;
+
+    /**
+     * As the `Finished` messages are message digests of the complete handshake
+     * (with a total of 192 bits for TLS 1.0 and more for SSL 3.0), they can
+     * be used for external authentication procedures when the authentication
+     * provided by SSL/TLS is not desired or is not enough.
+     *
+     * @return The latest `Finished` message that is expected or has actually been received from the socket as part of a SSL/TLS handshake, or `undefined` if there is no `Finished` message so
+     * far.
+     */
+    getTLSPeerFinishedMessage(): Buffer | undefined;
+
+    /**
+     * For a client, returns the TLS session ticket if one is available, or`undefined`. For a server, always returns `undefined`.
+     *
+     * It may be useful for debugging.
+     *
+     * See `Session Resumption` for more information.
+     */
+    getTLSTicket(): Buffer | undefined;
+
+    /**
+     * Returns a string containing the negotiated SSL/TLS protocol version of the
+     * current connection. The value `'unknown'` will be returned for connected
+     * sockets that have not completed the handshaking process. The value `null` will
+     * be returned for server sockets or disconnected client sockets.
+     *
+     * Protocol versions are:
+     *
+     * * `'SSLv3'`
+     * * `'TLSv1'`
+     * * `'TLSv1.1'`
+     * * `'TLSv1.2'`
+     * * `'TLSv1.3'`
+     *
+     */
+    getTLSVersion(): string;
+
+    /**
+     * See `Session Resumption` for more information.
+     * @return `true` if the session was reused, `false` otherwise.
+     */
+    isSessionReused(): boolean;
+
+    /**
+     * The `socket.setMaxSendFragment()` method sets the maximum TLS fragment size.
+     * Returns `true` if setting the limit succeeded; `false` otherwise.
+     *
+     * Smaller fragment sizes decrease the buffering latency on the client: larger
+     * fragments are buffered by the TLS layer until the entire fragment is received
+     * and its integrity is verified; large fragments can span multiple roundtrips
+     * and their processing can be delayed due to packet loss or reordering. However,
+     * smaller fragments add extra TLS framing bytes and CPU overhead, which may
+     * decrease overall server throughput.
+     * @param [size=16384] The maximum TLS fragment size. The maximum value is `16384`.
+     */
+    setMaxSendFragment(size: number): boolean;
   }
 
   interface SocketListener<Data = undefined> {

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -571,6 +571,7 @@ restart:
 
     s = (struct us_internal_ssl_socket_t *)context->sc.on_writable(
         &s->s); // cast here!
+
     // if we are closed here, then exit
     if (!s || us_socket_is_closed(0, &s->s)) {
       return s;
@@ -607,8 +608,9 @@ ssl_on_writable(struct us_internal_ssl_socket_t *s) {
     return 0;
   }
 
-  s = context->on_writable(s);
-
+  if (s->handshake_state == HANDSHAKE_COMPLETED) {
+    s = context->on_writable(s);
+  }
   return s;
 }
 
@@ -1518,11 +1520,12 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(
 // TODO does this need more changes?
 struct us_connecting_socket_t *us_internal_ssl_socket_context_connect(
     struct us_internal_ssl_socket_context_t *context, const char *host,
-    int port, int options, int socket_ext_size, int* is_connected) {
-  return us_socket_context_connect(
-      2, &context->sc, host, port, options,
-      sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) +
-          socket_ext_size, is_connected);
+    int port, int options, int socket_ext_size, int *is_connected) {
+  return us_socket_context_connect(2, &context->sc, host, port, options,
+                                   sizeof(struct us_internal_ssl_socket_t) -
+                                       sizeof(struct us_socket_t) +
+                                       socket_ext_size,
+                                   is_connected);
 }
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect_unix(
@@ -1611,9 +1614,10 @@ void us_internal_ssl_socket_context_on_connect_error(
     struct us_internal_ssl_socket_context_t *context,
     struct us_internal_ssl_socket_t *(*on_connect_error)(
         struct us_internal_ssl_socket_t *, int code)) {
-  us_socket_context_on_connect_error(
-      0, (struct us_socket_context_t *)context,
-      (struct us_connecting_socket_t * (*)(struct us_connecting_socket_t *, int)) on_connect_error);
+  us_socket_context_on_connect_error(0, (struct us_socket_context_t *)context,
+                                     (struct us_connecting_socket_t *
+                                      (*)(struct us_connecting_socket_t *, int))
+                                         on_connect_error);
 }
 
 void us_internal_ssl_socket_context_on_socket_connect_error(
@@ -1702,7 +1706,8 @@ void *us_internal_ssl_socket_ext(struct us_internal_ssl_socket_t *s) {
 }
 
 void *us_internal_connecting_ssl_socket_ext(struct us_connecting_socket_t *s) {
-  return (char*)(s + 1) + sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t);
+  return (char *)(s + 1) + sizeof(struct us_internal_ssl_socket_t) -
+         sizeof(struct us_socket_t);
 }
 
 int us_internal_ssl_socket_is_shut_down(struct us_internal_ssl_socket_t *s) {
@@ -1759,11 +1764,11 @@ struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_adopt_socket(
   // todo: this is completely untested
   int new_ext_size = ext_size;
   if (ext_size != -1) {
-    new_ext_size = sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + ext_size;
+    new_ext_size = sizeof(struct us_internal_ssl_socket_t) -
+                   sizeof(struct us_socket_t) + ext_size;
   }
   return (struct us_internal_ssl_socket_t *)us_socket_context_adopt_socket(
-      0, &context->sc, &s->s,
-      new_ext_size);
+      0, &context->sc, &s->s, new_ext_size);
 }
 
 struct us_internal_ssl_socket_t *
@@ -1890,17 +1895,20 @@ ssl_wrapped_on_connect_error(struct us_internal_ssl_socket_t *s, int code) {
           context);
 
   if (wrapped_context->events.on_connect_error) {
-    wrapped_context->events.on_connect_error((struct us_connecting_socket_t *)s, code);
+    wrapped_context->events.on_connect_error((struct us_connecting_socket_t *)s,
+                                             code);
   }
 
   if (wrapped_context->old_events.on_connect_error) {
-    wrapped_context->old_events.on_connect_error((struct us_connecting_socket_t *)s, code);
+    wrapped_context->old_events.on_connect_error(
+        (struct us_connecting_socket_t *)s, code);
   }
   return s;
 }
 
 struct us_internal_ssl_socket_t *
-ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s, int code) {
+ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s,
+                                    int code) {
   struct us_internal_ssl_socket_context_t *context =
       (struct us_internal_ssl_socket_context_t *)us_socket_context(0, &s->s);
   struct us_wrapped_socket_context_t *wrapped_context =
@@ -1908,11 +1916,13 @@ ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s, int code
           context);
 
   if (wrapped_context->events.on_connecting_socket_error) {
-    wrapped_context->events.on_connecting_socket_error((struct us_socket_t *)s, code);
+    wrapped_context->events.on_connecting_socket_error((struct us_socket_t *)s,
+                                                       code);
   }
 
   if (wrapped_context->old_events.on_connecting_socket_error) {
-    wrapped_context->old_events.on_connecting_socket_error((struct us_socket_t *)s, code);
+    wrapped_context->old_events.on_connecting_socket_error(
+        (struct us_socket_t *)s, code);
   }
   return s;
 }
@@ -1982,11 +1992,11 @@ struct us_internal_ssl_socket_t *us_internal_ssl_socket_wrap_with_tls(
 
   // we need to wrap these events because we need to call the old context events
   // as well
-  us_socket_context_on_connect_error(
-      0, context,
-      (struct us_connecting_socket_t * (*)(struct us_connecting_socket_t *, int))
-          ssl_wrapped_on_connect_error);
-us_socket_context_on_socket_connect_error(
+  us_socket_context_on_connect_error(0, context,
+                                     (struct us_connecting_socket_t *
+                                      (*)(struct us_connecting_socket_t *, int))
+                                         ssl_wrapped_on_connect_error);
+  us_socket_context_on_socket_connect_error(
       0, context,
       (struct us_socket_t * (*)(struct us_socket_t *, int))
           ssl_wrapped_on_socket_connect_error);

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -607,7 +607,9 @@ ssl_on_writable(struct us_internal_ssl_socket_t *s) {
     return 0;
   }
 
-  s = context->on_writable(s);
+  if (s->handshake_state == HANDSHAKE_COMPLETED) {
+    s = context->on_writable(s);
+  }
 
   return s;
 }
@@ -1518,12 +1520,11 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(
 // TODO does this need more changes?
 struct us_connecting_socket_t *us_internal_ssl_socket_context_connect(
     struct us_internal_ssl_socket_context_t *context, const char *host,
-    int port, int options, int socket_ext_size, int *is_connected) {
-  return us_socket_context_connect(2, &context->sc, host, port, options,
-                                   sizeof(struct us_internal_ssl_socket_t) -
-                                       sizeof(struct us_socket_t) +
-                                       socket_ext_size,
-                                   is_connected);
+    int port, int options, int socket_ext_size, int* is_connected) {
+  return us_socket_context_connect(
+      2, &context->sc, host, port, options,
+      sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) +
+          socket_ext_size, is_connected);
 }
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect_unix(
@@ -1612,10 +1613,9 @@ void us_internal_ssl_socket_context_on_connect_error(
     struct us_internal_ssl_socket_context_t *context,
     struct us_internal_ssl_socket_t *(*on_connect_error)(
         struct us_internal_ssl_socket_t *, int code)) {
-  us_socket_context_on_connect_error(0, (struct us_socket_context_t *)context,
-                                     (struct us_connecting_socket_t *
-                                      (*)(struct us_connecting_socket_t *, int))
-                                         on_connect_error);
+  us_socket_context_on_connect_error(
+      0, (struct us_socket_context_t *)context,
+      (struct us_connecting_socket_t * (*)(struct us_connecting_socket_t *, int)) on_connect_error);
 }
 
 void us_internal_ssl_socket_context_on_socket_connect_error(
@@ -1704,8 +1704,7 @@ void *us_internal_ssl_socket_ext(struct us_internal_ssl_socket_t *s) {
 }
 
 void *us_internal_connecting_ssl_socket_ext(struct us_connecting_socket_t *s) {
-  return (char *)(s + 1) + sizeof(struct us_internal_ssl_socket_t) -
-         sizeof(struct us_socket_t);
+  return (char*)(s + 1) + sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t);
 }
 
 int us_internal_ssl_socket_is_shut_down(struct us_internal_ssl_socket_t *s) {
@@ -1762,11 +1761,11 @@ struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_adopt_socket(
   // todo: this is completely untested
   int new_ext_size = ext_size;
   if (ext_size != -1) {
-    new_ext_size = sizeof(struct us_internal_ssl_socket_t) -
-                   sizeof(struct us_socket_t) + ext_size;
+    new_ext_size = sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + ext_size;
   }
   return (struct us_internal_ssl_socket_t *)us_socket_context_adopt_socket(
-      0, &context->sc, &s->s, new_ext_size);
+      0, &context->sc, &s->s,
+      new_ext_size);
 }
 
 struct us_internal_ssl_socket_t *
@@ -1893,20 +1892,17 @@ ssl_wrapped_on_connect_error(struct us_internal_ssl_socket_t *s, int code) {
           context);
 
   if (wrapped_context->events.on_connect_error) {
-    wrapped_context->events.on_connect_error((struct us_connecting_socket_t *)s,
-                                             code);
+    wrapped_context->events.on_connect_error((struct us_connecting_socket_t *)s, code);
   }
 
   if (wrapped_context->old_events.on_connect_error) {
-    wrapped_context->old_events.on_connect_error(
-        (struct us_connecting_socket_t *)s, code);
+    wrapped_context->old_events.on_connect_error((struct us_connecting_socket_t *)s, code);
   }
   return s;
 }
 
 struct us_internal_ssl_socket_t *
-ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s,
-                                    int code) {
+ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s, int code) {
   struct us_internal_ssl_socket_context_t *context =
       (struct us_internal_ssl_socket_context_t *)us_socket_context(0, &s->s);
   struct us_wrapped_socket_context_t *wrapped_context =
@@ -1914,13 +1910,11 @@ ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s,
           context);
 
   if (wrapped_context->events.on_connecting_socket_error) {
-    wrapped_context->events.on_connecting_socket_error((struct us_socket_t *)s,
-                                                       code);
+    wrapped_context->events.on_connecting_socket_error((struct us_socket_t *)s, code);
   }
 
   if (wrapped_context->old_events.on_connecting_socket_error) {
-    wrapped_context->old_events.on_connecting_socket_error(
-        (struct us_socket_t *)s, code);
+    wrapped_context->old_events.on_connecting_socket_error((struct us_socket_t *)s, code);
   }
   return s;
 }
@@ -1990,11 +1984,11 @@ struct us_internal_ssl_socket_t *us_internal_ssl_socket_wrap_with_tls(
 
   // we need to wrap these events because we need to call the old context events
   // as well
-  us_socket_context_on_connect_error(0, context,
-                                     (struct us_connecting_socket_t *
-                                      (*)(struct us_connecting_socket_t *, int))
-                                         ssl_wrapped_on_connect_error);
-  us_socket_context_on_socket_connect_error(
+  us_socket_context_on_connect_error(
+      0, context,
+      (struct us_connecting_socket_t * (*)(struct us_connecting_socket_t *, int))
+          ssl_wrapped_on_connect_error);
+us_socket_context_on_socket_connect_error(
       0, context,
       (struct us_socket_t * (*)(struct us_socket_t *, int))
           ssl_wrapped_on_socket_connect_error);

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// clang-format off
+
 #if (defined(LIBUS_USE_OPENSSL) || defined(LIBUS_USE_WOLFSSL))
 /* These are in sni_tree.cpp */
 void *sni_new();
@@ -607,9 +607,7 @@ ssl_on_writable(struct us_internal_ssl_socket_t *s) {
     return 0;
   }
 
-  if (s->handshake_state == HANDSHAKE_COMPLETED) {
-    s = context->on_writable(s);
-  }
+  s = context->on_writable(s);
 
   return s;
 }

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+// clang-format off
 #if (defined(LIBUS_USE_OPENSSL) || defined(LIBUS_USE_WOLFSSL))
 /* These are in sni_tree.cpp */
 void *sni_new();
@@ -571,7 +571,6 @@ restart:
 
     s = (struct us_internal_ssl_socket_t *)context->sc.on_writable(
         &s->s); // cast here!
-
     // if we are closed here, then exit
     if (!s || us_socket_is_closed(0, &s->s)) {
       return s;
@@ -611,6 +610,7 @@ ssl_on_writable(struct us_internal_ssl_socket_t *s) {
   if (s->handshake_state == HANDSHAKE_COMPLETED) {
     s = context->on_writable(s);
   }
+
   return s;
 }
 

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1225,8 +1225,6 @@ fn NewSocket(comptime ssl: bool) type {
             const handlers = this.handlers;
             const callback = handlers.onWritable;
             if (callback == .zero) return;
-            // if we are a SSL Socket and handshake is not done, we should not call the callback
-            if (ssl and this.authorized == false) return;
             var vm = handlers.vm;
             vm.eventLoop().enter();
             defer vm.eventLoop().exit();

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1225,7 +1225,7 @@ fn NewSocket(comptime ssl: bool) type {
             const handlers = this.handlers;
             const callback = handlers.onWritable;
             if (callback == .zero) return;
-            // if we SSL and handshake is not done, we should not call the callback
+            // if we are a SSL Socket and handshake is not done, we should not call the callback
             if (ssl and this.authorized == false) return;
             var vm = handlers.vm;
             vm.eventLoop().enter();

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -763,7 +763,7 @@ pub const Listener = struct {
             }
         }
 
-        var this: *Listener = handlers.vm.allocator.create(Listener) catch @panic("OOM");
+        var this: *Listener = handlers.vm.allocator.create(Listener) catch bun.outOfMemory();
         this.* = socket;
         this.socket_context.?.ext(ssl_enabled, *Listener).?.* = this;
 
@@ -798,7 +798,7 @@ pub const Listener = struct {
         const Socket = NewSocket(ssl);
         bun.assert(ssl == listener.ssl);
 
-        var this_socket = listener.handlers.vm.allocator.create(Socket) catch @panic("Out of memory");
+        var this_socket = listener.handlers.vm.allocator.create(Socket) catch bun.outOfMemory();
         this_socket.* = Socket{
             .handlers = &listener.handlers,
             .this_value = .zero,
@@ -1048,7 +1048,7 @@ pub const Listener = struct {
 
         default_data.ensureStillAlive();
 
-        var handlers_ptr = handlers.vm.allocator.create(Handlers) catch @panic("OOM");
+        var handlers_ptr = handlers.vm.allocator.create(Handlers) catch bun.outOfMemory();
         handlers_ptr.* = handlers;
         handlers_ptr.is_server = false;
 
@@ -1057,7 +1057,7 @@ pub const Listener = struct {
         handlers_ptr.promise.set(globalObject, promise_value);
 
         if (ssl_enabled) {
-            var tls = handlers.vm.allocator.create(TLSSocket) catch @panic("OOM");
+            var tls = handlers.vm.allocator.create(TLSSocket) catch bun.outOfMemory();
 
             tls.* = .{
                 .handlers = handlers_ptr,
@@ -1078,7 +1078,7 @@ pub const Listener = struct {
 
             return promise_value;
         } else {
-            var tcp = handlers.vm.allocator.create(TCPSocket) catch @panic("OOM");
+            var tcp = handlers.vm.allocator.create(TCPSocket) catch bun.outOfMemory();
 
             tcp.* = .{
                 .handlers = handlers_ptr,
@@ -1225,6 +1225,7 @@ fn NewSocket(comptime ssl: bool) type {
             const handlers = this.handlers;
             const callback = handlers.onWritable;
             if (callback == .zero) return;
+
             var vm = handlers.vm;
             vm.eventLoop().enter();
             defer vm.eventLoop().exit();
@@ -1488,7 +1489,6 @@ fn NewSocket(comptime ssl: bool) type {
             log("onHandshake({d})", .{success});
             JSC.markBinding(@src());
             if (this.detached) return;
-
             const authorized = if (success == 1) true else false;
 
             this.authorized = authorized;
@@ -1519,9 +1519,15 @@ fn NewSocket(comptime ssl: bool) type {
             // you should use getAuthorizationError and authorized getter to get those values in this case
             if (is_open) {
                 result = callback.callWithThis(globalObject, this_value, &[_]JSValue{this_value});
-                // clean onOpen callback so only called in the first handshake and not in every renegotiation
-                this.handlers.onOpen.unprotect();
-                this.handlers.onOpen = .zero;
+
+                // only call onOpen once for clients
+                if (!handlers.is_server) {
+                    // clean onOpen callback so only called in the first handshake and not in every renegotiation
+                    // on servers this would require a different approach but it's not needed because our servers will not call handshake multiple times
+                    // servers don't support renegotiation
+                    this.handlers.onOpen.unprotect();
+                    this.handlers.onOpen = .zero;
+                }
             } else {
                 // call handhsake callback with authorized and authorization error if has one
                 var authorization_error: JSValue = undefined;
@@ -2942,8 +2948,8 @@ fn NewSocket(comptime ssl: bool) type {
             const ext_size = @sizeOf(WrappedSocket);
 
             const is_server = this.handlers.is_server;
-            var tls = handlers.vm.allocator.create(TLSSocket) catch @panic("OOM");
-            var handlers_ptr = handlers.vm.allocator.create(Handlers) catch @panic("OOM");
+            var tls = handlers.vm.allocator.create(TLSSocket) catch bun.outOfMemory();
+            var handlers_ptr = handlers.vm.allocator.create(Handlers) catch bun.outOfMemory();
             handlers_ptr.* = handlers;
             handlers_ptr.is_server = is_server;
             handlers_ptr.protect();
@@ -2982,8 +2988,8 @@ fn NewSocket(comptime ssl: bool) type {
 
             tls.socket = new_socket;
 
-            var raw = handlers.vm.allocator.create(TLSSocket) catch @panic("OOM");
-            var raw_handlers_ptr = handlers.vm.allocator.create(Handlers) catch @panic("OOM");
+            var raw = handlers.vm.allocator.create(TLSSocket) catch bun.outOfMemory();
+            var raw_handlers_ptr = handlers.vm.allocator.create(Handlers) catch bun.outOfMemory();
             raw_handlers_ptr.* = .{
                 .vm = globalObject.bunVM(),
                 .globalObject = globalObject,

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -477,3 +477,24 @@ it("should connect directly when using an ip address", async () => {
   await promise;
   expect(opened).toBe(true);
 });
+
+it("should not call drain before handshake", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const socket = await Bun.connect({
+    hostname: "www.example.com",
+    tls: true,
+    port: 443,
+    socket: {
+      drain() {
+        if (!socket.authorized) {
+          reject(new Error("Socket not authorized"));
+        }
+      },
+      handshake() {
+        resolve();
+      },
+    },
+  });
+  await promise;
+  expect(socket.authorized).toBe(true);
+});

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -480,7 +480,7 @@ it("should connect directly when using an ip address", async () => {
 
 it("should not call drain before handshake", async () => {
   const { promise, resolve, reject } = Promise.withResolvers();
-  const socket = await Bun.connect({
+  using socket = await Bun.connect({
     hostname: "www.example.com",
     tls: true,
     port: 443,


### PR DESCRIPTION
…ome docs update

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
added a test
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
