### PR TITLE
bundler: make `import()` calls visit the options object

### DIFF
--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -534,140 +534,78 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
 
         pub fn colorCode(this: Keyword) ColorCode {
             return switch (this) {
-                Keyword.abstract => ColorCode.blue,
-                Keyword.as => ColorCode.blue,
-                Keyword.@"async" => ColorCode.magenta,
-                Keyword.@"await" => ColorCode.magenta,
-                Keyword.case => ColorCode.magenta,
-                Keyword.@"catch" => ColorCode.magenta,
-                Keyword.class => ColorCode.magenta,
-                Keyword.@"const" => ColorCode.magenta,
-                Keyword.@"continue" => ColorCode.magenta,
-                Keyword.debugger => ColorCode.magenta,
-                Keyword.default => ColorCode.magenta,
-                Keyword.delete => ColorCode.red,
-                Keyword.do => ColorCode.magenta,
-                Keyword.@"else" => ColorCode.magenta,
-                Keyword.@"break" => ColorCode.magenta,
-                Keyword.undefined => ColorCode.orange,
-                Keyword.@"enum" => ColorCode.blue,
-                Keyword.@"export" => ColorCode.magenta,
-                Keyword.extends => ColorCode.magenta,
-                Keyword.false => ColorCode.orange,
-                Keyword.finally => ColorCode.magenta,
-                Keyword.@"for" => ColorCode.magenta,
-                Keyword.function => ColorCode.magenta,
-                Keyword.@"if" => ColorCode.magenta,
-                Keyword.implements => ColorCode.blue,
-                Keyword.import => ColorCode.magenta,
-                Keyword.in => ColorCode.magenta,
-                Keyword.instanceof => ColorCode.magenta,
-                Keyword.interface => ColorCode.blue,
-                Keyword.let => ColorCode.magenta,
-                Keyword.new => ColorCode.magenta,
-                Keyword.null => ColorCode.orange,
-                Keyword.package => ColorCode.magenta,
-                Keyword.private => ColorCode.blue,
-                Keyword.protected => ColorCode.blue,
-                Keyword.public => ColorCode.blue,
-                Keyword.@"return" => ColorCode.magenta,
-                Keyword.static => ColorCode.magenta,
-                Keyword.super => ColorCode.magenta,
-                Keyword.@"switch" => ColorCode.magenta,
-                Keyword.this => ColorCode.orange,
-                Keyword.throw => ColorCode.magenta,
-                Keyword.true => ColorCode.orange,
-                Keyword.@"try" => ColorCode.magenta,
-                Keyword.type => ColorCode.blue,
-                Keyword.typeof => ColorCode.magenta,
-                Keyword.@"var" => ColorCode.magenta,
-                Keyword.void => ColorCode.magenta,
-                Keyword.@"while" => ColorCode.magenta,
-                Keyword.with => ColorCode.magenta,
-                Keyword.yield => ColorCode.magenta,
-                Keyword.string => ColorCode.blue,
-                Keyword.number => ColorCode.blue,
-                Keyword.boolean => ColorCode.blue,
-                Keyword.symbol => ColorCode.blue,
-                Keyword.any => ColorCode.blue,
-                Keyword.object => ColorCode.blue,
-                Keyword.unknown => ColorCode.blue,
-                Keyword.never => ColorCode.blue,
-                Keyword.namespace => ColorCode.blue,
-                Keyword.declare => ColorCode.blue,
-                Keyword.readonly => ColorCode.blue,
+                .abstract => .blue,
+                .as => .blue,
+                .@"async" => .magenta,
+                .@"await" => .magenta,
+                .case => .magenta,
+                .@"catch" => .magenta,
+                .class => .magenta,
+                .@"const" => .magenta,
+                .@"continue" => .magenta,
+                .debugger => .magenta,
+                .default => .magenta,
+                .delete => .red,
+                .do => .magenta,
+                .@"else" => .magenta,
+                .@"break" => .magenta,
+                .undefined => .orange,
+                .@"enum" => .blue,
+                .@"export" => .magenta,
+                .extends => .magenta,
+                .false => .orange,
+                .finally => .magenta,
+                .@"for" => .magenta,
+                .function => .magenta,
+                .@"if" => .magenta,
+                .implements => .blue,
+                .import => .magenta,
+                .in => .magenta,
+                .instanceof => .magenta,
+                .interface => .blue,
+                .let => .magenta,
+                .new => .magenta,
+                .null => .orange,
+                .package => .magenta,
+                .private => .blue,
+                .protected => .blue,
+                .public => .blue,
+                .@"return" => .magenta,
+                .static => .magenta,
+                .super => .magenta,
+                .@"switch" => .magenta,
+                .this => .orange,
+                .throw => .magenta,
+                .true => .orange,
+                .@"try" => .magenta,
+                .type => .blue,
+                .typeof => .magenta,
+                .@"var" => .magenta,
+                .void => .magenta,
+                .@"while" => .magenta,
+                .with => .magenta,
+                .yield => .magenta,
+                .string => .blue,
+                .number => .blue,
+                .boolean => .blue,
+                .symbol => .blue,
+                .any => .blue,
+                .object => .blue,
+                .unknown => .blue,
+                .never => .blue,
+                .namespace => .blue,
+                .declare => .blue,
+                .readonly => .blue,
             };
         }
     };
 
-    pub const Keywords = ComptimeStringMap(Keyword, .{
-        .{ "abstract", Keyword.abstract },
-        .{ "any", Keyword.any },
-        .{ "as", Keyword.as },
-        .{ "async", Keyword.@"async" },
-        .{ "await", Keyword.@"await" },
-        .{ "boolean", Keyword.boolean },
-        .{ "break", Keyword.@"break" },
-        .{ "case", Keyword.case },
-        .{ "catch", Keyword.@"catch" },
-        .{ "class", Keyword.class },
-        .{ "const", Keyword.@"const" },
-        .{ "continue", Keyword.@"continue" },
-        .{ "debugger", Keyword.debugger },
-        .{ "declare", Keyword.declare },
-        .{ "default", Keyword.default },
-        .{ "delete", Keyword.delete },
-        .{ "do", Keyword.do },
-        .{ "else", Keyword.@"else" },
-        .{ "enum", Keyword.@"enum" },
-        .{ "export", Keyword.@"export" },
-        .{ "extends", Keyword.extends },
-        .{ "false", Keyword.false },
-        .{ "finally", Keyword.finally },
-        .{ "for", Keyword.@"for" },
-        .{ "function", Keyword.function },
-        .{ "if", Keyword.@"if" },
-        .{ "implements", Keyword.implements },
-        .{ "import", Keyword.import },
-        .{ "in", Keyword.in },
-        .{ "instanceof", Keyword.instanceof },
-        .{ "interface", Keyword.interface },
-        .{ "let", Keyword.let },
-        .{ "namespace", Keyword.namespace },
-        .{ "never", Keyword.never },
-        .{ "new", Keyword.new },
-        .{ "null", Keyword.null },
-        .{ "number", Keyword.number },
-        .{ "object", Keyword.object },
-        .{ "package", Keyword.package },
-        .{ "private", Keyword.private },
-        .{ "protected", Keyword.protected },
-        .{ "public", Keyword.public },
-        .{ "readonly", Keyword.readonly },
-        .{ "return", Keyword.@"return" },
-        .{ "static", Keyword.static },
-        .{ "string", Keyword.string },
-        .{ "super", Keyword.super },
-        .{ "switch", Keyword.@"switch" },
-        .{ "symbol", Keyword.symbol },
-        .{ "this", Keyword.this },
-        .{ "throw", Keyword.throw },
-        .{ "true", Keyword.true },
-        .{ "try", Keyword.@"try" },
-        .{ "type", Keyword.type },
-        .{ "typeof", Keyword.typeof },
-        .{ "undefined", Keyword.undefined },
-        .{ "unknown", Keyword.unknown },
-        .{ "var", Keyword.@"var" },
-        .{ "void", Keyword.void },
-        .{ "while", Keyword.@"while" },
-        .{ "with", Keyword.with },
-        .{ "yield", Keyword.yield },
-    });
+    pub const Keywords = bun.ComptimeEnumMap(Keyword);
 
-    pub fn format(this: @This(), comptime _: []const u8, _: fmt.FormatOptions, writer: anytype) !void {
-        const text = this.text;
+    pub fn format(this: @This(), comptime unused_fmt: []const u8, _: fmt.FormatOptions, writer: anytype) !void {
+        comptime bun.assert(unused_fmt.len == 0);
 
+        var text = this.text;
         if (this.limited) {
             if (!this.enable_colors or text.len > 2048 or text.len == 0 or !strings.isAllASCII(text)) {
                 try writer.writeAll(text);
@@ -675,22 +613,21 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
             }
         }
 
-        var remain = text;
         var prev_keyword: ?Keyword = null;
 
-        outer: while (remain.len > 0) {
-            if (js_lexer.isIdentifierStart(remain[0])) {
+        outer: while (text.len > 0) {
+            if (js_lexer.isIdentifierStart(text[0])) {
                 var i: usize = 1;
 
-                while (i < remain.len and js_lexer.isIdentifierContinue(remain[i])) {
+                while (i < text.len and js_lexer.isIdentifierContinue(text[i])) {
                     i += 1;
                 }
 
-                if (Keywords.get(remain[0..i])) |keyword| {
+                if (Keywords.get(text[0..i])) |keyword| {
                     if (keyword != .as)
                         prev_keyword = keyword;
                     const code = keyword.colorCode();
-                    try writer.print(Output.prettyFmt("<r>{s}{s}<r>", true), .{ code.color(), remain[0..i] });
+                    try writer.print(Output.prettyFmt("<r>{s}{s}<r>", true), .{ code.color(), text[0..i] });
                 } else {
                     write: {
                         if (prev_keyword) |prev| {
@@ -698,20 +635,20 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
                                 .new => {
                                     prev_keyword = null;
 
-                                    if (i < remain.len and remain[i] == '(') {
-                                        try writer.print(Output.prettyFmt("<r><b>{s}<r>", true), .{remain[0..i]});
+                                    if (i < text.len and text[i] == '(') {
+                                        try writer.print(Output.prettyFmt("<r><b>{s}<r>", true), .{text[0..i]});
                                         break :write;
                                     }
                                 },
                                 .abstract, .namespace, .declare, .type, .interface => {
-                                    try writer.print(Output.prettyFmt("<r><b><blue>{s}<r>", true), .{remain[0..i]});
+                                    try writer.print(Output.prettyFmt("<r><b><blue>{s}<r>", true), .{text[0..i]});
                                     prev_keyword = null;
                                     break :write;
                                 },
                                 .import => {
-                                    if (strings.eqlComptime(remain[0..i], "from")) {
+                                    if (strings.eqlComptime(text[0..i], "from")) {
                                         const code = ColorCode.magenta;
-                                        try writer.print(Output.prettyFmt("<r>{s}{s}<r>", true), .{ code.color(), remain[0..i] });
+                                        try writer.print(Output.prettyFmt("<r>{s}{s}<r>", true), .{ code.color(), text[0..i] });
                                         prev_keyword = null;
 
                                         break :write;
@@ -721,25 +658,25 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
                             }
                         }
 
-                        try writer.writeAll(remain[0..i]);
+                        try writer.writeAll(text[0..i]);
                     }
                 }
-                remain = remain[i..];
+                text = text[i..];
             } else {
-                switch (remain[0]) {
+                switch (text[0]) {
                     '0'...'9' => {
                         prev_keyword = null;
                         var i: usize = 1;
-                        if (remain.len > 1 and remain[0] == '0' and remain[1] == 'x') {
+                        if (text.len > 1 and text[0] == '0' and text[1] == 'x') {
                             i += 1;
-                            while (i < remain.len and switch (remain[i]) {
+                            while (i < text.len and switch (text[i]) {
                                 '0'...'9', 'a'...'f', 'A'...'F' => true,
                                 else => false,
                             }) {
                                 i += 1;
                             }
                         } else {
-                            while (i < remain.len and switch (remain[i]) {
+                            while (i < text.len and switch (text[i]) {
                                 '0'...'9', '.', 'e', 'E', 'x', 'X', 'b', 'B', 'o', 'O' => true,
                                 else => false,
                             }) {
@@ -747,30 +684,30 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
                             }
                         }
 
-                        try writer.print(Output.prettyFmt("<r><yellow>{s}<r>", true), .{remain[0..i]});
-                        remain = remain[i..];
+                        try writer.print(Output.prettyFmt("<r><yellow>{s}<r>", true), .{text[0..i]});
+                        text = text[i..];
                     },
                     inline '`', '"', '\'' => |char| {
                         prev_keyword = null;
 
                         var i: usize = 1;
-                        while (i < remain.len and remain[i] != char) {
-                            if (comptime char == '`') {
-                                if (remain[i] == '$' and i + 1 < remain.len and remain[i + 1] == '{') {
+                        while (i < text.len and text[i] != char) {
+                            if (char == '`') {
+                                if (text[i] == '$' and i + 1 < text.len and text[i + 1] == '{') {
                                     const curly_start = i;
                                     i += 2;
 
-                                    while (i < remain.len and remain[i] != '}') {
-                                        if (remain[i] == '\\') {
+                                    while (i < text.len and text[i] != '}') {
+                                        if (text[i] == '\\') {
                                             i += 1;
                                         }
                                         i += 1;
                                     }
 
-                                    try writer.print(Output.prettyFmt("<r><green>{s}<r>", true), .{remain[0..curly_start]});
+                                    try writer.print(Output.prettyFmt("<r><green>{s}<r>", true), .{text[0..curly_start]});
                                     try writer.writeAll("${");
                                     const curly_remain = QuickAndDirtyJavaScriptSyntaxHighlighter{
-                                        .text = remain[curly_start + 2 .. i],
+                                        .text = text[curly_start + 2 .. i],
                                         .enable_colors = this.enable_colors,
                                         .limited = false,
                                     };
@@ -779,22 +716,22 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
                                         try curly_remain.format("", .{}, writer);
                                     }
 
-                                    if (i < remain.len and remain[i] == '}') {
+                                    if (i < text.len and text[i] == '}') {
                                         i += 1;
                                     }
                                     try writer.writeAll("}");
-                                    remain = remain[i..];
+                                    text = text[i..];
                                     i = 0;
-                                    if (remain.len > 0 and remain[0] == char) {
+                                    if (text.len > 0 and text[0] == char) {
                                         try writer.writeAll(Output.prettyFmt("<r><green>`<r>", true));
-                                        remain = remain[1..];
+                                        text = text[1..];
                                         continue :outer;
                                     }
                                     continue;
                                 }
                             }
 
-                            if (i + 1 < remain.len and remain[i] == '\\') {
+                            if (i + 1 < text.len and text[i] == '\\') {
                                 i += 1;
                             }
 
@@ -802,58 +739,58 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
                         }
 
                         // Include the trailing quote, if any
-                        i += @as(usize, @intFromBool(i > 1 and i < remain.len and remain[i] == char));
+                        i += @intFromBool(i < text.len);
 
-                        try writer.print(Output.prettyFmt("<r><green>{s}<r>", true), .{remain[0..i]});
-                        remain = remain[i..];
+                        try writer.print(Output.prettyFmt("<r><green>{s}<r>", true), .{text[0..i]});
+                        text = text[i..];
                     },
                     '/' => {
                         prev_keyword = null;
                         var i: usize = 1;
 
                         // the start of a line comment
-                        if (i < remain.len and remain[i] == '/') {
-                            while (i < remain.len and remain[i] != '\n') {
+                        if (i < text.len and text[i] == '/') {
+                            while (i < text.len and text[i] != '\n') {
                                 i += 1;
                             }
 
-                            const remain_to_print = remain[0..i];
-                            if (i < remain.len and remain[i] == '\n') {
+                            const remain_to_print = text[0..i];
+                            if (i < text.len and text[i] == '\n') {
                                 i += 1;
                             }
 
-                            if (i < remain.len and remain[i] == '\r') {
+                            if (i < text.len and text[i] == '\r') {
                                 i += 1;
                             }
 
                             try writer.print(Output.prettyFmt("<r><d>{s}<r>", true), .{remain_to_print});
-                            remain = remain[i..];
+                            text = text[i..];
                             continue;
                         }
 
                         as_multiline_comment: {
-                            if (i < remain.len and remain[i] == '*') {
+                            if (i < text.len and text[i] == '*') {
                                 i += 1;
 
-                                while (i + 2 < remain.len and !strings.eqlComptime(remain[i..][0..2], "*/")) {
+                                while (i + 2 < text.len and !strings.eqlComptime(text[i..][0..2], "*/")) {
                                     i += 1;
                                 }
 
-                                if (i + 2 < remain.len and strings.eqlComptime(remain[i..][0..2], "*/")) {
+                                if (i + 2 < text.len and strings.eqlComptime(text[i..][0..2], "*/")) {
                                     i += 2;
                                 } else {
                                     i = 1;
                                     break :as_multiline_comment;
                                 }
 
-                                try writer.print(Output.prettyFmt("<r><d>{s}<r>", true), .{remain[0..i]});
-                                remain = remain[i..];
+                                try writer.print(Output.prettyFmt("<r><d>{s}<r>", true), .{text[0..i]});
+                                text = text[i..];
                                 continue;
                             }
                         }
 
-                        try writer.writeAll(remain[0..i]);
-                        remain = remain[i..];
+                        try writer.writeAll(text[0..i]);
+                        text = text[i..];
                     },
                     '}', '{' => {
                         // support potentially highlighting "from" in an import statement
@@ -861,39 +798,39 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
                             prev_keyword = null;
                         }
 
-                        try writer.writeAll(remain[0..1]);
-                        remain = remain[1..];
+                        try writer.writeAll(text[0..1]);
+                        text = text[1..];
                     },
                     '[', ']' => {
                         prev_keyword = null;
-                        try writer.writeAll(remain[0..1]);
-                        remain = remain[1..];
+                        try writer.writeAll(text[0..1]);
+                        text = text[1..];
                     },
                     ';' => {
                         prev_keyword = null;
                         try writer.print(Output.prettyFmt("<r><d>;<r>", true), .{});
-                        remain = remain[1..];
+                        text = text[1..];
                     },
                     '.' => {
                         prev_keyword = null;
                         var i: usize = 1;
-                        if (remain.len > 1 and (js_lexer.isIdentifierStart(remain[1]) or remain[1] == '#')) {
+                        if (text.len > 1 and (js_lexer.isIdentifierStart(text[1]) or text[1] == '#')) {
                             i = 2;
 
-                            while (i < remain.len and js_lexer.isIdentifierContinue(remain[i])) {
+                            while (i < text.len and js_lexer.isIdentifierContinue(text[i])) {
                                 i += 1;
                             }
 
-                            if (i < remain.len and (remain[i] == '(')) {
-                                try writer.print(Output.prettyFmt("<r><i><b>{s}<r>", true), .{remain[0..i]});
-                                remain = remain[i..];
+                            if (i < text.len and (text[i] == '(')) {
+                                try writer.print(Output.prettyFmt("<r><i><b>{s}<r>", true), .{text[0..i]});
+                                text = text[i..];
                                 continue;
                             }
                             i = 1;
                         }
 
-                        try writer.writeAll(remain[0..1]);
-                        remain = remain[1..];
+                        try writer.writeAll(text[0..1]);
+                        text = text[1..];
                     },
 
                     '<' => {
@@ -901,44 +838,44 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
 
                         // JSX
                         jsx: {
-                            if (remain.len > 1 and remain[0] == '/') {
+                            if (text.len > 1 and text[0] == '/') {
                                 i = 2;
                             }
                             prev_keyword = null;
 
-                            while (i < remain.len and js_lexer.isIdentifierContinue(remain[i])) {
+                            while (i < text.len and js_lexer.isIdentifierContinue(text[i])) {
                                 i += 1;
                             } else {
                                 i = 1;
                                 break :jsx;
                             }
 
-                            while (i < remain.len and remain[i] != '>') {
+                            while (i < text.len and text[i] != '>') {
                                 i += 1;
 
-                                if (i < remain.len and remain[i] == '<') {
+                                if (i < text.len and text[i] == '<') {
                                     i = 1;
                                     break :jsx;
                                 }
                             }
 
-                            if (i < remain.len and remain[i] == '>') {
+                            if (i < text.len and text[i] == '>') {
                                 i += 1;
-                                try writer.print(Output.prettyFmt("<r><cyan>{s}<r>", true), .{remain[0..i]});
-                                remain = remain[i..];
+                                try writer.print(Output.prettyFmt("<r><cyan>{s}<r>", true), .{text[0..i]});
+                                text = text[i..];
                                 continue;
                             }
 
                             i = 1;
                         }
 
-                        try writer.print(Output.prettyFmt("<r>{s}<r>", true), .{remain[0..i]});
-                        remain = remain[i..];
+                        try writer.print(Output.prettyFmt("<r>{s}<r>", true), .{text[0..i]});
+                        text = text[i..];
                     },
 
                     else => {
-                        try writer.writeAll(remain[0..1]);
-                        remain = remain[1..];
+                        try writer.writeAll(text[0..1]);
+                        text = text[1..];
                     },
                 }
             }

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -2774,10 +2774,10 @@ pub const E = struct {
 
     pub const Import = struct {
         expr: ExprNodeIndex,
+        options: ExprNodeIndex = Expr.empty,
         import_record_index: u32,
-        // This will be dynamic at some point.
-        type_attribute: TypeAttribute = .none,
 
+        /// TODO:
         /// Comments inside "import()" expressions have special meaning for Webpack.
         /// Preserving comments inside these expressions makes it possible to use
         /// esbuild as a TypeScript-to-JavaScript frontend for Webpack to improve
@@ -2785,30 +2785,43 @@ pub const E = struct {
         /// because esbuild is not Webpack. But we do preserve them since doing so is
         /// harmless, easy to maintain, and useful to people. See the Webpack docs for
         /// more info: https://webpack.js.org/api/module-methods/#magic-comments.
-        /// TODO:
-        leading_interior_comments: []G.Comment = &([_]G.Comment{}),
+        // leading_interior_comments: []G.Comment = &([_]G.Comment{}),
 
         pub fn isImportRecordNull(this: *const Import) bool {
             return this.import_record_index == std.math.maxInt(u32);
         }
 
-        pub const TypeAttribute = enum {
-            none,
-            json,
-            toml,
-            text,
-            file,
+        pub fn importRecordTag(import: *const Import) ?ImportRecord.Tag {
+            const obj = import.options.data.as(.e_object) orelse
+                return null;
+            const with = obj.get("with") orelse obj.get("assert") orelse
+                return null;
+            const with_obj = with.data.as(.e_object) orelse
+                return null;
+            const str = (with_obj.get("type") orelse
+                return null).data.as(.e_string) orelse
+                return null;
 
-            pub fn tag(this: TypeAttribute) ImportRecord.Tag {
-                return switch (this) {
-                    .none => .none,
-                    .json => .with_type_json,
-                    .toml => .with_type_toml,
-                    .text => .with_type_text,
-                    .file => .with_type_file,
+            if (str.eqlComptime("json")) {
+                return .with_type_json;
+            } else if (str.eqlComptime("toml")) {
+                return .with_type_toml;
+            } else if (str.eqlComptime("text")) {
+                return .with_type_text;
+            } else if (str.eqlComptime("file")) {
+                return .with_type_file;
+            } else if (str.eqlComptime("sqlite")) {
+                const embed = brk: {
+                    const embed = with_obj.get("embed") orelse break :brk false;
+                    const embed_str = embed.data.as(.e_string) orelse break :brk false;
+                    break :brk embed_str.eqlComptime("true");
                 };
+
+                return if (embed) .with_type_sqlite_embedded else .with_type_sqlite;
             }
-        };
+
+            return null;
+        }
     };
 };
 
@@ -5461,9 +5474,8 @@ pub const Expr = struct {
                 .e_import => |el| {
                     const item = bun.create(allocator, E.Import, .{
                         .expr = try el.expr.deepClone(allocator),
+                        .options = try el.options.deepClone(allocator),
                         .import_record_index = el.import_record_index,
-                        .type_attribute = el.type_attribute,
-                        .leading_interior_comments = el.leading_interior_comments,
                     });
                     return .{ .e_import = item };
                 },

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -455,11 +455,12 @@ const BunJSX = struct {
     pub threadlocal var bun_jsx_identifier: E.Identifier = undefined;
 };
 pub fn ExpressionTransposer(
-    comptime Kontext: type,
-    comptime visitor: fn (ptr: *Kontext, arg: Expr, state: anytype) Expr,
+    comptime ContextType: type,
+    comptime StateType: type,
+    comptime visitor: fn (ptr: *ContextType, arg: Expr, state: StateType) Expr,
 ) type {
     return struct {
-        pub const Context = Kontext;
+        pub const Context = ContextType;
         pub const This = @This();
         context: *Context,
 
@@ -469,7 +470,7 @@ pub fn ExpressionTransposer(
             };
         }
 
-        pub fn maybeTransposeIf(self: *This, arg: Expr, state: anytype) Expr {
+        pub fn maybeTransposeIf(self: *This, arg: Expr, state: StateType) Expr {
             switch (arg.data) {
                 .e_if => |ex| {
                     return Expr.init(
@@ -488,7 +489,7 @@ pub fn ExpressionTransposer(
             }
         }
 
-        pub fn transposeKnownToBeIf(self: *This, arg: Expr, state: anytype) Expr {
+        pub fn transposeKnownToBeIf(self: *This, arg: Expr, state: StateType) Expr {
             return Expr.init(
                 E.If,
                 E.If{
@@ -517,7 +518,8 @@ const TransposeState = struct {
     is_then_catch_target: bool = false,
     is_require_immediately_assigned_to_decl: bool = false,
     loc: logger.Loc = logger.Loc.Empty,
-    type_attribute: E.Import.TypeAttribute = .none,
+    import_record_tag: ?ImportRecord.Tag = null,
+    import_options: Expr = Expr.empty,
 };
 
 var true_args = &[_]Expr{
@@ -5327,9 +5329,9 @@ fn NewParser_(
             return p.options.bundle and p.source.index.isRuntime();
         }
 
-        pub fn transposeImport(p: *P, arg: Expr, state: anytype) Expr {
+        pub fn transposeImport(p: *P, arg: Expr, state: *const TransposeState) Expr {
             // The argument must be a string
-            if (@as(Expr.Tag, arg.data) == .e_string) {
+            if (arg.data.as(.e_string)) |str| {
                 // Ignore calls to import() if the control flow is provably dead here.
                 // We don't want to spend time scanning the required files if they will
                 // never be used.
@@ -5337,18 +5339,19 @@ fn NewParser_(
                     return p.newExpr(E.Null{}, arg.loc);
                 }
 
-                const import_record_index = p.addImportRecord(.dynamic, arg.loc, arg.data.e_string.slice(p.allocator));
+                const import_record_index = p.addImportRecord(.dynamic, arg.loc, str.slice(p.allocator));
 
-                if (state.type_attribute.tag() != .none) {
-                    p.import_records.items[import_record_index].tag = state.type_attribute.tag();
+                if (state.import_record_tag) |tag| {
+                    p.import_records.items[import_record_index].tag = tag;
                 }
+
                 p.import_records.items[import_record_index].handles_import_errors = (state.is_await_target and p.fn_or_arrow_data_visit.try_body_count != 0) or state.is_then_catch_target;
                 p.import_records_for_current_part.append(p.allocator, import_record_index) catch unreachable;
+
                 return p.newExpr(E.Import{
                     .expr = arg,
                     .import_record_index = Ref.toInt(import_record_index),
-                    .type_attribute = state.type_attribute,
-                    // .leading_interior_comments = arg.getString().
+                    .options = state.import_options,
                 }, state.loc);
             }
 
@@ -5360,12 +5363,12 @@ fn NewParser_(
 
             return p.newExpr(E.Import{
                 .expr = arg,
+                .options = state.import_options,
                 .import_record_index = std.math.maxInt(u32),
-                .type_attribute = state.type_attribute,
             }, state.loc);
         }
 
-        pub fn transposeRequireResolve(p: *P, arg: Expr, require_resolve_ref: anytype) Expr {
+        pub fn transposeRequireResolve(p: *P, arg: Expr, require_resolve_ref: Expr) Expr {
             // The argument must be a string
             if (arg.data == .e_string) {
                 return p.transposeRequireResolveKnownString(arg);
@@ -5409,7 +5412,7 @@ fn NewParser_(
             );
         }
 
-        pub fn transposeRequire(p: *P, arg: Expr, state: anytype) Expr {
+        pub fn transposeRequire(p: *P, arg: Expr, state: *const TransposeState) Expr {
             if (!p.options.features.allow_runtime) {
                 const args = p.allocator.alloc(Expr, 1) catch bun.outOfMemory();
                 args[0] = arg;
@@ -5725,9 +5728,9 @@ fn NewParser_(
             }
         }
 
-        const ImportTransposer = ExpressionTransposer(P, P.transposeImport);
-        const RequireTransposer = ExpressionTransposer(P, P.transposeRequire);
-        const RequireResolveTransposer = ExpressionTransposer(P, P.transposeRequireResolve);
+        const ImportTransposer = ExpressionTransposer(P, *const TransposeState, P.transposeImport);
+        const RequireTransposer = ExpressionTransposer(P, *const TransposeState, P.transposeRequire);
+        const RequireResolveTransposer = ExpressionTransposer(P, Expr, P.transposeRequireResolve);
 
         const Binding2ExprWrapper = struct {
             pub const Namespace = Binding.ToExpr(P, P.wrapIdentifierNamespace);
@@ -15645,40 +15648,17 @@ fn NewParser_(
 
             const value = try p.parseExpr(.comma);
 
-            var type_attribute = E.Import.TypeAttribute.none;
-
+            var import_options = Expr.empty;
             if (p.lexer.token == .t_comma) {
                 // "import('./foo.json', )"
                 try p.lexer.next();
 
                 if (p.lexer.token != .t_close_paren) {
-                    // for now, we silently strip import assertions
                     // "import('./foo.json', { assert: { type: 'json' } })"
-                    const import_expr = try p.parseExpr(.comma);
-                    if (import_expr.data == .e_object) {
-                        if (import_expr.data.e_object.get("with") orelse import_expr.data.e_object.get("assert")) |with| {
-                            if (with.data == .e_object) {
-                                const with_object = with.data.e_object;
-                                if (with_object.get("type")) |field| {
-                                    if (field.data == .e_string) {
-                                        const str = field.data.e_string;
-                                        if (str.eqlComptime("json")) {
-                                            type_attribute = .json;
-                                        } else if (str.eqlComptime("toml")) {
-                                            type_attribute = .toml;
-                                        } else if (str.eqlComptime("text")) {
-                                            type_attribute = .text;
-                                        } else if (str.eqlComptime("file")) {
-                                            type_attribute = .file;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    import_options = try p.parseExpr(.comma);
 
                     if (p.lexer.token == .t_comma) {
-                        // "import('./foo.json', { assert: { type: 'json' } }, , )"
+                        // "import('./foo.json', { assert: { type: 'json' } }, )"
                         try p.lexer.next();
                     }
                 }
@@ -15694,18 +15674,20 @@ fn NewParser_(
 
                     return p.newExpr(E.Import{
                         .expr = value,
-                        .leading_interior_comments = comments,
+                        // .leading_interior_comments = comments,
                         .import_record_index = import_record_index,
-                        .type_attribute = type_attribute,
+                        .options = import_options,
                     }, loc);
                 }
             }
 
+            _ = comments; // TODO: leading_interior comments
+
             return p.newExpr(E.Import{
                 .expr = value,
-                .type_attribute = type_attribute,
-                .leading_interior_comments = comments,
+                // .leading_interior_comments = comments,
                 .import_record_index = std.math.maxInt(u32),
+                .options = import_options,
             }, loc);
         }
 
@@ -17568,20 +17550,6 @@ fn NewParser_(
                     }
                 },
                 .e_import => |e_| {
-                    const state = TransposeState{
-                        // we must check that the await_target is an e_import or it will crash
-                        // example from next.js where not checking causes a panic:
-                        // ```
-                        // const {
-                        //     normalizeLocalePath,
-                        //   } = require('../shared/lib/i18n/normalize-locale-path') as typeof import('../shared/lib/i18n/normalize-locale-path')
-                        // ```
-                        .is_await_target = if (p.await_target != null) p.await_target.? == .e_import and p.await_target.?.e_import == e_ else false,
-                        .is_then_catch_target = p.then_catch_chain.has_catch and std.meta.activeTag(p.then_catch_chain.next_target) == .e_import and expr.data.e_import == p.then_catch_chain.next_target.e_import,
-                        .loc = e_.expr.loc,
-                        .type_attribute = e_.type_attribute,
-                    };
-
                     // We want to forcefully fold constants inside of imports
                     // even when minification is disabled, so that if we have an
                     // import based on a string template, it does not cause a
@@ -17595,7 +17563,32 @@ fn NewParser_(
                     p.should_fold_typescript_constant_expressions = true;
 
                     e_.expr = p.visitExpr(e_.expr);
-                    return p.import_transposer.maybeTransposeIf(e_.expr, state);
+                    e_.options = p.visitExpr(e_.options);
+
+                    // Import transposition is able to duplicate the options structure, so
+                    // only perform it if the expression is side effect free.
+                    //
+                    // TODO: make this more like esbuild by emitting warnings that explain
+                    // why this import was not analyzed. (see esbuild 'unsupported-dynamic-import')
+                    if (p.exprCanBeRemovedIfUnused(&e_.options)) {
+                        const state = TransposeState{
+                            .is_await_target = if (p.await_target) |await_target|
+                                await_target == .e_import and await_target.e_import == e_
+                            else
+                                false,
+
+                            .is_then_catch_target = p.then_catch_chain.has_catch and
+                                p.then_catch_chain.next_target == .e_import and
+                                expr.data.e_import == p.then_catch_chain.next_target.e_import,
+
+                            .import_options = e_.options,
+
+                            .loc = e_.expr.loc,
+                            .import_record_tag = e_.importRecordTag(),
+                        };
+
+                        return p.import_transposer.maybeTransposeIf(e_.expr, &state);
+                    }
                 },
                 .e_call => |e_| {
                     p.call_target = e_.target.data;
@@ -17607,8 +17600,8 @@ fn NewParser_(
                     };
 
                     const target_was_identifier_before_visit = e_.target.data == .e_identifier;
-                    e_.target = p.visitExprInOut(e_.target, ExprIn{
-                        .has_chain_parent = (e_.optional_chain orelse js_ast.OptionalChain.start) == .continuation,
+                    e_.target = p.visitExprInOut(e_.target, .{
+                        .has_chain_parent = e_.optional_chain == .continuation,
                     });
 
                     // Copy the call side effect flag over if this is a known target
@@ -17694,17 +17687,18 @@ fn NewParser_(
                         if (e_.args.len == 1) {
                             const first = e_.args.first_();
                             const state = TransposeState{
-                                .is_require_immediately_assigned_to_decl = in.is_immediately_assigned_to_decl and first.data == .e_string,
+                                .is_require_immediately_assigned_to_decl = in.is_immediately_assigned_to_decl and
+                                    first.data == .e_string,
                             };
                             switch (first.data) {
                                 .e_string => {
                                     // require(FOO) => require(FOO)
-                                    return p.transposeRequire(first, state);
+                                    return p.transposeRequire(first, &state);
                                 },
                                 .e_if => {
                                     // require(FOO  ? '123' : '456') => FOO ? require('123') : require('456')
                                     // This makes static analysis later easier
-                                    return p.require_transposer.transposeKnownToBeIf(first, state);
+                                    return p.require_transposer.transposeKnownToBeIf(first, &state);
                                 },
                                 else => {},
                             }

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1919,6 +1919,8 @@ fn NewPrinter(
             level_: Level,
             flags: ExprFlag.Set,
         ) void {
+            _ = leading_interior_comments; // TODO:
+
             var level = level_;
             const wrap = level.gte(.new) or flags.contains(.forbid_call);
             if (wrap) p.print("(");
@@ -2090,14 +2092,14 @@ fn NewPrinter(
             }
 
             // External import()
-            if (leading_interior_comments.len > 0) {
-                p.printNewline();
-                p.indent();
-                for (leading_interior_comments) |comment| {
-                    p.printIndentedComment(comment.text);
-                }
-                p.printIndent();
-            }
+            // if (leading_interior_comments.len > 0) {
+            //     p.printNewline();
+            //     p.indent();
+            //     for (leading_interior_comments) |comment| {
+            //         p.printIndentedComment(comment.text);
+            //     }
+            //     p.printIndent();
+            // }
             p.addSourceMapping(record.range.loc);
 
             p.printSpaceBeforeIdentifier();
@@ -2138,11 +2140,11 @@ fn NewPrinter(
             }
             p.print(")");
 
-            if (leading_interior_comments.len > 0) {
-                p.printNewline();
-                p.unindent();
-                p.printIndent();
-            }
+            // if (leading_interior_comments.len > 0) {
+            //     p.printNewline();
+            //     p.unindent();
+            //     p.printIndent();
+            // }
 
             return;
         }
@@ -2514,7 +2516,6 @@ fn NewPrinter(
                     }
                 },
                 .e_import => |e| {
-
                     // Handle non-string expressions
                     if (e.isImportRecordNull()) {
                         const wrap = level.gte(.new) or flags.contains(.forbid_call);
@@ -2525,47 +2526,44 @@ fn NewPrinter(
                         p.printSpaceBeforeIdentifier();
                         p.addSourceMapping(expr.loc);
                         p.print("import(");
-                        if (e.leading_interior_comments.len > 0) {
-                            p.printNewline();
-                            p.indent();
-                            for (e.leading_interior_comments) |comment| {
-                                p.printIndentedComment(comment.text);
-                            }
-                            p.printIndent();
-                        }
+                        // TODO:
+                        // if (e.leading_interior_comments.len > 0) {
+                        //     p.printNewline();
+                        //     p.indent();
+                        //     for (e.leading_interior_comments) |comment| {
+                        //         p.printIndentedComment(comment.text);
+                        //     }
+                        //     p.printIndent();
+                        // }
                         p.printExpr(e.expr, .comma, ExprFlag.None());
 
-                        if (comptime is_bun_platform) {
+                        if (!e.options.isMissing()) {
                             // since we previously stripped type, it is a breaking change to
                             // enable this for non-bun platforms
-                            switch (e.type_attribute) {
-                                .none => {},
-                                .text => {
-                                    p.printWhitespacer(ws(", { with: { type: \"text\" } }"));
-                                },
-                                .json => {
-                                    p.printWhitespacer(ws(", { with: { type: \"json\" } }"));
-                                },
-                                .toml => {
-                                    p.printWhitespacer(ws(", { with: { type: \"toml\" } }"));
-                                },
-                                .file => {
-                                    p.printWhitespacer(ws(", { with: { type: \"file\" } }"));
-                                },
+                            if (is_bun_platform or bun.FeatureFlags.breaking_changes_1_2) {
+                                p.printWhitespacer(ws(", "));
+                                p.printExpr(e.options, .comma, .{});
                             }
                         }
 
-                        if (e.leading_interior_comments.len > 0) {
-                            p.printNewline();
-                            p.unindent();
-                            p.printIndent();
-                        }
+                        // TODO:
+                        // if (e.leading_interior_comments.len > 0) {
+                        //     p.printNewline();
+                        //     p.unindent();
+                        //     p.printIndent();
+                        // }
                         p.print(")");
                         if (wrap) {
                             p.print(")");
                         }
                     } else {
-                        p.printRequireOrImportExpr(e.import_record_index, false, e.leading_interior_comments, level, flags);
+                        p.printRequireOrImportExpr(
+                            e.import_record_index,
+                            false,
+                            &.{}, // e.leading_interior_comments,
+                            level,
+                            flags,
+                        );
                     }
                 },
                 .e_dot => |e| {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1199,6 +1199,19 @@ describe("bundler", () => {
       stdout: "false",
     },
   });
+  itBundled("edgecase/ImportOptionsArgument", {
+    files: {
+      "/entry.js": `
+        import('ext', { with: { get ''() { KEEP } } })
+          .then(function (error) {
+            console.log(error);
+          });
+      `,
+    },
+    dce: true,
+    external: ["ext"],
+    target: "bun",
+  });
   itBundled("edgecase/ConstantFoldingShiftOperations", {
     files: {
       "/entry.ts": `


### PR DESCRIPTION
### What does this PR do?

Fixes #12123

this disables `leading_interior_comments` entirely since it has not actually been implemented.

we now visit the options in `import(x, options)` during the visit pass. before this never happened. this also has the side effect of allowing this code

```ts
import("something", { with: { type: "te" + "xt" } ));
```

To use the `text` loader.

