### PR TITLE
use `comptime` in wherever possible

### DIFF
--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1042,7 +1042,7 @@ pub const EventLoop = struct {
                     this.virtual_machine.modules.onPoll();
                 },
                 @field(Task.Tag, typeBaseName(@typeName(GetAddrInfoRequestTask))) => {
-                    if (Environment.os == .windows) @panic("This should not be reachable on Windows");
+                    if (comptime Environment.isWindows) @panic("This should not be reachable on Windows");
 
                     var any: *GetAddrInfoRequestTask = task.get(GetAddrInfoRequestTask).?;
                     any.runFromJS();

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3110,7 +3110,7 @@ pub fn errnoToZigErr(err: anytype) anyerror {
         assert(num != 0);
     }
 
-    if (Environment.os == .windows) {
+    if (comptime Environment.isWindows) {
         // uv errors are negative, normalizing it will make this more resilient
         num = @abs(num);
     } else {

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -22,6 +22,7 @@ const bun = @import("root").bun;
 const builtin = @import("builtin");
 const mimalloc = @import("allocators/mimalloc.zig");
 const SourceMap = @import("./sourcemap/sourcemap.zig");
+const Environment = bun.Environment;
 const windows = std.os.windows;
 const Output = bun.Output;
 const Global = bun.Global;
@@ -697,7 +698,7 @@ pub fn init() void {
 }
 
 pub fn resetSegfaultHandler() void {
-    if (bun.Environment.os == .windows) {
+    if (comptime Environment.isWindows) {
         if (windows_segfault_handle) |handle| {
             const rc = windows.kernel32.RemoveVectoredExceptionHandler(handle);
             windows_segfault_handle = null;

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -1,6 +1,7 @@
 const tester = @import("../test/tester.zig");
 const std = @import("std");
 const strings = @import("../string_immutable.zig");
+const Environment = bun.Environment;
 const FeatureFlags = @import("../feature_flags.zig");
 const default_allocator = @import("../memory_allocator.zig").c_allocator;
 const bun = @import("root").bun;
@@ -1365,7 +1366,7 @@ pub fn joinAbsStringBufZTrailingSlash(cwd: []const u8, buf: []u8, _parts: anytyp
 
 fn _joinAbsStringBuf(comptime is_sentinel: bool, comptime ReturnType: type, _cwd: []const u8, buf: []u8, _parts: anytype, comptime platform: Platform) ReturnType {
     if (platform.resolve() == .windows or
-        (bun.Environment.os == .windows and platform == .loose))
+        (Environment.isWindows and platform == .loose))
     {
         return _joinAbsStringBufWindows(is_sentinel, ReturnType, _cwd, buf, _parts);
     }

--- a/src/which.zig
+++ b/src/which.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const bun = @import("root").bun;
+const Environment = bun.Environment;
 const PosixToWinNormalizer = bun.path.PosixToWinNormalizer;
 
 fn isValid(buf: *bun.PathBuffer, segment: []const u8, bin: []const u8) ?u16 {
@@ -19,7 +20,7 @@ pub fn which(buf: *bun.PathBuffer, path: []const u8, cwd: []const u8, bin: []con
     if (bin.len > bun.MAX_PATH_BYTES) return null;
     bun.Output.scoped(.which, true)("path={s} cwd={s} bin={s}", .{ path, cwd, bin });
 
-    if (bun.Environment.os == .windows) {
+    if (comptime Environment.isWindows) {
         var convert_buf: bun.WPathBuffer = undefined;
         const result = whichWin(&convert_buf, path, cwd, bin) orelse return null;
         const result_converted = bun.strings.convertUTF16toUTF8InBuffer(buf, result) catch unreachable;


### PR DESCRIPTION
I realized that several environment calls lack `comptime`