### PR TITLE
fix(install): `bun update` with unresolved package

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -6932,6 +6932,8 @@ pub const PackageManager = struct {
                                         const is_alias = entry.value.is_alias;
                                         const dep_name = entry.key;
                                         for (workspace_deps, workspace_resolution_ids) |workspace_dep, package_id| {
+                                            if (package_id == invalid_package_id) continue;
+
                                             const resolution = resolutions[package_id];
                                             if (resolution.tag != .npm) continue;
 
@@ -10994,6 +10996,7 @@ pub const PackageManager = struct {
                     const workspace_package_ids = workspace_res_list.get(lockfile.buffers.resolutions.items);
                     for (workspace_deps, workspace_package_ids) |dep, package_id| {
                         if (dep.version.tag != .npm and dep.version.tag != .dist_tag) continue;
+                        if (package_id == invalid_package_id) continue;
 
                         if (manager.updating_packages.getPtr(dep.name.slice(lockfile.buffers.string_bytes.items))) |entry_ptr| {
                             const original_resolution: Resolution = resolutions[package_id];

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -2371,6 +2371,35 @@ describe("workspaces", async () => {
 });
 
 describe("update", () => {
+  test("duplicate peer dependency (one package is invalid_package_id)", async () => {
+    await write(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "no-deps": "^1.0.0",
+        },
+        peerDependencies: {
+          "no-deps": "^1.0.0",
+        },
+      }),
+    );
+
+    await runBunUpdate(env, packageDir);
+    expect(await file(join(packageDir, "package.json")).json()).toEqual({
+      name: "foo",
+      dependencies: {
+        "no-deps": "^1.1.0",
+      },
+      peerDependencies: {
+        "no-deps": "^1.0.0",
+      },
+    });
+
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      version: "1.1.0",
+    });
+  });
   test("dist-tags", async () => {
     await write(
       join(packageDir, "package.json"),


### PR DESCRIPTION
### What does this PR do?
We need to check for `invalid_package_id` before using the id from the lockfile or the install, because the dependency might be a peer duplicate.

fixes #11544 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test with a dependency in `dependencies` and `peerDependencies`
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
