### PR TITLE
revert sourcemap-related logging change

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -285,7 +285,6 @@ pub const SavedSourceMap = struct {
         this: *SavedSourceMap,
         path: string,
         hint: SourceMap.ParseUrlResultHint,
-        log: ?*logger.Log,
     ) SourceMap.ParseUrl {
         const hash = bun.hash(path);
         const mapping = this.map.getEntry(hash) orelse return .{};
@@ -307,7 +306,7 @@ pub const SavedSourceMap = struct {
             Value.Tag.SourceProviderMap => {
                 var ptr = Value.from(mapping.value_ptr.*).as(SourceProviderMap);
 
-                if (ptr.getSourceMap(path, .none, hint, log)) |parse|
+                if (ptr.getSourceMap(path, .none, hint)) |parse|
                     if (parse.map) |map| {
                         mapping.value_ptr.* = Value.init(map).ptr();
                         return parse;
@@ -332,7 +331,7 @@ pub const SavedSourceMap = struct {
     }
 
     pub fn get(this: *SavedSourceMap, path: string) ?*ParsedSourceMap {
-        return this.getWithContent(path, .mappings_only, null).map;
+        return this.getWithContent(path, .mappings_only).map;
     }
 
     pub fn resolveMapping(
@@ -341,7 +340,6 @@ pub const SavedSourceMap = struct {
         line: i32,
         column: i32,
         source_handling: SourceMap.SourceContentHandling,
-        log: ?*logger.Log,
     ) ?SourceMap.Mapping.Lookup {
         this.mutex.lock();
         defer this.mutex.unlock();
@@ -349,7 +347,7 @@ pub const SavedSourceMap = struct {
         const parse = this.getWithContent(path, switch (source_handling) {
             .no_source_contents => .mappings_only,
             .source_contents => .{ .all = .{ .line = line, .column = column } },
-        }, log);
+        });
         const map = parse.map orelse return null;
         const mapping = parse.mapping orelse
             SourceMap.Mapping.find(map.mappings, line, column) orelse
@@ -2825,7 +2823,6 @@ pub const VirtualMachine = struct {
                 @max(frame.position.line, 0),
                 @max(frame.position.column_start, 0),
                 .no_source_contents,
-                null,
             )) |lookup| {
                 if (lookup.displaySourceURLIfNeeded(sourceURL.slice())) |source_url| {
                     frame.source_url.deref();
@@ -2928,12 +2925,6 @@ pub const VirtualMachine = struct {
         var top_source_url = top.source_url.toUTF8(bun.default_allocator);
         defer top_source_url.deinit();
 
-        var log = logger.Log.init(bun.default_allocator);
-        defer log.deinit();
-        defer {
-            log.printForLogLevel(Output.errorWriter()) catch {};
-        }
-
         const maybe_lookup = if (top.remapped)
             SourceMap.Mapping.Lookup{
                 .mapping = .{
@@ -2954,7 +2945,6 @@ pub const VirtualMachine = struct {
                 @max(top.position.line, 0),
                 @max(top.position.column_start, 0),
                 .source_contents,
-                &log,
             );
 
         if (maybe_lookup) |lookup| {
@@ -2974,6 +2964,8 @@ pub const VirtualMachine = struct {
                     }
                 }
 
+                var log = logger.Log.init(bun.default_allocator);
+                defer log.deinit();
                 var original_source = fetchWithoutOnLoadPlugins(this, this.global, top.source_url, bun.String.empty, &log, .print_source) catch return;
                 must_reset_parser_arena_later.* = true;
                 break :code original_source.source_code.toUTF8(bun.default_allocator);
@@ -3034,7 +3026,6 @@ pub const VirtualMachine = struct {
                     @max(frame.position.line, 0),
                     @max(frame.position.column_start, 0),
                     .no_source_contents,
-                    null,
                 )) |lookup| {
                     if (lookup.displaySourceURLIfNeeded(source_url.slice())) |src| {
                         frame.source_url.deref();


### PR DESCRIPTION
This reverts some behavior in #11509. The trade offs discussed with printing warnings are briefly commented in the code. I also used `logger.Log` incorrectly.