### PR TITLE
windows: bump llvm to 18.1.8

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -43,6 +43,11 @@ jobs:
     name: Build Submodules
     runs-on: ${{ inputs.runs-on }}
     steps:
+      - name: Install Scoop
+        run: |
+          Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+          Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+          Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
       - name: Setup Git
         run: |
           git config --global core.autocrlf false
@@ -73,10 +78,11 @@ jobs:
           path: bun-deps
           key: bun-${{ inputs.tag }}-deps-${{ steps.hash.outputs.hash }}
       - if: ${{ inputs.no-cache || !steps.cache.outputs.cache-hit }}
-        name: Install Ninja
+        name: Install LLVM and Ninja
         run: |
-          choco install -y ninja
-          choco install -y llvm --version=${{ env.LLVM_VERSION }} --force
+          scoop install ninja
+          scoop install llvm@${{ env.LLVM_VERSION }}
+          scoop install nasm@2.16.01
       - if: ${{ inputs.no-cache || !steps.cache.outputs.cache-hit }}
         name: Clone Submodules
         run: |
@@ -89,7 +95,6 @@ jobs:
           USE_LTO: 1
         run: |
           .\scripts\env.ps1 ${{ contains(inputs.tag, '-baseline') && '-Baseline' || '' }}
-          choco install -y nasm --version=2.16.01
           $env:BUN_DEPS_OUT_DIR = (mkdir -Force "./bun-deps")
           .\scripts\all-dependencies.ps1
       - name: Save Cache
@@ -137,6 +142,11 @@ jobs:
     needs: codegen
     runs-on: ${{ inputs.runs-on }}
     steps:
+      - name: Install Scoop
+        run: |
+          Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+          Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+          Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
       - name: Setup Git
         run: |
           git config --global core.autocrlf false
@@ -145,10 +155,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Install Ninja
+      - name: Install LLVM and Ninja
         run: |
-          choco install -y ninja
-          choco install -y llvm --version=${{ env.LLVM_VERSION }} --force
+          scoop install ninja
+          scoop install llvm@${{ env.LLVM_VERSION }}
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
@@ -215,6 +225,11 @@ jobs:
       - build-zig
       - codegen
     steps:
+      - name: Install Scoop
+        run: |
+          Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+          Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+          Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
       - name: Setup Git
         run: |
           git config --global core.autocrlf false
@@ -225,8 +240,8 @@ jobs:
           submodules: recursive
       - name: Install Ninja
         run: |
-          choco install -y ninja
-          choco install -y llvm --version=${{ env.LLVM_VERSION }} --force
+          scoop install ninja
+          scoop install llvm@${{ env.LLVM_VERSION }}
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,7 +31,7 @@ on:
 
 env:
   # Must specify exact version of LLVM for Windows
-  LLVM_VERSION: 16.0.6
+  LLVM_VERSION: 18.1.8
   BUN_VERSION: ${{ inputs.bun-version }}
   BUN_GARBAGE_COLLECTOR_LEVEL: 1
   BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: 1
@@ -43,8 +43,6 @@ jobs:
     name: Build Submodules
     runs-on: ${{ inputs.runs-on }}
     steps:
-      # - name: Install VS2022 BuildTools 17.9.7
-      # run: choco install -y visualstudio2022buildtools --version=117.9.7.0 --params "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --installChannelUri https://aka.ms/vs/17/release/180911598_-255012421/channel"
       - name: Setup Git
         run: |
           git config --global core.autocrlf false
@@ -139,8 +137,6 @@ jobs:
     needs: codegen
     runs-on: ${{ inputs.runs-on }}
     steps:
-      # - name: Install VS2022 BuildTools 17.9.7
-      # run: choco install -y visualstudio2022buildtools --version=117.9.7.0 --params "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --installChannelUri https://aka.ms/vs/17/release/180911598_-255012421/channel"
       - name: Setup Git
         run: |
           git config --global core.autocrlf false
@@ -219,8 +215,6 @@ jobs:
       - build-zig
       - codegen
     steps:
-      # - name: Install VS2022 BuildTools 17.9.7
-      # run: choco install -y visualstudio2022buildtools --version=117.9.7.0 --params "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --installChannelUri https://aka.ms/vs/17/release/180911598_-255012421/channel"
       - name: Setup Git
         run: |
           git config --global core.autocrlf false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,13 @@ else()
     message(STATUS "The CMake build type is: ${CMAKE_BUILD_TYPE}")
 endif()
 
+if (WIN32 AND NOT CMAKE_CL_SHOWINCLUDES_PREFIX)
+    # workaround until cmake fix is shipped https://github.com/ninja-build/ninja/issues/2280
+    # './build/.ninja_deps' may need to be deleted, the bug is "Note: including file: ..." is saved
+    # as part of some file paths
+    set(CMAKE_CL_SHOWINCLUDES_PREFIX "Note: including file:")
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(DEBUG ON)
     set(DEFAULT_ZIG_OPTIMIZE "Debug")
@@ -112,7 +119,11 @@ endif()
 # we do some extra work afterwards to double-check, and we will rerun BUN_FIND_LLVM if the compiler did not match.
 #
 # If the user passes -DLLVM_PREFIX, most of this logic is skipped, but we still warn if invalid.
-set(LLVM_VERSION 16)
+if(WIN32)
+    set(LLVM_VERSION 18)
+else()
+    set(LLVM_VERSION 16)
+endif()
 
 macro(BUN_FIND_LLVM)
     find_program(

--- a/docs/project/building-windows.md
+++ b/docs/project/building-windows.md
@@ -60,7 +60,7 @@ Visual Studio can be installed graphically using the wizard or through WinGet:
 
 After Visual Studio, you need the following:
 
-- LLVM 16
+- LLVM 18.1.8
 - Go
 - Rust
 - NASM
@@ -78,14 +78,14 @@ After Visual Studio, you need the following:
 
 ```ps1#WinGet
 ## Select "Add LLVM to the system PATH for all users" in the LLVM installer
-> winget install -i LLVM.LLVM -v 16.0.6 && winget install GoLang.Go Rustlang.Rustup NASM.NASM StrawberryPerl.StrawberryPerl RubyInstallerTeam.Ruby.3.2 OpenJS.NodeJS.LTS
+> winget install -i LLVM.LLVM -v 18.1.8 && winget install GoLang.Go Rustlang.Rustup NASM.NASM StrawberryPerl.StrawberryPerl RubyInstallerTeam.Ruby.3.2 OpenJS.NodeJS.LTS
 ```
 
 ```ps1#Scoop
 > irm https://get.scoop.sh | iex
 > scoop install nodejs-lts go rust nasm ruby perl
 # scoop seems to be buggy if you install llvm and the rest at the same time
-> scoop install llvm@16.0.6
+> scoop install llvm@18.1.8
 ```
 
 {% /codetabs %}

--- a/scripts/build-zstd.ps1
+++ b/scripts/build-zstd.ps1
@@ -3,9 +3,10 @@ $ErrorActionPreference = 'Stop'  # Setting strict mode, similar to 'set -euo pip
 
 Push-Location (Join-Path $BUN_DEPS_DIR 'zstd')
 try {
-  Remove-Item CMakeCache.txt -ErrorAction SilentlyContinue
+  Remove-Item CMakeCache.txt, CMakeFiles -Recurse -ErrorAction SilentlyContinue
   
-  Run cmake -S "build/cmake" @CMAKE_FLAGS -DZSTD_BUILD_STATIC=ON
+  # CL_SHOWINCLUDES_PREFIX is workaround for cmake bug in 3.28. .ninja_deps still needs to be deleted. Bug is fixed in 3.30
+  Run cmake -S "build/cmake" @CMAKE_FLAGS -DZSTD_BUILD_STATIC=ON -DCMAKE_CL_SHOWINCLUDES_PREFIX="Note: including file:"
   Run cmake --build . --clean-first --config Release
 
   Copy-Item lib/zstd_static.lib $BUN_DEPS_OUT_DIR/zstd.lib

--- a/scripts/env.ps1
+++ b/scripts/env.ps1
@@ -28,9 +28,6 @@ if ($env:VSINSTALLDIR -eq $null) {
   }
   Push-Location $vsDir
   try {
-    Import-Module 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\Microsoft.VisualStudio.DevShell.dll'
-    Enter-VsDevShell -VsInstallPath 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools' -DevCmdArguments '-arch=x64 -host_arch=x64'
-  } catch {
     $launchps = (Join-Path -Path $vsDir -ChildPath "Common7\Tools\Launch-VsDevShell.ps1")
     . $launchps -Arch amd64 -HostArch amd64
   } finally { Pop-Location }

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -584,7 +584,8 @@ static String computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObje
     // We need to sourcemap it if it's a GlobalObject.
     if (globalObject == lexicalGlobalObject) {
         size_t framesCount = stackTrace.size();
-        ZigStackFrame remappedFrames[framesCount];
+        ZigStackFrame remappedFrames[64];
+        framesCount = framesCount > 64 ? 64 : framesCount;
         for (int i = 0; i < framesCount; i++) {
             remappedFrames[i] = {};
             remappedFrames[i].source_url = Bun::toString(lexicalGlobalObject, stackTrace.at(i).sourceURL());


### PR DESCRIPTION
### What does this PR do?
removes the need to install an older version of visual studio in CI
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
