### PR TITLE
Speculative fix for #12079

### DIFF
--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -174,7 +174,8 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
     if (UNLIKELY(!castedThis)) {                                                                                 \
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected SQLStatement"_s)); \
         return JSValue::encode(jsUndefined());                                                                   \
-    }
+    }                                                                                                            \
+    auto thisAliveScope = EnsureStillAliveScope(castedThis);
 
 #define DO_REBIND(param)                                                                                                \
     if (param.isObject()) {                                                                                             \
@@ -1173,6 +1174,9 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementSerialize, (JSC::JSGlobalObject * lexical
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected attached database name"_s));
         return JSValue::encode(JSC::jsUndefined());
     }
+
+    EnsureStillAliveScope thisAliveScope(thisObject);
+
     sqlite3_int64 length = -1;
     unsigned char* data = sqlite3_serialize(db, attachedName.utf8().data(), &length, 0);
     if (UNLIKELY(data == nullptr && length)) {
@@ -1221,6 +1225,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementLoadExtensionFunction, (JSC::JSGlobalObje
         return JSValue::encode(JSC::jsUndefined());
     }
 
+    EnsureStillAliveScope thisAliveScope(thisObject);
+
     auto entryPointStr = callFrame->argumentCount() > 2 && callFrame->argument(2).isString() ? callFrame->argument(2).toWTFString(lexicalGlobalObject) : String();
     const char* entryPoint = entryPointStr.length() == 0 ? NULL : entryPointStr.utf8().data();
     char* error;
@@ -1254,6 +1260,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected SQL"_s));
         return JSValue::encode(JSC::jsUndefined());
     }
+    auto thisAliveScope = EnsureStillAliveScope(thisObject);
 
     if (callFrame->argumentCount() < 2) {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected at least 2 arguments"_s));
@@ -1274,8 +1281,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
 
     JSC::JSValue internalFlagsValue = callFrame->argument(1);
     JSC::JSValue diffValue = callFrame->argument(2);
-
     JSC::JSValue sqlValue = callFrame->argument(3);
+
     if (UNLIKELY(!sqlValue.isString())) {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected SQL string"_s));
         return JSValue::encode(JSC::jsUndefined());
@@ -1410,6 +1417,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementIsInTransactionFunction, (JSC::JSGlobalOb
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected SQLStatement"_s));
         return JSValue::encode(JSC::jsUndefined());
     }
+    EnsureStillAliveScope thisAliveScope(thisObject);
 
     JSC::JSValue dbNumber = callFrame->argument(0);
 
@@ -1446,6 +1454,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementPrepareStatementFunction, (JSC::JSGlobalO
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected SQLStatement"_s));
         return JSValue::encode(JSC::jsUndefined());
     }
+
+    EnsureStillAliveScope thisAliveScope(thisObject);
 
     JSC::JSValue dbNumber = callFrame->argument(0);
     JSC::JSValue sqlValue = callFrame->argument(1);
@@ -1548,6 +1558,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementOpenStatementFunction, (JSC::JSGlobalObje
         return JSValue::encode(jsUndefined());
     }
 
+    EnsureStillAliveScope thisAliveScope(constructor);
     if (callFrame->argumentCount() < 1) {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected 1 argument"_s));
         return JSValue::encode(jsUndefined());
@@ -1640,6 +1651,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return JSValue::encode(jsUndefined());
     }
 
+    EnsureStillAliveScope thisAliveScope(constructor);
+
     JSValue dbNumber = callFrame->argument(0);
     JSValue throwOnError = callFrame->argument(1);
     if (!dbNumber.isNumber()) {
@@ -1690,6 +1703,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected 2 arguments"_s));
         return JSValue::encode(jsUndefined());
     }
+
+    EnsureStillAliveScope thisAliveScope(thisObject);
 
     JSValue dbNumber = callFrame->argument(0);
     JSValue databaseFileName = callFrame->argument(1);
@@ -2079,6 +2094,8 @@ JSC_DEFINE_JIT_OPERATION(jsSQLStatementExecuteStatementFunctionGetWithoutTypeChe
 
     auto* stmt = castedThis->stmt;
     CHECK_PREPARED
+
+    EnsureStillAliveScope thisAliveScope(castedThis);
 
     int statusCode = sqlite3_reset(stmt);
     if (UNLIKELY(statusCode != SQLITE_OK)) {

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -2262,6 +2262,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun, (JSC::JSGlob
         DO_REBIND(arg0);
 
         if (UNLIKELY(scope.exception())) {
+            sqlite3_clear_bindings(stmt);
             sqlite3_reset(stmt);
             return JSValue::encode(jsUndefined());
         }


### PR DESCRIPTION
### What does this PR do?

Our bun:sqlite bindings are not using `EnsureStillAliveScope`, but practically all of our other bindings do that.

Let's see if it fixes #12079. 

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
