### PR TITLE
Handle EINTR in usockets

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -19,6 +19,9 @@
 
 #define __APPLE_USE_RFC_3542
 
+#define LIKELY(cond) __builtin_expect((_Bool)(cond), 1)
+#define UNLIKELY(cond) __builtin_expect((_Bool)(cond), 0)
+
 #include "libusockets.h"
 #include "internal/internal.h"
 
@@ -40,6 +43,12 @@
 
 #if defined(__APPLE__) && defined(__aarch64__)
 #define HAS_MSGX
+#endif
+
+#ifdef _WIN32
+    #define IS_EINTR(rc) (rc == SOCKET_ERROR && WSAGetLastError() == WSAEINTR)
+#else
+    #define IS_EINTR(rc) (rc == -1 && errno == EINTR)
 #endif
 
 /* We need to emulate sendmmsg, recvmmsg on platform who don't have it */
@@ -397,7 +406,9 @@ int bsd_addr_get_port(struct bsd_addr_t *addr) {
 // called by dispatch_ready_poll
 LIBUS_SOCKET_DESCRIPTOR bsd_accept_socket(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd_addr_t *addr) {
     LIBUS_SOCKET_DESCRIPTOR accepted_fd;
-    addr->len = sizeof(addr->mem);
+
+    while (1) {
+        addr->len = sizeof(addr->mem);
 
 #if defined(SOCK_CLOEXEC) && defined(SOCK_NONBLOCK)
     // Linux, FreeBSD
@@ -405,12 +416,18 @@ LIBUS_SOCKET_DESCRIPTOR bsd_accept_socket(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd
 #else
     // Windows, OS X
     accepted_fd = accept(fd, (struct sockaddr *) addr, &addr->len);
-
 #endif
 
-    /* We cannot rely on addr since it is not initialized if failed */
-    if (accepted_fd == LIBUS_SOCKET_ERROR) {
-        return LIBUS_SOCKET_ERROR;
+        if (UNLIKELY(IS_EINTR(accepted_fd))) {
+            continue;
+        }
+
+        /* We cannot rely on addr since it is not initialized if failed */
+        if (accepted_fd == LIBUS_SOCKET_ERROR) {
+            return LIBUS_SOCKET_ERROR;
+        }
+
+        break;
     }
 
     internal_finalize_bsd_addr(addr);
@@ -423,14 +440,22 @@ LIBUS_SOCKET_DESCRIPTOR bsd_accept_socket(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd
 #endif
 }
 
-int bsd_recv(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags) {
-    return recv(fd, buf, length, flags);
+ssize_t bsd_recv(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags) {
+    while (1) {
+        ssize_t ret = recv(fd, buf, length, flags);
+
+        if (UNLIKELY(IS_EINTR(ret))) {
+            continue;
+        }
+
+        return ret;
+    }
 }
 
 #if !defined(_WIN32)
 #include <sys/uio.h>
 
-int bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length, const char *payload, int payload_length) {
+ssize_t bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length, const char *payload, int payload_length) {
     struct iovec chunks[2];
 
     chunks[0].iov_base = (char *)header;
@@ -438,13 +463,21 @@ int bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length
     chunks[1].iov_base = (char *)payload;
     chunks[1].iov_len = payload_length;
 
-    return writev(fd, chunks, 2);
+    while (1) {
+        ssize_t written = writev(fd, chunks, 2);
+
+        if (UNLIKELY(IS_EINTR(written))) {
+            continue;
+        }
+
+        return written;
+    }
 }
 #else
-int bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length, const char *payload, int payload_length) {
-    int written = bsd_send(fd, header, header_length, 0);
+ssize_t bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length, const char *payload, int payload_length) {
+    ssize_t written = bsd_send(fd, header, header_length, 0);
     if (written == header_length) {
-        int second_write = bsd_send(fd, payload, payload_length, 0);
+        ssize_t second_write = bsd_send(fd, payload, payload_length, 0);
         if (second_write > 0) {
             written += second_write;
         }
@@ -453,26 +486,28 @@ int bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length
 }
 #endif
 
-int bsd_send(LIBUS_SOCKET_DESCRIPTOR fd, const char *buf, int length, int msg_more) {
-
+ssize_t bsd_send(LIBUS_SOCKET_DESCRIPTOR fd, const char *buf, int length, int msg_more) {
+    while (1) {
     // MSG_MORE (Linux), MSG_PARTIAL (Windows), TCP_NOPUSH (BSD)
 
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0
 #endif
 
-#ifdef MSG_MORE
+        #ifdef MSG_MORE
+            // for Linux we do not want signals
+            ssize_t rc = send(fd, buf, length, ((msg_more != 0) * MSG_MORE) | MSG_NOSIGNAL | MSG_DONTWAIT);
+        #else
+            // use TCP_NOPUSH
+            ssize_t rc = send(fd, buf, length, MSG_NOSIGNAL | MSG_DONTWAIT);
+        #endif
 
-    // for Linux we do not want signals
-    return send(fd, buf, length, ((msg_more != 0) * MSG_MORE) | MSG_NOSIGNAL | MSG_DONTWAIT);
+        if (UNLIKELY(IS_EINTR(rc))) {
+            continue;
+        }
 
-#else
-
-    // use TCP_NOPUSH
-
-    return send(fd, buf, length, MSG_NOSIGNAL | MSG_DONTWAIT);
-
-#endif
+        return rc;
+    }
 }
 
 int bsd_would_block() {
@@ -481,6 +516,23 @@ int bsd_would_block() {
 #else
     return errno == EWOULDBLOCK;// || errno == EAGAIN;
 #endif
+}
+
+static int us_internal_bind_and_listen(LIBUS_SOCKET_DESCRIPTOR listenFd, struct sockaddr *listenAddr, socklen_t listenAddrLength, int backlog) {
+    int result;
+    do 
+        result = bind(listenFd, listenAddr, listenAddrLength);
+    while (IS_EINTR(result));
+
+    if (result == -1) {
+        return -1;
+    }
+
+    do 
+        result = listen(listenFd, backlog);
+    while (IS_EINTR(result));
+
+    return 0;
 }
 
 inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd(
@@ -512,7 +564,7 @@ inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd
     setsockopt(listenFd, IPPROTO_IPV6, IPV6_V6ONLY, (void *) &disabled, sizeof(disabled));
 #endif
 
-    if (bind(listenFd, listenAddr->ai_addr, (socklen_t) listenAddr->ai_addrlen) || listen(listenFd, 512)) {
+    if (us_internal_bind_and_listen(listenFd, listenAddr->ai_addr, (socklen_t) listenAddr->ai_addrlen, 512)) {
         return LIBUS_SOCKET_ERROR;
     }
 
@@ -690,7 +742,7 @@ static LIBUS_SOCKET_DESCRIPTOR internal_bsd_create_listen_socket_unix(const char
     unlink(path);
 #endif
 
-    if (bind(listenFd, (struct sockaddr *)server_address, addrlen) || listen(listenFd, 512)) {
+    if (us_internal_bind_and_listen(listenFd, (struct sockaddr *) server_address, (socklen_t) addrlen, 512)) {
         #if defined(_WIN32)
           int shouldSimulateENOENT = WSAGetLastError() == WSAENETDOWN;
         #endif
@@ -925,7 +977,7 @@ static int bsd_do_connect_raw(LIBUS_SOCKET_DESCRIPTOR fd, struct sockaddr *addr,
      do {
         errno = 0;
         r = connect(fd, (struct sockaddr *)addr, namelen);
-    } while (r == -1 && errno == EINTR);
+    } while (IS_EINTR(r));
     
     // connect() can return -1 with an errno of 0.
     // the errno is the correct one in that case.

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -524,7 +524,7 @@ static int us_internal_bind_and_listen(LIBUS_SOCKET_DESCRIPTOR listenFd, struct 
         result = listen(listenFd, backlog);
     while (IS_EINTR(result));
 
-    return 0;
+    return result;
 }
 
 inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd(

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -19,9 +19,6 @@
 
 #define __APPLE_USE_RFC_3542
 
-#define LIKELY(cond) __builtin_expect((_Bool)(cond), 1)
-#define UNLIKELY(cond) __builtin_expect((_Bool)(cond), 0)
-
 #include "libusockets.h"
 #include "internal/internal.h"
 
@@ -45,11 +42,6 @@
 #define HAS_MSGX
 #endif
 
-#ifdef _WIN32
-    #define IS_EINTR(rc) (rc == SOCKET_ERROR && WSAGetLastError() == WSAEINTR)
-#else
-    #define IS_EINTR(rc) (rc == -1 && errno == EINTR)
-#endif
 
 /* We need to emulate sendmmsg, recvmmsg on platform who don't have it */
 int bsd_sendmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_sendbuf* sendbuf, int flags) {

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -112,7 +112,7 @@ struct us_loop_t *us_timer_loop(struct us_timer_t *t) {
 
 #if defined(LIBUS_USE_EPOLL) 
 
-#include <linux/syscall.h>
+#include <sys/syscall.h>
 static int has_epoll_pwait2 = -1;
 
 static int sys_epoll_pwait2(int epfd, struct epoll_event *events, int maxevents, const struct timespec *timeout, const sigset_t *sigmask, size_t sigsetsize) {

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -112,7 +112,7 @@ struct us_loop_t *us_timer_loop(struct us_timer_t *t) {
 
 #if defined(LIBUS_USE_EPOLL) 
 
-#include <sys/syscall.h>
+#include <linux/syscall.h>
 static int has_epoll_pwait2 = -1;
 
 static int sys_epoll_pwait2(int epfd, struct epoll_event *events, int maxevents, const struct timespec *timeout, const sigset_t *sigmask, size_t sigsetsize) {
@@ -141,7 +141,7 @@ static int bun_epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
         }
 
         do {
-            ret = epoll_pwait(epfd, events, maxevents, timeoutMs, NULL);
+            ret = epoll_wait(epfd, events, maxevents, timeoutMs);
         } while (IS_EINTR(ret));
     }
 

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -125,7 +125,7 @@ int us_poll_events(struct us_poll_t *p) {
          ((p->poll_type & POLL_TYPE_POLLING_OUT) ? LIBUS_SOCKET_WRITABLE : 0);
 }
 
-unsigned int us_internal_accept_poll_event(struct us_poll_t *p) { return 0; }
+size_t us_internal_accept_poll_event(struct us_poll_t *p) { return 0; }
 
 int us_internal_poll_type(struct us_poll_t *p) { return p->poll_type & POLL_TYPE_KIND_MASK; }
 

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+#pragma once
 #ifndef INTERNAL_H
 #define INTERNAL_H
 
@@ -22,6 +22,10 @@
 #ifndef __cplusplus
 #define alignas(x) __declspec(align(x))
 #endif
+
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+
 #else
 #include <stdalign.h>
 #endif
@@ -50,6 +54,17 @@ void us_internal_loop_update_pending_ready_polls(struct us_loop_t *loop,
 
 #ifdef LIBUS_USE_LIBUV
 #include "internal/eventing/libuv.h"
+#endif
+
+#ifndef LIKELY
+#define LIKELY(cond) __builtin_expect((_Bool)(cond), 1)
+#define UNLIKELY(cond) __builtin_expect((_Bool)(cond), 0)
+#endif
+
+#ifdef _WIN32
+#define IS_EINTR(rc) (rc == SOCKET_ERROR && WSAGetLastError() == WSAEINTR)
+#else
+#define IS_EINTR(rc) (rc == -1 && errno == EINTR)
 #endif
 
 /* Poll type and what it polls for */
@@ -118,7 +133,7 @@ void us_internal_async_set(struct us_internal_async *a,
 void us_internal_async_wakeup(struct us_internal_async *a);
 
 /* Eventing related */
-unsigned int us_internal_accept_poll_event(struct us_poll_t *p);
+size_t us_internal_accept_poll_event(struct us_poll_t *p);
 int us_internal_poll_type(struct us_poll_t *p);
 void us_internal_poll_set_type(struct us_poll_t *p, int poll_type);
 

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -134,9 +134,9 @@ int bsd_addr_get_port(struct bsd_addr_t *addr);
 // called by dispatch_ready_poll
 LIBUS_SOCKET_DESCRIPTOR bsd_accept_socket(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd_addr_t *addr);
 
-int bsd_recv(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags);
-int bsd_send(LIBUS_SOCKET_DESCRIPTOR fd, const char *buf, int length, int msg_more);
-int bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length, const char *payload, int payload_length);
+ssize_t bsd_recv(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags);
+ssize_t bsd_send(LIBUS_SOCKET_DESCRIPTOR fd, const char *buf, int length, int msg_more);
+ssize_t bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length, const char *payload, int payload_length);
 int bsd_would_block();
 
 // return LIBUS_SOCKET_ERROR or the fd that represents listen socket

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -5,11 +5,11 @@ describe("setTimeout", () => {
   it("abort() does not emit global error", async () => {
     let unhandledRejectionCaught = false;
 
-    const catchUnhandledRejection = () =>  {
+    const catchUnhandledRejection = () => {
       unhandledRejectionCaught = true;
     };
-    process.on('unhandledRejection', catchUnhandledRejection);
-    
+    process.on("unhandledRejection", catchUnhandledRejection);
+
     const c = new AbortController();
 
     global.setTimeout(() => c.abort());
@@ -17,9 +17,9 @@ describe("setTimeout", () => {
     await setTimeout(100, undefined, { signal: c.signal }).catch(() => "aborted");
 
     // let unhandledRejection to be fired
-    await setTimeout(100)
+    await setTimeout(100);
 
-    process.off('unhandledRejection', catchUnhandledRejection);
+    process.off("unhandledRejection", catchUnhandledRejection);
 
     expect(c.signal.aborted).toBe(true);
     expect(unhandledRejectionCaught).toBe(false);
@@ -30,11 +30,11 @@ describe("setImmediate", () => {
   it("abort() does not emit global error", async () => {
     let unhandledRejectionCaught = false;
 
-    const catchUnhandledRejection = () =>  {
+    const catchUnhandledRejection = () => {
       unhandledRejectionCaught = true;
     };
-    process.on('unhandledRejection', catchUnhandledRejection);
-    
+    process.on("unhandledRejection", catchUnhandledRejection);
+
     const c = new AbortController();
 
     global.setImmediate(() => c.abort());
@@ -42,9 +42,9 @@ describe("setImmediate", () => {
     await setImmediate(undefined, { signal: c.signal }).catch(() => "aborted");
 
     // let unhandledRejection to be fired
-    await setTimeout(100)
+    await setTimeout(100);
 
-    process.off('unhandledRejection', catchUnhandledRejection);
+    process.off("unhandledRejection", catchUnhandledRejection);
 
     expect(c.signal.aborted).toBe(true);
     expect(unhandledRejectionCaught).toBe(false);


### PR DESCRIPTION
### What does this PR do?

It seems that usockets wasn't handling `EINTR`.  This fixes that and also makes some values return `ssize_t` instead of `int`. The caller might still truncate.

Hypothetical scenario where this matters:
1. recv() returns EINTR in usockets
2. usockets sees an error
3. usockets closes the socket due to the error

This also uses `epoll_pwait2`, which allows using a higher resolution timer

### How did you verify your code works?

