### PR TITLE
Fix typo in pm_trusted_command.zig

### DIFF
--- a/src/cli/pm_trusted_command.zig
+++ b/src/cli/pm_trusted_command.zig
@@ -172,7 +172,7 @@ pub const TrustCommand = struct {
     fn printErrorZeroUntrustedDependenciesFound(trust_all: bool, packages_to_trust: []const string) void {
         Output.print("\n", .{});
         if (trust_all) {
-            Output.errGeneric("0 scripts ran. This means all dependencies are already trusted or non have scripts.", .{});
+            Output.errGeneric("0 scripts ran. This means all dependencies are already trusted or none have scripts.", .{});
         } else {
             Output.errGeneric("0 scripts ran. The following packages are already trusted, don't have scripts to run, or don't exist:\n\n", .{});
             for (packages_to_trust) |arg| {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix typo in `bun pm trust`
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)