### PR TITLE
fix(env_loader): incorrect implementation of map remove method

### DIFF
--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -1270,7 +1270,7 @@ pub const Map = struct {
     }
 
     pub fn remove(this: *Map, key: string) void {
-        this.map.remove(key);
+        _ = this.map.swapRemove(key);
     }
 };
 


### PR DESCRIPTION
### What does this PR do?

Fixes #11993

Correctly implements the remove method in the custom map within env_loader

- [x] Code changes