### PR TITLE
fix(fs:watch) fix missing char in filename

### DIFF
--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -239,16 +239,8 @@ pub const PathWatcherManager = struct {
                                     if (path.len <= 1) {
                                         continue;
                                     }
-                                    if (path.len == 0) {
-                                        while (path.len > 0) {
-                                            if (bun.strings.startsWithChar(path, '/')) {
-                                                path = path[1..];
-                                                break;
-                                            } else {
-                                                path = path[1..];
-                                            }
-                                        }
-                                    } else {
+
+                                    if (bun.strings.startsWithChar(path, '/')) {
                                         // Skip forward slash
                                         path = path[1..];
                                     }

--- a/test/js/node/watch/fixtures/relative.js
+++ b/test/js/node/watch/fixtures/relative.js
@@ -3,7 +3,7 @@ try {
   const watcher = fs.watch("relative.txt", { signal: AbortSignal.timeout(2000) });
 
   watcher.on("change", function (event, filename) {
-    if (filename !== "relative.txt" && event !== "change") {
+    if (filename !== "relative.txt" || event !== "change") {
       console.error("fail");
       clearInterval(interval);
       watcher.close();

--- a/test/js/node/watch/fixtures/relative_dir.js
+++ b/test/js/node/watch/fixtures/relative_dir.js
@@ -3,7 +3,7 @@ try {
   const watcher = fs.watch("./myrelativedir/", { signal: AbortSignal.timeout(2000) });
 
   watcher.on("change", function (event, filename) {
-    if (filename !== "relative.txt" && event !== "change") {
+    if (filename !== "relative.txt" || event !== "change") {
       console.error("fail");
       clearInterval(interval);
       watcher.close();

--- a/test/js/node/watch/fixtures/relative_dir.js
+++ b/test/js/node/watch/fixtures/relative_dir.js
@@ -1,0 +1,28 @@
+import fs from "fs";
+try {
+  const watcher = fs.watch("./myrelativedir/", { signal: AbortSignal.timeout(2000) });
+
+  watcher.on("change", function (event, filename) {
+    if (filename !== "relative.txt" && event !== "change") {
+      console.error("fail");
+      clearInterval(interval);
+      watcher.close();
+      process.exit(1);
+    } else {
+      clearInterval(interval);
+      watcher.close();
+    }
+  });
+  watcher.on("error", err => {
+    clearInterval(interval);
+    console.error(err.message);
+    process.exit(1);
+  });
+
+  const interval = setInterval(() => {
+    fs.writeFileSync("./myrelativedir/relative.txt", "world");
+  }, 10);
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -64,6 +64,19 @@ describe("fs.watch", () => {
     }
   });
 
+  test("should work with relative dirs", done => {
+    try {
+      const myrelativedir = path.join(testDir, "myrelativedir");
+      try {
+        fs.mkdirSync(myrelativedir);
+      } catch {}
+      fs.writeFileSync(path.join(myrelativedir, "relative.txt"), "hello");
+      bunRunAsScript(testDir, path.join(import.meta.dir, "fixtures", "relative_dir.js"));
+      done();
+    } catch (e: any) {
+      done(e);
+    }
+  });
   test("add file/folder to folder", done => {
     let count = 0;
     const root = path.join(testDir, "add-directory");


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix: https://github.com/oven-sh/bun/issues/11415
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Added tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
