### PR TITLE
fix(install): call `GetFinalPathNameByHandle` on cwd for postinstall scripts

### DIFF
--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1513,8 +1513,10 @@ pub fn spawnProcessWindows(
     const allocator = stack_allocator.get();
     const loop = options.windows.loop.platformEventLoop().uv_loop;
 
-    const cwd = try allocator.dupeZ(u8, options.cwd);
-    defer allocator.free(cwd);
+    var cwd_buf: bun.PathBuffer = undefined;
+    @memcpy(cwd_buf[0..options.cwd.len], options.cwd);
+    cwd_buf[options.cwd.len] = 0;
+    const cwd = cwd_buf[0..options.cwd.len :0];
 
     uv_process_options.cwd = cwd.ptr;
 

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -106,7 +106,7 @@ pub const LifecycleScriptSubprocess = struct {
 
         const manager = this.manager;
         const original_script = this.scripts.items[next_script_index].?;
-        const cwd = bun.path.z(this.scripts.cwd, &cwd_z_buf);
+        const cwd = this.scripts.cwd;
         const env = manager.env;
         this.stdout.setParent(this);
         this.stderr.setParent(this);

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -484,3 +484,28 @@ for (const glob of [true, false]) {
     });
   });
 }
+
+test("cwd in workspace script is not the symlink path on windows", async () => {
+  await Promise.all([
+    write(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        workspaces: ["pkg1"],
+      }),
+    ),
+    write(
+      join(packageDir, "pkg1", "package.json"),
+      JSON.stringify({
+        name: "pkg1",
+        scripts: {
+          postinstall: 'bun -e \'require("fs").writeFileSync("cwd", process.cwd())\'',
+        },
+      }),
+    ),
+  ]);
+
+  await runBunInstall(env, packageDir);
+
+  expect(await file(join(packageDir, "node_modules", "pkg1", "cwd")).text()).toBe(join(packageDir, "pkg1"));
+});


### PR DESCRIPTION
### What does this PR do?
This ensures any lifecycle scripts on Windows will have the expected `process.cwd()`. For example, workspace scripts would have `C:\path\to\proj\workspace` instead of `C:\path\to\proj\node_modules\workspace`.

fixes #12438 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
