### PR TITLE
fix(ci): make it so ci doesnt overwrite the release builds with canary's debug symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ yarn.lock
 zig-cache
 zig-out
 test/node.js/upstream
+.zig-cache

--- a/packages/bun-release/scripts/upload-s3.ts
+++ b/packages/bun-release/scripts/upload-s3.ts
@@ -35,7 +35,7 @@ if (latest.tag_name === release.tag_name) {
 } else if (release.tag_name === "canary") {
   try {
     const build = await getSemver("canary", await getBuild());
-    paths = ["releases/canary", `releases/${build}`, `releases/${full_commit_hash}`];
+    paths = ["releases/canary", `releases/${build}`, `releases/${full_commit_hash}-canary`];
   } catch (error) {
     console.warn(error);
     paths = ["releases/canary"];


### PR DESCRIPTION
i could write a 10 page rant about this whole situation but instead of that i am just going to fix the bug

see #11720. I will not mark this issue as fixed until i see with my own eyes that this attempt at writing a piece of reliable software works.