### PR TITLE
Replace some Identifier::fromString usages with vm->propertyNames

### DIFF
--- a/src/bun.js/bindings/BunInjectedScriptHost.cpp
+++ b/src/bun.js/bindings/BunInjectedScriptHost.cpp
@@ -33,7 +33,7 @@ JSValue BunInjectedScriptHost::subtype(JSGlobalObject* exec, JSValue value)
 static JSObject* constructInternalProperty(VM& vm, JSGlobalObject* exec, const String& name, JSValue value)
 {
     auto* object = constructEmptyObject(exec);
-    object->putDirect(vm, Identifier::fromString(vm, "name"_s), jsString(vm, name));
+    object->putDirect(vm, vm.propertyNames->name, jsString(vm, name));
     object->putDirect(vm, Identifier::fromString(vm, "value"_s), value);
     return object;
 }
@@ -41,7 +41,7 @@ static JSObject* constructInternalProperty(VM& vm, JSGlobalObject* exec, const S
 static JSObject* constructInternalProperty(VM& vm, JSGlobalObject* exec, const Identifier& name, JSValue value)
 {
     auto* object = constructEmptyObject(exec);
-    object->putDirect(vm, Identifier::fromString(vm, "name"_s), JSC::identifierToJSValue(vm, name));
+    object->putDirect(vm, vm.propertyNames->name, JSC::identifierToJSValue(vm, name));
     object->putDirect(vm, Identifier::fromString(vm, "value"_s), value);
     return object;
 }

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -205,7 +205,7 @@ static JSValue constructProcessReleaseObject(VM& vm, JSObject* processObject)
     auto* release = JSC::constructEmptyObject(globalObject);
 
     // SvelteKit compatibility hack
-    release->putDirect(vm, Identifier::fromString(vm, "name"_s), jsString(vm, WTF::String("node"_s)), 0);
+    release->putDirect(vm, vm.propertyNames->name, jsString(vm, WTF::String("node"_s)), 0);
 
     release->putDirect(vm, Identifier::fromString(vm, "lts"_s), jsBoolean(false), 0);
     release->putDirect(vm, Identifier::fromString(vm, "sourceUrl"_s), jsString(vm, WTF::String(std::span { Bun__githubURL, strlen(Bun__githubURL) })), 0);
@@ -1068,7 +1068,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_emitWarning, (JSGlobalObject * lexicalGlobalObj
         return createError(globalObject, str);
     })();
 
-    errorInstance->putDirect(vm, Identifier::fromString(vm, "name"_s), jsString(vm, String("warn"_s)), JSC::PropertyAttribute::DontEnum | 0);
+    errorInstance->putDirect(vm, vm.propertyNames->name, jsString(vm, String("warn"_s)), JSC::PropertyAttribute::DontEnum | 0);
 
     auto ident = Identifier::fromString(vm, "warning"_s);
     if (process->wrapped().hasEventListeners(ident)) {

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -711,14 +711,14 @@ extern Structure* createMockResultStructure(JSC::VM& vm, JSC::JSGlobalObject* gl
     structure = structure->addPropertyTransition(
         vm,
         structure,
-        JSC::Identifier::fromString(vm, "type"_s),
+        vm.propertyNames->type,
         0,
         offset);
 
     structure = structure->addPropertyTransition(
         vm,
         structure,
-        JSC::Identifier::fromString(vm, "value"_s),
+        vm.propertyNames->value,
         0, offset);
     return structure;
 }

--- a/src/bun.js/bindings/KeyObject.cpp
+++ b/src/bun.js/bindings/KeyObject.cpp
@@ -550,7 +550,7 @@ JSC_DEFINE_HOST_FUNCTION(KeyObject__createPrivateKey, (JSC::JSGlobalObject * glo
         }
     }
     if (format == "der"_s) {
-        JSValue typeJSValue = options->getIfPropertyExists(globalObject, PropertyName(Identifier::fromString(vm, "type"_s)));
+        JSValue typeJSValue = options->getIfPropertyExists(globalObject, PropertyName(vm.propertyNames->type));
         WTF::String type = "pkcs8"_s;
         if (!typeJSValue.isUndefinedOrNull() && !typeJSValue.isEmpty()) {
             if (!typeJSValue.isString()) {
@@ -1138,7 +1138,7 @@ JSC_DEFINE_HOST_FUNCTION(KeyObject__createPublicKey, (JSC::JSGlobalObject * glob
         }
     }
     if (format == "der"_s) {
-        JSValue typeJSValue = options->getIfPropertyExists(globalObject, PropertyName(Identifier::fromString(vm, "type"_s)));
+        JSValue typeJSValue = options->getIfPropertyExists(globalObject, PropertyName(vm.propertyNames->type));
         WTF::String type = "spki"_s;
         if (!typeJSValue.isUndefinedOrNull() && !typeJSValue.isEmpty()) {
             if (!typeJSValue.isString()) {
@@ -1800,7 +1800,7 @@ JSC_DEFINE_HOST_FUNCTION(KeyObject__Exports, (JSC::JSGlobalObject * globalObject
     auto id = wrapped.keyClass();
     if (auto* options = jsDynamicCast<JSC::JSObject*>(callFrame->argument(1))) {
         JSValue formatJSValue = options->getIfPropertyExists(globalObject, PropertyName(Identifier::fromString(vm, "format"_s)));
-        JSValue typeJSValue = options->getIfPropertyExists(globalObject, PropertyName(Identifier::fromString(vm, "type"_s)));
+        JSValue typeJSValue = options->getIfPropertyExists(globalObject, PropertyName(vm.propertyNames->type));
         JSValue passphraseJSValue = options->getIfPropertyExists(globalObject, PropertyName(Identifier::fromString(vm, "passphrase"_s)));
         KeyPassphrase passphrase(passphraseJSValue, globalObject, scope);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());

--- a/src/bun.js/bindings/webcore/JSPerformanceEntry.cpp
+++ b/src/bun.js/bindings/webcore/JSPerformanceEntry.cpp
@@ -235,7 +235,7 @@ static inline EncodedJSValue jsPerformanceEntryPrototypeFunction_toJSONBody(JSGl
     auto* result = constructEmptyObject(lexicalGlobalObject);
     auto nameValue = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, impl.name());
     RETURN_IF_EXCEPTION(throwScope, {});
-    result->putDirect(vm, Identifier::fromString(vm, "name"_s), nameValue);
+    result->putDirect(vm, vm.propertyNames->name, nameValue);
     auto entryTypeValue = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, impl.entryType());
     RETURN_IF_EXCEPTION(throwScope, {});
     result->putDirect(vm, Identifier::fromString(vm, "entryType"_s), entryTypeValue);

--- a/src/bun.js/bindings/webcore/JSPerformanceObserver.cpp
+++ b/src/bun.js/bindings/webcore/JSPerformanceObserver.cpp
@@ -95,7 +95,7 @@ template<> PerformanceObserver::Init convertDictionary<PerformanceObserver::Init
     if (isNullOrUndefined)
         typeValue = jsUndefined();
     else {
-        typeValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "type"_s));
+        typeValue = object->get(&lexicalGlobalObject, vm.propertyNames->type);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!typeValue.isUndefined()) {

--- a/src/bun.js/bindings/webcore/JSWorker.cpp
+++ b/src/bun.js/bindings/webcore/JSWorker.cpp
@@ -131,7 +131,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
     options.bun.unref = false;
 
     if (JSObject* optionsObject = JSC::jsDynamicCast<JSC::JSObject*>(argument1.value())) {
-        if (auto nameValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "name"_s))) {
+        if (auto nameValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->name)) {
             if (nameValue.isString()) {
                 options.name = nameValue.toWTFString(lexicalGlobalObject);
                 RETURN_IF_EXCEPTION(throwScope, encodedJSValue());

--- a/src/bun.js/bindings/webcore/JSWorkerOptions.cpp
+++ b/src/bun.js/bindings/webcore/JSWorkerOptions.cpp
@@ -57,7 +57,7 @@ template<> WorkerOptions convertDictionary<WorkerOptions>(JSGlobalObject& lexica
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSAesCbcCfbParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSAesCbcCfbParams.cpp
@@ -50,7 +50,7 @@ template<> CryptoAlgorithmAesCbcCfbParams convertDictionary<CryptoAlgorithmAesCb
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSAesCtrParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSAesCtrParams.cpp
@@ -51,7 +51,7 @@ template<> CryptoAlgorithmAesCtrParams convertDictionary<CryptoAlgorithmAesCtrPa
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSAesGcmParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSAesGcmParams.cpp
@@ -51,7 +51,7 @@ template<> CryptoAlgorithmAesGcmParams convertDictionary<CryptoAlgorithmAesGcmPa
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSAesKeyParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSAesKeyParams.cpp
@@ -48,7 +48,7 @@ template<> CryptoAlgorithmAesKeyParams convertDictionary<CryptoAlgorithmAesKeyPa
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSCryptoAesKeyAlgorithm.cpp
+++ b/src/bun.js/bindings/webcrypto/JSCryptoAesKeyAlgorithm.cpp
@@ -50,7 +50,7 @@ template<> CryptoAesKeyAlgorithm convertDictionary<CryptoAesKeyAlgorithm>(JSGlob
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {
@@ -86,10 +86,10 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
 
     auto nameValue = toJS<IDLDOMString>(lexicalGlobalObject, throwScope, dictionary.name);
     RETURN_IF_EXCEPTION(throwScope, {});
-    result->putDirect(vm, JSC::Identifier::fromString(vm, "name"_s), nameValue);
+    result->putDirect(vm, vm.propertyNames->name, nameValue);
     auto lengthValue = toJS<IDLUnsignedShort>(lexicalGlobalObject, throwScope, dictionary.length);
     RETURN_IF_EXCEPTION(throwScope, {});
-    result->putDirect(vm, JSC::Identifier::fromString(vm, "length"_s), lengthValue);
+    result->putDirect(vm, vm.propertyNames->length, lengthValue);
     return result;
 }
 

--- a/src/bun.js/bindings/webcrypto/JSCryptoAlgorithmParameters.cpp
+++ b/src/bun.js/bindings/webcrypto/JSCryptoAlgorithmParameters.cpp
@@ -47,7 +47,7 @@ template<> CryptoAlgorithmParameters convertDictionary<CryptoAlgorithmParameters
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSCryptoEcKeyAlgorithm.cpp
+++ b/src/bun.js/bindings/webcrypto/JSCryptoEcKeyAlgorithm.cpp
@@ -49,7 +49,7 @@ template<> CryptoEcKeyAlgorithm convertDictionary<CryptoEcKeyAlgorithm>(JSGlobal
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {
@@ -85,7 +85,7 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
 
     auto nameValue = toJS<IDLDOMString>(lexicalGlobalObject, throwScope, dictionary.name);
     RETURN_IF_EXCEPTION(throwScope, {});
-    result->putDirect(vm, JSC::Identifier::fromString(vm, "name"_s), nameValue);
+    result->putDirect(vm, vm.propertyNames->name, nameValue);
     auto namedCurveValue = toJS<IDLDOMString>(lexicalGlobalObject, throwScope, dictionary.namedCurve);
     RETURN_IF_EXCEPTION(throwScope, {});
     result->putDirect(vm, JSC::Identifier::fromString(vm, "namedCurve"_s), namedCurveValue);

--- a/src/bun.js/bindings/webcrypto/JSCryptoHmacKeyAlgorithm.cpp
+++ b/src/bun.js/bindings/webcrypto/JSCryptoHmacKeyAlgorithm.cpp
@@ -51,7 +51,7 @@ template<> CryptoHmacKeyAlgorithm convertDictionary<CryptoHmacKeyAlgorithm>(JSGl
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {
@@ -101,13 +101,13 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
 
     auto nameValue = toJS<IDLDOMString>(lexicalGlobalObject, throwScope, dictionary.name);
     RETURN_IF_EXCEPTION(throwScope, {});
-    result->putDirect(vm, JSC::Identifier::fromString(vm, "name"_s), nameValue);
+    result->putDirect(vm, vm.propertyNames->name, nameValue);
     auto hashValue = toJS<IDLDictionary<CryptoKeyAlgorithm>>(lexicalGlobalObject, globalObject, throwScope, dictionary.hash);
     RETURN_IF_EXCEPTION(throwScope, {});
     result->putDirect(vm, JSC::Identifier::fromString(vm, "hash"_s), hashValue);
     auto lengthValue = toJS<IDLUnsignedLong>(lexicalGlobalObject, throwScope, dictionary.length);
     RETURN_IF_EXCEPTION(throwScope, {});
-    result->putDirect(vm, JSC::Identifier::fromString(vm, "length"_s), lengthValue);
+    result->putDirect(vm, vm.propertyNames->length, lengthValue);
     return result;
 }
 

--- a/src/bun.js/bindings/webcrypto/JSCryptoKeyAlgorithm.cpp
+++ b/src/bun.js/bindings/webcrypto/JSCryptoKeyAlgorithm.cpp
@@ -49,7 +49,7 @@ template<> CryptoKeyAlgorithm convertDictionary<CryptoKeyAlgorithm>(JSGlobalObje
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {
@@ -71,7 +71,7 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
 
     auto nameValue = toJS<IDLDOMString>(lexicalGlobalObject, throwScope, dictionary.name);
     RETURN_IF_EXCEPTION(throwScope, {});
-    result->putDirect(vm, JSC::Identifier::fromString(vm, "name"_s), nameValue);
+    result->putDirect(vm, vm.propertyNames->name, nameValue);
     return result;
 }
 

--- a/src/bun.js/bindings/webcrypto/JSCryptoRsaHashedKeyAlgorithm.cpp
+++ b/src/bun.js/bindings/webcrypto/JSCryptoRsaHashedKeyAlgorithm.cpp
@@ -52,7 +52,7 @@ template<> CryptoRsaHashedKeyAlgorithm convertDictionary<CryptoRsaHashedKeyAlgor
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {
@@ -116,7 +116,7 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
 
     auto nameValue = toJS<IDLDOMString>(lexicalGlobalObject, throwScope, dictionary.name);
     RETURN_IF_EXCEPTION(throwScope, {});
-    result->putDirect(vm, JSC::Identifier::fromString(vm, "name"_s), nameValue);
+    result->putDirect(vm, vm.propertyNames->name, nameValue);
     auto modulusLengthValue = toJS<IDLUnsignedLong>(lexicalGlobalObject, throwScope, dictionary.modulusLength);
     RETURN_IF_EXCEPTION(throwScope, {});
     result->putDirect(vm, JSC::Identifier::fromString(vm, "modulusLength"_s), modulusLengthValue);

--- a/src/bun.js/bindings/webcrypto/JSCryptoRsaKeyAlgorithm.cpp
+++ b/src/bun.js/bindings/webcrypto/JSCryptoRsaKeyAlgorithm.cpp
@@ -51,7 +51,7 @@ template<> CryptoRsaKeyAlgorithm convertDictionary<CryptoRsaKeyAlgorithm>(JSGlob
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {
@@ -101,7 +101,7 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
 
     auto nameValue = toJS<IDLDOMString>(lexicalGlobalObject, throwScope, dictionary.name);
     RETURN_IF_EXCEPTION(throwScope, {});
-    result->putDirect(vm, JSC::Identifier::fromString(vm, "name"_s), nameValue);
+    result->putDirect(vm, vm.propertyNames->name, nameValue);
     auto modulusLengthValue = toJS<IDLUnsignedLong>(lexicalGlobalObject, throwScope, dictionary.modulusLength);
     RETURN_IF_EXCEPTION(throwScope, {});
     result->putDirect(vm, JSC::Identifier::fromString(vm, "modulusLength"_s), modulusLengthValue);

--- a/src/bun.js/bindings/webcrypto/JSEcKeyParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSEcKeyParams.cpp
@@ -47,7 +47,7 @@ template<> CryptoAlgorithmEcKeyParams convertDictionary<CryptoAlgorithmEcKeyPara
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSEcdhKeyDeriveParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSEcdhKeyDeriveParams.cpp
@@ -49,7 +49,7 @@ template<> CryptoAlgorithmEcdhKeyDeriveParams convertDictionary<CryptoAlgorithmE
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSEcdsaParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSEcdsaParams.cpp
@@ -50,7 +50,7 @@ template<> CryptoAlgorithmEcdsaParams convertDictionary<CryptoAlgorithmEcdsaPara
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSHkdfParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSHkdfParams.cpp
@@ -51,7 +51,7 @@ template<> CryptoAlgorithmHkdfParams convertDictionary<CryptoAlgorithmHkdfParams
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSHmacKeyParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSHmacKeyParams.cpp
@@ -51,7 +51,7 @@ template<> CryptoAlgorithmHmacKeyParams convertDictionary<CryptoAlgorithmHmacKey
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSPbkdf2Params.cpp
+++ b/src/bun.js/bindings/webcrypto/JSPbkdf2Params.cpp
@@ -52,7 +52,7 @@ template<> CryptoAlgorithmPbkdf2Params convertDictionary<CryptoAlgorithmPbkdf2Pa
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSRsaHashedImportParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSRsaHashedImportParams.cpp
@@ -50,7 +50,7 @@ template<> CryptoAlgorithmRsaHashedImportParams convertDictionary<CryptoAlgorith
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSRsaHashedKeyGenParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSRsaHashedKeyGenParams.cpp
@@ -52,7 +52,7 @@ template<> CryptoAlgorithmRsaHashedKeyGenParams convertDictionary<CryptoAlgorith
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSRsaKeyGenParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSRsaKeyGenParams.cpp
@@ -49,7 +49,7 @@ template<> CryptoAlgorithmRsaKeyGenParams convertDictionary<CryptoAlgorithmRsaKe
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSRsaOaepParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSRsaOaepParams.cpp
@@ -50,7 +50,7 @@ template<> CryptoAlgorithmRsaOaepParams convertDictionary<CryptoAlgorithmRsaOaep
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/JSRsaPssParams.cpp
+++ b/src/bun.js/bindings/webcrypto/JSRsaPssParams.cpp
@@ -48,7 +48,7 @@ template<> CryptoAlgorithmRsaPssParams convertDictionary<CryptoAlgorithmRsaPssPa
     if (isNullOrUndefined)
         nameValue = jsUndefined();
     else {
-        nameValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "name"_s));
+        nameValue = object->get(&lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!nameValue.isUndefined()) {

--- a/src/bun.js/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/bun.js/bindings/webcrypto/SubtleCrypto.cpp
@@ -111,7 +111,7 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
 
     if (std::holds_alternative<String>(algorithmIdentifier)) {
         auto newParams = Strong<JSObject>(vm, constructEmptyObject(&state));
-        newParams->putDirect(vm, Identifier::fromString(vm, "name"_s), jsString(vm, std::get<String>(algorithmIdentifier)));
+        newParams->putDirect(vm, vm.propertyNames->name, jsString(vm, std::get<String>(algorithmIdentifier)));
 
         return normalizeCryptoAlgorithmParameters(state, newParams, operation);
     }
@@ -268,10 +268,10 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         switch (*identifier) {
         case CryptoAlgorithmIdentifier::ECDH: {
             // Remove this hack once https://bugs.webkit.org/show_bug.cgi?id=169333 is fixed.
-            JSValue nameValue = value.get()->get(&state, Identifier::fromString(vm, "name"_s));
+            JSValue nameValue = value.get()->get(&state, vm.propertyNames->name);
             JSValue publicValue = value.get()->get(&state, Identifier::fromString(vm, "public"_s));
             JSObject* newValue = constructEmptyObject(&state);
-            newValue->putDirect(vm, Identifier::fromString(vm, "name"_s), nameValue);
+            newValue->putDirect(vm, vm.propertyNames->name, nameValue);
             newValue->putDirect(vm, Identifier::fromString(vm, "publicKey"_s), publicValue);
 
             auto params = convertDictionary<CryptoAlgorithmEcdhKeyDeriveParams>(state, newValue);


### PR DESCRIPTION
### What does this PR do?

Replace some Identifier::fromString usages with vm->propertyNames

Small performance thing

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
