### PR TITLE
fix(WebSocket) fix ref count so finalize is called

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -128,7 +128,9 @@
   },
   "files.associations": {
     "*.idl": "cpp",
-    "*.inc": "c",
+    "future": "cpp",
+    "regex": "cpp",
+    "system_error": "cpp",
   },
   "C_Cpp.files.exclude": {
     "**/.vscode": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -128,6 +128,7 @@
   },
   "files.associations": {
     "*.idl": "cpp",
+    "*.inc": "c",
   },
   "C_Cpp.files.exclude": {
     "**/.vscode": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -128,9 +128,6 @@
   },
   "files.associations": {
     "*.idl": "cpp",
-    "future": "cpp",
-    "regex": "cpp",
-    "system_error": "cpp",
   },
   "C_Cpp.files.exclude": {
     "**/.vscode": true,

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -486,6 +486,62 @@ it("should report failing websocket connection in onerror and onclose for connec
   await Promise.all([promise, promise2]);
 });
 
+it("instances should be finalized when GC'd", async () => {
+  const { expect } = require("bun:test");
+
+  using server = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      return server.upgrade(req);
+    },
+    websocket: {
+      open() {},
+      data() {},
+      message() {},
+      drain() {},
+    },
+  });
+
+  function openAndCloseWS() {
+    const { promise, resolve } = Promise.withResolvers();
+    const sock = new WebSocket(server.url.href.replace("http", "ws"));
+    sock.addEventListener("open", _ => {
+      sock.addEventListener("close", () => {
+        resolve();
+      });
+      sock.close();
+    });
+
+    return promise;
+  }
+
+  function getWebSocketCount() {
+    Bun.gc(true);
+    const objectTypeCounts = require("bun:jsc").heapStats().objectTypeCounts || {
+      WebSocket: 0,
+    };
+    return objectTypeCounts.WebSocket || 0;
+  }
+  let current_websocket_count = 0;
+  let initial_websocket_count = 0;
+
+  for (let i = 0; i < 1000; i++) {
+    await openAndCloseWS();
+    if (i % 100 === 0) {
+      current_websocket_count = getWebSocketCount();
+      // if we have more than 10 websockets open, we have a problem
+      expect(current_websocket_count).toBeLessThanOrEqual(10);
+      if (initial_websocket_count === 0) {
+        initial_websocket_count = current_websocket_count;
+      }
+    }
+  }
+
+  current_websocket_count = getWebSocketCount();
+  // expect that current and initial websocket be close to the same (normaly 1 or 2 difference)
+  expect(Math.abs(current_websocket_count - initial_websocket_count)).toBeLessThanOrEqual(5);
+});
+
 describe("websocket in subprocess", () => {
   it("should exit", async () => {
     let messageReceived = false;

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test";
 import { bunExe, bunEnv, gc, tls } from "harness";
 import { readFileSync } from "fs";
 import { join, resolve } from "path";
-import process from "process";
+import process, { nextTick } from "process";
 
 const TEST_WEBSOCKET_HOST = process.env.TEST_WEBSOCKET_HOST || "wss://ws.postman-echo.com/raw";
 const isWindows = process.platform === "win32";
@@ -536,7 +536,8 @@ it("instances should be finalized when GC'd", async () => {
       }
     }
   }
-
+  // wait next tick to run the last time
+  await Bun.sleep(1);
   current_websocket_count = getWebSocketCount();
   // expect that current and initial websocket be close to the same (normaly 1 or 2 difference)
   expect(Math.abs(current_websocket_count - initial_websocket_count)).toBeLessThanOrEqual(5);


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/11722
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Added test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
