### PR TITLE
Fix typo in ENV variable name

### DIFF
--- a/docs/guides/ecosystem/neon-serverless-postgres.md
+++ b/docs/guides/ecosystem/neon-serverless-postgres.md
@@ -20,7 +20,7 @@ $ bun add @neondatabase/serverless
 Create a `.env.local` file and add your [Neon Postgres connection string](https://neon.tech/docs/connect/connect-from-any-app) to it.
 
 ```sh
-DATBASE_URL=postgresql://username:password@ep-adj-noun-guid.us-east-1.aws.neon.tech/neondb?sslmode=require
+DATABASE_URL=postgresql://username:password@ep-adj-noun-guid.us-east-1.aws.neon.tech/neondb?sslmode=require
 ```
 
 ---


### PR DESCRIPTION
### What does this PR do?

Fix typo in documentation

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)