### PR TITLE
fix(bundler): importing modules with trailing slash no longer uses a builtin

### DIFF
--- a/src/import_record.zig
+++ b/src/import_record.zig
@@ -7,7 +7,6 @@ const Index = @import("ast/base.zig").Index;
 const Api = @import("./api/schema.zig").Api;
 
 pub const ImportKind = enum(u8) {
-
     // An entry point provided by the user
     entry_point,
 

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1443,6 +1443,20 @@ describe("bundler", () => {
       "/entry.ts": [`"Y" has already been declared`],
     },
   });
+  itBundled("edgecase/BuiltinWithTrailingSlash", {
+    files: {
+      "/entry.js": `
+        import * as process from 'process/';
+        console.log(JSON.stringify(process));
+      `,
+      "/node_modules/process/index.js": `
+        export default { hello: 'world' };
+      `,
+    },
+    run: {
+      stdout: `{"default":{"hello":"world"}}`,
+    },
+  });
 
   // TODO(@paperdave): test every case of this. I had already tested it manually, but it may break later
   const requireTranspilationListESM = [


### PR DESCRIPTION
### What does this PR do?

Fixes #12057 

Most of this PR just adds debug-only tools for debugging future module resolver bugs.

The relevant code to fix this is:

```diff
            // Check for external packages first
-           if (r.opts.external.node_modules.count() > 0) {
+           if (r.opts.external.node_modules.count() > 0 and
+               // Imports like "process/" need to resolve to the filesystem, not a builtin
+               !strings.hasSuffixComptime(import_path, "/"))
+           {
```