### PR TITLE
Warn when installing a global binary and global bin is not in path

### DIFF
--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -111,6 +111,7 @@ pub const Features = struct {
     pub var WebSocket: usize = 0;
     pub var no_avx: usize = 0;
     pub var no_avx2: usize = 0;
+    pub var binlinks: usize = 0;
     pub var builtin_modules = std.enums.EnumSet(bun.JSC.HardcodedModule).initEmpty();
 
     pub fn formatter() Formatter {

--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -366,6 +366,8 @@ pub const Bin = extern struct {
                 return;
             }
 
+            bun.Analytics.Features.binlinks += 1;
+
             if (comptime Environment.isWindows)
                 this.createWindowsShim(abs_target, abs_dest, global)
             else
@@ -399,7 +401,7 @@ pub const Bin = extern struct {
             }
         }
 
-        pub fn createWindowsShim(this: *Linker, abs_target: [:0]const u8, abs_dest: [:0]const u8, global: bool) void {
+        fn createWindowsShim(this: *Linker, abs_target: [:0]const u8, abs_dest: [:0]const u8, global: bool) void {
             const WinBinLinkingShim = @import("./windows-shim/BinLinkingShim.zig");
 
             var shim_buf: [65536]u8 = undefined;
@@ -486,7 +488,7 @@ pub const Bin = extern struct {
             };
         }
 
-        pub fn createSymlink(this: *Linker, abs_target: [:0]const u8, abs_dest: [:0]const u8, global: bool) void {
+        fn createSymlink(this: *Linker, abs_target: [:0]const u8, abs_dest: [:0]const u8, global: bool) void {
             defer {
                 if (this.err == null) {
                     _ = bun.sys.chmod(abs_target, umask | 0o777);

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -2586,6 +2586,10 @@ pub const PackageManager = struct {
     progress_name_buf_dynamic: []u8 = &[_]u8{},
     cpu_count: u32 = 0,
 
+    track_installed_bin: TrackInstalledBin = .{
+        .none = {},
+    },
+
     // progress bar stuff when not stack allocated
     root_progress_node: *Progress.Node = undefined,
 
@@ -2709,6 +2713,12 @@ pub const PackageManager = struct {
         }
         Global.crash();
     }
+
+    const TrackInstalledBin = union(enum) {
+        none: void,
+        pending: void,
+        basename: []const u8,
+    };
 
     // maybe rename to `PackageJSONCache` if we cache more than workspaces
     pub const WorkspacePackageJSONCache = struct {
@@ -9739,6 +9749,14 @@ pub const PackageManager = struct {
             Output.flush();
         }
 
+        // When you run `bun add -g <pkg>` or `bun install -g <pkg>` and the global bin dir is not in $PATH
+        // We should tell the user to add it to $PATH so they don't get confused.
+        if (subcommand == .add or subcommand == .install) {
+            if (manager.options.global and manager.options.log_level != .silent) {
+                manager.track_installed_bin = .{ .pending = {} };
+            }
+        }
+
         switch (manager.options.log_level) {
             inline else => |log_level| try manager.updatePackageJSONAndInstallWithManager(ctx, log_level),
         }
@@ -9749,6 +9767,122 @@ pub const PackageManager = struct {
 
         if (manager.any_failed_to_install) {
             Global.exit(1);
+        }
+
+        // Check if we need to print a warning like:
+        //
+        // > warn: To run "vite", add the global bin folder to $PATH:
+        // >
+        // > fish_add_path "/private/tmp/test"
+        //
+        if (subcommand == .add or subcommand == .install) {
+            if (manager.options.global) {
+                if (manager.options.bin_path.len > 0 and manager.track_installed_bin == .basename) {
+                    const needs_to_print = if (bun.getenvZ("PATH")) |PATH|
+                        // This is not perfect
+                        //
+                        // If you already have a different binary of the same
+                        // name, it will not detect that case.
+                        //
+                        // The problem is there are too many edgecases with filesystem paths.
+                        //
+                        // We want to veer towards false negative than false
+                        // positive. It would be annoying if this message
+                        // appears unnecessarily. It's kind of okay if it doesn't appear
+                        // when it should.
+                        //
+                        // If you set BUN_INSTALL_BIN to "/tmp/woo" on macOS and
+                        // we just checked for "/tmp/woo" in $PATH, it would
+                        // incorrectly print a warning because /tmp/ on macOS is
+                        // aliased to /private/tmp/
+                        //
+                        // Another scenario is case-insensitive filesystems. If you
+                        // have a binary called "esbuild" in /tmp/TeST and you
+                        // install esbuild, it will not detect that case if we naively
+                        // just checked for "esbuild" in $PATH where "$PATH" is /tmp/test
+                        bun.which(
+                            &package_json_cwd_buf,
+                            PATH,
+                            bun.fs.FileSystem.instance.top_level_dir,
+                            manager.track_installed_bin.basename,
+                        ) == null
+                    else
+                        true;
+
+                    if (needs_to_print) {
+                        const MoreInstructions = struct {
+                            shell: bun.CLI.ShellCompletions.Shell = .unknown,
+                            folder: []const u8,
+
+                            // Convert "/Users/Jarred Sumner" => "/Users/Jarred\ Sumner"
+                            const ShellPathFormatter = struct {
+                                folder: []const u8,
+
+                                pub fn format(instructions: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+                                    var remaining = instructions.folder;
+                                    while (bun.strings.indexOfChar(remaining, ' ')) |space| {
+                                        try writer.print(
+                                            "{}",
+                                            .{bun.fmt.fmtPath(u8, remaining[0..space], .{
+                                                .escape_backslashes = true,
+                                                .path_sep = if (Environment.isWindows) .windows else .posix,
+                                            })},
+                                        );
+                                        try writer.writeAll("\\ ");
+                                        remaining = remaining[@min(space + 1, remaining.len)..];
+                                    }
+
+                                    try writer.print(
+                                        "{}",
+                                        .{bun.fmt.fmtPath(u8, remaining, .{
+                                            .escape_backslashes = true,
+                                            .path_sep = if (Environment.isWindows) .windows else .posix,
+                                        })},
+                                    );
+                                }
+                            };
+
+                            pub fn format(instructions: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+                                const path = ShellPathFormatter{ .folder = instructions.folder };
+                                switch (instructions.shell) {
+                                    .unknown => {
+                                        // Unfortunately really difficult to do this in one line on PowerShell.
+                                        try writer.print("{}", .{path});
+                                    },
+                                    .bash => {
+                                        try writer.print("export PATH=\"{}:$PATH\"", .{path});
+                                    },
+                                    .zsh => {
+                                        try writer.print("export PATH=\"{}:$PATH\"", .{path});
+                                    },
+                                    .fish => {
+                                        // Regular quotes will do here.
+                                        try writer.print("fish_add_path {}", .{bun.fmt.quote(instructions.folder)});
+                                    },
+                                    .pwsh => {
+                                        try writer.print("$env:PATH += \";{}\"", .{path});
+                                    },
+                                }
+                            }
+                        };
+
+                        Output.prettyError("\n", .{});
+
+                        Output.warn(
+                            \\To run {}, add the global bin folder to $PATH:
+                            \\
+                            \\<cyan>{}<r>
+                            \\
+                        ,
+                            .{
+                                bun.fmt.quote(manager.track_installed_bin.basename),
+                                MoreInstructions{ .shell = bun.CLI.ShellCompletions.Shell.fromEnv([]const u8, bun.getenvZ("SHELL") orelse ""), .folder = manager.options.bin_path },
+                            },
+                        );
+                        Output.flush();
+                    }
+                }
+            }
         }
     }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8220,6 +8220,13 @@ pub const PackageManager = struct {
         unlink,
         patch,
         @"patch-commit",
+
+        pub fn canGloballyInstallPackages(this: Subcommand) bool {
+            return switch (this) {
+                .install, .update, .add => true,
+                else => false,
+            };
+        }
     };
 
     pub fn init(ctx: Command.Context, comptime subcommand: Subcommand) !*PackageManager {
@@ -9751,7 +9758,7 @@ pub const PackageManager = struct {
 
         // When you run `bun add -g <pkg>` or `bun install -g <pkg>` and the global bin dir is not in $PATH
         // We should tell the user to add it to $PATH so they don't get confused.
-        if (subcommand == .add or subcommand == .install) {
+        if (subcommand.canGloballyInstallPackages()) {
             if (manager.options.global and manager.options.log_level != .silent) {
                 manager.track_installed_bin = .{ .pending = {} };
             }
@@ -9775,7 +9782,7 @@ pub const PackageManager = struct {
         // >
         // > fish_add_path "/private/tmp/test"
         //
-        if (subcommand == .add or subcommand == .install) {
+        if (subcommand.canGloballyInstallPackages()) {
             if (manager.options.global) {
                 if (manager.options.bin_path.len > 0 and manager.track_installed_bin == .basename) {
                     const needs_to_print = if (bun.getenvZ("PATH")) |PATH|


### PR DESCRIPTION

### What does this PR do?

When you run `bun add -g typescript` and `$HOME/.bun/bin` is not in $PATH, bun install will now print a warning like the below:

```sh
bun add v1.1.19 (91600990)

installed typescript@5.5.3 with binaries:
 - tsc
 - tsserver

1 package installed [449.00ms]

warn: To run "tsc", add the global bin folder to $PATH:

fish_add_path "/Users/jarred/.bun/bin"
```


### How did you verify your code works?

