### PR TITLE
Fix crash in dns.lookup, ensure getaddrinfo() only returns IPv4-only or IPv6-only results when it should, normalize node:dns errors

### DIFF
--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1407,7 +1407,7 @@ pub const InternalDNS = struct {
         // https://github.com/nodejs/node/issues/33816
         // https://github.com/aio-libs/aiohttp/issues/5357
         // https://github.com/libuv/libuv/issues/2225
-        .flags = if (Environment.isPosix) bun.C.netdb.AI_ADDRCONFIG else std.c.AI_ADDRINFO,
+        .flags = if (Environment.isPosix) bun.C.netdb.AI_ADDRCONFIG else 0,
         .next = null,
         .protocol = 0,
         .socktype = std.c.SOCK.STREAM,

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1403,7 +1403,11 @@ pub const InternalDNS = struct {
         // If the system is IPv4-only or IPv6-only, then only return the corresponding address family.
         // https://github.com/nodejs/node/commit/54dd7c38e507b35ee0ffadc41a716f1782b0d32f
         // https://bugzilla.mozilla.org/show_bug.cgi?id=467497
-        .flags = if (Environment.isPosix) bun.C.netdb.AI_ADDRCONFIG else 0,
+        // https://github.com/adobe/chromium/blob/cfe5bf0b51b1f6b9fe239c2a3c2f2364da9967d7/net/base/host_resolver_proc.cc#L122-L241
+        // https://github.com/nodejs/node/issues/33816
+        // https://github.com/aio-libs/aiohttp/issues/5357
+        // https://github.com/libuv/libuv/issues/2225
+        .flags = if (Environment.isPosix) bun.C.netdb.AI_ADDRCONFIG else std.c.AI_ADDRINFO,
         .next = null,
         .protocol = 0,
         .socktype = std.c.SOCK.STREAM,

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -492,29 +492,15 @@ pub const CAresNameInfo = struct {
     pub fn processResolve(this: *@This(), err_: ?c_ares.Error, _: i32, result: ?c_ares.struct_nameinfo) void {
         if (err_) |err| {
             var promise = this.promise;
-            var globalThis = this.globalThis;
-            const error_value = globalThis.createErrorInstance("lookupService failed: {s}", .{err.label()});
-            error_value.put(
-                globalThis,
-                JSC.ZigString.static("code"),
-                JSC.ZigString.init(err.code()).toValueGC(globalThis),
-            );
-
-            promise.rejectTask(globalThis, error_value);
+            const globalThis = this.globalThis;
+            promise.rejectTask(globalThis, err.toJS(globalThis));
             this.deinit();
             return;
         }
         if (result == null) {
             var promise = this.promise;
-            var globalThis = this.globalThis;
-            const error_value = globalThis.createErrorInstance("lookupService failed: No results", .{});
-            error_value.put(
-                globalThis,
-                JSC.ZigString.static("code"),
-                JSC.ZigString.init("EUNREACHABLE").toValueGC(globalThis),
-            );
-
-            promise.rejectTask(globalThis, error_value);
+            const globalThis = this.globalThis;
+            promise.rejectTask(globalThis, c_ares.Error.ENOTFOUND.toJS(globalThis));
             this.deinit();
             return;
         }
@@ -910,29 +896,15 @@ pub const CAresReverse = struct {
     pub fn processResolve(this: *@This(), err_: ?c_ares.Error, _: i32, result: ?*c_ares.struct_hostent) void {
         if (err_) |err| {
             var promise = this.promise;
-            var globalThis = this.globalThis;
-            const error_value = globalThis.createErrorInstance("reverse failed: {s}", .{err.label()});
-            error_value.put(
-                globalThis,
-                JSC.ZigString.static("code"),
-                JSC.ZigString.init(err.code()).toValueGC(globalThis),
-            );
-
-            promise.rejectTask(globalThis, error_value);
+            const globalThis = this.globalThis;
+            promise.rejectTask(globalThis, err.toJS(globalThis));
             this.deinit();
             return;
         }
         if (result == null) {
             var promise = this.promise;
-            var globalThis = this.globalThis;
-            const error_value = globalThis.createErrorInstance("reverse failed: No results", .{});
-            error_value.put(
-                globalThis,
-                JSC.ZigString.static("code"),
-                JSC.ZigString.init("EUNREACHABLE").toValueGC(globalThis),
-            );
-
-            promise.rejectTask(globalThis, error_value);
+            const globalThis = this.globalThis;
+            promise.rejectTask(globalThis, c_ares.Error.ENOTFOUND.toJS(globalThis));
             this.deinit();
             return;
         }
@@ -989,28 +961,15 @@ pub fn CAresLookup(comptime cares_type: type, comptime type_name: []const u8) ty
         pub fn processResolve(this: *@This(), err_: ?c_ares.Error, _: i32, result: ?*cares_type) void {
             if (err_) |err| {
                 var promise = this.promise;
-                var globalThis = this.globalThis;
-                const error_value = globalThis.createErrorInstance("{s} lookup failed: {s}", .{ type_name, err.label() });
-                error_value.put(
-                    globalThis,
-                    JSC.ZigString.static("code"),
-                    JSC.ZigString.init(err.code()).toValueGC(globalThis),
-                );
-
-                promise.rejectTask(globalThis, error_value);
+                const globalThis = this.globalThis;
+                promise.rejectTask(globalThis, err.toJS(globalThis));
                 this.deinit();
                 return;
             }
             if (result == null) {
                 var promise = this.promise;
-                var globalThis = this.globalThis;
-                const error_value = globalThis.createErrorInstance("{s} lookup failed: {s}", .{ type_name, "No results" });
-                error_value.put(
-                    globalThis,
-                    JSC.ZigString.static("code"),
-                    JSC.ZigString.init("EUNREACHABLE").toValueGC(globalThis),
-                );
-                promise.rejectTask(globalThis, error_value);
+                const globalThis = this.globalThis;
+                promise.rejectTask(globalThis, c_ares.Error.ENOTFOUND.toJS(globalThis));
                 this.deinit();
                 return;
             }
@@ -1074,19 +1033,14 @@ pub const DNSLookup = struct {
         log("processGetAddrInfoNative: status={d}", .{status});
         if (c_ares.Error.initEAI(status)) |err| {
             var promise = this.promise;
-            var globalThis = this.globalThis;
+            const globalThis = this.globalThis;
 
             const error_value = brk: {
                 if (err == .ESERVFAIL) {
                     break :brk bun.sys.Error.fromCode(bun.C.getErrno(@as(c_int, -1)), .getaddrinfo).toJSC(globalThis);
                 }
-                const error_value = globalThis.createErrorInstance("DNS lookup failed: {s}", .{err.label()});
-                error_value.put(
-                    globalThis,
-                    JSC.ZigString.static("code"),
-                    JSC.ZigString.init(err.code()).toValueGC(globalThis),
-                );
-                break :brk error_value;
+
+                break :brk err.toJS(globalThis);
             };
 
             this.deinit();
@@ -1100,28 +1054,17 @@ pub const DNSLookup = struct {
         log("processGetAddrInfo", .{});
         if (err_) |err| {
             var promise = this.promise;
-            var globalThis = this.globalThis;
-            const error_value = globalThis.createErrorInstance("DNS lookup failed: {s}", .{err.label()});
-            error_value.put(
-                globalThis,
-                JSC.ZigString.static("code"),
-                JSC.ZigString.init(err.code()).toValueGC(globalThis),
-            );
-            promise.rejectTask(globalThis, error_value);
+            const globalThis = this.globalThis;
+            promise.rejectTask(globalThis, err.toJS(globalThis));
             this.deinit();
             return;
         }
 
         if (result == null or result.?.node == null) {
             var promise = this.promise;
-            var globalThis = this.globalThis;
+            const globalThis = this.globalThis;
 
-            const error_value = globalThis.createErrorInstance("DNS lookup failed: {s}", .{"No results"});
-            error_value.put(
-                globalThis,
-                JSC.ZigString.static("code"),
-                JSC.ZigString.init("EUNREACHABLE").toValueGC(globalThis),
-            );
+            const error_value = c_ares.Error.ENOTFOUND.toJS(globalThis);
             promise.rejectTask(globalThis, error_value);
             this.deinit();
             return;
@@ -2422,13 +2365,8 @@ pub const DNSResolver = struct {
         var channel: *c_ares.Channel = switch (resolver.getChannel()) {
             .result => |res| res,
             .err => |err| {
-                const system_error = JSC.SystemError{
-                    .errno = -1,
-                    .code = bun.String.static(err.code()),
-                    .message = bun.String.static(err.label()),
-                };
                 defer ip_slice.deinit();
-                globalThis.throwValue(system_error.toErrorInstance(globalThis));
+                globalThis.throwValue(err.toJS(globalThis));
                 return .zero;
             },
         };
@@ -2807,13 +2745,7 @@ pub const DNSResolver = struct {
         var channel: *c_ares.Channel = switch (this.getChannel()) {
             .result => |res| res,
             .err => |err| {
-                const system_error = JSC.SystemError{
-                    .errno = -1,
-                    .code = bun.String.static(err.code()),
-                    .message = bun.String.static(err.label()),
-                };
-
-                globalThis.throwValue(system_error.toErrorInstance(globalThis));
+                globalThis.throwValue(err.toJS(globalThis));
                 return .zero;
             },
         };

--- a/src/darwin_c.zig
+++ b/src/darwin_c.zig
@@ -816,3 +816,7 @@ pub const CLOCK_UPTIME_RAW = 8;
 pub const CLOCK_UPTIME_RAW_APPROX = 9;
 pub const CLOCK_PROCESS_CPUTIME_ID = 12;
 pub const CLOCK_THREAD_CPUTIME_ID = 1;
+
+pub const netdb = @cImport({
+    @cInclude("netdb.h");
+});

--- a/src/deps/c_ares.zig
+++ b/src/deps/c_ares.zig
@@ -1316,6 +1316,26 @@ pub const Error = enum(i32) {
     ECANCELLED = ARES_ECANCELLED,
     ESERVICE = ARES_ESERVICE,
 
+    pub fn toJS(this: Error, globalThis: *JSC.JSGlobalObject) JSC.JSValue {
+        const error_value = globalThis.createErrorInstance("{s}", .{this.label()});
+        error_value.put(
+            globalThis,
+            JSC.ZigString.static("name"),
+            JSC.ZigString.init("DNSException").toValueGC(globalThis),
+        );
+        error_value.put(
+            globalThis,
+            JSC.ZigString.static("code"),
+            JSC.ZigString.init(this.code()).toValueGC(globalThis),
+        );
+        error_value.put(
+            globalThis,
+            JSC.ZigString.static("errno"),
+            JSC.jsNumber(@intFromEnum(this)),
+        );
+        return error_value;
+    }
+
     pub fn initEAI(rc: i32) ?Error {
         if (comptime bun.Environment.isWindows) {
             // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/errors.js#L807-L815

--- a/src/dns.zig
+++ b/src/dns.zig
@@ -42,7 +42,12 @@ pub const GetAddrInfo = struct {
 
     pub const Options = packed struct {
         family: Family = .unspecified,
-        socktype: SocketType = .unspecified,
+        /// Leaving this unset leads to many duplicate addresses returned.
+        /// Node hardcodes to `SOCK_STREAM`.
+        /// There don't seem to be any issues in Node's repo about this
+        /// So I think it's likely that nobody actually needs `SOCK_DGRAM` as a flag
+        /// https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/src/cares_wrap.cc#L1609
+        socktype: SocketType = .stream,
         protocol: Protocol = .unspecified,
         backend: Backend = Backend.default,
         flags: i32 = 0,
@@ -171,7 +176,8 @@ pub const GetAddrInfo = struct {
 
         pub fn fromJS(value: JSC.JSValue, globalObject: *JSC.JSGlobalObject) !SocketType {
             if (value.isEmptyOrUndefinedOrNull())
-                return .unspecified;
+                // Default to .stream
+                return .stream;
 
             if (value.isNumber()) {
                 return switch (value.to(i32)) {

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -342,6 +342,7 @@ const mapLookupAll = res => {
 function throwIfEmpty(res) {
   if (res.length === 0) {
     const err = new Error("No records found");
+    err.name = "DNSException";
     err.code = "ENODATA";
     // Hardcoded errno
     err.errno = 1;

--- a/src/linux_c.zig
+++ b/src/linux_c.zig
@@ -698,3 +698,7 @@ pub const RENAME_WHITEOUT = 1 << 2;
 
 pub extern "C" fn quick_exit(code: c_int) noreturn;
 pub extern "C" fn memrchr(ptr: [*]const u8, val: c_int, len: usize) ?[*]const u8;
+
+pub const netdb = @cImport({
+    @cInclude("netdb.h");
+});

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -6,7 +6,7 @@ import { isIP, isIPv4, isIPv6 } from "node:net";
 const backends = ["system", "libc", "c-ares"];
 const validHostnames = ["localhost", "example.com"];
 const invalidHostnames = ["adsfa.asdfasdf.asdf.com"]; // known invalid
-const malformedHostnames = ["", " ", ".", " .", "localhost:80", "this is not a hostname"];
+const malformedHostnames = [" ", ".", " .", "localhost:80", "this is not a hostname"];
 const isWindows = process.platform === "win32";
 describe("dns", () => {
   describe.each(backends)("lookup() [backend: %s]", backend => {
@@ -102,12 +102,12 @@ describe("dns", () => {
         code: "DNS_ENOTFOUND",
       });
     });
-    // TODO: causes segfaults
-    // test.each(malformedHostnames)("%s", (hostname) => {
-    //   // @ts-expect-error
-    //   expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
-    //     code: "DNS_ENOTFOUND",
-    //   });
-    // });
+
+    test.each(malformedHostnames)("'%s'", hostname => {
+      // @ts-expect-error
+      expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
+        code: "DNS_ENOTFOUND",
+      });
+    });
   });
 });

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -100,6 +100,7 @@ describe("dns", () => {
       // @ts-expect-error
       expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
         code: "DNS_ENOTFOUND",
+        name: "DNSException",
       });
     });
 
@@ -107,6 +108,7 @@ describe("dns", () => {
       // @ts-expect-error
       expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
         code: "DNS_ENOTFOUND",
+        name: "DNSException",
       });
     });
   });


### PR DESCRIPTION
### What does this PR do?

This does three things:
1) Fixes a crash in dns.lookup
2) On IPv6-only networks or IPv4-only networks, `getaddrinfo()` will now only return connectable addresses due to the 
3) Normalize DNS errors to better match Node. Node treats `ENONAME`, `ENODATA` as both `ENOTFOUND`.

- Fixes #11882
- Fixes #8789
- Fixes #11205
- Fixes #6658 (may already have been fixed by happy eyeballs, but hard to tell)
- Fixes #7298 (may already have been fixed by happy eyeballs, but hard to tell)

Duplicates:
- Fixes https://github.com/oven-sh/bun/issues/12021
- Fixes https://github.com/oven-sh/bun/issues/11890
- Fixes https://github.com/oven-sh/bun/issues/11810

Not as confident this fixes these, but there's a high chance it does:
- https://github.com/oven-sh/bun/issues/11423
- https://github.com/oven-sh/bun/issues/11223
- https://github.com/oven-sh/bun/issues/4066

### How did you verify your code works?

Re-enabled some tests, but that crash in CI should be fixed