### PR TITLE
chore(test/bunx): remove duplicate check

### DIFF
--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -386,7 +386,6 @@ it('should set "npm_config_user_agent" to bun', async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await installFinished).toBe(0);
 
   const [err, out, exited] = await Promise.all([
     new Response(subprocess.stderr).text(),


### PR DESCRIPTION
### What does this PR do?

the `bun install` exit code is already checked earlier:

https://github.com/oven-sh/bun/blob/6c55ff6008884e84149f9d7bf01338aef006bb35/test/cli/install/bunx.test.ts#L381

so this pr removes the second check

was added in https://github.com/oven-sh/bun/pull/11817, sorry

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [x] Existing tests cover it
- [x] I ran my tests locally and they pass

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
