### PR TITLE
fix(Bun.serve) keep JS signal alive when not using async fetch

### DIFF
--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -103,15 +103,15 @@ pub const Request = struct {
         jsRequest: JSC.JSValue,
         globalThis: *JSC.JSGlobalObject,
     ) JSC.JSValue {
-        if(jsRequest.as(Request)) |request| {
-            if(Request.signalGetCached(jsRequest)) |js_signal| {
+        if (jsRequest.as(Request)) |request| {
+            if (Request.signalGetCached(jsRequest)) |js_signal| {
                 return js_signal;
             }
             const signal = request.getSignal(globalThis);
-            Request.signalSetCached(jsRequest, globalThis, signal);     
-            return signal;  
+            Request.signalSetCached(jsRequest, globalThis, signal);
+            return signal;
         }
-       return .zero;
+        return .zero;
     }
 
     pub fn init(

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -98,6 +98,22 @@ pub const Request = struct {
         }
     }
 
+    /// Returns cached signal or generate a new JS signal and cache it.
+    pub fn getSignalFromJS(
+        jsRequest: JSC.JSValue,
+        globalThis: *JSC.JSGlobalObject,
+    ) JSC.JSValue {
+        if(jsRequest.as(Request)) |request| {
+            if(Request.signalGetCached(jsRequest)) |js_signal| {
+                return js_signal;
+            }
+            const signal = request.getSignal(globalThis);
+            Request.signalSetCached(jsRequest, globalThis, signal);     
+            return signal;  
+        }
+       return .zero;
+    }
+
     pub fn init(
         url: bun.String,
         headers: ?*FetchHeaders,


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Added tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
