### PR TITLE
Add OS version to crash report message

### DIFF
--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -260,70 +260,74 @@ const platform_arch = if (Environment.isAarch64) Analytics.Architecture.arm else
 pub const GenerateHeader = struct {
     pub const GeneratePlatform = struct {
         var osversion_name: [32]u8 = undefined;
-        pub fn forMac() Analytics.Platform {
+        fn forMac() Analytics.Platform {
             @memset(&osversion_name, 0);
 
             var platform = Analytics.Platform{ .os = Analytics.OperatingSystem.macos, .version = &[_]u8{}, .arch = platform_arch };
             var len = osversion_name.len - 1;
-            if (std.c.sysctlbyname("kern.osrelease", &osversion_name, &len, null, 0) == -1) return platform;
+            // this previously used "kern.osrelease", which was the darwin xnu kernel version
+            // That is less useful than "kern.osproductversion", which is the macOS version
+            if (std.c.sysctlbyname("kern.osproductversion", &osversion_name, &len, null, 0) == -1) return platform;
 
             platform.version = bun.sliceTo(&osversion_name, 0);
             return platform;
         }
 
         pub var linux_os_name: std.c.utsname = undefined;
-        var platform_: ?Analytics.Platform = null;
+        var platform_: Analytics.Platform = undefined;
         pub const Platform = Analytics.Platform;
-
         var linux_kernel_version: Semver.Version = undefined;
+        var run_once = std.once(struct {
+            fn run() void {
+                if (comptime Environment.isMac) {
+                    platform_ = forMac();
+                } else if (comptime Environment.isPosix) {
+                    platform_ = forLinux();
+
+                    const release = bun.sliceTo(&linux_os_name.release, 0);
+                    const sliced_string = Semver.SlicedString.init(release, release);
+                    const result = Semver.Version.parse(sliced_string);
+                    linux_kernel_version = result.version.min();
+                } else if (Environment.isWindows) {
+                    platform_ = Platform{
+                        .os = Analytics.OperatingSystem.windows,
+                        .version = &[_]u8{},
+                        .arch = platform_arch,
+                    };
+                }
+            }
+        }.run);
 
         pub fn forOS() Analytics.Platform {
-            if (platform_ != null) return platform_.?;
-
-            if (comptime Environment.isMac) {
-                platform_ = forMac();
-                return platform_.?;
-            } else if (comptime Environment.isPosix) {
-                platform_ = forLinux();
-
-                const release = bun.sliceTo(&linux_os_name.release, 0);
-                const sliced_string = Semver.SlicedString.init(release, release);
-                const result = Semver.Version.parse(sliced_string);
-                linux_kernel_version = result.version.min();
-            } else {
-                platform_ = Platform{
-                    .os = Analytics.OperatingSystem.windows,
-                    .version = &[_]u8{},
-                    .arch = platform_arch,
-                };
-            }
-
-            return platform_.?;
+            run_once.call();
+            return platform_;
         }
 
         pub fn kernelVersion() Semver.Version {
-            if (comptime !Environment.isLinux) {
+            if (comptime Environment.isLinux) {
                 @compileError("This function is only implemented on Linux");
             }
             _ = forOS();
 
-            // we only care about major, minor, patch so we don't care about the string
-            return linux_kernel_version;
+            if (Environment.isLinux) {
+                return linux_kernel_version;
+            }
         }
 
-        pub fn forLinux() Analytics.Platform {
+        fn forLinux() Analytics.Platform {
             linux_os_name = std.mem.zeroes(@TypeOf(linux_os_name));
 
             _ = std.c.uname(&linux_os_name);
 
+            // Confusingly, the "release" tends to contain the kernel version much more frequently than the "version" field.
             const release = bun.sliceTo(&linux_os_name.release, 0);
-            const version = std.mem.sliceTo(&linux_os_name.version, @as(u8, 0));
+
             // Linux DESKTOP-P4LCIEM 5.10.16.3-microsoft-standard-WSL2 #1 SMP Fri Apr 2 22:23:49 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
             if (std.mem.indexOf(u8, release, "microsoft") != null) {
-                return Analytics.Platform{ .os = Analytics.OperatingSystem.wsl, .version = version, .arch = platform_arch };
+                return Analytics.Platform{ .os = Analytics.OperatingSystem.wsl, .version = release, .arch = platform_arch };
             }
 
-            return Analytics.Platform{ .os = Analytics.OperatingSystem.linux, .version = version, .arch = platform_arch };
+            return Analytics.Platform{ .os = Analytics.OperatingSystem.linux, .version = release, .arch = platform_arch };
         }
     };
 };

--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -304,14 +304,12 @@ pub const GenerateHeader = struct {
         }
 
         pub fn kernelVersion() Semver.Version {
-            if (comptime Environment.isLinux) {
+            if (comptime !Environment.isLinux) {
                 @compileError("This function is only implemented on Linux");
             }
             _ = forOS();
 
-            if (Environment.isLinux) {
-                return linux_kernel_version;
-            }
+            return linux_kernel_version;
         }
 
         fn forLinux() Analytics.Platform {

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -749,10 +749,11 @@ pub fn printMetadata(writer: anytype) !void {
         if (bun.Environment.isLinux) {
             // TODO: musl
             const version = gnu_get_libc_version() orelse "";
+            const kernel_version = bun.Analytics.GenerateHeader.GeneratePlatform.kernelVersion();
             if (platform.os == .wsl) {
-                try writer.print("WSL Kernel v{s} | glibc v{s}\n", .{ platform.version, bun.sliceTo(version, 0) });
+                try writer.print("WSL Kernel v{d}.{d}.{d} | glibc v{s}\n", .{ kernel_version.major, kernel_version.minor, kernel_version.patch, bun.sliceTo(version, 0) });
             } else {
-                try writer.print("Linux Kernel v{s} | glibc v{s}\n", .{ platform.version, bun.sliceTo(version, 0) });
+                try writer.print("Linux Kernel v{d}.{d}.{d} | glibc v{s}\n", .{ kernel_version.major, kernel_version.minor, kernel_version.patch, bun.sliceTo(version, 0) });
             }
         } else if (bun.Environment.isMac) {
             try writer.print("macOS v{s}\n", .{platform.version});

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -736,6 +736,8 @@ pub fn handleSegfaultWindows(info: *windows.EXCEPTION_POINTERS) callconv(windows
     );
 }
 
+extern "C" fn gnu_get_libc_version() ?[*:0]const u8;
+
 pub fn printMetadata(writer: anytype) !void {
     if (Output.enable_ansi_colors) {
         try writer.writeAll(Output.prettyFmt("<r><d>", true));
@@ -743,6 +745,18 @@ pub fn printMetadata(writer: anytype) !void {
 
     try writer.writeAll(metadata_version_line);
     {
+        const platform = bun.Analytics.GenerateHeader.GeneratePlatform.forOS();
+        if (bun.Environment.isLinux) {
+            // TODO: musl
+            const version = gnu_get_libc_version() orelse "";
+            if (platform.os == .wsl) {
+                try writer.print("WSL Kernel v{s} | glibc v{s}\n", .{ platform.version, bun.sliceTo(version, 0) });
+            } else {
+                try writer.print("Linux Kernel v{s} | glibc v{s}\n", .{ platform.version, bun.sliceTo(version, 0) });
+            }
+        } else if (bun.Environment.isMac) {
+            try writer.print("macOS v{s}\n", .{platform.version});
+        }
         try writer.print("Args: ", .{});
         var arg_chars_left: usize = if (bun.Environment.isDebug) 4096 else 196;
         for (bun.argv, 0..) |arg, i| {


### PR DESCRIPTION
### What does this PR do?

Add OS version to crash report message

```ts
============================================================
Bun v1.1.17 (314666d8) macOS Silicon
macOS v14.4.1
Args: "bun-debug" "--eval" "Bun.FFI.read.i32(0)"
Features: jsc bunfig tsconfig(2) 
Builtins: "bun:main" 
Elapsed: 40ms | User: 25ms | Sys: 41ms
RSS: 57.62MB | Peak: 57.62MB | Commit: 1.07GB | Faults: 42
```

The new line is:
> macOS v14.4.1

We were also using the wrong field for the linux kernel version, so it was usually empty.

### How did you verify your code works?

Manually