### PR TITLE
fix: add error messages for using readable stream to etc methods

### DIFF
--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -107,6 +107,10 @@ export function initializeReadableStream(
 
 $linkTimeConstant;
 export function readableStreamToArray(stream: ReadableStream): Promise<unknown[]> {
+  if (!(stream instanceof ReadableStream)) {
+    throw new Error("readableStreamToArray expects a ReadableStream");
+  }
+
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
   if (underlyingSource !== undefined) {
@@ -117,7 +121,11 @@ export function readableStreamToArray(stream: ReadableStream): Promise<unknown[]
 
 $linkTimeConstant;
 export function readableStreamToText(stream: ReadableStream): Promise<string> {
-  // this is a direct stream
+  if (!(stream instanceof ReadableStream)) {
+    throw new Error("readableStreamToText expects a ReadableStream");
+  }
+
+  // Direct streams do not have underlyingSource set
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
   if (underlyingSource !== undefined) {
     return $readableStreamToTextDirect(stream, underlyingSource);
@@ -127,9 +135,12 @@ export function readableStreamToText(stream: ReadableStream): Promise<string> {
 
 $linkTimeConstant;
 export function readableStreamToArrayBuffer(stream: ReadableStream<ArrayBuffer>): Promise<ArrayBuffer> | ArrayBuffer {
-  // this is a direct stream
-  var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
+  if (!(stream instanceof ReadableStream)) {
+    throw new Error("readableStreamToArrayBuffer expects a ReadableStream");
+  }
 
+  // Direct streams do not have underlyingSource set
+  var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
   if (underlyingSource !== undefined) {
     return $readableStreamToArrayBufferDirect(stream, underlyingSource, false);
   }
@@ -146,9 +157,12 @@ export function readableStreamToArrayBuffer(stream: ReadableStream<ArrayBuffer>)
 
 $linkTimeConstant;
 export function readableStreamToBytes(stream: ReadableStream<ArrayBuffer>): Promise<Uint8Array> | Uint8Array {
-  // this is a direct stream
-  var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
+  if (!(stream instanceof ReadableStream)) {
+    throw new Error("readableStreamToBytes expects a ReadableStream");
+  }
 
+  // Direct streams do not have underlyingSource set
+  var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
   if (underlyingSource !== undefined) {
     return $readableStreamToArrayBufferDirect(stream, underlyingSource, true);
   }
@@ -168,18 +182,28 @@ export function readableStreamToFormData(
   stream: ReadableStream<ArrayBuffer>,
   contentType: string | ArrayBuffer | ArrayBufferView,
 ): Promise<FormData> {
-  return Bun.readableStreamToBlob(stream).then(blob => {
-    return FormData.from(blob, contentType);
-  });
+  if (!(stream instanceof ReadableStream)) {
+    throw new Error("readableStreamToFormData expects a ReadableStream");
+  }
+
+  return Bun.readableStreamToBlob(stream).then(blob => FormData.from(blob, contentType));
 }
 
 $linkTimeConstant;
 export function readableStreamToJSON(stream: ReadableStream): unknown {
+  if (!(stream instanceof ReadableStream)) {
+    throw new Error("readableStreamToJSON expects a ReadableStream");
+  }
+
   return Promise.resolve(Bun.readableStreamToText(stream)).then(globalThis.JSON.parse);
 }
 
 $linkTimeConstant;
 export function readableStreamToBlob(stream: ReadableStream): Promise<Blob> {
+  if (!(stream instanceof ReadableStream)) {
+    throw new Error("readableStreamToBlob expects a ReadableStream");
+  }
+
   return Promise.resolve(Bun.readableStreamToArray(stream)).then(array => new Blob(array));
 }
 

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1863,6 +1863,9 @@ export function readableStreamIntoText(stream) {
 }
 
 export function readableStreamToArrayBufferDirect(stream, underlyingSource, asUint8Array) {
+  $assert(stream instanceof ReadableStream);
+  $assert(underlyingSource);
+
   var sink = new Bun.ArrayBufferSink();
   $putByIdDirectPrivate(stream, "underlyingSource", undefined);
   var highWaterMark = $getByIdDirectPrivate(stream, "highWaterMark");
@@ -1930,6 +1933,8 @@ export function readableStreamToArrayBufferDirect(stream, underlyingSource, asUi
 }
 
 export async function readableStreamToTextDirect(stream, underlyingSource) {
+  $assert(stream instanceof ReadableStream);
+  $assert(underlyingSource);
   const capability = $initializeTextStream.$call(stream, underlyingSource, undefined);
   var reader = stream.getReader();
 
@@ -1950,6 +1955,9 @@ export async function readableStreamToTextDirect(stream, underlyingSource) {
 }
 
 export async function readableStreamToArrayDirect(stream, underlyingSource) {
+  $assert(stream instanceof ReadableStream);
+  $assert(underlyingSource);
+
   const capability = $initializeArrayStream.$call(stream, underlyingSource, undefined);
   underlyingSource = undefined;
   var reader = stream.getReader();

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1055,3 +1055,16 @@ it("fs.createReadStream(filename) should be able to break inside async loop", as
     expect(true).toBe(true);
   }
 });
+
+test.each([
+  "readableStreamToArray",
+  "readableStreamToText",
+  "readableStreamToArrayBuffer",
+  "readableStreamToBytes",
+  "readableStreamToFormData",
+  "readableStreamToJSON",
+  "readableStreamToBlob",
+])("passing %s an empty object throws descriptive error", name => {
+  const fn = Bun[name];
+  expect(() => fn({})).toThrow(`${name} expects a ReadableStream`);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes this report on discord:

<img width="663" alt="image" src="https://github.com/oven-sh/bun/assets/24465214/7625a264-6330-45a5-ac5f-9cef613345f3">
