### PR TITLE
Add the --stable option help message to the bun upgrade command

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2265,6 +2265,9 @@ pub const Command = struct {
                         \\  <d>Install the most recent canary version of Bun<r>
                         \\  <b><green>bun upgrade --canary<r>
                         \\
+                        \\  <d>To switch back to a stable release from canary<r>
+                        \\  <b><green>bun upgrade --stable<r>
+                        \\
                         \\Full documentation is available at <magenta>https://bun.sh/docs/installation#upgrading<r>
                         \\
                     ;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- fixes #10560

A description of the `--stable` option has been added to the help message of the bun upgade command.

```shell
$ build/bun-debug upgrade --help

Usage: bun upgrade [...flags]
  Upgrade Bun

Examples:
  Install the latest stable version
  bun upgrade

  Install the most recent canary version of Bun
  bun upgrade --canary

  To switch back to a stable release from canary
  bun upgrade --stable

Full documentation is available at https://bun.sh/docs/installation#upgrading
```

-----

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)


I ran the test locally, does this pass the test?

```shell
$ build/bun-debug test
...

[alloc] destroy() = src.bun.js.api.bun.process.Process@4084041a0
[EventLoop] exit() = 0
ASSERTION FAILED: m_terminationException
/Users/runner/work/WebKit/WebKit/Source/JavaScriptCore/runtime/VM.h(388) : Exception *JSC::VM::terminationException() const
zsh: trace trap  build/bun-debug test
```