### PR TITLE
fix(install): ensure capacity of `preinstall_state` before cleaning lockfile

### DIFF
--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -1210,13 +1210,12 @@ void WebSocket::didClose(unsigned unhandledBufferedAmount, unsigned short code, 
     // so we just call decPendingActivityCount() after dispatching the event
     ASSERT(m_pendingActivityCount > 0);
 
-
     if (this->hasEventListeners("close"_s)) {
         this->dispatchEvent(CloseEvent::create(wasClean, code, reason));
 
         // we deinit if possible in the next tick
         if (auto* context = scriptExecutionContext()) {
-            context->postTask([this, code, wasClean, reason, protectedThis = Ref { *this }](ScriptExecutionContext& context) {
+            context->postTask([this, protectedThis = Ref { *this }](ScriptExecutionContext& context) {
                 ASSERT(scriptExecutionContext());
                 protectedThis->decPendingActivityCount();
             });

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -3232,7 +3232,7 @@ pub const PackageManager = struct {
         }
     }
 
-    fn ensurePreinstallStateListCapacity(this: *PackageManager, count: usize) !void {
+    pub fn ensurePreinstallStateListCapacity(this: *PackageManager, count: usize) !void {
         if (this.preinstall_state.items.len >= count) {
             return;
         }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -3232,19 +3232,19 @@ pub const PackageManager = struct {
         }
     }
 
-    pub fn ensurePreinstallStateListCapacity(this: *PackageManager, count: usize) !void {
+    pub fn ensurePreinstallStateListCapacity(this: *PackageManager, count: usize) void {
         if (this.preinstall_state.items.len >= count) {
             return;
         }
 
         const offset = this.preinstall_state.items.len;
-        try this.preinstall_state.ensureTotalCapacity(this.allocator, count);
+        this.preinstall_state.ensureTotalCapacity(this.allocator, count) catch bun.outOfMemory();
         this.preinstall_state.expandToCapacity();
         @memset(this.preinstall_state.items[offset..], PreinstallState.unknown);
     }
 
     pub fn setPreinstallState(this: *PackageManager, package_id: PackageID, lockfile: *Lockfile, value: PreinstallState) void {
-        this.ensurePreinstallStateListCapacity(lockfile.packages.len) catch return;
+        this.ensurePreinstallStateListCapacity(lockfile.packages.len);
         this.preinstall_state.items[package_id] = value;
     }
 

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -846,7 +846,10 @@ pub fn cleanWithLogger(
     // never grow
 
     // preinstall_state is used during installPackages. the indexes(package ids) need
-    // to be remapped
+    // to be remapped. Also ensure `preinstall_state` has enough capacity to contain
+    // all packages. It's possible it doesn't because non-npm packages do not use
+    // preinstall state before linking stage.
+    manager.ensurePreinstallStateListCapacity(old.packages.len);
     var preinstall_state = manager.preinstall_state;
     var old_preinstall_state = preinstall_state.clone(old.allocator) catch bun.outOfMemory();
     defer old_preinstall_state.deinit(old.allocator);


### PR DESCRIPTION
### What does this PR do?
`preinstall_state` isn't guaranteed to have enough room to contain all packages, so we need to ensure it does. 

fixes #11755 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
