### PR TITLE
Make console.log(someFunction) print AsyncFunction when appropriate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,7 @@
   // Zig
   "zig.initialSetupDone": true,
   "zig.buildOption": "build",
-  "zig.zls.zigLibPath": "src/deps/zig/lib",
+  "zig.zls.zigLibPath": "${workspaceFolder}/src/deps/zig/lib",
   "zig.buildArgs": ["-Dgenerated-code=./build/codegen"],
   "zig.zls.buildOnSaveStep": "check",
   // "zig.zls.enableBuildOnSave": true,

--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2077,10 +2077,22 @@ pub const Formatter = struct {
                 var printable = value.getName(this.globalThis);
                 defer printable.deref();
 
+                const proto = value.getPrototype(this.globalThis);
+                const func_name = proto.getName(this.globalThis); // "Function" | "AsyncFunction" | "GeneratorFunction" | "AsyncGeneratorFunction"
+                defer func_name.deref();
+
                 if (printable.isEmpty()) {
-                    writer.print(comptime Output.prettyFmt("<cyan>[Function]<r>", enable_ansi_colors), .{});
+                    if (func_name.isEmpty()) {
+                        writer.print(comptime Output.prettyFmt("<cyan>[Function]<r>", enable_ansi_colors), .{});
+                    } else {
+                        writer.print(comptime Output.prettyFmt("<cyan>[{}]<r>", enable_ansi_colors), .{func_name});
+                    }
                 } else {
-                    writer.print(comptime Output.prettyFmt("<cyan>[Function: {}]<r>", enable_ansi_colors), .{printable});
+                    if (func_name.isEmpty()) {
+                        writer.print(comptime Output.prettyFmt("<cyan>[Function: {}]<r>", enable_ansi_colors), .{printable});
+                    } else {
+                        writer.print(comptime Output.prettyFmt("<cyan>[{}: {}]<r>", enable_ansi_colors), .{ func_name, printable });
+                    }
                 }
             },
             .GetterSetter => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,9 +1,5 @@
 import { it, expect, describe } from "bun:test";
 import util from "util";
-import { bunEnv, bunExe } from "harness";
-import { mkdirSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 it("prototype", () => {
   const prototypes = [
@@ -525,38 +521,23 @@ it("Bun.inspect array with non-indexed properties", () => {
 ]`);
 });
 
-it("console.logging function displays async and generator names", async () => {
-  const prefix = join(tmpdir(), "console-logging-function-async");
+// it("console.logging function displays async and generator names", async () => {
+//   it.each
+// });
 
-  const cases = [
-    "console.log(function a() {});",
-    "console.log(async function b() {});",
-    "console.log(function* c() {});",
-    "console.log(async function* d() {});",
-  ];
+describe("console.logging function displays async and generator names", async () => {
+  const cases = [function a() {}, async function b() {}, function* c() {}, async function* d() {}];
 
   const expected_logs = [
-    "[Function: a]\n",
-    "[AsyncFunction: b]\n",
-    "[GeneratorFunction: c]\n",
-    "[AsyncGeneratorFunction: d]\n",
+    "[Function: a]",
+    "[AsyncFunction: b]",
+    "[GeneratorFunction: c]",
+    "[AsyncGeneratorFunction: d]",
   ];
 
   for (let i = 0; i < cases.length; i++) {
-    const inputPath = join(prefix, `case-${i}.js`);
-    try {
-      mkdirSync(prefix, { recursive: true });
-    } catch (e) {}
-    await Bun.write(inputPath, cases[i]);
-
-    const { stdout, exitCode } = Bun.spawnSync({
-      cmd: [bunExe(), "run", inputPath],
-      stderr: "inherit",
-      env: bunEnv,
-      cwd: prefix,
+    it(expected_logs[i], () => {
+      expect(Bun.inspect(cases[i])).toBe(expected_logs[i]);
     });
-
-    expect(exitCode).toBe(0);
-    expect(stdout.toString()).toBe(expected_logs[i]);
   }
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -521,10 +521,6 @@ it("Bun.inspect array with non-indexed properties", () => {
 ]`);
 });
 
-// it("console.logging function displays async and generator names", async () => {
-//   it.each
-// });
-
 describe("console.logging function displays async and generator names", async () => {
   const cases = [function a() {}, async function b() {}, function* c() {}, async function* d() {}];
 


### PR DESCRIPTION
### What does this PR do?

Fix for #10173, console logging a function object will be one of:
- Function
- AsyncFunction
- GeneratorFunction
- AsyncGeneratorFunction

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

Zig files changed:
- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
