### PR TITLE
Fix error in plugins.md

### DIFF
--- a/docs/runtime/plugins.md
+++ b/docs/runtime/plugins.md
@@ -164,7 +164,7 @@ In this case we're using `"object"`—a built-in loader (intended for use by plu
 
 - `wasm`
 - `.wasm`
-- Import a native Node.js addon
+- Import a WebAssemby module
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

Changed `Import a native Node.js addon` to `Import a WebAssembly module` for `.wasm` file extension

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes