### PR TITLE
fix(Bun.serve) fix async upgrade using custom protocols

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2523,7 +2523,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             };
 
             // we have to clone the request headers here since they will soon belong to a different request
-            if (!request_object.hasHeaders()) {
+            if (!request_object.hasFetchHeaders()) {
                 request_object.setFetchHeaders(JSC.FetchHeaders.createFromUWS(ctx.server.globalThis, req));
             }
 
@@ -5269,8 +5269,14 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
 
             var sec_websocket_key_str = ZigString.Empty;
 
+            var sec_websocket_protocol = ZigString.Empty;
+
+            var sec_websocket_extensions = ZigString.Empty;
+
             if (request.getFetchHeaders()) |head| {
                 sec_websocket_key_str = head.fastGet(.SecWebSocketKey) orelse ZigString.Empty;
+                sec_websocket_protocol = head.fastGet(.SecWebSocketProtocol) orelse ZigString.Empty;
+                sec_websocket_extensions = head.fastGet(.SecWebSocketExtensions) orelse ZigString.Empty;
             }
 
             if (sec_websocket_key_str.len == 0) {
@@ -5281,12 +5287,18 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 return JSC.jsBoolean(false);
             }
 
-            var sec_websocket_protocol = ZigString.init(upgrader.req.header("sec-websocket-protocol") orelse "");
-            var sec_websocket_extensions = ZigString.init(upgrader.req.header("sec-websocket-extensions") orelse "");
+            if (sec_websocket_protocol.len == 0) {
+                sec_websocket_protocol = ZigString.init(upgrader.req.header("sec-websocket-protocol") orelse "");
+            }
+
+            if (sec_websocket_extensions.len == 0) {
+                sec_websocket_extensions = ZigString.init(upgrader.req.header("sec-websocket-extensions") orelse "");
+            }
 
             if (sec_websocket_protocol.len > 0) {
                 sec_websocket_protocol.markUTF8();
             }
+
             if (sec_websocket_extensions.len > 0) {
                 sec_websocket_extensions.markUTF8();
             }

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -61,7 +61,7 @@ pub fn InitRequestBodyValue(value: Body.Value) !*BodyValueRef {
 // https://developer.mozilla.org/en-US/docs/Web/API/Request
 pub const Request = struct {
     url: bun.String = bun.String.empty,
-    // PS: renamed to _headers to avoid direct manipulation, use getFetchHeaders, setFetchHeaders, ensureFetchHeaders, hasHeaders instead
+    // NOTE(@cirospaciari): renamed to _headers to avoid direct manipulation, use getFetchHeaders, setFetchHeaders, ensureFetchHeaders and hasFetchHeaders instead
     _headers: ?*FetchHeaders = null,
     signal: ?*AbortSignal = null,
     body: *BodyValueRef,
@@ -738,7 +738,7 @@ pub const Request = struct {
     }
 
     // Returns if the request has headers already cached/set.
-    pub fn hasHeaders(this: *Request) bool {
+    pub fn hasFetchHeaders(this: *Request) bool {
         return this._headers != null;
     }
 

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -61,8 +61,8 @@ pub fn InitRequestBodyValue(value: Body.Value) !*BodyValueRef {
 // https://developer.mozilla.org/en-US/docs/Web/API/Request
 pub const Request = struct {
     url: bun.String = bun.String.empty,
-
-    headers: ?*FetchHeaders = null,
+    // PS: renamed to _headers to avoid direct manipulation, use getFetchHeaders, setFetchHeaders, ensureFetchHeaders, hasHeaders instead
+    _headers: ?*FetchHeaders = null,
     signal: ?*AbortSignal = null,
     body: *BodyValueRef,
     method: Method = Method.GET,
@@ -98,6 +98,20 @@ pub const Request = struct {
         }
     }
 
+    pub fn init(
+        url: bun.String,
+        headers: ?*FetchHeaders,
+        body: *BodyValueRef,
+        method: Method,
+    ) Request {
+        return Request{
+            .url = url,
+            ._headers = headers,
+            .body = body,
+            .method = method,
+        };
+    }
+
     pub fn getContentType(
         this: *Request,
     ) ?ZigString.Slice {
@@ -107,7 +121,7 @@ pub const Request = struct {
             }
         }
 
-        if (this.headers) |headers| {
+        if (this._headers) |headers| {
             if (headers.fastGet(.ContentType)) |value| {
                 return value.toSlice(bun.default_allocator);
             }
@@ -194,7 +208,7 @@ pub const Request = struct {
     }
 
     pub fn mimeType(this: *const Request) string {
-        if (this.headers) |headers| {
+        if (this._headers) |headers| {
             if (headers.fastGet(.ContentType)) |content_type| {
                 return content_type.slice();
             }
@@ -271,9 +285,9 @@ pub const Request = struct {
     }
 
     pub fn finalizeWithoutDeinit(this: *Request) void {
-        if (this.headers) |headers| {
+        if (this._headers) |headers| {
             headers.deref();
-            this.headers = null;
+            this._headers = null;
         }
 
         this.url.deref();
@@ -301,7 +315,7 @@ pub const Request = struct {
         this: *Request,
         globalObject: *JSC.JSGlobalObject,
     ) callconv(.C) JSC.JSValue {
-        if (this.headers) |headers_ref| {
+        if (this._headers) |headers_ref| {
             if (headers_ref.get("referrer", globalObject)) |referrer| {
                 return ZigString.init(referrer).toValueGC(globalObject);
             }
@@ -532,7 +546,7 @@ pub const Request = struct {
 
                     if (!fields.contains(.headers)) {
                         if (request.cloneHeaders(globalThis)) |headers| {
-                            req.headers = headers;
+                            req._headers = headers;
                             fields.insert(.headers);
                         }
                     }
@@ -556,7 +570,7 @@ pub const Request = struct {
 
                     if (!fields.contains(.headers)) {
                         if (response.init.headers) |headers| {
-                            req.headers = headers.cloneThis(globalThis);
+                            req._headers = headers.cloneThis(globalThis);
                             fields.insert(.headers);
                         }
                     }
@@ -631,17 +645,17 @@ pub const Request = struct {
             }
 
             if (!fields.contains(.method) or !fields.contains(.headers)) {
-                if (Response.Init.init(globalThis.allocator(), globalThis, value) catch null) |init| {
+                if (Response.Init.init(globalThis.allocator(), globalThis, value) catch null) |response_init| {
                     if (!explicit_check or (explicit_check and value.fastGet(globalThis, .method) != null)) {
                         if (!fields.contains(.method)) {
-                            req.method = init.method;
+                            req.method = response_init.method;
                             fields.insert(.method);
                         }
                     }
                     if (!explicit_check or (explicit_check and value.fastGet(globalThis, .headers) != null)) {
-                        if (init.headers) |headers| {
+                        if (response_init.headers) |headers| {
                             if (!fields.contains(.headers)) {
-                                req.headers = headers;
+                                req._headers = headers;
                                 fields.insert(.headers);
                             } else {
                                 headers.deref();
@@ -680,11 +694,11 @@ pub const Request = struct {
         req.url = href;
 
         if (req.body.value == .Blob and
-            req.headers != null and
+            req._headers != null and
             req.body.value.Blob.content_type.len > 0 and
-            !req.headers.?.fastHas(.ContentType))
+            !req._headers.?.fastHas(.ContentType))
         {
-            req.headers.?.put("content-type", req.body.value.Blob.content_type, globalThis);
+            req._headers.?.put("content-type", req.body.value.Blob.content_type, globalThis);
         }
 
         req.calculateEstimatedByteSize();
@@ -714,12 +728,6 @@ pub const Request = struct {
         return &this.body.value;
     }
 
-    pub fn getFetchHeaders(
-        this: *Request,
-    ) ?*FetchHeaders {
-        return this.headers;
-    }
-
     pub fn doClone(
         this: *Request,
         globalThis: *JSC.JSGlobalObject,
@@ -729,36 +737,77 @@ pub const Request = struct {
         return cloned.toJS(globalThis);
     }
 
-    pub fn getHeaders(
+    // Returns if the request has headers already cached/set.
+    pub fn hasHeaders(this: *Request) bool {
+        return this._headers != null;
+    }
+
+    /// Sets the headers of the request. This will take ownership of the headers.
+    /// it will deref the previous headers if they exist.
+    pub fn setFetchHeaders(
+        this: *Request,
+        headers: ?*FetchHeaders,
+    ) void {
+        if (this._headers) |old_headers| {
+            old_headers.deref();
+        }
+
+        this._headers = headers;
+    }
+
+    /// Returns the headers of the request. If the headers are not already cached, it will create a new FetchHeaders object.
+    /// If the headers are empty, it will look at request_context to get the headers.
+    /// If the headers are empty and request_context is null, it will create an empty FetchHeaders object.
+    pub fn ensureFetchHeaders(
         this: *Request,
         globalThis: *JSC.JSGlobalObject,
-    ) callconv(.C) JSC.JSValue {
-        if (this.headers == null) {
-            if (this.request_context.getRequest()) |req| {
-                this.headers = FetchHeaders.createFromUWS(globalThis, req);
-            } else {
-                this.headers = FetchHeaders.createEmpty();
+    ) *FetchHeaders {
+        if (this._headers) |headers| {
+            // headers is already set
+            return headers;
+        }
 
-                if (this.body.value == .Blob) {
-                    const content_type = this.body.value.Blob.content_type;
-                    if (content_type.len > 0) {
-                        this.headers.?.put("content-type", content_type, globalThis);
-                    }
+        if (this.request_context.getRequest()) |req| {
+            // we have a request context, so we can get the headers from it
+            this._headers = FetchHeaders.createFromUWS(globalThis, req);
+        } else {
+            // we don't have a request context, so we need to create an empty headers object
+            this._headers = FetchHeaders.createEmpty();
+
+            if (this.body.value == .Blob) {
+                const content_type = this.body.value.Blob.content_type;
+                if (content_type.len > 0) {
+                    this._headers.?.put("content-type", content_type, globalThis);
                 }
             }
         }
 
-        return this.headers.?.toJS(globalThis);
+        return this._headers.?;
+    }
+
+    /// Returns the headers of the request. This will not look at the request contex to get the headers.
+    pub fn getFetchHeaders(
+        this: *Request,
+    ) ?*FetchHeaders {
+        return this._headers;
+    }
+
+    /// This should only be called by the JS code. use getFetchHeaders to get the current headers or ensureFetchHeaders to get the headers and create them if they don't exist.
+    pub fn getHeaders(
+        this: *Request,
+        globalThis: *JSC.JSGlobalObject,
+    ) callconv(.C) JSC.JSValue {
+        return this.ensureFetchHeaders(globalThis).toJS(globalThis);
     }
 
     pub fn cloneHeaders(this: *Request, globalThis: *JSGlobalObject) ?*FetchHeaders {
-        if (this.headers == null) {
+        if (this._headers == null) {
             if (this.request_context.getRequest()) |uws_req| {
-                this.headers = FetchHeaders.createFromUWS(globalThis, uws_req);
+                this._headers = FetchHeaders.createFromUWS(globalThis, uws_req);
             }
         }
 
-        if (this.headers) |head| {
+        if (this._headers) |head| {
             if (head.isEmpty()) {
                 return null;
             }
@@ -789,7 +838,7 @@ pub const Request = struct {
             .body = body,
             .url = if (preserve_url) original_url else this.url.dupeRef(),
             .method = this.method,
-            .headers = this.cloneHeaders(globalThis),
+            ._headers = this.cloneHeaders(globalThis),
         };
 
         if (this.signal) |signal| {

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -560,7 +560,7 @@ pub const Response = struct {
                 // fast path: it's a Request object or a Response object
                 // we can skip calling JS getters
                 if (response_init.asDirect(Request)) |req| {
-                    if (req.headers) |headers| {
+                    if (req.getFetchHeaders()) |headers| {
                         if (!headers.isEmpty()) {
                             result.headers = headers.cloneThis(ctx);
                         }
@@ -2023,7 +2023,7 @@ pub const Fetch = struct {
                                 }
                                 headers = Headers.from(headers__, allocator, .{ .body = &body }) catch unreachable;
                                 headers__.deref();
-                            } else if (request.headers) |head| {
+                            } else if (request.getFetchHeaders()) |head| {
                                 if (head.fastGet(JSC.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
                                     if (hostname) |host| {
                                         allocator.free(host);
@@ -2032,7 +2032,7 @@ pub const Fetch = struct {
                                 }
                                 headers = Headers.from(head, allocator, .{ .body = &body }) catch unreachable;
                             }
-                        } else if (request.headers) |head| {
+                        } else if (request.getFetchHeaders()) |head| {
                             headers = Headers.from(head, allocator, .{ .body = &body }) catch unreachable;
                         }
 
@@ -2173,7 +2173,7 @@ pub const Fetch = struct {
 
                     if (get_fetch_headers: {
                         if (can_use_fast_getters)
-                            break :get_fetch_headers request.headers;
+                            break :get_fetch_headers request.getFetchHeaders();
 
                         if (first_arg.fastGet(globalThis, .headers)) |headers_value| {
                             // Faster path: existing FetchHeaders object:


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/7514
Fix: https://github.com/oven-sh/bun/issues/8986
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
