### PR TITLE
bun-sqlite: add sqlite3_update_hook

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -487,6 +487,46 @@ declare module "bun:sqlite" {
      * @link https://www.sqlite.org/c3ref/file_control.html
      */
     fileControl(zDbName: string, op: number, arg?: ArrayBufferView | number): number;
+
+    /**
+     * Registers a listener for the specified update type.
+     * @param {("insert" | "update" | "delete")} updateType - The type of update to listen for.
+     * @param {(dbName: string, tableName: string, rowId: number) => void} listener - The callback function to be invoked when the event occurs.
+     */
+    on(
+      updateType: "insert" | "update" | "delete",
+      listener: (dbName: string, tableName: string, rowId: number) => void,
+    ): void;
+
+    /**
+     * Unregisters a listener for the specified update type.
+     * @param {("insert" | "update" | "delete")} updateType - The type of update the listener was registered for.
+     * @param {(dbName: string, tableName: string, rowId: number) => void} listener - The callback function to be removed.
+     */
+    off(
+      updateType: "insert" | "update" | "delete",
+      listener: (dbName: string, tableName: string, rowId: number) => void,
+    ): void;
+
+    /**
+     * Registers a listener for the specified update type.
+     * @param {("insert" | "update" | "delete")} updateType - The type of update to listen for.
+     * @param {(dbName: string, tableName: string, rowId: number) => void} listener - The callback function to be invoked when the event occurs.
+     */
+    addEventListener(
+      updateType: "insert" | "update" | "delete",
+      listener: (dbName: string, tableName: string, rowId: number) => void,
+    ): void;
+
+    /**
+     * Unregisters a listener for the specified update type.
+     * @param {("insert" | "update" | "delete")} updateType - The type of update the listener was registered for.
+     * @param {(dbName: string, tableName: string, rowId: number) => void} listener - The callback function to be removed.
+     */
+    removeEventListener(
+      updateType: "insert" | "update" | "delete",
+      listener: (dbName: string, tableName: string, rowId: number) => void,
+    ): void;
   }
 
   /**

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -1764,6 +1764,110 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
 
     return JSValue::encode(jsNumber(statusCode));
 }
+typedef struct {
+    Strong<JSC::JSGlobalObject> globalObject;
+    Strong<JSC::JSFunction> callback;
+} UpdateHookData;
+
+UpdateHookData * data = nullptr;
+
+void on_update_hook(void * dataPtr, int type, const char * dbName, const char * tableName, sqlite_int64 rowId) {
+    UpdateHookData* data = (UpdateHookData *)dataPtr;
+
+    auto globalObject = data->globalObject.get();
+    auto callback = data->callback.get();
+
+    JSValue typeValue = jsNumber(type);
+    JSValue dbNameValue = jsString(globalObject->vm(), makeString(ASCIILiteral::fromLiteralUnsafe(dbName)));
+    JSValue tableNameValue = jsString(globalObject->vm(), makeString(ASCIILiteral::fromLiteralUnsafe(tableName)));
+    JSValue rowIdValue = jsNumber(rowId);
+
+    JSC::CallData callData = JSC::getCallData(callback);
+    JSC::MarkedArgumentBuffer args;
+    args.append(typeValue);
+    args.append(dbNameValue);
+    args.append(tableNameValue);
+    args.append(rowIdValue);
+    call(data->globalObject.get(), callback, callData, JSC::jsUndefined(), args);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsSQLStatementUpdateHookFunction, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    JSC::VM& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    UpdateHookData * tmp = nullptr;
+
+    JSValue thisValue = callFrame->thisValue();
+    JSSQLStatementConstructor* thisObject = jsDynamicCast<JSSQLStatementConstructor*>(thisValue.getObject());
+    if (UNLIKELY(!thisObject)) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected SQLStatement"_s));
+        return JSValue::encode(jsUndefined());
+    }
+
+    if (callFrame->argumentCount() < 2) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected 2 arguments"_s));
+        return JSValue::encode(jsUndefined());
+    }
+
+    JSValue dbNumber = callFrame->argument(0);
+    JSValue cb = callFrame->argument(1);
+
+    if (!dbNumber.isNumber()) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected number"_s));
+        return JSValue::encode(jsUndefined());
+    }
+
+    int dbIndex = dbNumber.toInt32(lexicalGlobalObject);
+    if (dbIndex < 0 || dbIndex >= databases().size()) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Invalid database handle"_s));
+        return JSValue::encode(jsUndefined());
+    }
+
+    sqlite3* db = databases()[dbIndex]->db;
+    // no-op if already closed
+    if (!db) {
+        return JSValue::encode(jsUndefined());
+    }
+
+    // A null callback disables the hook
+    if (cb.isNull()) {
+        sqlite3_update_hook(db, nullptr, nullptr);
+        if (data != nullptr) {
+            data->callback.clear();
+            data->globalObject.clear();
+            delete data;
+        } 
+        return JSValue::encode(jsUndefined());
+    }
+
+    // If it wasn't null, it must be a function
+    if (!cb.isCallable()) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Expected callback"_s));
+        return JSValue::encode(jsUndefined());
+    }
+
+    JSFunction* callback = jsCast<JSFunction*>(cb);
+
+    if (data != nullptr) {
+        tmp = data;
+    }
+    data = new UpdateHookData;
+
+    Strong callbackRef = Strong<JSFunction>(vm, callback); 
+    Strong globalObjectRef = Strong<JSGlobalObject>(vm, lexicalGlobalObject);
+    data->callback = callbackRef;
+    data->globalObject = globalObjectRef;
+
+   sqlite3_update_hook(db, on_update_hook, data);
+
+    if (tmp != nullptr) {
+        tmp->callback.clear();
+        tmp->globalObject.clear();
+        delete tmp;
+    }
+
+    return JSValue::encode(jsUndefined());
+}
 
 /* Hash table for constructor */
 static const HashTableValue JSSQLStatementConstructorTableValues[] = {
@@ -1777,6 +1881,7 @@ static const HashTableValue JSSQLStatementConstructorTableValues[] = {
     { "serialize"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementSerialize, 1 } },
     { "deserialize"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementDeserialize, 2 } },
     { "fcntl"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementFcntlFunction, 2 } },
+    { "updateHook"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementUpdateHookFunction, 2 } },
 };
 
 const ClassInfo JSSQLStatementConstructor::s_info = { "SQLStatement"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSSQLStatementConstructor) };

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -1775,11 +1775,14 @@ void on_update_hook(void * dataPtr, int type, const char * dbName, const char * 
     UpdateHookData* data = (UpdateHookData *)dataPtr;
 
     auto globalObject = data->globalObject.get();
+    auto &vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    RETURN_IF_EXCEPTION(scope, void());
     auto callback = data->callback.get();
 
     JSValue typeValue = jsNumber(type);
-    JSValue dbNameValue = jsString(globalObject->vm(), makeString(ASCIILiteral::fromLiteralUnsafe(dbName)));
-    JSValue tableNameValue = jsString(globalObject->vm(), makeString(ASCIILiteral::fromLiteralUnsafe(tableName)));
+    JSValue dbNameValue = jsString(globalObject->vm(), String::fromUTF8(dbName));
+    JSValue tableNameValue = jsString(globalObject->vm(), String::fromUTF8(tableName));
     JSValue rowIdValue = jsNumber(rowId);
 
     JSC::CallData callData = JSC::getCallData(callback);

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -93,11 +93,11 @@ const constants = {
 };
 
 // https://www.sqlite.org/c3ref/c_alter_table.html
-const sqliteActionCodes = {
-  SQLITE_DELETE: 9,
-  SQLITE_INSERT: 18,
-  SQLITE_UPDATE: 23,
-};
+const enum sqliteActionCodes {
+  SQLITE_DELETE = 9,
+  SQLITE_INSERT = 18,
+  SQLITE_UPDATE = 23,
+}
 
 var SQL;
 

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -1,3 +1,4 @@
+const { EventEmitter } = require("node:events");
 // Hardcoded module "sqlite"
 
 const kSafeIntegersFlag = 1 << 1;
@@ -89,6 +90,13 @@ const constants = {
   SQLITE_FCNTL_EXTERNAL_READER: 40,
   SQLITE_FCNTL_CKSM_FILE: 41,
   SQLITE_FCNTL_RESET_CACHE: 42,
+};
+
+// https://www.sqlite.org/c3ref/c_alter_table.html
+const sqliteActionCodes = {
+  SQLITE_DELETE: 9,
+  SQLITE_INSERT: 18,
+  SQLITE_UPDATE: 23,
 };
 
 var SQL;
@@ -336,6 +344,7 @@ class Database {
   #cachedQueriesValues = [];
   filename;
   #hasClosed = false;
+  #eventEmitter = new EventEmitter();
   get handle() {
     return this.#handle;
   }
@@ -500,6 +509,47 @@ class Database {
 
     // Return the default version of the transaction function
     return properties.default.value;
+  }
+
+  private hasAnyListeners(): boolean {
+    const events = this.#eventEmitter.eventNames();
+    return events.some(event => this.#eventEmitter.listenerCount(event) > 0);
+  }
+
+  private onUpdate(type: number, dbName: string, tableName: string, rowId: number) {
+    if (type === sqliteActionCodes.SQLITE_INSERT) {
+      this.#eventEmitter.emit("insert", dbName, tableName, rowId);
+    }
+    if (type === sqliteActionCodes.SQLITE_UPDATE) {
+      this.#eventEmitter.emit("update", dbName, tableName, rowId);
+    }
+    if (type === sqliteActionCodes.SQLITE_DELETE) {
+      this.#eventEmitter.emit("delete", dbName, tableName, rowId);
+    }
+  }
+
+  on(type, listener) {
+    if (!this.hasAnyListeners()) {
+      SQL.updateHook(this.#handle, this.onUpdate.bind(this));
+    }
+
+    this.#eventEmitter.on(type, listener);
+  }
+
+  off(type, listener) {
+    this.#eventEmitter.off(type, listener);
+
+    if (!this.hasAnyListeners()) {
+      SQL.updateHook(this.#handle, null);
+    }
+  }
+
+  addEventListener(type, listener) {
+    this.on(type, listener);
+  }
+
+  removeEventListener(type, listener) {
+    this.off(type, listener);
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Add some methods to `Database` to listen for Data Change Notification Callbacks provided by `sqlite3_update_hook` https://www.sqlite.org/c3ref/update_hook.html

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

 I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test sqlite.test.js`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
