### PR TITLE
try removing saturating subtraction for symbol uses

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -3977,7 +3977,7 @@ pub const Parser = struct {
 
                                         part.import_record_indices.push(p.allocator, right.data.e_require_string.import_record_index) catch unreachable;
                                         p.symbols.items[p.module_ref.innerIndex()].use_count_estimate = 0;
-                                        p.symbols.items[namespace_ref.innerIndex()].use_count_estimate -|= 1;
+                                        p.symbols.items[namespace_ref.innerIndex()].use_count_estimate -= 1;
                                         _ = part.symbol_uses.swapRemove(namespace_ref);
 
                                         for (before.items, 0..) |before_part, i| {
@@ -5731,7 +5731,7 @@ fn NewParser_(
             var symbols = p.symbols.items;
 
             for (symbol_use_refs, symbol_use_values) |ref, prev| {
-                symbols[ref.innerIndex()].use_count_estimate -|= prev.count_estimate;
+                symbols[ref.innerIndex()].use_count_estimate -= prev.count_estimate;
             }
             const declared_refs = part.declared_symbols.refs();
             for (declared_refs) |declared| {
@@ -18952,7 +18952,7 @@ fn NewParser_(
                     // specially. This lets us do tree shaking for cross-file TypeScript enums.
                     if (p.options.bundle and !p.is_control_flow_dead) {
                         const use = p.symbol_uses.getPtr(id.ref).?;
-                        use.count_estimate -|= 1;
+                        use.count_estimate -= 1;
                         // note: this use is not removed as we assume it exists later
 
                         // Add a special symbol use instead
@@ -19044,9 +19044,9 @@ fn NewParser_(
         pub fn ignoreUsage(p: *P, ref: Ref) void {
             if (!p.is_control_flow_dead and !p.is_revisit_for_substitution) {
                 if (comptime Environment.allow_assert) assert(@as(usize, ref.innerIndex()) < p.symbols.items.len);
-                p.symbols.items[ref.innerIndex()].use_count_estimate -|= 1;
+                p.symbols.items[ref.innerIndex()].use_count_estimate -= 1;
                 var use = p.symbol_uses.get(ref) orelse return;
-                use.count_estimate -|= 1;
+                use.count_estimate -= 1;
                 if (use.count_estimate == 0) {
                     _ = p.symbol_uses.swapRemove(ref);
                 } else {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
