### PR TITLE
fix #11649

### DIFF
--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -2280,8 +2280,8 @@ pub const CreateListExamplesCommand = struct {
         env_loader.loadProcess();
 
         var progress = std.Progress{};
-        const node = progress.start("Fetching manifest", 0);
         progress.supports_ansi_escape_codes = Output.enable_ansi_colors_stderr;
+        const node = progress.start("Fetching manifest", 0);
         progress.refresh();
 
         const examples = try Example.fetchAllLocalAndRemote(ctx, node, &env_loader, filesystem);

--- a/src/cli/pm_trusted_command.zig
+++ b/src/cli/pm_trusted_command.zig
@@ -322,8 +322,8 @@ pub const TrustCommand = struct {
         var progress = &pm.progress;
 
         if (pm.options.log_level.showProgress()) {
-            root_node = progress.start("", 0);
             progress.supports_ansi_escape_codes = Output.enable_ansi_colors_stderr;
+            root_node = progress.start("", 0);
 
             scripts_node = root_node.start(PackageManager.ProgressStrings.script(), scripts_count);
             pm.scripts_node = &scripts_node;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -10564,8 +10564,8 @@ pub const PackageManager = struct {
         var progress = &this.progress;
 
         if (comptime log_level.showProgress()) {
-            root_node = progress.start("", 0);
             progress.supports_ansi_escape_codes = Output.enable_ansi_colors_stderr;
+            root_node = progress.start("", 0);
             download_node = root_node.start(ProgressStrings.download(), 0);
 
             install_node = root_node.start(ProgressStrings.install(), this.lockfile.packages.len);
@@ -10944,8 +10944,8 @@ pub const PackageManager = struct {
         }
     }
     pub fn startProgressBar(manager: *PackageManager) void {
-        manager.downloads_node = manager.progress.start(ProgressStrings.download(), 0);
         manager.progress.supports_ansi_escape_codes = Output.enable_ansi_colors_stderr;
+        manager.downloads_node = manager.progress.start(ProgressStrings.download(), 0);
         manager.setNodeName(manager.downloads_node.?, ProgressStrings.download_no_emoji_, ProgressStrings.download_emoji, true);
         manager.downloads_node.?.setEstimatedTotalItems(manager.total_tasks + manager.extracted_count);
         manager.downloads_node.?.setCompletedItems(manager.total_tasks - manager.pendingTaskCount());
@@ -11601,8 +11601,8 @@ pub const PackageManager = struct {
             var save_node: *Progress.Node = undefined;
 
             if (comptime log_level.showProgress()) {
-                save_node = manager.progress.start(ProgressStrings.save(), 0);
                 manager.progress.supports_ansi_escape_codes = Output.enable_ansi_colors_stderr;
+                save_node = manager.progress.start(ProgressStrings.save(), 0);
                 save_node.activate();
 
                 manager.progress.refresh();
@@ -11637,8 +11637,8 @@ pub const PackageManager = struct {
         if (manager.options.do.save_yarn_lock) {
             var node: *Progress.Node = undefined;
             if (comptime log_level.showProgress()) {
-                node = manager.progress.start("Saving yarn.lock", 0);
                 manager.progress.supports_ansi_escape_codes = Output.enable_ansi_colors_stderr;
+                node = manager.progress.start("Saving yarn.lock", 0);
                 manager.progress.refresh();
             } else if (comptime log_level != .silent) {
                 Output.prettyErrorln("Saved yarn.lock", .{});


### PR DESCRIPTION
### What does this PR do?
`supports_ansi_escape_codes` needs to be set before we create a node with `start()`. Related https://github.com/oven-sh/bun/pull/11503#discussion_r1623095193

fixes #11649 

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
