### PR TITLE
Fixes #12070

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9592,7 +9592,7 @@ pub const PackageManager = struct {
             // add
             // remove
             outer: for (positionals) |positional| {
-                var input: []u8 = @constCast(std.mem.trim(u8, positional, " \n\r\t"));
+                var input: []u8 = bun.default_allocator.dupe(u8, std.mem.trim(u8, positional, " \n\r\t")) catch bun.outOfMemory();
                 {
                     var temp: [2048]u8 = undefined;
                     const len = std.mem.replace(u8, input, "\\\\", "/", &temp);

--- a/test/cli/install/bun-repl.test.ts
+++ b/test/cli/install/bun-repl.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "bun:test";
+import "harness";
+
+// https://github.com/oven-sh/bun/issues/12070
+test("bun repl", () => {
+  expect(["repl", "-e", "process.exit(0)"]).toRun();
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #12070

Between Zig v0.12.0 and v0.13.0, strings were changed to be written to the text segment of the executable instead of the data segment. This means that mutating global constants will now cause a segmentation fault. Our code was unintentionally relying on this behavior - that mutating const data wouldn't cause issues.

### How did you verify your code works?

There is a hello world `bun repl` test.