### PR TITLE
feat(serve) Polyfill Response to improve Remix support

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1517,13 +1517,12 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             ctx.renderMissing();
         }
 
-        
-        fn renderPolyfill(ctx: *RequestContext, value: JSC.JSValue, comptime renderMissingIfInvalid: bool) bool { 
+        fn renderPolyfill(ctx: *RequestContext, value: JSC.JSValue, comptime renderMissingIfInvalid: bool) bool {
             // We need at least know the status, headers and can have or not a body
             // { status: number, headers: Header, body: ReadableStream | null }
             value.ensureStillAlive();
-            if(!value.isObject()) {
-                if(comptime renderMissingIfInvalid) {
+            if (!value.isObject()) {
+                if (comptime renderMissingIfInvalid) {
                     renderMissingInvalidResponse(ctx, value);
                 }
                 return false;
@@ -1531,41 +1530,40 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             const globalThis = ctx.server.globalThis;
             var status_code: u16 = 0;
             // status is required
-            if(value.get(globalThis, "status")) |status_js| {
-                if(status_js.isNumber()) {
+            if (value.get(globalThis, "status")) |status_js| {
+                if (status_js.isNumber()) {
                     status_code = status_js.to(u16);
                 } else {
-                    if(comptime renderMissingIfInvalid) {
+                    if (comptime renderMissingIfInvalid) {
                         renderMissingInvalidResponse(ctx, value);
                     }
                     return false;
                 }
             } else {
-                if(comptime renderMissingIfInvalid) {
+                if (comptime renderMissingIfInvalid) {
                     renderMissingInvalidResponse(ctx, value);
                 }
                 return false;
             }
 
-
             var headers: ?*JSC.FetchHeaders = null;
             var deinit_headers = false;
             // headers are required
             if (value.get(globalThis, "headers")) |js_headers| {
-                if(js_headers.as(JSC.FetchHeaders)) |headers_| {
+                if (js_headers.as(JSC.FetchHeaders)) |headers_| {
                     headers = headers_;
-                } else if(JSC.FetchHeaders.createFromJS(globalThis, js_headers)) |headers_| {
+                } else if (JSC.FetchHeaders.createFromJS(globalThis, js_headers)) |headers_| {
                     // should we allow this branch? maybe Headers are also Polyfill?
                     headers = headers_;
                     deinit_headers = true;
                 } else {
-                    if(comptime renderMissingIfInvalid) {
+                    if (comptime renderMissingIfInvalid) {
                         renderMissingInvalidResponse(ctx, value);
                     }
                     return false;
                 }
             } else {
-                if(comptime renderMissingIfInvalid) {
+                if (comptime renderMissingIfInvalid) {
                     renderMissingInvalidResponse(ctx, value);
                 }
                 return false;
@@ -1576,23 +1574,23 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             ctx.flags.response_protected = true;
             JSC.C.JSValueProtect(globalThis, value.asObjectRef());
 
-            defer if(deinit_headers) headers.?.deref();
-                                                                      
+            defer if (deinit_headers) headers.?.deref();
+
             ctx.renderPolyfillMetadata(status_code, headers);
 
             // body is optional
             if (value.get(globalThis, "body")) |body| {
-                if(JSC.WebCore.ReadableStream.fromJS(body, globalThis)) |stream| {
+                if (JSC.WebCore.ReadableStream.fromJS(body, globalThis)) |stream| {
                     ctx.setAbortHandler();
                     var body_value: JSC.WebCore.Body.Value = .{
-                        .Locked  = .{
+                        .Locked = .{
                             .readable = JSC.WebCore.ReadableStream.Strong.init(stream, globalThis),
                             .global = globalThis,
                         },
                     };
                     ctx.doRenderWithBody(&body_value);
                 } else {
-                     ctx.renderMissingCorked();
+                    ctx.renderMissingCorked();
                 }
             } else {
                 ctx.renderMissingCorked();
@@ -2578,7 +2576,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                             // TODO: should this timeout?
                             this.setAbortHandler();
                             this.ref();
-                            if(this.response_ptr) |response_ptr| {
+                            if (this.response_ptr) |response_ptr| {
                                 response_ptr.body.value = .{
                                     .Locked = .{
                                         .readable = JSC.WebCore.ReadableStream.Strong.init(stream, globalThis),
@@ -3286,7 +3284,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     } else if (result.as(Response)) |response| {
                         this.render(response);
                         return;
-                    } else if(this.renderPolyfill(result, false)) {
+                    } else if (this.renderPolyfill(result, false)) {
                         return;
                     }
                 }
@@ -3489,7 +3487,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 this.flags.needs_content_range = false;
             }
         }
-        
+
         pub fn renderPolyfillMetadata(this: *RequestContext, status_code: u16, headers: ?*JSC.FetchHeaders) void {
             if (this.resp == null) return;
             const resp = this.resp.?;


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/2532
Fix: https://github.com/oven-sh/bun/issues/10787
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Added tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
