### PR TITLE
Support cancelling pending transpilations

### DIFF
--- a/src/bun.js/Weak.zig
+++ b/src/bun.js/Weak.zig
@@ -4,6 +4,8 @@ const JSC = bun.JSC;
 pub const WeakRefType = enum(u32) {
     None = 0,
     FetchResponse = 1,
+
+    TranspilerJob = 5,
 };
 const WeakImpl = opaque {
     pub fn init(globalThis: *JSC.JSGlobalObject, value: JSC.JSValue, refType: WeakRefType, ctx: ?*anyopaque) *WeakImpl {

--- a/src/bun.js/bindings/Weak.cpp
+++ b/src/bun.js/bindings/Weak.cpp
@@ -10,12 +10,18 @@ namespace Bun {
 enum class WeakRefType : uint32_t {
     None = 0,
     FetchResponse = 1,
+
+    TranspilerJob = 5,
 };
 
 typedef void (*WeakRefFinalizeFn)(void* context);
 
+// clang-format off
 #define FOR_EACH_WEAK_REF_TYPE(macro) \
-    macro(FetchResponse)
+    macro(FetchResponse)              \
+    macro(TranspilerJob)
+
+// clang-format on
 
 #define DECLARE_WEAK_REF_OWNER(X) \
     extern "C" void Bun__##X##_finalize(void* context);
@@ -31,6 +37,9 @@ public:
             switch (T) {
             case WeakRefType::FetchResponse:
                 Bun__FetchResponse_finalize(context);
+                break;
+            case WeakRefType::TranspilerJob:
+                Bun__TranspilerJob_finalize(context);
                 break;
             default:
                 break;
@@ -51,6 +60,9 @@ static JSC::WeakHandleOwner* getWeakRefOwner(WeakRefType type)
     switch (type) {
     case WeakRefType::FetchResponse: {
         return getWeakRefOwner<WeakRefType::FetchResponse>();
+    }
+    case WeakRefType::TranspilerJob: {
+        return getWeakRefOwner<WeakRefType::TranspilerJob>();
     }
     default: {
         RELEASE_ASSERT_NOT_REACHED();
@@ -74,9 +86,7 @@ public:
         this->m_cell = JSC::Weak<JSC::JSObject>(object, getWeakRefOwner(kind), ctx);
     }
 
-    WeakRef()
-    {
-    }
+    WeakRef() = default;
 
     JSC::Weak<JSC::JSObject> m_cell;
 };

--- a/src/lock.zig
+++ b/src/lock.zig
@@ -122,6 +122,12 @@ pub const Lock = struct {
             @panic(message);
         }
     }
+
+    pub inline fn assertLocked(this: *Lock, comptime message: []const u8) void {
+        if (this.mutex.state.load(.Monotonic) == 0) {
+            @panic(message);
+        }
+    }
 };
 
 pub fn spinCycle() void {}

--- a/src/sourcemap/CodeCoverage.zig
+++ b/src/sourcemap/CodeCoverage.zig
@@ -369,7 +369,6 @@ pub const ByteRangeMapping = struct {
 
         var executable_lines: Bitset = Bitset{};
         var lines_which_have_executed: Bitset = Bitset{};
-        const parsed_mappings_ = bun.JSC.VirtualMachine.get().source_mappings.get(source_url.slice());
 
         var functions = std.ArrayListUnmanaged(CodeCoverageReport.Block){};
         try functions.ensureTotalCapacityPrecise(allocator, function_blocks.len);
@@ -386,6 +385,11 @@ pub const ByteRangeMapping = struct {
         errdefer executable_lines.deinit(allocator);
         errdefer lines_which_have_executed.deinit(allocator);
         var line_count: u32 = 0;
+
+        var vm = bun.JSC.VirtualMachine.get();
+        vm.source_mappings.lock();
+        defer vm.source_mappings.unlock();
+        const parsed_mappings_ = vm.source_mappings.get(source_url.slice());
 
         if (ignore_sourcemap or parsed_mappings_ == null) {
             line_count = @truncate(line_starts.len);


### PR DESCRIPTION
### What does this PR do?

When you use `bun --hot`, it reloads every file.

So if you make a small change to a large file repeatedly, it's going to potentially block transpilation/reloading from continuing.

This reduces hot reloading memory usage and makes it faster by "cancelling" async transpilation when the promise to fetch the ESM is garbage collected. 

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
