### PR TITLE
docs(argv): Correct cli file name

### DIFF
--- a/docs/guides/process/argv.md
+++ b/docs/guides/process/argv.md
@@ -13,7 +13,7 @@ console.log(Bun.argv);
 Running this file with arguments results in the following:
 
 ```sh
-$ bun run cli.tsx --flag1 --flag2 value
+$ bun run cli.ts --flag1 --flag2 value
 [ '/path/to/bun', '/path/to/cli.ts', '--flag1', '--flag2', 'value' ]
 ```
 
@@ -47,7 +47,7 @@ console.log(positionals);
 then it outputs
 
 ```
-$ bun run cli.tsx --flag1 --flag2 value
+$ bun run cli.ts --flag1 --flag2 value
 {
   flag1: true,
   flag2: "value",


### PR DESCRIPTION
### What does this PR do?

Edit the argv docs (https://bun.sh/guides/process/argv) to correct the filename used in cli commands to match the filename displayed as the output.

It doesn't really make sense for a CLI to be in a .tsx file.


- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
