### PR TITLE
Add pluralization to test command summary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Configuring a development environment for Bun can take 10-30 minutes depending on your internet connection and computer speed. You will need ~10GB of free disk space for the repository and build artifacts.
 
-If you are using Windows, please refer to [this guide](/docs/project/building-windows)
+If you are using Windows, please refer to [this guide](/docs/project/building-windows.md)
 
 ## Install Dependencies
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -267,7 +267,10 @@ pub const CommandLineReporter = struct {
         const tests = this.summary.fail + this.summary.pass + this.summary.skip + this.summary.todo;
         const files = this.summary.files;
 
-        Output.prettyError("Ran {d} tests across {d} files. ", .{ tests, files });
+        const pluralizedTests = if (tests === 1) "test" else "tests";
+        const pluralizedFiles = if (files === 1) "file" else "files";
+
+        Output.prettyError("Ran {d} {s} across {d} {s}. ", .{ tests, pluralizedTests, files, pluralizedFiles });
         Output.printStartEnd(bun.start_time, std.time.nanoTimestamp());
     }
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -267,8 +267,8 @@ pub const CommandLineReporter = struct {
         const tests = this.summary.fail + this.summary.pass + this.summary.skip + this.summary.todo;
         const files = this.summary.files;
 
-        const pluralizedTests = if (tests === 1) "test" else "tests";
-        const pluralizedFiles = if (files === 1) "file" else "files";
+        const pluralizedTests = if (tests == 1) "test" else "tests";
+        const pluralizedFiles = if (files == 1) "file" else "files";
 
         Output.prettyError("Ran {d} {s} across {d} {s}. ", .{ tests, pluralizedTests, files, pluralizedFiles });
         Output.printStartEnd(bun.start_time, std.time.nanoTimestamp());


### PR DESCRIPTION
### What does this PR do?

This PR adds basic pluralization for the test results.
So no more `Ran 1 tests across 1 files.`, `Ran 1 test across 1 file.` instead.

Besides this, I encountered a bad link in the CONTRIBUTING.md which I also fixed.

- [x] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

- [x] I included a test for the new code, **or an existing test covers it**
