### PR TITLE
build(windows): fix esbuild errors when bundling node-fallbacks

### DIFF
--- a/scripts/make-old-js.ps1
+++ b/scripts/make-old-js.ps1
@@ -5,11 +5,20 @@ $npm_client = "npm"
 $root = Join-Path (Split-Path -Path $MyInvocation.MyCommand.Definition -Parent) "..\"
 
 # search for .cmd or .exe 
-$esbuild = Join-Path $root "node_modules\.bin\esbuild.cmd"
-if (!(Test-Path $esbuild)) {
-    $esbuild = Join-Path $root "node_modules\.bin\esbuild.exe"
+function Get-Esbuild-Path {
+  param(
+      $Path
+  )
+
+  $Result = Join-Path $Path "node_modules\.bin\esbuild.cmd"
+  if (Test-Path $Result) {
+      return $Result
+  }
+
+  return Join-Path $Path "node_modules\.bin\esbuild.exe"
 }
 
+$esbuild = Get-Esbuild-Path $root
 
 $env:NODE_ENV = "production"
 
@@ -34,5 +43,5 @@ Pop-Location
 # node-fallbacks
 Push-Location src\node-fallbacks
 & ${npm_client} install
-& ${esbuild} --bundle @(Get-Item .\*.js) --outdir=out --format=esm --minify --platform=browser
+& (Get-Esbuild-Path (Get-Location)) --bundle @(Get-Item .\*.js) --outdir=out --format=esm --minify --platform=browser
 Pop-Location


### PR DESCRIPTION
### What does this PR do?

This PR fixes errors that occurs when esbuild bundles node-fallbacks.

<details>
<summary>Error logs</summary>

```
up to date, audited 112 packages in 1s

27 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
X [ERROR] Could not resolve "http"

    node_modules/https-browserify/index.js:1:19:
      1 │ var http = require('http')
        ╵                    ~~~~~~

  The package "http" wasn't found on the file system but is built into node. Are you trying to
  bundle for node? You can use "--platform=node" to do that, which will remove this error.

X [ERROR] Could not resolve "stream"

    node_modules/browserify-zlib/lib/index.js:4:24:
      4 │ var Transform = require('stream').Transform;
        ╵                         ~~~~~~~~

  The package "stream" wasn't found on the file system but is built into node. Are you trying to
  bundle for node? You can use "--platform=node" to do that, which will remove this error.

X [ERROR] Could not resolve "stream"

    node_modules/cipher-base/index.js:2:24:
      2 │ var Transform = require('stream').Transform
        ╵                         ~~~~~~~~

  The package "stream" wasn't found on the file system but is built into node. Are you trying to
  bundle for node? You can use "--platform=node" to do that, which will remove this error.

X [ERROR] Could not resolve "stream"

    node_modules/hash-base/index.js:3:24:
      3 │ var Transform = require('stream').Transform
        ╵                         ~~~~~~~~

  The package "stream" wasn't found on the file system but is built into node. Are you trying to
  bundle for node? You can use "--platform=node" to do that, which will remove this error.

4 errors
node:child_process:929
    throw err;
    ^

Error: Command failed: C:\Users\Hibana\Desktop\bun-experiments\node_modules\@esbuild\win32-x64\esbuild.exe --bundle C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\assert.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\buffer.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\console.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\constants.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\crypto.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\domain.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\events.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\http.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\https.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\net.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\os.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\path.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\process.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\punycode.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\querystring.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\stream.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\string_decoder.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\sys.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\timers.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\tty.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\url.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\util.js C:\Users\Hibana\Desktop\bun-experiments\src\node-fallbacks\zlib.js --outdir=out --format=esm --minify --platform=browser
    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:538:14)
    at checkExecSyncError (node:child_process:890:11)
    at Object.execFileSync (node:child_process:926:15)
    at Object.<anonymous> (C:\Users\Hibana\Desktop\bun-experiments\node_modules\esbuild\bin\esbuild:219:28)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 11580,
  stdout: null,
  stderr: null
}

Node.js v20.15.1
PS C:\Users\Hibana\Desktop\bun-experiments> .\node_modules\.bin\esbuild.exe --version
0.21.5
PS C:\Users\Hibana\Desktop\bun-experiments>
```
</details>

This is windows-only bug because Makefile for Linux/macOS runs npm script to build `node-fallbacks` which uses esbuild version `^0.14.10` from `node-fallbacks` package.json (current `make-old-js.ps1` uses esbuild version from project root node_modules, which is `^0.21.4`). 

As I investigated, the bug appeared after d105b048b1bcaeb19ce6b644276a343259420470 commit with esbuild version bump. If we try to install esbuild with version `^0.17.15`, this bug will disappear (without changes in scripts).
<details>
<summary>Logs with installed esbuild 0.17.19</summary>

```
up to date, audited 112 packages in 1s

27 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

  out\crypto.js          642.2kb
  out\zlib.js            233.2kb
  out\https.js           132.1kb
  out\http.js            131.8kb
  out\stream.js          115.7kb
  out\assert.js           65.8kb
  out\querystring.js      33.9kb
  out\string_decoder.js   32.2kb
  out\util.js             30.7kb
  out\sys.js              30.5kb
  out\buffer.js           27.9kb
  out\url.js               8.0kb
  out\domain.js            7.2kb
  out\events.js            6.0kb
  out\path.js              4.8kb
  out\timers.js            3.4kb
  out\process.js           2.3kb
  out\punycode.js          2.3kb
  out\os.js                1.6kb
  out\net.js               715b
  out\tty.js               283b
  out\console.js            36b
  out\constants.js           0b

Done in 156ms
PS C:\Users\Hibana\Desktop\bun-experiments> .\node_modules\.bin\esbuild.exe --version
0.17.19
PS C:\Users\Hibana\Desktop\bun-experiments>
```
</details>


</details>

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<details>
<summary>Logs with fix from this PR</summary>

```
up to date, audited 112 packages in 1s

27 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

  out\crypto.js          642.5kb
  out\zlib.js            233.0kb
  out\https.js           132.0kb
  out\http.js            131.7kb
  out\stream.js          115.7kb
  out\assert.js           65.6kb
  out\querystring.js      33.8kb
  out\string_decoder.js   32.1kb
  out\util.js             30.7kb
  out\sys.js              30.5kb
  out\buffer.js           27.8kb
  out\url.js               8.0kb
  out\domain.js            7.2kb
  out\events.js            6.0kb
  out\path.js              4.8kb
  out\timers.js            3.4kb
  out\process.js           2.3kb
  out\punycode.js          2.3kb
  out\os.js                1.6kb
  out\net.js               715b
  out\tty.js               283b
  out\console.js            36b
  out\constants.js           0b

Done in 153ms
PS C:\Users\Hibana\Desktop\bun-experiments> .\node_modules\.bin\esbuild.exe --version
0.21.5
PS C:\Users\Hibana\Desktop\bun-experiments>
```