### PR TITLE
fix race condition in fetch progress updates

### DIFF
--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1701,7 +1701,7 @@ pub const Fetch = struct {
             defer task.mutex.unlock();
             log("callback success {} has_more {} bytes {}", .{ result.isSuccess(), result.has_more, result.body.?.list.items.len });
 
-            task.result = result;
+            task.result.merge(result);
 
             // metadata should be provided only once so we preserve it until we consume it
             if (result.metadata) |metadata| {

--- a/src/http.zig
+++ b/src/http.zig
@@ -3106,6 +3106,54 @@ pub const HTTPClientResult = struct {
             };
         }
     };
+
+    pub fn merge(this: *HTTPClientResult, other: HTTPClientResult) void {
+        if (other.body != null) {
+            if (this.body == null) {
+                this.body = other.body;
+            } else {
+                if (comptime Environment.allow_assert) {
+                    bun.assert(this.body == other.body);
+                }
+            }
+        }
+
+        if (!other.has_more) {
+            this.has_more = false;
+        }
+
+        if (other.fail != null) {
+            this.fail = other.fail;
+        }
+
+        if (other.metadata != null) {
+            if (this.metadata == null) {
+                this.metadata = other.metadata;
+            } else {
+                if (comptime Environment.allow_assert) {
+                    @panic("duplicate http metadata");
+                }
+            }
+        }
+
+        if (other.body_size != .unknown) {
+            this.body_size = other.body_size;
+        }
+
+        if (other.redirected) {
+            this.redirected = true;
+        }
+
+        if (other.certificate_info != null) {
+            if (this.certificate_info == null) {
+                this.certificate_info = other.certificate_info;
+            } else {
+                if (comptime Environment.allow_assert) {
+                    @panic("duplicate http certificate info");
+                }
+            }
+        }
+    }
 };
 
 pub fn toResult(this: *HTTPClient) HTTPClientResult {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -91,7 +91,6 @@ it("not skip verification when doing a lot of requests", async () => {
 
   await promise;
   expect(count).toBe(1);
-
 });
 
 it("fetch with rejectUnauthorized: false should not call checkServerIdentity", async () => {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -78,14 +78,21 @@ it("fetch with valid tls and non-native checkServerIdentity should work", async 
 });
 
 it("not skip verification when doing a lot of requests", async () => {
-  const url = `https://example.com`;
   let count = 0;
-  const iterations = 100;
-  for (let i = 0; i < iterations; i++) {
-    await fetch(url, {keepalive: false, tls: { checkServerIdentity() { count++; return undefined; }}});
-  }
-  expect(count).toBe(iterations);
-}, { timeout: 10000 });
+  let promise = fetch(`https://example.com`, {
+    tls: {
+      checkServerIdentity() {
+        ++count;
+      },
+    },
+  });
+  let wait_until = performance.now() + 1000;
+  while (performance.now() < wait_until) {}
+
+  await promise;
+  expect(count).toBe(1);
+
+});
 
 it("fetch with rejectUnauthorized: false should not call checkServerIdentity", async () => {
   let count = 0;

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -77,6 +77,16 @@ it("fetch with valid tls and non-native checkServerIdentity should work", async 
   expect(count).toBe(2);
 });
 
+it("not skip verification when doing a lot of requests", async () => {
+  const url = `https://example.com`;
+  let count = 0;
+  const iterations = 100;
+  for (let i = 0; i < iterations; i++) {
+    await fetch(url, {keepalive: false, tls: { checkServerIdentity() { count++; return undefined; }}});
+  }
+  expect(count).toBe(iterations);
+}, { timeout: 10000 });
+
 it("fetch with rejectUnauthorized: false should not call checkServerIdentity", async () => {
   let count = 0;
 


### PR DESCRIPTION
### What does this PR do?
The http thread sends progress updates to the fetch tasklet by setting the `result` member and scheduling a task on the main thread. Previously, when a new progress update was available, the `result` member was just overridden. This could lose previous updates. Now, we merge the existing result with the new result to ensure nothing is lost. This fixes the root cause of the flaky `fetch.tls` test.

Currently, this code crashes because it more reliably hits a bug that already existed previously: The `FetchTasklet` is deinitialized, and later the `HTTPClient` attempts to report an update to it, at which point it accesses uninitialized memory. 

Potential fixes:
- signal to the `HTTPClient` that it should stop sending progress updates
- use reference counting on the `FetchTasklet`

### How did you verify your code works?
A test that spinloops after starting a fetch request and then verifies that certificate verification still occurred as intended.