### PR TITLE
Add failing test for #4722

### DIFF
--- a/test/regression/issue/04722.test.ts
+++ b/test/regression/issue/04722.test.ts
@@ -1,0 +1,38 @@
+import { bunEnv, bunExe } from "harness";
+import { file, spawn, write } from "bun";
+import { expect, it } from "bun:test";
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+const tmp = realpathSync(tmpdir());
+
+// https://github.com/oven-sh/bun/issues/4722
+it("existing snapshots are correctly parsed and matched against tests", async () => {
+  const code = `
+    it("test", () => {
+      expect("\`\${contents}\`").toMatchSnapshot();
+    });
+  `;
+  const testDir = await mkdtemp(join(tmp, "04722-test-"));
+  const filename = "04722.test.js";
+  try {
+    await write(join(testDir, filename), code);
+    for (let i = 0; i < 2; i++) {
+      const testRun = spawn({
+        cmd: [bunExe(), "test", filename],
+        cwd: testDir,
+        stdout: null,
+        stdin: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
+      expect(await testRun.exited).toBe(0);
+      const snapshotFile = file(join(testDir, "__snapshots__", `${filename}.snap`));
+      expect(await snapshotFile.text()).toBe('// Bun Snapshot v1, https://goo.gl/fbAQLP\n\nexports[`test 1`] = \`"\\\`${contents}\\\`"\`;\n');
+    }
+  } finally {
+    await rm(testDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
This issue describes a problem where snapshots are not correctly being matched against existing tests, causing duplicate snapshots to be written.

### What does this PR do?

This PR adds a test that provokes the issue described in #4722. 

### How did you verify your code works?

```shell
$ bun-debug test test/regression/issue/04722.test.ts
<debug output omitted>
28 |         stderr: "pipe",
29 |         env: bunEnv,
30 |       });
31 |       expect(await testRun.exited).toBe(0);
32 |       const snapshotFile = file(join(testDir, "__snapshots__", `${filename}.snap`));
33 |       expect(await snapshotFile.text()).toBe('// Bun Snapshot v1, https://goo.gl/fbAQLP\n\nexports[`test 1`] = \`"\\\`${contents}\\\`"\`;\n');
                                             ^
error: expect(received).toBe(expected)

Expected: "// Bun Snapshot v1, https://goo.gl/fbAQLP\n\nexports[`test 1`] = `\"\\`${contents}\\`\"`;\n"
Received: "// Bun Snapshot v1, https://goo.gl/fbAQLP\n\nexports[`test 1`] = `\"\\`${contents}\\`\"`;\n\nexports[`test 1`] = `\"\\`${contents}\\`\"`;\n"

      at <redacted>/bun/test/regression/issue/04722.test.ts:33:41
      at asyncFunctionResume (:1:11)
      at promiseReactionJobWithoutPromiseUnwrapAsyncContext (:1:11)
      at promiseReactionJob (:1:11)
✗ existing snapshots are correctly parsed and matched against tests [78.82ms]

 0 pass
 1 fail
 4 expect() calls
Ran 1 tests across 1 files. [173.00ms]
```