### PR TITLE
Remove extraneous `Bun.ArrayBufferSink` mention.

### DIFF
--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -200,8 +200,6 @@ Bun.openInEditor(import.meta.url, {
 });
 ```
 
-Bun.ArrayBufferSink;
-
 ## `Bun.deepEquals()`
 
 Recursively checks if two objects are equivalent. This is used internally by `expect().toEqual()` in `bun:test`.


### PR DESCRIPTION
### What does this PR do?

This removes a mention to `Bun.ArrayBufferSink` that appears to be a leftover on the [Bun.openInEditor()](https://bun.sh/docs/api/utils#bun-openineditor) method documentation.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
