### PR TITLE
heavy revision on heap_breakdown's safety

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -74,31 +74,30 @@ pub const StandaloneModuleGraph = struct {
         loader: bun.options.Loader,
         contents: []const u8 = "",
         sourcemap: LazySourceMap,
-        blob_: ?*bun.JSC.WebCore.Blob = null,
+        cached_blob: ?*bun.JSC.WebCore.Blob = null,
 
         pub fn blob(this: *File, globalObject: *bun.JSC.JSGlobalObject) *bun.JSC.WebCore.Blob {
-            if (this.blob_ == null) {
+            if (this.cached_blob == null) {
                 var store = bun.JSC.WebCore.Blob.Store.init(@constCast(this.contents), bun.default_allocator);
                 // make it never free
                 store.ref();
 
-                var blob_ = bun.default_allocator.create(bun.JSC.WebCore.Blob) catch bun.outOfMemory();
-                blob_.* = bun.JSC.WebCore.Blob.initWithStore(store, globalObject);
-                blob_.allocator = bun.default_allocator;
+                const b = bun.JSC.WebCore.Blob.initWithStore(store, globalObject).new();
+                b.allocator = bun.default_allocator;
 
                 if (bun.http.MimeType.byExtensionNoDefault(bun.strings.trimLeadingChar(std.fs.path.extension(this.name), '.'))) |mime| {
                     store.mime_type = mime;
-                    blob_.content_type = mime.value;
-                    blob_.content_type_was_set = true;
-                    blob_.content_type_allocated = false;
+                    b.content_type = mime.value;
+                    b.content_type_was_set = true;
+                    b.content_type_allocated = false;
                 }
 
                 store.data.bytes.stored_name = bun.PathString.init(this.name);
 
-                this.blob_ = blob_;
+                this.cached_blob = b;
             }
 
-            return this.blob_.?;
+            return this.cached_blob.?;
         }
     };
 

--- a/src/brotli.zig
+++ b/src/brotli.zig
@@ -11,17 +11,17 @@ const mimalloc = bun.Mimalloc;
 
 const BrotliAllocator = struct {
     pub fn alloc(_: ?*anyopaque, len: usize) callconv(.C) *anyopaque {
-        if (comptime bun.is_heap_breakdown_enabled) {
-            const zone = bun.HeapBreakdown.malloc_zone_t.get(BrotliAllocator);
-            return zone.malloc_zone_malloc(len).?;
+        if (bun.heap_breakdown.enabled) {
+            const zone = bun.heap_breakdown.getZone(BrotliAllocator);
+            return zone.malloc_zone_malloc(len) orelse bun.outOfMemory();
         }
 
-        return mimalloc.mi_malloc(len) orelse unreachable;
+        return mimalloc.mi_malloc(len) orelse bun.outOfMemory();
     }
 
     pub fn free(_: ?*anyopaque, data: ?*anyopaque) callconv(.C) void {
-        if (comptime bun.is_heap_breakdown_enabled) {
-            const zone = bun.HeapBreakdown.malloc_zone_t.get(BrotliAllocator);
+        if (bun.heap_breakdown.enabled) {
+            const zone = bun.heap_breakdown.getZone(BrotliAllocator);
             zone.malloc_zone_free(data);
             return;
         }

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1299,7 +1299,7 @@ extern fn dump_zone_malloc_stats() void;
 
 fn dump_mimalloc(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) JSC.JSValue {
     globalObject.bunVM().arena.dumpStats();
-    if (comptime bun.is_heap_breakdown_enabled) {
+    if (bun.heap_breakdown.enabled) {
         dump_zone_malloc_stats();
     }
     return .undefined;
@@ -2246,13 +2246,7 @@ pub const Crypto = struct {
                 };
                 this.ref = .{};
                 this.promise.strong = .{};
-
-                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch bun.outOfMemory();
-                concurrent_task.* = JSC.ConcurrentTask{
-                    .task = JSC.Task.init(&result.task),
-                    .auto_delete = true,
-                };
-                this.event_loop.enqueueTaskConcurrent(concurrent_task);
+                this.event_loop.enqueueTaskConcurrent(JSC.ConcurrentTask.createFrom(&result.task));
                 this.deinit();
             }
         };
@@ -2488,13 +2482,7 @@ pub const Crypto = struct {
                 };
                 this.ref = .{};
                 this.promise.strong = .{};
-
-                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch bun.outOfMemory();
-                concurrent_task.* = JSC.ConcurrentTask{
-                    .task = JSC.Task.init(&result.task),
-                    .auto_delete = true,
-                };
-                this.event_loop.enqueueTaskConcurrent(concurrent_task);
+                this.event_loop.enqueueTaskConcurrent(JSC.ConcurrentTask.createFrom(&result.task));
                 this.deinit();
             }
         };

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -683,16 +683,7 @@ pub const JSBundler = struct {
             completion.ref();
 
             this.js_task = AnyTask.init(this);
-            const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch {
-                completion.deref();
-                this.deinit();
-                return;
-            };
-            concurrent_task.* = JSC.ConcurrentTask{
-                .auto_delete = true,
-                .task = this.js_task.task(),
-            };
-            completion.jsc_event_loop.enqueueTaskConcurrent(concurrent_task);
+            completion.jsc_event_loop.enqueueTaskConcurrent(JSC.ConcurrentTask.create(this.js_task.task()));
         }
 
         pub fn runOnJSThread(this: *Resolve) void {
@@ -839,15 +830,7 @@ pub const JSBundler = struct {
             completion.ref();
 
             this.js_task = AnyTask.init(this);
-            const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch {
-                completion.deref();
-                this.deinit();
-                return;
-            };
-            concurrent_task.* = JSC.ConcurrentTask{
-                .auto_delete = true,
-                .task = this.js_task.task(),
-            };
+            const concurrent_task = JSC.ConcurrentTask.createFrom(&this.js_task);
             completion.jsc_event_loop.enqueueTaskConcurrent(concurrent_task);
         }
 

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1933,9 +1933,8 @@ pub const MiniEventLoop = struct {
 
     pub fn stderr(this: *MiniEventLoop) *JSC.WebCore.Blob.Store {
         return this.stderr_store orelse brk: {
-            const store = bun.default_allocator.create(JSC.WebCore.Blob.Store) catch bun.outOfMemory();
             var mode: bun.Mode = 0;
-            const fd = if (comptime Environment.isWindows) bun.FDImpl.fromUV(2).encode() else bun.STDERR_FD;
+            const fd = if (Environment.isWindows) bun.FDImpl.fromUV(2).encode() else bun.STDERR_FD;
 
             switch (bun.sys.fstat(fd)) {
                 .result => |stat| {
@@ -1944,7 +1943,7 @@ pub const MiniEventLoop = struct {
                 .err => {},
             }
 
-            store.* = JSC.WebCore.Blob.Store{
+            const store = JSC.WebCore.Blob.Store.new(.{
                 .ref_count = std.atomic.Value(u32).init(2),
                 .allocator = bun.default_allocator,
                 .data = .{
@@ -1956,7 +1955,7 @@ pub const MiniEventLoop = struct {
                         .mode = mode,
                     },
                 },
-            };
+            });
 
             this.stderr_store = store;
             break :brk store;
@@ -1965,7 +1964,6 @@ pub const MiniEventLoop = struct {
 
     pub fn stdout(this: *MiniEventLoop) *JSC.WebCore.Blob.Store {
         return this.stdout_store orelse brk: {
-            const store = bun.default_allocator.create(JSC.WebCore.Blob.Store) catch bun.outOfMemory();
             var mode: bun.Mode = 0;
             const fd = if (Environment.isWindows) bun.FDImpl.fromUV(1).encode() else bun.STDOUT_FD;
 
@@ -1976,7 +1974,7 @@ pub const MiniEventLoop = struct {
                 .err => {},
             }
 
-            store.* = JSC.WebCore.Blob.Store{
+            const store = JSC.WebCore.Blob.Store.new(.{
                 .ref_count = std.atomic.Value(u32).init(2),
                 .allocator = bun.default_allocator,
                 .data = .{
@@ -1988,7 +1986,7 @@ pub const MiniEventLoop = struct {
                         .mode = mode,
                     },
                 },
-            };
+            });
 
             this.stdout_store = store;
             break :brk store;

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -460,12 +460,9 @@ pub export fn Bun__reportUnhandledError(globalObject: *JSGlobalObject, value: JS
 pub export fn Bun__queueTaskConcurrently(global: *JSGlobalObject, task: *JSC.CppTask) void {
     JSC.markBinding(@src());
 
-    const concurrent = bun.default_allocator.create(JSC.ConcurrentTask) catch unreachable;
-    concurrent.* = JSC.ConcurrentTask{
-        .task = Task.init(task),
-        .auto_delete = true,
-    };
-    global.bunVMConcurrently().eventLoop().enqueueTaskConcurrent(concurrent);
+    global.bunVMConcurrently().eventLoop().enqueueTaskConcurrent(
+        JSC.ConcurrentTask.create(Task.init(task)),
+    );
 }
 
 pub export fn Bun__handleRejectedPromise(global: *JSGlobalObject, promise: *JSC.JSPromise) void {

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -895,12 +895,7 @@ pub const ModuleLoader = struct {
             pub fn onWakeHandler(ctx: *anyopaque, _: *PackageManager) void {
                 debug("onWake", .{});
                 var this = bun.cast(*Queue, ctx);
-                const concurrent_task = bun.default_allocator.create(JSC.ConcurrentTask) catch bun.outOfMemory();
-                concurrent_task.* = .{
-                    .task = JSC.Task.init(this),
-                    .auto_delete = true,
-                };
-                this.vm().enqueueTaskConcurrent(concurrent_task);
+                this.vm().enqueueTaskConcurrent(JSC.ConcurrentTask.createFrom(this));
             }
 
             pub fn onPoll(this: *Queue) void {

--- a/src/bun.js/node/node_fs_binding.zig
+++ b/src/bun.js/node/node_fs_binding.zig
@@ -260,8 +260,7 @@ pub const NodeJSFS = struct {
 };
 
 pub fn createBinding(globalObject: *JSC.JSGlobalObject) JSC.JSValue {
-    var module = globalObject.allocator().create(NodeJSFS) catch bun.outOfMemory();
-    module.* = .{};
+    const module = NodeJSFS.new(.{});
 
     const vm = globalObject.bunVM();
     if (vm.standalone_module_graph != null)

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -7,6 +7,8 @@
 // Otherwise, you risk a circular dependency or Zig including multiple copies of this file which leads to strange bugs.
 const builtin = @import("builtin");
 const std = @import("std");
+const bun = @This();
+
 pub const Environment = @import("env.zig");
 
 pub const use_mimalloc = !Environment.isTest;
@@ -1670,7 +1672,6 @@ pub fn reloadProcess(
     }
 
     Output.Source.Stdio.restore();
-    const bun = @This();
 
     if (comptime Environment.isWindows) {
         // on windows we assume that we have a parent process that is monitoring us and will restart us if we exit with a magic exit code
@@ -2933,15 +2934,15 @@ pub noinline fn outOfMemory() noreturn {
     crash_handler.crashHandler(.out_of_memory, null, @returnAddress());
 }
 
+/// Wrapper around allocator.create(T) that safely initializes the pointer. Prefer this over
+/// `std.mem.Allocator.create`, but prefer using `bun.new` over `create(default_allocator, T, t)`
 pub fn create(allocator: std.mem.Allocator, comptime T: type, t: T) *T {
     const ptr = allocator.create(T) catch outOfMemory();
     ptr.* = t;
     return ptr;
 }
 
-pub const is_heap_breakdown_enabled = Environment.allow_assert and Environment.isMac;
-
-pub const HeapBreakdown = if (is_heap_breakdown_enabled) @import("./heap_breakdown.zig") else struct {};
+pub const heap_breakdown = @import("./heap_breakdown.zig");
 
 /// Globally-allocate a value on the heap.
 ///
@@ -2950,71 +2951,54 @@ pub const HeapBreakdown = if (is_heap_breakdown_enabled) @import("./heap_breakdo
 ///
 /// On macOS, you can use `Bun.unsafe.mimallocDump()`
 /// to dump the heap.
-pub inline fn new(comptime T: type, t: T) *T {
-    if (comptime @hasDecl(T, "is_bun.New()")) {
-        // You will get weird memory bugs in debug builds if you use the wrong allocator.
-        @compileError("Use " ++ @typeName(T) ++ ".new() instead of bun.new()");
-    }
-    if (comptime is_heap_breakdown_enabled) {
-        const ptr = HeapBreakdown.allocator(T).create(T) catch outOfMemory();
-        ptr.* = t;
-        return ptr;
+pub inline fn new(comptime T: type, init: T) *T {
+    const ptr = if (heap_breakdown.enabled)
+        heap_breakdown.getZone(T).create(T, init)
+    else ptr: {
+        const ptr = default_allocator.create(T) catch outOfMemory();
+        ptr.* = init;
+        break :ptr ptr;
+    };
+
+    if (comptime Environment.allow_assert) {
+        const logAlloc = Output.scoped(.alloc, @hasDecl(T, "logAllocations"));
+        logAlloc("new({s}) = {*}", .{ meta.typeName(T), ptr });
     }
 
-    const ptr = default_allocator.create(T) catch outOfMemory();
-    ptr.* = t;
     return ptr;
 }
 
-pub const newWithAlloc = @compileError("If you're going to use a global allocator, don't conditionally use it. Use bun.New() instead.");
-pub const destroyWithAlloc = @compileError("If you're going to use a global allocator, don't conditionally use it. Use bun.New() instead.");
+/// Free a globally-allocated a value from `bun.new()`. Using this with
+/// pointers allocated from other means may cause crashes.
+pub inline fn destroy(ptr: anytype) void {
+    const T = std.meta.Child(@TypeOf(ptr));
 
-pub inline fn dupe(comptime T: type, t: *T) *T {
-    if (comptime is_heap_breakdown_enabled) {
-        const ptr = HeapBreakdown.allocator(T).create(T) catch outOfMemory();
-        ptr.* = t.*;
-        return ptr;
+    if (Environment.allow_assert) {
+        const logAlloc = Output.scoped(.alloc, @hasDecl(T, "logAllocations"));
+        logAlloc("destroy({s}) = {*}", .{ meta.typeName(T), ptr });
     }
 
-    const ptr = default_allocator.create(T) catch outOfMemory();
-    ptr.* = t.*;
-    return ptr;
+    if (heap_breakdown.enabled) {
+        heap_breakdown.getZone(T).destroy(T, ptr);
+    } else {
+        default_allocator.destroy(ptr);
+    }
+}
+
+pub inline fn dupe(comptime T: type, t: *T) *T {
+    return new(T, t.*);
 }
 
 pub fn New(comptime T: type) type {
     return struct {
-        const allocation_logger = Output.scoped(.alloc, @hasDecl(T, "logAllocations"));
-        pub const @"is_bun.New()" = true;
+        pub const ban_standard_library_allocator = true;
 
         pub inline fn destroy(self: *T) void {
-            if (comptime Environment.allow_assert) {
-                allocation_logger("destroy({*})", .{self});
-            }
-
-            if (comptime is_heap_breakdown_enabled) {
-                HeapBreakdown.allocator(T).destroy(self);
-            } else {
-                default_allocator.destroy(self);
-            }
+            bun.destroy(self);
         }
 
         pub inline fn new(t: T) *T {
-            if (comptime is_heap_breakdown_enabled) {
-                const ptr = HeapBreakdown.allocator(T).create(T) catch outOfMemory();
-                ptr.* = t;
-                if (comptime Environment.allow_assert) {
-                    allocation_logger("new() = {*}", .{ptr});
-                }
-                return ptr;
-            }
-
-            const ptr = default_allocator.create(T) catch outOfMemory();
-            ptr.* = t;
-
-            if (comptime Environment.allow_assert) {
-                allocation_logger("new() = {*}", .{ptr});
-            }
-            return ptr;
+            return bun.new(T, t);
         }
     };
 }
@@ -3040,28 +3024,23 @@ pub fn NewRefCounted(comptime T: type, comptime deinit_fn: ?fn (self: *T) void) 
     const log = Output.scoped(output_name, true);
 
     return struct {
-        const allocation_logger = Output.scoped(.alloc, @hasDecl(T, "logAllocations"));
-
         pub fn destroy(self: *T) void {
-            if (comptime Environment.allow_assert) {
+            if (Environment.allow_assert) {
                 assert(self.ref_count == 0);
-                allocation_logger("destroy() = {*}", .{self});
             }
 
-            if (comptime is_heap_breakdown_enabled) {
-                HeapBreakdown.allocator(T).destroy(self);
-            } else {
-                default_allocator.destroy(self);
-            }
+            bun.destroy(self);
         }
 
         pub fn ref(self: *T) void {
-            if (comptime Environment.isDebug) log("0x{x} ref {d} + 1 = {d}", .{ @intFromPtr(self), self.ref_count, self.ref_count + 1 });
+            if (Environment.isDebug) log("0x{x} ref {d} + 1 = {d}", .{ @intFromPtr(self), self.ref_count, self.ref_count + 1 });
+
             self.ref_count += 1;
         }
 
         pub fn deref(self: *T) void {
-            if (comptime Environment.isDebug) log("0x{x} deref {d} - 1 = {d}", .{ @intFromPtr(self), self.ref_count, self.ref_count - 1 });
+            if (Environment.isDebug) log("0x{x} deref {d} - 1 = {d}", .{ @intFromPtr(self), self.ref_count, self.ref_count - 1 });
+
             self.ref_count -= 1;
 
             if (self.ref_count == 0) {
@@ -3074,45 +3053,17 @@ pub fn NewRefCounted(comptime T: type, comptime deinit_fn: ?fn (self: *T) void) 
         }
 
         pub inline fn new(t: T) *T {
-            if (comptime is_heap_breakdown_enabled) {
-                const ptr = HeapBreakdown.allocator(T).create(T) catch outOfMemory();
-                ptr.* = t;
+            const ptr = bun.new(T, t);
 
-                if (comptime Environment.allow_assert) {
-                    if (ptr.ref_count != 1) {
-                        std.debug.panic("Expected ref_count to be 1, got {d}", .{ptr.ref_count});
-                    }
-                    allocation_logger("new() = {*}", .{ptr});
+            if (Environment.allow_assert) {
+                if (ptr.ref_count != 1) {
+                    Output.panic("Expected ref_count to be 1, got {d}", .{ptr.ref_count});
                 }
-
-                return ptr;
-            }
-
-            const ptr = default_allocator.create(T) catch outOfMemory();
-            ptr.* = t;
-
-            if (comptime Environment.allow_assert) {
-                assert(ptr.ref_count == 1);
-                allocation_logger("new() = {*}", .{ptr});
             }
 
             return ptr;
         }
     };
-}
-
-/// Free a globally-allocated a value.
-///
-/// Must have used `new` to allocate the value.
-///
-/// On macOS, you can use `Bun.unsafe.mimallocDump()`
-/// to dump the heap.
-pub inline fn destroy(t: anytype) void {
-    if (comptime is_heap_breakdown_enabled) {
-        HeapBreakdown.allocator(std.meta.Child(@TypeOf(t))).destroy(t);
-    } else {
-        default_allocator.destroy(t);
-    }
 }
 
 pub fn exitThread() noreturn {

--- a/src/heap_breakdown.zig
+++ b/src/heap_breakdown.zig
@@ -1,60 +1,57 @@
 const bun = @import("root").bun;
 const std = @import("std");
-const HeapBreakdown = @This();
+const Environment = bun.Environment;
+const Allocator = std.mem.Allocator;
+const vm_size_t = usize;
+
+pub const enabled = Environment.allow_assert and Environment.isMac;
 
 pub fn allocator(comptime T: type) std.mem.Allocator {
-    return malloc_zone_t.get(T).getAllocator();
+    return getZone(T).allocator();
 }
 
-pub const malloc_zone_t = opaque {
-    const Allocator = std.mem.Allocator;
-    const vm_size_t = usize;
+pub fn getZone(comptime T: type) *Zone {
+    comptime bun.assert(enabled);
 
-    pub extern fn malloc_default_zone() *malloc_zone_t;
-    pub extern fn malloc_create_zone(start_size: vm_size_t, flags: c_uint) *malloc_zone_t;
-    pub extern fn malloc_destroy_zone(zone: *malloc_zone_t) void;
-    pub extern fn malloc_zone_malloc(zone: *malloc_zone_t, size: usize) ?*anyopaque;
-    pub extern fn malloc_zone_calloc(zone: *malloc_zone_t, num_items: usize, size: usize) ?*anyopaque;
-    pub extern fn malloc_zone_valloc(zone: *malloc_zone_t, size: usize) ?*anyopaque;
-    pub extern fn malloc_zone_free(zone: *malloc_zone_t, ptr: ?*anyopaque) void;
-    pub extern fn malloc_zone_realloc(zone: *malloc_zone_t, ptr: ?*anyopaque, size: usize) ?*anyopaque;
-    pub extern fn malloc_zone_from_ptr(ptr: ?*const anyopaque) *malloc_zone_t;
-    pub extern fn malloc_zone_memalign(zone: *malloc_zone_t, alignment: usize, size: usize) ?*anyopaque;
-    pub extern fn malloc_zone_batch_malloc(zone: *malloc_zone_t, size: usize, results: [*]?*anyopaque, num_requested: c_uint) c_uint;
-    pub extern fn malloc_zone_batch_free(zone: *malloc_zone_t, to_be_freed: [*]?*anyopaque, num: c_uint) void;
-    pub extern fn malloc_default_purgeable_zone() *malloc_zone_t;
-    pub extern fn malloc_make_purgeable(ptr: ?*anyopaque) void;
-    pub extern fn malloc_make_nonpurgeable(ptr: ?*anyopaque) c_int;
-    pub extern fn malloc_zone_register(zone: *malloc_zone_t) void;
-    pub extern fn malloc_zone_unregister(zone: *malloc_zone_t) void;
-    pub extern fn malloc_set_zone_name(zone: *malloc_zone_t, name: ?[*:0]const u8) void;
-    pub extern fn malloc_get_zone_name(zone: *malloc_zone_t) ?[*:0]const u8;
-    pub extern fn malloc_zone_pressure_relief(zone: *malloc_zone_t, goal: usize) usize;
+    const static = struct {
+        pub var zone: std.atomic.Value(?*Zone) = .{ .raw = null };
+        pub var lock: bun.Lock = bun.Lock.init();
+    };
 
-    pub fn get(comptime T: type) *malloc_zone_t {
-        const Holder = struct {
-            pub var zone_t: std.atomic.Value(?*malloc_zone_t) = std.atomic.Value(?*malloc_zone_t).init(null);
-            pub var zone_t_lock: bun.Lock = bun.Lock.init();
-        };
-        return Holder.zone_t.load(.monotonic) orelse brk: {
-            Holder.zone_t_lock.lock();
-            defer Holder.zone_t_lock.unlock();
+    return static.zone.load(.monotonic) orelse brk: {
+        static.lock.lock();
+        defer static.lock.unlock();
 
-            if (Holder.zone_t.load(.monotonic)) |z| {
-                break :brk z;
-            }
-
-            const z = malloc_zone_t.create(T);
-            Holder.zone_t.store(z, .monotonic);
+        if (static.zone.load(.monotonic)) |z| {
             break :brk z;
+        }
+
+        const z = Zone.init(T);
+        static.zone.store(z, .monotonic);
+        break :brk z;
+    };
+}
+
+pub const Zone = opaque {
+    pub fn init(comptime T: type) *Zone {
+        const zone = malloc_create_zone(0, 0);
+
+        const title: [:0]const u8 = comptime title: {
+            const base_name = if (@hasDecl(T, "heap_label"))
+                T.heap_label
+            else
+                bun.meta.typeBaseName(@typeName(T));
+            break :title "Bun__" ++ base_name;
         };
+        malloc_set_zone_name(zone, title.ptr);
+
+        return zone;
     }
 
-    fn alignedAlloc(zone: *malloc_zone_t, len: usize, alignment: usize) ?[*]u8 {
+    fn alignedAlloc(zone: *Zone, len: usize, alignment: usize) ?[*]u8 {
         // The posix_memalign only accepts alignment values that are a
         // multiple of the pointer size
         const eff_alignment = @max(alignment, @sizeOf(usize));
-
         const ptr = malloc_zone_memalign(zone, eff_alignment, len);
         return @as(?[*]u8, @ptrCast(ptr));
     }
@@ -63,9 +60,9 @@ pub const malloc_zone_t = opaque {
         return std.c.malloc_size(ptr);
     }
 
-    fn alloc(ptr: *anyopaque, len: usize, log2_align: u8, _: usize) ?[*]u8 {
-        const alignment = @as(usize, 1) << @as(Allocator.Log2Align, @intCast(log2_align));
-        return alignedAlloc(@ptrCast(ptr), len, alignment);
+    fn rawAlloc(zone: *anyopaque, len: usize, log2_align: u8, _: usize) ?[*]u8 {
+        const alignment = @as(usize, 1) << @intCast(log2_align);
+        return alignedAlloc(@ptrCast(zone), len, alignment);
     }
 
     fn resize(_: *anyopaque, buf: []u8, _: u8, new_len: usize, _: usize) bool {
@@ -81,32 +78,55 @@ pub const malloc_zone_t = opaque {
         return false;
     }
 
-    fn free(ptr: *anyopaque, buf: [*]u8, _: u8, _: usize) void {
-        malloc_zone_free(@ptrCast(ptr), @ptrCast(buf));
+    fn rawFree(zone: *anyopaque, buf: [*]u8, _: u8, _: usize) void {
+        malloc_zone_free(@ptrCast(zone), @ptrCast(buf));
     }
 
-    pub const VTable = std.mem.Allocator.VTable{
-        .alloc = @ptrCast(&alloc),
-        .resize = @ptrCast(&resize),
-        .free = @ptrCast(&free),
+    pub const vtable = std.mem.Allocator.VTable{
+        .alloc = &rawAlloc,
+        .resize = &resize,
+        .free = &rawFree,
     };
 
-    pub fn create(comptime T: type) *malloc_zone_t {
-        const zone = malloc_create_zone(0, 0);
-        const title = struct {
-            const base_name = if (@hasDecl(T, "heap_label")) T.heap_label else bun.meta.typeBaseName(@typeName(T));
-            pub const title_: []const u8 = "Bun__" ++ base_name ++ .{0};
-            pub const title: [:0]const u8 = title_[0 .. title_.len - 1 :0];
-        }.title;
-        malloc_set_zone_name(zone, title.ptr);
-
-        return zone;
-    }
-
-    pub fn getAllocator(zone: *malloc_zone_t) std.mem.Allocator {
-        return Allocator{
-            .vtable = &VTable,
+    pub fn allocator(zone: *Zone) std.mem.Allocator {
+        return .{
+            .vtable = &vtable,
             .ptr = zone,
         };
     }
+
+    /// Create a single-item pointer with initialized data.
+    pub inline fn create(zone: *Zone, comptime T: type, data: T) *T {
+        const ptr: *T = @alignCast(@ptrCast(
+            rawAlloc(zone, @sizeOf(T), @alignOf(T), @returnAddress()) orelse bun.outOfMemory(),
+        ));
+        ptr.* = data;
+        return ptr;
+    }
+
+    /// Free a single-item pointer
+    pub inline fn destroy(zone: *Zone, comptime T: type, ptr: *T) void {
+        malloc_zone_free(zone, @ptrCast(ptr));
+    }
+
+    pub extern fn malloc_default_zone() *Zone;
+    pub extern fn malloc_create_zone(start_size: vm_size_t, flags: c_uint) *Zone;
+    pub extern fn malloc_destroy_zone(zone: *Zone) void;
+    pub extern fn malloc_zone_malloc(zone: *Zone, size: usize) ?*anyopaque;
+    pub extern fn malloc_zone_calloc(zone: *Zone, num_items: usize, size: usize) ?*anyopaque;
+    pub extern fn malloc_zone_valloc(zone: *Zone, size: usize) ?*anyopaque;
+    pub extern fn malloc_zone_free(zone: *Zone, ptr: ?*anyopaque) void;
+    pub extern fn malloc_zone_realloc(zone: *Zone, ptr: ?*anyopaque, size: usize) ?*anyopaque;
+    pub extern fn malloc_zone_from_ptr(ptr: ?*const anyopaque) *Zone;
+    pub extern fn malloc_zone_memalign(zone: *Zone, alignment: usize, size: usize) ?*anyopaque;
+    pub extern fn malloc_zone_batch_malloc(zone: *Zone, size: usize, results: [*]?*anyopaque, num_requested: c_uint) c_uint;
+    pub extern fn malloc_zone_batch_free(zone: *Zone, to_be_freed: [*]?*anyopaque, num: c_uint) void;
+    pub extern fn malloc_default_purgeable_zone() *Zone;
+    pub extern fn malloc_make_purgeable(ptr: ?*anyopaque) void;
+    pub extern fn malloc_make_nonpurgeable(ptr: ?*anyopaque) c_int;
+    pub extern fn malloc_zone_register(zone: *Zone) void;
+    pub extern fn malloc_zone_unregister(zone: *Zone) void;
+    pub extern fn malloc_set_zone_name(zone: *Zone, name: ?[*:0]const u8) void;
+    pub extern fn malloc_get_zone_name(zone: *Zone) ?[*:0]const u8;
+    pub extern fn malloc_zone_pressure_relief(zone: *Zone, goal: usize) usize;
 };

--- a/src/patch.zig
+++ b/src/patch.zig
@@ -611,11 +611,11 @@ fn patchFileSecondPass(files: []FileDeets) ParseErr!PatchFile {
                 result.parts.append(bun.default_allocator, .{
                     .file_deletion = bun.new(FileDeletion, FileDeletion{
                         .hunk = if (file.hunks.items.len > 0) brk: {
-                            var value = file.hunks.items[0];
+                            const value = file.hunks.items[0];
                             file.hunks.items[0] = .{
                                 .header = Hunk.Header.zeroes,
                             };
-                            break :brk bun.dupe(Hunk, &value);
+                            break :brk bun.new(Hunk, value);
                         } else null,
                         .path = path,
                         .mode = parseFileMode(file.deleted_file_mode.?) orelse {
@@ -632,11 +632,11 @@ fn patchFileSecondPass(files: []FileDeets) ParseErr!PatchFile {
                 result.parts.append(bun.default_allocator, .{
                     .file_creation = bun.new(FileCreation, FileCreation{
                         .hunk = if (file.hunks.items.len > 0) brk: {
-                            var value = file.hunks.items[0];
+                            const value = file.hunks.items[0];
                             file.hunks.items[0] = .{
                                 .header = Hunk.Header.zeroes,
                             };
-                            break :brk bun.dupe(Hunk, &value);
+                            break :brk bun.new(Hunk, value);
                         } else null,
                         .path = path,
                         .mode = parseFileMode(file.new_file_mode.?) orelse {


### PR DESCRIPTION
### What does this PR do?

I wish we had some internal docs on heap breakdown. It is very cool. This PR makes it more safe for us to use.

Rename `bun.HeapBreakdown` to `bun.heap_breakdown`. Rename `bun.is_heap_breakdown_enabled` to `bun.heap_breakdown.enabled`.

To use the heap breakdown allocator functions directly, recommend using `heap_breakdown.getZone(T).create(T, t)`. But it is better to simply use the `bun.New` mixin, which opts you into heap breakdown automatically.

Refactors the following: `bun.new`, `bun.destroy`, `bun.create`, `bun.New`, `bun.NewRefCounted`. They are much easier to read now.

Main motivation for this is to introduce a new assertion which ensures types that forcefully opt into heap breakdown (From `bun.New`) are impossible to create via standard library allocators.

![image](https://github.com/oven-sh/bun/assets/24465214/136ae33a-d2d9-41ae-8f45-f725332b8477)
