### PR TITLE
remove glibc `memfd_create` from required symbols

### DIFF
--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1301,13 +1301,8 @@ pub fn spawnProcessPosix(
                             else => "spawn_stdio_generic",
                         };
 
-                        // We use the linux syscall api because the glibc requirement is 2.27, which is a little close for comfort.
-                        const rc = std.os.linux.memfd_create(label, 0);
-                        if (bun.C.getErrno(rc) != .SUCCESS) {
-                            break :use_memfd;
-                        }
+                        const fd = bun.sys.memfd_create(label, 0).unwrap() catch break :use_memfd;
 
-                        const fd = bun.toFD(@as(u32, @intCast(rc)));
                         to_close_on_error.append(fd) catch {};
                         to_set_cloexec.append(fd) catch {};
                         try actions.dup2(fd, fileno);

--- a/src/bun.js/api/bun/spawn/stdio.zig
+++ b/src/bun.js/api/bun/spawn/stdio.zig
@@ -111,20 +111,7 @@ pub const Stdio = union(enum) {
             else => "spawn_stdio_memory_file",
         };
 
-        // We use the linux syscall api because the glibc requirement is 2.27, which is a little close for comfort.
-        const rc = std.c.memfd_create(label, 0);
-
-        log("memfd_create({s}) = {d}", .{ label, rc });
-
-        switch (bun.C.getErrno(rc)) {
-            .SUCCESS => {},
-            else => |errno| {
-                log("Failed to create memfd: {s}", .{@tagName(errno)});
-                return;
-            },
-        }
-
-        const fd = bun.toFD(rc);
+        const fd = bun.sys.memfd_create(label, 0).unwrap() catch return;
 
         var remain = this.byteSlice();
 

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -577,7 +577,6 @@ pub const Version = struct {
                                 }
                             }
 
-
                             if (url.len > 4 and strings.eqlComptime(url[0.."git@".len], "git@")) {
                                 url = url["git@".len..];
                             }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -756,16 +756,7 @@ pub const Task = struct {
                 const url = this.request.git_clone.url.slice();
                 var attempt: u8 = 1;
                 const dir = brk: {
-                    if (Repository.tryHTTPS(url)) |https| break :brk Repository.download(
-                        manager.allocator,
-                        manager.env,
-                        manager.log,
-                        manager.getCacheDirectory(),
-                        this.id,
-                        name,
-                        https,
-                        attempt
-                    ) catch |err| {
+                    if (Repository.tryHTTPS(url)) |https| break :brk Repository.download(manager.allocator, manager.env, manager.log, manager.getCacheDirectory(), this.id, name, https, attempt) catch |err| {
                         // Exit early if git checked and could
                         // not find the repository, skip ssh
                         if (err == error.RepositoryNotFound) {
@@ -780,16 +771,7 @@ pub const Task = struct {
                         break :brk null;
                     };
                     break :brk null;
-                } orelse if (Repository.trySSH(url)) |ssh| Repository.download(
-                    manager.allocator,
-                    manager.env,
-                    manager.log,
-                    manager.getCacheDirectory(),
-                    this.id,
-                    name,
-                    ssh,
-                    attempt
-                ) catch |err| {
+                } orelse if (Repository.trySSH(url)) |ssh| Repository.download(manager.allocator, manager.env, manager.log, manager.getCacheDirectory(), this.id, name, ssh, attempt) catch |err| {
                     this.err = err;
                     this.status = Status.fail;
                     this.data = .{ .git_clone = bun.invalid_fd };

--- a/src/linux_memfd_allocator.zig
+++ b/src/linux_memfd_allocator.zig
@@ -137,6 +137,7 @@ pub const LinuxMemFdAllocator = struct {
         var label_buf: [128]u8 = undefined;
         const label = std.fmt.bufPrintZ(&label_buf, "memfd-num-{d}", .{memfd_counter.fetchAdd(1, .monotonic)}) catch "";
 
+        // Using huge pages was slower.
         const fd = switch (bun.sys.memfd_create(label, std.os.linux.MFD.CLOEXEC)) {
             .err => |err| return .{ .err = bun.sys.Error.fromCode(err.getErrno(), .open) },
             .result => |fd| fd,

--- a/src/linux_memfd_allocator.zig
+++ b/src/linux_memfd_allocator.zig
@@ -134,26 +134,13 @@ pub const LinuxMemFdAllocator = struct {
             unreachable;
         }
 
-        const rc = brk: {
-            var label_buf: [128]u8 = undefined;
-            const label = std.fmt.bufPrintZ(&label_buf, "memfd-num-{d}", .{memfd_counter.fetchAdd(1, .monotonic)}) catch "";
+        var label_buf: [128]u8 = undefined;
+        const label = std.fmt.bufPrintZ(&label_buf, "memfd-num-{d}", .{memfd_counter.fetchAdd(1, .monotonic)}) catch "";
 
-            // Using huge pages was slower.
-            const code = std.c.memfd_create(label.ptr, std.os.linux.MFD.CLOEXEC | 0);
-
-            bun.sys.syslog("memfd_create({s}) = {d}", .{ label, code });
-            break :brk code;
+        const fd = switch (bun.sys.memfd_create(label, std.os.linux.MFD.CLOEXEC)) {
+            .err => |err| return .{ .err = bun.sys.Error.fromCode(err.getErrno(), .open) },
+            .result => |fd| fd,
         };
-
-        switch (bun.C.getErrno(rc)) {
-            .SUCCESS => {},
-            else => |errno| {
-                bun.sys.syslog("Failed to create memfd: {s}", .{@tagName(errno)});
-                return .{ .err = bun.sys.Error.fromCode(errno, .open) };
-            },
-        }
-
-        const fd = bun.toFD(rc);
 
         if (bytes.len > 0)
             // Hint at the size of the file

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2223,7 +2223,8 @@ pub fn memfd_create(name: [:0]const u8, flags: u32) Maybe(bun.FileDescriptor) {
 
     log("memfd_create({s}, {d}) = {d}", .{ name, flags, rc });
 
-    return Maybe(bun.FileDescriptor).errnoSys(rc, .memfd_create) orelse .{ .result = bun.toFD(rc) };
+    return Maybe(bun.FileDescriptor).errnoSys(rc, .memfd_create) orelse
+        .{ .result = bun.toFD(@as(c_int, @intCast(rc))) };
 }
 
 pub fn setPipeCapacityOnLinux(fd: bun.FileDescriptor, capacity: usize) Maybe(usize) {


### PR DESCRIPTION
### What does this PR do?
Fixes using bun with Vercel
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
