### PR TITLE
fix(serve) fix abrupt close when downloading data

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1536,9 +1536,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             ctx.render(response);
         }
 
-          pub fn isDeadRequest(this: *RequestContext) bool {
+        pub fn isDeadRequest(this: *RequestContext) bool {
             if (this.ref_count > 1) return false;
-
 
             if (this.request_body) |body| {
                 if (body.value == .Locked) {
@@ -2613,7 +2612,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         }
 
         fn detachResponse(this: *RequestContext) void {
-            if(this.resp) |resp| {
+            if (this.resp) |resp| {
                 resp.clearAborted();
             }
             this.resp = null;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2627,9 +2627,6 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         }
 
         fn detachResponse(this: *RequestContext) void {
-            if (this.resp) |resp| {
-                resp.clearAborted();
-            }
             this.resp = null;
         }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1535,7 +1535,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
             ctx.render(response);
         }
-        
+
         pub fn shouldRenderMissing(this: *RequestContext) bool {
             // If we did not respond yet, we should render missing
             // To allow this all the conditions above should be true:

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1594,8 +1594,9 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         pub fn deref(this: *RequestContext) void {
             streamLog("deref", .{});
             bun.assert(this.ref_count > 0);
-            this.ref_count -|= 1;
-            if (this.ref_count == 0) {
+            const ref_count = this.ref_count;
+            this.ref_count -= 1;
+            if (ref_count == 1) {
                 this.finalizeWithoutDeinit();
                 this.deinit();
             }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2617,6 +2617,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
         fn detachResponse(this: *RequestContext) void {
             if (this.resp) |resp| {
+                this.resp = null;
+
                 // onAbort should have set this to null
                 bun.assert(!this.flags.aborted);
                 if (this.flags.is_waiting_for_request_body) {
@@ -2628,7 +2630,6 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     this.flags.has_abort_handler = false;
                 }
             }
-            this.resp = null;
         }
 
         fn isAbortedOrEnded(this: *const RequestContext) bool {


### PR DESCRIPTION
### What does this PR do?
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
Added a test
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
