### PR TITLE
Fix memory leak in `withFileTypes: true` in fs.readdir

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -189,7 +189,7 @@ pub const Async = struct {
                     std.mem.doNotOptimizeAway(&node_fs);
                 }
 
-                this.globalObject.bunVMConcurrently().eventLoop().enqueueTaskConcurrent(JSC.ConcurrentTask.create(JSC.Task.init(this)));
+                this.globalObject.bunVMConcurrently().eventLoop().enqueueTaskConcurrent(JSC.ConcurrentTask.createFrom(this));
             }
 
             pub fn runFromJSThread(this: *Task) void {
@@ -5044,7 +5044,10 @@ pub const NodeFS = struct {
         const dir = fd.asDir();
         const is_u16 = comptime Environment.isWindows and (ExpectedType == bun.String or ExpectedType == Dirent);
 
-        var dirent_path: ?bun.String = null;
+        var dirent_path: bun.String = bun.String.dead;
+        defer {
+            dirent_path.deref();
+        }
 
         var iterator = DirIterator.iterate(dir, comptime if (is_u16) .u16 else .u8);
         var entry = iterator.next();
@@ -5075,7 +5078,7 @@ pub const NodeFS = struct {
             .result => |ent| ent,
         }) |current| : (entry = iterator.next()) {
             if (ExpectedType == Dirent) {
-                if (dirent_path == null) {
+                if (dirent_path.isEmpty()) {
                     dirent_path = bun.String.createUTF8(basename);
                 }
             }
@@ -5083,10 +5086,10 @@ pub const NodeFS = struct {
                 const utf8_name = current.name.slice();
                 switch (ExpectedType) {
                     Dirent => {
-                        dirent_path.?.ref();
+                        dirent_path.ref();
                         entries.append(.{
                             .name = bun.String.createUTF8(utf8_name),
-                            .path = dirent_path.?,
+                            .path = dirent_path,
                             .kind = current.kind,
                         }) catch bun.outOfMemory();
                     },
@@ -5102,10 +5105,10 @@ pub const NodeFS = struct {
                 const utf16_name = current.name.slice();
                 switch (ExpectedType) {
                     Dirent => {
-                        dirent_path.?.ref();
+                        dirent_path.ref();
                         entries.append(.{
                             .name = bun.String.createUTF16(utf16_name),
-                            .path = dirent_path.?,
+                            .path = dirent_path,
                             .kind = current.kind,
                         }) catch bun.outOfMemory();
                     },
@@ -5115,9 +5118,6 @@ pub const NodeFS = struct {
                     else => @compileError("unreachable"),
                 }
             }
-        }
-        if (dirent_path) |*p| {
-            p.deref();
         }
 
         return Maybe(void).success;
@@ -5177,7 +5177,10 @@ pub const NodeFS = struct {
 
         var iterator = DirIterator.iterate(fd.asDir(), .u8);
         var entry = iterator.next();
-        var dirent_path_prev: ?bun.String = null;
+        var dirent_path_prev: bun.String = bun.String.empty;
+        defer {
+            dirent_path_prev.deref();
+        }
 
         while (switch (entry) {
             .err => |err| {
@@ -5231,13 +5234,15 @@ pub const NodeFS = struct {
             switch (comptime ExpectedType) {
                 Dirent => {
                     const path_u8 = bun.path.dirname(bun.path.join(&[_]string{ root_basename, name_to_copy }, .auto), .auto);
-                    if (dirent_path_prev == null or bun.strings.eql(dirent_path_prev.?.byteSlice(), path_u8)) {
+                    if (dirent_path_prev.isEmpty() or !bun.strings.eql(dirent_path_prev.byteSlice(), path_u8)) {
+                        dirent_path_prev.deref();
                         dirent_path_prev = bun.String.createUTF8(path_u8);
                     }
-                    dirent_path_prev.?.ref();
+                    dirent_path_prev.ref();
+
                     entries.append(.{
                         .name = bun.String.createUTF8(utf8_name),
-                        .path = dirent_path_prev.?,
+                        .path = dirent_path_prev,
                         .kind = current.kind,
                     }) catch bun.outOfMemory();
                 },
@@ -5249,9 +5254,6 @@ pub const NodeFS = struct {
                 },
                 else => bun.outOfMemory(),
             }
-        }
-        if (dirent_path_prev) |*p| {
-            p.deref();
         }
 
         return Maybe(void).success;
@@ -5330,7 +5332,10 @@ pub const NodeFS = struct {
 
             var iterator = DirIterator.iterate(fd.asDir(), .u8);
             var entry = iterator.next();
-            var dirent_path_prev: ?bun.String = null;
+            var dirent_path_prev: bun.String = bun.String.dead;
+            defer {
+                dirent_path_prev.deref();
+            }
 
             while (switch (entry) {
                 .err => |err| {
@@ -5370,13 +5375,14 @@ pub const NodeFS = struct {
                 switch (comptime ExpectedType) {
                     Dirent => {
                         const path_u8 = bun.path.dirname(bun.path.join(&[_]string{ root_basename, name_to_copy }, .auto), .auto);
-                        if (dirent_path_prev == null or bun.strings.eql(dirent_path_prev.?.byteSlice(), path_u8)) {
+                        if (dirent_path_prev.isEmpty() or !bun.strings.eql(dirent_path_prev.byteSlice(), path_u8)) {
+                            dirent_path_prev.deref();
                             dirent_path_prev = bun.String.createUTF8(path_u8);
                         }
-                        dirent_path_prev.?.ref();
+                        dirent_path_prev.ref();
                         entries.append(.{
                             .name = bun.String.createUTF8(utf8_name),
-                            .path = dirent_path_prev.?,
+                            .path = dirent_path_prev,
                             .kind = current.kind,
                         }) catch bun.outOfMemory();
                     },
@@ -5388,9 +5394,6 @@ pub const NodeFS = struct {
                     },
                     else => @compileError("Impossible"),
                 }
-            }
-            if (dirent_path_prev) |*p| {
-                p.deref();
             }
         }
 


### PR DESCRIPTION
### What does this PR do?

The `path` / `parentPath` string in `fs.DirEnt` was being re-created for every file or folder in the directory, and then leaked. This memory leak started in #11135. Thanks to @billywhizz for uncovering this leak.

### How did you verify your code works?

A test will be added to #12391 

| Runtime | RSS |
|----------|-----|
| `bun --smol` (this PR) |  37 MB |
| `node` |  59 MB |
| `bun` (this PR) |  99 MB |
| `bun` stable | 250 MB |

```ts
import { readdirSync, promises as fs } from "fs";
const readdir = readdirSync;
// const { readdir } = fs;

await (async function () {
  for (let i = 0; i < 10000; i++) {
    for (let { parentPath, path, name } of await readdir(
      "/Users/jarred/Code/bun/test/js/node",
      { recursive: true, withFileTypes: true }
    )) {
    }
  }
})();

if (globalThis.Bun) {
  Bun.gc(true);
  Bun.unsafe.mimallocDump();
}
console.log("RSS", (process.memoryUsage.rss() / 1024 / 1024) | 0, "MB");
```

| Runtime | RSS |
|----------|-----|
| `bun --smol` (this PR) | 52 MB |
| `node` |  60 MB |
| `bun` (this PR) | 68 MB |
| `bun` stable | 265 MB |

```ts
import { readdirSync, promises as fs } from "fs";
const { readdir } = fs;

await (async function () {
  for (let i = 0; i < 10000; i++) {
    for (let { parentPath, path, name } of await readdir(
      "/Users/jarred/Code/bun/test/js/node",
      { recursive: true, withFileTypes: true }
    )) {
    }
  }
})();

if (globalThis.Bun) {
  Bun.gc(true);
  Bun.unsafe.mimallocDump();
}
console.log("RSS", (process.memoryUsage.rss() / 1024 / 1024) | 0, "MB");
```

Note that there may still be a leak in `fs.promises.readdir` with `recursive: true`. This specifically addresses `withFileTypes`.

