### PR TITLE
Fix expect.toThrow(expect.any()) matcher to correctly handle ExpectAny objects

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -2285,7 +2285,11 @@ pub const Expect = struct {
                 globalThis.throw("Expected value must be string or Error: {any}", .{value.toFmt(globalThis, &fmt)});
                 return .zero;
             } else if (value.isObject()) {
-                if (ExpectAny.constructorValueGetCached(value)) |v| break :brk v;
+                if (ExpectAny.fromJSDirect(value)) |_| {
+                    if (ExpectAny.constructorValueGetCached(value)) |innerConstructorValue| {
+                        break :brk innerConstructorValue;
+                    }
+                }
             }
             break :brk value;
         } else .zero;

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -2284,6 +2284,8 @@ pub const Expect = struct {
                 var fmt = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
                 globalThis.throw("Expected value must be string or Error: {any}", .{value.toFmt(globalThis, &fmt)});
                 return .zero;
+            } else if (value.isObject()) {
+                if (ExpectAny.constructorValueGetCached(value)) |v| break :brk v;
             }
             break :brk value;
         } else .zero;

--- a/test/regression/issue/12650.test.js
+++ b/test/regression/issue/12650.test.js
@@ -1,0 +1,23 @@
+import {expect, describe, it} from "bun:test";
+
+// Custom class for testing
+class CustomException extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CustomException";
+  }
+}
+
+describe('Test expect.toThrow(expect.any())', () => {
+  it('should throw an error', () => {
+    expect(() => {
+      throw new CustomException("Custom error message")
+    }).toThrow(expect.any(Error))
+  })
+
+  it('should throw a CustomException', () => {
+    expect(() => {
+      throw new CustomException("Custom error message")
+    }).toThrow(expect.any(CustomException))
+  })
+})


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue with the `expect.toThrow(expect.any())` matcher in Bun's testing framework. Previously, this matcher was not correctly handling `ExpectAny` objects created by `expect.any()`, leading to test failures that would pass in Jest.
Link to the issue: https://github.com/oven-sh/bun/issues/12650

Specifically, this PR:

- Modifies the `toThrow` matcher to correctly unwrap `ExpectAny` objects
- Ensures that the constructor comparison is done with the actual constructor passed to `expect.any()`, rather than the `ExpectAny` object itself

- [x] Code changes

### How did you verify your code works?

I wrote automated tests to verify the fix:
```ts
import {expect, describe, it} from "bun:test";

// Custom class for testing
class CustomException extends Error {
  constructor(message: string) {
    super(message);
    this.name = "CustomException";
  }
}

describe('Test expect.toThrow(expect.any())', () => {
  it('should throw an error', () => {
    expect(() => {
      throw new CustomException("Custom error message")
    }).toThrow(expect.any(Error))
  })

  it('should throw a CustomException', () => {
    expect(() => {
      throw new CustomException("Custom error message")
    }).toThrow(expect.any(CustomException))
  })
})
```
This test now passes in Bun, matching the behavior in Jest.

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test.ts`)

### Additional Notes

This fix brings Bun's `expect.toThrow(expect.any())` behavior in line with Jest's implementation, Though I'm not familiar with bun's codebase, is there a way to know if value is an instance of ExpectAny before trying to get the cached value ?