### PR TITLE
Mark `semver.order` as `this:void`

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2968,7 +2968,7 @@ declare module "bun" {
      * Returns 0 if the versions are equal, 1 if `v1` is greater, or -1 if `v2` is greater.
      * Throws an error if either version is invalid.
      */
-    order(v1: StringLike, v2: StringLike): -1 | 0 | 1;
+    order(this: void, v1: StringLike, v2: StringLike): -1 | 0 | 1;
   }
   var semver: Semver;
 


### PR DESCRIPTION
### What does this PR do?

The [recommended](https://bun.sh/docs/api/semver) way to use `semver.order` is:

```ts
myArrayOfSemvers.sort(semver.order);
```

If you are using the [`@typescript-eslint/unbound-method`](https://typescript-eslint.io/rules/unbound-method/) lint rule then you will get an error on this line:

> Avoid referencing unbound methods which may cause unintentional scoping of `this`.
> If your function does not access `this`, you can annotate it with `this: void`, or
> consider using an arrow function instead.

I'm guessing this is the correct place to make the change so that the error won't be triggered. I'm also assuming that `semver.order` doesn't access `this`?

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
