### PR TITLE
fix: prepend ctx.positionals to vm.argv

### DIFF
--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -178,9 +178,9 @@ pub const Run = struct {
         var vm = run.vm;
         var b = &vm.bundler;
         vm.preload = ctx.preloads;
-        vm.argv = ctx.passthrough;
         vm.arena = &run.arena;
         vm.allocator = arena.allocator();
+        vm.argv = try std.mem.concat(ctx.allocator, []const u8, &[_][]const []const u8{ ctx.positionals, ctx.passthrough });
 
         if (ctx.runtime_options.eval.script.len > 0) {
             const script_source = try bun.default_allocator.create(logger.Source);

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -180,7 +180,7 @@ pub const Run = struct {
         vm.preload = ctx.preloads;
         vm.arena = &run.arena;
         vm.allocator = arena.allocator();
-        vm.argv = try std.mem.concat(ctx.allocator, []const u8, &[_][]const []const u8{ ctx.positionals, ctx.passthrough });
+        vm.argv = try std.mem.concat(ctx.allocator, []const u8, &.{ ctx.positionals, ctx.passthrough });
 
         if (ctx.runtime_options.eval.script.len > 0) {
             const script_source = try bun.default_allocator.create(logger.Source);

--- a/test/regression/issue/12209.test.ts
+++ b/test/regression/issue/12209.test.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "bun:test";
+import { bunExe } from "harness";
+import { execFile } from "node:child_process";
+import util from "node:util";
+
+const execFileAsync = util.promisify(execFile);
+
+test("https://github.com/oven-sh/bun/issues/12209", async () => {
+	// use these instead of [1,2,3] so it's easier to .toContain it
+	const numArgs = ["7392", "5104", "8627"];
+	const args = ["-e", "console.log(process.argv)", ...numArgs];
+	const result = await execFileAsync(bunExe(), args);
+	for (const numArg of numArgs) {
+		expect(result.stdout).toContain(numArg);
+	}
+	expect(result.stderr).toBe("");
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #12209. Issue is ctx.positionals isn't passed to vm.argv

We also can do ctx.passthrough = concat(args.positional(), args.remaining()) on cli.zig if that's preferred.

<img width="814" alt="image" src="https://github.com/oven-sh/bun/assets/170739895/b48a873a-99e9-4982-9a83-8957c0225ffc">

This is my first patch to Bun, do let me know if I'm missing anything :)

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)