### PR TITLE
In AbortSignal, use Ref explicitly to ensure its alive

### DIFF
--- a/src/bun.js/bindings/webcore/AbortSignal.cpp
+++ b/src/bun.js/bindings/webcore/AbortSignal.cpp
@@ -158,9 +158,8 @@ void AbortSignal::signalAbort(JSC::JSValue reason)
     dispatchEvent(Event::create(eventNames().abortEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
     // 6. For each dependent signal of signal, call signal's signalAbort method with reason.
-    auto dependentSignals = std::exchange(m_dependentSignals, {});
-    for (auto& signal : dependentSignals)
-        signal.signalAbort(reason);
+    for (Ref dependentSignal : std::exchange(m_dependentSignals, {}))
+        dependentSignal->signalAbort(reason);
 }
 
 void AbortSignal::cleanNativeBindings(void* ref)


### PR DESCRIPTION
### What does this PR do?

I pressed the merge button without first checking WebKit's implementation

@cirospaciari did you try this instead?

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
