### PR TITLE
Revert "feat: :art: Show better `bun upgrade` progress"

### DIFF
--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -513,13 +513,7 @@ pub const UpgradeCommand = struct {
 
         {
             var refresher = std.Progress{};
-
-            // This cannot be stack-owned because it is shared by the http thread
-            const progress_string_buf: []u8 = bun.default_allocator.alloc(u8, 512) catch bun.outOfMemory();
-            defer bun.default_allocator.free(progress_string_buf);
-
-            var progress = refresher.start("Downloading", 0);
-
+            var progress = refresher.start("Downloading", version.size);
             refresher.refresh();
             var async_http = try ctx.allocator.create(HTTP.AsyncHTTP);
             var zip_file_buffer = try ctx.allocator.create(MutableString);
@@ -540,8 +534,6 @@ pub const UpgradeCommand = struct {
             );
             async_http.client.timeout = timeout;
             async_http.client.progress_node = progress;
-            async_http.client.progress_string_buf = progress_string_buf;
-            async_http.client.estimated_content_length = version.size;
             async_http.client.reject_unauthorized = env_loader.getTLSRejectUnauthorized();
 
             const response = try async_http.sendSync(true);
@@ -549,9 +541,6 @@ pub const UpgradeCommand = struct {
             switch (response.status_code) {
                 404 => {
                     if (use_canary) {
-                        progress.end();
-                        refresher.refresh();
-
                         Output.prettyErrorln(
                             \\<r><red>error:<r> Canary builds are not available for this platform yet
                             \\

--- a/src/deps/picohttp.zig
+++ b/src/deps/picohttp.zig
@@ -197,15 +197,6 @@ pub const Response = struct {
         const response = try parseParts(buf, src, &offset);
         return response;
     }
-
-    pub fn getHeader(response: Response, name: []const u8) ?[]const u8 {
-        for (response.headers) |header| {
-            if (bun.strings.eqlInsensitive(name, header.name)) {
-                return header.value;
-            }
-        }
-        return null;
-    }
 };
 
 pub const Headers = struct {

--- a/src/http.zig
+++ b/src/http.zig
@@ -1506,10 +1506,6 @@ redirect_type: FetchRedirect = FetchRedirect.follow,
 redirect: []u8 = &.{},
 timeout: usize = 0,
 progress_node: ?*std.Progress.Node = null,
-progress_string_buf: []u8 = undefined,
-downloaded_bytes: u64 = 0,
-estimated_content_length: u64 = 0,
-
 disable_timeout: bool = false,
 disable_keepalive: bool = false,
 disable_decompression: bool = false,
@@ -2714,15 +2710,6 @@ pub fn onData(this: *HTTPClient, comptime is_ssl: bool, incoming_data: []const u
             // we save the successful parsed response
             this.state.pending_response = response;
 
-            // For requests that have progress nodes, check for content-length header to provide better download estimates.
-            if (this.progress_node != null) {
-                if (response.getHeader("content-length")) |length_str| {
-                    if (std.fmt.parseInt(u64, length_str, 10)) |estimated_length| {
-                        this.estimated_content_length = estimated_length;
-                    } else |_| {}
-                }
-            }
-
             const body_buf = to_read[@min(@as(usize, @intCast(response.bytes_read)), to_read.len)..];
             // handle the case where we have a 100 Continue
             if (response.status_code == 100) {
@@ -3146,22 +3133,6 @@ pub fn toResult(this: *HTTPClient) HTTPClientResult {
     };
 }
 
-fn updateProgress(this: *HTTPClient) void {
-    // Zig 0.12's progress API does not support floating point or percentage progresses,
-    // only integers. To get around this, the items' name is adjusted with the desired
-    // format message.
-    if (this.progress_node) |progress| {
-        progress.activate();
-        progress.setName(
-            std.fmt.bufPrint(this.progress_string_buf, "Downloading [{s:.2} / {s:.2}]", .{
-                bun.fmt.size(this.downloaded_bytes),
-                bun.fmt.size(this.estimated_content_length),
-            }) catch "Downloading",
-        );
-        progress.context.maybeRefresh();
-    }
-}
-
 // preallocate a buffer for the body no more than 256 MB
 // the intent is to avoid an OOM caused by a malicious server
 // reporting gigantic Conten-Length and then
@@ -3185,10 +3156,11 @@ fn handleResponseBodyFromSinglePacket(this: *HTTPClient, incoming_data: []const 
         this.state.total_body_received += incoming_data.len;
     }
     defer {
-        this.downloaded_bytes += incoming_data.len;
-
-        if (this.progress_node != null)
-            this.updateProgress();
+        if (this.progress_node) |progress| {
+            progress.activate();
+            progress.setCompletedItems(incoming_data.len);
+            progress.context.maybeRefresh();
+        }
     }
     // we can ignore the body data in redirects
     if (this.state.is_redirect_pending) return;
@@ -3239,20 +3211,23 @@ fn handleResponseBodyFromMultiplePackets(this: *HTTPClient, incoming_data: []con
     }
 
     this.state.total_body_received += remainder.len;
-    this.downloaded_bytes += incoming_data.len;
 
-    if (this.progress_node != null)
-        this.updateProgress();
+    if (this.progress_node) |progress| {
+        progress.activate();
+        progress.setCompletedItems(this.state.total_body_received);
+        progress.context.maybeRefresh();
+    }
 
     // done or streaming
     const is_done = content_length != null and this.state.total_body_received >= content_length.?;
     if (is_done or this.signals.get(.body_streaming) or content_length == null) {
         const processed = try this.state.processBodyBuffer(buffer.*);
 
-        this.downloaded_bytes = this.state.total_body_received;
-        if (this.progress_node != null)
-            this.updateProgress();
-
+        if (this.progress_node) |progress| {
+            progress.activate();
+            progress.setCompletedItems(this.state.total_body_received);
+            progress.context.maybeRefresh();
+        }
         return is_done or processed;
     }
     return false;
@@ -3304,10 +3279,11 @@ fn handleResponseBodyChunkedEncodingFromMultiplePackets(
         -1 => return error.InvalidHTTPResponse,
         // Needs more data
         -2 => {
-            this.downloaded_bytes = buffer.list.items.len;
-            if (this.progress_node != null)
-                this.updateProgress();
-
+            if (this.progress_node) |progress| {
+                progress.activate();
+                progress.setCompletedItems(buffer.list.items.len);
+                progress.context.maybeRefresh();
+            }
             // streaming chunks
             if (this.signals.get(.body_streaming)) {
                 return try this.state.processBodyBuffer(buffer);
@@ -3322,9 +3298,11 @@ fn handleResponseBodyChunkedEncodingFromMultiplePackets(
                 buffer,
             );
 
-            this.downloaded_bytes = buffer.list.items.len;
-            if (this.progress_node != null)
-                this.updateProgress();
+            if (this.progress_node) |progress| {
+                progress.activate();
+                progress.setCompletedItems(buffer.list.items.len);
+                progress.context.maybeRefresh();
+            }
 
             return true;
         },
@@ -3376,10 +3354,11 @@ fn handleResponseBodyChunkedEncodingFromSinglePacket(
         },
         // Needs more data
         -2 => {
-            this.downloaded_bytes += buffer.len;
-            if (this.progress_node != null)
-                this.updateProgress();
-
+            if (this.progress_node) |progress| {
+                progress.activate();
+                progress.setCompletedItems(buffer.len);
+                progress.context.maybeRefresh();
+            }
             const body_buffer = this.state.getBodyBuffer();
             try body_buffer.appendSliceExact(buffer);
 
@@ -3396,9 +3375,11 @@ fn handleResponseBodyChunkedEncodingFromSinglePacket(
 
             try this.handleResponseBodyFromSinglePacket(buffer);
             assert(this.state.body_out_str.?.list.items.ptr != buffer.ptr);
-            this.downloaded_bytes += buffer.len;
-            if (this.progress_node != null)
-                this.updateProgress();
+            if (this.progress_node) |progress| {
+                progress.activate();
+                progress.setCompletedItems(buffer.len);
+                progress.context.maybeRefresh();
+            }
 
             return true;
         },


### PR DESCRIPTION
```sh
============================================================
Bun v1.1.11 (4fb6056f) Windows x64
Elapsed: 222ms | User: 0ms | Sys: 15ms
RSS: 55.85MB | Peak: 55.85MB | Commit: 117.04MB | Faults: 13848

panic(thread 3956): Segmentation fault at address 0xFFFFFFFFFFFFFFFF
oh no: Bun has crashed. This indicates a bug in Bun, not your code.

To send a redacted crash report to Bun's team,
please file a GitHub issue using the link below:

 https://bun.report/1.1.11/wp14fb6056AACiB\VCRUNTIME140.dll23oE08i2Kgv+3Zgv93Zi9g4ZolvjYkwi/Vkoyj9C6mj/2C80o1eA2DD
```

Reverts oven-sh/bun#11402