### PR TITLE
fix(setSystemTime) fix number parameter behavior

### DIFF
--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -1363,7 +1363,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalO
         return JSValue::encode(callFrame->thisValue());
     }
     // number > 0 is a valid date otherwise it's invalid and we should reset the time (set to -1)
-    globalObject->overridenDateNow = (argument0.isNumber() && argument0.asNumber() > 0) ? argument0.asNumber() : -1;
+    globalObject->overridenDateNow = (argument0.isNumber() && argument0.asNumber() >= 0) ? argument0.asNumber() : -1;
 
     return JSValue::encode(callFrame->thisValue());
 }

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -1362,12 +1362,9 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalO
         }
         return JSValue::encode(callFrame->thisValue());
     }
+    // number > 0 is a valid date otherwise it's invalid and we should reset the time (set to -1)
+    globalObject->overridenDateNow = (argument0.isNumber() && argument0.asNumber() > 0) ? argument0.asNumber() : -1;
 
-    if (argument0.isNumber() && argument0.asNumber() > 0) {
-        globalObject->overridenDateNow = argument0.asNumber();
-    }
-
-    globalObject->overridenDateNow = -1;
     return JSValue::encode(callFrame->thisValue());
 }
 

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -20,7 +20,9 @@ test("we can go back in time", () => {
     expect(DateBeforeMocked).not.toBe(Date);
     expect(DateBeforeMocked.now).not.toBe(Date.now);
   }
-
+  jest.setSystemTime(new Date("2020-01-01T00:00:00.000Z").getTime());
+  expect(new Date().toISOString()).toBe("2020-01-01T00:00:00.000Z");
+  expect(Date.now()).toBe(1577836800000);
   jest.useRealTimers();
   const now = new Date();
   now.setHours(0, 0, 0, 0);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix: https://github.com/oven-sh/bun/issues/12626
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
