### PR TITLE
Change "what's new" link to bun blog instead of release page

### DIFF
--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -948,20 +948,20 @@ pub const UpgradeCommand = struct {
                     \\
                     \\<b><green>Welcome to Bun v{s}!<r>
                     \\
+                    \\What's new in Bun v{s}:
+                    \\
+                    \\    <cyan>https://bun.sh/blog/release-notes/{s}<r>
+                    \\
                     \\Report any bugs:
                     \\
                     \\    https://github.com/oven-sh/bun/issues
                     \\
-                    \\What's new:
-                    \\
-                    \\    <cyan>https://bun.sh/blog/{s}<r>
-                    \\
-                    \\Changelog:
+                    \\Commit log:
                     \\
                     \\    https://github.com/oven-sh/bun/compare/{s}...{s}
                     \\
                 ,
-                    .{ version_name, version.tag, bun_v, version.tag },
+                    .{ version_name, version_name, version.tag, bun_v, version.tag },
                 );
             }
 

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -954,7 +954,7 @@ pub const UpgradeCommand = struct {
                     \\
                     \\What's new:
                     \\
-                    \\    <cyan>https://github.com/oven-sh/bun/releases/tag/{s}<r>
+                    \\    <cyan>https://bun.sh/blog/{s}<r>
                     \\
                     \\Changelog:
                     \\


### PR DESCRIPTION
Instead of linking to the release, the "what's new" link shown on `bun upgrade` links to the relevant blog post.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)