### PR TITLE
fix(install): git dependencies without `package.json` or a name

### DIFF
--- a/src/install/repository.zig
+++ b/src/install/repository.zig
@@ -320,6 +320,14 @@ pub const Repository = extern struct {
         defer package_dir.close();
 
         const json_file, const json_buf = bun.sys.File.readFileFrom(package_dir, "package.json", allocator).unwrap() catch |err| {
+            if (err == error.ENOENT) {
+                // allow git dependencies without package.json
+                return .{
+                    .url = url,
+                    .resolved = resolved,
+                };
+            }
+
             log.addErrorFmt(
                 null,
                 logger.Loc.Empty,
@@ -348,8 +356,10 @@ pub const Repository = extern struct {
         return .{
             .url = url,
             .resolved = resolved,
-            .json_path = ret_json_path,
-            .json_buf = json_buf,
+            .json = .{
+                .path = ret_json_path,
+                .buf = json_buf,
+            },
         };
     }
 };

--- a/src/install/repository.zig
+++ b/src/install/repository.zig
@@ -34,6 +34,48 @@ pub const Repository = extern struct {
         .{ "gitlab", ".com" },
     });
 
+    pub fn createDependencyNameFromVersionLiteral(
+        allocator: std.mem.Allocator,
+        repository: *const Repository,
+        lockfile: *Install.Lockfile,
+        dep_id: Install.DependencyID,
+    ) []u8 {
+        const buf = lockfile.buffers.string_bytes.items;
+        const dep = lockfile.buffers.dependencies.items[dep_id];
+        const version_literal = dep.version.literal.slice(buf);
+        const repo_name = repository.repo;
+        const repo_name_str = lockfile.str(&repo_name);
+        if (repo_name_str.len == 0) {
+            const name_buf = allocator.alloc(u8, bun.sha.EVP.SHA1.digest) catch bun.outOfMemory();
+            var sha1 = bun.sha.SHA1.init();
+            defer sha1.deinit();
+            sha1.update(version_literal);
+            sha1.final(name_buf[0..bun.sha.SHA1.digest]);
+            return name_buf[0..bun.sha.SHA1.digest];
+        }
+
+        var len: usize = 0;
+        var remain = repo_name_str;
+        while (strings.indexOfChar(remain, '@')) |at_index| {
+            len += remain[0..at_index].len;
+            remain = remain[at_index + 1 ..];
+        }
+        len += remain.len;
+
+        const name_buf = allocator.alloc(u8, len) catch bun.outOfMemory();
+        var name = name_buf;
+        len = 0;
+        remain = repo_name_str;
+        while (strings.indexOfChar(remain, '@')) |at_index| {
+            @memcpy(name[0..at_index], remain[0..at_index]);
+            name = name[at_index + 1 ..];
+            remain = remain[at_index + 1 ..];
+        }
+
+        @memcpy(name[0..remain.len], remain);
+        return name_buf[0..name_buf.len];
+    }
+
     pub fn order(lhs: *const Repository, rhs: *const Repository, lhs_buf: []const u8, rhs_buf: []const u8) std.math.Order {
         const owner_order = lhs.owner.order(&rhs.owner, lhs_buf, rhs_buf);
         if (owner_order != .eq) return owner_order;


### PR DESCRIPTION
### What does this PR do?
Git dependencies might not have package.json, and if they do it might be missing the name field or the name could be empty. In these situations this pr will attempt to create the dependency name from the repository name.

fixes #11637 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added tests for repos with missing package.json, package.json with a name, and package.json with an empty name
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
