### PR TITLE
Change .mjs to .mts during TypeScript module resolution (fixes #12471)

### DIFF
--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -1733,7 +1733,6 @@ describe("bundler", () => {
     useDefineForClassFields: true,
   });
   itBundled("ts/ImportMTS", {
-    todo: true,
     files: {
       "/entry.ts": `import './imported.mjs'`,
       "/imported.mts": `console.log('works')`,


### PR DESCRIPTION
### What does this PR do?

TypeScript files can now use `.mjs` in an `import` to refer to files that are named `.mts`.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
