### PR TITLE
Remove empty if statement in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1423,10 +1423,6 @@ else()
     )
 endif()
 
-if(WIN32)
-    # delayimp -delayload:shell32.dll -delayload:ole32.dll
-endif()
-
 if(BUN_LINK_ONLY)
     message(STATUS "NOTE: BUN_LINK_ONLY is ON, this build config will only link the Bun executable")
 endif()


### PR DESCRIPTION
There is a redundant branch condition in CMakeLists.txt. There used to be some code that was run, but it has been commented out.
