### PR TITLE
refactor OOM errors

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -78,11 +78,11 @@ pub const StandaloneModuleGraph = struct {
 
         pub fn blob(this: *File, globalObject: *bun.JSC.JSGlobalObject) *bun.JSC.WebCore.Blob {
             if (this.blob_ == null) {
-                var store = bun.JSC.WebCore.Blob.Store.init(@constCast(this.contents), bun.default_allocator) catch @panic("out of memory");
+                var store = bun.JSC.WebCore.Blob.Store.init(@constCast(this.contents), bun.default_allocator) catch bun.outOfMemory();
                 // make it never free
                 store.ref();
 
-                var blob_ = bun.default_allocator.create(bun.JSC.WebCore.Blob) catch @panic("out of memory");
+                var blob_ = bun.default_allocator.create(bun.JSC.WebCore.Blob) catch bun.outOfMemory();
                 blob_.* = bun.JSC.WebCore.Blob.initWithStore(store, globalObject);
                 blob_.allocator = bun.default_allocator;
 
@@ -346,7 +346,7 @@ pub const StandaloneModuleGraph = struct {
                                         std.fs.path.sep_str,
                                         zname,
                                         &.{0},
-                                    }) catch @panic("OOM");
+                                    }) catch bun.outOfMemory();
                                     zname = zname_z[0..zname_z.len -| 1 :0];
                                     continue;
                                 }

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1926,7 +1926,7 @@ pub const Crypto = struct {
                     hash: []const u8,
 
                     pub fn toErrorInstance(this: Value, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
-                        const error_code = std.fmt.allocPrint(bun.default_allocator, "PASSWORD_{}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}) catch @panic("out of memory");
+                        const error_code = std.fmt.allocPrint(bun.default_allocator, "PASSWORD_{}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}) catch bun.outOfMemory();
                         defer bun.default_allocator.free(error_code);
                         const instance = globalObject.createErrorInstance("Password hashing failed with error \"{s}\"", .{@errorName(this.err)});
                         instance.put(globalObject, ZigString.static("code"), JSC.ZigString.init(error_code).toValueGC(globalObject));
@@ -1971,7 +1971,7 @@ pub const Crypto = struct {
             pub fn run(task: *bun.ThreadPool.Task) void {
                 var this = @fieldParentPtr(HashJob, "task", task);
 
-                var result = bun.default_allocator.create(Result) catch @panic("out of memory");
+                var result = bun.default_allocator.create(Result) catch bun.outOfMemory();
                 result.* = Result{
                     .value = getValue(this.password, this.algorithm),
                     .task = JSC.AnyTask.New(Result, Result.runFromJS).init(result),
@@ -1982,7 +1982,7 @@ pub const Crypto = struct {
                 this.ref = .{};
                 this.promise.strong = .{};
 
-                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch @panic("out of memory");
+                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch bun.outOfMemory();
                 concurrent_task.* = JSC.ConcurrentTask{
                     .task = JSC.Task.init(&result.task),
                     .auto_delete = true,
@@ -2015,7 +2015,7 @@ pub const Crypto = struct {
                 unreachable;
             }
 
-            var job = bun.default_allocator.create(HashJob) catch @panic("out of memory");
+            var job = bun.default_allocator.create(HashJob) catch bun.outOfMemory();
             var promise = JSC.JSPromise.Strong.init(globalObject);
 
             job.* = HashJob{
@@ -2057,7 +2057,7 @@ pub const Crypto = struct {
                 unreachable;
             }
 
-            var job = bun.default_allocator.create(VerifyJob) catch @panic("out of memory");
+            var job = bun.default_allocator.create(VerifyJob) catch bun.outOfMemory();
             var promise = JSC.JSPromise.Strong.init(globalObject);
 
             job.* = VerifyJob{
@@ -2168,7 +2168,7 @@ pub const Crypto = struct {
                     pass: bool,
 
                     pub fn toErrorInstance(this: Value, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
-                        const error_code = std.fmt.allocPrint(bun.default_allocator, "PASSWORD{}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}) catch @panic("out of memory");
+                        const error_code = std.fmt.allocPrint(bun.default_allocator, "PASSWORD{}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}) catch bun.outOfMemory();
                         defer bun.default_allocator.free(error_code);
                         const instance = globalObject.createErrorInstance("Password verification failed with error \"{s}\"", .{@errorName(this.err)});
                         instance.put(globalObject, ZigString.static("code"), JSC.ZigString.init(error_code).toValueGC(globalObject));
@@ -2213,7 +2213,7 @@ pub const Crypto = struct {
             pub fn run(task: *bun.ThreadPool.Task) void {
                 var this = @fieldParentPtr(VerifyJob, "task", task);
 
-                var result = bun.default_allocator.create(Result) catch @panic("out of memory");
+                var result = bun.default_allocator.create(Result) catch bun.outOfMemory();
                 result.* = Result{
                     .value = getValue(this.password, this.prev_hash, this.algorithm),
                     .task = JSC.AnyTask.New(Result, Result.runFromJS).init(result),
@@ -2224,7 +2224,7 @@ pub const Crypto = struct {
                 this.ref = .{};
                 this.promise.strong = .{};
 
-                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch @panic("out of memory");
+                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch bun.outOfMemory();
                 concurrent_task.* = JSC.ConcurrentTask{
                     .task = JSC.Task.init(&result.task),
                     .auto_delete = true,
@@ -2558,7 +2558,7 @@ pub const Crypto = struct {
             var new: CryptoHasher = undefined;
             switch (this.*) {
                 .evp => |*inner| {
-                    new = .{ .evp = inner.copy(globalObject.bunVM().rareData().boringEngine()) catch @panic("Out of memory") };
+                    new = .{ .evp = inner.copy(globalObject.bunVM().rareData().boringEngine()) catch bun.outOfMemory() };
                 },
                 .zig => |*inner| {
                     new = .{ .zig = inner.copy() };

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -408,7 +408,7 @@ pub const JSBundler = struct {
                         val = JSC.ZigString.fromUTF8("\"\"");
                     }
 
-                    const key = prop.toOwnedSlice(bun.default_allocator) catch @panic("OOM");
+                    const key = prop.toOwnedSlice(bun.default_allocator) catch bun.outOfMemory();
 
                     // value is always cloned
                     const value = val.toSlice(bun.default_allocator);
@@ -443,7 +443,7 @@ pub const JSBundler = struct {
                         Api.Loader,
                         options.Loader.api_names,
                     );
-                    loader_names[loader_iter.i] = prop.toOwnedSlice(bun.default_allocator) catch @panic("OOM");
+                    loader_names[loader_iter.i] = prop.toOwnedSlice(bun.default_allocator) catch bun.outOfMemory();
                 }
 
                 this.loaders = Api.LoaderMap{

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -461,7 +461,7 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
             }
 
             if (out.isEmpty()) break :tsconfig;
-            transpiler.tsconfig_buf = out.toOwnedSlice(allocator) catch @panic("OOM");
+            transpiler.tsconfig_buf = out.toOwnedSlice(allocator) catch bun.outOfMemory();
 
             // TODO: JSC -> Ast conversion
             if (TSConfigJSON.parse(
@@ -505,7 +505,7 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
             }
 
             if (out.isEmpty()) break :macros;
-            transpiler.macros_buf = out.toOwnedSlice(allocator) catch @panic("OOM");
+            transpiler.macros_buf = out.toOwnedSlice(allocator) catch bun.outOfMemory();
             const source = logger.Source.initPathString("macros.json", transpiler.macros_buf);
             const json = (VirtualMachine.get().bundler.resolver.caches.json.parseJSON(
                 &transpiler.log,

--- a/src/bun.js/api/glob.zig
+++ b/src/bun.js/api/glob.zig
@@ -337,7 +337,7 @@ pub fn constructor(
 
     const all_ascii = isAllAscii(pat_str);
 
-    var glob = alloc.create(Glob) catch @panic("OOM");
+    var glob = alloc.create(Glob) catch bun.outOfMemory();
     glob.* = .{ .pattern = pat_str, .is_ascii = all_ascii };
 
     if (!all_ascii) {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5644,7 +5644,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 },
             };
 
-            const buf = std.fmt.allocPrint(default_allocator, "{any}", .{fmt}) catch @panic("Out of memory");
+            const buf = std.fmt.allocPrint(default_allocator, "{any}", .{fmt}) catch bun.outOfMemory();
             defer default_allocator.free(buf);
 
             var value = bun.String.createUTF8(buf);
@@ -5788,7 +5788,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
         }
 
         pub fn init(config: ServerConfig, globalThis: *JSGlobalObject) *ThisServer {
-            var server = bun.default_allocator.create(ThisServer) catch @panic("Out of memory!");
+            var server = bun.default_allocator.create(ThisServer) catch bun.outOfMemory();
             server.* = .{
                 .globalThis = globalThis,
                 .config = config,
@@ -5798,7 +5798,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             };
 
             if (RequestContext.pool == null) {
-                RequestContext.pool = server.allocator.create(RequestContext.RequestContextStackAllocator) catch @panic("Out of memory!");
+                RequestContext.pool = server.allocator.create(RequestContext.RequestContextStackAllocator) catch bun.outOfMemory();
                 RequestContext.pool.?.* = RequestContext.RequestContextStackAllocator.init(server.allocator);
             }
 

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -206,7 +206,7 @@ pub const ManagedTask = struct {
     pub fn New(comptime Type: type, comptime Callback: anytype) type {
         return struct {
             pub fn init(ctx: *Type) Task {
-                var managed = bun.default_allocator.create(ManagedTask) catch @panic("out of memory!");
+                var managed = bun.default_allocator.create(ManagedTask) catch bun.outOfMemory();
                 managed.* = ManagedTask{
                     .callback = wrap,
                     .ctx = ctx,
@@ -319,7 +319,7 @@ pub const JSCScheduler = struct {
     export fn Bun__queueJSCDeferredWorkTaskConcurrently(jsc_vm: *VirtualMachine, task: *JSCScheduler.JSCDeferredWorkTask) void {
         JSC.markBinding(@src());
         var loop = jsc_vm.eventLoop();
-        var concurrent_task = bun.default_allocator.create(ConcurrentTask) catch @panic("out of memory!");
+        var concurrent_task = bun.default_allocator.create(ConcurrentTask) catch bun.outOfMemory();
         loop.enqueueTaskConcurrent(concurrent_task.from(task, .auto_deinit));
     }
 
@@ -492,7 +492,7 @@ pub const ConcurrentTask = struct {
         auto_deinit,
     };
     pub fn create(task: Task) *ConcurrentTask {
-        const created = bun.default_allocator.create(ConcurrentTask) catch @panic("out of memory!");
+        const created = bun.default_allocator.create(ConcurrentTask) catch bun.outOfMemory();
         created.* = .{
             .task = task,
             .next = null,

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -2036,7 +2036,7 @@ pub const VirtualMachine = struct {
                 specifier_utf8.slice(),
                 source_utf8.slice(),
                 error.NameTooLong,
-            ) catch @panic("Out of Memory");
+            ) catch bun.outOfMemory();
             const msg = logger.Msg{
                 .data = logger.rangeData(
                     null,
@@ -3702,7 +3702,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                     return;
             }
 
-            var reloader = bun.default_allocator.create(Reloader) catch @panic("OOM");
+            var reloader = bun.default_allocator.create(Reloader) catch bun.outOfMemory();
             reloader.* = .{
                 .ctx = this,
                 .verbose = if (@hasField(Ctx, "log")) this.log.level.atLeast(.info) else false,

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -433,7 +433,7 @@ pub const RuntimeTranspilerStore = struct {
             }
 
             if (ast_memory_store == null) {
-                ast_memory_store = bun.default_allocator.create(js_ast.ASTMemoryAllocator) catch @panic("out of memory!");
+                ast_memory_store = bun.default_allocator.create(js_ast.ASTMemoryAllocator) catch bun.outOfMemory();
                 ast_memory_store.?.* = js_ast.ASTMemoryAllocator{
                     .allocator = allocator,
                     .previous = null,
@@ -888,7 +888,7 @@ pub const ModuleLoader = struct {
             pub fn onWakeHandler(ctx: *anyopaque, _: *PackageManager) void {
                 debug("onWake", .{});
                 var this = bun.cast(*Queue, ctx);
-                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch @panic("OOM");
+                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch bun.outOfMemory();
                 concurrent_task.* = .{
                     .task = JSC.Task.init(this),
                     .auto_delete = true,

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -1179,7 +1179,7 @@ pub const Arguments = struct {
         pub fn toThreadSafe(this: *@This()) void {
             this.buffers.value.protect();
 
-            const clone = bun.default_allocator.dupe(bun.PlatformIOVec, this.buffers.buffers.items) catch @panic("out of memory");
+            const clone = bun.default_allocator.dupe(bun.PlatformIOVec, this.buffers.buffers.items) catch bun.outOfMemory();
             this.buffers.buffers.deinit();
             this.buffers.buffers.items = clone;
             this.buffers.buffers.capacity = clone.len;
@@ -1270,7 +1270,7 @@ pub const Arguments = struct {
         pub fn toThreadSafe(this: *@This()) void {
             this.buffers.value.protect();
 
-            const clone = bun.default_allocator.dupe(bun.PlatformIOVec, this.buffers.buffers.items) catch @panic("out of memory");
+            const clone = bun.default_allocator.dupe(bun.PlatformIOVec, this.buffers.buffers.items) catch bun.outOfMemory();
             this.buffers.buffers.deinit();
             this.buffers.buffers.items = clone;
             this.buffers.buffers.capacity = clone.len;
@@ -5502,7 +5502,7 @@ pub const NodeFS = struct {
                                 return .{
                                     .result = .{
                                         .buffer = Buffer.fromBytes(
-                                            bun.default_allocator.dupe(u8, file.contents) catch @panic("out of memory"),
+                                            bun.default_allocator.dupe(u8, file.contents) catch bun.outOfMemory(),
                                             bun.default_allocator,
                                             .Uint8Array,
                                         ),
@@ -5511,13 +5511,13 @@ pub const NodeFS = struct {
                             } else if (comptime string_type == .default)
                                 return .{
                                     .result = .{
-                                        .string = bun.default_allocator.dupe(u8, file.contents) catch @panic("out of memory"),
+                                        .string = bun.default_allocator.dupe(u8, file.contents) catch bun.outOfMemory(),
                                     },
                                 }
                             else
                                 return .{
                                     .result = .{
-                                        .null_terminated = bun.default_allocator.dupeZ(u8, file.contents) catch @panic("out of memory"),
+                                        .null_terminated = bun.default_allocator.dupeZ(u8, file.contents) catch bun.outOfMemory(),
                                     },
                                 };
                         }

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -41,7 +41,7 @@ pub const StatWatcherScheduler = struct {
     task: JSC.WorkPoolTask = .{ .callback = &workPoolCallback },
 
     pub fn init(allocator: std.mem.Allocator, _: *bun.JSC.VirtualMachine) *StatWatcherScheduler {
-        const this = allocator.create(StatWatcherScheduler) catch @panic("out of memory");
+        const this = allocator.create(StatWatcherScheduler) catch bun.outOfMemory();
         this.* = .{};
         return this;
     }
@@ -321,7 +321,7 @@ pub const StatWatcher = struct {
         pub fn createAndSchedule(
             watcher: *StatWatcher,
         ) void {
-            var task = bun.default_allocator.create(InitialStatTask) catch @panic("out of memory");
+            var task = bun.default_allocator.create(InitialStatTask) catch bun.outOfMemory();
             task.* = .{ .watcher = watcher };
             JSC.WorkPool.schedule(&task.task);
         }

--- a/src/bun.js/rare_data.zig
+++ b/src/bun.js/rare_data.zig
@@ -91,7 +91,7 @@ pub fn mimeTypeFromString(this: *RareData, allocator: std.mem.Allocator, str: []
     if (this.mime_types == null) {
         this.mime_types = bun.http.MimeType.createHashTable(
             allocator,
-        ) catch @panic("Out of memory");
+        ) catch bun.outOfMemory();
     }
 
     return this.mime_types.?.get(str);
@@ -133,12 +133,12 @@ pub const HotMap = struct {
     }
 
     pub fn insert(this: *HotMap, key: []const u8, ptr: anytype) void {
-        const entry = this._map.getOrPut(key) catch @panic("Out of memory");
+        const entry = this._map.getOrPut(key) catch bun.outOfMemory();
         if (entry.found_existing) {
             @panic("HotMap already contains key");
         }
 
-        entry.key_ptr.* = this._map.allocator.dupe(u8, key) catch @panic("Out of memory");
+        entry.key_ptr.* = this._map.allocator.dupe(u8, key) catch bun.outOfMemory();
         entry.value_ptr.* = Entry.init(ptr);
     }
 

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -102,18 +102,18 @@ pub const WebWorker = struct {
             return null;
         };
 
-        var worker = bun.default_allocator.create(WebWorker) catch @panic("OOM");
+        var worker = bun.default_allocator.create(WebWorker) catch bun.outOfMemory();
         worker.* = WebWorker{
             .cpp_worker = cpp_worker,
             .parent = parent,
             .parent_context_id = parent_context_id,
             .execution_context_id = this_context_id,
             .mini = mini,
-            .specifier = bun.default_allocator.dupe(u8, path.text) catch @panic("OOM"),
+            .specifier = bun.default_allocator.dupe(u8, path.text) catch bun.outOfMemory(),
             .store_fd = parent.bundler.resolver.store_fd,
             .name = brk: {
                 if (!name_str.isEmpty()) {
-                    break :brk std.fmt.allocPrintZ(bun.default_allocator, "{}", .{name_str}) catch @panic("OOM");
+                    break :brk std.fmt.allocPrintZ(bun.default_allocator, "{}", .{name_str}) catch bun.outOfMemory();
                 }
                 break :brk "";
             },
@@ -237,7 +237,7 @@ pub const WebWorker = struct {
             },
         );
         buffered_writer.flush() catch {
-            @panic("OOM");
+            bun.outOfMemory();
         };
         JSC.markBinding(@src());
         WebWorker__dispatchError(globalObject, worker.cpp_worker, bun.String.createUTF8(array.toOwnedSliceLeaky()), error_instance);

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -3621,7 +3621,7 @@ pub const Blob = struct {
                 duped.content_type_was_set = duped.content_type.len > 0;
             }
         } else if (duped.content_type_allocated and duped.allocator != null and include_content_type) {
-            duped.content_type = bun.default_allocator.dupe(u8, this.content_type) catch @panic("Out of memory");
+            duped.content_type = bun.default_allocator.dupe(u8, this.content_type) catch bun.outOfMemory();
         }
 
         duped.allocator = null;

--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -737,7 +737,7 @@ pub const Body = struct {
                         );
                     } else {
                         new_blob = Blob.init(
-                            bun.default_allocator.dupe(u8, wtf.latin1Slice()) catch @panic("Out of memory"),
+                            bun.default_allocator.dupe(u8, wtf.latin1Slice()) catch bun.outOfMemory(),
                             bun.default_allocator,
                             JSC.VirtualMachine.get().global,
                         );
@@ -1313,7 +1313,7 @@ pub const BodyValueBufferer = struct {
 
         const chunk = stream.slice();
         log("onStreamPipe chunk {}", .{chunk.len});
-        _ = sink.stream_buffer.write(chunk) catch @panic("OOM");
+        _ = sink.stream_buffer.write(chunk) catch bun.outOfMemory();
         if (stream.isDone()) {
             const bytes = sink.stream_buffer.list.items;
             log("onStreamPipe done {}", .{bytes.len});
@@ -1468,7 +1468,7 @@ pub const BodyValueBufferer = struct {
                     sink.byte_stream = byte_stream;
                     log("byte stream pre-buffered {}", .{bytes.len});
 
-                    _ = sink.stream_buffer.write(bytes) catch @panic("OOM");
+                    _ = sink.stream_buffer.write(bytes) catch bun.outOfMemory();
                     return;
                 },
             }

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1733,7 +1733,7 @@ pub const Fetch = struct {
                 }
             } else {
                 if (success) {
-                    _ = task.scheduled_response_buffer.write(task.response_buffer.list.items) catch @panic("OOM");
+                    _ = task.scheduled_response_buffer.write(task.response_buffer.list.items) catch bun.outOfMemory();
                 }
                 // reset for reuse
                 task.response_buffer.reset();
@@ -1799,7 +1799,7 @@ pub const Fetch = struct {
 
         var exception_val = [_]JSC.C.JSValueRef{null};
         const exception: JSC.C.ExceptionRef = &exception_val;
-        var memory_reporter = bun.default_allocator.create(JSC.MemoryReportingAllocator) catch @panic("out of memory");
+        var memory_reporter = bun.default_allocator.create(JSC.MemoryReportingAllocator) catch bun.outOfMemory();
         // used to clean up dynamically allocated memory on error (a poor man's errdefer)
         var is_error = false;
         var allocator = memory_reporter.wrap(bun.default_allocator);

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -4169,7 +4169,7 @@ pub const ByteBlobLoader = struct {
         temporary = temporary[this.offset..];
         temporary = temporary[0..@min(16384, @min(temporary.len, this.remain))];
 
-        const cloned = bun.ByteList.init(temporary).listManaged(bun.default_allocator).clone() catch @panic("Out of memory");
+        const cloned = bun.ByteList.init(temporary).listManaged(bun.default_allocator).clone() catch bun.outOfMemory();
         this.offset +|= @as(Blob.SizeType, @truncate(cloned.items.len));
         this.remain -|= @as(Blob.SizeType, @truncate(cloned.items.len));
 

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1662,7 +1662,7 @@ pub const BundleV2 = struct {
 
         errdefer {
             var out_log = Logger.Log.init(bun.default_allocator);
-            this.bundler.log.appendToWithRecycled(&out_log, true) catch @panic("OOM");
+            this.bundler.log.appendToWithRecycled(&out_log, true) catch bun.outOfMemory();
             completion.log = out_log;
         }
 
@@ -1688,7 +1688,7 @@ pub const BundleV2 = struct {
             .next = null,
         };
         var out_log = Logger.Log.init(bun.default_allocator);
-        this.bundler.log.appendToWithRecycled(&out_log, true) catch @panic("OOM");
+        this.bundler.log.appendToWithRecycled(&out_log, true) catch bun.outOfMemory();
         completion.log = out_log;
         completion.jsc_event_loop.enqueueTaskConcurrent(concurrent_task);
     }
@@ -1854,7 +1854,7 @@ pub const BundleV2 = struct {
             estimated_resolve_queue_count += @as(usize, @intFromBool(!(import_record.is_internal or import_record.is_unused or import_record.source_index.isValid())));
         }
         var resolve_queue = ResolveQueue.init(this.graph.allocator);
-        resolve_queue.ensureTotalCapacity(estimated_resolve_queue_count) catch @panic("OOM");
+        resolve_queue.ensureTotalCapacity(estimated_resolve_queue_count) catch bun.outOfMemory();
 
         var last_error: ?anyerror = null;
 
@@ -3700,9 +3700,9 @@ const LinkerGraph = struct {
 
         {
             var input_symbols = js_ast.Symbol.Map.initList(js_ast.Symbol.NestedList.init(this.ast.items(.symbols)));
-            var symbols = input_symbols.symbols_for_source.clone(this.allocator) catch @panic("Out of memory");
+            var symbols = input_symbols.symbols_for_source.clone(this.allocator) catch bun.outOfMemory();
             for (symbols.slice(), input_symbols.symbols_for_source.slice()) |*dest, src| {
-                dest.* = src.clone(this.allocator) catch @panic("Out of memory");
+                dest.* = src.clone(this.allocator) catch bun.outOfMemory();
             }
             this.symbols = js_ast.Symbol.Map.initList(symbols);
         }
@@ -3908,7 +3908,7 @@ const LinkerContext = struct {
 
             const source: *const Logger.Source = &this.parse_graph.input_files.items(.source)[source_index];
             const mutable = MutableString.initEmpty(allocator);
-            quoted_source_contents.* = (js_printer.quoteForJSON(source.contents, mutable, false) catch @panic("Out of memory")).list.items;
+            quoted_source_contents.* = (js_printer.quoteForJSON(source.contents, mutable, false) catch bun.outOfMemory()).list.items;
         }
     };
 

--- a/src/http.zig
+++ b/src/http.zig
@@ -906,7 +906,7 @@ pub fn checkServerIdentity(
                 if (client.signals.get(.cert_errors)) {
                     // clone the relevant data
                     const cert_size = BoringSSL.i2d_X509(x509, null);
-                    const cert = bun.default_allocator.alloc(u8, @intCast(cert_size)) catch @panic("OOM");
+                    const cert = bun.default_allocator.alloc(u8, @intCast(cert_size)) catch bun.outOfMemory();
                     var cert_ptr = cert.ptr;
                     const result_size = BoringSSL.i2d_X509(x509, &cert_ptr);
                     assert(result_size == cert_size);
@@ -918,11 +918,11 @@ pub fn checkServerIdentity(
 
                     client.state.certificate_info = .{
                         .cert = cert,
-                        .hostname = bun.default_allocator.dupe(u8, hostname) catch @panic("OOM"),
+                        .hostname = bun.default_allocator.dupe(u8, hostname) catch bun.outOfMemory(),
                         .cert_error = .{
                             .error_no = certError.error_no,
-                            .code = bun.default_allocator.dupeZ(u8, certError.code) catch @panic("OOM"),
-                            .reason = bun.default_allocator.dupeZ(u8, certError.reason) catch @panic("OOM"),
+                            .code = bun.default_allocator.dupeZ(u8, certError.code) catch bun.outOfMemory(),
+                            .reason = bun.default_allocator.dupeZ(u8, certError.reason) catch bun.outOfMemory(),
                         },
                     };
 
@@ -2676,7 +2676,7 @@ pub fn onData(this: *HTTPClient, comptime is_ssl: bool, incoming_data: []const u
             var needs_move = true;
             if (this.state.response_message_buffer.list.items.len > 0) {
                 // this one probably won't be another chunk, so we use appendSliceExact() to avoid over-allocating
-                this.state.response_message_buffer.appendSliceExact(incoming_data) catch @panic("Out of memory");
+                this.state.response_message_buffer.appendSliceExact(incoming_data) catch bun.outOfMemory();
                 to_read = this.state.response_message_buffer.list.items;
                 needs_move = false;
             }

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -461,7 +461,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
 
             var body = data;
             if (this.body.items.len > 0) {
-                this.body.appendSlice(bun.default_allocator, data) catch @panic("out of memory");
+                this.body.appendSlice(bun.default_allocator, data) catch bun.outOfMemory();
                 body = this.body.items;
             }
 
@@ -483,7 +483,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                     },
                     error.ShortRead => {
                         if (this.body.items.len == 0) {
-                            this.body.appendSlice(bun.default_allocator, data) catch @panic("out of memory");
+                            this.body.appendSlice(bun.default_allocator, data) catch bun.outOfMemory();
                         }
                         return;
                     },

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -88,9 +88,9 @@ pub fn initializeMiniStore() void {
         pub threadlocal var instance: ?*@This() = null;
     };
     if (MiniStore.instance == null) {
-        var mini_store = bun.default_allocator.create(MiniStore) catch @panic("OOM");
+        var mini_store = bun.default_allocator.create(MiniStore) catch bun.outOfMemory();
         mini_store.* = .{
-            .heap = bun.MimallocArena.init() catch @panic("OOM"),
+            .heap = bun.MimallocArena.init() catch bun.outOfMemory(),
             .memory_allocator = undefined,
         };
         mini_store.memory_allocator = .{ .allocator = mini_store.heap.allocator() };

--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -2733,7 +2733,7 @@ fn NewLexer_(
             // them. <CR><LF> and <CR> LineTerminatorSequences are normalized to
             // <LF> for both TV and TRV. An explicit EscapeSequence is needed to
             // include a <CR> or <CR><LF> sequence.
-            var bytes = MutableString.initCopy(lexer.allocator, text) catch @panic("Out of memory");
+            var bytes = MutableString.initCopy(lexer.allocator, text) catch bun.outOfMemory();
             var end: usize = 0;
             var i: usize = 0;
             var c: u8 = '0';

--- a/src/main_wasm.zig
+++ b/src/main_wasm.zig
@@ -453,7 +453,7 @@ export fn getTests(opts_array: u64) u64 {
     defer arena.deinit();
     var log_ = Logger.Log.init(allocator);
     var reader = ApiReader.init(Uint8Array.fromJS(opts_array), allocator);
-    var opts = Api.GetTestsRequest.decode(&reader) catch @panic("out of memory");
+    var opts = Api.GetTestsRequest.decode(&reader) catch bun.outOfMemory();
     var code = Logger.Source.initPathString(if (opts.path.len > 0) opts.path else "my-test-file.test.tsx", opts.contents);
     code.contents_is_recycled = true;
     defer {
@@ -464,7 +464,7 @@ export fn getTests(opts_array: u64) u64 {
     var parser = JSParser.Parser.init(.{
         .jsx = .{},
         .ts = true,
-    }, &log_, &code, define, allocator) catch @panic("out of memory");
+    }, &log_, &code, define, allocator) catch bun.outOfMemory();
 
     var anaylzer = TestAnalyzer{
         .items = std.ArrayList(

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -1278,7 +1278,7 @@ pub fn joinStringBufT(comptime T: type, buf: []T, parts: anytype, comptime _plat
     }
 
     if (count * 2 > temp_buf.len) {
-        temp_buf = bun.default_allocator.alloc(T, count * 2) catch @panic("Out of memory");
+        temp_buf = bun.default_allocator.alloc(T, count * 2) catch bun.outOfMemory();
         free_temp_buf = true;
     }
 

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -60,7 +60,7 @@ pub fn OOM(e: anyerror) noreturn {
     if (comptime bun.Environment.allow_assert) {
         if (e != error.OutOfMemory) bun.outOfMemory();
     }
-    @panic("Out of memory");
+    bun.outOfMemory();
 }
 
 const log = bun.Output.scoped(.SHELL, false);

--- a/src/sourcemap/CodeCoverage.zig
+++ b/src/sourcemap/CodeCoverage.zig
@@ -36,7 +36,7 @@ pub const CodeCoverageReport = struct {
     };
 
     pub fn linesCoverageFraction(this: *const CodeCoverageReport) f64 {
-        var intersected = this.executable_lines.clone(bun.default_allocator) catch @panic("OOM");
+        var intersected = this.executable_lines.clone(bun.default_allocator) catch bun.outOfMemory();
         defer intersected.deinit(bun.default_allocator);
         intersected.setIntersection(this.lines_which_have_executed);
 
@@ -162,7 +162,7 @@ pub const CodeCoverageReport = struct {
 
         try writer.writeAll(comptime prettyFmt("<r><d> | <r>", enable_colors));
 
-        var executable_lines_that_havent_been_executed = report.lines_which_have_executed.clone(bun.default_allocator) catch @panic("OOM");
+        var executable_lines_that_havent_been_executed = report.lines_which_have_executed.clone(bun.default_allocator) catch bun.outOfMemory();
         defer executable_lines_that_havent_been_executed.deinit(bun.default_allocator);
         executable_lines_that_havent_been_executed.toggleAll();
 
@@ -326,13 +326,13 @@ pub const ByteRangeMapping = struct {
     pub threadlocal var map: ?*HashMap = null;
     pub fn generate(str: bun.String, source_contents_str: bun.String, source_id: i32) callconv(.C) void {
         var _map = map orelse brk: {
-            map = bun.JSC.VirtualMachine.get().allocator.create(HashMap) catch @panic("OOM");
+            map = bun.JSC.VirtualMachine.get().allocator.create(HashMap) catch bun.outOfMemory();
             map.?.* = HashMap.init(bun.JSC.VirtualMachine.get().allocator);
             break :brk map.?;
         };
         var slice = str.toUTF8(bun.default_allocator);
         const hash = bun.hash(slice.slice());
-        var entry = _map.getOrPut(hash) catch @panic("Out of memory");
+        var entry = _map.getOrPut(hash) catch bun.outOfMemory();
         if (entry.found_existing) {
             entry.value_ptr.deinit();
         }

--- a/src/string_mutable.zig
+++ b/src/string_mutable.zig
@@ -228,7 +228,7 @@ pub const MutableString = struct {
     }
 
     pub fn toOwnedSlice(self: *MutableString) string {
-        return self.list.toOwnedSlice(self.allocator) catch @panic("Allocation Error"); // TODO
+        return self.list.toOwnedSlice(self.allocator) catch bun.outOfMemory(); // TODO
     }
 
     pub fn toOwnedSliceLeaky(self: *MutableString) []u8 {
@@ -255,7 +255,7 @@ pub const MutableString = struct {
 
     pub fn toOwnedSliceLength(self: *MutableString, length: usize) string {
         self.list.shrinkAndFree(self.allocator, length);
-        return self.list.toOwnedSlice(self.allocator) catch @panic("Allocation Error"); // TODO
+        return self.list.toOwnedSlice(self.allocator) catch bun.outOfMemory(); // TODO
     }
 
     // pub fn deleteAt(self: *MutableString, i: usize)  {


### PR DESCRIPTION
### What does this PR do?
Refactor OOM panics into `bun.outOfMemory()`calls
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
I compiles
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
