### PR TITLE
Fix truncating in BigIntStats

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1444,10 +1444,10 @@ pub fn StatType(comptime Big: bool) type {
                     const Type = @TypeOf(value);
                     if (comptime Big and @typeInfo(Type) == .Int) {
                         if (Type == u64) {
-                            return JSC.JSValue.fromUInt64NoTruncate(globalObject, @intCast(value));
+                            return JSC.JSValue.fromUInt64NoTruncate(globalObject, value);
                         }
 
-                        return JSC.JSValue.fromInt64NoTruncate(globalObject, @intCast(value));
+                        return JSC.JSValue.fromInt64NoTruncate(globalObject, value);
                     }
 
                     return JSC.JSValue.jsNumber(value);

--- a/src/js/node/stream.ts
+++ b/src/js/node/stream.ts
@@ -5720,7 +5720,7 @@ function createNativeStreamReadable(Readable) {
       ProcessNextTick(() => {
         this.push(null);
       });
-      return view?.byteLength ?? 0 > 0 ? view : undefined;
+      return (view?.byteLength ?? 0 > 0) ? view : undefined;
     } else if ($isTypedArrayView(result)) {
       if (result.byteLength >= this[highWaterMark] && !this[hasResized] && !isClosed) {
         this[_adjustHighWaterMark]();

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1259,7 +1259,7 @@ for (const [key, blob] of build.outputs) {
         const outfiletext = api.readFile(path.relative(root, outfile ?? outputPaths[0]));
         const regex = /\/\/\s+(.+?)\nvar\s+([a-zA-Z0-9_$]+)\s+=\s+__commonJS/g;
         const matches = [...outfiletext.matchAll(regex)].map(match => ("/" + match[1]).replaceAll("\\", "/"));
-        const expectedMatches = (cjs2esm === true ? [] : cjs2esm.unhandled ?? []).map(a => a.replaceAll("\\", "/"));
+        const expectedMatches = (cjs2esm === true ? [] : (cjs2esm.unhandled ?? [])).map(a => a.replaceAll("\\", "/"));
         try {
           expect(matches.sort()).toEqual(expectedMatches.sort());
         } catch (error) {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -891,7 +891,7 @@ function createTest(input?: string | (string | { filename: string; contents: str
   const inputs = Array.isArray(input) ? input : [input ?? ""];
   for (const input of inputs) {
     const contents = typeof input === "string" ? input : input.contents;
-    const name = typeof input === "string" ? filename ?? `bun-test-${Math.random()}.test.ts` : input.filename;
+    const name = typeof input === "string" ? (filename ?? `bun-test-${Math.random()}.test.ts`) : input.filename;
 
     const path = join(cwd, name);
     try {

--- a/test/integration/next-pages/src/pages/index.tsx
+++ b/test/integration/next-pages/src/pages/index.tsx
@@ -122,7 +122,7 @@ export async function getStaticProps() {
       bunVersion:
         process.env.NODE_ENV === "production"
           ? "[production needs a constant string]"
-          : process.versions.bun ?? "not in bun",
+          : (process.versions.bun ?? "not in bun"),
     },
   };
 }

--- a/test/js/node/fs/fs-stats-truncate.test.ts
+++ b/test/js/node/fs/fs-stats-truncate.test.ts
@@ -1,0 +1,43 @@
+// BUN-2C1
+//   const value = @field(this, @tagName(field));
+//  if (comptime (Big and @typeInfo(@TypeOf(value)) == .Int)) {
+//    return JSC.JSValue.fromInt64NoTruncate(globalObject, @intCast(value));
+//  }
+import { Stats, statSync } from "node:fs";
+import { test, expect } from "bun:test";
+
+test("fs.stats truncate", async () => {
+  const stats = new Stats(...Array.from({ length: 14 }, () => Number.MAX_VALUE));
+  expect(stats.dev).toBeNumber();
+  expect(stats.mode).toBeNumber();
+  expect(stats.nlink).toBeNumber();
+  expect(stats.uid).toBeNumber();
+  expect(stats.gid).toBeNumber();
+  expect(stats.rdev).toBeNumber();
+  expect(stats.blksize).toBeNumber();
+  expect(stats.ino).toBeNumber();
+  expect(stats.size).toBeNumber();
+  expect(stats.blocks).toBeNumber();
+  expect(stats.atimeMs).toBeNumber();
+  expect(stats.mtimeMs).toBeNumber();
+  expect(stats.ctimeMs).toBeNumber();
+  expect(stats.birthtimeMs).toBeNumber();
+});
+
+test("fs.stats truncate (bigint)", async () => {
+  const stats = statSync(import.meta.path, { bigint: true });
+  expect(stats.dev).toBeTypeOf("bigint");
+  expect(stats.mode).toBeTypeOf("bigint");
+  expect(stats.nlink).toBeTypeOf("bigint");
+  expect(stats.uid).toBeTypeOf("bigint");
+  expect(stats.gid).toBeTypeOf("bigint");
+  expect(stats.rdev).toBeTypeOf("bigint");
+  expect(stats.blksize).toBeTypeOf("bigint");
+  expect(stats.ino).toBeTypeOf("bigint");
+  expect(stats.size).toBeTypeOf("bigint");
+  expect(stats.blocks).toBeTypeOf("bigint");
+  expect(stats.atimeMs).toBeTypeOf("bigint");
+  expect(stats.mtimeMs).toBeTypeOf("bigint");
+  expect(stats.ctimeMs).toBeTypeOf("bigint");
+  expect(stats.birthtimeMs).toBeTypeOf("bigint");
+});

--- a/test/js/node/fs/fs-stats-truncate.test.ts
+++ b/test/js/node/fs/fs-stats-truncate.test.ts
@@ -8,20 +8,20 @@ import { test, expect } from "bun:test";
 
 test("fs.stats truncate", async () => {
   const stats = new Stats(...Array.from({ length: 14 }, () => Number.MAX_VALUE));
-  expect(stats.dev).toBeNumber();
-  expect(stats.mode).toBeNumber();
-  expect(stats.nlink).toBeNumber();
-  expect(stats.uid).toBeNumber();
-  expect(stats.gid).toBeNumber();
-  expect(stats.rdev).toBeNumber();
-  expect(stats.blksize).toBeNumber();
-  expect(stats.ino).toBeNumber();
-  expect(stats.size).toBeNumber();
-  expect(stats.blocks).toBeNumber();
-  expect(stats.atimeMs).toBeNumber();
-  expect(stats.mtimeMs).toBeNumber();
-  expect(stats.ctimeMs).toBeNumber();
-  expect(stats.birthtimeMs).toBeNumber();
+  expect(stats.dev).toBeGreaterThan(0);
+  expect(stats.mode).toBeGreaterThan(0);
+  expect(stats.nlink).toBeGreaterThan(0);
+  expect(stats.uid).toBeGreaterThan(0);
+  expect(stats.gid).toBeGreaterThan(0);
+  expect(stats.rdev).toBeGreaterThan(0);
+  expect(stats.blksize).toBeGreaterThan(0);
+  expect(stats.ino).toBeGreaterThan(0);
+  expect(stats.size).toBeGreaterThan(0);
+  expect(stats.blocks).toBeGreaterThan(0);
+  expect(stats.atimeMs).toBeGreaterThan(0);
+  expect(stats.mtimeMs).toBeGreaterThan(0);
+  expect(stats.ctimeMs).toBeGreaterThan(0);
+  expect(stats.birthtimeMs).toBeGreaterThan(0);
 });
 
 test("fs.stats truncate (bigint)", async () => {

--- a/test/snippets/bundled-entry-point.js
+++ b/test/snippets/bundled-entry-point.js
@@ -1,6 +1,6 @@
 import "react";
 
-var hello = 123 ? null ?? "world" : "ok";
+var hello = 123 ? (null ?? "world") : "ok";
 
 export function test() {
   return testDone(import.meta.url);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
