### PR TITLE
Clean up some expect() matchers

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -398,7 +398,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         var _msg: ZigString = ZigString.Empty;
 
@@ -445,7 +445,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         var _msg: ZigString = ZigString.Empty;
 
@@ -488,7 +488,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
         const thisValue = callframe.this();
         const arguments_ = callframe.arguments(2);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toBe() takes 1 argument", .{});
@@ -555,7 +555,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
         const thisValue = callframe.this();
         const arguments_ = callframe.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toHaveLength() takes 1 argument", .{});
@@ -630,7 +630,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toBeOneOf() takes 1 argument", .{});
@@ -716,7 +716,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toContain() takes 1 argument", .{});
@@ -814,7 +814,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toContainKey() takes 1 argument", .{});
@@ -874,7 +874,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toContainKeys() takes 1 argument", .{});
@@ -947,7 +947,7 @@ pub const Expect = struct {
         defer this.postMatch(globalObject);
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalObject.throwInvalidArguments("toContainAllKeys() takes 1 argument", .{});
@@ -970,9 +970,9 @@ pub const Expect = struct {
 
         const count = expected.getLength(globalObject);
 
-        var iter_value = value.keys(globalObject);
-        if (iter_value.getLength(globalObject) == count) {
-            var itr = iter_value.arrayIterator(globalObject);
+        var keys = value.keys(globalObject);
+        if (keys.getLength(globalObject) == count) {
+            var itr = keys.arrayIterator(globalObject);
             outer: {
                 while (itr.next()) |item| {
                     var i: u32 = 0;
@@ -990,20 +990,20 @@ pub const Expect = struct {
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalObject, .quote_strings = true };
-        const value_fmt = value.keys(globalObject).toFmt(globalObject, &formatter);
+        const value_fmt = keys.toFmt(globalObject, &formatter);
         const expected_fmt = expected.toFmt(globalObject, &formatter);
         if (not) {
-            const received_fmt = value.keys(globalObject).toFmt(globalObject, &formatter);
+            const received_fmt = keys.toFmt(globalObject, &formatter);
             const expected_line = "Expected to not contain all keys: <green>{any}<r>\nReceived: <red>{any}<r>\n";
-            const fmt = comptime getSignature("toContainAllKeys", "<green>expected<r>", true) ++ "\n\n" ++ expected_line;
-            globalObject.throwPretty(fmt, .{ expected_fmt, received_fmt });
+            const fmt = "\n\n" ++ expected_line;
+            this.throw(globalObject, comptime getSignature("toContainAllKeys", "<green>expected<r>", true), fmt, .{ expected_fmt, received_fmt });
             return .zero;
         }
 
         const expected_line = "Expected to contain all keys: <green>{any}<r>\n";
         const received_line = "Received: <red>{any}<r>\n";
-        const fmt = comptime getSignature("toContainAllKeys", "<green>expected<r>", false) ++ "\n\n" ++ expected_line ++ received_line;
-        globalObject.throwPretty(fmt, .{ expected_fmt, value_fmt });
+        const fmt = "\n\n" ++ expected_line ++ received_line;
+        this.throw(globalObject, comptime getSignature("toContainAllKeys", "<green>expected<r>", false), fmt, .{ expected_fmt, value_fmt });
         return .zero;
     }
 
@@ -1015,7 +1015,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toContainAnyKeys() takes 1 argument", .{});
@@ -1083,7 +1083,7 @@ pub const Expect = struct {
         defer this.postMatch(globalObject);
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalObject.throwInvalidArguments("toContainValue() takes 1 argument", .{});
@@ -1099,7 +1099,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         var pass = false;
 
-        var values = value.values(globalObject);
+        const values = value.values(globalObject);
         var itr = values.arrayIterator(globalObject);
         while (itr.next()) |item| {
             if (item.jestDeepEquals(expected, globalObject)) {
@@ -1118,15 +1118,15 @@ pub const Expect = struct {
         if (not) {
             const received_fmt = value.toFmt(globalObject, &formatter);
             const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
-            const fmt = comptime getSignature("toContainValue", "<green>expected<r>", true) ++ "\n\n" ++ expected_line;
-            globalObject.throwPretty(fmt, .{ expected_fmt, received_fmt });
+            const fmt = "\n\n" ++ expected_line;
+            this.throw(globalObject, comptime getSignature("toContainValue", "<green>expected<r>", true), fmt, .{ expected_fmt, received_fmt });
             return .zero;
         }
 
         const expected_line = "Expected to contain: <green>{any}<r>\n";
         const received_line = "Received: <red>{any}<r>\n";
-        const fmt = comptime getSignature("toContainValue", "<green>expected<r>", false) ++ "\n\n" ++ expected_line ++ received_line;
-        globalObject.throwPretty(fmt, .{ expected_fmt, value_fmt });
+        const fmt = "\n\n" ++ expected_line ++ received_line;
+        this.throw(globalObject, comptime getSignature("toContainValue", "<green>expected<r>", false), fmt, .{ expected_fmt, value_fmt });
         return .zero;
     }
 
@@ -1138,7 +1138,7 @@ pub const Expect = struct {
         defer this.postMatch(globalObject);
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalObject.throwInvalidArguments("toContainValues() takes 1 argument", .{});
@@ -1158,7 +1158,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         var pass = true;
 
-        var values = value.values(globalObject);
+        const values = value.values(globalObject);
         var itr = expected.arrayIterator(globalObject);
         const count = values.getLength(globalObject);
 
@@ -1183,15 +1183,15 @@ pub const Expect = struct {
         if (not) {
             const received_fmt = value.toFmt(globalObject, &formatter);
             const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
-            const fmt = comptime getSignature("toContainValues", "<green>expected<r>", true) ++ "\n\n" ++ expected_line;
-            globalObject.throwPretty(fmt, .{ expected_fmt, received_fmt });
+            const fmt = "\n\n" ++ expected_line;
+            this.throw(globalObject, comptime getSignature("toContainValues", "<green>expected<r>", true), fmt, .{ expected_fmt, received_fmt });
             return .zero;
         }
 
         const expected_line = "Expected to contain: <green>{any}<r>\n";
         const received_line = "Received: <red>{any}<r>\n";
-        const fmt = comptime getSignature("toContainValues", "<green>expected<r>", false) ++ "\n\n" ++ expected_line ++ received_line;
-        globalObject.throwPretty(fmt, .{ expected_fmt, value_fmt });
+        const fmt = "\n\n" ++ expected_line ++ received_line;
+        this.throw(globalObject, comptime getSignature("toContainValues", "<green>expected<r>", false), fmt, .{ expected_fmt, value_fmt });
         return .zero;
     }
 
@@ -1203,7 +1203,7 @@ pub const Expect = struct {
         defer this.postMatch(globalObject);
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalObject.throwInvalidArguments("toContainAllValues() takes 1 argument", .{});
@@ -1254,15 +1254,15 @@ pub const Expect = struct {
         if (not) {
             const received_fmt = value.toFmt(globalObject, &formatter);
             const expected_line = "Expected to not contain all values: <green>{any}<r>\nReceived: <red>{any}<r>\n";
-            const fmt = comptime getSignature("toContainAllValues", "<green>expected<r>", true) ++ "\n\n" ++ expected_line;
-            globalObject.throwPretty(fmt, .{ expected_fmt, received_fmt });
+            const fmt = "\n\n" ++ expected_line;
+            this.throw(globalObject, comptime getSignature("toContainAllValues", "<green>expected<r>", true), fmt, .{ expected_fmt, received_fmt });
             return .zero;
         }
 
         const expected_line = "Expected to contain all values: <green>{any}<r>\n";
         const received_line = "Received: <red>{any}<r>\n";
-        const fmt = comptime getSignature("toContainAllValues", "<green>expected<r>", false) ++ "\n\n" ++ expected_line ++ received_line;
-        globalObject.throwPretty(fmt, .{ expected_fmt, value_fmt });
+        const fmt = "\n\n" ++ expected_line ++ received_line;
+        this.throw(globalObject, comptime getSignature("toContainAllValues", "<green>expected<r>", false), fmt, .{ expected_fmt, value_fmt });
         return .zero;
     }
 
@@ -1274,7 +1274,7 @@ pub const Expect = struct {
         defer this.postMatch(globalObject);
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalObject.throwInvalidArguments("toContainAnyValues() takes 1 argument", .{});
@@ -1319,15 +1319,15 @@ pub const Expect = struct {
         if (not) {
             const received_fmt = value.toFmt(globalObject, &formatter);
             const expected_line = "Expected to not contain any of the following values: <green>{any}<r>\nReceived: <red>{any}<r>\n";
-            const fmt = comptime getSignature("toContainAnyValues", "<green>expected<r>", true) ++ "\n\n" ++ expected_line;
-            globalObject.throwPretty(fmt, .{ expected_fmt, received_fmt });
+            const fmt = "\n\n" ++ expected_line;
+            this.throw(globalObject, comptime getSignature("toContainAnyValues", "<green>expected<r>", true), fmt, .{ expected_fmt, received_fmt });
             return .zero;
         }
 
         const expected_line = "Expected to contain any of the following values: <green>{any}<r>\n";
         const received_line = "Received: <red>{any}<r>\n";
-        const fmt = comptime getSignature("toContainAnyValues", "<green>expected<r>", false) ++ "\n\n" ++ expected_line ++ received_line;
-        globalObject.throwPretty(fmt, .{ expected_fmt, value_fmt });
+        const fmt = "\n\n" ++ expected_line ++ received_line;
+        this.throw(globalObject, comptime getSignature("toContainAnyValues", "<green>expected<r>", false), fmt, .{ expected_fmt, value_fmt });
         return .zero;
     }
 
@@ -1339,7 +1339,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toContainEqual() takes 1 argument", .{});
@@ -3520,7 +3520,7 @@ pub const Expect = struct {
 
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toInclude() requires 1 argument", .{});
@@ -3577,7 +3577,7 @@ pub const Expect = struct {
 
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(2);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 2) {
             globalThis.throwInvalidArguments("toIncludeRepeated() requires 2 arguments", .{});
@@ -3688,7 +3688,7 @@ pub const Expect = struct {
 
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toSatisfy() requires 1 argument", .{});
@@ -3752,7 +3752,7 @@ pub const Expect = struct {
 
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toStartWith() requires 1 argument", .{});
@@ -3809,7 +3809,7 @@ pub const Expect = struct {
 
         const thisValue = callFrame.this();
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("toEndWith() requires 1 argument", .{});
@@ -4010,7 +4010,7 @@ pub const Expect = struct {
 
         const thisValue = callframe.this();
         const arguments_ = callframe.arguments(1);
-        const arguments: []const JSValue = arguments_.ptr[0..arguments_.len];
+        const arguments: []const JSValue = arguments_.slice();
         defer this.postMatch(globalThis);
         const value: JSValue = this.getValue(globalThis, thisValue, "toHaveBeenCalledTimes", "<green>expected<r>") orelse return .zero;
 
@@ -4116,8 +4116,7 @@ pub const Expect = struct {
         JSC.markBinding(@src());
 
         const thisValue = callframe.this();
-        const arguments_ = callframe.argumentsPtr()[0..callframe.argumentsCount()];
-        const arguments: []const JSValue = arguments_.ptr[0..arguments_.len];
+        const arguments = callframe.argumentsPtr()[0..callframe.argumentsCount()];
         defer this.postMatch(globalThis);
         const value: JSValue = this.getValue(globalThis, thisValue, "toHaveBeenCalledWith", "<green>expected<r>") orelse return .zero;
 
@@ -4180,8 +4179,7 @@ pub const Expect = struct {
         JSC.markBinding(@src());
 
         const thisValue = callframe.this();
-        const arguments_ = callframe.argumentsPtr()[0..callframe.argumentsCount()];
-        const arguments: []const JSValue = arguments_.ptr[0..arguments_.len];
+        const arguments = callframe.argumentsPtr()[0..callframe.argumentsCount()];
         defer this.postMatch(globalThis);
         const value: JSValue = this.getValue(globalThis, thisValue, "toHaveBeenLastCalledWith", "<green>expected<r>") orelse return .zero;
 
@@ -4243,8 +4241,7 @@ pub const Expect = struct {
         JSC.markBinding(@src());
 
         const thisValue = callframe.this();
-        const arguments_ = callframe.argumentsPtr()[0..callframe.argumentsCount()];
-        const arguments: []const JSValue = arguments_.ptr[0..arguments_.len];
+        const arguments = callframe.argumentsPtr()[0..callframe.argumentsCount()];
         defer this.postMatch(globalThis);
         const value: JSValue = this.getValue(globalThis, thisValue, "toHaveBeenNthCalledWith", "<green>expected<r>") orelse return .zero;
 
@@ -4765,7 +4762,7 @@ pub const Expect = struct {
         defer globalThis.bunVM().autoGarbageCollect();
 
         const arguments_ = callFrame.arguments(1);
-        const arguments = arguments_.ptr[0..arguments_.len];
+        const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
             globalThis.throwInvalidArguments("expect.assertions() takes 1 argument", .{});

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2439,6 +2439,7 @@ describe("expect()", () => {
     expect({ 1: "hello", b: "world" }).toContainAllKeys(["1", "b"]);
     expect({ a: "hello", b: "world" }).not.toContainAllKeys(["c"]);
     expect({ a: "hello", b: "world" }).not.toContainAllKeys(["a"]);
+    expect({ "": "hello", b: "world" }).toContainAllKeys(["", "b"]);
   });
 
   test("toContainAnyKeys", () => {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -382,7 +382,7 @@ it("it accepts stdio passthrough", async () => {
   const [err, out, exitCode] = await Promise.all([new Response(stderr).text(), new Response(stdout).text(), exited]);
   try {
     // This command outputs in either `["hello", "world"]` or `["world", "hello"]` order.
-    expect([err.split("\n")[0], ...err.split("\n").slice(1, -1).sort()]).toEqual([
+    expect([err.split("\n")[0], ...err.split("\n").slice(1, -1).sort(), err.split("\n").at(-1)]).toEqual([
       "$ run-p echo-hello echo-world",
       "$ echo hello",
       "$ echo world",


### PR DESCRIPTION
### What does this PR do?

Clean up some expect() matchers

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
