### PR TITLE
5% faster fs.readdirSync for small directories on macOS 

### DIFF
--- a/src/bun.js/node/dir_iterator.zig
+++ b/src/bun.js/node/dir_iterator.zig
@@ -56,6 +56,7 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
             buf: [8192]u8, // TODO align(@alignOf(os.system.dirent)),
             index: usize,
             end_index: usize,
+            received_eof: bool = false,
 
             const Self = @This();
 
@@ -77,6 +78,22 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
             fn nextDarwin(self: *Self) Result {
                 start_over: while (true) {
                     if (self.index >= self.end_index) {
+                        if (self.received_eof) {
+                            return .{ .result = null };
+                        }
+
+                        // getdirentries64() writes to the last 4 bytes of the
+                        // buffer to indicate EOF. If that value is not zero, we
+                        // have reached the end of the directory and we can skip
+                        // the extra syscall.
+                        // https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/bsd/vfs/vfs_syscalls.c#L10444-L10470
+                        const GETDIRENTRIES64_EXTENDED_BUFSIZE = 1024;
+                        comptime std.debug.assert(@sizeOf(@TypeOf(self.buf)) >= GETDIRENTRIES64_EXTENDED_BUFSIZE);
+                        self.received_eof = false;
+                        // Always zero the bytes where the flag will be written
+                        // so we don't confuse garbage with EOF.
+                        self.buf[self.buf.len - 4 ..][0..4].* = .{ 0, 0, 0, 0 };
+
                         const rc = posix.system.__getdirentries64(
                             self.dir.fd,
                             &self.buf,
@@ -85,7 +102,11 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
                         );
 
                         if (rc < 1) {
-                            if (rc == 0) return Result{ .result = null };
+                            if (rc == 0) {
+                                self.received_eof = true;
+                                return Result{ .result = null };
+                            }
+
                             if (Result.errnoSys(rc, .getdirentries64)) |err| {
                                 return err;
                             }
@@ -93,6 +114,7 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
 
                         self.index = 0;
                         self.end_index = @as(usize, @intCast(rc));
+                        self.received_eof = self.end_index <= (self.buf.len - 4) and @as(u32, @bitCast(self.buf[self.buf.len - 4 ..][0..4].*)) == 1;
                     }
                     const darwin_entry = @as(*align(1) posix.system.dirent, @ptrCast(&self.buf[self.index]));
                     const next_index = self.index + darwin_entry.reclen;

--- a/src/bun.js/node/dir_iterator.zig
+++ b/src/bun.js/node/dir_iterator.zig
@@ -88,7 +88,7 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
                         // the extra syscall.
                         // https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/bsd/vfs/vfs_syscalls.c#L10444-L10470
                         const GETDIRENTRIES64_EXTENDED_BUFSIZE = 1024;
-                        comptime std.debug.assert(@sizeOf(@TypeOf(self.buf)) >= GETDIRENTRIES64_EXTENDED_BUFSIZE);
+                        comptime bun.assert(@sizeOf(@TypeOf(self.buf)) >= GETDIRENTRIES64_EXTENDED_BUFSIZE);
                         self.received_eof = false;
                         // Always zero the bytes where the flag will be written
                         // so we don't confuse garbage with EOF.


### PR DESCRIPTION
### What does this PR do?

Read the EOF flag from `getdirentries64`

Yields about a 5% performance improvement when reading small directories by skipping the extra system call to getdirentries since it already told us that there are no more dir entries.

See also:
- https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/bsd/vfs/vfs_syscalls.c#L10444-L10470
- https://github.com/apple-oss-distributions/Libc/blob/main/gen/FreeBSD/opendir.c#L373-L392


New:
```zig
cpu: Apple M3 Max
runtime: bun 1.1.17 (arm64-darwin)

benchmark                                              time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------------------------------------------- -----------------------------
readdirSync("/tmp/small-dir", {recursive: false})    7.41 µs/iter     (7.29 µs … 7.62 µs)    7.4 µs   7.62 µs   7.62 µs

 1 files/dirs in /tmp/small-dir
 SHA256: 7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519
```

Bun v1.1.16:
```zig
runtime: bun 1.1.16 (arm64-darwin)

benchmark                                              time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------------------------------------------- -----------------------------
readdirSync("/tmp/small-dir", {recursive: false})    7.92 µs/iter     (7.76 µs … 8.03 µs)   7.95 µs   8.03 µs   8.03 µs

 1 files/dirs in /tmp/small-dir
 SHA256: 7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519
```

Node.js:
```zig
runtime: node v22.3.0 (arm64-darwin)

benchmark                                              time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------------------------------------------- -----------------------------
readdirSync("/tmp/small-dir", {recursive: false})    7.96 µs/iter     (7.89 µs … 8.24 µs)   7.95 µs   8.24 µs   8.24 µs

 1 files/dirs in /tmp/small-dir
 SHA256: 7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519
```

### How did you verify your code works?

There are existing tests, but I also stepped through with the debugger on both large and small directories and verified the received_eof flag is set when it should and when it shouldn't be. 
