### PR TITLE
Use stderr instead of stdout in bun patch errors

### DIFF
--- a/src/install/patch_install.zig
+++ b/src/install/patch_install.zig
@@ -158,7 +158,7 @@ pub const PatchTask = struct {
         if (this.callback.apply.logger.errors > 0) {
             defer this.callback.apply.logger.deinit();
             Output.errGeneric("failed to apply patchfile ({s})", .{this.callback.apply.patchfilepath});
-            this.callback.apply.logger.printForLogLevel(Output.writer()) catch {};
+            this.callback.apply.logger.printForLogLevel(Output.errorWriter()) catch {};
         }
     }
 
@@ -183,7 +183,7 @@ pub const PatchTask = struct {
             }
             if (calc_hash.logger.errors > 0) {
                 Output.prettyErrorln("\n\n", .{});
-                calc_hash.logger.printForLogLevel(Output.writer()) catch {};
+                calc_hash.logger.printForLogLevel(Output.errorWriter()) catch {};
             }
             Output.flush();
             Global.crash();

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -10,7 +10,6 @@ describe("bundler", () => {
     target: "bun",
     outfile: "",
     outdir: "/out",
-
     files: {
       "/entry.ts": /* js */ `
         import db from './db.sqlite' with {type: "sqlite", embed: "true"};


### PR DESCRIPTION
### What does this PR do?

Use stderr instead of stdout in bun patch errors

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
