### PR TITLE
fix(install): `bun update` keeps pinned versions

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -6928,7 +6928,6 @@ pub const PackageManager = struct {
                                     // fetchSwapRemove because we want to update the first dependency with a matching
                                     // name, or none at all
                                     if (manager.updating_packages.fetchSwapRemove(key_str)) |entry| {
-                                        const original_version_literal = entry.value.original_version_literal;
                                         const is_alias = entry.value.is_alias;
                                         const dep_name = entry.key;
                                         for (workspace_deps, workspace_resolution_ids) |workspace_dep, package_id| {
@@ -6946,27 +6945,26 @@ pub const PackageManager = struct {
                                                 if (!manager.options.do.update_to_latest and npm_version.version.isExact()) break :updated;
                                             }
 
-                                            const original_version_to_use = brk: {
-                                                if (options.exact_versions or !is_alias) break :brk original_version_literal;
-                                                if (strings.lastIndexOfChar(original_version_literal, '@')) |at_index| {
-                                                    break :brk original_version_literal[at_index + 1 ..];
-                                                }
-                                                break :brk original_version_literal;
-                                            };
-                                            _ = original_version_to_use;
-
                                             const new_version = new_version: {
-                                                const resolved_version = resolution.value.npm.version.fmt(string_buf);
-                                                break :new_version try std.fmt.allocPrint(allocator, "{}", .{resolved_version});
-                                                // if (options.exact_versions) {
-                                                // }
+                                                const version_fmt = resolution.value.npm.version.fmt(string_buf);
+                                                if (options.exact_versions) {
+                                                    break :new_version try std.fmt.allocPrint(allocator, "{}", .{version_fmt});
+                                                }
 
-                                                // const pinned_version = Semver.Version.whichVersionIsPinned(original_version_to_use);
-                                                // break :new_version try switch (pinned_version) {
-                                                //     .patch => std.fmt.allocPrint(allocator, "{}", .{resolved_version}),
-                                                //     .minor => std.fmt.allocPrint(allocator, "~{}", .{resolved_version}),
-                                                //     .major => std.fmt.allocPrint(allocator, "^{}", .{resolved_version}),
-                                                // };
+                                                const version_literal = version_literal: {
+                                                    if (!is_alias) break :version_literal entry.value.original_version_literal;
+                                                    if (strings.lastIndexOfChar(entry.value.original_version_literal, '@')) |at_index| {
+                                                        break :version_literal entry.value.original_version_literal[at_index + 1 ..];
+                                                    }
+                                                    break :version_literal entry.value.original_version_literal;
+                                                };
+
+                                                const pinned_version = Semver.Version.whichVersionIsPinned(version_literal);
+                                                break :new_version try switch (pinned_version) {
+                                                    .patch => std.fmt.allocPrint(allocator, "{}", .{version_fmt}),
+                                                    .minor => std.fmt.allocPrint(allocator, "~{}", .{version_fmt}),
+                                                    .major => std.fmt.allocPrint(allocator, "^{}", .{version_fmt}),
+                                                };
                                             };
 
                                             if (is_alias) {
@@ -7392,18 +7390,48 @@ pub const PackageManager = struct {
                 if (request.e_string) |e_string| {
                     e_string.data = switch (request.resolution.tag) {
                         .npm => brk: {
-                            if (manager.subcommand == .update and manager.options.do.update_to_latest) {
-                                switch (request.version.tag) {
-                                    .dist_tag => {
+                            if (manager.subcommand == .update and (request.version.tag == .dist_tag or request.version.tag == .npm)) {
+                                if (manager.updating_packages.fetchSwapRemove(request.name)) |entry| {
+                                    var alias_at_index: ?usize = null;
 
-                                    },
-                                    .npm => {
-                                        
+                                    const new_version = new_version: {
+                                        const version_fmt = request.resolution.value.npm.version.fmt(manager.lockfile.buffers.string_bytes.items);
+                                        if (options.exact_versions) {
+                                            break :new_version try std.fmt.allocPrint(allocator, "{}", .{version_fmt});
+                                        }
+
+                                        const version_literal = version_literal: {
+                                            if (!entry.value.is_alias) break :version_literal entry.value.original_version_literal;
+                                            if (strings.lastIndexOfChar(entry.value.original_version_literal, '@')) |at_index| {
+                                                alias_at_index = at_index;
+                                                break :version_literal entry.value.original_version_literal[at_index + 1 ..];
+                                            }
+
+                                            break :version_literal entry.value.original_version_literal;
+                                        };
+
+                                        const pinned_version = Semver.Version.whichVersionIsPinned(version_literal);
+                                        break :new_version try switch (pinned_version) {
+                                            .patch => std.fmt.allocPrint(allocator, "{}", .{version_fmt}),
+                                            .minor => std.fmt.allocPrint(allocator, "~{}", .{version_fmt}),
+                                            .major => std.fmt.allocPrint(allocator, "^{}", .{version_fmt}),
+                                        };
+                                    };
+
+                                    if (entry.value.is_alias) {
+                                        const dep_literal = entry.value.original_version_literal;
+
+                                        if (strings.lastIndexOfChar(dep_literal, '@')) |at_index| {
+                                            break :brk try std.fmt.allocPrint(allocator, "{s}@{s}", .{
+                                                dep_literal[0..at_index],
+                                                new_version,
+                                            });
+                                        }
                                     }
-                                }
 
+                                    break :brk new_version;
+                                }
                             }
-                            if (manager.updating_packages.fetchSwapRemove())
                             if (request.version.tag == .dist_tag or
                                 (manager.subcommand == .update and request.version.tag == .npm and !request.version.value.npm.version.isExact()))
                             {

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -26,250 +26,268 @@ expect.extend({
   toHaveBins,
 });
 
-it("should update to latest version of dependency", async () => {
-  const urls: string[] = [];
-  const registry = {
-    "0.0.3": {
+for (const { input } of [{ input: { baz: "~0.0.3", moo: "~0.1.0" } }, { input: { baz: "^0.0.3", moo: "^0.1.0" } }]) {
+  it(`should update to latest version of dependency (${input.baz[0]})`, async () => {
+    const urls: string[] = [];
+    const tilde = input.baz[0] === "~";
+    const registry = {
+      "0.0.3": {
+        bin: {
+          "baz-run": "index.js",
+        },
+      },
+      "0.0.5": {
+        bin: {
+          "baz-exec": "index.js",
+        },
+      },
+      latest: "0.0.3",
+    };
+    setHandler(dummyRegistry(urls, registry));
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          baz: input.baz,
+        },
+      }),
+    );
+    const {
+      stdout: stdout1,
+      stderr: stderr1,
+      exited: exited1,
+    } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err1 = await new Response(stderr1).text();
+    expect(err1).not.toContain("error:");
+    expect(err1).toContain("Saved lockfile");
+    const out1 = await new Response(stdout1).text();
+    expect(out1.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+      "",
+      "+ baz@0.0.3",
+      "",
+      "1 package installed",
+    ]);
+    expect(await exited1).toBe(0);
+    expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.3.tgz`]);
+    expect(requested).toBe(2);
+    expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
+    expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
+    expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
+    expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
+    expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
+      name: "baz",
+      version: "0.0.3",
       bin: {
         "baz-run": "index.js",
       },
-    },
-    "0.0.5": {
+    });
+    await access(join(package_dir, "bun.lockb"));
+    // Perform `bun update` with updated registry & lockfile from before
+    await rm(join(package_dir, "node_modules"), { force: true, recursive: true });
+    urls.length = 0;
+    registry.latest = "0.0.5";
+    setHandler(dummyRegistry(urls, registry));
+    const {
+      stdout: stdout2,
+      stderr: stderr2,
+      exited: exited2,
+    } = spawn({
+      cmd: [bunExe(), "update", "baz"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err2 = await new Response(stderr2).text();
+    expect(err2).not.toContain("error:");
+    expect(err2).toContain("Saved lockfile");
+    const out2 = await new Response(stdout2).text();
+    expect(out2.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+      "",
+      `installed baz@${tilde ? "0.0.5" : "0.0.3"} with binaries:`,
+      ` - ${tilde ? "baz-exec" : "baz-run"}`,
+      "",
+      "1 package installed",
+    ]);
+    expect(await exited2).toBe(0);
+    expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-${tilde ? "0.0.5" : "0.0.3"}.tgz`]);
+    expect(requested).toBe(4);
+    expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
+    expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins([tilde ? "baz-exec" : "baz-run"]);
+    expect(join(package_dir, "node_modules", ".bin", tilde ? "baz-exec" : "baz-run")).toBeValidBin(
+      join("..", "baz", "index.js"),
+    );
+    expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
+    expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
+      name: "baz",
+      version: tilde ? "0.0.5" : "0.0.3",
       bin: {
-        "baz-exec": "index.js",
+        [tilde ? "baz-exec" : "baz-run"]: "index.js",
       },
-    },
-    latest: "0.0.3",
-  };
-  setHandler(dummyRegistry(urls, registry));
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({
+    });
+    expect(await file(join(package_dir, "package.json")).json()).toEqual({
       name: "foo",
       dependencies: {
-        baz: "~0.0.2",
+        baz: tilde ? "~0.0.5" : "^0.0.3",
       },
-    }),
-  );
-  const {
-    stdout: stdout1,
-    stderr: stderr1,
-    exited: exited1,
-  } = spawn({
-    cmd: [bunExe(), "install"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
+    });
+    await access(join(package_dir, "bun.lockb"));
   });
-  const err1 = await new Response(stderr1).text();
-  expect(err1).not.toContain("error:");
-  expect(err1).toContain("Saved lockfile");
-  const out1 = await new Response(stdout1).text();
-  expect(out1.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-    "",
-    "+ baz@0.0.3",
-    "",
-    "1 package installed",
-  ]);
-  expect(await exited1).toBe(0);
-  expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.3.tgz`]);
-  expect(requested).toBe(2);
-  expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
-  expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
-  expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
-    name: "baz",
-    version: "0.0.3",
-    bin: {
-      "baz-run": "index.js",
-    },
-  });
-  await access(join(package_dir, "bun.lockb"));
-  // Perform `bun update` with updated registry & lockfile from before
-  await rm(join(package_dir, "node_modules"), { force: true, recursive: true });
-  urls.length = 0;
-  registry.latest = "0.0.5";
-  setHandler(dummyRegistry(urls, registry));
-  const {
-    stdout: stdout2,
-    stderr: stderr2,
-    exited: exited2,
-  } = spawn({
-    cmd: [bunExe(), "update", "baz"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  const err2 = await new Response(stderr2).text();
-  expect(err2).not.toContain("error:");
-  expect(err2).toContain("Saved lockfile");
-  const out2 = await new Response(stdout2).text();
-  expect(out2.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-    "",
-    "installed baz@0.0.5 with binaries:",
-    " - baz-exec",
-    "",
-    "1 package installed",
-  ]);
-  expect(await exited2).toBe(0);
-  expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.5.tgz`]);
-  expect(requested).toBe(4);
-  expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-exec"]);
-  expect(join(package_dir, "node_modules", ".bin", "baz-exec")).toBeValidBin(join("..", "baz", "index.js"));
-  expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
-  expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
-    name: "baz",
-    version: "0.0.5",
-    bin: {
-      "baz-exec": "index.js",
-    },
-  });
-  expect(await file(join(package_dir, "package.json")).json()).toEqual({
-    name: "foo",
-    dependencies: {
-      baz: "~0.0.5",
-    },
-  });
-  await access(join(package_dir, "bun.lockb"));
-});
 
-it("should update to latest versions of dependencies", async () => {
-  const urls: string[] = [];
-  const registry = {
-    "0.0.3": {
+  it(`should update to latest versions of dependencies (${input.baz[0]})`, async () => {
+    const tilde = input.baz[0] === "~";
+    const urls: string[] = [];
+    const registry = {
+      "0.0.3": {
+        bin: {
+          "baz-run": "index.js",
+        },
+      },
+      "0.0.5": {
+        bin: {
+          "baz-exec": "index.js",
+        },
+      },
+      "0.1.0": {},
+      latest: "0.0.3",
+    };
+    setHandler(dummyRegistry(urls, registry));
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "@barn/moo": input.moo,
+          baz: input.baz,
+        },
+      }),
+    );
+    const {
+      stdout: stdout1,
+      stderr: stderr1,
+      exited: exited1,
+    } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err1 = await new Response(stderr1).text();
+    expect(err1).not.toContain("error:");
+    expect(err1).toContain("Saved lockfile");
+    const out1 = await new Response(stdout1).text();
+    expect(out1.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+      "",
+      "+ @barn/moo@0.1.0",
+      "+ baz@0.0.3",
+      "",
+      "2 packages installed",
+    ]);
+    expect(await exited1).toBe(0);
+    expect(urls.sort()).toEqual([
+      `${root_url}/@barn%2fmoo`,
+      `${root_url}/@barn/moo-0.1.0.tgz`,
+      `${root_url}/baz`,
+      `${root_url}/baz-0.0.3.tgz`,
+    ]);
+    expect(requested).toBe(4);
+    expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "baz"]);
+    expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
+    expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
+    expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
+    expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
+    expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
+    expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
+      name: "baz",
+      version: "0.0.3",
       bin: {
         "baz-run": "index.js",
       },
-    },
-    "0.0.5": {
+    });
+    await access(join(package_dir, "bun.lockb"));
+    // Perform `bun update` with updated registry & lockfile from before
+    await rm(join(package_dir, "node_modules"), { force: true, recursive: true });
+    urls.length = 0;
+    registry.latest = "0.0.5";
+    setHandler(dummyRegistry(urls, registry));
+    const {
+      stdout: stdout2,
+      stderr: stderr2,
+      exited: exited2,
+    } = spawn({
+      cmd: [bunExe(), "update"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err2 = await new Response(stderr2).text();
+    expect(err2).not.toContain("error:");
+    expect(err2).toContain("Saved lockfile");
+    const out2 = await new Response(stdout2).text();
+    if (tilde) {
+      expect(out2.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        "",
+        "^ baz 0.0.3 -> 0.0.5",
+        "",
+        "+ @barn/moo@0.1.0",
+        "",
+        "2 packages installed",
+      ]);
+    } else {
+      expect(out2.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        "",
+        "+ @barn/moo@0.1.0",
+        "+ baz@0.0.3",
+        "",
+        "2 packages installed",
+      ]);
+    }
+    expect(await exited2).toBe(0);
+    expect(urls.sort()).toEqual([
+      `${root_url}/@barn%2fmoo`,
+      `${root_url}/@barn/moo-0.1.0.tgz`,
+      `${root_url}/baz`,
+      tilde ? `${root_url}/baz-0.0.5.tgz` : `${root_url}/baz-0.0.3.tgz`,
+    ]);
+    expect(requested).toBe(8);
+    expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "baz"]);
+    expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins([tilde ? "baz-exec" : "baz-run"]);
+    expect(join(package_dir, "node_modules", ".bin", tilde ? "baz-exec" : "baz-run")).toBeValidBin(
+      join("..", "baz", "index.js"),
+    );
+    expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
+    expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
+    expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
+    expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
+      name: "baz",
+      version: tilde ? "0.0.5" : "0.0.3",
       bin: {
-        "baz-exec": "index.js",
+        [tilde ? "baz-exec" : "baz-run"]: "index.js",
       },
-    },
-    "0.1.0": {},
-    latest: "0.0.3",
-  };
-  setHandler(dummyRegistry(urls, registry));
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({
+    });
+    expect(await file(join(package_dir, "package.json")).json()).toEqual({
       name: "foo",
       dependencies: {
-        "@barn/moo": "^0.1.0",
-        baz: "~0.0.2",
+        "@barn/moo": tilde ? "~0.1.0" : "^0.1.0",
+        baz: tilde ? "~0.0.5" : "^0.0.3",
       },
-    }),
-  );
-  const {
-    stdout: stdout1,
-    stderr: stderr1,
-    exited: exited1,
-  } = spawn({
-    cmd: [bunExe(), "install"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
+    });
+    await access(join(package_dir, "bun.lockb"));
   });
-  const err1 = await new Response(stderr1).text();
-  expect(err1).not.toContain("error:");
-  expect(err1).toContain("Saved lockfile");
-  const out1 = await new Response(stdout1).text();
-  expect(out1.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-    "",
-    "+ @barn/moo@0.1.0",
-    "+ baz@0.0.3",
-    "",
-    "2 packages installed",
-  ]);
-  expect(await exited1).toBe(0);
-  expect(urls.sort()).toEqual([
-    `${root_url}/@barn%2fmoo`,
-    `${root_url}/@barn/moo-0.1.0.tgz`,
-    `${root_url}/baz`,
-    `${root_url}/baz-0.0.3.tgz`,
-  ]);
-  expect(requested).toBe(4);
-  expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-  expect(join(package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
-  expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
-  expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
-    name: "baz",
-    version: "0.0.3",
-    bin: {
-      "baz-run": "index.js",
-    },
-  });
-  await access(join(package_dir, "bun.lockb"));
-  // Perform `bun update` with updated registry & lockfile from before
-  await rm(join(package_dir, "node_modules"), { force: true, recursive: true });
-  urls.length = 0;
-  registry.latest = "0.0.5";
-  setHandler(dummyRegistry(urls, registry));
-  const {
-    stdout: stdout2,
-    stderr: stderr2,
-    exited: exited2,
-  } = spawn({
-    cmd: [bunExe(), "update"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  const err2 = await new Response(stderr2).text();
-  expect(err2).not.toContain("error:");
-  expect(err2).toContain("Saved lockfile");
-  const out2 = await new Response(stdout2).text();
-  expect(out2.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-    "",
-    "^ baz 0.0.3 -> 0.0.5",
-    "",
-    "+ @barn/moo@0.1.0",
-    "",
-    "2 packages installed",
-  ]);
-  expect(await exited2).toBe(0);
-  expect(urls.sort()).toEqual([
-    `${root_url}/@barn%2fmoo`,
-    `${root_url}/@barn/moo-0.1.0.tgz`,
-    `${root_url}/baz`,
-    `${root_url}/baz-0.0.5.tgz`,
-  ]);
-  expect(requested).toBe(8);
-  expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "@barn", "baz"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-exec"]);
-  expect(join(package_dir, "node_modules", ".bin", "baz-exec")).toBeValidBin(join("..", "baz", "index.js"));
-  expect(await readdirSorted(join(package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
-  expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
-    name: "baz",
-    version: "0.0.5",
-    bin: {
-      "baz-exec": "index.js",
-    },
-  });
-  expect(await file(join(package_dir, "package.json")).json()).toEqual({
-    name: "foo",
-    dependencies: {
-      "@barn/moo": "^0.1.0",
-      baz: "~0.0.5",
-    },
-  });
-  await access(join(package_dir, "bun.lockb"));
-});
+}
 
 it("lockfile should not be modified when there are no version changes, issue#5888", async () => {
   // Install packages

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -133,7 +133,7 @@ it("should update to latest version of dependency", async () => {
   expect(await file(join(package_dir, "package.json")).json()).toEqual({
     name: "foo",
     dependencies: {
-      baz: "^0.0.5",
+      baz: "~0.0.5",
     },
   });
   await access(join(package_dir, "bun.lockb"));
@@ -265,7 +265,7 @@ it("should update to latest versions of dependencies", async () => {
     name: "foo",
     dependencies: {
       "@barn/moo": "^0.1.0",
-      baz: "^0.0.5",
+      baz: "~0.0.5",
     },
   });
   await access(join(package_dir, "bun.lockb"));

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -2551,12 +2551,115 @@ describe("update", () => {
       });
     });
 
+    for (const latest of [true, false]) {
+      test(`update no args${latest ? " --latest" : ""}`, async () => {
+        await write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "foo",
+            dependencies: {
+              "a1": "npm:no-deps@1",
+              "a10": "npm:no-deps@~1.0",
+              "a11": "npm:no-deps@^1.0",
+              "a12": "npm:no-deps@~1.0.1",
+              "a13": "npm:no-deps@^1.0.1",
+              "a14": "npm:no-deps@~1.1.0",
+              "a15": "npm:no-deps@^1.1.0",
+              "a2": "npm:no-deps@1.0",
+              "a3": "npm:no-deps@1.1",
+              "a4": "npm:no-deps@1.0.1",
+              "a5": "npm:no-deps@1.1.0",
+              "a6": "npm:no-deps@~1",
+              "a7": "npm:no-deps@^1",
+              "a8": "npm:no-deps@~1.1",
+              "a9": "npm:no-deps@^1.1",
+            },
+          }),
+        );
+
+        if (latest) {
+          await runBunUpdate(env, packageDir, ["--latest"]);
+          expect(await file(join(packageDir, "package.json")).json()).toEqual({
+            name: "foo",
+            dependencies: {
+              "a1": "npm:no-deps@^2.0.0",
+              "a10": "npm:no-deps@~2.0.0",
+              "a11": "npm:no-deps@^2.0.0",
+              "a12": "npm:no-deps@~2.0.0",
+              "a13": "npm:no-deps@^2.0.0",
+              "a14": "npm:no-deps@~2.0.0",
+              "a15": "npm:no-deps@^2.0.0",
+              "a2": "npm:no-deps@~2.0.0",
+              "a3": "npm:no-deps@~2.0.0",
+              "a4": "npm:no-deps@2.0.0",
+              "a5": "npm:no-deps@2.0.0",
+              "a6": "npm:no-deps@~2.0.0",
+              "a7": "npm:no-deps@^2.0.0",
+              "a8": "npm:no-deps@~2.0.0",
+              "a9": "npm:no-deps@^2.0.0",
+            },
+          });
+        } else {
+          await runBunUpdate(env, packageDir);
+          expect(await file(join(packageDir, "package.json")).json()).toEqual({
+            name: "foo",
+            dependencies: {
+              "a1": "npm:no-deps@^1.1.0",
+              "a10": "npm:no-deps@~1.0.1",
+              "a11": "npm:no-deps@^1.1.0",
+              "a12": "npm:no-deps@~1.0.1",
+              "a13": "npm:no-deps@^1.1.0",
+              "a14": "npm:no-deps@~1.1.0",
+              "a15": "npm:no-deps@^1.1.0",
+              "a2": "npm:no-deps@~1.0.1",
+              "a3": "npm:no-deps@~1.1.0",
+              "a4": "npm:no-deps@1.0.1",
+              "a5": "npm:no-deps@1.1.0",
+              "a6": "npm:no-deps@~1.1.0",
+              "a7": "npm:no-deps@^1.1.0",
+              "a8": "npm:no-deps@~1.1.0",
+              "a9": "npm:no-deps@^1.1.0",
+            },
+          });
+        }
+        const files = await Promise.all(
+          ["a1", "a10", "a11", "a12", "a13", "a14", "a15", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"].map(alias =>
+            file(join(packageDir, "node_modules", alias, "package.json")).json(),
+          ),
+        );
+
+        if (latest) {
+          // each version should be "2.0.0"
+          expect(files).toMatchObject(Array(15).fill({ version: "2.0.0" }));
+        } else {
+          expect(files).toMatchObject([
+            { version: "1.1.0" },
+            { version: "1.0.1" },
+            { version: "1.1.0" },
+            { version: "1.0.1" },
+            { version: "1.1.0" },
+            { version: "1.1.0" },
+            { version: "1.1.0" },
+            { version: "1.0.1" },
+            { version: "1.1.0" },
+            { version: "1.0.1" },
+            { version: "1.1.0" },
+            { version: "1.1.0" },
+            { version: "1.1.0" },
+            { version: "1.1.0" },
+            { version: "1.1.0" },
+          ]);
+        }
+      });
+    }
+
     test("with package name in args", async () => {
       await write(
         join(packageDir, "package.json"),
         JSON.stringify({
           name: "foo",
           dependencies: {
+            "a-dep": "1.0.3",
             "no-deps": "~1.0.0",
           },
         }),
@@ -2569,11 +2672,23 @@ describe("update", () => {
       });
 
       let { out } = await runBunUpdate(env, packageDir, ["no-deps"]);
-      expect(out).toEqual(["", "Checked 1 install across 2 packages (no changes)"]);
+      expect(out).toEqual(["", "installed no-deps@1.0.1", "", expect.stringContaining("done"), ""]);
       expect(await file(join(packageDir, "package.json")).json()).toEqual({
         name: "foo",
         dependencies: {
+          "a-dep": "1.0.3",
           "no-deps": "~1.0.1",
+        },
+      });
+
+      // update with --latest should only change the update request and keep `~`
+      ({ out } = await runBunUpdate(env, packageDir, ["no-deps", "--latest"]));
+      expect(out).toEqual(["", "installed no-deps@2.0.0", "", "1 package installed"]);
+      expect(await file(join(packageDir, "package.json")).json()).toEqual({
+        name: "foo",
+        dependencies: {
+          "a-dep": "1.0.3",
+          "no-deps": "~2.0.0",
         },
       });
     });
@@ -2880,7 +2995,9 @@ describe("update", () => {
         "dep-loop-entry": "1.0.0",
         "dep-with-tags": "^2.0.0",
         "dev-deps": "1.0.0",
-        "a-dep": "1.0.5",
+
+        // a-dep should keep caret
+        "a-dep": "^1.0.5",
       },
     });
 


### PR DESCRIPTION
### What does this PR do?
`bun update` will keep `~` or `^` if it's used in the version. Previously only `^` would stay if used.

Also fixes a bug where `--latest` would not apply to packages passed to `bun update`.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
