### PR TITLE
Utilize Promise.all for Efficient Asynchronous Operations 🚀

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2111,36 +2111,40 @@ comptime {
 ]);
 if (!process.env.ONLY_ZIG) {
   const allHeaders = classes.map(a => generateHeader(a.name, a));
-  await writeIfNotChanged(`${outBase}/ZigGeneratedClasses.h`, [
-    GENERATED_CLASSES_HEADER[0],
-    ...[...new Set(extraIncludes.map(a => `#include "${a}";` + "\n"))],
-    GENERATED_CLASSES_HEADER[1],
-    ...allHeaders,
-    GENERATED_CLASSES_FOOTER,
+  await Promise.all([
+    writeIfNotChanged(`${outBase}/ZigGeneratedClasses.h`, [
+      GENERATED_CLASSES_HEADER[0],
+      ...[...new Set(extraIncludes.map(a => `#include "${a}";` + "\n"))],
+      GENERATED_CLASSES_HEADER[1],
+      ...allHeaders,
+      GENERATED_CLASSES_FOOTER,
+    ]),
+
+    writeIfNotChanged(`${outBase}/ZigGeneratedClasses.cpp`, [
+      GENERATED_CLASSES_IMPL_HEADER,
+      ...classes.map(a => generateImpl(a.name, a)),
+      writeCppSerializers(classes),
+      GENERATED_CLASSES_IMPL_FOOTER,
+    ]),
+
+    writeIfNotChanged(
+      `${outBase}/ZigGeneratedClasses+lazyStructureHeader.h`,
+      classes.map(a => generateLazyClassStructureHeader(a.name, a)).join("\n"),
+    ), 
+
+    writeIfNotChanged(
+      `${outBase}/ZigGeneratedClasses+DOMClientIsoSubspaces.h`,
+      classes.map(a => [`std::unique_ptr<GCClient::IsoSubspace> ${clientSubspaceFor(a.name)};`].join("\n")),
+    ),
+
+    writeIfNotChanged(
+      `${outBase}/ZigGeneratedClasses+DOMIsoSubspaces.h`,
+      classes.map(a => [`std::unique_ptr<IsoSubspace> ${subspaceFor(a.name)};`].join("\n")),
+    ),
+
+    writeIfNotChanged(
+      `${outBase}/ZigGeneratedClasses+lazyStructureImpl.h`,
+      initLazyClasses(classes.map(a => generateLazyClassStructureImpl(a.name, a))) + "\n" + visitLazyClasses(classes),
+    )
   ]);
-  await writeIfNotChanged(`${outBase}/ZigGeneratedClasses.cpp`, [
-    GENERATED_CLASSES_IMPL_HEADER,
-    ...classes.map(a => generateImpl(a.name, a)),
-    writeCppSerializers(classes),
-    GENERATED_CLASSES_IMPL_FOOTER,
-  ]);
-  await writeIfNotChanged(
-    `${outBase}/ZigGeneratedClasses+lazyStructureHeader.h`,
-    classes.map(a => generateLazyClassStructureHeader(a.name, a)).join("\n"),
-  );
-
-  await writeIfNotChanged(
-    `${outBase}/ZigGeneratedClasses+DOMClientIsoSubspaces.h`,
-    classes.map(a => [`std::unique_ptr<GCClient::IsoSubspace> ${clientSubspaceFor(a.name)};`].join("\n")),
-  );
-
-  await writeIfNotChanged(
-    `${outBase}/ZigGeneratedClasses+DOMIsoSubspaces.h`,
-    classes.map(a => [`std::unique_ptr<IsoSubspace> ${subspaceFor(a.name)};`].join("\n")),
-  );
-
-  await writeIfNotChanged(
-    `${outBase}/ZigGeneratedClasses+lazyStructureImpl.h`,
-    initLazyClasses(classes.map(a => generateLazyClassStructureImpl(a.name, a))) + "\n" + visitLazyClasses(classes),
-  );
 }


### PR DESCRIPTION
### What does this PR do?



This pull request refactors the code to leverage `Promise.all` for running multiple asynchronous functions concurrently. By utilizing `Promise.all`, we achieve improved performance and readability when dealing with asynchronous operations.

**Benefits of Promise.all:**

* **Improved Performance:** `Promise.all` allows all the asynchronous functions to execute concurrently, potentially leading to significant performance gains, especially when dealing with independent tasks.
* **Simplified Code:** By using `Promise.all`, we can group multiple asynchronous operations into a single line, making the code more concise and easier to maintain.


<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
