### PR TITLE
Make ${encoding}Slice & ${encoding}Write work on Uint8Array

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -423,7 +423,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionUmask,
     }
 
     if (!numberValue.isAnyInt()) {
-        throwRangeError(globalObject, throwScope, "The \"mask\" argument must be an integer"_s);
+        throwNodeRangeError(globalObject, throwScope, "The \"mask\" argument must be an integer"_s);
         return JSValue::encode({});
     }
 
@@ -434,7 +434,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionUmask,
         StringBuilder messageBuilder;
         messageBuilder.append("The \"mask\" value must be in range [0, 4294967295]. Received value: "_s);
         messageBuilder.append(int52ToString(vm, newUmask, 10)->getString(globalObject));
-        throwRangeError(globalObject, throwScope, messageBuilder.toString());
+        throwNodeRangeError(globalObject, throwScope, messageBuilder.toString());
         return JSValue::encode({});
     }
 
@@ -2637,7 +2637,7 @@ JSC_DEFINE_CUSTOM_SETTER(setProcessDebugPort,
     JSValue value = JSValue::decode(encodedValue);
 
     if (!value.isInt32AsAnyInt()) {
-        throwRangeError(globalObject, scope, "debugPort must be 0 or in range 1024 to 65535"_s);
+        throwNodeRangeError(globalObject, scope, "debugPort must be 0 or in range 1024 to 65535"_s);
         return false;
     }
 
@@ -2645,7 +2645,7 @@ JSC_DEFINE_CUSTOM_SETTER(setProcessDebugPort,
 
     if (port != 0) {
         if (port < 1024 || port > 65535) {
-            throwRangeError(globalObject, scope, "debugPort must be 0 or in range 1024 to 65535"_s);
+            throwNodeRangeError(globalObject, scope, "debugPort must be 0 or in range 1024 to 65535"_s);
             return false;
         }
     }
@@ -2739,7 +2739,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionKill,
     int pid = callFrame->argument(0).toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     if (pid < 0) {
-        throwRangeError(globalObject, scope, "pid must be a positive integer"_s);
+        throwNodeRangeError(globalObject, scope, "pid must be a positive integer"_s);
         return JSValue::encode(jsUndefined());
     }
 
@@ -2754,7 +2754,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionKill,
             signal = num;
             RETURN_IF_EXCEPTION(scope, {});
         } else {
-            throwRangeError(globalObject, scope, "Unknown signal name"_s);
+            throwNodeRangeError(globalObject, scope, "Unknown signal name"_s);
             return JSValue::encode(jsUndefined());
         }
 

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -44,7 +44,6 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <_types/_uint8_t.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -1,5 +1,13 @@
 
+
 #include "root.h"
+
+#include "JavaScriptCore/Error.h"
+#include "JavaScriptCore/JSArrayBufferView.h"
+#include "JavaScriptCore/JSCell.h"
+#include "JavaScriptCore/JSGlobalObject.h"
+#include "BufferEncodingType.h"
+#include "JavaScriptCore/JSCJSValue.h"
 
 #include "JSBuffer.h"
 
@@ -36,6 +44,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
+#include <_types/_uint8_t.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>
@@ -44,6 +53,7 @@
 
 #include "JSBufferEncodingType.h"
 #include "wtf/Assertions.h"
+#include "wtf/Forward.h"
 #include <JavaScriptCore/JSBase.h>
 #if ENABLE(MEDIA_SOURCE)
 #include "BufferMediaSource.h"
@@ -160,7 +170,7 @@ static inline uint32_t parseIndex(JSC::JSGlobalObject* lexicalGlobalObject, JSC:
         return num.value();
 
     if (arg.isNumber())
-        throwRangeError(lexicalGlobalObject, scope, "Invalid array length"_s);
+        throwNodeRangeError(lexicalGlobalObject, scope, "Invalid array length"_s);
     else
         throwTypeError(lexicalGlobalObject, scope, "Expected number"_s);
 
@@ -316,7 +326,7 @@ static inline JSC::JSUint8Array* JSBuffer__bufferFromLengthAsArray(JSC::JSGlobal
     auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject->vm());
 
     if (UNLIKELY(length < 0)) {
-        throwRangeError(lexicalGlobalObject, throwScope, "Invalid array length"_s);
+        throwNodeRangeError(lexicalGlobalObject, throwScope, "Invalid array length"_s);
         return nullptr;
     }
 
@@ -351,7 +361,7 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_allocUnsafeBody(JS
     double lengthDouble = lengthValue.toIntegerWithTruncation(lexicalGlobalObject);
 
     if (UNLIKELY(lengthDouble < 0 || lengthDouble > UINT_MAX)) {
-        throwRangeError(lexicalGlobalObject, throwScope, "Buffer size must be 0...4294967295"_s);
+        throwNodeRangeError(lexicalGlobalObject, throwScope, "Buffer size must be 0...4294967295"_s);
         return {};
     }
 
@@ -479,7 +489,7 @@ static inline JSC::EncodedJSValue jsBufferConstructorFunction_allocBody(JSC::JSG
     double lengthDouble = lengthValue.toIntegerWithTruncation(lexicalGlobalObject);
 
     if (UNLIKELY(lengthDouble < 0 || lengthDouble > UINT_MAX)) {
-        throwRangeError(lexicalGlobalObject, scope, "Buffer size must be 0...4294967295"_s);
+        throwNodeRangeError(lexicalGlobalObject, scope, "Buffer size must be 0...4294967295"_s);
         return {};
     }
 
@@ -1179,7 +1189,7 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlob
     }
 
     if (UNLIKELY(end > limit)) {
-        throwRangeError(lexicalGlobalObject, scope, "end out of range"_s);
+        throwNodeRangeError(lexicalGlobalObject, scope, "end out of range"_s);
         return JSC::JSValue::encode(jsUndefined());
     }
 
@@ -1389,7 +1399,7 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_swap16Body(JSC::JSGl
     constexpr int elemSize = 2;
     int64_t length = static_cast<int64_t>(castedThis->byteLength());
     if (length % elemSize != 0) {
-        throwRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 16-bits"_s);
+        throwNodeRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 16-bits"_s);
         return JSC::JSValue::encode(jsUndefined());
     }
 
@@ -1418,7 +1428,7 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_swap32Body(JSC::JSGl
     constexpr int elemSize = 4;
     int64_t length = static_cast<int64_t>(castedThis->byteLength());
     if (length % elemSize != 0) {
-        throwRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 32-bits"_s);
+        throwNodeRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 32-bits"_s);
         return JSC::JSValue::encode(jsUndefined());
     }
 
@@ -1452,7 +1462,7 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_swap64Body(JSC::JSGl
     constexpr size_t elemSize = 8;
     int64_t length = static_cast<int64_t>(castedThis->byteLength());
     if (length % elemSize != 0) {
-        throwRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 64-bits"_s);
+        throwNodeRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 64-bits"_s);
         return JSC::JSValue::encode(jsUndefined());
     }
 
@@ -1479,7 +1489,7 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_swap64Body(JSC::JSGl
     return JSC::JSValue::encode(castedThis);
 }
 
-static inline JSC::EncodedJSValue jsBufferToString(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSUint8Array* castedThis, size_t offset, size_t length, WebCore::BufferEncodingType encoding)
+static inline JSC::EncodedJSValue jsBufferToString(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSArrayBufferView* castedThis, size_t offset, size_t length, WebCore::BufferEncodingType encoding)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -1493,7 +1503,7 @@ static inline JSC::EncodedJSValue jsBufferToString(JSC::VM& vm, JSC::JSGlobalObj
     case WebCore::BufferEncodingType::latin1: {
         LChar* data = nullptr;
         auto str = String::createUninitialized(length, data);
-        memcpy(data, reinterpret_cast<const char*>(castedThis->typedVector() + offset), length);
+        memcpy(data, reinterpret_cast<const char*>(castedThis->vector()) + offset, length);
         return JSC::JSValue::encode(JSC::jsString(vm, WTFMove(str)));
     }
 
@@ -1505,7 +1515,7 @@ static inline JSC::EncodedJSValue jsBufferToString(JSC::VM& vm, JSC::JSGlobalObj
             return JSC::JSValue::encode(JSC::jsEmptyString(vm));
         } else {
             auto str = String::createUninitialized(u16length, data);
-            memcpy(reinterpret_cast<void*>(data), reinterpret_cast<void*>(castedThis->typedVector() + offset), u16length * 2);
+            memcpy(reinterpret_cast<void*>(data), reinterpret_cast<const char*>(castedThis->vector()) + offset, u16length * 2);
             return JSC::JSValue::encode(JSC::jsString(vm, str));
         }
 
@@ -1517,7 +1527,7 @@ static inline JSC::EncodedJSValue jsBufferToString(JSC::VM& vm, JSC::JSGlobalObj
         // so we might as well allocate upfront
         LChar* data = nullptr;
         auto str = String::createUninitialized(length, data);
-        Bun__encoding__writeLatin1(castedThis->typedVector() + offset, length, data, length, static_cast<uint8_t>(encoding));
+        Bun__encoding__writeLatin1(reinterpret_cast<const unsigned char*>(castedThis->vector()) + offset, length, data, length, static_cast<uint8_t>(encoding));
         return JSC::JSValue::encode(JSC::jsString(vm, WTFMove(str)));
     }
 
@@ -1526,7 +1536,7 @@ static inline JSC::EncodedJSValue jsBufferToString(JSC::VM& vm, JSC::JSGlobalObj
     case WebCore::BufferEncodingType::base64:
     case WebCore::BufferEncodingType::base64url:
     case WebCore::BufferEncodingType::hex: {
-        ret = Bun__encoding__toString(castedThis->typedVector() + offset, length, lexicalGlobalObject, static_cast<uint8_t>(encoding));
+        ret = Bun__encoding__toString(reinterpret_cast<const unsigned char*>(castedThis->vector()) + offset, length, lexicalGlobalObject, static_cast<uint8_t>(encoding));
         break;
     }
     default: {
@@ -1544,12 +1554,31 @@ static inline JSC::EncodedJSValue jsBufferToString(JSC::VM& vm, JSC::JSGlobalObj
     RELEASE_AND_RETURN(scope, JSC::JSValue::encode(retValue));
 }
 
+// https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/src/node_buffer.cc#L208-L233
+bool inline parseArrayIndex(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSC::JSValue value, size_t& out, ASCIILiteral errorMessage)
+{
+    if (value.isUndefined()) {
+        return true;
+    }
+
+    int64_t index = static_cast<int64_t>(value.toIntegerWithTruncation(globalObject));
+    RETURN_IF_EXCEPTION(scope, false);
+
+    if (index < 0) {
+        throwNodeRangeError(globalObject, scope, errorMessage);
+        return false;
+    }
+
+    out = static_cast<size_t>(index);
+    return true;
+}
+
 static inline JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSArrayBufferView>::ClassParameter castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     uint32_t start = 0;
-    uint32_t end = castedThis->length();
+    uint32_t end = castedThis->byteLength();
     uint32_t byteLength = end;
     WebCore::BufferEncodingType encoding = WebCore::BufferEncodingType::utf8;
 
@@ -1591,6 +1620,45 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JS
     return jsBufferToString(vm, lexicalGlobalObject, castedThis, start, end > start ? end - start : 0, encoding);
 }
 
+// https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/src/node_buffer.cc#L544
+template<BufferEncodingType encoding>
+static inline JSC::EncodedJSValue jsBufferPrototypeFunction_toStringWithEncodingBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* castedThis = JSC::jsDynamicCast<JSC::JSArrayBufferView*>(callFrame->thisValue());
+
+    if (UNLIKELY(!castedThis)) {
+        throwTypeError(lexicalGlobalObject, scope, "Expected ArrayBufferView"_s);
+        return {};
+    }
+
+    size_t length = castedThis->byteLength();
+    size_t start = 0;
+    size_t end = length;
+
+    if (end == 0)
+        return JSC::JSValue::encode(JSC::jsEmptyString(vm));
+
+    if (UNLIKELY(!parseArrayIndex(scope, lexicalGlobalObject, callFrame->argument(0), start, "start must be a positive integer"_s))) {
+        return {};
+    }
+
+    if (UNLIKELY(!parseArrayIndex(scope, lexicalGlobalObject, callFrame->argument(1), end, "end must be a positive integer"_s))) {
+        return {};
+    }
+
+    if (end < start)
+        end = start;
+
+    if (!(end <= length)) {
+        throwNodeRangeError(lexicalGlobalObject, scope, "end out of range"_s);
+        return JSC::JSValue::encode(jsUndefined());
+    }
+
+    return jsBufferToString(vm, lexicalGlobalObject, castedThis, start, end - start, encoding);
+}
+
 // DOMJIT makes it slower! TODO: investigate why
 // JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(jsBufferPrototypeToStringWithoutTypeChecks, JSValue, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::JSUint8Array* thisValue, JSC::JSString* encodingValue));
 
@@ -1614,6 +1682,59 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JS
 
 //     return JSValue::decode(jsBufferToString(vm, lexicalGlobalObject, thisValue, 0, thisValue->byteLength(), encoding));
 // }
+
+// https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/src/node_buffer.cc#L711
+template<BufferEncodingType encoding>
+static inline JSC::EncodedJSValue jsBufferPrototypeFunction_writeEncodingBody(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSArrayBufferView* castedThis, JSString* str, JSValue offsetValue, JSValue lengthValue)
+{
+    size_t offset = 0;
+    size_t length = castedThis->byteLength();
+    size_t max = length;
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!parseArrayIndex(scope, lexicalGlobalObject, offsetValue, offset, "offset must be > 0"_s)) {
+        return {};
+    }
+
+    if (offset > max) {
+        throwNodeRangeError(lexicalGlobalObject, scope, "offset is out of bounds"_s);
+        return JSC::JSValue::encode(jsUndefined());
+    }
+
+    if (!parseArrayIndex(scope, lexicalGlobalObject, lengthValue, length, "length must be > 0"_s)) {
+        return {};
+    }
+
+    size_t max_length = std::min(max - offset, max);
+
+    RELEASE_AND_RETURN(scope, writeToBuffer(lexicalGlobalObject, castedThis, str, offset, max_length, encoding));
+}
+
+template<BufferEncodingType encoding>
+static inline JSC::EncodedJSValue jsBufferPrototypeFunctionWriteWithEncoding(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* castedThis = JSC::jsDynamicCast<JSC::JSArrayBufferView*>(callFrame->thisValue());
+
+    JSString* text = callFrame->argument(0).toStringOrNull(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSValue offsetValue = callFrame->argument(1);
+    JSValue lengthValue = callFrame->argument(2);
+
+    if (UNLIKELY(!castedThis)) {
+        throwTypeError(lexicalGlobalObject, scope, "Expected ArrayBufferView"_s);
+        return {};
+    }
+
+    if (UNLIKELY(castedThis->isDetached())) {
+        throwTypeError(lexicalGlobalObject, scope, "ArrayBufferView is detached"_s);
+        return {};
+    }
+
+    return jsBufferPrototypeFunction_writeEncodingBody<encoding>(vm, lexicalGlobalObject, castedThis, text, offsetValue, lengthValue);
+}
 
 static inline JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSArrayBufferView>::ClassParameter castedThis)
 {
@@ -1682,7 +1803,7 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlo
     int32_t userOffset = offsetValue.toInt32(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(jsUndefined()));
     if (userOffset < 0 || userOffset > max) {
-        throwRangeError(lexicalGlobalObject, scope, "Offset is out of bounds"_s);
+        throwNodeRangeError(lexicalGlobalObject, scope, "Offset is out of bounds"_s);
         return JSC::JSValue::encode(jsUndefined());
     }
     offset = static_cast<uint32_t>(userOffset);
@@ -1903,30 +2024,94 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_write, (JSGlobalObject * lexi
     return IDLOperation<JSArrayBufferView>::call<jsBufferPrototypeFunction_writeBody>(*lexicalGlobalObject, *callFrame, "write");
 }
 
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_utf16leWrite, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunctionWriteWithEncoding<WebCore::BufferEncodingType::utf16le>(lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_utf8Write, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunctionWriteWithEncoding<WebCore::BufferEncodingType::utf8>(lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_latin1Write, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunctionWriteWithEncoding<WebCore::BufferEncodingType::latin1>(lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_asciiWrite, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunctionWriteWithEncoding<WebCore::BufferEncodingType::ascii>(lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_base64Write, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunctionWriteWithEncoding<WebCore::BufferEncodingType::base64>(lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_base64urlWrite, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunctionWriteWithEncoding<WebCore::BufferEncodingType::base64url>(lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_hexWrite, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunctionWriteWithEncoding<WebCore::BufferEncodingType::hex>(lexicalGlobalObject, callFrame);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_utf8Slice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::utf8>(lexicalGlobalObject, callFrame);
+}
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_utf16leSlice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::utf16le>(lexicalGlobalObject, callFrame);
+}
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_latin1Slice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::latin1>(lexicalGlobalObject, callFrame);
+}
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_asciiSlice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::ascii>(lexicalGlobalObject, callFrame);
+}
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_base64Slice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::base64>(lexicalGlobalObject, callFrame);
+}
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_base64urlSlice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::base64url>(lexicalGlobalObject, callFrame);
+}
+JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_hexSlice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::hex>(lexicalGlobalObject, callFrame);
+}
+
 /* */
 
 /* Hash table for prototype */
 
 static const HashTableValue JSBufferPrototypeTableValues[]
     = {
-          { "asciiSlice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeAsciiSliceCodeGenerator, 2 } },
-          { "asciiWrite"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeAsciiWriteCodeGenerator, 1 } },
-          { "base64Slice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeBase64SliceCodeGenerator, 2 } },
-          { "base64Write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeBase64WriteCodeGenerator, 1 } },
-          { "base64urlSlice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeBase64urlSliceCodeGenerator, 2 } },
-          { "base64urlWrite"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeBase64urlWriteCodeGenerator, 1 } },
+          { "asciiSlice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_asciiSlice, 2 } },
+          { "asciiWrite"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_asciiWrite, 3 } },
+          { "base64Slice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_base64Slice, 2 } },
+          { "base64Write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_base64Write, 3 } },
+          { "base64urlSlice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_base64urlSlice, 2 } },
+          { "base64urlWrite"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_base64urlWrite, 3 } },
           { "compare"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_compare, 5 } },
           { "copy"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_copy, 4 } },
           { "equals"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_equals, 1 } },
           { "fill"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_fill, 4 } },
-          { "hexSlice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeHexSliceCodeGenerator, 2 } },
-          { "hexWrite"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeHexWriteCodeGenerator, 1 } },
+          { "hexSlice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_hexSlice, 2 } },
+          { "hexWrite"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_hexWrite, 3 } },
           { "includes"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_includes, 3 } },
           { "indexOf"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_indexOf, 3 } },
           { "inspect"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeInspectCodeGenerator, 2 } },
           { "lastIndexOf"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_lastIndexOf, 3 } },
-          { "latin1Slice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeLatin1SliceCodeGenerator, 2 } },
-          { "latin1Write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeLatin1WriteCodeGenerator, 1 } },
+          { "latin1Slice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_latin1Slice, 2 } },
+          { "latin1Write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_latin1Write, 3 } },
           { "offset"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::Accessor | JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinAccessorType, jsBufferPrototypeOffsetCodeGenerator, 0 } },
           { "parent"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::Accessor | JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinAccessorType, jsBufferPrototypeParentCodeGenerator, 0 } },
           { "readBigInt64"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeReadBigInt64LECodeGenerator, 1 } },
@@ -1976,12 +2161,12 @@ static const HashTableValue JSBufferPrototypeTableValues[]
           { "toJSON"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeToJSONCodeGenerator, 1 } },
           { "toLocaleString"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_toString, 4 } },
           { "toString"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_toString, 4 } },
-          { "ucs2Slice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeUcs2SliceCodeGenerator, 2 } },
-          { "ucs2Write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeUcs2WriteCodeGenerator, 1 } },
-          { "utf16leSlice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeUtf16leSliceCodeGenerator, 2 } },
-          { "utf16leWrite"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeUtf16leWriteCodeGenerator, 1 } },
-          { "utf8Slice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeUtf8SliceCodeGenerator, 2 } },
-          { "utf8Write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeUtf8WriteCodeGenerator, 1 } },
+          { "ucs2Slice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_utf16leSlice, 2 } },
+          { "ucs2Write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_utf16leWrite, 3 } },
+          { "utf16leSlice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_utf16leSlice, 2 } },
+          { "utf16leWrite"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_utf16leWrite, 3 } },
+          { "utf8Slice"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_utf8Slice, 2 } },
+          { "utf8Write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_utf8Write, 3 } },
           { "write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBufferPrototypeFunction_write, 4 } },
           { "writeBigInt64BE"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeWriteBigInt64BECodeGenerator, 1 } },
           { "writeBigInt64LE"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, jsBufferPrototypeWriteBigInt64LECodeGenerator, 1 } },
@@ -2197,7 +2382,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSBuffer, (JSC::JSGlobalObject * lexicalGlobal
                 if (buffer->isResizableOrGrowableShared()) {
                     if (UNLIKELY(offset > byteLength)) {
                         // TOOD: return Node.js error
-                        throwRangeError(globalObject, throwScope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
+                        throwNodeRangeError(globalObject, throwScope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
                         return JSValue::encode({});
                     }
                 } else {

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -1693,16 +1693,16 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_writeEncodingBody(JS
     size_t max = length;
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!parseArrayIndex(scope, lexicalGlobalObject, offsetValue, offset, "offset must be > 0"_s)) {
+    if (UNLIKELY(!parseArrayIndex(scope, lexicalGlobalObject, offsetValue, offset, "offset must be > 0"_s))) {
         return {};
     }
 
-    if (offset > max) {
+    if (UNLIKELY(offset > max)) {
         throwNodeRangeError(lexicalGlobalObject, scope, "offset is out of bounds"_s);
         return JSC::JSValue::encode(jsUndefined());
     }
 
-    if (!parseArrayIndex(scope, lexicalGlobalObject, lengthValue, max, "length must be > 0"_s)) {
+    if (UNLIKELY(!parseArrayIndex(scope, lexicalGlobalObject, lengthValue, max, "length must be > 0"_s))) {
         return {};
     }
 

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -1,7 +1,6 @@
-
-
 #include "root.h"
 
+#include "JavaScriptCore/JSString.h"
 #include "JavaScriptCore/Error.h"
 #include "JavaScriptCore/JSArrayBufferView.h"
 #include "JavaScriptCore/JSCell.h"
@@ -1621,29 +1620,32 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JS
 
 // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/src/node_buffer.cc#L544
 template<BufferEncodingType encoding>
-static inline JSC::EncodedJSValue jsBufferPrototypeFunction_toStringWithEncodingBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+static inline JSC::EncodedJSValue jsBufferPrototypeFunction_SliceWithEncoding(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* castedThis = JSC::jsDynamicCast<JSC::JSArrayBufferView*>(callFrame->thisValue());
+    const JSValue startValue = callFrame->argument(0);
+    const JSValue endValue = callFrame->argument(1);
 
     if (UNLIKELY(!castedThis)) {
         throwTypeError(lexicalGlobalObject, scope, "Expected ArrayBufferView"_s);
         return {};
     }
 
-    size_t length = castedThis->byteLength();
+    const size_t length = castedThis->byteLength();
+    if (UNLIKELY(length == 0)) {
+        return JSC::JSValue::encode(JSC::jsEmptyString(vm));
+    }
+
     size_t start = 0;
     size_t end = length;
 
-    if (end == 0)
-        return JSC::JSValue::encode(JSC::jsEmptyString(vm));
-
-    if (UNLIKELY(!parseArrayIndex(scope, lexicalGlobalObject, callFrame->argument(0), start, "start must be a positive integer"_s))) {
+    if (UNLIKELY(!parseArrayIndex(scope, lexicalGlobalObject, startValue, start, "start must be a positive integer"_s))) {
         return {};
     }
 
-    if (UNLIKELY(!parseArrayIndex(scope, lexicalGlobalObject, callFrame->argument(1), end, "end must be a positive integer"_s))) {
+    if (UNLIKELY(!parseArrayIndex(scope, lexicalGlobalObject, endValue, end, "end must be a positive integer"_s))) {
         return {};
     }
 
@@ -1700,7 +1702,7 @@ static inline JSC::EncodedJSValue jsBufferPrototypeFunction_writeEncodingBody(JS
         return JSC::JSValue::encode(jsUndefined());
     }
 
-    if (!parseArrayIndex(scope, lexicalGlobalObject, lengthValue, length, "length must be > 0"_s)) {
+    if (!parseArrayIndex(scope, lexicalGlobalObject, lengthValue, max, "length must be > 0"_s)) {
         return {};
     }
 
@@ -2060,31 +2062,31 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_hexWrite, (JSGlobalObject * l
 
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_utf8Slice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::utf8>(lexicalGlobalObject, callFrame);
+    return jsBufferPrototypeFunction_SliceWithEncoding<WebCore::BufferEncodingType::utf8>(lexicalGlobalObject, callFrame);
 }
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_utf16leSlice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::utf16le>(lexicalGlobalObject, callFrame);
+    return jsBufferPrototypeFunction_SliceWithEncoding<WebCore::BufferEncodingType::utf16le>(lexicalGlobalObject, callFrame);
 }
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_latin1Slice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::latin1>(lexicalGlobalObject, callFrame);
+    return jsBufferPrototypeFunction_SliceWithEncoding<WebCore::BufferEncodingType::latin1>(lexicalGlobalObject, callFrame);
 }
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_asciiSlice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::ascii>(lexicalGlobalObject, callFrame);
+    return jsBufferPrototypeFunction_SliceWithEncoding<WebCore::BufferEncodingType::ascii>(lexicalGlobalObject, callFrame);
 }
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_base64Slice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::base64>(lexicalGlobalObject, callFrame);
+    return jsBufferPrototypeFunction_SliceWithEncoding<WebCore::BufferEncodingType::base64>(lexicalGlobalObject, callFrame);
 }
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_base64urlSlice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::base64url>(lexicalGlobalObject, callFrame);
+    return jsBufferPrototypeFunction_SliceWithEncoding<WebCore::BufferEncodingType::base64url>(lexicalGlobalObject, callFrame);
 }
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_hexSlice, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    return jsBufferPrototypeFunction_toStringWithEncodingBody<WebCore::BufferEncodingType::hex>(lexicalGlobalObject, callFrame);
+    return jsBufferPrototypeFunction_SliceWithEncoding<WebCore::BufferEncodingType::hex>(lexicalGlobalObject, callFrame);
 }
 
 /* */

--- a/src/bun.js/bindings/JSBufferList.cpp
+++ b/src/bun.js/bindings/JSBufferList.cpp
@@ -49,7 +49,8 @@ JSC::JSValue JSBufferList::concat(JSC::VM& vm, JSC::JSGlobalObject* lexicalGloba
             return throwTypeError(lexicalGlobalObject, throwScope, "concat can only be called when all buffers are Uint8Array"_s);
         }
         if (UNLIKELY(array->byteLength() > n)) {
-            return throwRangeError(lexicalGlobalObject, throwScope, "specified size too small to fit all buffers"_s);
+            throwNodeRangeError(lexicalGlobalObject, throwScope, "specified size too small to fit all buffers"_s);
+            return {};
         }
         RELEASE_AND_RETURN(throwScope, array);
     }
@@ -68,7 +69,8 @@ JSC::JSValue JSBufferList::concat(JSC::VM& vm, JSC::JSGlobalObject* lexicalGloba
         }
         const size_t length = array->byteLength();
         if (UNLIKELY(i + length > n)) {
-            return throwRangeError(lexicalGlobalObject, throwScope, "specified size too small to fit all buffers"_s);
+            throwNodeRangeError(lexicalGlobalObject, throwScope, "specified size too small to fit all buffers"_s);
+            return {};
         }
         if (UNLIKELY(!uint8Array->setFromTypedArray(lexicalGlobalObject, i, array, 0, length, JSC::CopyType::Unobservable))) {
             return throwOutOfMemoryError(lexicalGlobalObject, throwScope);

--- a/src/bun.js/bindings/webcore/JSDOMOperation.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMOperation.cpp
@@ -19,4 +19,27 @@ JSC::JSObject* createNotEnoughArgumentsErrorBun(JSC::JSGlobalObject* globalObjec
 
     return error;
 }
+
+void throwNodeRangeError(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, const String& message)
+{
+    auto* error = createRangeError(lexicalGlobalObject, message);
+    if (LIKELY(error)) {
+        auto& vm = getVM(lexicalGlobalObject);
+        auto& builtinNames = Bun::builtinNames(vm);
+        error->putDirect(vm, builtinNames.codePublicName(), jsString(vm, String("ERR_OUT_OF_RANGE"_s)));
+        scope.throwException(lexicalGlobalObject, error);
+    }
+}
+
+void throwNodeRangeError(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, ASCIILiteral message)
+{
+    auto* error = createRangeError(lexicalGlobalObject, message);
+    if (LIKELY(error)) {
+        auto& vm = getVM(lexicalGlobalObject);
+        auto& builtinNames = Bun::builtinNames(vm);
+        error->putDirect(vm, builtinNames.codePublicName(), jsString(vm, String("ERR_OUT_OF_RANGE"_s)));
+        scope.throwException(lexicalGlobalObject, error);
+    }
+}
+
 }

--- a/src/bun.js/bindings/webcore/JSDOMOperation.h
+++ b/src/bun.js/bindings/webcore/JSDOMOperation.h
@@ -79,4 +79,7 @@ JSC::JSObject* createNotEnoughArgumentsErrorBun(JSGlobalObject* globalObject);
 #define createNotEnoughArgumentsError WebCore::createNotEnoughArgumentsErrorBun
 #endif
 
+void throwNodeRangeError(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, ASCIILiteral message);
+void throwNodeRangeError(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, const String& message);
+
 } // namespace WebCore

--- a/src/js/builtins/JSBufferPrototype.ts
+++ b/src/js/builtins/JSBufferPrototype.ts
@@ -400,56 +400,6 @@ export function writeBigUInt64BE(this: BufferExt, value, offset) {
   return offset + 8;
 }
 
-export function utf8Write(this: BufferExt, text, offset, length) {
-  return this.write(text, offset, length, "utf8");
-}
-export function ucs2Write(this: BufferExt, text, offset, length) {
-  return this.write(text, offset, length, "ucs2");
-}
-export function utf16leWrite(this: BufferExt, text, offset, length) {
-  return this.write(text, offset, length, "utf16le");
-}
-export function latin1Write(this: BufferExt, text, offset, length) {
-  return this.write(text, offset, length, "latin1");
-}
-export function asciiWrite(this: BufferExt, text, offset, length) {
-  return this.write(text, offset, length, "ascii");
-}
-export function base64Write(this: BufferExt, text, offset, length) {
-  return this.write(text, offset, length, "base64");
-}
-export function base64urlWrite(this: BufferExt, text, offset, length) {
-  return this.write(text, offset, length, "base64url");
-}
-export function hexWrite(this: BufferExt, text, offset, length) {
-  return this.write(text, offset, length, "hex");
-}
-
-export function utf8Slice(this: BufferExt, start, end) {
-  return this.toString("utf8", start, end);
-}
-export function ucs2Slice(this: BufferExt, start, end) {
-  return this.toString("ucs2", start, end);
-}
-export function utf16leSlice(this: BufferExt, start, end) {
-  return this.toString("utf16le", start, end);
-}
-export function latin1Slice(this: BufferExt, start, end) {
-  return this.toString("latin1", start, end);
-}
-export function asciiSlice(this: BufferExt, start, end) {
-  return this.toString("ascii", start, end);
-}
-export function base64Slice(this: BufferExt, start, end) {
-  return this.toString("base64", start, end);
-}
-export function base64urlSlice(this: BufferExt, start, end) {
-  return this.toString("base64url", start, end);
-}
-export function hexSlice(this: BufferExt, start, end) {
-  return this.toString("hex", start, end);
-}
-
 export function toJSON(this: BufferExt) {
   const type = "Buffer";
   const data = Array.from(this);

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -2560,6 +2560,7 @@ it("Buffer.latin1Slice() on a Uint8Array", () => {
   expect(() => latin1Slice.call(buf, 1, 4)).toThrow(RangeError);
   expect(() => latin1Slice.call(buf, 4, 1)).toThrow(RangeError);
   expect(() => latin1Slice.call(buf, 4, 0)).toThrow(RangeError);
+  expect(() => latin1Slice.call(buf, 3, 999999)).toThrow(RangeError);
 
   expect(latin1Slice.call(buf, 3)).toStrictEqual("");
   expect(latin1Slice.call(buf, 3, 1)).toStrictEqual("");
@@ -2587,6 +2588,7 @@ it("Buffer.latin1Write() on a Uint8Array", () => {
   expect(latin1Write.call(buf, "í", 28)).toBe(1);
   expect(latin1Write.call(buf, "é", 30)).toBe(1);
   expect(latin1Write.call(buf, "ò", 32)).toBe(1);
+  expect(latin1Write.call(buf, "ò", 32, 999999)).toBe(1);
 
   expect(buf).toStrictEqual(
     new Uint8Array(Buffer.from("6f6c64206d63646f6e616c6420686164206120666172e920ed20e920ed20e920f2", "hex")),

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -2537,6 +2537,60 @@ it("Buffer.latin1Slice()", () => {
   expect(buf.latin1Slice()).toStrictEqual("âéö");
   expect(buf.latin1Slice(1)).toStrictEqual("éö");
   expect(buf.latin1Slice(1, 2)).toStrictEqual("é");
+
+  expect(() => buf.latin1Slice(1, 4)).toThrow(RangeError);
+  expect(() => buf.latin1Slice(4, 1)).toThrow(RangeError);
+  expect(() => buf.latin1Slice(4, 0)).toThrow(RangeError);
+
+  expect(buf.latin1Slice(3)).toStrictEqual("");
+  expect(buf.latin1Slice(3, 1)).toStrictEqual("");
+  expect(buf.latin1Slice(2, 1)).toStrictEqual("");
+  expect(buf.latin1Slice(1, 1)).toStrictEqual("");
+  expect(buf.latin1Slice(1, 0)).toStrictEqual("");
+});
+
+it("Buffer.latin1Slice() on a Uint8Array", () => {
+  const buf = new Uint8Array(Buffer.from("âéö", "latin1"));
+  const latin1Slice = Buffer.prototype.latin1Slice;
+
+  expect(latin1Slice.call(buf)).toStrictEqual("âéö");
+  expect(latin1Slice.call(buf, 1)).toStrictEqual("éö");
+  expect(latin1Slice.call(buf, 1, 2)).toStrictEqual("é");
+
+  expect(() => latin1Slice.call(buf, 1, 4)).toThrow(RangeError);
+  expect(() => latin1Slice.call(buf, 4, 1)).toThrow(RangeError);
+  expect(() => latin1Slice.call(buf, 4, 0)).toThrow(RangeError);
+
+  expect(latin1Slice.call(buf, 3)).toStrictEqual("");
+  expect(latin1Slice.call(buf, 3, 1)).toStrictEqual("");
+  expect(latin1Slice.call(buf, 2, 1)).toStrictEqual("");
+  expect(latin1Slice.call(buf, 1, 1)).toStrictEqual("");
+  expect(latin1Slice.call(buf, 1, 0)).toStrictEqual("");
+});
+
+it("Buffer.latin1Slice() on non-ArrayBufferView fails", () => {
+  const buf = new Array(new Uint8Array(Buffer.from("âéö", "latin1")));
+  const latin1Slice = Buffer.prototype.latin1Slice;
+
+  expect(() => latin1Slice.call(buf)).toThrow(TypeError);
+  expect(() => latin1Slice.call(buf, 1)).toThrow(TypeError);
+  expect(() => latin1Slice.call(Symbol("wat"), 1)).toThrow(TypeError);
+});
+
+it("Buffer.latin1Write() on a Uint8Array", () => {
+  const buf = new Uint8Array(Buffer.from("old mcdonald had a farm é í é í ò", "latin1"));
+  const latin1Write = Buffer.prototype.latin1Write;
+
+  expect(latin1Write.call(buf, "é", 22)).toBe(1);
+  expect(latin1Write.call(buf, "í", 24)).toBe(1);
+  expect(latin1Write.call(buf, "é", 26)).toBe(1);
+  expect(latin1Write.call(buf, "í", 28)).toBe(1);
+  expect(latin1Write.call(buf, "é", 30)).toBe(1);
+  expect(latin1Write.call(buf, "ò", 32)).toBe(1);
+
+  expect(buf).toStrictEqual(
+    new Uint8Array(Buffer.from("6f6c64206d63646f6e616c6420686164206120666172e920ed20e920ed20e920f2", "hex")),
+  );
 });
 
 it("Buffer.utf8Slice()", () => {


### PR DESCRIPTION
### What does this PR do?

The various encoding-specific methods in Node's Buffer implementation are supposed to work on both Uint8Array and Buffer classes. 

Libraries expect this behavior, such as @kriszyp's [lmdb-js](https://github.com/kriszyp/lmdb-js/blob/ffe9138adadf92d9b67435a5350d5a19d36212d8/read.js#L764-L770)

```js
// use the faster utf8Slice if available, otherwise fall back to TextDecoder (a little slower)
// note applying Buffer's utf8Slice to a Uint8Array works in Node, but not in Bun.
value = bytes.utf8Slice
? bytes.utf8Slice(0, lastSize)
: textDecoder.decode(
	Uint8ArraySlice.call(bytes, 0, lastSize),
);
```

We were also not returning the `code` property for RangeError.

### How did you verify your code works?

There are tests