### PR TITLE
fix(server) wait for readFile on abort/process exit cases

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -2099,9 +2099,9 @@ pub const AsyncHTTP = struct {
 
             const active_requests = AsyncHTTP.active_requests_count.fetchSub(1, .monotonic);
             assert(active_requests > 0);
-            
+
             // if we abort before connecting we can cause stackoverflow by calling drainEvents
-            if(result.fail) |err|{
+            if (result.fail) |err| {
                 if (err == error.Aborted) return;
             }
 
@@ -2109,7 +2109,6 @@ pub const AsyncHTTP = struct {
                 http_thread.drainEvents();
             }
         }
-        
     }
 
     pub fn startAsyncHTTP(task: *Task) void {

--- a/src/http.zig
+++ b/src/http.zig
@@ -2101,7 +2101,7 @@ pub const AsyncHTTP = struct {
             assert(active_requests > 0);
 
             // if we abort before connecting we can cause stackoverflow by calling drainEvents
-            if(result.fail) |err|{
+            if (result.fail) |err| {
                 if (err == error.AbortedBeforeConnecting) return;
             }
 

--- a/src/http.zig
+++ b/src/http.zig
@@ -3137,7 +3137,7 @@ pub const HTTPClientResult = struct {
     }
 
     pub fn isAbort(this: *const HTTPClientResult) bool {
-        return if (this.fail) |e| e == error.Aborted else false;
+        return if (this.fail) |e| (e == error.Aborted or e == error.AbortedBeforeConnecting) else false;
     }
 
     pub const Callback = struct {

--- a/src/http.zig
+++ b/src/http.zig
@@ -2101,8 +2101,8 @@ pub const AsyncHTTP = struct {
             assert(active_requests > 0);
 
             // if we abort before connecting we can cause stackoverflow by calling drainEvents
-            if (result.fail) |err| {
-                if (err == error.Aborted) return;
+            if(result.fail) |err|{
+                if (err == error.AbortedBeforeConnecting) return;
             }
 
             if (AsyncHTTP.active_requests_count.load(.monotonic) < AsyncHTTP.max_simultaneous_requests.load(.monotonic)) {
@@ -2319,7 +2319,7 @@ fn start_(this: *HTTPClient, comptime is_ssl: bool) void {
 
     // Aborted before connecting
     if (this.signals.get(.aborted)) {
-        this.fail(error.Aborted);
+        this.fail(error.AbortedBeforeConnecting);
         return;
     }
 

--- a/src/http.zig
+++ b/src/http.zig
@@ -2099,15 +2099,10 @@ pub const AsyncHTTP = struct {
 
             const active_requests = AsyncHTTP.active_requests_count.fetchSub(1, .monotonic);
             assert(active_requests > 0);
+        }
 
-            // if we abort before connecting we can cause stackoverflow by calling drainEvents
-            if (result.fail) |err| {
-                if (err == error.AbortedBeforeConnecting) return;
-            }
-
-            if (AsyncHTTP.active_requests_count.load(.monotonic) < AsyncHTTP.max_simultaneous_requests.load(.monotonic)) {
-                http_thread.drainEvents();
-            }
+        if (!http_thread.queued_tasks.isEmpty() and AsyncHTTP.active_requests_count.load(.monotonic) < AsyncHTTP.max_simultaneous_requests.load(.monotonic)) {
+            http_thread.loop.loop.wakeup();
         }
     }
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -198,7 +198,7 @@ it("should be able to stop in the middle of a file response", async () => {
       expect(response.status).toBe(200);
     } catch {}
   }
-  const fixture = path.join(import.meta.dir, "server-bigfile-send.fixture.js");
+  const fixture = join(import.meta.dir, "server-bigfile-send.fixture.js");
   for (let i = 0; i < 10; i++) {
     const process = Bun.spawn([bunExe(), fixture], {
       env: bunEnv,

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -186,38 +186,6 @@ it("should display a welcome message when the response value type is incorrect",
   );
 });
 
-it("should be able to stop in the middle of a file response", async () => {
-  async function doRequest(url) {
-    try {
-      const response = await fetch(url, { signal: AbortSignal.timeout(10) });
-      const read = response.body.getReader();
-      while (true) {
-        const { value, done } = await read.read();
-        if (done) break;
-      }
-      expect(response.status).toBe(200);
-    } catch {}
-  }
-  const fixture = join(import.meta.dir, "server-bigfile-send.fixture.js");
-  for (let i = 0; i < 3; i++) {
-    const process = Bun.spawn([bunExe(), fixture], {
-      env: bunEnv,
-      stderr: "inherit",
-      stdout: "pipe",
-      stdin: "ignore",
-    });
-    const { value } = await process.stdout.getReader().read();
-    const url = new TextDecoder().decode(value).trim();
-    const requests = [];
-    for (let j = 0; j < 1_000; j++) {
-      requests.push(doRequest(url));
-    }
-    await Promise.all(requests);
-    expect(process.exitCode || 0).toBe(0);
-    process.kill();
-  }
-}, 30_000);
-
 it("request.signal works in trivial case", async () => {
   var aborty = new AbortController();
   var signaler = Promise.withResolvers();
@@ -1541,3 +1509,36 @@ it("should work with dispose keyword", async () => {
   }
   expect(fetch(url)).rejects.toThrow();
 });
+
+it("should be able to stop in the middle of a file response", async () => {
+  async function doRequest(url: string) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(10) });
+      const read = (response.body as ReadableStream<any>).getReader();
+      while (true) {
+        const { value, done } = await read.read();
+        if (done) break;
+      }
+      expect(response.status).toBe(200);
+    } catch {}
+  }
+  const fixture = join(import.meta.dir, "server-bigfile-send.fixture.js");
+  for (let i = 0; i < 3; i++) {
+    const process = Bun.spawn([bunExe(), fixture], {
+      env: bunEnv,
+      stderr: "inherit",
+      stdout: "pipe",
+      stdin: "ignore",
+    });
+    const { value } = await process.stdout.getReader().read();
+    const url = new TextDecoder().decode(value).trim();
+    const requests = [];
+    for (let j = 0; j < 5_000; j++) {
+      requests.push(doRequest(url));
+    }
+    // only await for 1k requests (and kill the process)
+    await Promise.all(requests.slice(0, 1_000));
+    expect(process.exitCode || 0).toBe(0);
+    process.kill();
+  }
+}, 60_000);

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -199,25 +199,24 @@ it("should be able to stop in the middle of a file response", async () => {
     } catch {}
   }
   const fixture = join(import.meta.dir, "server-bigfile-send.fixture.js");
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 3; i++) {
     const process = Bun.spawn([bunExe(), fixture], {
       env: bunEnv,
       stderr: "inherit",
       stdout: "pipe",
       stdin: "ignore",
     });
-    const { stdout, exited } = process;
-    const { value } = await stdout.getReader().read();
+    const { value } = await process.stdout.getReader().read();
     const url = new TextDecoder().decode(value).trim();
     const requests = [];
-    for (let j = 0; j < 10_000; j++) {
+    for (let j = 0; j < 1_000; j++) {
       requests.push(doRequest(url));
     }
     await Promise.all(requests);
     expect(process.exitCode || 0).toBe(0);
     process.kill();
   }
-});
+}, 30_000);
 
 it("request.signal works in trivial case", async () => {
   var aborty = new AbortController();

--- a/test/js/bun/http/server-bigfile-send.fixture.js
+++ b/test/js/bun/http/server-bigfile-send.fixture.js
@@ -1,0 +1,13 @@
+import { serve, file } from "bun";
+import { join } from "node:path";
+const bigfile = join("...", "...", "web", "encoding", "utf8-encoding-fixture.bin");
+const server = serve({
+  port: 0,
+  async fetch() {
+    return new Response(file(bigfile), {
+      headers: { "Content-Type": "text/html" },
+    });
+  },
+});
+
+console.log(server.url.href);

--- a/test/js/bun/http/server-bigfile-send.fixture.js
+++ b/test/js/bun/http/server-bigfile-send.fixture.js
@@ -1,6 +1,6 @@
 import { serve, file } from "bun";
 import { join } from "node:path";
-const bigfile = join("...", "...", "web", "encoding", "utf8-encoding-fixture.bin");
+const bigfile = join(import.meta.dir, "../../web/encoding/utf8-encoding-fixture.bin");
 const server = serve({
   port: 0,
   async fetch() {


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/12010
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Added test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
