### PR TITLE
fix: add Symbol.toStringTag to KeyObject instances

### DIFF
--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -11832,8 +11832,9 @@ class KeyObject {
     }
     this.$bunNativePtr = key;
   }
-  toString() {
-    return "[object KeyObject]";
+
+  get [Symbol.toStringTag]() {
+    return "KeyObject"
   }
 
   static from(key) {


### PR DESCRIPTION
### What does this PR do?

As per https://github.com/nodejs/node/pull/46043, this adds Symbol.toStringTag getter to KeyObject.
