### PR TITLE
Support `NODE_TLS_REJECT_UNAUTHORIZED=0` at runtime and implement `BUN_CONFIG_VERBOSE_FETCH`

### DIFF
--- a/docs/runtime/env.md
+++ b/docs/runtime/env.md
@@ -143,6 +143,16 @@ These environment variables are read by Bun and configure aspects of its behavio
 
 ---
 
+- `NODE_TLS_REJECT_UNAUTHORIZED`
+- `NODE_TLS_REJECT_UNAUTHORIZED=0` disables SSL certificate validation. This is useful for testing and debugging, but should never be used in production. This was originally a Node.js environment variable, but Bun also respects it.
+
+---
+
+- `BUN_CONFIG_VERBOSE_FETCH`
+- If `BUN_CONFIG_VERBOSE_FETCH=1`, then fetch requests will log the url, method, request headers and response headers to the console. This is useful for debugging network requests. This also works with `node:http`.
+
+---
+
 - `BUN_RUNTIME_TRANSPILER_CACHE_PATH`
 - The runtime transpiler caches the transpiled output of source files larger than 50 kb. This makes CLIs using Bun load faster. If `BUN_RUNTIME_TRANSPILER_CACHE_PATH` is set, then the runtime transpiler will cache transpiled output to the specified directory. If `BUN_RUNTIME_TRANSPILER_CACHE_PATH` is set to an empty string or the string `"0"`, then the runtime transpiler will not cache transpiled output. If `BUN_RUNTIME_TRANSPILER_CACHE_PATH` is unset, then the runtime transpiler will cache transpiled output to the platform-specific cache directory.
 

--- a/docs/runtime/env.md
+++ b/docs/runtime/env.md
@@ -144,7 +144,7 @@ These environment variables are read by Bun and configure aspects of its behavio
 ---
 
 - `NODE_TLS_REJECT_UNAUTHORIZED`
-- `NODE_TLS_REJECT_UNAUTHORIZED=0` disables SSL certificate validation. This is useful for testing and debugging, but should never be used in production. This was originally a Node.js environment variable, but Bun also respects it.
+- `NODE_TLS_REJECT_UNAUTHORIZED=0` disables SSL certificate validation. This is useful for testing and debugging, but you should be very hesitant to use this in production. Note: This environment variable was originally introduced by Node.js and we kept the name for compatibility.
 
 ---
 

--- a/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
@@ -12,6 +12,7 @@
 
 #include "BunClientData.h"
 #include "wtf/Compiler.h"
+#include "wtf/Forward.h"
 
 using namespace JSC;
 
@@ -233,14 +234,13 @@ JSC_DEFINE_CUSTOM_SETTER(jsBunConfigVerboseFetchSetter, (JSGlobalObject * global
         return false;
 
     JSValue decodedValue = JSValue::decode(value);
-    if (decodedValue.isString()) {
-        WTF::String str = decodedValue.toWTFString(globalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-        if (str == "1"_s || str == "true"_s) {
-            Bun__setVerboseFetchValue(1);
-        } else {
-            Bun__setVerboseFetchValue(0);
-        }
+    WTF::String str = decodedValue.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+
+    if (str == "1"_s || str == "true"_s) {
+        Bun__setVerboseFetchValue(1);
+    } else {
+        Bun__setVerboseFetchValue(0);
     }
 
     const auto& privateName = BUN_CONFIG_VERBOSE_FETCH_PRIVATE_PROPERTY(vm);

--- a/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
@@ -11,6 +11,7 @@
 #include <JavaScriptCore/JSStringInlines.h>
 
 #include "BunClientData.h"
+#include "wtf/Compiler.h"
 
 using namespace JSC;
 
@@ -121,6 +122,135 @@ JSC_DEFINE_CUSTOM_SETTER(jsTimeZoneEnvironmentVariableSetter, (JSGlobalObject * 
     return true;
 }
 
+extern "C" int Bun__getTLSRejectUnauthorizedValue();
+extern "C" int Bun__setTLSRejectUnauthorizedValue(int value);
+extern "C" int Bun__getVerboseFetchValue();
+extern "C" int Bun__setVerboseFetchValue(int value);
+
+ALWAYS_INLINE static Identifier NODE_TLS_REJECT_UNAUTHORIZED_PRIVATE_PROPERTY(VM& vm)
+{
+    auto* clientData = WebCore::clientData(vm);
+    auto& builtinNames = clientData->builtinNames();
+    // We just pick one to reuse. This will never be exposed to a user. And we
+    // don't want to pay the cost of adding another one.
+    return builtinNames.textDecoderStreamDecoderPrivateName();
+}
+
+ALWAYS_INLINE static Identifier BUN_CONFIG_VERBOSE_FETCH_PRIVATE_PROPERTY(VM& vm)
+{
+    auto* clientData = WebCore::clientData(vm);
+    auto& builtinNames = clientData->builtinNames();
+    // We just pick one to reuse. This will never be exposed to a user. And we
+    // don't want to pay the cost of adding another one.
+    return builtinNames.textEncoderStreamEncoderPrivateName();
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsNodeTLSRejectUnauthorizedGetter, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* thisObject = jsDynamicCast<JSObject*>(JSValue::decode(thisValue));
+    if (UNLIKELY(!thisObject))
+        return JSValue::encode(jsUndefined());
+
+    const auto& privateName = NODE_TLS_REJECT_UNAUTHORIZED_PRIVATE_PROPERTY(vm);
+    JSValue result = thisObject->getDirect(vm, privateName);
+    if (UNLIKELY(result)) {
+        return JSValue::encode(result);
+    }
+
+    ZigString name = toZigString(propertyName.publicName());
+    ZigString value = { nullptr, 0 };
+
+    if (!Bun__getEnvValue(globalObject, &name, &value) || value.len == 0) {
+        return JSValue::encode(jsUndefined());
+    }
+
+    return JSValue::encode(jsString(vm, Zig::toStringCopy(value)));
+}
+
+JSC_DEFINE_CUSTOM_SETTER(jsNodeTLSRejectUnauthorizedSetter, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, PropertyName propertyName))
+{
+    VM& vm = globalObject->vm();
+    JSC::JSObject* object = JSValue::decode(thisValue).getObject();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (!object)
+        return false;
+
+    JSValue decodedValue = JSValue::decode(value);
+    if (decodedValue.isString()) {
+        WTF::String str = decodedValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (str == "0"_s || str == "false"_s) {
+            Bun__setTLSRejectUnauthorizedValue(0);
+        } else {
+            Bun__setTLSRejectUnauthorizedValue(1);
+        }
+    }
+
+    const auto& privateName = NODE_TLS_REJECT_UNAUTHORIZED_PRIVATE_PROPERTY(vm);
+    object->putDirect(vm, privateName, JSValue::decode(value), 0);
+
+    // TODO: this is an assertion failure
+    // Recreate this because the property visibility needs to be set correctly
+    // object->putDirectWithoutTransition(vm, propertyName, JSC::CustomGetterSetter::create(vm, jsTimeZoneEnvironmentVariableGetter, jsTimeZoneEnvironmentVariableSetter), JSC::PropertyAttribute::CustomAccessor | 0);
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsBunConfigVerboseFetchGetter, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* thisObject = jsDynamicCast<JSObject*>(JSValue::decode(thisValue));
+    if (UNLIKELY(!thisObject))
+        return JSValue::encode(jsUndefined());
+
+    const auto& privateName = BUN_CONFIG_VERBOSE_FETCH_PRIVATE_PROPERTY(vm);
+    JSValue result = thisObject->getDirect(vm, privateName);
+    if (UNLIKELY(result)) {
+        return JSValue::encode(result);
+    }
+
+    ZigString name = toZigString(propertyName.publicName());
+    ZigString value = { nullptr, 0 };
+
+    if (!Bun__getEnvValue(globalObject, &name, &value) || value.len == 0) {
+        return JSValue::encode(jsUndefined());
+    }
+
+    return JSValue::encode(jsString(vm, Zig::toStringCopy(value)));
+}
+
+JSC_DEFINE_CUSTOM_SETTER(jsBunConfigVerboseFetchSetter, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, PropertyName propertyName))
+{
+    VM& vm = globalObject->vm();
+    JSC::JSObject* object = JSValue::decode(thisValue).getObject();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (!object)
+        return false;
+
+    JSValue decodedValue = JSValue::decode(value);
+    if (decodedValue.isString()) {
+        WTF::String str = decodedValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (str == "1"_s || str == "true"_s) {
+            Bun__setVerboseFetchValue(1);
+        } else {
+            Bun__setVerboseFetchValue(0);
+        }
+    }
+
+    const auto& privateName = BUN_CONFIG_VERBOSE_FETCH_PRIVATE_PROPERTY(vm);
+    object->putDirect(vm, privateName, JSValue::decode(value), 0);
+
+    // TODO: this is an assertion failure
+    // Recreate this because the property visibility needs to be set correctly
+    // object->putDirectWithoutTransition(vm, propertyName, JSC::CustomGetterSetter::create(vm, jsTimeZoneEnvironmentVariableGetter, jsTimeZoneEnvironmentVariableSetter), JSC::PropertyAttribute::CustomAccessor | 0);
+    return true;
+}
+
 JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
@@ -140,7 +270,12 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 #endif
 
     static NeverDestroyed<String> TZ = MAKE_STATIC_STRING_IMPL("TZ");
+    String NODE_TLS_REJECT_UNAUTHORIZED = String("NODE_TLS_REJECT_UNAUTHORIZED"_s);
+    String BUN_CONFIG_VERBOSE_FETCH = String("BUN_CONFIG_VERBOSE_FETCH"_s);
     bool hasTZ = false;
+    bool hasNodeTLSRejectUnauthorized = false;
+    bool hasBunConfigVerboseFetch = false;
+
     for (size_t i = 0; i < count; i++) {
         unsigned char* chars;
         size_t len = Bun__getEnvKey(list, i, &chars);
@@ -150,6 +285,14 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 #endif
         if (name == TZ) {
             hasTZ = true;
+            continue;
+        }
+        if (name == NODE_TLS_REJECT_UNAUTHORIZED) {
+            hasNodeTLSRejectUnauthorized = true;
+            continue;
+        }
+        if (name == BUN_CONFIG_VERBOSE_FETCH) {
+            hasBunConfigVerboseFetch = true;
             continue;
         }
         ASSERT(len > 0);
@@ -184,6 +327,22 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     object->putDirectCustomAccessor(
         vm,
         Identifier::fromString(vm, TZ), JSC::CustomGetterSetter::create(vm, jsTimeZoneEnvironmentVariableGetter, jsTimeZoneEnvironmentVariableSetter), TZAttrs);
+
+    unsigned int NODE_TLS_REJECT_UNAUTHORIZED_Attrs = JSC::PropertyAttribute::CustomAccessor | 0;
+    if (!hasNodeTLSRejectUnauthorized) {
+        NODE_TLS_REJECT_UNAUTHORIZED_Attrs |= JSC::PropertyAttribute::DontEnum;
+    }
+    object->putDirectCustomAccessor(
+        vm,
+        Identifier::fromString(vm, NODE_TLS_REJECT_UNAUTHORIZED), JSC::CustomGetterSetter::create(vm, jsNodeTLSRejectUnauthorizedGetter, jsNodeTLSRejectUnauthorizedSetter), NODE_TLS_REJECT_UNAUTHORIZED_Attrs);
+
+    unsigned int BUN_CONFIG_VERBOSE_FETCH_Attrs = JSC::PropertyAttribute::CustomAccessor | 0;
+    if (!hasBunConfigVerboseFetch) {
+        BUN_CONFIG_VERBOSE_FETCH_Attrs |= JSC::PropertyAttribute::DontEnum;
+    }
+    object->putDirectCustomAccessor(
+        vm,
+        Identifier::fromString(vm, BUN_CONFIG_VERBOSE_FETCH), JSC::CustomGetterSetter::create(vm, jsBunConfigVerboseFetchGetter, jsBunConfigVerboseFetchSetter), BUN_CONFIG_VERBOSE_FETCH_Attrs);
 
 #if OS(WINDOWS)
     JSC::JSFunction* getSourceEvent = JSC::JSFunction::create(vm, processObjectInternalsWindowsEnvCodeGenerator(vm), globalObject);

--- a/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
@@ -179,14 +179,15 @@ JSC_DEFINE_CUSTOM_SETTER(jsNodeTLSRejectUnauthorizedSetter, (JSGlobalObject * gl
         return false;
 
     JSValue decodedValue = JSValue::decode(value);
-    if (decodedValue.isString()) {
-        WTF::String str = decodedValue.toWTFString(globalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-        if (str == "0"_s || str == "false"_s) {
-            Bun__setTLSRejectUnauthorizedValue(0);
-        } else {
-            Bun__setTLSRejectUnauthorizedValue(1);
-        }
+    WTF::String str = decodedValue.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+
+    // TODO: only check "0". Node doesn't check both. But we already did. So we
+    // should wait to do that until Bun v1.2.0.
+    if (str == "0"_s || str == "false"_s) {
+        Bun__setTLSRejectUnauthorizedValue(0);
+    } else {
+        Bun__setTLSRejectUnauthorizedValue(1);
     }
 
     const auto& privateName = NODE_TLS_REJECT_UNAUTHORIZED_PRIVATE_PROPERTY(vm);

--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -78,8 +78,8 @@
 
 namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(WebSocket);
+extern "C" int Bun__getTLSRejectUnauthorizedValue();
 
-extern "C" bool Bun__defaultRejectUnauthorized(JSGlobalObject* lexicalGlobalObject);
 static size_t getFramingOverhead(size_t payloadSize)
 {
     static const size_t hybiBaseFramingOverhead = 2; // Every frame has at least two-byte header.
@@ -164,7 +164,7 @@ WebSocket::WebSocket(ScriptExecutionContext& context)
 {
     m_state = CONNECTING;
     m_hasPendingActivity.store(true);
-    m_rejectUnauthorized = Bun__defaultRejectUnauthorized(context.jsGlobalObject());
+    m_rejectUnauthorized = Bun__getTLSRejectUnauthorizedValue() != 0;
 }
 
 WebSocket::~WebSocket()

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -112,6 +112,9 @@ pub const Loader = struct {
         }
     }
 
+    /// Checks whether `NODE_TLS_REJECT_UNAUTHORIZED` is set to `0` or `false`.
+    ///
+    /// **Prefer VirtualMachine.getTLSRejectUnauthorized()** for JavaScript, as individual workers could have different settings.
     pub fn getTLSRejectUnauthorized(this: *Loader) bool {
         if (this.reject_unauthorized) |reject_unauthorized| {
             return reject_unauthorized;

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -143,15 +143,6 @@ const ErrorCode = enum(i32) {
     tls_handshake_failed,
 };
 
-pub export fn Bun__defaultRejectUnauthorized(global: *JSC.JSGlobalObject) callconv(.C) bool {
-    var vm = global.bunVM();
-    return vm.bundler.env.getTLSRejectUnauthorized();
-}
-
-comptime {
-    _ = Bun__defaultRejectUnauthorized;
-}
-
 const CppWebSocket = opaque {
     extern fn WebSocket__didConnect(
         websocket_context: *CppWebSocket,

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1012,3 +1012,16 @@ declare module "bun:test" {
   interface Matchers<T> extends BunHarnessTestMatchers {}
   interface AsymmetricMatchers extends BunHarnessTestMatchers {}
 }
+
+/**
+ * Set `NODE_TLS_REJECT_UNAUTHORIZED` for a scope.
+ */
+export function rejectUnauthorizedScope(value: boolean) {
+  const original_rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = value ? "1" : "0";
+  return {
+    [Symbol.dispose]() {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = original_rejectUnauthorized;
+    },
+  };
+}

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -396,7 +396,7 @@ describe("Server", () => {
     const url = `${server.hostname}:${server.port}`;
 
     try {
-      // should fail
+      // This should fail because it's "http://" and not "https://"
       await fetch(`http://${url}`, { tls: { rejectUnauthorized: false } });
       expect.unreachable();
     } catch (err: any) {
@@ -404,7 +404,7 @@ describe("Server", () => {
     }
 
     {
-      const result = await fetch(`https://${url}`, { tls: { rejectUnauthorized: false } }).then(res => res.text());
+      const result = await fetch(server.url, { tls: { rejectUnauthorized: false } }).then(res => res.text());
       expect(result).toBe("Hello");
     }
 
@@ -412,18 +412,18 @@ describe("Server", () => {
     // the next attempt, when the next attempt has reject unauthorized enabled
     {
       expect(
-        async () => await fetch(`https://${url}`, { tls: { rejectUnauthorized: true } }).then(res => res.text()),
+        async () => await fetch(server.url, { tls: { rejectUnauthorized: true } }).then(res => res.text()),
       ).toThrow("self signed certificate");
     }
 
     {
       using _ = rejectUnauthorizedScope(true);
-      expect(async () => await fetch(`https://${url}`).then(res => res.text())).toThrow("self signed certificate");
+      expect(async () => await fetch(server.url).then(res => res.text())).toThrow("self signed certificate");
     }
 
     {
       using _ = rejectUnauthorizedScope(false);
-      const result = await fetch(`https://${url}`).then(res => res.text());
+      const result = await fetch(server.url).then(res => res.text());
       expect(result).toBe("Hello");
     }
   });


### PR DESCRIPTION
### What does this PR do?

- Fixes a bug with HTTPS keep-alive when `NODE_TLS_REJECT_UNAUTHORIZED=0` is set.
- Implements support for setting `process.env.NODE_TLS_REJECT_UNAUTHORIZED=0` at runtime
- Implements `BUN_CONFIG_VERBOSE_FETCH=1`

<img width="432" alt="image" src="https://github.com/oven-sh/bun/assets/709451/95d9ebb8-4e25-418e-b68a-a21590e55f02">


### How did you verify your code works?

There is a test for `NODE_TLS_REJECT_UNAUTHORIZED=0` and `NODE_TLS_REJECT_UNAUTHORIZED=1` and the keep-alive fix.