### PR TITLE
fix(napi) `napi_call_threadsafe_function` should work with null data and  `napi_create_threadsafe_function` should keep the process alive by default

### DIFF
--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1632,6 +1632,9 @@ pub export fn napi_create_threadsafe_function(
     };
 
     function.finalizer = .{ .data = thread_finalize_data, .fun = thread_finalize_cb };
+    // nodejs by default keeps the event loop alive until the thread-safe function is destroyed
+    function.ref();
+
     result.* = function;
     return .ok;
 }

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1632,7 +1632,7 @@ pub export fn napi_create_threadsafe_function(
     };
 
     function.finalizer = .{ .data = thread_finalize_data, .fun = thread_finalize_cb };
-    // nodejs by default keeps the event loop alive until the thread-safe function is destroyed
+    // nodejs by default keeps the event loop alive until the thread-safe function is unref'd
     function.ref();
 
     result.* = function;

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -42,7 +42,11 @@ napi_value tsfn_name_11949;
 
 static void test_issue_11949_callback(napi_env env, napi_value js_callback,
                                       void *context, void *data) {
-  printf("data: %p\n", data);
+  if (data != nullptr) {
+    printf("data: %p\n", data);
+  } else {
+    printf("data: nullptr\n");
+  }
   napi_unref_threadsafe_function(env, tsfn_11949);
 }
 

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -37,6 +37,34 @@ napi_value test_issue_7685(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+napi_threadsafe_function tsfn_11949;
+napi_value tsfn_name_11949;
+
+static void test_issue_11949_callback(napi_env env, napi_value js_callback,
+                                      void *context, void *data) {
+  printf("data: %p\n", data);
+  napi_unref_threadsafe_function(env, tsfn_11949);
+}
+
+static napi_value test_issue_11949(const Napi::CallbackInfo &info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+  napi_status status;
+  status = napi_create_string_utf8(env, "TSFN", 4, &tsfn_name_11949);
+  assert(status == napi_ok);
+  status = napi_create_threadsafe_function(
+      env, NULL, NULL, tsfn_name_11949, 0, 1, NULL, NULL, NULL,
+      &test_issue_11949_callback, &tsfn_11949);
+  assert(status == napi_ok);
+  status =
+      napi_call_threadsafe_function(tsfn_11949, NULL, napi_tsfn_nonblocking);
+  assert(status == napi_ok);
+  napi_value result;
+  status = napi_get_undefined(env, &result);
+  assert(status == napi_ok);
+  return result;
+}
+
 napi_value
 test_napi_get_value_string_utf8_with_buffer(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
@@ -78,12 +106,11 @@ test_napi_get_value_string_utf8_with_buffer(const Napi::CallbackInfo &info) {
 Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
   // check that these symbols are defined
   auto *isolate = v8::Isolate::GetCurrent();
-  node::AddEnvironmentCleanupHook(
-      isolate, [](void *) {}, isolate);
-  node::RemoveEnvironmentCleanupHook(
-      isolate, [](void *) {}, isolate);
+  node::AddEnvironmentCleanupHook(isolate, [](void *) {}, isolate);
+  node::RemoveEnvironmentCleanupHook(isolate, [](void *) {}, isolate);
 
   exports.Set("test_issue_7685", Napi::Function::New(env, test_issue_7685));
+  exports.Set("test_issue_11949", Napi::Function::New(env, test_issue_11949));
 
   exports.Set(
       "test_napi_get_value_string_utf8_with_buffer",

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -24,6 +24,12 @@ describe("napi", () => {
       checkSameOutput("test_issue_7685", args);
     });
   });
+  describe("issue_11949", () => {
+    it("napi_call_threadsafe_function should accept null", () => {
+      const result = checkSameOutput("test_issue_11949", []);
+      expect(result).toBe("data: 0000000000000000");
+    });
+  });
 
   describe("napi_get_value_string_utf8 with buffer", () => {
     // see https://github.com/oven-sh/bun/issues/6949

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -27,7 +27,7 @@ describe("napi", () => {
   describe("issue_11949", () => {
     it("napi_call_threadsafe_function should accept null", () => {
       const result = checkSameOutput("test_issue_11949", []);
-      expect(result).toBe("data: 0000000000000000");
+      expect(result).toStartWith("data: nullptr");
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix: #11949
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
Added a test
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
