### PR TITLE
Fix "lines" and "functions" in coverage threshold guide

### DIFF
--- a/docs/guides/test/coverage-threshold.md
+++ b/docs/guides/test/coverage-threshold.md
@@ -52,7 +52,7 @@ Different thresholds can be set for line-level and function-level coverage.
 ```toml
 [test]
 # to set different thresholds for lines and functions
-coverageThreshold = { line = 0.5, function = 0.7 }
+coverageThreshold = { lines = 0.5, functions = 0.7 }
 ```
 
 ---


### PR DESCRIPTION
### What does this PR do?

Fixes two typos in the [coverage threshold](https://bun.sh/guides/test/coverage-threshold) guide.

- [x] Documentation
- [ ] Code changes
