### PR TITLE
Make `Lockfile.Buffers.readArray` more careful

### DIFF
--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -5580,6 +5580,11 @@ const Buffers = struct {
             return error.CorruptLockfile;
         }
 
+        // We shouldn't be going backwards.
+        if (start_pos < stream.pos) {
+            return error.CorruptLockfile;
+        }
+
         const end_pos = try reader.readInt(u64, .little);
 
         // If its 0xDEADBEEF, then that means the value was never written in the lockfile.

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -5581,7 +5581,7 @@ const Buffers = struct {
         }
 
         // We shouldn't be going backwards.
-        if (start_pos < stream.pos) {
+        if (start_pos < (stream.pos -| @sizeOf(u64))) {
             return error.CorruptLockfile;
         }
 

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -5568,19 +5568,48 @@ const Buffers = struct {
 
         var reader = stream.reader();
         const start_pos = try reader.readInt(u64, .little);
+
+        // If its 0xDEADBEEF, then that means the value was never written in the lockfile.
+        if (start_pos == 0xDEADBEEF) {
+            return error.CorruptLockfile;
+        }
+
+        // These are absolute numbers, it shouldn't be zero.
+        // There's a prefix before any of the arrays, so it can never be zero here.
+        if (start_pos == 0) {
+            return error.CorruptLockfile;
+        }
+
         const end_pos = try reader.readInt(u64, .little);
 
-        stream.pos = end_pos;
+        // If its 0xDEADBEEF, then that means the value was never written in the lockfile.
+        // That shouldn't happen.
+        if (end_pos == 0xDEADBEEF) {
+            return error.CorruptLockfile;
+        }
+
+        // These are absolute numbers, it shouldn't be zero.
+        if (end_pos == 0) {
+            return error.CorruptLockfile;
+        }
+
+        // Prevent integer overflow.
+        if (start_pos > end_pos) {
+            return error.CorruptLockfile;
+        }
+
+        // Prevent buffer overflow.
+        if (end_pos > stream.buffer.len) {
+            return error.CorruptLockfile;
+        }
+
         const byte_len = end_pos - start_pos;
+        stream.pos = end_pos;
 
         if (byte_len == 0) return ArrayList{
             .items = &[_]PointerType{},
             .capacity = 0,
         };
-
-        if (stream.pos > stream.buffer.len) {
-            return error.BufferOverflow;
-        }
 
         const misaligned = std.mem.bytesAsSlice(PointerType, stream.buffer[start_pos..end_pos]);
 


### PR DESCRIPTION
### What does this PR do?

- Check that the end position of an array > start position
- Check that start/end offsets aren't 0
- Check that the start position is not less than the current position

Inspired by:

panic: integer overflow

- [lockfile.zig:5588](https://github.com/oven-sh/bun/blob/bf7b327f68568104a5e40c1944b7b255b02f0745/src/install/lockfile.zig#L5588): readArray
- [lockfile.zig:5768](https://github.com/oven-sh/bun/blob/bf7b327f68568104a5e40c1944b7b255b02f0745/src/install/lockfile.zig#L5768): load
- [lockfile.zig:6052](https://github.com/oven-sh/bun/blob/bf7b327f68568104a5e40c1944b7b255b02f0745/src/install/lockfile.zig#L6052): load
- [lockfile.zig:263](https://github.com/oven-sh/bun/blob/bf7b327f68568104a5e40c1944b7b255b02f0745/src/install/lockfile.zig#L263): loadFromDisk
- [install.zig:13043](https://github.com/oven-sh/bun/blob/bf7b327f68568104a5e40c1944b7b255b02f0745/src/install/install.zig#L13043): installWithManager
- [filter_run.zig:431](https://github.com/oven-sh/bun/blob/bf7b327f68568104a5e40c1944b7b255b02f0745/src/cli/filter_run.zig#L431): install
- [cli.zig:1494](https://github.com/oven-sh/bun/blob/bf7b327f68568104a5e40c1944b7b255b02f0745/src/cli.zig#L1494): start
- [cli.zig:62](https://github.com/oven-sh/bun/blob/bf7b327f68568104a5e40c1944b7b255b02f0745/src/cli.zig#L62): start
- [main.zig:51](https://github.com/oven-sh/bun/blob/bf7b327f68568104a5e40c1944b7b255b02f0745/src/main.zig#L51): main
- [exe_common.inl:78](https://github.com/oven-sh/bun/blob/bf7b327f68568104a5e40c1944b7b255b02f0745/src/src/startup/exe_common.inl#L78): invoke_main

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
