### PR TITLE
Update install.sh to try ~/.bash_profile first for PATH modification

### DIFF
--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -263,8 +263,8 @@ bash)
     )
 
     bash_configs=(
-        "$HOME/.bashrc"
         "$HOME/.bash_profile"
+        "$HOME/.bashrc"
     )
 
     if [[ ${XDG_CONFIG_HOME:-} ]]; then


### PR DESCRIPTION
I suggest swapping lines 254 and 255 for modifying PATH under Bash so that .bash_profile is tried first, before .bashrc, as .bash_profile is where PATH is normally set.

### What does this PR do?

Initializes $bash_configs with ~/.bash_profile as the first element instead, bumping ~/.bashrc from first to second. This is important because the following loop uses this order to search for files to modify and stops after the first one found.

- [ ] Code changes

### How did you verify your code works?

I didn't run any tests for such a small change.

Only a single line change in install.sh, no Zig or Typescript changes