### PR TITLE
Add internal `test.leak` method to `bun:test`

### DIFF
--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -746,7 +746,7 @@ pub const ModuleLoader = struct {
     transpile_source_code_arena: ?*bun.ArenaAllocator = null,
     eval_source: ?*logger.Source = null,
 
-    pub var is_allowed_to_use_internal_testing_apis = false;
+    pub export var is_allowed_to_use_internal_testing_apis = false;
 
     /// This must be called after calling transpileSourceCode
     pub fn resetArena(this: *ModuleLoader, jsc_vm: *VirtualMachine) void {

--- a/test/bunfig.toml
+++ b/test/bunfig.toml
@@ -1,0 +1,8 @@
+[test]
+# Large monorepos (like Bun) may want to specify the test directory more specifically 
+# By default, `bun test` scans every single folder recursively which, if you
+# have a gigantic submodule (like WebKit), requires lots of directory
+# traversals
+#
+# Instead, we can only scan the test directory for Bun's runtime tests
+preload = "./preload.ts"

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1180,6 +1180,8 @@ if (secretTestFn) {
     if (!options) {
       options = {};
     }
+
+    // Default delta is 20 MB.
     const delta = options?.delta ?? 20;
     options.label ??= label;
 
@@ -1200,6 +1202,10 @@ declare module "bun:test" {
     minimumMilliseocnds?: number;
     verbose?: boolean;
     maxWarmup?: number;
+
+    /**
+     * Default delta is 20 MB.
+     */
     delta?: number;
   }
   interface Test {

--- a/test/js/bun/shell/echo-hi-leak-test.test.ts
+++ b/test/js/bun/shell/echo-hi-leak-test.test.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "bun:test";
+
+test.leak(
+  "echo hi",
+  async () => {
+    await Bun.$`echo hi`.quiet();
+  },
+  { delta: 5, repeatCount: 500 },
+);
+
+test.leak(
+  "echo hi text",
+  async () => {
+    await Bun.$`echo hi`.text();
+  },
+  { delta: 5, repeatCount: 500 },
+);

--- a/test/js/web/request/request-clone-leak.test.ts
+++ b/test/js/web/request/request-clone-leak.test.ts
@@ -50,54 +50,15 @@ const constructorArgs = [
       },
     },
   ],
-];
+] as const;
 for (let i = 0; i < constructorArgs.length; i++) {
   const args = constructorArgs[i];
-  test("new Request(test #" + i + ")", () => {
-    Bun.gc(true);
-
-    for (let i = 0; i < 1000; i++) {
-      new Request(...args);
-    }
-
-    Bun.gc(true);
-    const baseline = (process.memoryUsage.rss() / 1024 / 1024) | 0;
-    for (let i = 0; i < 2000; i++) {
-      for (let j = 0; j < 500; j++) {
-        new Request(...args);
-      }
-      Bun.gc();
-    }
-    Bun.gc(true);
-
-    const memory = (process.memoryUsage.rss() / 1024 / 1024) | 0;
-    const delta = Math.max(memory, baseline) - Math.min(baseline, memory);
-    console.log("RSS delta: ", delta, "MB");
-    expect(delta).toBeLessThan(30);
+  test.leak("new Request(test #" + i + ")", async () => {
+    new Request(...args);
   });
 
-  test("request.clone(test #" + i + ")", () => {
-    Bun.gc(true);
-
-    for (let i = 0; i < 1000; i++) {
-      const request = new Request(...args);
-      request.clone();
-    }
-
-    Bun.gc(true);
-    const baseline = (process.memoryUsage.rss() / 1024 / 1024) | 0;
-    for (let i = 0; i < 2000; i++) {
-      for (let j = 0; j < 500; j++) {
-        const request = new Request(...args);
-        request.clone();
-      }
-      Bun.gc();
-    }
-    Bun.gc(true);
-
-    const memory = (process.memoryUsage.rss() / 1024 / 1024) | 0;
-    const delta = Math.max(memory, baseline) - Math.min(baseline, memory);
-    console.log("RSS delta: ", delta, "MB");
-    expect(delta).toBeLessThan(30);
+  test.leak("request.clone(test #" + i + ")", async () => {
+    const request = new Request(...args);
+    request.clone();
   });
 }


### PR DESCRIPTION
### What does this PR do?

This makes it easy for us to add memory leak tests

```ts
  test.leak("new Request(url)", async () => {
    new Request("http://localhost:3000");
  });
```

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
