### PR TITLE
fix(install): use correct lockfile when printing install summary

### DIFF
--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -1246,7 +1246,7 @@ pub const Behavior = packed struct(u8) {
             (features.optional_dependencies and this.isOptional()) or
             (features.dev_dependencies and this.isDev()) or
             (features.peer_dependencies and this.isPeer()) or
-            this.isWorkspace();
+            (features.workspaces and this.isWorkspaceOnly());
     }
 
     pub fn format(self: Behavior, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -939,6 +939,10 @@ pub fn NewPackageInstall(comptime kind: PkgInstallKind) type {
             skipped: u32 = 0,
             successfully_installed: ?Bitset = null,
 
+            /// The lockfile used by `installPackages`. Might be different from the lockfile
+            /// on disk if `--production` is used and dev dependencies are removed.
+            lockfile_used_for_install: *Lockfile,
+
             /// Package name hash -> number of scripts skipped.
             /// Multiple versions of the same package might add to the count, and each version
             /// might have a different number of scripts
@@ -12008,7 +12012,9 @@ pub const PackageManager = struct {
             skip_delete = false;
         }
 
-        var summary = PackageInstall.Summary{};
+        var summary = PackageInstall.Summary{
+            .lockfile_used_for_install = this.lockfile,
+        };
 
         {
             var iterator = Lockfile.Tree.Iterator.init(this.lockfile);
@@ -12971,7 +12977,9 @@ pub const PackageManager = struct {
             }
         }
 
-        var install_summary = PackageInstall.Summary{};
+        var install_summary = PackageInstall.Summary{
+            .lockfile_used_for_install = manager.lockfile,
+        };
         if (manager.options.do.install_packages) {
             install_summary = try manager.installPackages(
                 ctx,
@@ -13111,7 +13119,7 @@ pub const PackageManager = struct {
         if (comptime log_level != .silent) {
             if (manager.options.do.summary) {
                 var printer = Lockfile.Printer{
-                    .lockfile = manager.lockfile,
+                    .lockfile = install_summary.lockfile_used_for_install,
                     .options = manager.options,
                     .updates = manager.update_requests,
                     .successfully_installed = install_summary.successfully_installed,

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -717,12 +717,13 @@ pub fn maybeCloneFilteringRootPackages(
     const old_packages = old.packages.slice();
     const old_dependencies_lists = old_packages.items(.dependencies);
     const old_resolutions_lists = old_packages.items(.resolutions);
+    const old_resolutions = old_packages.items(.resolution);
     var any_changes = false;
     const end: PackageID = @truncate(old.packages.len);
 
     // set all disabled dependencies of workspaces to `invalid_package_id`
     for (0..end) |package_id| {
-        if (!old.isWorkspacePackageId(@intCast(package_id))) continue;
+        if (package_id != 0 and old_resolutions[package_id].tag != .workspace) continue;
 
         const old_workspace_dependencies_list = old_dependencies_lists[package_id];
         var old_workspace_resolutions_list = old_resolutions_lists[package_id];
@@ -855,11 +856,6 @@ pub fn isWorkspaceDependency(this: *const Lockfile, id: DependencyID) bool {
     }
 
     return false;
-}
-
-/// Is this package id a workspace package (including workspace root)?
-pub fn isWorkspacePackageId(this: *const Lockfile, id: PackageID) bool {
-    return id == 0 or this.packages.items(.resolution)[id].tag == .workspace;
 }
 
 /// Does this tree id belong to a workspace (including workspace root)?

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -863,6 +863,7 @@ pub fn isWorkspaceTreeId(this: *const Lockfile, id: Tree.Id) bool {
     return id == 0 or this.buffers.dependencies.items[this.buffers.trees.items[id].dependency_id].behavior.isWorkspaceOnly();
 }
 
+/// Returns the package id of the workspace the install is taking place in.
 pub fn getWorkspacePackageID(this: *const Lockfile, workspace_name_hash: ?PackageNameHash) PackageID {
     return if (workspace_name_hash) |workspace_name_hash_| brk: {
         const packages = this.packages.slice();

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -896,10 +896,18 @@ export function tmpdirSync(pattern: string = "bun.test.") {
 export async function runBunInstall(
   env: NodeJS.ProcessEnv,
   cwd: string,
-  options?: { allowWarnings?: boolean; allowErrors?: boolean; expectedExitCode?: number; savesLockfile?: boolean },
+  options?: {
+    allowWarnings?: boolean;
+    allowErrors?: boolean;
+    expectedExitCode?: number;
+    savesLockfile?: boolean;
+    production?: boolean;
+  },
 ) {
+  const production = options?.production ?? false;
+  const args = production ? [bunExe(), "install", "--production"] : [bunExe(), "install"];
   const { stdout, stderr, exited } = Bun.spawn({
-    cmd: [bunExe(), "install"],
+    cmd: args,
     cwd,
     stdout: "pipe",
     stdin: "ignore",
@@ -916,7 +924,7 @@ export async function runBunInstall(
   if (!options?.allowWarnings) {
     expect(err).not.toContain("warn:");
   }
-  if (options?.savesLockfile ?? true) {
+  if ((options?.savesLockfile ?? true) && !production) {
     expect(err).toContain("Saved lockfile");
   }
   let out = await new Response(stdout).text();


### PR DESCRIPTION
### What does this PR do?
When `--production` is enabled an in-memory only lockfile is created without dev dependencies. This change makes sure we use this lockfile when printing the install summary.

Also fixed in this pr: excluding dev dependencies in workspaces from `--production` installs

fixes #11913 
fixes #7969 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test for workspaces with `devDependencies`
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
