### PR TITLE
fix(jest): `beforeEach`, `afterEach` not called for `test.todo`

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -684,13 +684,6 @@ pub const TestScope = struct {
         return JSValue.jsUndefined();
     }
 
-    pub fn shouldEvaluateScope(this: *const TestScope) bool {
-        if (this.tag == .skip or
-            this.tag == .todo) return false;
-        if (Jest.runner.?.only and this.tag == .only) return true;
-        return this.parent.shouldEvaluateScope();
-    }
-
     pub fn run(
         this: *TestScope,
         task: *TestRunnerTask,
@@ -1203,16 +1196,12 @@ pub const DescribeScope = struct {
     }
 
     pub fn onTestComplete(this: *DescribeScope, globalThis: *JSGlobalObject, test_id: TestRunner.Test.ID, skipped: bool) void {
-        var should_eval_test_scope = true;
         // invalidate it
         this.current_test_id = std.math.maxInt(TestRunner.Test.ID);
-        if (test_id != std.math.maxInt(TestRunner.Test.ID)) {
-            this.pending_tests.unset(test_id);
-            should_eval_test_scope = this.tests.items[test_id].shouldEvaluateScope();
-        }
+        if (test_id != std.math.maxInt(TestRunner.Test.ID)) this.pending_tests.unset(test_id);
         globalThis.bunVM().onUnhandledRejectionCtx = null;
 
-        if (!skipped and should_eval_test_scope) {
+        if (!skipped) {
             if (this.runCallback(globalThis, .afterEach)) |err| {
                 _ = globalThis.bunVM().uncaughtException(globalThis, err, true);
             }
@@ -1398,12 +1387,10 @@ pub const TestRunnerTask = struct {
             this.needs_before_each = false;
             const label = test_.label;
 
-            if (test_.shouldEvaluateScope()) {
-                if (this.describe.runCallback(globalThis, .beforeEach)) |err| {
-                    _ = jsc_vm.uncaughtException(globalThis, err, true);
-                    Jest.runner.?.reportFailure(test_id, this.source_file_path, label, 0, 0, this.describe);
-                    return false;
-                }
+            if (this.describe.runCallback(globalThis, .beforeEach)) |err| {
+                _ = jsc_vm.uncaughtException(globalThis, err, true);
+                Jest.runner.?.reportFailure(test_id, this.source_file_path, label, 0, 0, this.describe);
+                return false;
             }
         }
 
@@ -1564,7 +1551,7 @@ pub const TestRunnerTask = struct {
             },
             .pending => @panic("Unexpected pending test"),
         }
-        describe.onTestComplete(globalThis, test_id, result == .skip);
+        describe.onTestComplete(globalThis, test_id, result == .skip or (!Jest.runner.?.test_options.run_todo and result == .todo));
         Jest.runner.?.runNextTest();
     }
 

--- a/test/js/bun/test/jest-hooks.test.ts
+++ b/test/js/bun/test/jest-hooks.test.ts
@@ -223,4 +223,29 @@ describe("test jest hooks in bun-test", () => {
       expect(afterEachCalled).toBe(1);
     });
   });
+
+  describe("beforeEach, afterEach with test.todo()", () => {
+    let beforeEachCalled = 0;
+    let afterEachCalled = 0;
+
+    beforeEach(() => {
+      beforeEachCalled++;
+    });
+
+    afterEach(() => {
+      afterEachCalled++;
+    });
+
+    it.todo("TODO test");
+
+    it("should have not called beforeEach or afterEach for test.todo", () => {
+      expect(beforeEachCalled).toEqual(1); // Called once just before this test
+      expect(afterEachCalled).toEqual(0);
+    });
+
+    it("should have called afterEach for previous test", () => {
+      expect(beforeEachCalled).toEqual(2); // Called once just before this test
+      expect(afterEachCalled).toEqual(1);
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fixes #12303

Checks if should eval scope before running `beforeEach` and `afterEach`, which includes checking if the scope is tagged with `.todo`
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
