### PR TITLE
fix(install): semver mistaking `.` as the beginning of pre/build tags

### DIFF
--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -1199,7 +1199,8 @@ pub const Version = extern struct {
                     }
 
                     if (i < input.len and switch (input[i]) {
-                        '.' => true,
+                        // `.` is expected only if there are remaining core version numbers
+                        '.' => part_i != 3,
                         else => false,
                     }) {
                         i += 1;

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -6421,6 +6421,10 @@ const prereleaseFailTests = [
       title: "greater than or equal to highest prerelease + 1",
       depVersion: ">=5.0.0-alpha.154",
     },
+    {
+      title: "`.` instead of `-` should fail",
+      depVersion: "5.0.0.alpha.150",
+    },
   ],
   // prereleases-4 has one version
   // - 2.0.0-pre.0


### PR DESCRIPTION
### What does this PR do?
Currently, if there is a package with a version `5.0.0-alpha.150` (valid semver) published in the registry, Bun will successfully install the package with the version `5.0.0.alpha.150` (invalid, `-` is replaced with `.`). This pr changes this situation to fail to resolve the package, because these versions are not equal.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
