### PR TITLE
fix: create_command telling to 'cd' when it should be omitted or `cd .`

### DIFF
--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1548,18 +1548,33 @@ pub const CreateCommand = struct {
             , .{create_react_app_entry_point_path});
         }
 
-        Output.pretty(
-            \\
-            \\<d>#<r><b> To get started, run:<r>
-            \\
-            \\  <b><cyan>cd {s}<r>
-            \\  <b><cyan>{s}<r>
-            \\
-            \\
-        , .{
-            filesystem.relativeTo(destination),
-            start_command,
-        });
+        const isEmptyDestination = std.mem.eql(u8, filesystem.relativeTo(destination), "");
+
+        if (isEmptyDestination) {
+            Output.pretty(
+                \\
+                \\<d>#<r><b> To get started, run:<r>
+                \\
+                \\  <b><cyan>{s}<r>
+                \\
+                \\
+            , .{
+                start_command,
+            });
+        } else {
+            Output.pretty(
+                \\
+                \\<d>#<r><b> To get started, run:<r>
+                \\
+                \\  <b><cyan>cd {s}<r>
+                \\  <b><cyan>{s}<r>
+                \\
+                \\
+            , .{
+                filesystem.relativeTo(destination),
+                start_command,
+            });
+        }
 
         Output.flush();
 

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1548,9 +1548,10 @@ pub const CreateCommand = struct {
             , .{create_react_app_entry_point_path});
         }
 
-        const isEmptyDestination = std.mem.eql(u8, filesystem.relativeTo(destination), "");
+        const rel_destination = filesystem.relativeTo(destination);
+        const is_empty_destination = rel_destination.len == 0;
 
-        if (isEmptyDestination) {
+        if (is_empty_destination) {
             Output.pretty(
                 \\
                 \\<d>#<r><b> To get started, run:<r>
@@ -1571,7 +1572,7 @@ pub const CreateCommand = struct {
                 \\
                 \\
             , .{
-                filesystem.relativeTo(destination),
+                rel_destination,
                 start_command,
             });
         }

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -107,6 +107,24 @@ it("should create template from local folder", async () => {
   expect(dirStat.isDirectory()).toBe(true);
 });
 
+it("should not mention cd prompt when created in current directory", async () => {
+  const { stdout, exited } = spawn({
+    cmd: [bunExe(), "create", "https://github.com/dylan-conway/create-test", "."],
+    cwd: x_dir,
+    stdout: "pipe",
+    stdin: "inherit",
+    stderr: "inherit",
+    env,
+  });
+
+  await exited;
+
+  const out = await Bun.readableStreamToText(stdout);
+
+  expect(out).toContain("bun dev");
+  expect(out).not.toContain("\n\n  cd \n  bun dev\n\n");
+});
+
 for (const repo of ["https://github.com/dylan-conway/create-test", "github.com/dylan-conway/create-test"]) {
   it(`should create and install github template from ${repo}`, async () => {
     const { stderr, stdout, exited } = spawn({


### PR DESCRIPTION
### What does this PR do?

Fixes #11566

Omits the `cd` line from the `# To get started, run:` section, when using the `bun create` command for creating a project in the current directory, instead of telling the user to do `cd` and sending them to the `$HOME` dir.

- [x] Code changes

### How did you verify your code works?

it's a simple condition change, so i did not run any tests on it.

