### PR TITLE
fix(bun:test): `deepEquals` undefined properties bugfix

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -1190,6 +1190,15 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                             }
                         }
 
+                        // Try to get the right value from the left. We don't need to check if they're equal
+                        // because the above loop has already iterated each property in the left. If we've
+                        // seen this property before, it was already `deepEquals`ed. If it doesn't exist,
+                        // the objects are not equal.
+                        if (o1->getDirectOffset(vm, JSC::PropertyName(entry.key())) == invalidOffset) {
+                            result = false;
+                            return false;
+                        }
+
                         if (remain == 0) {
                             result = false;
                             return false;
@@ -4794,7 +4803,7 @@ JSC__JSValue JSC__JSValue__fastGet_(JSC__JSValue JSValue0, JSC__JSGlobalObject* 
 {
     JSC::JSValue value = JSC::JSValue::decode(JSValue0);
     ASSERT(value.isCell());
-    return JSValue::encode( value.getObject()->getIfPropertyExists(globalObject, builtinNameMap(globalObject, arg2)));
+    return JSValue::encode(value.getObject()->getIfPropertyExists(globalObject, builtinNameMap(globalObject, arg2)));
 }
 
 bool JSC__JSValue__toBooleanSlow(JSC__JSValue JSValue0, JSC__JSGlobalObject* globalObject)

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -476,6 +476,20 @@ describe("expect()", () => {
     }
   });
 
+  test("deepEquals bugfix #11370", () => {
+    // Two objects with equal number of properties, but left object has
+    // undefined keys and right object has keys that don't exist
+    // in left object.
+
+    expect({ b: undefined }).not.toEqual({ a: 1 });
+    expect({ b: 1 }).not.toEqual({ a: undefined });
+    // @ts-expect-error
+    expect({ b: undefined }).toEqual({ a: undefined });
+    expect({ b: undefined }).not.toStrictEqual({ a: 1 });
+    expect({ b: 1 }).not.toStrictEqual({ a: undefined });
+    expect({ b: undefined }).not.toStrictEqual({ a: undefined });
+  });
+
   // Doesn't work on jest because of https://github.com/jestjs/jest/issues/10788
   if (isBun) {
     test("deepEquals works with proxies", () => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -488,6 +488,16 @@ describe("expect()", () => {
     expect({ b: undefined }).not.toStrictEqual({ a: 1 });
     expect({ b: 1 }).not.toStrictEqual({ a: undefined });
     expect({ b: undefined }).not.toStrictEqual({ a: undefined });
+    // @ts-expect-error
+    expect({ c: undefined, a: 1, b: undefined }).toEqual({ a: 1 });
+    // @ts-expect-error
+    expect({ a: 1 }).toEqual({ c: undefined, a: 1, b: undefined });
+    expect({ c: undefined, a: 1, b: undefined }).not.toStrictEqual({ a: 1 });
+    // @ts-expect-error
+    expect({ a: 1, b: undefined }).toEqual({ a: 1, c: undefined });
+    // @ts-expect-error
+    expect({ a: 1, c: undefined }).toEqual({ a: 1, b: undefined });
+    expect({ a: 1, b: undefined }).not.toStrictEqual({ a: 1, c: undefined });
   });
 
   // Doesn't work on jest because of https://github.com/jestjs/jest/issues/10788


### PR DESCRIPTION
### What does this PR do?
This change checks that keys in right object exist in the left object as we iterate them, in addition to checking if property count is equal. Because the left object keys have already been iterated and `deepEqual`'ed with the right object, only their existence needs to be checked. If it exists, it was seen and compared. If it doesn't exist and the value isn't undefined, they're not equal.

fixes #11370 

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test for a few objects that repro this bug, and a few that don't.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
