### PR TITLE
Rename code coverage reporter for `console` -> `text`

### DIFF
--- a/docs/test/coverage.md
+++ b/docs/test/coverage.md
@@ -68,16 +68,24 @@ coverageIgnoreSourcemaps = true   # default false
 
 By default, coverage reports will be printed to the console.
 
-You can specify the reporters and the directory where the reports will be saved.
-This is needed, especially when you integrate coverages with tools like CodeCov, CodeClimate, Coveralls and so on.
+For persistent code coverage reports in CI environments and for other tools, you can pass a `--coverage-reporter=lcov` CLI option or `coverageReporter` option in `bunfig.toml`.
 
 ```toml
-coverageReporters  = ["console", "lcov"]  # default ["console"]
+[test]
+coverageReporter  = ["text", "lcov"]  # default ["text"]
 coverageDir = "path/to/somewhere"  # default "coverage"
 ```
 
-| Reporter  | Description |
-|-----------|-------------|
-| `console` | Prints a text summary of the coverage to the console. |
-| `lcov`    | Save coverage in [lcov](https://github.com/linux-test-project/lcov) format. |
+| Reporter | Description                                                                 |
+| -------- | --------------------------------------------------------------------------- |
+| `text`   | Prints a text summary of the coverage to the console.                       |
+| `lcov`   | Save coverage in [lcov](https://github.com/linux-test-project/lcov) format. |
 
+#### lcov coverage reporter
+
+To generate an lcov report, you can use the `lcov` reporter. This will generate an `lcov.info` file in the `coverage` directory.
+
+```toml
+[test]
+coverageReporter = "lcov"
+```

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -249,7 +249,7 @@ pub const Arguments = struct {
         clap.parseParam("--only                           Only run tests that are marked with \"test.only()\"") catch unreachable,
         clap.parseParam("--todo                           Include tests that are marked with \"test.todo()\"") catch unreachable,
         clap.parseParam("--coverage                       Generate a coverage profile") catch unreachable,
-        clap.parseParam("--coverage-reporter <STR>...     Report coverage in 'console' and/or 'lcov'. Defaults to 'console'.") catch unreachable,
+        clap.parseParam("--coverage-reporter <STR>...     Report coverage in 'text' and/or 'lcov'. Defaults to 'text'.") catch unreachable,
         clap.parseParam("--coverage-dir <STR>             Directory for coverage files. Defaults to 'coverage'.") catch unreachable,
         clap.parseParam("--bail <NUMBER>?                 Exit the test suite after <NUMBER> failures. If you do not specify a number, it defaults to 1.") catch unreachable,
         clap.parseParam("-t, --test-name-pattern <STR>    Run only tests with a name that matches the given regex.") catch unreachable,
@@ -444,10 +444,10 @@ pub const Arguments = struct {
             }
 
             if (args.options("--coverage-reporter").len > 0) {
-                ctx.test_options.coverage.reporters = .{ .console = false, .lcov = false };
+                ctx.test_options.coverage.reporters = .{ .text = false, .lcov = false };
                 for (args.options("--coverage-reporter")) |reporter| {
-                    if (bun.strings.eqlComptime(reporter, "console")) {
-                        ctx.test_options.coverage.reporters.console = true;
+                    if (bun.strings.eqlComptime(reporter, "text")) {
+                        ctx.test_options.coverage.reporters.text = true;
                     } else if (bun.strings.eqlComptime(reporter, "lcov")) {
                         ctx.test_options.coverage.reporters.lcov = true;
                     } else {

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -717,7 +717,7 @@ pub const TestCommand = struct {
         lcov,
     };
     const Reporters = struct {
-        console: bool,
+        text: bool,
         lcov: bool,
     };
 

--- a/src/sourcemap/CodeCoverage.zig
+++ b/src/sourcemap/CodeCoverage.zig
@@ -65,7 +65,7 @@ pub const CodeCoverageReport = struct {
         return (@as(f64, @floatFromInt(this.functions_which_have_executed.count())) / total_count);
     }
 
-    pub const Console = struct {
+    pub const Text = struct {
         pub fn writeFormatWithValues(
             filename: []const u8,
             max_filename_length: usize,
@@ -685,7 +685,7 @@ pub const ByteRangeMapping = struct {
         var buffered_writer = mutable_str.bufferedWriter();
         var writer = buffered_writer.writer();
 
-        CodeCoverageReport.Console.writeFormat(&report, source_url.utf8ByteLength(), &coverage_fraction, "", &writer, false) catch {
+        CodeCoverageReport.Text.writeFormat(&report, source_url.utf8ByteLength(), &coverage_fraction, "", &writer, false) catch {
             globalThis.throwOutOfMemory();
             return .zero;
         };


### PR DESCRIPTION
### What does this PR do?

Rename code coverage reporter for `console` -> `text`

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
