### PR TITLE
fix .use_count integer underflow

### DIFF
--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1334,6 +1334,26 @@ describe("bundler", () => {
       `,
     },
   });
+  itBundled("edgecase/IntegerUnderflow#12547", {
+    files: {
+      "/entry.js": `
+        import { a } from 'external';
+
+        function func() {
+            const b = 1 + a.c;
+            return b;
+        }
+      `,
+    },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    external: ["external"],
+    onAfterBundle(api) {
+      // DCE is not yet able to eliminate the `a` or even the `as c`. Equivalent to esbuild as of 2024-07-15
+      api.expectFile("/out.js").toBe(`import{a as c}from"external";\n`);
+    },
+  });
 
   // TODO(@paperdave): test every case of this. I had already tested it manually, but it may break later
   const requireTranspilationListESM = [


### PR DESCRIPTION
### What does this PR do?

Fixes #12547
Fixes #12480
Fixes #12344

Fixes a crash when bundling a file with a property access on an externally imported module.

Saturating subtraction is the norm when dealing with estimated use counts in our codebase. Feels suspicious but it works.

This also improves minified printing of import statements, which happens from `--external` or `--splitting`

```diff
-import{a} from"./external";console.log(a);
+import{a}from"./external";console.log(a);
```

---

Most of my time was spent getting a small reproduction. To make this faster in the future, the crash reporter now will log what file it was currently parsing/visiting/printing in addition to the crash report. This is done in release builds to give the end user a pointer at what file caused it, and to lightly push them to attach it with the GitHub issue if they reported it.

I think this type of message is extremely helpful. To encourage this pattern more, I've made it extremely easy to expand `bun.crash_reporter.Action`; it is a simple zig union.

```zig
pub const Action = union(enum) {
    parse: []const u8,
    visit: []const u8,
    print: []const u8,
};
```