### PR TITLE
fix(SSL) Fix clients write retry

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -719,7 +719,8 @@ create_ssl_context_from_options(struct us_socket_context_options_t options) {
 
   /* Default options we rely on - changing these will break our logic */
   SSL_CTX_set_read_ahead(ssl_context, 1);
-  SSL_CTX_set_mode(ssl_context, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+  SSL_CTX_set_mode(ssl_context, SSL_MODE_ENABLE_PARTIAL_WRITE |
+                                    SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 
   /* Anything below TLS 1.2 is disabled */
   SSL_CTX_set_min_proto_version(ssl_context, TLS1_2_VERSION);
@@ -1072,7 +1073,8 @@ SSL_CTX *create_ssl_context_from_bun_options(
 
   /* Default options we rely on - changing these will break our logic */
   SSL_CTX_set_read_ahead(ssl_context, 1);
-  SSL_CTX_set_mode(ssl_context, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+  SSL_CTX_set_mode(ssl_context, SSL_MODE_ENABLE_PARTIAL_WRITE |
+                                    SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 
   /* Anything below TLS 1.2 is disabled */
   SSL_CTX_set_min_proto_version(ssl_context, TLS1_2_VERSION);
@@ -1520,11 +1522,12 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(
 // TODO does this need more changes?
 struct us_connecting_socket_t *us_internal_ssl_socket_context_connect(
     struct us_internal_ssl_socket_context_t *context, const char *host,
-    int port, int options, int socket_ext_size, int* is_connected) {
-  return us_socket_context_connect(
-      2, &context->sc, host, port, options,
-      sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) +
-          socket_ext_size, is_connected);
+    int port, int options, int socket_ext_size, int *is_connected) {
+  return us_socket_context_connect(2, &context->sc, host, port, options,
+                                   sizeof(struct us_internal_ssl_socket_t) -
+                                       sizeof(struct us_socket_t) +
+                                       socket_ext_size,
+                                   is_connected);
 }
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect_unix(
@@ -1613,9 +1616,10 @@ void us_internal_ssl_socket_context_on_connect_error(
     struct us_internal_ssl_socket_context_t *context,
     struct us_internal_ssl_socket_t *(*on_connect_error)(
         struct us_internal_ssl_socket_t *, int code)) {
-  us_socket_context_on_connect_error(
-      0, (struct us_socket_context_t *)context,
-      (struct us_connecting_socket_t * (*)(struct us_connecting_socket_t *, int)) on_connect_error);
+  us_socket_context_on_connect_error(0, (struct us_socket_context_t *)context,
+                                     (struct us_connecting_socket_t *
+                                      (*)(struct us_connecting_socket_t *, int))
+                                         on_connect_error);
 }
 
 void us_internal_ssl_socket_context_on_socket_connect_error(
@@ -1679,6 +1683,12 @@ int us_internal_ssl_socket_write(struct us_internal_ssl_socket_t *s,
     us_socket_flush(0, &s->s);
   }
 
+  if (written != length) {
+    loop->data.last_write_failed = 1;
+    us_poll_change(&s->s.p, loop,
+                   LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
+  }
+
   if (written > 0) {
     return written;
   }
@@ -1704,7 +1714,8 @@ void *us_internal_ssl_socket_ext(struct us_internal_ssl_socket_t *s) {
 }
 
 void *us_internal_connecting_ssl_socket_ext(struct us_connecting_socket_t *s) {
-  return (char*)(s + 1) + sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t);
+  return (char *)(s + 1) + sizeof(struct us_internal_ssl_socket_t) -
+         sizeof(struct us_socket_t);
 }
 
 int us_internal_ssl_socket_is_shut_down(struct us_internal_ssl_socket_t *s) {
@@ -1761,11 +1772,11 @@ struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_adopt_socket(
   // todo: this is completely untested
   int new_ext_size = ext_size;
   if (ext_size != -1) {
-    new_ext_size = sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + ext_size;
+    new_ext_size = sizeof(struct us_internal_ssl_socket_t) -
+                   sizeof(struct us_socket_t) + ext_size;
   }
   return (struct us_internal_ssl_socket_t *)us_socket_context_adopt_socket(
-      0, &context->sc, &s->s,
-      new_ext_size);
+      0, &context->sc, &s->s, new_ext_size);
 }
 
 struct us_internal_ssl_socket_t *
@@ -1892,17 +1903,20 @@ ssl_wrapped_on_connect_error(struct us_internal_ssl_socket_t *s, int code) {
           context);
 
   if (wrapped_context->events.on_connect_error) {
-    wrapped_context->events.on_connect_error((struct us_connecting_socket_t *)s, code);
+    wrapped_context->events.on_connect_error((struct us_connecting_socket_t *)s,
+                                             code);
   }
 
   if (wrapped_context->old_events.on_connect_error) {
-    wrapped_context->old_events.on_connect_error((struct us_connecting_socket_t *)s, code);
+    wrapped_context->old_events.on_connect_error(
+        (struct us_connecting_socket_t *)s, code);
   }
   return s;
 }
 
 struct us_internal_ssl_socket_t *
-ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s, int code) {
+ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s,
+                                    int code) {
   struct us_internal_ssl_socket_context_t *context =
       (struct us_internal_ssl_socket_context_t *)us_socket_context(0, &s->s);
   struct us_wrapped_socket_context_t *wrapped_context =
@@ -1910,11 +1924,13 @@ ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s, int code
           context);
 
   if (wrapped_context->events.on_connecting_socket_error) {
-    wrapped_context->events.on_connecting_socket_error((struct us_socket_t *)s, code);
+    wrapped_context->events.on_connecting_socket_error((struct us_socket_t *)s,
+                                                       code);
   }
 
   if (wrapped_context->old_events.on_connecting_socket_error) {
-    wrapped_context->old_events.on_connecting_socket_error((struct us_socket_t *)s, code);
+    wrapped_context->old_events.on_connecting_socket_error(
+        (struct us_socket_t *)s, code);
   }
   return s;
 }
@@ -1984,11 +2000,11 @@ struct us_internal_ssl_socket_t *us_internal_ssl_socket_wrap_with_tls(
 
   // we need to wrap these events because we need to call the old context events
   // as well
-  us_socket_context_on_connect_error(
-      0, context,
-      (struct us_connecting_socket_t * (*)(struct us_connecting_socket_t *, int))
-          ssl_wrapped_on_connect_error);
-us_socket_context_on_socket_connect_error(
+  us_socket_context_on_connect_error(0, context,
+                                     (struct us_connecting_socket_t *
+                                      (*)(struct us_connecting_socket_t *, int))
+                                         ssl_wrapped_on_connect_error);
+  us_socket_context_on_socket_connect_error(
       0, context,
       (struct us_socket_t * (*)(struct us_socket_t *, int))
           ssl_wrapped_on_socket_connect_error);

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1534,7 +1534,7 @@ struct us_connecting_socket_t *us_internal_ssl_socket_context_connect(
       2, &context->sc, host, port, options,
       sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) +
           socket_ext_size, is_connected);
-
+}
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect_unix(
     struct us_internal_ssl_socket_context_t *context, const char *server_path,
     size_t pathlen, int options, int socket_ext_size) {

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1529,13 +1529,11 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(
 // TODO does this need more changes?
 struct us_connecting_socket_t *us_internal_ssl_socket_context_connect(
     struct us_internal_ssl_socket_context_t *context, const char *host,
-    int port, int options, int socket_ext_size, int *is_connected) {
-  return us_socket_context_connect(2, &context->sc, host, port, options,
-                                   sizeof(struct us_internal_ssl_socket_t) -
-                                       sizeof(struct us_socket_t) +
-                                       socket_ext_size,
-                                   is_connected);
-}
+    int port, int options, int socket_ext_size, int* is_connected) {
+  return us_socket_context_connect(
+      2, &context->sc, host, port, options,
+      sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) +
+          socket_ext_size, is_connected);
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect_unix(
     struct us_internal_ssl_socket_context_t *context, const char *server_path,
@@ -1623,10 +1621,9 @@ void us_internal_ssl_socket_context_on_connect_error(
     struct us_internal_ssl_socket_context_t *context,
     struct us_internal_ssl_socket_t *(*on_connect_error)(
         struct us_internal_ssl_socket_t *, int code)) {
-  us_socket_context_on_connect_error(0, (struct us_socket_context_t *)context,
-                                     (struct us_connecting_socket_t *
-                                      (*)(struct us_connecting_socket_t *, int))
-                                         on_connect_error);
+  us_socket_context_on_connect_error(
+      0, (struct us_socket_context_t *)context,
+      (struct us_connecting_socket_t * (*)(struct us_connecting_socket_t *, int)) on_connect_error);
 }
 
 void us_internal_ssl_socket_context_on_socket_connect_error(
@@ -1715,8 +1712,7 @@ void *us_internal_ssl_socket_ext(struct us_internal_ssl_socket_t *s) {
 }
 
 void *us_internal_connecting_ssl_socket_ext(struct us_connecting_socket_t *s) {
-  return (char *)(s + 1) + sizeof(struct us_internal_ssl_socket_t) -
-         sizeof(struct us_socket_t);
+  return (char*)(s + 1) + sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t);
 }
 
 int us_internal_ssl_socket_is_shut_down(struct us_internal_ssl_socket_t *s) {
@@ -1773,11 +1769,11 @@ struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_adopt_socket(
   // todo: this is completely untested
   int new_ext_size = ext_size;
   if (ext_size != -1) {
-    new_ext_size = sizeof(struct us_internal_ssl_socket_t) -
-                   sizeof(struct us_socket_t) + ext_size;
+    new_ext_size = sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + ext_size;
   }
   return (struct us_internal_ssl_socket_t *)us_socket_context_adopt_socket(
-      0, &context->sc, &s->s, new_ext_size);
+      0, &context->sc, &s->s,
+      new_ext_size);
 }
 
 struct us_internal_ssl_socket_t *
@@ -1904,20 +1900,17 @@ ssl_wrapped_on_connect_error(struct us_internal_ssl_socket_t *s, int code) {
           context);
 
   if (wrapped_context->events.on_connect_error) {
-    wrapped_context->events.on_connect_error((struct us_connecting_socket_t *)s,
-                                             code);
+    wrapped_context->events.on_connect_error((struct us_connecting_socket_t *)s, code);
   }
 
   if (wrapped_context->old_events.on_connect_error) {
-    wrapped_context->old_events.on_connect_error(
-        (struct us_connecting_socket_t *)s, code);
+    wrapped_context->old_events.on_connect_error((struct us_connecting_socket_t *)s, code);
   }
   return s;
 }
 
 struct us_internal_ssl_socket_t *
-ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s,
-                                    int code) {
+ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s, int code) {
   struct us_internal_ssl_socket_context_t *context =
       (struct us_internal_ssl_socket_context_t *)us_socket_context(0, &s->s);
   struct us_wrapped_socket_context_t *wrapped_context =
@@ -1925,13 +1918,11 @@ ssl_wrapped_on_socket_connect_error(struct us_internal_ssl_socket_t *s,
           context);
 
   if (wrapped_context->events.on_connecting_socket_error) {
-    wrapped_context->events.on_connecting_socket_error((struct us_socket_t *)s,
-                                                       code);
+    wrapped_context->events.on_connecting_socket_error((struct us_socket_t *)s, code);
   }
 
   if (wrapped_context->old_events.on_connecting_socket_error) {
-    wrapped_context->old_events.on_connecting_socket_error(
-        (struct us_socket_t *)s, code);
+    wrapped_context->old_events.on_connecting_socket_error((struct us_socket_t *)s, code);
   }
   return s;
 }
@@ -2001,11 +1992,11 @@ struct us_internal_ssl_socket_t *us_internal_ssl_socket_wrap_with_tls(
 
   // we need to wrap these events because we need to call the old context events
   // as well
-  us_socket_context_on_connect_error(0, context,
-                                     (struct us_connecting_socket_t *
-                                      (*)(struct us_connecting_socket_t *, int))
-                                         ssl_wrapped_on_connect_error);
-  us_socket_context_on_socket_connect_error(
+  us_socket_context_on_connect_error(
+      0, context,
+      (struct us_connecting_socket_t * (*)(struct us_connecting_socket_t *, int))
+          ssl_wrapped_on_connect_error);
+us_socket_context_on_socket_connect_error(
       0, context,
       (struct us_socket_t * (*)(struct us_socket_t *, int))
           ssl_wrapped_on_socket_connect_error);

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -722,6 +722,8 @@ create_ssl_context_from_options(struct us_socket_context_options_t options) {
 
   /* Default options we rely on - changing these will break our logic */
   SSL_CTX_set_read_ahead(ssl_context, 1);
+  /* we should always accept moving write buffer so we can retry writes with a
+   * buffer allocated in a different address */
   SSL_CTX_set_mode(ssl_context, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 
   /* Anything below TLS 1.2 is disabled */
@@ -733,10 +735,7 @@ create_ssl_context_from_options(struct us_socket_context_options_t options) {
   /* Important option for lowering memory usage, but lowers performance slightly
    */
   if (options.ssl_prefer_low_memory_usage) {
-    // we should always accept moving write buffer so we can retry writes with a
-    // buffer allocated in a different address
-    SSL_CTX_set_mode(ssl_context, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER |
-                                      SSL_MODE_RELEASE_BUFFERS);
+    SSL_CTX_set_mode(ssl_context, SSL_MODE_RELEASE_BUFFERS);
   }
 
   if (options.passphrase) {
@@ -1078,6 +1077,8 @@ SSL_CTX *create_ssl_context_from_bun_options(
 
   /* Default options we rely on - changing these will break our logic */
   SSL_CTX_set_read_ahead(ssl_context, 1);
+  /* we should always accept moving write buffer so we can retry writes with a
+   * buffer allocated in a different address */
   SSL_CTX_set_mode(ssl_context, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 
   /* Anything below TLS 1.2 is disabled */
@@ -1089,10 +1090,7 @@ SSL_CTX *create_ssl_context_from_bun_options(
   /* Important option for lowering memory usage, but lowers performance slightly
    */
   if (options.ssl_prefer_low_memory_usage) {
-    // we should always accept moving write buffer so we can retry writes with a
-    // buffer allocated in a different address
-    SSL_CTX_set_mode(ssl_context, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER |
-                                      SSL_MODE_RELEASE_BUFFERS);
+    SSL_CTX_set_mode(ssl_context, SSL_MODE_RELEASE_BUFFERS);
   }
 
   if (options.passphrase) {

--- a/src/deps/boringssl.translated.zig
+++ b/src/deps/boringssl.translated.zig
@@ -19029,18 +19029,12 @@ pub const SSL = opaque {
         if (hostname.len > 0) ssl.setHostname(hostname);
         _ = SSL_clear_options(ssl, SSL_OP_LEGACY_SERVER_CONNECT);
         _ = SSL_set_options(ssl, SSL_OP_LEGACY_SERVER_CONNECT);
-        const mode = SSL_MODE_CBC_RECORD_SPLITTING | SSL_MODE_ENABLE_FALSE_START | SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER;
-
-        _ = SSL_set_mode(ssl, mode);
-        _ = SSL_clear_mode(ssl, mode);
 
         const alpns = &[_]u8{ 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
         bun.assert(SSL_set_alpn_protos(ssl, alpns, alpns.len) == 0);
 
         SSL_enable_signed_cert_timestamps(ssl);
         SSL_enable_ocsp_stapling(ssl);
-
-        // bun.assert(SSL_set_strict_cipher_list(ssl, SSL_DEFAULT_CIPHER_LIST) == 0);
 
         SSL_set_enable_ech_grease(ssl, 1);
     }
@@ -19167,7 +19161,6 @@ pub const SSL_CTX = opaque {
     pub fn setup(ctx: *SSL_CTX) void {
         if (auto_crypto_buffer_pool == null) auto_crypto_buffer_pool = CRYPTO_BUFFER_POOL_new();
         SSL_CTX_set0_buffer_pool(ctx, auto_crypto_buffer_pool);
-        // _ = SSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY);
         _ = SSL_CTX_set_cipher_list(ctx, SSL_DEFAULT_CIPHER_LIST);
         SSL_CTX_set_quiet_shutdown(ctx, 1);
     }

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -399,6 +399,7 @@ pub fn WindowsPipeReader(
             }
             var this: *This = bun.cast(*This, fs.data);
             fs.deinit();
+            if (this.flags.is_done) return;
 
             switch (nread_int) {
                 // 0 actually means EOF too

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -399,7 +399,6 @@ pub fn WindowsPipeReader(
             }
             var this: *This = bun.cast(*This, fs.data);
             fs.deinit();
-            if (this.flags.is_done) return;
 
             switch (nread_int) {
                 // 0 actually means EOF too

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import crypto from "crypto";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { tls, bunEnv, bunExe, gc } from "harness";
@@ -681,9 +682,9 @@ describe("websocket in subprocess", () => {
     const { promise, resolve, reject } = Promise.withResolvers();
     const ws = new WebSocket("https://echo.websocket.org/");
 
-    const payload = crypto.randomBytes(1024 * 64);
-    const iterations = 3;
-    const expected = 1024 * 64 * iterations;
+    const payload = crypto.randomBytes(1024 * 16);
+    const iterations = 10;
+    const expected = payload.byteLength * iterations;
 
     let total_received = 0;
     const timeout = setTimeout(() => {

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -676,4 +676,41 @@ describe("websocket in subprocess", () => {
     server.stop(true);
     expect(await subprocess.exited).toBe(0);
   });
+
+  it("should be able to send big messages", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const ws = new WebSocket("https://echo.websocket.org/");
+
+    const payload = crypto.randomBytes(1024 * 64);
+    const iterations = 3;
+    const expected = 1024 * 64 * iterations;
+
+    let total_received = 0;
+    const timeout = setTimeout(() => {
+      ws.close();
+    }, 4000);
+    ws.addEventListener("close", e => {
+      clearTimeout(timeout);
+      resolve(total_received);
+    });
+
+    ws.addEventListener("message", e => {
+      if (typeof e.data === "string") {
+        return;
+      }
+      const received = e.data.byteLength || e.data.size || 0;
+      total_received += received;
+      if (total_received >= expected) {
+        ws.close();
+      }
+    });
+    ws.addEventListener("error", reject);
+    ws.addEventListener("open", () => {
+      for (let i = 0; i < 10; i++) {
+        ws.send(payload);
+      }
+    });
+
+    expect(await promise).toBe(expected);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix: https://github.com/oven-sh/bun/issues/11144
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Added a test
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
