### PR TITLE
Fix crash on aborted timer

### DIFF
--- a/src/js/node/timers.promises.ts
+++ b/src/js/node/timers.promises.ts
@@ -123,10 +123,9 @@ function setImmediatePromise(value, options = {}) {
       signal.addEventListener("abort", onCancel);
     }
   });
-  if (typeof onCancel !== "undefined") {
-    returnValue.finally(() => signal.removeEventListener("abort", onCancel));
-  }
-  return returnValue;
+  return typeof onCancel !== "undefined"
+    ? returnValue.finally(() => signal.removeEventListener("abort", onCancel))
+    : returnValue;
 }
 
 function setIntervalPromise(after = 1, value, options = {}) {

--- a/src/js/node/timers.promises.ts
+++ b/src/js/node/timers.promises.ts
@@ -84,10 +84,9 @@ function setTimeoutPromise(after = 1, value, options = {}) {
       signal.addEventListener("abort", onCancel);
     }
   });
-  if (typeof onCancel !== "undefined") {
-    returnValue.finally(() => signal.removeEventListener("abort", onCancel));
-  }
-  return returnValue;
+  return typeof onCancel !== "undefined"
+    ? returnValue.finally(() => signal.removeEventListener("abort", onCancel))
+    : returnValue;
 }
 
 function setImmediatePromise(value, options = {}) {

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -5,20 +5,24 @@ describe("setTimeout", () => {
   it("abort() does not emit global error", async () => {
     let unhandledRejectionCaught = false;
 
-    process.on('unhandledRejection', () => {
+    const catchUnhandledRejection = () =>  {
       unhandledRejectionCaught = true;
-    });
+    };
+    process.on('unhandledRejection', catchUnhandledRejection);
     
     const c = new AbortController();
 
-    setTimeout(() => c.abort());
+    global.setTimeout(() => c.abort());
 
-    await setTimeout(50, undefined, { signal: c.signal }).catch(() => "aborted");
+    await setTimeout(100, undefined, { signal: c.signal }).catch(() => "aborted");
 
     // let unhandledRejection to be fired
-    await setTimeout()
+    await setTimeout(100)
 
-    expect(unhandledRejectionCaught).to.be.false;
+    process.off('unhandledRejection', catchUnhandledRejection);
+
+    expect(c.signal.aborted).toBe(true);
+    expect(unhandledRejectionCaught).toBe(false);
   });
 });
 
@@ -26,19 +30,23 @@ describe("setImmediate", () => {
   it("abort() does not emit global error", async () => {
     let unhandledRejectionCaught = false;
 
-    process.on('unhandledRejection', () => {
+    const catchUnhandledRejection = () =>  {
       unhandledRejectionCaught = true;
-    });
+    };
+    process.on('unhandledRejection', catchUnhandledRejection);
     
     const c = new AbortController();
 
-    setImmediate(() => c.abort());
+    global.setImmediate(() => c.abort());
 
     await setImmediate(undefined, { signal: c.signal }).catch(() => "aborted");
 
     // let unhandledRejection to be fired
-    await setTimeout()
+    await setTimeout(100)
 
-    expect(unhandledRejectionCaught).to.be.false;
+    process.off('unhandledRejection', catchUnhandledRejection);
+
+    expect(c.signal.aborted).toBe(true);
+    expect(unhandledRejectionCaught).toBe(false);
   });
 });

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -1,22 +1,44 @@
 import { describe, test, it, expect } from "bun:test";
 import { setTimeout, setImmediate } from "node:timers/promises";
 
-for (const fn of [setTimeout, setImmediate]) {
-  describe(fn.name, () => {
-    it("abort() does not emit global error", async () => {
-      let unhandledRejectionCaught = false;
+describe("setTimeout", () => {
+  it("abort() does not emit global error", async () => {
+    let unhandledRejectionCaught = false;
 
-      process.on('unhandledRejection', () => {
-        unhandledRejectionCaught = true;
-      });
-      
-      const c = new AbortController();
-
-      global[fn.name](() => c.abort());
-
-      await fn(100, undefined, { signal: c.signal }).catch(() => "aborted");
-
-      expect(unhandledRejectionCaught).to.be.false;
+    process.on('unhandledRejection', () => {
+      unhandledRejectionCaught = true;
     });
+    
+    const c = new AbortController();
+
+    setTimeout(() => c.abort());
+
+    await setTimeout(50, undefined, { signal: c.signal }).catch(() => "aborted");
+
+    // let unhandledRejection to be fired
+    await setTimeout()
+
+    expect(unhandledRejectionCaught).to.be.false;
   });
-}
+});
+
+describe("setImmediate", () => {
+  it("abort() does not emit global error", async () => {
+    let unhandledRejectionCaught = false;
+
+    process.on('unhandledRejection', () => {
+      unhandledRejectionCaught = true;
+    });
+    
+    const c = new AbortController();
+
+    setImmediate(() => c.abort());
+
+    await setImmediate(undefined, { signal: c.signal }).catch(() => "aborted");
+
+    // let unhandledRejection to be fired
+    await setTimeout()
+
+    expect(unhandledRejectionCaught).to.be.false;
+  });
+});

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, it, expect } from "bun:test";
+import { setTimeout, setImmediate } from "node:timers/promises";
+
+for (const fn of [setTimeout, setImmediate]) {
+  describe(fn.name, () => {
+    it("abort() does not emit global error", async () => {
+      let unhandledRejectionCaught = false;
+
+      process.on('unhandledRejection', () => {
+        unhandledRejectionCaught = true;
+      });
+      
+      const c = new AbortController();
+
+      global[fn.name](() => c.abort());
+
+      await fn(100, undefined, { signal: c.signal }).catch(() => "aborted");
+
+      expect(unhandledRejectionCaught).to.be.false;
+    });
+  });
+}


### PR DESCRIPTION
### What does this PR do?

fixes #12347 

return the promise returned by .finally() instead of bare returnValue to allow the user code to catch emitted abort error

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

## How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

 I wrote automated tests 

<!-- If JavaScript/TypeScript modules or builtins changed:-->

- [x] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)



<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
