### PR TITLE
Use `bun.ComptimeStringMap` instead of `std.StaticStringMap`

### DIFF
--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -23,7 +23,7 @@ pub const Mode = enum {
     /// This must match the behavior of node.js, and supports bun <--> node.js/etc communication.
     json,
 
-    const Map = std.StaticStringMap(Mode).initComptime(.{
+    const Map = bun.ComptimeStringMap(Mode, .{
         .{ "advanced", .advanced },
         .{ "json", .json },
     });

--- a/src/js_lexer_tables.zig
+++ b/src/js_lexer_tables.zig
@@ -7,7 +7,7 @@ const unicode = std.unicode;
 const default_allocator = bun.default_allocator;
 const string = @import("string_types.zig").string;
 const CodePoint = @import("string_types.zig").CodePoint;
-const ComptimeStringMap = @import("./comptime_string_map.zig").ComptimeStringMap;
+const ComptimeStringMap = bun.ComptimeStringMap;
 
 pub const T = enum(u8) {
     t_end_of_file,

--- a/src/js_lexer_tables.zig
+++ b/src/js_lexer_tables.zig
@@ -159,7 +159,7 @@ pub const T = enum(u8) {
     }
 };
 
-pub const Keywords = std.StaticStringMap(T).initComptime(.{
+pub const Keywords = bun.ComptimeStringMap(T, .{
     .{ "break", .t_break },
     .{ "case", .t_case },
     .{ "catch", .t_catch },
@@ -198,7 +198,7 @@ pub const Keywords = std.StaticStringMap(T).initComptime(.{
     .{ "with", .t_with },
 });
 
-pub const StrictModeReservedWords = std.StaticStringMap(void).initComptime(.{
+pub const StrictModeReservedWords = bun.ComptimeStringMap(void, .{
     .{ "implements", {} },
     .{ "interface", {} },
     .{ "let", {} },
@@ -210,7 +210,7 @@ pub const StrictModeReservedWords = std.StaticStringMap(void).initComptime(.{
     .{ "yield", {} },
 });
 
-pub const StrictModeReservedWordsRemap = std.StaticStringMap(string).initComptime(.{
+pub const StrictModeReservedWordsRemap = bun.ComptimeStringMap(string, .{
     .{ "implements", "_implements" },
     .{ "interface", "_interface" },
     .{ "let", "_let" },
@@ -235,7 +235,7 @@ pub const PropertyModifierKeyword = enum {
     p_set,
     p_static,
 
-    pub const List = std.StaticStringMap(PropertyModifierKeyword).initComptime(.{
+    pub const List = bun.ComptimeStringMap(PropertyModifierKeyword, .{
         .{ "abstract", .p_abstract },
         .{ "async", .p_async },
         .{ "declare", .p_declare },
@@ -250,7 +250,7 @@ pub const PropertyModifierKeyword = enum {
     });
 };
 
-pub const TypeScriptAccessibilityModifier = std.StaticStringMap(void).initComptime(.{
+pub const TypeScriptAccessibilityModifier = bun.ComptimeStringMap(void, .{
     .{ "override", void },
     .{ "private", void },
     .{ "protected", void },
@@ -519,7 +519,7 @@ pub const TypescriptStmtKeyword = enum {
     ts_stmt_global,
     ts_stmt_declare,
 
-    pub const List = std.StaticStringMap(TypescriptStmtKeyword).initComptime(.{
+    pub const List = bun.ComptimeStringMap(TypescriptStmtKeyword, .{
         .{
             "type",
             TypescriptStmtKeyword.ts_stmt_type,
@@ -552,7 +552,7 @@ pub const TypescriptStmtKeyword = enum {
 };
 
 //  Error: meta is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.
-pub const ChildlessJSXTags = std.StaticStringMap(void).initComptime(.{
+pub const ChildlessJSXTags = bun.ComptimeStringMap(void, .{
     .{ "area", void },
     .{ "base", void },
     .{ "br", void },
@@ -572,7 +572,7 @@ pub const ChildlessJSXTags = std.StaticStringMap(void).initComptime(.{
 });
 
 // In a microbenchmark, this outperforms
-pub const jsxEntity = std.StaticStringMap(CodePoint).initComptime(.{
+pub const jsxEntity = bun.ComptimeStringMap(CodePoint, .{
     .{ "Aacute", @as(CodePoint, 0x00C1) },
     .{ "aacute", @as(CodePoint, 0x00E1) },
     .{ "Acirc", @as(CodePoint, 0x00C2) },

--- a/src/js_lexer_tables.zig
+++ b/src/js_lexer_tables.zig
@@ -7,6 +7,7 @@ const unicode = std.unicode;
 const default_allocator = bun.default_allocator;
 const string = @import("string_types.zig").string;
 const CodePoint = @import("string_types.zig").CodePoint;
+const ComptimeStringMap = @import("./comptime_string_map.zig").ComptimeStringMap;
 
 pub const T = enum(u8) {
     t_end_of_file,
@@ -159,7 +160,7 @@ pub const T = enum(u8) {
     }
 };
 
-pub const Keywords = bun.ComptimeStringMap(T, .{
+pub const Keywords = ComptimeStringMap(T, .{
     .{ "break", .t_break },
     .{ "case", .t_case },
     .{ "catch", .t_catch },
@@ -198,7 +199,7 @@ pub const Keywords = bun.ComptimeStringMap(T, .{
     .{ "with", .t_with },
 });
 
-pub const StrictModeReservedWords = bun.ComptimeStringMap(void, .{
+pub const StrictModeReservedWords = ComptimeStringMap(void, .{
     .{ "implements", {} },
     .{ "interface", {} },
     .{ "let", {} },
@@ -210,7 +211,7 @@ pub const StrictModeReservedWords = bun.ComptimeStringMap(void, .{
     .{ "yield", {} },
 });
 
-pub const StrictModeReservedWordsRemap = bun.ComptimeStringMap(string, .{
+pub const StrictModeReservedWordsRemap = ComptimeStringMap(string, .{
     .{ "implements", "_implements" },
     .{ "interface", "_interface" },
     .{ "let", "_let" },
@@ -235,7 +236,7 @@ pub const PropertyModifierKeyword = enum {
     p_set,
     p_static,
 
-    pub const List = bun.ComptimeStringMap(PropertyModifierKeyword, .{
+    pub const List = ComptimeStringMap(PropertyModifierKeyword, .{
         .{ "abstract", .p_abstract },
         .{ "async", .p_async },
         .{ "declare", .p_declare },
@@ -250,7 +251,7 @@ pub const PropertyModifierKeyword = enum {
     });
 };
 
-pub const TypeScriptAccessibilityModifier = bun.ComptimeStringMap(void, .{
+pub const TypeScriptAccessibilityModifier = ComptimeStringMap(void, .{
     .{ "override", void },
     .{ "private", void },
     .{ "protected", void },
@@ -519,7 +520,7 @@ pub const TypescriptStmtKeyword = enum {
     ts_stmt_global,
     ts_stmt_declare,
 
-    pub const List = bun.ComptimeStringMap(TypescriptStmtKeyword, .{
+    pub const List = ComptimeStringMap(TypescriptStmtKeyword, .{
         .{
             "type",
             TypescriptStmtKeyword.ts_stmt_type,
@@ -552,7 +553,7 @@ pub const TypescriptStmtKeyword = enum {
 };
 
 //  Error: meta is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.
-pub const ChildlessJSXTags = bun.ComptimeStringMap(void, .{
+pub const ChildlessJSXTags = ComptimeStringMap(void, .{
     .{ "area", void },
     .{ "base", void },
     .{ "br", void },
@@ -572,7 +573,7 @@ pub const ChildlessJSXTags = bun.ComptimeStringMap(void, .{
 });
 
 // In a microbenchmark, this outperforms
-pub const jsxEntity = bun.ComptimeStringMap(CodePoint, .{
+pub const jsxEntity = ComptimeStringMap(CodePoint, .{
     .{ "Aacute", @as(CodePoint, 0x00C1) },
     .{ "aacute", @as(CodePoint, 0x00E1) },
     .{ "Acirc", @as(CodePoint, 0x00C2) },

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -1013,7 +1013,7 @@ pub const TypeScript = struct {
                 else => return null,
             }
         }
-        pub const IMap = std.StaticStringMap(Kind).initComptime(.{
+        pub const IMap = bun.ComptimeStringMap(Kind, .{
             .{ "unique", .unique },
             .{ "abstract", .abstract },
             .{ "asserts", .asserts },
@@ -2560,7 +2560,7 @@ const AsyncPrefixExpression = enum(u2) {
     is_async,
     is_await,
 
-    const map = std.StaticStringMap(AsyncPrefixExpression).initComptime(.{
+    const map = bun.ComptimeStringMap(AsyncPrefixExpression, .{
         .{ "yield", .is_yield },
         .{ "await", .is_await },
         .{ "async", .is_async },

--- a/src/open.zig
+++ b/src/open.zig
@@ -66,7 +66,7 @@ pub const Editor = enum(u8) {
     const StringMap = std.EnumMap(Editor, string);
     const StringArrayMap = std.EnumMap(Editor, []const [:0]const u8);
 
-    const name_map = std.StaticStringMap(Editor).initComptime(.{
+    const name_map = bun.ComptimeStringMap(Editor, .{
         .{ "sublime", .sublime },
         .{ "subl", .sublime },
         .{ "vscode", .vscode },

--- a/src/options.zig
+++ b/src/options.zig
@@ -298,7 +298,7 @@ pub const ExternalModules = struct {
         "zlib",
     };
 
-    pub const NodeBuiltinsMap = std.StaticStringMap(void).initComptime(.{
+    pub const NodeBuiltinsMap = bun.ComptimeStringMap(void, .{
         .{ "_http_agent", {} },
         .{ "_http_client", {} },
         .{ "_http_common", {} },
@@ -370,7 +370,7 @@ pub const ModuleType = enum {
     cjs,
     esm,
 
-    pub const List = std.StaticStringMap(ModuleType).initComptime(.{
+    pub const List = bun.ComptimeStringMap(ModuleType, .{
         .{ "commonjs", ModuleType.cjs },
         .{ "module", ModuleType.esm },
     });

--- a/src/resolver/tsconfig_json.zig
+++ b/src/resolver/tsconfig_json.zig
@@ -67,7 +67,7 @@ pub const TSConfigJSON = struct {
         remove,
         invalid,
 
-        pub const List = std.StaticStringMap(ImportsNotUsedAsValue).initComptime(.{
+        pub const List = bun.ComptimeStringMap(ImportsNotUsedAsValue, .{
             .{ "preserve", .preserve },
             .{ "error", .err },
             .{ "remove", .remove },

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -5,11 +5,11 @@ describe("setTimeout", () => {
   it("abort() does not emit global error", async () => {
     let unhandledRejectionCaught = false;
 
-    const catchUnhandledRejection = () =>  {
+    const catchUnhandledRejection = () => {
       unhandledRejectionCaught = true;
     };
-    process.on('unhandledRejection', catchUnhandledRejection);
-    
+    process.on("unhandledRejection", catchUnhandledRejection);
+
     const c = new AbortController();
 
     global.setTimeout(() => c.abort());
@@ -17,9 +17,9 @@ describe("setTimeout", () => {
     await setTimeout(100, undefined, { signal: c.signal }).catch(() => "aborted");
 
     // let unhandledRejection to be fired
-    await setTimeout(100)
+    await setTimeout(100);
 
-    process.off('unhandledRejection', catchUnhandledRejection);
+    process.off("unhandledRejection", catchUnhandledRejection);
 
     expect(c.signal.aborted).toBe(true);
     expect(unhandledRejectionCaught).toBe(false);
@@ -30,11 +30,11 @@ describe("setImmediate", () => {
   it("abort() does not emit global error", async () => {
     let unhandledRejectionCaught = false;
 
-    const catchUnhandledRejection = () =>  {
+    const catchUnhandledRejection = () => {
       unhandledRejectionCaught = true;
     };
-    process.on('unhandledRejection', catchUnhandledRejection);
-    
+    process.on("unhandledRejection", catchUnhandledRejection);
+
     const c = new AbortController();
 
     global.setImmediate(() => c.abort());
@@ -42,9 +42,9 @@ describe("setImmediate", () => {
     await setImmediate(undefined, { signal: c.signal }).catch(() => "aborted");
 
     // let unhandledRejection to be fired
-    await setTimeout(100)
+    await setTimeout(100);
 
-    process.off('unhandledRejection', catchUnhandledRejection);
+    process.off("unhandledRejection", catchUnhandledRejection);
 
     expect(c.signal.aborted).toBe(true);
     expect(unhandledRejectionCaught).toBe(false);


### PR DESCRIPTION
### What does this PR do?

Use `bun.ComptimeStringMap` instead of `std.StaticStringMap`

Ours is faster

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
