### PR TITLE
Fix cloning `File` with `structuredClone`

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -93,10 +93,7 @@ jobs:
           CCACHE_DIR: ccache
         run: |
           .\scripts\env.ps1 ${{ contains(inputs.tag, '-baseline') && '-Baseline' || '' }}
-          Invoke-WebRequest -Uri "https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/win64/nasm-2.16.01-win64.zip" -OutFile nasm.zip
-          Expand-Archive nasm.zip (mkdir -Force "nasm")
-          $Nasm = (Get-ChildItem "nasm")
-          $env:Path += ";${Nasm}"
+          choco install -y nasm --version=2.16.01
           $env:BUN_DEPS_OUT_DIR = (mkdir -Force "./bun-deps")
           .\scripts\all-dependencies.ps1
       - name: Save Cache

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1457,7 +1457,7 @@ pub const Blob = struct {
         if (!set_last_modified) {
             // `lastModified` should be the current date in milliseconds if unspecified.
             // https://developer.mozilla.org/en-US/docs/Web/API/File/lastModified
-            blob.last_modified = @floatFromInt(bun.timespec.now().ms());
+            blob.last_modified = @floatFromInt(std.time.milliTimestamp());
         }
 
         if (blob.content_type.len == 0) {

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -117,6 +117,10 @@ pub const Blob = struct {
     pub const SizeType = u52;
     pub const max_size = std.math.maxInt(SizeType);
 
+    /// 1: Initial
+    /// 2: Added byte for whether it's a dom file, length and bytes for `stored_name`,
+    ///    and f64 for `last_modified`. Removed reserved bytes, it's handled by version
+    ///    number.
     const serialization_version: u8 = 2;
 
     pub fn getFormDataEncoding(this: *Blob) ?*bun.FormData.AsyncFormData {

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1457,7 +1457,7 @@ pub const Blob = struct {
         if (!set_last_modified) {
             // `lastModified` should be the current date in milliseconds if unspecified.
             // https://developer.mozilla.org/en-US/docs/Web/API/File/lastModified
-            blob.last_modified = @floatFromInt(std.time.milliTimestamp());
+            blob.last_modified = @floatFromInt(bun.timespec.now().ms());
         }
 
         if (blob.content_type.len == 0) {

--- a/test/js/bun/globals.test.js
+++ b/test/js/bun/globals.test.js
@@ -57,11 +57,12 @@ it("name", () => {
 
 describe("File", () => {
   it("constructor", () => {
+    const now = Date.now();
     const file = new File(["foo"], "bar.txt", { type: "text/plain;charset=utf-8" });
     expect(file.name).toBe("bar.txt");
     expect(file.type).toBe("text/plain;charset=utf-8");
     expect(file.size).toBe(3);
-    expect(file.lastModified).toBe(0);
+    expect(file.lastModified).toBeGreaterThanOrEqual(now);
   });
 
   it("constructor with lastModified", () => {
@@ -73,11 +74,12 @@ describe("File", () => {
   });
 
   it("constructor with undefined name", () => {
+    const now = Date.now();
     const file = new File(["foo"], undefined);
     expect(file.name).toBe("undefined");
     expect(file.type).toBe("");
     expect(file.size).toBe(3);
-    expect(file.lastModified).toBe(0);
+    expect(file.lastModified).toBeGreaterThanOrEqual(now);
   });
 
   it("constructor throws invalid args", () => {
@@ -119,6 +121,7 @@ describe("File", () => {
         return super.text();
       }
     }
+    const now = Date.now();
     const foo = new Foo(["foo"], "bar.txt", { type: "text/plain;charset=utf-8" });
     expect(foo instanceof File).toBe(true);
     expect(foo instanceof Blob).toBe(true);
@@ -129,7 +132,7 @@ describe("File", () => {
     expect(foo.name).toBe("bar.txt");
     expect(foo.type).toBe("text/plain;charset=utf-8");
     expect(foo.size).toBe(3);
-    expect(foo.lastModified).toBe(0);
+    expect(foo.lastModified).toBeGreaterThanOrEqual(now);
     expect(await foo.text()).toBe("foo");
   });
 });

--- a/test/js/bun/globals.test.js
+++ b/test/js/bun/globals.test.js
@@ -57,12 +57,11 @@ it("name", () => {
 
 describe("File", () => {
   it("constructor", () => {
-    const now = Date.now();
     const file = new File(["foo"], "bar.txt", { type: "text/plain;charset=utf-8" });
     expect(file.name).toBe("bar.txt");
     expect(file.type).toBe("text/plain;charset=utf-8");
     expect(file.size).toBe(3);
-    expect(file.lastModified).toBeGreaterThanOrEqual(now);
+    expect(file.lastModified).toBeGreaterThan(0);
   });
 
   it("constructor with lastModified", () => {
@@ -74,12 +73,11 @@ describe("File", () => {
   });
 
   it("constructor with undefined name", () => {
-    const now = Date.now();
     const file = new File(["foo"], undefined);
     expect(file.name).toBe("undefined");
     expect(file.type).toBe("");
     expect(file.size).toBe(3);
-    expect(file.lastModified).toBeGreaterThanOrEqual(now);
+    expect(file.lastModified).toBeGreaterThan(0);
   });
 
   it("constructor throws invalid args", () => {
@@ -121,7 +119,6 @@ describe("File", () => {
         return super.text();
       }
     }
-    const now = Date.now();
     const foo = new Foo(["foo"], "bar.txt", { type: "text/plain;charset=utf-8" });
     expect(foo instanceof File).toBe(true);
     expect(foo instanceof Blob).toBe(true);
@@ -132,7 +129,7 @@ describe("File", () => {
     expect(foo.name).toBe("bar.txt");
     expect(foo.type).toBe("text/plain;charset=utf-8");
     expect(foo.size).toBe(3);
-    expect(foo.lastModified).toBeGreaterThanOrEqual(now);
+    expect(foo.lastModified).toBeGreaterThanOrEqual(0);
     expect(await foo.text()).toBe("foo");
   });
 });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -166,6 +166,28 @@ describe("structured clone", () => {
       expect(cloned.lastModified).toBe(blob.lastModified);
       expect(cloned.name).toBe(blob.name);
     });
+    describe("dom file", async () => {
+      test("without lastModified", async () => {
+        const file = new File(["hi"], "example.txt", { type: "text/plain" });
+        expect(file.lastModified).toBeGreaterThan(0);
+        expect(file.name).toBe("example.txt");
+        expect(file.size).toBe(2);
+        const cloned = structuredClone(file);
+        expect(cloned.lastModified).toBe(file.lastModified);
+        expect(cloned.name).toBe(file.name);
+        expect(cloned.size).toBe(file.size);
+      });
+      test("with lastModified", async () => {
+        const file = new File(["hi"], "example.txt", { type: "text/plain", lastModified: 123 });
+        expect(file.lastModified).toBe(123);
+        expect(file.name).toBe("example.txt");
+        expect(file.size).toBe(2);
+        const cloned = structuredClone(file);
+        expect(cloned.lastModified).toBe(123);
+        expect(cloned.name).toBe(file.name);
+        expect(cloned.size).toBe(file.size);
+      });
+    });
     test("unpaired high surrogate (invalid utf-8)", async () => {
       const blob = createBlob(encode_cesu8([0xd800]));
       const cloned = structuredClone(blob);


### PR DESCRIPTION
### What does this PR do?
Fixes #11696 

- bumps `Blob` serialization version to 2.
- now serializes a byte for whether it's a dom file, the length and bytes for `stored_name`, and a `f64` for `lastModified`.

Also sets `lastModified` to the current time in milliseconds if it's not in options when creating a `File`. Previously we set it to zero.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
