### PR TITLE
Fix runtime stack trace computation

### DIFF
--- a/packages/bun-error/index.tsx
+++ b/packages/bun-error/index.tsx
@@ -511,13 +511,7 @@ const SourceLines = ({
   );
 };
 
-const BuildErrorSourceLines = ({
-  location,
-  filename,
-}: {
-  location: Location;
-  filename: string;
-}) => {
+const BuildErrorSourceLines = ({ location, filename }: { location: Location; filename: string }) => {
   const { line, line_text, column } = location;
   const sourceLines: SourceLine[] = [{ line, text: line_text }];
   const buildURL = React.useCallback((line, column) => srcFileURL(filename, line, column), [srcFileURL, filename]);
@@ -612,7 +606,7 @@ const NativeStackFrame = ({
   const {
     file,
     function_name: functionName,
-    position: { line, column_start: column },
+    position: { line, column },
     scope,
   } = frame;
   const fileName = normalizedFilename(file, cwd);
@@ -689,21 +683,21 @@ const NativeStackTrace = ({
   return (
     <div ref={ref} className={`BunError-NativeStackTrace`}>
       <a
-        href={urlBuilder(filename, position.line, position.column_start)}
+        href={urlBuilder(filename, position.line, position.column)}
         data-line={position.line}
-        data-column={position.column_start}
+        data-column={position.column}
         data-is-client="true"
         target="_blank"
         onClick={openWithoutFlashOfNewTab}
         className="BunError-NativeStackTrace-filename"
       >
-        {filename}:{position.line}:{position.column_start}
+        {filename}:{position.line}:{position.column}
       </a>
       {sourceLines.length > 0 && (
         <SourceLines
           highlight={position.line}
           sourceLines={sourceLines}
-          highlightColumnStart={position.column_start}
+          highlightColumnStart={position.column}
           buildURL={buildURL}
           highlightColumnEnd={position.column_stop}
         >
@@ -715,7 +709,7 @@ const NativeStackTrace = ({
           highlight={position.line}
           sourceLines={sourceLines}
           setSourceLines={setSourceLines}
-          highlightColumnStart={position.column_start}
+          highlightColumnStart={position.column}
           buildURL={buildURL}
           highlightColumnEnd={position.column_stop}
         >
@@ -737,13 +731,7 @@ const Indent = ({ by, children }) => {
   );
 };
 
-const JSException = ({
-  value,
-  isClient = false,
-}: {
-  value: JSExceptionType;
-  isClient: boolean;
-}) => {
+const JSException = ({ value, isClient = false }: { value: JSExceptionType; isClient: boolean }) => {
   const tag = isClient ? ErrorTagType.client : ErrorTagType.server;
   const [sourceLines, _setSourceLines] = React.useState(value?.stack?.source_lines ?? []);
   var message = value.message || "";
@@ -791,7 +779,7 @@ const JSException = ({
                 sourceLines={sourceLines}
                 setSourceLines={setSourceLines}
               >
-                <Indent by={value.stack.frames[0].position.column_start}>
+                <Indent by={value.stack.frames[0].position.column}>
                   <span className="BunError-error-typename">{fancyTypeError.runtimeTypeName}</span>
                 </Indent>
               </NativeStackTrace>
@@ -853,13 +841,7 @@ const JSException = ({
   }
 };
 
-const Summary = ({
-  errorCount,
-  onClose,
-}: {
-  errorCount: number;
-  onClose: () => void;
-}) => {
+const Summary = ({ errorCount, onClose }: { errorCount: number; onClose: () => void }) => {
   return (
     <div className="BunError-Summary">
       <div className="BunError-Summary-ErrorIcon"></div>
@@ -1001,11 +983,7 @@ const Footer = ({ toMarkdown, data }) => (
   </div>
 );
 
-const BuildFailureMessageContainer = ({
-  messages,
-}: {
-  messages: Message[];
-}) => {
+const BuildFailureMessageContainer = ({ messages }: { messages: Message[] }) => {
   return (
     <div id="BunErrorOverlay-container">
       <div className="BunError-content">
@@ -1153,14 +1131,14 @@ export function renderRuntimeError(error: Error) {
         file: error[fileNameProperty] || "",
         position: {
           line: +error[lineNumberProperty] || 1,
-          column_start: +error[columnNumberProperty] || 1,
+          column: +error[columnNumberProperty] || 1,
         },
       } as StackFrame);
     } else if (exception.stack && exception.stack.frames.length > 0) {
       exception.stack.frames[0].position.line = error[lineNumberProperty];
 
       if (Number.isFinite(error[columnNumberProperty])) {
-        exception.stack.frames[0].position.column_start = error[columnNumberProperty];
+        exception.stack.frames[0].position.column = error[columnNumberProperty];
       }
     }
   }
@@ -1214,27 +1192,27 @@ export function renderRuntimeError(error: Error) {
           }
           var frame = exception.stack.frames[frameIndex];
 
-          const { line, column_start } = frame.position;
-          const remapped = remapPosition(mappings, line, column_start);
+          const { line, column } = frame.position;
+          const remapped = remapPosition(mappings, line, column);
           if (!remapped) return null;
           frame.position.line_start = frame.position.line = remapped[0];
           frame.position.column_stop =
             frame.position.expression_stop =
             frame.position.expression_start =
-            frame.position.column_start =
+            frame.position.column =
               remapped[1];
         }, console.error);
       } else {
         if (!mappings) return null;
         var frame = exception.stack.frames[frameIndex];
-        const { line, column_start } = frame.position;
-        const remapped = remapPosition(mappings, line, column_start);
+        const { line, column } = frame.position;
+        const remapped = remapPosition(mappings, line, column);
         if (!remapped) return null;
         frame.position.line_start = frame.position.line = remapped[0];
         frame.position.column_stop =
           frame.position.expression_stop =
           frame.position.expression_start =
-          frame.position.column_start =
+          frame.position.column =
             remapped[1];
       }
     });

--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -355,14 +355,8 @@ export interface StackFrame {
 }
 
 export interface StackFramePosition {
-  source_offset: int32;
   line: int32;
-  line_start: int32;
-  line_stop: int32;
-  column_start: int32;
-  column_stop: int32;
-  expression_start: int32;
-  expression_stop: int32;
+  column: int32;
 }
 
 export interface SourceLine {

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -148,14 +148,9 @@ function encodeStackFrame(message, bb) {
 function decodeStackFramePosition(bb) {
   var result = {};
 
-  result["source_offset"] = bb.readInt32();
   result["line"] = bb.readInt32();
-  result["line_start"] = bb.readInt32();
-  result["line_stop"] = bb.readInt32();
-  result["column_start"] = bb.readInt32();
-  result["column_stop"] = bb.readInt32();
-  result["expression_start"] = bb.readInt32();
-  result["expression_stop"] = bb.readInt32();
+  result["column"] = bb.readInt32();
+
   return result;
 }
 

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const bun = @import("root").bun;
 
 pub const Reader = struct {
     const Self = @This();
@@ -423,7 +424,7 @@ pub const Api = struct {
         }
     };
 
-    pub const StackFramePosition = @import("root").bun.JSC.ZigStackFramePosition;
+    pub const StackFramePosition = bun.JSC.ZigStackFramePosition;
 
     pub const SourceLine = struct {
         /// line

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -423,56 +423,7 @@ pub const Api = struct {
         }
     };
 
-    pub const StackFramePosition = packed struct {
-        /// source_offset
-        source_offset: i32 = 0,
-
-        /// line
-        line: i32 = 0,
-
-        /// line_start
-        line_start: i32 = 0,
-
-        /// line_stop
-        line_stop: i32 = 0,
-
-        /// column_start
-        column_start: i32 = 0,
-
-        /// column_stop
-        column_stop: i32 = 0,
-
-        /// expression_start
-        expression_start: i32 = 0,
-
-        /// expression_stop
-        expression_stop: i32 = 0,
-
-        pub fn decode(reader: anytype) anyerror!StackFramePosition {
-            var this = std.mem.zeroes(StackFramePosition);
-
-            this.source_offset = try reader.readValue(i32);
-            this.line = try reader.readValue(i32);
-            this.line_start = try reader.readValue(i32);
-            this.line_stop = try reader.readValue(i32);
-            this.column_start = try reader.readValue(i32);
-            this.column_stop = try reader.readValue(i32);
-            this.expression_start = try reader.readValue(i32);
-            this.expression_stop = try reader.readValue(i32);
-            return this;
-        }
-
-        pub fn encode(this: *const @This(), writer: anytype) anyerror!void {
-            try writer.writeInt(this.source_offset);
-            try writer.writeInt(this.line);
-            try writer.writeInt(this.line_start);
-            try writer.writeInt(this.line_stop);
-            try writer.writeInt(this.column_start);
-            try writer.writeInt(this.column_stop);
-            try writer.writeInt(this.expression_start);
-            try writer.writeInt(this.expression_stop);
-        }
-    };
+    pub const StackFramePosition = @import("root").bun.JSC.ZigStackFramePosition;
 
     pub const SourceLine = struct {
         /// line

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -26,6 +26,7 @@
 
 #include "ProcessBindingTTYWrap.h"
 #include "wtf/text/ASCIILiteral.h"
+#include "wtf/text/OrdinalNumber.h"
 
 #ifndef WIN32
 #include <errno.h>
@@ -1591,10 +1592,14 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
             vm.interpreter.getStackTrace(javascriptStack, stackFrames, 1);
             String name = "Error"_s;
             String message = "JavaScript Callstack"_s;
-            unsigned int line = 0;
-            unsigned int column = 0;
+            OrdinalNumber line = OrdinalNumber::beforeFirst();
+            OrdinalNumber column = OrdinalNumber::beforeFirst();
             WTF::String sourceURL;
-            WTF::String stackProperty = Bun::formatStackTrace(vm, globalObject, name, message, line, column, sourceURL, stackFrames, nullptr);
+            WTF::String stackProperty = Bun::formatStackTrace(
+                vm, globalObject, name, message,
+                line, column,
+                sourceURL, stackFrames, nullptr);
+
             WTF::String stack;
             // first line after "Error:"
             size_t firstLine = stackProperty.find('\n');

--- a/src/bun.js/bindings/CallSite.cpp
+++ b/src/bun.js/bindings/CallSite.cpp
@@ -58,8 +58,8 @@ void CallSite::finishCreation(VM& vm, JSC::JSGlobalObject* globalObject, JSCStac
 
     const auto* sourcePositions = stackFrame.getSourcePositions();
     if (sourcePositions) {
-        m_lineNumber = sourcePositions->line.oneBasedInt();
-        m_columnNumber = sourcePositions->startColumn.oneBasedInt();
+        m_lineNumber = sourcePositions->line;
+        m_columnNumber = sourcePositions->startColumn;
     }
 
     if (stackFrame.isEval()) {
@@ -105,8 +105,8 @@ void CallSite::formatAsString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WT
     JSString* myFunctionName = functionName().toString(globalObject);
     JSString* mySourceURL = sourceURL().toString(globalObject);
 
-    JSString* myColumnNumber = columnNumber() >= 0 ? JSValue(columnNumber()).toString(globalObject) : jsEmptyString(vm);
-    JSString* myLineNumber = lineNumber() >= 0 ? JSValue(lineNumber()).toString(globalObject) : jsEmptyString(vm);
+    JSString* myColumnNumber = columnNumber().zeroBasedInt() >= 0 ? JSValue(columnNumber().oneBasedInt()).toString(globalObject) : jsEmptyString(vm);
+    JSString* myLineNumber = lineNumber().zeroBasedInt() >= 0 ? JSValue(lineNumber().oneBasedInt()).toString(globalObject) : jsEmptyString(vm);
 
     bool myIsConstructor = isConstructor();
 

--- a/src/bun.js/bindings/CallSite.cpp
+++ b/src/bun.js/bindings/CallSite.cpp
@@ -59,7 +59,7 @@ void CallSite::finishCreation(VM& vm, JSC::JSGlobalObject* globalObject, JSCStac
     const auto* sourcePositions = stackFrame.getSourcePositions();
     if (sourcePositions) {
         m_lineNumber = sourcePositions->line;
-        m_columnNumber = sourcePositions->startColumn;
+        m_columnNumber = sourcePositions->column;
     }
 
     if (stackFrame.isEval()) {

--- a/src/bun.js/bindings/CallSite.h
+++ b/src/bun.js/bindings/CallSite.h
@@ -9,6 +9,7 @@
 
 #include <JavaScriptCore/JSObject.h>
 #include "BunClientData.h"
+#include "wtf/text/OrdinalNumber.h"
 
 using namespace JSC;
 using namespace WebCore;
@@ -31,8 +32,8 @@ private:
     JSC::WriteBarrier<JSC::Unknown> m_function;
     JSC::WriteBarrier<JSC::Unknown> m_functionName;
     JSC::WriteBarrier<JSC::Unknown> m_sourceURL;
-    int32_t m_lineNumber = -1;
-    int32_t m_columnNumber = -1;
+    OrdinalNumber m_lineNumber;
+    OrdinalNumber m_columnNumber;
     unsigned int m_flags;
 
 public:
@@ -70,23 +71,23 @@ public:
     JSC::JSValue function() const { return m_function.get(); }
     JSC::JSValue functionName() const { return m_functionName.get(); }
     JSC::JSValue sourceURL() const { return m_sourceURL.get(); }
-    int32_t lineNumber() const { return m_lineNumber; }
-    int32_t columnNumber() const { return m_columnNumber; }
+    OrdinalNumber lineNumber() const { return m_lineNumber; }
+    OrdinalNumber columnNumber() const { return m_columnNumber; }
     bool isEval() const { return m_flags & static_cast<unsigned int>(Flags::IsEval); }
     bool isConstructor() const { return m_flags & static_cast<unsigned int>(Flags::IsConstructor); }
     bool isStrict() const { return m_flags & static_cast<unsigned int>(Flags::IsStrict); }
     bool isNative() const { return m_flags & static_cast<unsigned int>(Flags::IsNative); }
 
-    void setLineNumber(int32_t lineNumber) { m_lineNumber = lineNumber; }
-    void setColumnNumber(int32_t columnNumber) { m_columnNumber = columnNumber; }
+    void setLineNumber(OrdinalNumber lineNumber) { m_lineNumber = lineNumber; }
+    void setColumnNumber(OrdinalNumber columnNumber) { m_columnNumber = columnNumber; }
 
     void formatAsString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::StringBuilder& sb);
 
 private:
     CallSite(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure)
-        , m_lineNumber(-1)
-        , m_columnNumber(-1)
+        , m_lineNumber(OrdinalNumber::beforeFirst())
+        , m_columnNumber(OrdinalNumber::beforeFirst())
         , m_flags(0)
     {
     }

--- a/src/bun.js/bindings/CallSitePrototype.cpp
+++ b/src/bun.js/bindings/CallSitePrototype.cpp
@@ -139,14 +139,14 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetLineNumber, (JSGlobalObject * globa
 {
     ENTER_PROTO_FUNC();
     // https://github.com/mozilla/source-map/blob/60adcb064bf033702d954d6d3f9bc3635dcb744b/lib/source-map-consumer.js#L484-L486
-    return JSC::JSValue::encode(jsNumber(std::max(callSite->lineNumber(), 1)));
+    return JSC::JSValue::encode(jsNumber(std::max(callSite->lineNumber().oneBasedInt(), 1)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetColumnNumber, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();
     // https://github.com/mozilla/source-map/blob/60adcb064bf033702d954d6d3f9bc3635dcb744b/lib/source-map-consumer.js#L488-L489
-    return JSC::JSValue::encode(jsNumber(std::max(callSite->columnNumber(), 0)));
+    return JSC::JSValue::encode(jsNumber(std::max(callSite->columnNumber().zeroBasedInt(), 0)));
 }
 
 // TODO:

--- a/src/bun.js/bindings/ErrorStackFrame.cpp
+++ b/src/bun.js/bindings/ErrorStackFrame.cpp
@@ -68,9 +68,9 @@ ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::
 
     /// JavaScriptCore places error divots at different places than v8
     // Uncomment to debug this:
-    printf("lc = %d : %d (byte = %d)\n", pos.line.oneBasedInt(), pos.column.oneBasedInt(), expr.divot);
-    printf("off = %d : %d\n", expr.startOffset, expr.endOffset);
-    printf("name = %s\n", inst->name());
+    // printf("lc = %d : %d (byte = %d)\n", pos.line.oneBasedInt(), pos.column.oneBasedInt(), expr.divot);
+    // printf("off = %d : %d\n", expr.startOffset, expr.endOffset);
+    // printf("name = %s\n", inst->name());
 
     switch (inst->opcodeID()) {
     case op_construct:

--- a/src/bun.js/bindings/ErrorStackFrame.cpp
+++ b/src/bun.js/bindings/ErrorStackFrame.cpp
@@ -1,0 +1,91 @@
+#include "root.h"
+#include "JavaScriptCore/CodeBlock.h"
+#include "headers-handwritten.h"
+#include "JavaScriptCore/BytecodeIndex.h"
+#include "wtf/Assertions.h"
+#include "wtf/text/OrdinalNumber.h"
+
+namespace Bun {
+using namespace JSC;
+
+/// Adjust a `ZigStackFramePosition` by a number of bytes. This accounts for when the adjustment
+/// crosses line boundaries, and thus requires the source code in order to properly compute
+/// the result.
+void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, CodeBlock* code)
+{
+    if (pos.byte_position - amount < 0) {
+        pos.line = OrdinalNumber::fromZeroBasedInt(0);
+        pos.column = OrdinalNumber::fromZeroBasedInt(0);
+        pos.byte_position = 0;
+        return;
+    }
+
+    pos.column = OrdinalNumber::fromZeroBasedInt(pos.column.zeroBasedInt() - amount);
+    if (pos.column.zeroBasedInt() < 0) {
+        auto source = code->source().provider()->source();
+        if (!source.is8Bit()) {
+            // Debug-only assertion
+            // Bun does not yet use 16-bit sources anywhere. The transpiler ensures everything
+            // fit's into latin1 / 8-bit strings for on-average lower memory usage.
+            ASSERT_NOT_REACHED("16-bit source re-mapping is not implemented here.");
+
+            pos.line = OrdinalNumber::fromZeroBasedInt(0);
+            pos.column = OrdinalNumber::fromZeroBasedInt(0);
+            pos.byte_position = 0;
+            return;
+        }
+
+        for (int i = 0; i < amount; i++) {
+            if (source[pos.byte_position - i] == '\n') {
+                pos.line = OrdinalNumber::fromZeroBasedInt(pos.line.zeroBasedInt() - 1);
+            }
+        }
+
+        int columns = 0;
+        // Initial -1 to skip the newline that gets counted.
+        int i = pos.byte_position - amount - 1;
+        while (i > 0 && source[i] != '\n') {
+            columns += 1;
+            i -= 1;
+        }
+        pos.column = OrdinalNumber::fromZeroBasedInt(columns);
+    }
+
+    pos.byte_position -= amount;
+}
+
+ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc)
+{
+    auto expr = code->expressionInfoForBytecodeIndex(bc);
+
+    ZigStackFramePosition pos {
+        .line = OrdinalNumber::fromOneBasedInt(expr.lineColumn.line),
+        .column = OrdinalNumber::fromOneBasedInt(expr.lineColumn.column),
+        .byte_position = (int)expr.divot,
+    };
+
+    auto inst = code->instructionAt(bc);
+
+    /// JavaScriptCore places error divots at different places than v8
+    // Uncomment to debug this:
+    printf("lc = %d : %d (byte = %d)\n", pos.line.oneBasedInt(), pos.column.oneBasedInt(), expr.divot);
+    printf("off = %d : %d\n", expr.startOffset, expr.endOffset);
+    printf("name = %s\n", inst->name());
+
+    switch (inst->opcodeID()) {
+    case op_construct:
+    case op_construct_varargs:
+        // The divot by default is pointing at the `(` or the end of the class name.
+        // We want to point at the `new` keyword, which is conveniently at the
+        // expression start.
+        adjustPositionBackwards(pos, expr.startOffset, code);
+        break;
+
+    default:
+        break;
+    }
+
+    return pos;
+}
+
+} // namespace Bun

--- a/src/bun.js/bindings/ErrorStackFrame.h
+++ b/src/bun.js/bindings/ErrorStackFrame.h
@@ -1,0 +1,9 @@
+#include "root.h"
+#include "headers-handwritten.h"
+#include "JavaScriptCore/BytecodeIndex.h"
+
+namespace Bun {
+
+ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
+
+} // namespace Bun

--- a/src/bun.js/bindings/ErrorStackTrace.cpp
+++ b/src/bun.js/bindings/ErrorStackTrace.cpp
@@ -5,6 +5,7 @@
 
 #include "config.h"
 #include "ErrorStackTrace.h"
+#include "JavaScriptCore/Error.h"
 #include "wtf/text/OrdinalNumber.h"
 
 #include <JavaScriptCore/CatchScope.h>
@@ -15,6 +16,8 @@
 #include <JavaScriptCore/StackVisitor.h>
 #include <JavaScriptCore/NativeCallee.h>
 #include <wtf/IterationStatus.h>
+
+#include "ErrorStackFrame.h"
 
 using namespace JSC;
 using namespace WebCore;
@@ -359,12 +362,13 @@ bool JSCStackFrame::calculateSourcePositions()
     if (!m_codeBlock) {
         return false;
     }
+    if (!hasBytecodeIndex()) {
+        return false;
+    }
 
-    JSC::BytecodeIndex bytecodeIndex = hasBytecodeIndex() ? m_bytecodeIndex : JSC::BytecodeIndex();
-
-    auto lineColumn = m_codeBlock->lineColumnForBytecodeIndex(bytecodeIndex);
-    m_sourcePositions.line = OrdinalNumber::fromOneBasedInt(lineColumn.line);
-    m_sourcePositions.column = OrdinalNumber::fromOneBasedInt(lineColumn.column);
+    auto location = Bun::getAdjustedPositionForBytecode(m_codeBlock, m_bytecodeIndex);
+    m_sourcePositions.line = location.line;
+    m_sourcePositions.column = location.column;
 
     return true;
 }

--- a/src/bun.js/bindings/ErrorStackTrace.cpp
+++ b/src/bun.js/bindings/ErrorStackTrace.cpp
@@ -367,8 +367,8 @@ bool JSCStackFrame::calculateSourcePositions()
     }
 
     auto location = Bun::getAdjustedPositionForBytecode(m_codeBlock, m_bytecodeIndex);
-    m_sourcePositions.line = location.line;
-    m_sourcePositions.column = location.column;
+    m_sourcePositions.line = location.line();
+    m_sourcePositions.column = location.column();
 
     return true;
 }

--- a/src/bun.js/bindings/ErrorStackTrace.cpp
+++ b/src/bun.js/bindings/ErrorStackTrace.cpp
@@ -5,6 +5,7 @@
 
 #include "config.h"
 #include "ErrorStackTrace.h"
+#include "wtf/text/OrdinalNumber.h"
 
 #include <JavaScriptCore/CatchScope.h>
 #include <JavaScriptCore/DebuggerPrimitives.h>
@@ -361,62 +362,9 @@ bool JSCStackFrame::calculateSourcePositions()
 
     JSC::BytecodeIndex bytecodeIndex = hasBytecodeIndex() ? m_bytecodeIndex : JSC::BytecodeIndex();
 
-    /* Get the "raw" position info.
-     * Note that we're using m_codeBlock->unlinkedCodeBlock()->expressionRangeForBytecodeOffset rather than m_codeBlock->expressionRangeForBytecodeOffset
-     * in order get the "raw" offsets and avoid the CodeBlock's expressionRangeForBytecodeOffset modifications to the line and column numbers,
-     * (we don't need the column number from it, and we'll calculate the line "fixes" ourselves). */
-    ExpressionInfo::Entry info = m_codeBlock->unlinkedCodeBlock()->expressionInfoForBytecodeIndex(bytecodeIndex);
-    info.divot += m_codeBlock->sourceOffset();
-
-    /* On the first line of the source code, it seems that we need to "fix" the column with the starting
-     * offset. We currently use codeBlock->source()->startPosition().m_column.oneBasedInt() as the
-     * offset in the first line rather than codeBlock->firstLineColumnOffset(), which seems simpler
-     * (and what CodeBlock::expressionRangeForBytecodeOffset does). This is because firstLineColumnOffset
-     * values seems different from what we expect (according to v8's tests) and I haven't dove into the
-     * relevant parts in JSC (yet) to figure out why. */
-    unsigned columnOffset = info.lineColumn.line ? 0 : m_codeBlock->source().startColumn().zeroBasedInt();
-
-    // "Fix" the line number
-    JSC::ScriptExecutable* executable = m_codeBlock->ownerExecutable();
-    info.lineColumn.line = executable->overrideLineNumber(m_vm).value_or(info.lineColumn.line + executable->firstLine());
-
-    // Calculate the staring\ending offsets of the entire expression
-    int expressionStart = info.divot - info.startOffset;
-    int expressionStop = info.divot + info.endOffset;
-
-    // Make sure the range is valid
-    StringView sourceString = m_codeBlock->source().provider()->source();
-    if (!expressionStop || expressionStart > static_cast<int>(sourceString.length())) {
-        return false;
-    }
-
-    // Search for the beginning of the line
-    unsigned int lineStart = expressionStart;
-    while ((lineStart > 0) && ('\n' != sourceString[lineStart - 1])) {
-        lineStart--;
-    }
-    // Search for the end of the line
-    unsigned int lineStop = expressionStop;
-    unsigned int sourceLength = sourceString.length();
-    while ((lineStop < sourceLength) && ('\n' != sourceString[lineStop])) {
-        lineStop++;
-    }
-
-    /* Finally, store the source "positions" info.
-     * Notes:
-     * - The retrieved column seem to point the "end column". To make sure we're current, we'll calculate the
-     *   columns ourselves, since we've already found where the line starts. Note that in v8 it should be 0-based
-     *   here (in contrast the 1-based column number in v8::StackFrame).
-     * - The static_casts are ugly, but comes from differences between JSC and v8's api, and should be OK
-     *   since no source should be longer than "max int" chars.
-     */
-    m_sourcePositions.expressionStart = WTF::OrdinalNumber::fromZeroBasedInt(expressionStart);
-    m_sourcePositions.expressionStop = WTF::OrdinalNumber::fromZeroBasedInt(expressionStop);
-    m_sourcePositions.line = WTF::OrdinalNumber::fromZeroBasedInt(static_cast<int>(info.lineColumn.line));
-    m_sourcePositions.startColumn = WTF::OrdinalNumber::fromZeroBasedInt((expressionStart - lineStart) + columnOffset);
-    m_sourcePositions.endColumn = WTF::OrdinalNumber::fromZeroBasedInt(m_sourcePositions.startColumn.zeroBasedInt() + (expressionStop - expressionStart));
-    m_sourcePositions.lineStart = WTF::OrdinalNumber::fromZeroBasedInt(static_cast<int>(lineStart));
-    m_sourcePositions.lineStop = WTF::OrdinalNumber::fromZeroBasedInt(static_cast<int>(lineStop));
+    auto lineColumn = m_codeBlock->lineColumnForBytecodeIndex(bytecodeIndex);
+    m_sourcePositions.line = OrdinalNumber::fromOneBasedInt(lineColumn.line);
+    m_sourcePositions.column = OrdinalNumber::fromOneBasedInt(lineColumn.column);
 
     return true;
 }

--- a/src/bun.js/bindings/ErrorStackTrace.h
+++ b/src/bun.js/bindings/ErrorStackTrace.h
@@ -18,7 +18,7 @@ namespace Zig {
 
 /* JSCStackFrame is an alternative to JSC::StackFrame, which provides the following advantages\changes:
  * - Also hold the call frame (ExecState). This is mainly used by CallSite to get "this value".
- * - More detailed and v8 compatible "source offsets" caculations: JSC::StackFrame only provides the
+ * - More detailed and v8 compatible "source offsets" calculations: JSC::StackFrame only provides the
  *   line number and column numbers. It's column calculation seems to be different than v8's column.
  *   According to v8's unit tests, it seems that their column number points to the beginning of
  *   the expression which raised the exception, while in JSC the column returned by computeLineAndColumn
@@ -34,19 +34,14 @@ namespace Zig {
  * - String properties are exposed (and cached) as JSStrings, instead of WTF::String.
  * - Helper functions like isEval and isConstructor.
  *
- * Note that this is not a heap allocated, garbage collected, JSCell. It must be stack allocated, as it doens't
+ * Note that this is not a heap allocated, garbage collected, JSCell. It must be stack allocated, as it doesn't
  * use any write barriers and rely on the GC to see the stored JSC object pointers on the stack.
  */
 class JSCStackFrame {
 public:
     struct SourcePositions {
-        WTF::OrdinalNumber expressionStart;
-        WTF::OrdinalNumber expressionStop;
         WTF::OrdinalNumber line;
-        WTF::OrdinalNumber startColumn;
-        WTF::OrdinalNumber endColumn;
-        WTF::OrdinalNumber lineStart;
-        WTF::OrdinalNumber lineStop;
+        WTF::OrdinalNumber column;
     };
 
 private:
@@ -97,7 +92,7 @@ public:
         return m_bytecodeIndex;
     }
 
-    // Returns null if can't retreive the source positions
+    // Returns null if can't retrieve the source positions
     SourcePositions* getSourcePositions();
 
     bool isWasmFrame() const { return m_isWasmFrame; }
@@ -111,7 +106,7 @@ private:
      * the same logic, which is to first try the function's "display name", and if it's not defined,
      * the function's name. In JSC, StackFrame::functionName uses JSC::getCalculatedDisplayName,
      * which will internally call the JSFunction\InternalFunction's calculatedDisplayName function.
-     * But, those function don't check the function's "name" property if the "dispaly name" isn't defined.
+     * But, those function don't check the function's "name" property if the "display name" isn't defined.
      * See JSFunction::name()'s and InternalFunction::name()'s implementation. According to v8's unit tests,
      * v8 does check the name property in StackFrame::GetFunctionName (see the last part of the
      * "CaptureStackTrace" test in test-api.cc).

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -148,7 +148,7 @@
 #include "UtilInspect.h"
 #include "Base64Helpers.h"
 #include "wtf/text/OrdinalNumber.h"
-#include <sys/_types/_int32_t.h>
+
 #if ENABLE(REMOTE_INSPECTOR)
 #include "JavaScriptCore/RemoteInspectorServer.h"
 #endif

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -302,14 +302,14 @@ static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalO
         }
     }
 
-    bool orignialSkipNextComputeErrorInfo = skipNextComputeErrorInfo;
+    bool originalSkipNextComputeErrorInfo = skipNextComputeErrorInfo;
     skipNextComputeErrorInfo = true;
     if (errorObject->hasProperty(lexicalGlobalObject, vm.propertyNames->stack)) {
         skipNextComputeErrorInfo = true;
         errorObject->deleteProperty(lexicalGlobalObject, vm.propertyNames->stack);
     }
 
-    skipNextComputeErrorInfo = orignialSkipNextComputeErrorInfo;
+    skipNextComputeErrorInfo = originalSkipNextComputeErrorInfo;
 
     JSValue stackStringValue = jsString(vm, sb.toString());
 
@@ -593,7 +593,7 @@ static String computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObje
             remappedFrames[i].source_url = Bun::toString(lexicalGlobalObject, stackTrace.at(i).sourceURL());
             if (JSCStackFrame::SourcePositions* sourcePositions = stackTrace.at(i).getSourcePositions()) {
                 remappedFrames[i].position.line = sourcePositions->line;
-                remappedFrames[i].position.column = sourcePositions->startColumn;
+                remappedFrames[i].position.column = sourcePositions->column;
             } else {
                 remappedFrames[i].position.line = OrdinalNumber::beforeFirst();
                 remappedFrames[i].position.column = OrdinalNumber::beforeFirst();
@@ -2484,7 +2484,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
         remappedFrames[i].source_url = Bun::toString(lexicalGlobalObject, stackTrace.at(i).sourceURL());
         if (JSCStackFrame::SourcePositions* sourcePositions = stackTrace.at(i).getSourcePositions()) {
             remappedFrames[i].position.line = sourcePositions->line;
-            remappedFrames[i].position.column = sourcePositions->startColumn;
+            remappedFrames[i].position.column = sourcePositions->column;
         } else {
             remappedFrames[i].position.line = OrdinalNumber::beforeFirst();
             remappedFrames[i].position.column = OrdinalNumber::beforeFirst();

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -387,8 +387,8 @@ WTF::String Bun::formatStackTrace(
                 ZigStackFrame remappedFrame = {};
                 memset(&remappedFrame, 0, sizeof(ZigStackFrame));
 
-                remappedFrame.position.line = originalLine;
-                remappedFrame.position.column = OrdinalNumber::fromZeroBasedInt(0);
+                remappedFrame.position.line_zero_based = originalLine.zeroBasedInt();
+                remappedFrame.position.column_zero_based = 0;
 
                 String sourceURLForFrame = err->sourceURL();
 
@@ -416,12 +416,12 @@ WTF::String Bun::formatStackTrace(
                 if (remappedFrame.remapped) {
                     errorInstance->putDirect(vm, Identifier::fromString(vm, "originalLine"_s), jsNumber(originalLine.oneBasedInt()), 0);
                     hasSet = true;
-                    line = remappedFrame.position.line;
+                    line = remappedFrame.position.line();
                 }
 
                 if (remappedFrame.remapped) {
                     sb.append(":"_s);
-                    sb.append(remappedFrame.position.line.oneBasedInt());
+                    sb.append(remappedFrame.position.line().oneBasedInt());
                 } else {
                     sb.append(":"_s);
                     sb.append(originalLine.oneBasedInt());
@@ -489,8 +489,8 @@ WTF::String Bun::formatStackTrace(
             OrdinalNumber thisLine = OrdinalNumber::fromOneBasedInt(lineColumn.line);
             OrdinalNumber thisColumn = OrdinalNumber::fromOneBasedInt(lineColumn.column);
             ZigStackFrame remappedFrame = {};
-            remappedFrame.position.line = thisLine;
-            remappedFrame.position.column = thisColumn;
+            remappedFrame.position.line_zero_based = thisLine.zeroBasedInt();
+            remappedFrame.position.column_zero_based = thisColumn.zeroBasedInt();
 
             String sourceURLForFrame = frame.sourceURL(vm);
 
@@ -524,9 +524,9 @@ WTF::String Bun::formatStackTrace(
             sb.append(" ("_s);
             sb.append(sourceURLForFrame);
             sb.append(":"_s);
-            sb.append(remappedFrame.position.line.oneBasedInt());
+            sb.append(remappedFrame.position.line().oneBasedInt());
             sb.append(":"_s);
-            sb.append(remappedFrame.position.column.oneBasedInt());
+            sb.append(remappedFrame.position.column().oneBasedInt());
             sb.append(")"_s);
         } else {
             sb.append(" (native)"_s);
@@ -592,11 +592,11 @@ static String computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObje
             remappedFrames[i] = {};
             remappedFrames[i].source_url = Bun::toString(lexicalGlobalObject, stackTrace.at(i).sourceURL());
             if (JSCStackFrame::SourcePositions* sourcePositions = stackTrace.at(i).getSourcePositions()) {
-                remappedFrames[i].position.line = sourcePositions->line;
-                remappedFrames[i].position.column = sourcePositions->column;
+                remappedFrames[i].position.line_zero_based = sourcePositions->line.zeroBasedInt();
+                remappedFrames[i].position.column_zero_based = sourcePositions->column.zeroBasedInt();
             } else {
-                remappedFrames[i].position.line = OrdinalNumber::beforeFirst();
-                remappedFrames[i].position.column = OrdinalNumber::beforeFirst();
+                remappedFrames[i].position.line_zero_based = -1;
+                remappedFrames[i].position.column_zero_based = -1;
             }
         }
 
@@ -606,8 +606,8 @@ static String computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObje
             JSC::JSValue callSiteValue = callSites->getIndex(lexicalGlobalObject, i);
             CallSite* callSite = JSC::jsDynamicCast<CallSite*>(callSiteValue);
             if (remappedFrames[i].remapped) {
-                callSite->setColumnNumber(remappedFrames[i].position.column);
-                callSite->setLineNumber(remappedFrames[i].position.line);
+                callSite->setColumnNumber(remappedFrames[i].position.column());
+                callSite->setLineNumber(remappedFrames[i].position.line());
             }
         }
     }
@@ -2483,11 +2483,11 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
         memset(remappedFrames + i, 0, sizeof(ZigStackFrame));
         remappedFrames[i].source_url = Bun::toString(lexicalGlobalObject, stackTrace.at(i).sourceURL());
         if (JSCStackFrame::SourcePositions* sourcePositions = stackTrace.at(i).getSourcePositions()) {
-            remappedFrames[i].position.line = sourcePositions->line;
-            remappedFrames[i].position.column = sourcePositions->column;
+            remappedFrames[i].position.line_zero_based = sourcePositions->line.zeroBasedInt();
+            remappedFrames[i].position.column_zero_based = sourcePositions->column.zeroBasedInt();
         } else {
-            remappedFrames[i].position.line = OrdinalNumber::beforeFirst();
-            remappedFrames[i].position.column = OrdinalNumber::beforeFirst();
+            remappedFrames[i].position.line_zero_based = -1;
+            remappedFrames[i].position.column_zero_based = -1;
         }
     }
 
@@ -2501,8 +2501,8 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
         JSC::JSValue callSiteValue = callSites->getIndex(lexicalGlobalObject, i);
         CallSite* callSite = JSC::jsDynamicCast<CallSite*>(callSiteValue);
         if (remappedFrames[i].remapped) {
-            callSite->setColumnNumber(remappedFrames[i].position.column);
-            callSite->setLineNumber(remappedFrames[i].position.line);
+            callSite->setColumnNumber(remappedFrames[i].position.column());
+            callSite->setLineNumber(remappedFrames[i].position.line());
         }
     }
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -147,6 +147,8 @@
 #include "ZigSourceProvider.h"
 #include "UtilInspect.h"
 #include "Base64Helpers.h"
+#include "wtf/text/OrdinalNumber.h"
+#include <sys/_types/_int32_t.h>
 #if ENABLE(REMOTE_INSPECTOR)
 #include "JavaScriptCore/RemoteInspectorServer.h"
 #endif
@@ -344,7 +346,16 @@ static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalO
     return stackStringValue;
 }
 
-WTF::String Bun::formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* globalObject, const WTF::String& name, const WTF::String& message, unsigned& line, unsigned& column, WTF::String& sourceURL, Vector<JSC::StackFrame>& stackTrace, JSC::JSObject* errorInstance)
+WTF::String Bun::formatStackTrace(
+    JSC::VM& vm,
+    JSC::JSGlobalObject* globalObject,
+    const WTF::String& name,
+    const WTF::String& message,
+    OrdinalNumber& line,
+    OrdinalNumber& column,
+    WTF::String& sourceURL,
+    Vector<JSC::StackFrame>& stackTrace,
+    JSC::JSObject* errorInstance)
 {
     WTF::StringBuilder sb;
 
@@ -376,8 +387,8 @@ WTF::String Bun::formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* globalObject
                 ZigStackFrame remappedFrame = {};
                 memset(&remappedFrame, 0, sizeof(ZigStackFrame));
 
-                remappedFrame.position.line = originalLine.zeroBasedInt() + 1;
-                remappedFrame.position.column_start = 0;
+                remappedFrame.position.line = originalLine;
+                remappedFrame.position.column = OrdinalNumber::fromZeroBasedInt(0);
 
                 String sourceURLForFrame = err->sourceURL();
 
@@ -410,7 +421,7 @@ WTF::String Bun::formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* globalObject
 
                 if (remappedFrame.remapped) {
                     sb.append(":"_s);
-                    sb.append(remappedFrame.position.line);
+                    sb.append(remappedFrame.position.line.oneBasedInt());
                 } else {
                     sb.append(":"_s);
                     sb.append(originalLine.oneBasedInt());
@@ -474,14 +485,12 @@ WTF::String Bun::formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* globalObject
         }
 
         if (frame.hasLineAndColumnInfo()) {
-            unsigned int thisLine = 0;
-            unsigned int thisColumn = 0;
             LineColumn lineColumn = frame.computeLineAndColumn();
-            thisLine = lineColumn.line;
-            thisColumn = lineColumn.column;
+            OrdinalNumber thisLine = OrdinalNumber::fromOneBasedInt(lineColumn.line);
+            OrdinalNumber thisColumn = OrdinalNumber::fromOneBasedInt(lineColumn.column);
             ZigStackFrame remappedFrame = {};
             remappedFrame.position.line = thisLine;
-            remappedFrame.position.column_start = thisColumn;
+            remappedFrame.position.column = thisColumn;
 
             String sourceURLForFrame = frame.sourceURL(vm);
 
@@ -506,8 +515,8 @@ WTF::String Bun::formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* globalObject
 
                 if (remappedFrame.remapped) {
                     if (errorInstance) {
-                        errorInstance->putDirect(vm, Identifier::fromString(vm, "originalLine"_s), jsNumber(thisLine), 0);
-                        errorInstance->putDirect(vm, Identifier::fromString(vm, "originalColumn"_s), jsNumber(thisColumn), 0);
+                        errorInstance->putDirect(vm, Identifier::fromString(vm, "originalLine"_s), jsNumber(thisLine.oneBasedInt()), 0);
+                        errorInstance->putDirect(vm, Identifier::fromString(vm, "originalColumn"_s), jsNumber(thisColumn.oneBasedInt()), 0);
                     }
                 }
             }
@@ -515,9 +524,9 @@ WTF::String Bun::formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* globalObject
             sb.append(" ("_s);
             sb.append(sourceURLForFrame);
             sb.append(":"_s);
-            sb.append(remappedFrame.position.line);
+            sb.append(remappedFrame.position.line.oneBasedInt());
             sb.append(":"_s);
-            sb.append(remappedFrame.position.column_start);
+            sb.append(remappedFrame.position.column.oneBasedInt());
             sb.append(")"_s);
         } else {
             sb.append(" (native)"_s);
@@ -532,7 +541,14 @@ WTF::String Bun::formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* globalObject
 }
 
 // error.stack calls this function
-static String computeErrorInfoWithoutPrepareStackTrace(JSC::VM& vm, Zig::GlobalObject* globalObject, Vector<StackFrame>& stackTrace, unsigned& line, unsigned& column, String& sourceURL, JSObject* errorInstance)
+static String computeErrorInfoWithoutPrepareStackTrace(
+    JSC::VM& vm,
+    Zig::GlobalObject* globalObject,
+    Vector<StackFrame>& stackTrace,
+    OrdinalNumber& line,
+    OrdinalNumber& column,
+    String& sourceURL,
+    JSObject* errorInstance)
 {
 
     WTF::String name = "Error"_s;
@@ -554,7 +570,7 @@ static String computeErrorInfoWithoutPrepareStackTrace(JSC::VM& vm, Zig::GlobalO
     return Bun::formatStackTrace(vm, globalObject, name, message, line, column, sourceURL, stackTrace, errorInstance);
 }
 
-static String computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, Vector<StackFrame>& stackFrames, unsigned& line, unsigned& column, String& sourceURL, JSObject* errorObject, JSObject* prepareStackTrace)
+static String computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, Vector<StackFrame>& stackFrames, OrdinalNumber& line, OrdinalNumber& column, String& sourceURL, JSObject* errorObject, JSObject* prepareStackTrace)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -576,11 +592,11 @@ static String computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObje
             remappedFrames[i] = {};
             remappedFrames[i].source_url = Bun::toString(lexicalGlobalObject, stackTrace.at(i).sourceURL());
             if (JSCStackFrame::SourcePositions* sourcePositions = stackTrace.at(i).getSourcePositions()) {
-                remappedFrames[i].position.line = sourcePositions->line.oneBasedInt();
-                remappedFrames[i].position.column_start = sourcePositions->startColumn.oneBasedInt() + 1;
+                remappedFrames[i].position.line = sourcePositions->line;
+                remappedFrames[i].position.column = sourcePositions->startColumn;
             } else {
-                remappedFrames[i].position.line = -1;
-                remappedFrames[i].position.column_start = -1;
+                remappedFrames[i].position.line = OrdinalNumber::beforeFirst();
+                remappedFrames[i].position.column = OrdinalNumber::beforeFirst();
             }
         }
 
@@ -590,11 +606,8 @@ static String computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObje
             JSC::JSValue callSiteValue = callSites->getIndex(lexicalGlobalObject, i);
             CallSite* callSite = JSC::jsDynamicCast<CallSite*>(callSiteValue);
             if (remappedFrames[i].remapped) {
-                int32_t remappedColumnStart = remappedFrames[i].position.column_start;
-                callSite->setColumnNumber(remappedColumnStart);
-
-                int32_t remappedLine = remappedFrames[i].position.line;
-                callSite->setLineNumber(remappedLine);
+                callSite->setColumnNumber(remappedFrames[i].position.column);
+                callSite->setLineNumber(remappedFrames[i].position.line);
             }
         }
     }
@@ -614,11 +627,14 @@ static String computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObje
     return String();
 }
 
-static String computeErrorInfo(JSC::VM& vm, Vector<StackFrame>& stackTrace, unsigned& line, unsigned& column, String& sourceURL, JSObject* errorInstance)
+static String computeErrorInfo(JSC::VM& vm, Vector<StackFrame>& stackTrace, unsigned& line_in, unsigned& column_in, String& sourceURL, JSObject* errorInstance)
 {
     if (skipNextComputeErrorInfo) {
         return String();
     }
+
+    OrdinalNumber line = OrdinalNumber::fromOneBasedInt(line_in);
+    OrdinalNumber column = OrdinalNumber::fromOneBasedInt(column_in);
 
     Zig::GlobalObject* globalObject = nullptr;
 
@@ -2467,11 +2483,11 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
         memset(remappedFrames + i, 0, sizeof(ZigStackFrame));
         remappedFrames[i].source_url = Bun::toString(lexicalGlobalObject, stackTrace.at(i).sourceURL());
         if (JSCStackFrame::SourcePositions* sourcePositions = stackTrace.at(i).getSourcePositions()) {
-            remappedFrames[i].position.line = sourcePositions->line.oneBasedInt();
-            remappedFrames[i].position.column_start = sourcePositions->startColumn.oneBasedInt() + 1;
+            remappedFrames[i].position.line = sourcePositions->line;
+            remappedFrames[i].position.column = sourcePositions->startColumn;
         } else {
-            remappedFrames[i].position.line = -1;
-            remappedFrames[i].position.column_start = -1;
+            remappedFrames[i].position.line = OrdinalNumber::beforeFirst();
+            remappedFrames[i].position.column = OrdinalNumber::beforeFirst();
         }
     }
 
@@ -2485,11 +2501,8 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
         JSC::JSValue callSiteValue = callSites->getIndex(lexicalGlobalObject, i);
         CallSite* callSite = JSC::jsDynamicCast<CallSite*>(callSiteValue);
         if (remappedFrames[i].remapped) {
-            int32_t remappedColumnStart = remappedFrames[i].position.column_start;
-            callSite->setColumnNumber(remappedColumnStart);
-
-            int32_t remappedLine = remappedFrames[i].position.line;
-            callSite->setLineNumber(remappedLine);
+            callSite->setColumnNumber(remappedFrames[i].position.column);
+            callSite->setLineNumber(remappedFrames[i].position.line);
         }
     }
 

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -588,7 +588,7 @@ public:
 // TODO: move this
 namespace Bun {
 
-String formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* globalObject, const WTF::String& name, const WTF::String& message, unsigned& line, unsigned& column, WTF::String& sourceURL, Vector<JSC::StackFrame>& stackTrace, JSC::JSObject* errorInstance);
+String formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* globalObject, const WTF::String& name, const WTF::String& message, OrdinalNumber& line, OrdinalNumber& column, WTF::String& sourceURL, Vector<JSC::StackFrame>& stackTrace, JSC::JSObject* errorInstance);
 
 }
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -53,6 +53,7 @@
 
 #include "wtf/Assertions.h"
 #include "wtf/text/ExternalStringImpl.h"
+#include "wtf/text/OrdinalNumber.h"
 #include "wtf/text/StringCommon.h"
 #include "wtf/text/StringImpl.h"
 #include "wtf/text/StringView.h"
@@ -3898,83 +3899,52 @@ static void populateStackFrameMetadata(JSC::VM& vm, const JSC::StackFrame* stack
         frame->function_name = Bun::toStringRef(JSC::getCalculatedDisplayName(vm, callee));
     }
 }
-// Based on
-// https://github.com/mceSystems/node-jsc/blob/master/deps/jscshim/src/shim/JSCStackTrace.cpp#L298
+
 static void populateStackFramePosition(const JSC::StackFrame* stackFrame, BunString* source_lines,
-    int32_t* source_line_numbers, uint8_t source_lines_count,
+    OrdinalNumber* source_line_numbers, uint8_t source_lines_count,
     ZigStackFramePosition* position)
 {
     auto m_codeBlock = stackFrame->codeBlock();
     if (!m_codeBlock)
         return;
 
-    // https://github.com/oven-sh/bun/issues/6951
     auto* provider = m_codeBlock->source().provider();
-
     if (UNLIKELY(!provider))
         return;
-
-    // Make sure the range is valid
+    // Make sure the range is valid:
+    // https://github.com/oven-sh/bun/issues/6951
     WTF::StringView sourceString = provider->source();
-
     if (UNLIKELY(sourceString.isNull()))
         return;
 
     JSC::BytecodeIndex bytecodeOffset = stackFrame->hasBytecodeIndex() ? stackFrame->bytecodeIndex() : JSC::BytecodeIndex();
 
-    /* Get the "raw" position info.
-     * Note that we're using m_codeBlock->unlinkedCodeBlock()->expressionRangeForBytecodeOffset
-     * rather than m_codeBlock->expressionRangeForBytecodeOffset in order get the "raw" offsets and
-     * avoid the CodeBlock's expressionRangeForBytecodeOffset modifications to the line and column
-     * numbers, (we don't need the column number from it, and we'll calculate the line "fixes"
-     * ourselves). */
-    ExpressionInfo::Entry info = m_codeBlock->unlinkedCodeBlock()->expressionInfoForBytecodeIndex(bytecodeOffset);
-    info.divot += m_codeBlock->sourceOffset();
+    auto expr = m_codeBlock->expressionInfoForBytecodeIndex(bytecodeOffset);
+    OrdinalNumber line = OrdinalNumber::fromOneBasedInt(expr.lineColumn.line);
+    OrdinalNumber column = OrdinalNumber::fromOneBasedInt(expr.lineColumn.column);
 
-    // TODO: evaluate if using the API from UnlinkedCodeBlock can be used instead of iterating
-    // through source text.
+    position->line = line;
+    position->column = column;
 
-    /* On the first line of the source code, it seems that we need to "fix" the column with the
-     * starting offset. We currently use codeBlock->source()->startPosition().m_column.oneBasedInt()
-     * as the offset in the first line rather than codeBlock->firstLineColumnOffset(), which seems
-     * simpler (and what CodeBlock::expressionRangeForBytecodeOffset does). This is because
-     * firstLineColumnOffset values seems different from what we expect (according to v8's tests)
-     * and I haven't dove into the relevant parts in JSC (yet) to figure out why. */
-    unsigned columnOffset = info.lineColumn.line ? 0 : m_codeBlock->source().startColumn().zeroBasedInt();
-
-    // "Fix" the line number
-    JSC::ScriptExecutable* executable = m_codeBlock->ownerExecutable();
-    if (std::optional<int> overrideLine = executable->overrideLineNumber(m_codeBlock->vm())) {
-        info.lineColumn.line = overrideLine.value();
-    } else {
-        info.lineColumn.line += executable->firstLine();
-    }
-
-    // Calculate the staring\ending offsets of the entire expression
-    int expressionStart = info.divot - info.startOffset;
-    int expressionStop = info.divot + info.endOffset;
-    if (expressionStop < 1 || expressionStart > static_cast<int>(sourceString.length())) {
-        return;
-    }
-
-    // Search for the beginning of the line
-    unsigned int lineStart = expressionStart > 0 ? expressionStart : 0;
-    while ((lineStart > 0) && ('\n' != sourceString[lineStart - 1])) {
-        lineStart--;
-    }
-    // Search for the end of the line
-    unsigned int lineStop = expressionStop;
-    unsigned int sourceLength = sourceString.length();
-    while ((lineStop < sourceLength) && ('\n' != sourceString[lineStop])) {
-        lineStop++;
-    }
     if (source_lines_count > 1 && source_lines != nullptr && sourceString.is8Bit()) {
-        auto chars = sourceString.span8().data();
+        // Search for the beginning of the line
+        unsigned int lineStart = expr.divot;
+        while (lineStart > 0 && sourceString[lineStart] != '\n') {
+            lineStart--;
+        }
+
+        // Search for the end of the line
+        unsigned int lineEnd = expr.divot;
+        unsigned int maxSearch = sourceString.length();
+        while (lineEnd < maxSearch && sourceString[lineEnd] != '\n') {
+            lineEnd++;
+        }
+
+        const unsigned char* bytes = sourceString.span8().data();
 
         // Most of the time, when you look at a stack trace, you want a couple lines above
-
-        source_lines[0] = Bun::toStringRef(sourceString.substring(lineStart, lineStop - lineStart).toStringWithoutCopying());
-        source_line_numbers[0] = info.lineColumn.line - 1;
+        source_lines[0] = Bun::toStringRef(sourceString.substring(lineStart, lineEnd - lineStart).toStringWithoutCopying());
+        source_line_numbers[0] = line;
 
         if (lineStart > 0) {
             auto byte_offset_in_source_string = lineStart - 1;
@@ -3983,9 +3953,10 @@ static void populateStackFramePosition(const JSC::StackFrame* stackFrame, BunStr
 
             {
                 // This should probably be code points instead of newlines
-                while (byte_offset_in_source_string > 0 && chars[byte_offset_in_source_string] != '\n') {
+                while (byte_offset_in_source_string > 0 && bytes[byte_offset_in_source_string] != '\n') {
                     byte_offset_in_source_string--;
                 }
+
                 byte_offset_in_source_string -= byte_offset_in_source_string > 0;
             }
 
@@ -3993,14 +3964,16 @@ static void populateStackFramePosition(const JSC::StackFrame* stackFrame, BunStr
                 unsigned int end_of_line_offset = byte_offset_in_source_string;
 
                 // This should probably be code points instead of newlines
-                while (byte_offset_in_source_string > 0 && chars[byte_offset_in_source_string] != '\n') {
+                while (byte_offset_in_source_string > 0 && bytes[byte_offset_in_source_string] != '\n') {
                     byte_offset_in_source_string--;
                 }
 
                 // We are at the beginning of the line
-                source_lines[source_line_i] = Bun::toStringRef(sourceString.substring(byte_offset_in_source_string, end_of_line_offset - byte_offset_in_source_string + 1).toStringWithoutCopying());
+                source_lines[source_line_i] = Bun::toStringRef(
+                    sourceString.substring(byte_offset_in_source_string, end_of_line_offset - byte_offset_in_source_string + 1)
+                        .toStringWithoutCopying());
 
-                source_line_numbers[source_line_i] = info.lineColumn.line - source_line_i - 1;
+                source_line_numbers[source_line_i] = line.fromZeroBasedInt(line.zeroBasedInt() - source_line_i);
                 source_line_i++;
 
                 remaining_lines_to_grab--;
@@ -4009,27 +3982,8 @@ static void populateStackFramePosition(const JSC::StackFrame* stackFrame, BunStr
             }
         }
     }
-
-    /* Finally, store the source "positions" info.
-     * Notes:
-     * - The retrieved column seem to point the "end column". To make sure we're current, we'll
-     *calculate the columns ourselves, since we've already found where the line starts. Note that in
-     *v8 it should be 0-based here (in contrast the 1-based column number in v8::StackFrame).
-     * - The static_casts are ugly, but comes from differences between JSC and v8's api, and should
-     *be OK since no source should be longer than "max int" chars.
-     * TODO: If expressionStart == expressionStop, then m_endColumn will be equal to m_startColumn.
-     *Should we handle this case?
-     */
-    position->expression_start = expressionStart;
-    position->expression_stop = expressionStop;
-    position->line = WTF::OrdinalNumber::fromOneBasedInt(static_cast<int>(info.lineColumn.line)).zeroBasedInt();
-    position->column_start = (expressionStart - lineStart) + columnOffset;
-    position->column_stop = position->column_start + (expressionStop - expressionStart);
-    position->line_start = lineStart;
-    position->line_stop = lineStop;
-
-    return;
 }
+
 static void populateStackFrame(JSC::VM& vm, ZigStackTrace* trace, const JSC::StackFrame* stackFrame,
     ZigStackFrame* frame, bool is_top)
 {
@@ -4237,6 +4191,7 @@ static void fromErrorInstance(ZigException* except, JSC::JSGlobalObject* global,
 {
     JSC::JSObject* obj = JSC::jsDynamicCast<JSC::JSObject*>(val);
     JSC::VM& vm = global->vm();
+    printf("wAH");
 
     bool getFromSourceURL = false;
     if (stackTrace != nullptr && stackTrace->size() > 0) {
@@ -4314,9 +4269,8 @@ static void fromErrorInstance(ZigException* except, JSC::JSGlobalObject* global,
                     String sourceURL = frame.sourceURL.toString();
                     current.function_name = Bun::toStringRef(functionName);
                     current.source_url = Bun::toStringRef(sourceURL);
-                    current.position.line = frame.lineNumber.zeroBasedInt();
-                    current.position.column_start = frame.columnNumber.zeroBasedInt();
-                    current.position.column_stop = frame.columnNumber.zeroBasedInt();
+                    current.position.line = frame.lineNumber;
+                    current.position.column = frame.columnNumber;
 
                     current.remapped = true;
 
@@ -4345,11 +4299,11 @@ static void fromErrorInstance(ZigException* except, JSC::JSGlobalObject* global,
                 except->stack.frames_ptr[0].source_url = Bun::toStringRef(global, sourceURL);
 
                 if (JSC::JSValue column = obj->getIfPropertyExists(global, vm.propertyNames->column)) {
-                    except->stack.frames_ptr[0].position.column_start = column.toInt32(global);
+                    except->stack.frames_ptr[0].position.column = OrdinalNumber::fromOneBasedInt(column.toInt32(global));
                 }
 
                 if (JSC::JSValue line = obj->getIfPropertyExists(global, vm.propertyNames->line)) {
-                    except->stack.frames_ptr[0].position.line = line.toInt32(global);
+                    except->stack.frames_ptr[0].position.line = OrdinalNumber::fromOneBasedInt(line.toInt32(global));
 
                     if (JSC::JSValue lineText = obj->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "lineText"_s))) {
                         if (JSC::JSString* jsStr = lineText.toStringOrNull(global)) {
@@ -4417,9 +4371,9 @@ void exceptionFromString(ZigException* except, JSC::JSValue value, JSC::JSGlobal
             if (line) {
                 // TODO: don't sourcemap it twice
                 if (auto originalLine = obj->getIfPropertyExists(global, JSC::Identifier::fromString(global->vm(), "originalLine"_s))) {
-                    except->stack.frames_ptr[0].position.line = originalLine.toInt32(global);
+                    except->stack.frames_ptr[0].position.line = OrdinalNumber::fromOneBasedInt(originalLine.toInt32(global));
                 } else {
-                    except->stack.frames_ptr[0].position.line = line.toInt32(global);
+                    except->stack.frames_ptr[0].position.line = OrdinalNumber::fromOneBasedInt(line.toInt32(global));
                 }
                 except->stack.frames_len = 1;
             }

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4191,7 +4191,6 @@ static void fromErrorInstance(ZigException* except, JSC::JSGlobalObject* global,
 {
     JSC::JSObject* obj = JSC::jsDynamicCast<JSC::JSObject*>(val);
     JSC::VM& vm = global->vm();
-    printf("wAH");
 
     bool getFromSourceURL = false;
     if (stackTrace != nullptr && stackTrace->size() > 0) {

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3925,6 +3925,7 @@ static void populateStackFramePosition(const JSC::StackFrame* stackFrame, BunStr
 
     position->line = line;
     position->column = column;
+    position->byte_position = expr.divot;
 
     if (source_lines_count > 1 && source_lines != nullptr && sourceString.is8Bit()) {
         // Search for the beginning of the line

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -556,17 +556,7 @@ pub const ZigStackFrame = extern struct {
             frame.file = try std.fmt.allocPrint(allocator, "{}", .{this.sourceURLFormatter(root_path, origin, true, false)});
         }
 
-        // frame.position.source_offset = this.position.source_offset;
-
-        // For remapped code, we add 1 to the line number
-        // frame.position.line = this.position.line + @as(i32, @intFromBool(this.remapped));
-
-        frame.position.line = this.position.line;
-        frame.position.column = this.position.column;
-        // frame.position.column_start = this.position.column_start;
-        // frame.position.column_stop = this.position.column_stop;
-        // frame.position.expression_start = this.position.expression_start;
-        // frame.position.expression_stop = this.position.expression_stop;
+        frame.position = this.position;
         frame.scope = @as(Api.StackFrameScope, @enumFromInt(@intFromEnum(this.code_type)));
 
         return frame;

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -553,20 +553,20 @@ pub const ZigStackFrame = extern struct {
         }
 
         if (!this.source_url.isEmpty()) {
-            frame.file = try std.fmt.allocPrint(allocator, "{any}", .{this.sourceURLFormatter(root_path, origin, true, false)});
+            frame.file = try std.fmt.allocPrint(allocator, "{}", .{this.sourceURLFormatter(root_path, origin, true, false)});
         }
 
-        frame.position.source_offset = this.position.source_offset;
+        // frame.position.source_offset = this.position.source_offset;
 
         // For remapped code, we add 1 to the line number
-        frame.position.line = this.position.line + @as(i32, @intFromBool(this.remapped));
+        // frame.position.line = this.position.line + @as(i32, @intFromBool(this.remapped));
 
-        frame.position.line_start = this.position.line_start;
-        frame.position.line_stop = this.position.line_stop;
-        frame.position.column_start = this.position.column_start;
-        frame.position.column_stop = this.position.column_stop;
-        frame.position.expression_start = this.position.expression_start;
-        frame.position.expression_stop = this.position.expression_stop;
+        frame.position.line = this.position.line;
+        frame.position.column = this.position.column;
+        // frame.position.column_start = this.position.column_start;
+        // frame.position.column_stop = this.position.column_stop;
+        // frame.position.expression_start = this.position.expression_start;
+        // frame.position.expression_stop = this.position.expression_stop;
         frame.scope = @as(Api.StackFrameScope, @enumFromInt(@intFromEnum(this.code_type)));
 
         return frame;
@@ -580,6 +580,7 @@ pub const ZigStackFrame = extern struct {
         exclude_line_column: bool = false,
         remapped: bool = false,
         root_path: string = "",
+
         pub fn format(this: SourceURLFormatter, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
             if (this.enable_color) {
                 try writer.writeAll(Output.prettyFmt("<r><cyan>", true));
@@ -607,7 +608,7 @@ pub const ZigStackFrame = extern struct {
             try writer.writeAll(source_slice);
 
             if (this.enable_color) {
-                if (this.position.line > -1) {
+                if (this.position.line.isValid()) {
                     try writer.writeAll(comptime Output.prettyFmt("<r>", true));
                 } else {
                     try writer.writeAll(comptime Output.prettyFmt("<r>", true));
@@ -615,29 +616,31 @@ pub const ZigStackFrame = extern struct {
             }
 
             if (!this.exclude_line_column) {
-                if (this.position.line > -1 and this.position.column_start > -1) {
+                if (this.position.line.isValid() and this.position.column.isValid()) {
                     if (this.enable_color) {
                         try std.fmt.format(
                             writer,
-                            // :
                             comptime Output.prettyFmt("<d>:<r><yellow>{d}<r><d>:<yellow>{d}<r>", true),
-                            .{ this.position.line + 1, this.position.column_start + 1 },
+                            .{ this.position.line.oneBased(), this.position.column.oneBased() },
                         );
                     } else {
-                        try std.fmt.format(writer, ":{d}:{d}", .{ this.position.line + 1, this.position.column_start + 1 });
+                        try std.fmt.format(writer, ":{d}:{d}", .{
+                            this.position.line.oneBased(),
+                            this.position.column.oneBased(),
+                        });
                     }
-                } else if (this.position.line > -1) {
+                } else if (this.position.line.isValid()) {
                     if (this.enable_color) {
                         try std.fmt.format(
                             writer,
                             comptime Output.prettyFmt("<d>:<r><yellow>{d}<r>", true),
                             .{
-                                this.position.line + 1,
+                                this.position.line.oneBased(),
                             },
                         );
                     } else {
                         try std.fmt.format(writer, ":{d}", .{
-                            this.position.line + 1,
+                            this.position.line.oneBased(),
                         });
                     }
                 }
@@ -716,27 +719,31 @@ pub const ZigStackFrame = extern struct {
 };
 
 pub const ZigStackFramePosition = extern struct {
-    source_offset: i32,
-    line: i32,
-    line_start: i32,
-    line_stop: i32,
-    column_start: i32,
-    column_stop: i32,
-    expression_start: i32,
-    expression_stop: i32,
+    line: bun.Ordinal,
+    column: bun.Ordinal,
+    /// -1 if not present
+    line_start_byte: c_int,
 
     pub const Invalid = ZigStackFramePosition{
-        .source_offset = -1,
-        .line = -1,
-        .line_start = -1,
-        .line_stop = -1,
-        .column_start = -1,
-        .column_stop = -1,
-        .expression_start = -1,
-        .expression_stop = -1,
+        .line = .invalid,
+        .column = .invalid,
+        .line_start_byte = -1,
     };
+
     pub fn isInvalid(this: *const ZigStackFramePosition) bool {
         return std.mem.eql(u8, std.mem.asBytes(this), std.mem.asBytes(&Invalid));
+    }
+
+    pub fn decode(reader: anytype) !@This() {
+        return .{
+            .line = bun.Ordinal.fromZeroBased(try reader.readValue(i32)),
+            .column = bun.Ordinal.fromZeroBased(try reader.readValue(i32)),
+        };
+    }
+
+    pub fn encode(this: *const @This(), writer: anytype) anyerror!void {
+        try writer.writeInt(this.line.zeroBased());
+        try writer.writeInt(this.column.zeroBased());
     }
 };
 

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -141,6 +141,7 @@ const ZigStackFrameCode ZigStackFrameCodeConstructor = 6;
 typedef struct ZigStackFramePosition {
     WTF::OrdinalNumber line;
     WTF::OrdinalNumber column;
+    int byte_position;
 } ZigStackFramePosition;
 
 typedef struct ZigStackFrame {

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "wtf/Compiler.h"
 #include "wtf/text/OrdinalNumber.h"
 #ifndef HEADERS_HANDWRITTEN
 #define HEADERS_HANDWRITTEN
@@ -139,9 +140,18 @@ const ZigStackFrameCode ZigStackFrameCodeWasm = 5;
 const ZigStackFrameCode ZigStackFrameCodeConstructor = 6;
 
 typedef struct ZigStackFramePosition {
-    WTF::OrdinalNumber line;
-    WTF::OrdinalNumber column;
-    int byte_position;
+    int32_t line_zero_based;
+    int32_t column_zero_based;
+    int32_t byte_position;
+
+    ALWAYS_INLINE WTF::OrdinalNumber column()
+    {
+        return OrdinalNumber::fromZeroBasedInt(this->column_zero_based);
+    }
+    ALWAYS_INLINE WTF::OrdinalNumber line()
+    {
+        return OrdinalNumber::fromZeroBasedInt(this->line_zero_based);
+    }
 } ZigStackFramePosition;
 
 typedef struct ZigStackFrame {

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "wtf/text/OrdinalNumber.h"
 #ifndef HEADERS_HANDWRITTEN
 #define HEADERS_HANDWRITTEN
 typedef uint16_t ZigErrorCode;
@@ -138,14 +139,8 @@ const ZigStackFrameCode ZigStackFrameCodeWasm = 5;
 const ZigStackFrameCode ZigStackFrameCodeConstructor = 6;
 
 typedef struct ZigStackFramePosition {
-    int32_t source_offset;
-    int32_t line;
-    int32_t line_start;
-    int32_t line_stop;
-    int32_t column_start;
-    int32_t column_stop;
-    int32_t expression_start;
-    int32_t expression_stop;
+    WTF::OrdinalNumber line;
+    WTF::OrdinalNumber column;
 } ZigStackFramePosition;
 
 typedef struct ZigStackFrame {
@@ -158,7 +153,7 @@ typedef struct ZigStackFrame {
 
 typedef struct ZigStackTrace {
     BunString* source_lines_ptr;
-    int32_t* source_lines_numbers;
+    OrdinalNumber* source_lines_numbers;
     uint8_t source_lines_len;
     uint8_t source_lines_to_collect;
     ZigStackFrame* frames_ptr;

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -3001,7 +3001,6 @@ pub const VirtualMachine = struct {
                     line_number.* = current_line_number;
                     current_line_number -= 1;
                 }
-                
 
                 exception.stack.source_lines_len = @as(u8, @truncate(lines.len));
             }

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -97,6 +97,8 @@ const BuildMessage = JSC.BuildMessage;
 const ResolveMessage = JSC.ResolveMessage;
 const Async = bun.Async;
 
+const Ordinal = bun.Ordinal;
+
 pub const OpaqueCallback = *const fn (current: ?*anyopaque) callconv(.C) void;
 pub fn OpaqueWrap(comptime Context: type, comptime Function: fn (this: *Context) void) OpaqueCallback {
     return struct {
@@ -2820,8 +2822,8 @@ pub const VirtualMachine = struct {
 
             if (this.source_mappings.resolveMapping(
                 sourceURL.slice(),
-                @max(frame.position.line, 0),
-                @max(frame.position.column_start, 0),
+                @max(frame.position.line.zeroBased(), 0),
+                @max(frame.position.column.zeroBased(), 0),
                 .no_source_contents,
             )) |lookup| {
                 if (lookup.displaySourceURLIfNeeded(sourceURL.slice())) |source_url| {
@@ -2829,8 +2831,8 @@ pub const VirtualMachine = struct {
                     frame.source_url = source_url;
                 }
                 const mapping = lookup.mapping;
-                frame.position.line = mapping.original.lines;
-                frame.position.column_start = mapping.original.columns;
+                frame.position.line = Ordinal.fromZeroBased(mapping.original.lines);
+                frame.position.column = Ordinal.fromZeroBased(mapping.original.columns);
                 frame.remapped = true;
             } else {
                 // we don't want it to be remapped again
@@ -2930,8 +2932,8 @@ pub const VirtualMachine = struct {
                 .mapping = .{
                     .generated = .{},
                     .original = .{
-                        .lines = @max(top.position.line, 0),
-                        .columns = @max(top.position.column_start, 0),
+                        .lines = @max(top.position.line.zeroBased(), 0),
+                        .columns = @max(top.position.column.zeroBased(), 0),
                     },
                     .source_index = 0,
                 },
@@ -2942,8 +2944,8 @@ pub const VirtualMachine = struct {
         else
             this.source_mappings.resolveMapping(
                 top_source_url.slice(),
-                @max(top.position.line, 0),
-                @max(top.position.column_start, 0),
+                @max(top.position.line.zeroBased(), 0),
+                @max(top.position.column.zeroBased(), 0),
                 .source_contents,
             );
 
@@ -2972,18 +2974,13 @@ pub const VirtualMachine = struct {
             };
             source_code_slice.* = code;
 
-            top.position.line = mapping.original.lines;
-            top.position.line_start = mapping.original.lines;
-            top.position.line_stop = mapping.original.lines + 1;
-            top.position.column_start = mapping.original.columns;
-            top.position.column_stop = mapping.original.columns + 1;
+            top.position.line = Ordinal.fromZeroBased(mapping.original.lines);
+            top.position.column = Ordinal.fromZeroBased(mapping.original.columns);
+
             exception.remapped = true;
             top.remapped = true;
-            // This expression range is no longer accurate
-            top.position.expression_start = mapping.original.columns;
-            top.position.expression_stop = mapping.original.columns + 1;
 
-            const last_line = @max(top.position.line, 0);
+            const last_line = @max(top.position.line.zeroBased(), 0);
             if (strings.getLinesInText(
                 code.slice(),
                 @intCast(last_line),
@@ -3007,12 +3004,12 @@ pub const VirtualMachine = struct {
 
                 exception.stack.source_lines_len = @as(u8, @truncate(lines.len));
 
-                top.position.column_stop = @as(i32, @intCast(source_lines[lines.len - 1].length()));
-                top.position.line_stop = top.position.column_stop;
+                // top.position.column_stop = @as(i32, @intCast(source_lines[lines.len - 1].length()));
+                // top.position.line_stop = top.position.column_stop;
 
                 // This expression range is no longer accurate
-                top.position.expression_start = mapping.original.columns;
-                top.position.expression_stop = top.position.column_stop;
+                // top.position.expression_start = mapping.original.columns;
+                // top.position.expression_stop = top.position.column_stop;
             }
         }
 
@@ -3023,8 +3020,8 @@ pub const VirtualMachine = struct {
                 defer source_url.deinit();
                 if (this.source_mappings.resolveMapping(
                     source_url.slice(),
-                    @max(frame.position.line, 0),
-                    @max(frame.position.column_start, 0),
+                    @max(frame.position.line.zeroBased(), 0),
+                    @max(frame.position.column.zeroBased(), 0),
                     .no_source_contents,
                 )) |lookup| {
                     if (lookup.displaySourceURLIfNeeded(source_url.slice())) |src| {
@@ -3032,9 +3029,9 @@ pub const VirtualMachine = struct {
                         frame.source_url = src;
                     }
                     const mapping = lookup.mapping;
-                    frame.position.line = mapping.original.lines;
                     frame.remapped = true;
-                    frame.position.column_start = mapping.original.columns;
+                    frame.position.line = Ordinal.fromZeroBased(mapping.original.lines);
+                    frame.position.column = Ordinal.fromZeroBased(mapping.original.columns);
                 }
             }
         }
@@ -3183,8 +3180,8 @@ pub const VirtualMachine = struct {
                         .{ display_line, bun.fmt.fmtJavaScript(clamped, allow_ansi_color) },
                     );
 
-                    if (clamped.len < max_line_length_with_divot or top.position.column_start > max_line_length_with_divot) {
-                        const indent = max_line_number_pad + " | ".len + @as(u64, @intCast(top.position.column_start));
+                    if (clamped.len < max_line_length_with_divot or top.position.column.zeroBased() > max_line_length_with_divot) {
+                        const indent = max_line_number_pad + " | ".len + @as(u64, @intCast(top.position.column.zeroBased()));
 
                         try writer.writeByteNTimes(' ', indent);
                         try writer.print(comptime Output.prettyFmt(
@@ -3366,8 +3363,8 @@ pub const VirtualMachine = struct {
                 const file = bun.path.relative(dir, source_url.slice());
                 writer.print("\n::error file={s},line={d},col={d},title=", .{
                     file,
-                    frame.position.line_start + 1,
-                    frame.position.column_start,
+                    frame.position.line.oneBased(),
+                    frame.position.column.oneBased(),
                 }) catch {};
                 has_location = true;
             }

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -3001,15 +3001,9 @@ pub const VirtualMachine = struct {
                     line_number.* = current_line_number;
                     current_line_number -= 1;
                 }
+                
 
                 exception.stack.source_lines_len = @as(u8, @truncate(lines.len));
-
-                // top.position.column_stop = @as(i32, @intCast(source_lines[lines.len - 1].length()));
-                // top.position.line_stop = top.position.column_stop;
-
-                // This expression range is no longer accurate
-                // top.position.expression_start = mapping.original.columns;
-                // top.position.expression_stop = top.position.column_stop;
             }
         }
 

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -234,6 +234,7 @@ fn dumpSourceStringFailiable(vm: *VirtualMachine, specifier: string, written: []
                 js_printer.formatJSONStringUTF8(source_file),
                 mappings.formatVLQs(),
             });
+            try bufw.flush();
         }
     } else {
         dir.writeFile(std.fs.path.basename(specifier), written) catch return;

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3495,16 +3495,7 @@ pub fn OrdinalT(comptime Int: type) type {
         }
 
         pub fn isValid(ord: @This()) bool {
-            return ord.zeroBased() > 0;
-        }
-
-        pub fn format(
-            _: @This(),
-            comptime _: []const u8,
-            _: std.fmt.FormatOptions,
-            _: anytype,
-        ) !void {
-            @compileError("Do not format `Ordinal` directly. Call oneBased or zeroBased to specify.");
+            return ord.zeroBased() >= 0;
         }
     };
 }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3458,3 +3458,56 @@ pub const timespec = extern struct {
         return now().addMs(interval);
     }
 };
+
+/// An abstract number of element in a sequence. The sequence has a first element.
+/// This type should be used instead of integer because 2 contradicting traditions can
+/// call a first element '0' or '1' which makes integer type ambiguous.
+pub fn OrdinalT(comptime Int: type) type {
+    return enum(Int) {
+        invalid = switch (@typeInfo(Int).Int.signedness) {
+            .unsigned => std.math.maxInt(Int),
+            .signed => -1,
+        },
+        start = 0,
+        _,
+
+        pub fn fromZeroBased(int: Int) @This() {
+            assert(int >= 0);
+            assert(int != std.math.maxInt(Int));
+            return @enumFromInt(int);
+        }
+
+        pub fn fromOneBased(int: Int) @This() {
+            assert(int > 0);
+            return @enumFromInt(int - 1);
+        }
+
+        pub fn zeroBased(ord: @This()) Int {
+            return @intFromEnum(ord);
+        }
+
+        pub fn oneBased(ord: @This()) Int {
+            return @intFromEnum(ord) + 1;
+        }
+
+        pub fn add(ord: @This(), inc: Int) @This() {
+            return fromZeroBased(ord.zeroBased() + inc);
+        }
+
+        pub fn isValid(ord: @This()) bool {
+            return ord.zeroBased() > 0;
+        }
+
+        pub fn format(
+            _: @This(),
+            comptime _: []const u8,
+            _: std.fmt.FormatOptions,
+            _: anytype,
+        ) !void {
+            @compileError("Do not format `Ordinal` directly. Call oneBased or zeroBased to specify.");
+        }
+    };
+}
+
+/// ABI-equivalent of WTF::OrdinalNumber
+pub const Ordinal = OrdinalT(c_int);

--- a/src/js/node/assert.ts
+++ b/src/js/node/assert.ts
@@ -774,7 +774,7 @@ should equal
           (_this.expected = expected),
           (_this.operator = operator),
           Error.captureStackTrace && Error.captureStackTrace(_assertThisInitialized(_this), stackStartFn),
-          console.log({ x: _this.stack }),
+          _this.stack,
           (_this.name = "AssertionError"),
           _possibleConstructorReturn(_this)
         );
@@ -852,7 +852,6 @@ var require_assert = __commonJS({
       assert = (module2.exports = ok),
       NO_EXCEPTION_SENTINEL = {};
     function innerFail(obj) {
-      console.log(obj);
       throw obj.message instanceof Error ? obj.message : new AssertionError(obj);
     }
     function fail(actual, expected, message, operator, stackStartFn) {

--- a/src/js/node/assert.ts
+++ b/src/js/node/assert.ts
@@ -774,7 +774,7 @@ should equal
           (_this.expected = expected),
           (_this.operator = operator),
           Error.captureStackTrace && Error.captureStackTrace(_assertThisInitialized(_this), stackStartFn),
-          _this.stack,
+          console.log({ x: _this.stack }),
           (_this.name = "AssertionError"),
           _possibleConstructorReturn(_this)
         );
@@ -852,6 +852,7 @@ var require_assert = __commonJS({
       assert = (module2.exports = ok),
       NO_EXCEPTION_SENTINEL = {};
     function innerFail(obj) {
+      console.log(obj);
       throw obj.message instanceof Error ? obj.message : new AssertionError(obj);
     }
     function fail(actual, expected, message, operator, stackStartFn) {

--- a/test/js/node/v8/error-prepare-stack-default-fixture.js
+++ b/test/js/node/v8/error-prepare-stack-default-fixture.js
@@ -15,9 +15,10 @@ const err2 = new Error();
 Error.captureStackTrace(err2);
 const stack2 = err2.stack;
 
-const stackIgnoringLineAndColumn = stack2.replaceAll(":16:2", "N");
-const stack2IgnoringLineAndColumn = stack.replaceAll(":11:2", "N");
+const stackIgnoringLineAndColumn = stack.replaceAll(":10:24", "N");
+const stack2IgnoringLineAndColumn = stack2.replaceAll(":15:24", "N");
 if (stackIgnoringLineAndColumn !== stack2IgnoringLineAndColumn) {
-  console.log(stackIgnoringLineAndColumn, stack2IgnoringLineAndColumn);
+  console.log(stackIgnoringLineAndColumn);
+  console.log(stack2IgnoringLineAndColumn);
   throw new Error("Stacks are different");
 }


### PR DESCRIPTION
Fixes #9302
Fixes #8880

After the previous adventure of source-mapping related issues, it seems the big issue blocking sourcemaps from working is simply our code reading line+column numbers from JavaScriptCore.

The original code
```diff
-   /* Get the "raw" position info.
-    * Note that we're using m_codeBlock->unlinkedCodeBlock()->expressionRangeForBytecodeOffset
-    * rather than m_codeBlock->expressionRangeForBytecodeOffset in order get the "raw" offsets and
-    * avoid the CodeBlock's expressionRangeForBytecodeOffset modifications to the line and column
-    * numbers, (we don't need the column number from it, and we'll calculate the line "fixes"
-    * ourselves). */
-   ExpressionInfo::Entry info = m_codeBlock->unlinkedCodeBlock()->expressionInfoForBytecodeIndex(bytecodeOffset);
```

Is an alright idea, but the code that handles fixing this raw info does not work, with cases as simple as:

```
// @bun
var l = Object.create; (() => { throw new Error() })();
```

Instead we will simply use `expressionInfoForBytecodeIndex` on the linked code block to retrive all of the computed offsets.

```diff
+auto expr = m_codeBlock->expressionInfoForBytecodeIndex(bytecodeOffset);
```

And to prevent zero-based vs one-based, I am using `OrdinalNumber` practically everywhere to ensure these numbers are interpretted correctly.

Draft PR because there are surely test failures which will need to be corrected with proper location info, but I am noticing some potential mistakes in regards to oneBasedInt and zeroBasedInt