### PR TITLE
base64 decode the request body instead of encoding it a second time

### DIFF
--- a/packages/bun-lambda/runtime.ts
+++ b/packages/bun-lambda/runtime.ts
@@ -290,7 +290,7 @@ function formatBody(body?: string, isBase64Encoded?: boolean): string | null {
   if (!isBase64Encoded) {
     return body;
   }
-  return Buffer.from(body).toString("base64");
+  return Buffer.from(body, "base64").toString("utf8");
 }
 
 type HttpEventV1 = {


### PR DESCRIPTION
### What does this PR do?

The Bun lambda layer is correctly identifying when a request body is base64 encoded. However, instead of base64 decoding it, it encodes it a second time. This PR corrects the mistake.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Tested on an AWS environment. This package didn't have any tests before so I just performed manual testing.