### PR TITLE
docs(guides): add example how to parse query params for Bun.serve

### DIFF
--- a/docs/guides/http/server.md
+++ b/docs/guides/http/server.md
@@ -11,6 +11,11 @@ const server = Bun.serve({
   async fetch (req) {
     const path = new URL(req.url).pathname;
 
+    // parse query params
+    const { paramA, paramB } = Object.fromEntries(
+      new URL(req.url).searchParams.entries()
+    );
+
     // respond with text/html
     if (path === "/") return new Response("Welcome to Bun!");
 


### PR DESCRIPTION
### What does this PR do?

Guide describes all basic routing logic, but it doesn't tell anything about query params.
I've added a small snippet to make this guide complete.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
