### PR TITLE
Check that ccache points to a regular file instead of a non-empty string

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -43,7 +43,7 @@ export CMAKE_FLAGS=(
 )
 
 CCACHE=$(which ccache || which sccache || echo "")
-if [ -n "$CCACHE" ]; then
+if [ -f "$CCACHE" ]; then
   CMAKE_FLAGS+=(
     -DCMAKE_C_COMPILER_LAUNCHER="$CCACHE"
     -DCMAKE_CXX_COMPILER_LAUNCHER="$CCACHE"


### PR DESCRIPTION
### What does this PR do?

Check that ccache points to a regular file instead of a non-empty string

### How did you verify your code works?

This doesn't print hi:
```sh
if [ -f /opt/homebrew/bin/node123 ]; then
  echo 'hi'
fi
```

This does print hi:
```sh
if [ -f /opt/homebrew/bin/node ]; then
  echo 'hi'
fi
```