### PR TITLE
fix(transpiler): mark non-ascii TS enum keys as UTF-16

### DIFF
--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -2284,9 +2284,8 @@ pub const E = struct {
                     .is_utf16 = true,
                 };
             }
-            return .{
-                .data = value,
-            };
+
+            return .{ .data = value };
         }
 
         pub fn slice16(this: *const String) []const u16 {

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -11453,7 +11453,6 @@ fn NewParser_(
                 try p.lexer.next();
 
                 // Identifiers can be referenced by other values
-
                 if (!opts.is_typescript_declare and needs_symbol) {
                     value.ref = try p.declareSymbol(.other, value.loc, try value.name.string(p.allocator));
                 }

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -11441,7 +11441,11 @@ fn NewParser_(
                 if (p.lexer.token == .t_string_literal) {
                     value.name = p.lexer.toEString();
                 } else if (p.lexer.isIdentifierOrKeyword()) {
-                    value.name = E.String{ .data = p.lexer.identifier };
+                    const id = p.lexer.identifier;
+                    value.name = if (bun.strings.isAllASCII(id))
+                        .{ .data = id }
+                    else
+                        E.String.init(try bun.strings.toUTF16AllocForReal(p.allocator, id, false, false));
                     needs_symbol = true;
                 } else {
                     try p.lexer.expect(.t_identifier);

--- a/test/cli/run/run-unicode.test.ts
+++ b/test/cli/run/run-unicode.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { mkdirSync, realpathSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, bunRun } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -18,4 +18,21 @@ test("running a weird filename works", async () => {
     stdio: ["ignore", "pipe", "inherit"],
   });
   expect(stdout.toString("utf8")).toEqual("hello world\n");
+});
+
+test("ts enum with utf16 works", () => {
+  const result = bunRun(join(import.meta.dir, "ts-enum-fixture.ts"));
+  expect(result.stdout).toBe(`{
+  "1": "aaaa\u5FEB\u00E9\u00E9",
+  "123": "bbb",
+  "\u5B89\u5168\u4E32\u884C": "\u5B89\u5168\u4E32\u884C",
+  aaa: "\u5E73\u8861\u4E32\u884C",
+  "aa\u90ED": "\u5FEB\u901F\u4E32\u884C",
+  "\u5B89\u5168\u5E76\u884C": "\u5B89\u5168\u5E76\u884C",
+  "\u5E73\u8861\u5E76\u884C": "\u5E73\u8861\u5E76\u884C",
+  "\u5FEB\u901F\u5E76\u884C": "\u5FEB\u901F\u5E76\u884C",
+  "aaaa\u5FEB\u00E9\u00E9": 1,
+  "Fran\u00E7ais": 123,
+  bbb: 123,
+}`);
 });

--- a/test/cli/run/ts-enum-fixture.ts
+++ b/test/cli/run/ts-enum-fixture.ts
@@ -1,0 +1,14 @@
+// https://github.com/oven-sh/bun/issues/11963
+enum Enum {
+  安全串行 = "安全串行",
+  aaa = "平衡串行",
+  aa郭 = "快速串行",
+  安全并行 = "安全并行",
+  平衡并行 = "平衡并行",
+  '快速并行' = "快速并行",
+  aaaa\u5FEBé\u00E9 = 1,
+  Français = 123,
+  bbb = Français,
+}
+
+console.log(Enum)

--- a/test/cli/run/ts-enum-fixture.ts
+++ b/test/cli/run/ts-enum-fixture.ts
@@ -5,10 +5,10 @@ enum Enum {
   aa郭 = "快速串行",
   安全并行 = "安全并行",
   平衡并行 = "平衡并行",
-  '快速并行' = "快速并行",
-  aaaa\u5FEBé\u00E9 = 1,
+  "快速并行" = "快速并行",
+  aaaa快éé = 1,
   Français = 123,
   bbb = Français,
 }
 
-console.log(Enum)
+console.log(Enum);


### PR DESCRIPTION
### What does this PR do?

As we know, when transpiling for bun runtime, the source code must be output to latin1 (in practice, i believe we use just ascii subset). Enum keys evaded this.

TODO: write test case, example below

Fixes #11963
Fixes #9524

```
export enum GrabbingScheme {
  安全串行 = "安全串行",
  aaa = "平衡串行",
  aa郭 = "快速串行",
  安全并行 = "安全并行",
  平衡并行 = "平衡并行",
  '快速并行' = "快速并行",
  awa\u5FEB = 1,
  hello = 1,
}

const x = { 快速并行: 1 };
console.log(GrabbingScheme)
```