### PR TITLE
Add warning for users who haven't updated to required minimum bun version that includes $ utility 

### DIFF
--- a/docs/runtime/shell.md
+++ b/docs/runtime/shell.md
@@ -1,5 +1,10 @@
 Bun Shell makes shell scripting with JavaScript & TypeScript fun. It's a cross-platform bash-like shell with seamless JavaScript interop.
 
+
+:::warning  
+Only available from bun v1.0.7 onwards.
+:::
+
 Quickstart:
 
 ```js


### PR DESCRIPTION


I don't know exactly which version bun starts having the $ shell utility, but it starts at some specific version and otherwise you get a cryptic error. Include this warning so that bun users that haven't updated can update immediately to use the shell utility. Also help me get my first contribution to open source :)


