### PR TITLE
Add getBuiltinModule function to Process object

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -6,16 +6,13 @@
 #include "CommonJSModuleRecord.h"
 #include "JavaScriptCore/CallData.h"
 #include "JavaScriptCore/CatchScope.h"
-#include "JavaScriptCore/EnumerationMode.h"
 #include "JavaScriptCore/ExceptionScope.h"
 #include "JavaScriptCore/JSCJSValue.h"
 #include "JavaScriptCore/JSCast.h"
-#include "JavaScriptCore/JSMap.h"
 #include "JavaScriptCore/JSString.h"
 #include "JavaScriptCore/Protect.h"
 #include "JavaScriptCore/PutPropertySlot.h"
 #include "ModuleLoader.h"
-#include "PathInlines.h"
 #include "ScriptExecutionContext.h"
 #include "headers-handwritten.h"
 #include "node_api.h"
@@ -23,7 +20,6 @@
 #include "headers.h"
 #include "JSEnvironmentVariableMap.h"
 #include "ImportMetaObject.h"
-#include <optional>
 #include <sys/stat.h>
 #include "ConsoleObject.h"
 #include <JavaScriptCore/GetterSetter.h>


### PR DESCRIPTION
# Add `process.getBuiltinModule` function

- Implement `Process_functionLoadBuiltinModule` to load built-in modules
- Add `getBuiltinModule` to the `processObjectTable`
- Return the exports object of the loaded module
- TODO

Related issue: https://github.com/oven-sh/bun/issues/12161

### What does this PR do?

This PR adds `getBuiltinModule` to the `process` object in Bun. This function allows direct access to built-in modules without using `require`.

The main changes include:
- Adding `Process_functionLoadBuiltinModule` that handles the loading of built-in modules
- Registering this function in the `processObjectTable` to make it available as `process.getBuiltinModule`
- Implementing the logic to fetch and return the exports of the requested built-in module

This feature solves the problem of accessing built-in modules in environments where top-level `await` is not available or desirable, and provides a consistent API with recent versions of Node.js.

- [x] Code changes

## Additional Notes
This implementation aims to match the behavior of Node.js 22.3.0+. 
