### PR TITLE
State the min. version for cross-compilation to Linux, macOS etc

### DIFF
--- a/docs/bundler/executables.md
+++ b/docs/bundler/executables.md
@@ -23,6 +23,9 @@ All imported files and packages are bundled into the executable, along with a co
 
 ## Cross-compile to other platforms
 
+> [!WARNING]
+> You need to be using v1.1.5+ of Bun to access this feature. Run `bun -v` to view your version and if it doesn't meet the requirements, run `bun upgrade` to upgrade to the latest version. Prior to 1.1.5 the acceptable params for `--target` were `browser`, `bun` or `node`.
+> See this [Bun blog post](https://bun.sh/blog/bun-v1.1.5) for details on when it was added.
 The `--target` flag lets you compile your standalone executable for a different operating system, architecture, or version of Bun than the machine you're running `bun build` on.
 
 To build for Linux x64 (most servers):


### PR DESCRIPTION
According to the below, the ability to cross-compile for custom targets like `--target=bun-linux-x64` was added in v1.1.5. I'm just updating the docs to state that minimum version requirement. https://bun.sh/blog/bun-v1.1.5

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
