### PR TITLE
Support `NODE_EXTRA_CA_CERTS`

### DIFF
--- a/test/js/node/http/fixtures/node-extra-ca-certs.js
+++ b/test/js/node/http/fixtures/node-extra-ca-certs.js
@@ -1,0 +1,17 @@
+(async () => {
+  const port = process.argv[2] ? parseInt(process.argv[2]) : null;
+
+  try {
+    const res = await fetch(`https://localhost:${port}`, {
+      tls: {
+        rejectUnauthorized: true,
+      },
+    });
+    const t = await res.text();
+    console.log(`res: ${t}`);
+    process.exit(0);
+  } catch (error) {
+    console.log(error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
### What does this PR do?

- [x] Code changes

Load ca certificates from NODE_EXTRA_CA_CERTS

Respects the Node.js API and loads the CA file pointed to by the environment variable NODE_EXTRA_CA_CERTS into the global SSL context.

This works for fetch, https.request and (should also cover) requests made by the bun CLI, f.ex `bun install`.

I haven't added tests for `bun install` since there isn't really existing test infra for bun install network activity.


### How did you verify your code works?

I wrote automated tests


If Zig files changed:

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)


___

A couple notes on this:
- I looked into using the envLoader for getting the env var, but in (almost) all instances the `HTTPThread` is initialized before the envLoader, and it would require quite a bit of rebasing to get the envMap context into the `HTTPContext` initialization. The way it's done now, it requires minimal code changes while still being compatible with Node.js.
- I passed the ca file into the socket context initialization, since the option is already there, however the code for loading ca files to the certificate store will crash when it fails (see the last test I added). I looked into exposing the API for adding additional CAs to the global socket context, so I could do that as well, if the current behavior is unwanted. I just went with the current method to minimize changes and keeping it simple.


Fixes #7124 
Fixes #7200 
Fixes #271