### PR TITLE
fix(install): bugfix for tarball `"overrides"`

### DIFF
--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -385,7 +385,9 @@ pub const Bin = extern struct {
                 var shebang_buf: [1024]u8 = undefined;
                 const read = bin.read(&shebang_buf).unwrap() catch return;
                 const chunk = shebang_buf[0..read];
-                if (chunk.len < 7 or chunk[0] != '#' or chunk[1] != '!') return;
+                // 123 4 5
+                // #!a\r\n
+                if (chunk.len < 5 or chunk[0] != '#' or chunk[1] != '!') return;
 
                 if (strings.indexOfChar(chunk, '\n')) |newline| {
                     if (newline > 0 and chunk[newline - 1] == '\r') {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -4978,6 +4978,7 @@ pub const PackageManager = struct {
                         else => name,
                     };
                     name_hash = String.Builder.stringHash(this.lockfile.str(&name));
+                    this.lockfile.buffers.dependencies.items[id].version = new;
                     break :version new;
                 }
             }

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -128,6 +128,28 @@ describe("optionalDependencies", () => {
   }
 });
 
+test("tarball override does not crash", async () => {
+  await write(
+    join(packageDir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      dependencies: {
+        "two-range-deps": "||",
+      },
+      overrides: {
+        "no-deps": `http://localhost:${port}/no-deps/-/no-deps-2.0.0.tgz`,
+      },
+    }),
+  );
+
+  await runBunInstall(env, packageDir);
+
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    name: "no-deps",
+    version: "2.0.0",
+  });
+});
+
 describe.each(["--production", "without --production"])("%s", flag => {
   const prod = flag === "--production";
   const order = ["devDependencies", "dependencies"];


### PR DESCRIPTION
### What does this PR do?
fixes #12233 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
