### PR TITLE
Accept undefined as explicit second argument for path.*.basename

### DIFF
--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -453,7 +453,7 @@ pub inline fn basenameJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, 
 }
 
 pub fn basename(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const suffix_ptr: ?JSC.JSValue = if (args_len > 1) args_ptr[1] else null;
+    const suffix_ptr: ?JSC.JSValue = if (args_len > 1 and args_ptr[1] != .undefined) args_ptr[1] else null;
 
     if (suffix_ptr) |_suffix_ptr| {
         // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.

--- a/test/js/node/path/basename.test.js
+++ b/test/js/node/path/basename.test.js
@@ -45,6 +45,7 @@ describe("path.dirname", () => {
     assert.strictEqual(path.win32.basename("basename.ext\\"), "basename.ext");
     assert.strictEqual(path.win32.basename("basename.ext\\\\"), "basename.ext");
     assert.strictEqual(path.win32.basename("foo"), "foo");
+    assert.strictEqual(path.win32.basename("foo", undefined), "foo");
     assert.strictEqual(path.win32.basename("aaa\\bbb", "\\bbb"), "bbb");
     assert.strictEqual(path.win32.basename("aaa\\bbb", "a\\bbb"), "bbb");
     assert.strictEqual(path.win32.basename("aaa\\bbb", "bbb"), "bbb");
@@ -72,6 +73,7 @@ describe("path.dirname", () => {
     assert.strictEqual(path.posix.basename("basename.ext\\"), "basename.ext\\");
     assert.strictEqual(path.posix.basename("basename.ext\\\\"), "basename.ext\\\\");
     assert.strictEqual(path.posix.basename("foo"), "foo");
+    assert.strictEqual(path.posix.basename("foo", undefined), "foo");
   });
 
   test("posix with control characters", () => {


### PR DESCRIPTION
### What does this PR do?

Makes `path.basename` and variants (`path.posix.basename` and `path.win32.basename`) accept `undefined` passed as the extension argument, like Node does. Previously they could be called with only one argument but they would throw if `undefined` were passed explicitly.

Fixes #12588.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)