### PR TITLE
Fixed proxies getting ignored by http

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -1411,6 +1411,7 @@ class ClientRequest extends OutgoingMessage {
       proxy = `${protocol}//${this.#host}${this.#useDefaultPort ? "" : ":" + this.#port}`;
     } else {
       url = `${protocol}//${this.#host}${this.#useDefaultPort ? "" : ":" + this.#port}${path}`;
+      proxy = this.#options.agents?.http?.proxy?.href ?? this.#options.agents?.https?.proxy?.href;
     }
     const tls = protocol === "https:" && this.#tls ? { ...this.#tls, serverName: this.#tls.servername } : undefined;
     try {


### PR DESCRIPTION
### What does this PR do?

Fixes #12005 . The axios adapter passes the proxy url through the agents in the http options.

### How did you verify your code works?

Confirmed that proxies are now successfully passed to fetch.