### PR TITLE
add noUncheckedIndexedAccess to tsconfig init stricter flags

### DIFF
--- a/src/cli/tsconfig-for-init.json
+++ b/src/cli/tsconfig-for-init.json
@@ -22,6 +22,7 @@
     // Some stricter flags (disabled by default)
     "noUnusedLocals": false,
     "noUnusedParameters": false,
+    "noUncheckedIndexedAccess": false,
     "noPropertyAccessFromIndexSignature": false
   }
 }


### PR DESCRIPTION
Adds the TS config option [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) to the stricter flags section generated from `bun init`. Defaults to false.
