### PR TITLE
Fix: test coverage node_modules exclusion in Windows

### DIFF
--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -598,7 +598,7 @@ const Scanner = struct {
         };
 
         // always ignore node_modules.
-        if (strings.contains(slice, "/" ++ "node_modules" ++ "/")) {
+        if (strings.contains(slice, "/node_modules/") or strings.contains(slice, "\\node_modules\\")) {
             return false;
         }
 

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -54,3 +54,26 @@ export class Y {
   expect(result.signalCode).toBeUndefined();
   expect(readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8")).toMatchSnapshot();
 });
+
+test("coverage excludes node_modules directory", () => {
+  const dir = tempDirWithFiles("cov", {
+    "node_modules/pi/index.js": `
+    export const pi = 3.14;
+    `,
+    "demo.test.ts": `
+    import { pi } from 'pi';
+    console.log(pi);
+    `,
+  });
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage"], {
+    cwd: dir,
+    env: {
+      ...bunEnv,
+    },
+    stdio: [null, null, "pipe"],
+  });
+  expect(result.stderr.toString("utf-8")).toContain("demo.test.ts");
+  expect(result.stderr.toString("utf-8")).not.toContain("node_modules");
+  expect(result.exitCode).toBe(0);
+  expect(result.signalCode).toBeUndefined();
+});


### PR DESCRIPTION
### What does this PR do?

Fixes the issue where test coverage was not excluding node_modules directory files from the report in Windows.

This PR addresses the following issues:
- Fixes https://github.com/oven-sh/bun/issues/12573
- Fixes  https://github.com/oven-sh/bun/issues/11613

**Root Cause**
The root cause of the issue is that Windows uses backslashes in paths rather than forward slashes, and the bun code was assuming it is always forward slashes regardless of the environment.

**Fix Approach**
Although it's ideal to abstract away the path formation differences (e.g., arrays of path pieces held in a path value object), for the sake of simplicity and to avoid a huge refactor just to fix this issue, I have taken the simplest approach to address the problem at hand.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- I have built the changed bun in my Windows machine and ran `bun-debug.exe` against a repository facing the issue.
- Added automated tests, too:
- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test coverage`)


<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
