### PR TITLE
Re-enable GitHub actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,245 @@
+name: CI
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.run-id  || github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      run-id:
+        type: string
+        description: The workflow ID to download artifacts (skips the build step)
+  pull_request:
+    paths-ignore:
+      - .vscode/**/*
+      - docs/**/*
+      - examples/**/*
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - .vscode/**/*
+      - docs/**/*
+      - examples/**/*
+
+jobs:
+  format:
+    if: ${{ !inputs.run-id }}
+    name: Format
+    uses: ./.github/workflows/run-format.yml
+    secrets: inherit
+    with:
+      zig-version: 0.13.0
+    permissions:
+      contents: write
+  lint:
+    if: ${{ !inputs.run-id }}
+    name: Lint
+    uses: ./.github/workflows/run-lint.yml
+    secrets: inherit
+  linux-x64:
+    if: ${{ !inputs.run-id }}
+    name: Build linux-x64
+    uses: ./.github/workflows/build-linux.yml
+    secrets: inherit
+    with:
+      runs-on: ${{ github.repository_owner == 'oven-sh' && 'namespace-profile-bun-ci-linux-x64' || 'ubuntu-latest' }}
+      tag: linux-x64
+      arch: x64
+      cpu: haswell
+      canary: true
+      no-cache: true
+  linux-x64-baseline:
+    if: ${{ !inputs.run-id }}
+    name: Build linux-x64-baseline
+    uses: ./.github/workflows/build-linux.yml
+    secrets: inherit
+    with:
+      runs-on: ${{ github.repository_owner == 'oven-sh' && 'namespace-profile-bun-ci-linux-x64' || 'ubuntu-latest' }}
+      tag: linux-x64-baseline
+      arch: x64
+      cpu: nehalem
+      canary: true
+      no-cache: true
+  linux-aarch64:
+    if: ${{ !inputs.run-id && github.repository_owner == 'oven-sh' }}
+    name: Build linux-aarch64
+    uses: ./.github/workflows/build-linux.yml
+    secrets: inherit
+    with:
+      runs-on: namespace-profile-bun-ci-linux-aarch64
+      tag: linux-aarch64
+      arch: aarch64
+      cpu: native
+      canary: true
+      no-cache: true
+  darwin-x64:
+    if: ${{ !inputs.run-id }}
+    name: Build darwin-x64
+    uses: ./.github/workflows/build-darwin.yml
+    secrets: inherit
+    with:
+      runs-on: ${{ github.repository_owner == 'oven-sh' && 'macos-12-large' || 'macos-12' }}
+      tag: darwin-x64
+      arch: x64
+      cpu: haswell
+      canary: true
+  darwin-x64-baseline:
+    if: ${{ !inputs.run-id }}
+    name: Build darwin-x64-baseline
+    uses: ./.github/workflows/build-darwin.yml
+    secrets: inherit
+    with:
+      runs-on: ${{ github.repository_owner == 'oven-sh' && 'macos-12-large' || 'macos-12' }}
+      tag: darwin-x64-baseline
+      arch: x64
+      cpu: nehalem
+      canary: true
+  darwin-aarch64:
+    if: ${{ !inputs.run-id }}
+    name: Build darwin-aarch64
+    uses: ./.github/workflows/build-darwin.yml
+    secrets: inherit
+    with:
+      runs-on: ${{ github.repository_owner == 'oven-sh' && 'namespace-profile-bun-ci-darwin-aarch64' || 'macos-12' }}
+      tag: darwin-aarch64
+      arch: aarch64
+      cpu: native
+      canary: true
+  windows-x64:
+    if: ${{ !inputs.run-id }}
+    name: Build windows-x64
+    uses: ./.github/workflows/build-windows.yml
+    secrets: inherit
+    with:
+      runs-on: windows
+      tag: windows-x64
+      arch: x64
+      cpu: haswell
+      canary: true
+  windows-x64-baseline:
+    if: ${{ !inputs.run-id }}
+    name: Build windows-x64-baseline
+    uses: ./.github/workflows/build-windows.yml
+    secrets: inherit
+    with:
+      runs-on: windows
+      tag: windows-x64-baseline
+      arch: x64
+      cpu: nehalem
+      canary: true
+  linux-x64-test:
+    if: ${{ inputs.run-id || github.event_name == 'pull_request' }}
+    name: Test linux-x64
+    needs: linux-x64
+    uses: ./.github/workflows/run-test.yml
+    secrets: inherit
+    with:
+      run-id: ${{ inputs.run-id }}
+      pr-number: ${{ github.event.number }}
+      runs-on: ${{ github.repository_owner == 'oven-sh' && 'namespace-profile-bun-ci-linux-x64' || 'ubuntu-latest' }}
+      tag: linux-x64
+  linux-x64-baseline-test:
+    if: ${{ inputs.run-id || github.event_name == 'pull_request' }}
+    name: Test linux-x64-baseline
+    needs: linux-x64-baseline
+    uses: ./.github/workflows/run-test.yml
+    secrets: inherit
+    with:
+      run-id: ${{ inputs.run-id }}
+      pr-number: ${{ github.event.number }}
+      runs-on: ${{ github.repository_owner == 'oven-sh' && 'namespace-profile-bun-ci-linux-x64' || 'ubuntu-latest' }}
+      tag: linux-x64-baseline
+  linux-aarch64-test:
+    if: ${{ inputs.run-id || github.event_name == 'pull_request' && github.repository_owner == 'oven-sh'}}
+    name: Test linux-aarch64
+    needs: linux-aarch64
+    uses: ./.github/workflows/run-test.yml
+    secrets: inherit
+    with:
+      run-id: ${{ inputs.run-id }}
+      pr-number: ${{ github.event.number }}
+      runs-on: namespace-profile-bun-ci-linux-aarch64
+      tag: linux-aarch64
+  darwin-x64-test:
+    if: ${{ inputs.run-id || github.event_name == 'pull_request' }}
+    name: Test darwin-x64
+    needs: darwin-x64
+    uses: ./.github/workflows/run-test.yml
+    secrets: inherit
+    with:
+      run-id: ${{ inputs.run-id }}
+      pr-number: ${{ github.event.number }}
+      runs-on: ${{ github.repository_owner == 'oven-sh' && 'macos-12-large' || 'macos-12' }}
+      tag: darwin-x64
+  darwin-x64-baseline-test:
+    if: ${{ inputs.run-id || github.event_name == 'pull_request' }}
+    name: Test darwin-x64-baseline
+    needs: darwin-x64-baseline
+    uses: ./.github/workflows/run-test.yml
+    secrets: inherit
+    with:
+      run-id: ${{ inputs.run-id }}
+      pr-number: ${{ github.event.number }}
+      runs-on: ${{ github.repository_owner == 'oven-sh' && 'macos-12-large' || 'macos-12' }}
+      tag: darwin-x64-baseline
+  darwin-aarch64-test:
+    if: ${{ inputs.run-id || github.event_name == 'pull_request' }}
+    name: Test darwin-aarch64
+    needs: darwin-aarch64
+    uses: ./.github/workflows/run-test.yml
+    secrets: inherit
+    with:
+      run-id: ${{ inputs.run-id }}
+      pr-number: ${{ github.event.number }}
+      runs-on: ${{ github.repository_owner == 'oven-sh' && 'namespace-profile-bun-ci-darwin-aarch64' || 'macos-12' }}
+      tag: darwin-aarch64
+  windows-x64-test:
+    if: ${{ inputs.run-id || github.event_name == 'pull_request' }}
+    name: Test windows-x64
+    needs: windows-x64
+    uses: ./.github/workflows/run-test.yml
+    secrets: inherit
+    with:
+      run-id: ${{ inputs.run-id }}
+      pr-number: ${{ github.event.number }}
+      runs-on: windows
+      tag: windows-x64
+  windows-x64-baseline-test:
+    if: ${{ inputs.run-id || github.event_name == 'pull_request' }}
+    name: Test windows-x64-baseline
+    needs: windows-x64-baseline
+    uses: ./.github/workflows/run-test.yml
+    secrets: inherit
+    with:
+      run-id: ${{ inputs.run-id }}
+      pr-number: ${{ github.event.number }}
+      runs-on: windows
+      tag: windows-x64-baseline
+  cleanup:
+    if: ${{ always() }}
+    name: Cleanup
+    needs:
+      - linux-x64
+      - linux-x64-baseline
+      - linux-aarch64
+      - darwin-x64
+      - darwin-x64-baseline
+      - darwin-aarch64
+      - windows-x64
+      - windows-x64-baseline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup Artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: |
+            bun-*-cpp
+            bun-*-zig
+            bun-*-deps
+            bun-*-codegen


### PR DESCRIPTION
### What does this PR do?

There are a few things not working yet in the buildkite-based CI:
- Canary builds are not marked as canary builds, also causing debug symbols to not work right
- We cannot exclusively run tests with LTO disabled when `main` is built with LTO enabled. The release build has to be extremely similar to the `main` build. There could be bugs that only occur when LTO is enabled.


### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
