### PR TITLE
Disable asynchronous unwind tables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1194,6 +1194,12 @@ else()
         -mno-omit-leaf-frame-pointer
         -faddrsig
     )
+
+    if(LINUX)
+        target_compile_options(${bun} PUBLIC
+            -fno-asynchronous-unwind-tables
+        )
+    endif()
 endif()
 
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1193,13 +1193,8 @@ else()
         -fno-omit-frame-pointer
         -mno-omit-leaf-frame-pointer
         -faddrsig
+        -fno-asynchronous-unwind-tables
     )
-
-    if(LINUX)
-        target_compile_options(${bun} PUBLIC
-            -fno-asynchronous-unwind-tables
-        )
-    endif()
 endif()
 
 if(APPLE)

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -35,6 +35,11 @@ if [[ $(uname -s) == 'Linux' && ($(uname -m) == 'aarch64' || $(uname -m) == 'arm
   export CXXFLAGS="$CXXFLAGS -march=armv8-a+crc -mtune=ampere1 "
 fi
 
+if 9[[ $(uname -s) == 'Linux' ]]; then
+  export CFLAGS="$CFLAGS -fno-asynchronous-unwind-tables "
+  export CXXFLAGS="$CXXFLAGS -fno-asynchronous-unwind-tables "
+fi
+
 export CMAKE_FLAGS=(
   -DCMAKE_C_COMPILER="${CC}"
   -DCMAKE_CXX_COMPILER="${CXX}"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -27,18 +27,15 @@ export CPUS=${CPUS:-$(nproc || sysctl -n hw.ncpu || echo 1)}
 export CMAKE_CXX_COMPILER=${CXX}
 export CMAKE_C_COMPILER=${CC}
 
-export CFLAGS='-O3 -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer'
-export CXXFLAGS='-O3 -fno-exceptions -fno-rtti -fvisibility=hidden -fvisibility-inlines-hidden -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer'
+export CFLAGS='-O3 -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-asynchronous-unwind-tables '
+export CXXFLAGS='-O3 -fno-exceptions -fno-rtti -fvisibility=hidden -fvisibility-inlines-hidden -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-asynchronous-unwind-tables '
 
 if [[ $(uname -s) == 'Linux' && ($(uname -m) == 'aarch64' || $(uname -m) == 'arm64') ]]; then
   export CFLAGS="$CFLAGS -march=armv8-a+crc -mtune=ampere1 "
   export CXXFLAGS="$CXXFLAGS -march=armv8-a+crc -mtune=ampere1 "
 fi
 
-if 9[[ $(uname -s) == 'Linux' ]]; then
-  export CFLAGS="$CFLAGS -fno-asynchronous-unwind-tables "
-  export CXXFLAGS="$CXXFLAGS -fno-asynchronous-unwind-tables "
-fi
+
 
 export CMAKE_FLAGS=(
   -DCMAKE_C_COMPILER="${CC}"


### PR DESCRIPTION
### What does this PR do?

Might shave off 900 KB on macOS and 400 KB on Linux

macOS:

```
❯ bloaty (which bun)
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  72.2%  38.2Mi  63.4%  38.2Mi    __TEXT,__text
   0.0%       0  11.6%  6.97Mi    __DATA,__bss
   9.3%  4.92Mi   8.2%  4.92Mi    __TEXT,__const
   8.2%  4.36Mi   7.2%  4.36Mi    __DATA_CONST,__const
   6.1%  3.20Mi   5.3%  3.20Mi    __TEXT,__cstring
   1.7%   910Ki   1.5%   910Ki    __TEXT,__eh_frame
```

Linux:
```
❯ bloaty (which bun)
    FILE SIZE        VM SIZE
 --------------  --------------
  47.5%  43.7Mi  44.0%  43.7Mi    .text
  42.2%  38.8Mi  39.0%  38.8Mi    .rodata
   0.0%       0   7.4%  7.35Mi    .bss
   4.9%  4.48Mi   4.1%  4.10Mi    .data.rel.ro
   2.4%  2.23Mi   2.2%  2.23Mi    .eh_frame
   2.2%  1.99Mi   2.0%  1.99Mi    .rela.dyn
   0.4%   413Ki   0.4%   413Ki    .eh_frame_hdr
```


>    1.7%   910Ki   1.5%   910Ki    __TEXT,__eh_frame
>    0.4%   413Ki   0.4%   413Ki    .eh_frame_hdr

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
