### PR TITLE
shell: Fix memory leak, lazily create `ShellInterpreter` object

### DIFF
--- a/src/bun.js/api/Shell.classes.ts
+++ b/src/bun.js/api/Shell.classes.ts
@@ -9,7 +9,6 @@ export default [
     hasPendingActivity: true,
     configurable: false,
     klass: {},
-    JSType: "0b11101110",
     values: ["resolve", "reject"],
     proto: {
       run: {

--- a/src/bun.js/api/ShellArgs.classes.ts
+++ b/src/bun.js/api/ShellArgs.classes.ts
@@ -2,27 +2,31 @@ import { define } from "../../codegen/class-definitions";
 
 export default [
   define({
-    name: "ShellInterpreter",
+    name: "ParsedShellScript",
     construct: true,
     noConstructor: true,
     finalize: true,
-    hasPendingActivity: true,
+    hasPendingActivity: false,
     configurable: false,
     klass: {},
     JSType: "0b11101110",
     values: ["resolve", "reject"],
     proto: {
-      run: {
-        fn: "runFromJS",
+      setCwd: {
+        fn: "setCwd",
+        length: 1,
+      },
+      setEnv: {
+        fn: "setEnv",
+        length: 1,
+      },
+      setQuiet: {
+        fn: "setQuiet",
         length: 0,
       },
-      isRunning: {
-        fn: "isRunning",
-        length: 0,
-      },
-      started: {
-        fn: "getStarted",
-        length: 0,
+      setResolveAndReject: {
+        fn: "setResolveAndReject",
+        length: 2,
       },
     },
   }),

--- a/src/bun.js/api/ShellArgs.classes.ts
+++ b/src/bun.js/api/ShellArgs.classes.ts
@@ -10,7 +10,6 @@ export default [
     configurable: false,
     klass: {},
     JSType: "0b11101110",
-    values: ["resolve", "reject"],
     proto: {
       setCwd: {
         fn: "setCwd",
@@ -23,10 +22,6 @@ export default [
       setQuiet: {
         fn: "setQuiet",
         length: 0,
-      },
-      setResolveAndReject: {
-        fn: "setResolveAndReject",
-        length: 2,
       },
     },
   }),

--- a/src/bun.js/api/ShellArgs.classes.ts
+++ b/src/bun.js/api/ShellArgs.classes.ts
@@ -9,7 +9,6 @@ export default [
     hasPendingActivity: false,
     configurable: false,
     klass: {},
-    JSType: "0b11101110",
     proto: {
       setCwd: {
         fn: "setCwd",

--- a/src/bun.js/bindings/BunObject+exports.h
+++ b/src/bun.js/bindings/BunObject+exports.h
@@ -14,7 +14,6 @@
     macro(SHA384) \
     macro(SHA512) \
     macro(SHA512_256) \
-    macro(ShellInterpreter) \
     macro(TOML) \
     macro(Transpiler) \
     macro(argv) \
@@ -65,6 +64,8 @@
     macro(write) \
     macro(stringWidth) \
     macro(shellEscape) \
+    macro(createShellInterpreter) \
+    macro(createParsedShellScript) \
 
 #define DECLARE_ZIG_BUN_OBJECT_CALLBACK(name) extern "C" JSC::EncodedJSValue BunObject_callback_##name(JSC::JSGlobalObject*, JSC::CallFrame*);
 FOR_EACH_CALLBACK(DECLARE_ZIG_BUN_OBJECT_CALLBACK);

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -1,4 +1,3 @@
-
 #include "root.h"
 #include "ZigGlobalObject.h"
 #include "JavaScriptCore/ArgList.h"
@@ -253,13 +252,14 @@ static JSValue constructPasswordObject(VM& vm, JSObject* bunObject)
 static JSValue constructBunShell(VM& vm, JSObject* bunObject)
 {
     auto* globalObject = jsCast<Zig::GlobalObject*>(bunObject->globalObject());
-    JSValue interpreter = BunObject_getter_wrap_ShellInterpreter(vm, bunObject);
-
+    JSFunction* createParsedShellScript = JSFunction::create(vm, bunObject->globalObject(), 2, "createParsedShellScript"_s, BunObject_callback_createParsedShellScript, ImplementationVisibility::Private, NoIntrinsic);
+    JSFunction* createShellInterpreterFunction = JSFunction::create(vm, bunObject->globalObject(), 1, "createShellInterpreter"_s, BunObject_callback_createShellInterpreter, ImplementationVisibility::Private, NoIntrinsic);
     JSC::JSFunction* createShellFn = JSC::JSFunction::create(vm, shellCreateBunShellTemplateFunctionCodeGenerator(vm), globalObject);
 
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto args = JSC::MarkedArgumentBuffer();
-    args.append(interpreter);
+    args.append(createShellInterpreterFunction);
+    args.append(createParsedShellScript);
     JSC::JSValue shell = JSC::call(globalObject, createShellFn, args, "BunShell"_s);
     RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/bun.js/bindings/generated_classes_list.zig
+++ b/src/bun.js/bindings/generated_classes_list.zig
@@ -28,6 +28,7 @@ pub const Classes = struct {
     pub const FileSystemRouter = JSC.API.FileSystemRouter;
     pub const Glob = JSC.API.Glob;
     pub const ShellInterpreter = JSC.API.Shell.Interpreter;
+    pub const ParsedShellScript = JSC.API.Shell.ParsedShellScript;
     pub const Bundler = JSC.API.JSBundler;
     pub const JSBundler = Bundler;
     pub const Transpiler = JSC.API.JSTranspiler;

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -99,6 +99,8 @@ export function createBunShellTemplateFunction(createShellInterpreter, createPar
     #args: ParsedShellScript | undefined = undefined;
     #hasRun: boolean = false;
     #throws: boolean = true;
+    #resolve: Function;
+    #reject: Function;
 
     constructor(args: ParsedShellScript, throws: boolean) {
       // Create the error immediately so it captures the stacktrace at the point
@@ -130,8 +132,8 @@ export function createBunShellTemplateFunction(createShellInterpreter, createPar
       this.#throws = throws;
       this.#args = args;
       this.#hasRun = false;
-
-      args.setResolveAndReject(resolve, reject);
+      this.#resolve = resolve;
+      this.#reject = reject;
 
       // this.#immediate = setImmediate(autoStartShell, this).unref();
     }
@@ -159,7 +161,7 @@ export function createBunShellTemplateFunction(createShellInterpreter, createPar
       if (!this.#hasRun) {
         this.#hasRun = true;
 
-        let interp = createShellInterpreter(this.#args);
+        let interp = createShellInterpreter(this.#resolve, this.#reject, this.#args);
         this.#args = undefined;
         interp.run();
         interp = undefined;

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -1,9 +1,10 @@
 import type { ShellOutput } from "bun";
 
 type ShellInterpreter = any;
+type ParsedShellScript = any;
 type Resolve = (value: ShellOutput) => void;
 
-export function createBunShellTemplateFunction(ShellInterpreter) {
+export function createBunShellTemplateFunction(createShellInterpreter, createParsedShellScript) {
   function lazyBufferToHumanReadableString(this: Buffer) {
     return this.toString();
   }
@@ -95,12 +96,11 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
   }
 
   class ShellPromise extends Promise<ShellOutput> {
-    #core: ShellInterpreter;
+    #args: ParsedShellScript | undefined = undefined;
     #hasRun: boolean = false;
     #throws: boolean = true;
-    // #immediate;
 
-    constructor(core: ShellInterpreter, throws: boolean) {
+    constructor(args: ParsedShellScript, throws: boolean) {
       // Create the error immediately so it captures the stacktrace at the point
       // of the shell script's invocation. Just creating the error should be
       // relatively cheap, the costly work is actually computing the stacktrace
@@ -109,8 +109,8 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
       let resolve, reject;
 
       super((res, rej) => {
-        resolve = code => {
-          const out = new ShellOutput(core.getBufferedStdout(), core.getBufferedStderr(), code);
+        resolve = (code, stdout, stderr) => {
+          const out = new ShellOutput(stdout, stderr, code);
           if (this.#throws && code !== 0) {
             potentialError!.initialize(out, code);
             rej(potentialError);
@@ -121,37 +121,19 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
             res(out);
           }
         };
-        reject = code => {
-          potentialError!.initialize(new ShellOutput(core.getBufferedStdout(), core.getBufferedStderr(), code), code);
+        reject = (code, stdout, stderr) => {
+          potentialError!.initialize(new ShellOutput(stdout, stderr, code), code);
           rej(potentialError);
         };
       });
 
       this.#throws = throws;
-      this.#core = core;
+      this.#args = args;
       this.#hasRun = false;
 
-      core.setResolve(resolve);
-      core.setReject(reject);
+      args.setResolveAndReject(resolve, reject);
 
       // this.#immediate = setImmediate(autoStartShell, this).unref();
-    }
-
-    get interpreter() {
-      if (IS_BUN_DEVELOPMENT) {
-        return this.#core;
-      }
-    }
-
-    get stdin(): WritableStream {
-      this.#run();
-      return this.#core.stdin;
-    }
-
-    // For TransformStream
-    get writable() {
-      this.#run();
-      return this.#core.stdin;
     }
 
     cwd(newCwd?: string): this {
@@ -159,7 +141,7 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
       if (typeof newCwd === "undefined" || newCwd === "." || newCwd === "" || newCwd === "./") {
         newCwd = defaultCwd;
       }
-      this.#core.setCwd(newCwd);
+      this.#args.setCwd(newCwd);
       return this;
     }
 
@@ -169,7 +151,7 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
         newEnv = defaultEnv;
       }
 
-      this.#core.setEnv(newEnv);
+      this.#args.setEnv(newEnv);
       return this;
     }
 
@@ -177,14 +159,16 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
       if (!this.#hasRun) {
         this.#hasRun = true;
 
-        if (this.#core.isRunning()) return;
-        this.#core.run();
+        let interp = createShellInterpreter(this.#args);
+        this.#args = undefined;
+        interp.run();
+        interp = undefined;
       }
     }
 
     #quiet(): this {
       this.#throwIfRunning();
-      this.#core.setQuiet();
+      this.#args.setQuiet();
       return this;
     }
 
@@ -308,17 +292,17 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
 
   var BunShell = function BunShell(first, ...rest) {
     if (first?.raw === undefined) throw new Error("Please use '$' as a tagged template function: $`cmd arg1 arg2`");
-    const core = new ShellInterpreter(first.raw, ...rest);
+    const parsed_shell_script = createParsedShellScript(first.raw, rest);
 
     const cwd = BunShell[cwdSymbol];
     const env = BunShell[envSymbol];
     const throws = BunShell[throwsSymbol];
 
     // cwd must be set before env or else it will be injected into env as "PWD=/"
-    if (cwd) core.setCwd(cwd);
-    if (env) core.setEnv(env);
+    if (cwd) parsed_shell_script.setCwd(cwd);
+    if (env) parsed_shell_script.setEnv(env);
 
-    return new ShellPromise(core, throws);
+    return new ShellPromise(parsed_shell_script, throws);
   };
 
   function Shell() {
@@ -328,17 +312,17 @@ export function createBunShellTemplateFunction(ShellInterpreter) {
 
     var Shell = function Shell(first, ...rest) {
       if (first?.raw === undefined) throw new Error("Please use '$' as a tagged template function: $`cmd arg1 arg2`");
-      const core = new ShellInterpreter(first.raw, ...rest);
+      const parsed_shell_script = createParsedShellScript(first.raw, rest);
 
       const cwd = Shell[cwdSymbol];
       const env = Shell[envSymbol];
       const throws = Shell[throwsSymbol];
 
       // cwd must be set before env or else it will be injected into env as "PWD=/"
-      if (cwd) core.setCwd(cwd);
-      if (env) core.setEnv(env);
+      if (cwd) parsed_shell_script.setCwd(cwd);
+      if (env) parsed_shell_script.setEnv(env);
 
-      return new ShellPromise(core, throws);
+      return new ShellPromise(parsed_shell_script, throws);
     };
 
     Object.setPrototypeOf(Shell, ShellPrototype.prototype);

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -23,8 +23,8 @@ export const patchInternals = {
 };
 
 export const shellInternals = {
-  lex: $newZigFunction("shell.zig", "TestingAPIs.shellLex", 1),
-  parse: $newZigFunction("shell.zig", "TestingAPIs.shellParse", 1),
+  lex: (a, ...b) => $newZigFunction("shell.zig", "TestingAPIs.shellLex", 2)(a.raw, b),
+  parse: (a, ...b) => $newZigFunction("shell.zig", "TestingAPIs.shellParse", 2)(a.raw, b),
   /**
    * Checks if the given builtin is disabled on the current platform
    *

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -617,6 +617,7 @@ pub const ShellArgs = struct {
 
     pub fn deinit(this: *ShellArgs) void {
         this.__arena.deinit();
+        bun.destroy(this.__arena);
         this.destroy();
     }
 

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -4527,7 +4527,7 @@ pub const TestingAPIs = struct {
         var out_parser: ?Parser = null;
         var out_lex_result: ?LexResult = null;
 
-        const script_ast = Interpreter.parse(&arena, script.items[0..], jsobjs.items[0..], jsstrings.items[0..], &out_parser, &out_lex_result) catch |err| {
+        const script_ast = Interpreter.parse(arena.allocator(), script.items[0..], jsobjs.items[0..], jsstrings.items[0..], &out_parser, &out_lex_result) catch |err| {
             if (err == ParseError.Lex) {
                 if (bun.Environment.allow_assert) assert(out_lex_result != null);
                 const str = out_lex_result.?.combineErrors(arena.allocator());

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -24,6 +24,7 @@ pub const subproc = @import("./subproc.zig");
 pub const EnvMap = interpret.EnvMap;
 pub const EnvStr = interpret.EnvStr;
 pub const Interpreter = interpret.Interpreter;
+pub const ParsedShellScript = interpret.ParsedShellScript;
 pub const Subprocess = subproc.ShellSubprocess;
 pub const ExitCode = interpret.ExitCode;
 pub const IOWriter = Interpreter.IOWriter;
@@ -3762,7 +3763,7 @@ pub const Test = struct {
 pub fn shellCmdFromJS(
     globalThis: *JSC.JSGlobalObject,
     string_args: JSValue,
-    template_args: []const JSValue,
+    template_args: *JSC.JSArrayIterator,
     out_jsobjs: *std.ArrayList(JSValue),
     jsstrings: *std.ArrayList(bun.String),
     out_script: *std.ArrayList(u8),
@@ -3782,7 +3783,10 @@ pub fn shellCmdFromJS(
         // const str = js_value.getZigString(globalThis);
         // try script.appendSlice(str.full());
         if (i < last) {
-            const template_value = template_args[i];
+            const template_value = template_args.next() orelse {
+                globalThis.throw("Shell script is missing JSValue arg", .{});
+                return false;
+            };
             if (!(try handleTemplateValue(globalThis, template_value, out_jsobjs, out_script, jsstrings, jsobjref_buf[0..]))) return false;
         }
     }
@@ -4400,7 +4404,11 @@ pub const TestingAPIs = struct {
         var arena = std.heap.ArenaAllocator.init(bun.default_allocator);
         defer arena.deinit();
 
-        const template_args = callframe.argumentsPtr()[1..callframe.argumentsCount()];
+        const template_args_js = arguments.nextEat() orelse {
+            globalThis.throw("shell: expected 2 arguments, got 0", .{});
+            return .undefined;
+        };
+        var template_args = template_args_js.arrayIterator(globalThis);
         var stack_alloc = std.heap.stackFallback(@sizeOf(bun.String) * 4, arena.allocator());
         var jsstrings = std.ArrayList(bun.String).initCapacity(stack_alloc.get(), 4) catch {
             globalThis.throwOutOfMemory();
@@ -4420,7 +4428,7 @@ pub const TestingAPIs = struct {
         }
 
         var script = std.ArrayList(u8).init(arena.allocator());
-        if (!(shellCmdFromJS(globalThis, string_args, template_args, &jsobjs, &jsstrings, &script) catch {
+        if (!(shellCmdFromJS(globalThis, string_args, &template_args, &jsobjs, &jsstrings, &script) catch {
             globalThis.throwOutOfMemory();
             return JSValue.undefined;
         })) {
@@ -4486,7 +4494,11 @@ pub const TestingAPIs = struct {
         var arena = bun.ArenaAllocator.init(bun.default_allocator);
         defer arena.deinit();
 
-        const template_args = callframe.argumentsPtr()[1..callframe.argumentsCount()];
+        const template_args_js = arguments.nextEat() orelse {
+            globalThis.throw("shell: expected 2 arguments, got 0", .{});
+            return .undefined;
+        };
+        var template_args = template_args_js.arrayIterator(globalThis);
         var stack_alloc = std.heap.stackFallback(@sizeOf(bun.String) * 4, arena.allocator());
         var jsstrings = std.ArrayList(bun.String).initCapacity(stack_alloc.get(), 4) catch {
             globalThis.throwOutOfMemory();
@@ -4505,7 +4517,7 @@ pub const TestingAPIs = struct {
             }
         }
         var script = std.ArrayList(u8).init(arena.allocator());
-        if (!(shellCmdFromJS(globalThis, string_args, template_args, &jsobjs, &jsstrings, &script) catch {
+        if (!(shellCmdFromJS(globalThis, string_args, &template_args, &jsobjs, &jsstrings, &script) catch {
             globalThis.throwOutOfMemory();
             return JSValue.undefined;
         })) {

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -4394,7 +4394,7 @@ pub const TestingAPIs = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) callconv(.C) JSC.JSValue {
-        const arguments_ = callframe.arguments(1);
+        const arguments_ = callframe.arguments(2);
         var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
         const string_args = arguments.nextEat() orelse {
             globalThis.throw("shell_parse: expected 2 arguments, got 0", .{});
@@ -4484,7 +4484,7 @@ pub const TestingAPIs = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) callconv(.C) JSC.JSValue {
-        const arguments_ = callframe.arguments(1);
+        const arguments_ = callframe.arguments(2);
         var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
         const string_args = arguments.nextEat() orelse {
             globalThis.throw("shell_parse: expected 2 arguments, got 0", .{});

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -7,10 +7,25 @@
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdir, rm, stat } from "fs/promises";
-import { bunEnv, bunExe, isWindows, runWithErrorPromise, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv as __bunEnv, bunExe, isWindows, runWithErrorPromise, tempDirWithFiles, tmpdirSync } from "harness";
 import { join, sep } from "path";
 import { createTestBuilder, sortedShellOutput } from "./util";
 const TestBuilder = createTestBuilder(import.meta.path);
+
+export const bunEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  GITHUB_ACTIONS: "false",
+  BUN_DEBUG_QUIET_LOGS: "1",
+  NO_COLOR: "1",
+  FORCE_COLOR: undefined,
+  TZ: "Etc/UTC",
+  CI: "1",
+  BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
+  BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+  BUN_GARBAGE_COLLECTOR_LEVEL: process.env.BUN_GARBAGE_COLLECTOR_LEVEL || "0",
+  // windows doesn't set this, but we do to match posix compatibility
+  PWD: process.env.PWD || process.cwd(),
+};
 
 $.env(bunEnv);
 $.cwd(process.cwd());

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -24,11 +24,11 @@ export const bunEnv: NodeJS.ProcessEnv = {
   BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
   BUN_GARBAGE_COLLECTOR_LEVEL: process.env.BUN_GARBAGE_COLLECTOR_LEVEL || "0",
   // windows doesn't set this, but we do to match posix compatibility
-  PWD: process.env.PWD || process.cwd(),
+  PWD: (process.env.PWD || process.cwd()).replaceAll("\\", "/"),
 };
 
 $.env(bunEnv);
-$.cwd(process.cwd());
+$.cwd(process.cwd().replaceAll("\\", "/"));
 $.nothrow();
 
 let temp_dir: string;

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -754,7 +754,7 @@ booga"
 
     test("cd -", async () => {
       const { stdout } = await $`cd ${temp_dir} && pwd && cd - && pwd`;
-      expect(stdout.toString()).toEqual(`${temp_dir}\n${process.cwd()}\n`);
+      expect(stdout.toString()).toEqual(`${temp_dir}\n${process.cwd().replaceAll("\\", "/")}\n`);
     });
   });
 

--- a/test/js/bun/shell/leak.test.ts
+++ b/test/js/bun/shell/leak.test.ts
@@ -87,6 +87,7 @@ describe("fd leak", () => {
       writeFileSync(tempfile, testcode);
 
       const impl = /* ts */ `
+              import { heapStats } from "bun:jsc";
               const TestBuilder = createTestBuilder(import.meta.path);
 
               const threshold = ${threshold}
@@ -102,7 +103,7 @@ describe("fd leak", () => {
 
                 const objectTypeCounts = heapStats().objectTypeCounts;
                 heapStats().objectTypeCounts.ParsedShellScript
-                if (objectTypeCounts.ParsedShellScript > 3 or objectTypeCounts.ShellInterpreter > 3) {
+                if (objectTypeCounts.ParsedShellScript > 3 || objectTypeCounts.ShellInterpreter > 3) {
                   console.error('TOO many ParsedShellScript or ShellInterpreter objects', objectTypeCounts.ParsedShellScript, objectTypeCounts.ShellInterpreter)
                   process.exit(1);
                 }

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -692,16 +692,10 @@ describe("lex shell", () => {
         Delimit: {},
       },
       {
-        CmdSubstBegin: {},
-      },
-      {
-        Text: "ls",
+        Text: "`ls`",
       },
       {
         Delimit: {},
-      },
-      {
-        CmdSubstEnd: {},
       },
       {
         Eof: {},


### PR DESCRIPTION
### What does this PR do?

Fixes #11816

**Problem**
- ShellPromise's `resolve/reject` functions closes over `ShellInterpreter` class
- the `ShellInterpreter` class holds strong references to `resolve/reject` functions
- this makes it possible for the `ShellInterpreter` class to never be deinitialized
- was not caught in shell leak tests because of immediately immediately invoked function syntax: `(async function() { /* shell stuff */ })()`

**Fix**
- lazily create `ShellInterpreter` when the `ShellPromise` is actually awaited
- instead of giving `resolve/reject` to `ShellInterpreter`, give it to new `ParsedShellScript` class which holds script AST and other options
- this breaks cycle: now `resolve/reject` don't refer to `ShellInterpreter`
- put `values: ["resolve", "reject"]` in the `ShellInterpreter` class generator
- give `ShellInterpreter` `resolve/reject` when it gets created