### PR TITLE
 Copy a42b74ae8139738a14148f94543c659ec2d5b92b from libxev

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -549,8 +549,24 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
     }
 
     cb->machport_buf = us_malloc(MACHPORT_BUF_LEN);
-    kern_return_t kr = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE, &cb->port);
+    mach_port_t self = mach_task_self();
+    kern_return_t kr = mach_port_allocate(self, MACH_PORT_RIGHT_RECEIVE, &cb->port);
 
+    if (UNLIKELY(kr != KERN_SUCCESS)) {
+        return NULL;
+    }
+
+    // Insert a send right into the port since we also use this to send
+    kr = mach_port_insert_right(self, cb->port, cb->port, MACH_MSG_TYPE_MAKE_SEND);
+    if (UNLIKELY(kr != KERN_SUCCESS)) {
+        return NULL;
+    }
+
+    // Modify the port queue size to be 1 because we are only
+    // using it for notifications and not for any other purpose.
+    mach_port_limits_t limits = { .mpl_qlimit = 1 };
+    kr = mach_port_set_attributes(self, cb->port, MACH_PORT_LIMITS_INFO, (mach_port_info_t)&limits, MACH_PORT_LIMITS_INFO_COUNT);
+    
     if (UNLIKELY(kr != KERN_SUCCESS)) {
         return NULL;
     }
@@ -605,15 +621,32 @@ void us_internal_async_wakeup(struct us_internal_async *a) {
     mach_msg_empty_send_t message;
     memset(&message, 0, sizeof(message));
     message.header.msgh_size = sizeof(message);
-    message.header.msgh_bits = MACH_MSGH_BITS_REMOTE(MACH_MSG_TYPE_MAKE_SEND_ONCE);
+    // We use COPY_SEND which will not increment any send ref
+    // counts because it'll reuse the existing send right.
+    message.header.msgh_bits = MACH_MSGH_BITS_REMOTE(MACH_MSG_TYPE_COPY_SEND);
     message.header.msgh_remote_port = internal_cb->port;
-    kern_return_t kr = mach_msg_send(&message.header);
-    if (kr != KERN_SUCCESS) {
-        // If us_internal_async_wakeup is being called by other threads faster
-        // than the pump can dispatch work, the kernel message queue for the wakeup
-        // port can fill The kernel does return a SEND_ONCE right in the case of
-        // failure, which must be destroyed to avoid leaking.
-        mach_msg_destroy(&message.header);
+    message.header.msgh_local_port = MACH_PORT_NULL;
+    mach_msg_return_t kr = mach_msg_send(&message.header);
+    
+    switch (kr) {
+        case KERN_SUCCESS: {
+            break;
+        }
+        
+        // This means that the send would've blocked because the
+        // queue is full. We assume success because the port is full.
+        case MACH_SEND_TIMED_OUT: {
+            break;
+        }
+
+        // No space means it will wake up.
+        case MACH_SEND_NO_BUFFER: {
+            break;
+        }
+
+        default: {
+            mach_msg_destroy(&message.header);
+        }
     }
 }
 #endif

--- a/src/io/io_darwin.cpp
+++ b/src/io/io_darwin.cpp
@@ -7,17 +7,35 @@
 // errno
 #include <errno.h>
 
+#include "wtf/Assertions.h"
+
 extern "C" mach_port_t io_darwin_create_machport(uint64_t wakeup, int32_t fd,
                                                  void *wakeup_buffer_,
                                                  size_t nbytes) {
 
   mach_port_t port;
-  // Create a Mach port that will be used to wake up the pump
-  kern_return_t kr =
-      mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE, &port);
-  if (kr != KERN_SUCCESS) {
-    return 0;
+  mach_port_t self = mach_task_self();
+  kern_return_t kr = mach_port_allocate(self, MACH_PORT_RIGHT_RECEIVE, &port);
+
+  if (UNLIKELY(kr != KERN_SUCCESS)) {
+      return 0;
   }
+
+  // Insert a send right into the port since we also use this to send
+  kr = mach_port_insert_right(self, port, port, MACH_MSG_TYPE_MAKE_SEND);
+  if (UNLIKELY(kr != KERN_SUCCESS)) {
+      return 0;
+  }
+
+  // Modify the port queue size to be 1 because we are only
+  // using it for notifications and not for any other purpose.
+  mach_port_limits_t limits = { .mpl_qlimit = 1 };
+  kr = mach_port_set_attributes(self, port, MACH_PORT_LIMITS_INFO, (mach_port_info_t)&limits, MACH_PORT_LIMITS_INFO_COUNT);
+  
+  if (UNLIKELY(kr != KERN_SUCCESS)) {
+      return 0;
+  }
+
 
   // Configure the event to directly receive the Mach message as part of the
   // kevent64() call.
@@ -58,39 +76,46 @@ extern "C" bool getaddrinfo_send_reply(mach_port_t port,
 }
 
 extern "C" bool io_darwin_schedule_wakeup(mach_port_t waker) {
-  mach_msg_empty_send_t message;
-  memset(&message, 0, sizeof(message));
-  message.header.msgh_size = sizeof(message);
-  // We use COPY_SEND which will not increment any send ref
-  // counts because it'll reuse the existing send right.
-  message.header.msgh_bits = MACH_MSGH_BITS_REMOTE(MACH_MSG_TYPE_COPY_SEND);
-  message.header.msgh_remote_port = waker;
-  message.header.msgh_local_port = MACH_PORT_NULL;
-  mach_msg_return_t kr = mach_msg_send(&message.header);
-  
-  switch (kr) {
-      case KERN_SUCCESS: {
-          break;
-      }
-      
-      // This means that the send would've blocked because the
-      // queue is full. We assume success because the port is full.
-      case MACH_SEND_TIMED_OUT: {
-          break;
-      }
+  mach_msg_header_t msg = {
+      .msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND, 0),
+      .msgh_size = sizeof(mach_msg_header_t),
+      .msgh_remote_port = waker,
+      .msgh_local_port = MACH_PORT_NULL,
+      .msgh_voucher_port = 0,
+      .msgh_id = 0,
+  };
 
-      // No space means it will wake up.
-      case MACH_SEND_NO_BUFFER: {
-          break;
-      }
+    mach_msg_return_t kr = mach_msg(
+        &msg,
+        MACH_SEND_MSG | MACH_SEND_TIMEOUT,
+        msg.msgh_size,
+        0,
+        MACH_PORT_NULL,
+        0, // Fail instantly if the port is full
+        MACH_PORT_NULL
+    );
+    
+    switch (kr) {
+        case KERN_SUCCESS: {
+            return true;
+        }
+        
+        // This means that the send would've blocked because the
+        // queue is full. We assume success because the port is full.
+        case MACH_SEND_TIMED_OUT: {
+            return true;
+        }
 
-      default: {
-          mach_msg_destroy(&message.header);
-          return false;
-      }
-  }
+        // No space means it will wake up.
+        case MACH_SEND_NO_BUFFER: {
+            return true;
+        }
 
-  return true;
+        default: {
+            ASSERT_NOT_REACHED_WITH_MESSAGE("mach_msg failed with %d", kr);
+            return false;
+        }
+    }
 }
 
 #else


### PR DESCRIPTION


### What does this PR do?

Copy the code from these

- https://github.com/mitchellh/libxev/pull/102
- https://github.com/ghostty-org/ghostty/issues/1836

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
