### PR TITLE
Fix minor spelling mistake in bun:test toThrowError()

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1230,7 +1230,7 @@ declare module "bun:test" {
      * - If expected is a `string` or `RegExp`, it will check the `message` property.
      * - If expected is an `Error` object, it will check the `name` and `message` properties.
      * - If expected is an `Error` constructor, it will check the class of the `Error`.
-     * - If expected is not provided, it will check if anything as thrown.
+     * - If expected is not provided, it will check if anything has thrown.
      *
      * @example
      * function fail() {


### PR DESCRIPTION
### What does this PR do?

Fix spelling mistake 

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
Change does not affect bun's functionality.
<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
