### PR TITLE
Fix crash when throwing an exception in setTimeout

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -964,7 +964,7 @@ pub const VirtualMachine = struct {
         }
         this.is_handling_uncaught_exception = true;
         defer this.is_handling_uncaught_exception = false;
-        const handled = Bun__handleUncaughtException(globalObject, err, if (is_rejection) 1 else 0) > 0;
+        const handled = Bun__handleUncaughtException(globalObject, err.toError() orelse err, if (is_rejection) 1 else 0) > 0;
         if (!handled) {
             // TODO maybe we want a separate code path for uncaught exceptions
             this.unhandled_error_counter += 1;

--- a/test/js/node/process/process-onUncaughtExceptionSetTimeout.js
+++ b/test/js/node/process/process-onUncaughtExceptionSetTimeout.js
@@ -1,3 +1,5 @@
+import { expect } from "bun:test";
+
 let monitorCalled = false;
 
 setTimeout(() => {
@@ -29,6 +31,20 @@ process.on("uncaughtException", err => {
   if (!err) {
     process.exit(1);
   }
+
+  expect(Bun.inspect(err)).toBe(`46 |   //
+47 |   //
+48 | });
+49 |\x20
+50 | setTimeout(() => {
+51 |   throw new Error(\"Error\");
+                 ^
+error: Error
+      at /Users/dave/code/bun/test/js/node/process/process-onUncaughtExceptionSetTimeout.js:51:13
+`);
+  //
+  //
+  //
 });
 
 setTimeout(() => {

--- a/test/js/node/process/process-onUncaughtExceptionSetTimeout.js
+++ b/test/js/node/process/process-onUncaughtExceptionSetTimeout.js
@@ -1,7 +1,6 @@
 import { expect } from "bun:test";
 
 let monitorCalled = false;
-/Users/dave / code / bun / test / js / node / process / process - onUncaughtExceptionSetTimeout.js
 setTimeout(() => {
   // uncaughtExceptionMonitor should be called
   if (!monitorCalled) {

--- a/test/js/node/process/process-onUncaughtExceptionSetTimeout.js
+++ b/test/js/node/process/process-onUncaughtExceptionSetTimeout.js
@@ -1,0 +1,36 @@
+let monitorCalled = false;
+
+setTimeout(() => {
+  // uncaughtExceptionMonitor should be called
+  if (!monitorCalled) {
+    process.exit(1);
+  }
+  // timeouts should be processed
+  process.exit(42);
+}, 100);
+
+process.on("uncaughtExceptionMonitor", err => {
+  // Ensure this is not zero or another invalid argument
+  Object.getOwnPropertyNames(err);
+  String(err);
+
+  monitorCalled = true;
+  if (!err) {
+    process.exit(1);
+  }
+});
+
+process.on("uncaughtException", err => {
+  // Ensure this is not zero or another invalid argument
+  Object.getOwnPropertyNames(err);
+  String(err);
+
+  // there should be an error
+  if (!err) {
+    process.exit(1);
+  }
+});
+
+setTimeout(() => {
+  throw new Error("Error");
+}, 1);

--- a/test/js/node/process/process-onUncaughtExceptionSetTimeout.js
+++ b/test/js/node/process/process-onUncaughtExceptionSetTimeout.js
@@ -1,7 +1,7 @@
 import { expect } from "bun:test";
 
 let monitorCalled = false;
-
+/Users/dave / code / bun / test / js / node / process / process - onUncaughtExceptionSetTimeout.js
 setTimeout(() => {
   // uncaughtExceptionMonitor should be called
   if (!monitorCalled) {
@@ -10,6 +10,8 @@ setTimeout(() => {
   // timeouts should be processed
   process.exit(42);
 }, 100);
+
+const hello = Math.random().toFixed(1);
 
 process.on("uncaughtExceptionMonitor", err => {
   // Ensure this is not zero or another invalid argument
@@ -32,21 +34,9 @@ process.on("uncaughtException", err => {
     process.exit(1);
   }
 
-  expect(Bun.inspect(err)).toBe(`46 |   //
-47 |   //
-48 | });
-49 |\x20
-50 | setTimeout(() => {
-51 |   throw new Error(\"Error\");
-                 ^
-error: Error
-      at /Users/dave/code/bun/test/js/node/process/process-onUncaughtExceptionSetTimeout.js:51:13
-`);
-  //
-  //
-  //
+  expect(Bun.inspect(err)).toContain(hello);
 });
 
 setTimeout(() => {
-  throw new Error("Error");
+  throw new Error(hello);
 }, 1);

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -601,6 +601,11 @@ it("catches exceptions with process.on('uncaughtException', fn)", async () => {
   expect(await proc.exited).toBe(42);
 });
 
+it("catches exceptions with process.on('uncaughtException', fn) from setTimeout", async () => {
+  const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-onUncaughtExceptionSetTimeout.js")]);
+  expect(await proc.exited).toBe(42);
+});
+
 it("catches exceptions with process.on('unhandledRejection', fn)", async () => {
   const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-onUnhandledRejection.js")]);
   expect(await proc.exited).toBe(42);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
