### PR TITLE
Update cache.md

### DIFF
--- a/docs/install/cache.md
+++ b/docs/install/cache.md
@@ -1,6 +1,6 @@
 All packages downloaded from the registry are stored in a global cache at `~/.bun/install/cache`. They are stored in subdirectories named like `${name}@${version}`, so multiple versions of a package can be cached.
 
-{% details summary="Configuring cache behavior" (bunfig.toml) %}
+{% details summary="Configuring cache behavior (bunfig.toml)" %}
 
 ```toml
 [install.cache]


### PR DESCRIPTION
Fixed typo, close quote was mis-placed for details element so the element was not working

### What does this PR do?

- [x] Documentation or TypeScript types

Fixing empty details on configuring cache behavior:
![image](https://github.com/oven-sh/bun/assets/95184938/ccfb80cc-17ff-4c3f-ba0e-2fc3597372d4)
