### PR TITLE
fix(windows): dont call SetConsoleMode on stdin

### DIFF
--- a/src/output.zig
+++ b/src/output.zig
@@ -196,7 +196,6 @@ pub const Source = struct {
             if (w.kernel32.GetConsoleMode(stdin, &mode) != 0) {
                 console_mode[0] = mode;
                 bun_stdio_tty[0] = 1;
-                _ = w.SetConsoleMode(stdin, mode | w.ENABLE_VIRTUAL_TERMINAL_INPUT);
             }
 
             if (w.kernel32.GetConsoleMode(stdout, &mode) != 0) {


### PR DESCRIPTION
### What does this PR do?

Running `bun` with no arguments on Windows would leave the terminal in an invalid state, which powershell would not expect and exit.

![image](https://github.com/oven-sh/bun/assets/24465214/901700c7-38eb-4055-a674-a5b7e820c128)

I am unaware of any place we actually depend on setting `ENABLE_VIRTUAL_TERMINAL_PROCESSING`. Node.js only does this within libuv's tty stuff, so we should not need to touch it at all.

From MS Docs:

> Setting this flag directs the Virtual Terminal processing engine to convert user input received by the console window into [Console Virtual Terminal Sequences](https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences) that can be retrieved by a supporting application through [ReadFile](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile) or [ReadConsole](https://learn.microsoft.com/en-us/windows/console/readconsole) functions.
>
> The typical usage of this flag is intended in conjunction with ENABLE_VIRTUAL_TERMINAL_PROCESSING on the output handle to connect to an application that communicates exclusively via virtual terminal sequences.

We do not use it for this or anything else.

### How did you verify your code works?

Manually testing a set of prompt libraries, `bun init`, etc