### PR TITLE
Introduce `bun --fetch-preconnect <url> ./my-script.ts`

### DIFF
--- a/docs/api/fetch.md
+++ b/docs/api/fetch.md
@@ -214,6 +214,8 @@ $ bun --fetch-preconnect https://bun.sh ./my-script.ts
 
 This is sort of like `<link rel="preconnect">` in HTML.
 
+This feature is not implemented on Windows yet. If you're interested in using this feature on Windows, please file an issue and we can implement support for it on Windows.
+
 ### Connection pooling & HTTP keep-alive
 
 Bun automatically reuses connections to the same host. This is known as connection pooling. This can significantly reduce the time it takes to establish a connection. You don't need to do anything to enable this; it's automatic.

--- a/docs/api/fetch.md
+++ b/docs/api/fetch.md
@@ -135,6 +135,43 @@ const response = await fetch("http://example.com", {
 controller.abort();
 ```
 
+## Debugging
+
+To help with debugging, you can pass `verbose: true` to `fetch`:
+
+```ts
+const response = await fetch("http://example.com", {
+  verbose: true,
+});
+```
+
+This will print the request and response headers to your terminal:
+
+```sh
+[fetch] > HTTP/1.1 GET http://example.com/
+[fetch] > Connection: keep-alive
+[fetch] > User-Agent: Bun/1.1.21
+[fetch] > Accept: */*
+[fetch] > Host: example.com
+[fetch] > Accept-Encoding: gzip, deflate, br
+
+[fetch] < 200 OK
+[fetch] < Content-Encoding: gzip
+[fetch] < Age: 201555
+[fetch] < Cache-Control: max-age=604800
+[fetch] < Content-Type: text/html; charset=UTF-8
+[fetch] < Date: Sun, 21 Jul 2024 02:41:14 GMT
+[fetch] < Etag: "3147526947+gzip"
+[fetch] < Expires: Sun, 28 Jul 2024 02:41:14 GMT
+[fetch] < Last-Modified: Thu, 17 Oct 2019 07:18:26 GMT
+[fetch] < Server: ECAcc (sac/254F)
+[fetch] < Vary: Accept-Encoding
+[fetch] < X-Cache: HIT
+[fetch] < Content-Length: 648
+```
+
+Note: `verbose: boolean` is not part of the Web standard `fetch` API and is specific to Bun.
+
 ## Performance
 
 Before an HTTP request can be sent, the DNS lookup must be performed. This can take a significant amount of time, especially if the DNS server is slow or the network connection is poor.

--- a/docs/api/fetch.md
+++ b/docs/api/fetch.md
@@ -220,7 +220,7 @@ Bun automatically reuses connections to the same host. This is known as connecti
 
 ### Response buffering
 
-Bun goes to great lengths to optimize the performance of reading the response body. The fastest way to read the response body is to use one of the resposne body methods:
+Bun goes to great lengths to optimize the performance of reading the response body. The fastest way to read the response body is to use one of these methods:
 
 - `response.text(): Promise<string>`
 - `response.json(): Promise<any>`
@@ -228,3 +228,11 @@ Bun goes to great lengths to optimize the performance of reading the response bo
 - `response.bytes(): Promise<Uint8Array>`
 - `response.arrayBuffer(): Promise<ArrayBuffer>`
 - `response.blob(): Promise<Blob>`
+
+You can also use `Bun.write` to write the response body to a file on disk:
+
+```ts
+import { write } from "bun";
+
+await write("output.txt", response);
+```

--- a/docs/nav.ts
+++ b/docs/nav.ts
@@ -287,8 +287,11 @@ export default {
 
     divider("API"),
     page("api/http", "HTTP server", {
-      description: `Bun implements Web-standard fetch, plus a Bun-native API for building fast HTTP servers.`,
+      description: `Bun implements a fast HTTP server built on Request/Response objects, along with supporting node:http APIs.`,
     }), // "`Bun.serve`"),
+    page("api/fetch", "HTTP client", {
+      description: `Bun implements Web-standard fetch with some Bun-native extensions.`,
+    }), // "fetch"),
     page("api/websockets", "WebSockets", {
       description: `Bun supports server-side WebSockets with on-the-fly compression, TLS support, and a Bun-native pubsub API.`,
     }), // "`Bun.serve`"),

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3100,6 +3100,10 @@ declare module "bun" {
    */
   function openInEditor(path: string, options?: EditorOptions): void;
 
+  const fetch: typeof globalThis.fetch & {
+    preconnect(url: string): void;
+  };
+
   interface EditorOptions {
     editor?: "vscode" | "subl";
     line?: number;

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -907,26 +907,42 @@ declare global {
     new (): ShadowRealm;
   };
 
-  /**
-   * Send a HTTP(s) request
-   *
-   * @param request Request object
-   * @param init A structured value that contains settings for the fetch() request.
-   *
-   * @returns A promise that resolves to {@link Response} object.
-   */
+  interface Fetch {
+    /**
+     * Send a HTTP(s) request
+     *
+     * @param request Request object
+     * @param init A structured value that contains settings for the fetch() request.
+     *
+     * @returns A promise that resolves to {@link Response} object.
+     */
+    (request: Request, init?: RequestInit): Promise<Response>;
 
-  // tslint:disable-next-line:unified-signatures
-  function fetch(request: Request, init?: RequestInit): Promise<Response>;
-  /**
-   * Send a HTTP(s) request
-   *
-   * @param url URL string
-   * @param init A structured value that contains settings for the fetch() request.
-   *
-   * @returns A promise that resolves to {@link Response} object.
-   */
-  function fetch(url: string | URL | Request, init?: FetchRequestInit): Promise<Response>;
+    /**
+     * Send a HTTP(s) request
+     *
+     * @param url URL string
+     * @param init A structured value that contains settings for the fetch() request.
+     *
+     * @returns A promise that resolves to {@link Response} object.
+     */
+    (url: string | URL | Request, init?: FetchRequestInit): Promise<Response>;
+
+    (input: string | URL | globalThis.Request, init?: RequestInit): Promise<Response>;
+
+    /**
+     * Start the DNS resolution, TCP connection, and TLS handshake for a request
+     * before the request is actually sent.
+     *
+     * This can reduce the latency of a request when you know there's some
+     * long-running task that will delay the request starting.
+     *
+     * This is a bun-specific API and is not part of the Fetch API specification.
+     */
+    preconnect(url: string | URL): void;
+  }
+
+  var fetch: Fetch;
 
   function queueMicrotask(callback: (...args: any[]) => void): void;
   /**

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -49,6 +49,7 @@ BUN_DECLARE_HOST_FUNCTION(Bun__DNSResolver__lookupService);
 BUN_DECLARE_HOST_FUNCTION(Bun__DNSResolver__prefetch);
 BUN_DECLARE_HOST_FUNCTION(Bun__DNSResolver__getCacheStats);
 BUN_DECLARE_HOST_FUNCTION(Bun__fetch);
+BUN_DECLARE_HOST_FUNCTION(Bun__fetchPreconnect);
 
 namespace Bun {
 
@@ -265,6 +266,17 @@ extern "C" JSC::EncodedJSValue JSPasswordObject__create(JSGlobalObject*);
 static JSValue constructPasswordObject(VM& vm, JSObject* bunObject)
 {
     return JSValue::decode(JSPasswordObject__create(bunObject->globalObject()));
+}
+
+JSValue constructBunFetchObject(VM& vm, JSObject* bunObject)
+{
+    JSFunction* fetchFn = JSFunction::create(vm, bunObject->globalObject(), 1, "fetch"_s, Bun__fetch, ImplementationVisibility::Public, NoIntrinsic);
+
+    auto* globalObject = jsCast<Zig::GlobalObject*>(bunObject->globalObject());
+    fetchFn->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "preconnect"_s), 1, Bun__fetchPreconnect, ImplementationVisibility::Public, NoIntrinsic,
+        JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete | 0);
+
+    return fetchFn;
 }
 
 static JSValue constructBunShell(VM& vm, JSObject* bunObject)
@@ -549,14 +561,14 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     cwd                                            BunObject_getter_wrap_cwd                                           DontEnum|DontDelete|PropertyCallback
     deepEquals                                     functionBunDeepEquals                                               DontDelete|Function 2
     deepMatch                                      functionBunDeepMatch                                                DontDelete|Function 2
-    deflateSync                                    BunObject_callback_deflateSync                                      DontDelete|Function 1
+    deflateSync                                    BunObject_callback_deflateSync                                        DontDelete|Function 1
     dns                                            constructDNSObject                                                  ReadOnly|DontDelete|PropertyCallback
     enableANSIColors                               BunObject_getter_wrap_enableANSIColors                              DontDelete|PropertyCallback
     env                                            constructEnvObject                                                  ReadOnly|DontDelete|PropertyCallback
     escapeHTML                                     functionBunEscapeHTML                                               DontDelete|Function 2
-    fetch                                          Bun__fetch                                                          ReadOnly|DontDelete|Function 1
-    file                                           BunObject_callback_file                                             DontDelete|Function 1
-    fileURLToPath                                  functionFileURLToPath                                               DontDelete|Function 1
+    fetch                                         constructBunFetchObject                                              ReadOnly|DontDelete|PropertyCallback
+    file                                           BunObject_callback_file                                               DontDelete|Function 1
+    fileURLToPath                                  functionFileURLToPath                                                DontDelete|Function 1
     gc                                             BunObject_callback_gc                                               DontDelete|Function 1
     generateHeapSnapshot                           BunObject_callback_generateHeapSnapshot                             DontDelete|Function 1
     gunzipSync                                     BunObject_callback_gunzipSync                                       DontDelete|Function 1

--- a/src/bun.js/bindings/BunObject.h
+++ b/src/bun.js/bindings/BunObject.h
@@ -12,5 +12,7 @@ JSC_DECLARE_HOST_FUNCTION(functionBunNanoseconds);
 JSC_DECLARE_HOST_FUNCTION(functionPathToFileURL);
 JSC_DECLARE_HOST_FUNCTION(functionFileURLToPath);
 
+JSC::JSValue constructBunFetchObject(VM& vm, JSObject* bunObject);
 JSC::JSObject* createBunObject(VM& vm, JSObject* globalObject);
+
 }

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -165,7 +165,6 @@
 using namespace Bun;
 
 BUN_DECLARE_HOST_FUNCTION(Bun__NodeUtil__jsParseArgs);
-BUN_DECLARE_HOST_FUNCTION(Bun__fetch);
 BUN_DECLARE_HOST_FUNCTION(BUN__HTTP2__getUnpackedSettings);
 BUN_DECLARE_HOST_FUNCTION(BUN__HTTP2_getPackedSettings);
 

--- a/src/bun.js/bindings/ZigGlobalObject.lut.txt
+++ b/src/bun.js/bindings/ZigGlobalObject.lut.txt
@@ -11,7 +11,7 @@
   clearTimeout                    functionClearTimeout                                 Function 1
   confirm                         WebCore__confirm                                     Function 1
   dispatchEvent                   jsFunctionDispatchEvent                              Function 1
-  fetch                           Bun__fetch                                           Function 2
+  fetch                           constructBunFetchObject                              PropertyCallback
   postMessage                     jsFunctionPostMessage                                Function 1
   prompt                          WebCore__prompt                                      Function 1
   queueMicrotask                  functionQueueMicrotask                               Function 2

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -206,6 +206,7 @@ pub const Arguments = struct {
         clap.parseParam("-p, --port <STR>                  Set the default port for Bun.serve") catch unreachable,
         clap.parseParam("-u, --origin <STR>") catch unreachable,
         clap.parseParam("--conditions <STR>...             Pass custom conditions to resolve") catch unreachable,
+        clap.parseParam("--fetch-preconnect <STR>...       Preconnect to a URL while code is loading") catch unreachable,
     };
 
     const auto_or_run_params = [_]ParamType{
@@ -649,6 +650,8 @@ pub const Arguments = struct {
             }
             ctx.runtime_options.if_present = args.flag("--if-present");
             ctx.runtime_options.smol = args.flag("--smol");
+            ctx.runtime_options.preconnect = args.options("--fetch-preconnect");
+
             if (args.option("--inspect")) |inspect_flag| {
                 ctx.runtime_options.debugger = if (inspect_flag.len == 0)
                     Command.Debugger{ .enable = .{} }
@@ -1228,6 +1231,7 @@ pub const Command = struct {
             script: []const u8 = "",
             eval_and_print: bool = false,
         } = .{},
+        preconnect: []const []const u8 = &[_][]const u8{},
     };
 
     var global_cli_ctx: Context = undefined;

--- a/src/feature_flags.zig
+++ b/src/feature_flags.zig
@@ -181,3 +181,6 @@ pub const breaking_changes_1_2 = false;
 pub const nonblocking_stdout_and_stderr_on_posix = false;
 
 pub const postgresql = env.is_canary or env.isDebug;
+
+// TODO: fix Windows-only test failures in fetch-preconnect.test.ts
+pub const is_fetch_preconnect_supported = env.isPosix;

--- a/src/url.zig
+++ b/src/url.zig
@@ -130,7 +130,7 @@ pub const URL = struct {
     }
 
     pub fn hasValidPort(this: *const URL) bool {
-        return (this.getPort() orelse 0) > 1;
+        return (this.getPort() orelse 0) > 0;
     }
 
     pub fn isEmpty(this: *const URL) bool {

--- a/test/js/web/fetch/fetch-preconnect.test.ts
+++ b/test/js/web/fetch/fetch-preconnect.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test";
 import "harness";
 it("fetch.preconnect works", async () => {
   const { promise, resolve } = Promise.withResolvers();
-  const listener = Bun.listen({
+  using listener = Bun.listen({
     port: 0,
     hostname: "localhost",
     socket: {
@@ -22,7 +22,43 @@ it("fetch.preconnect works", async () => {
 
   const response = await fetchPromise;
   expect(response.status).toBe(200);
-  listener.stop(true);
+});
+
+describe("closing the connection doesn't break the request", () => {
+  for (let at of ["before", "after"]) {
+    it(at, async () => {
+      let { promise, resolve } = Promise.withResolvers();
+      using listener = Bun.listen({
+        port: 0,
+        hostname: "localhost",
+        socket: {
+          open(socket) {
+            resolve(socket);
+          },
+          data() {},
+          close() {},
+        },
+      });
+      fetch.preconnect(`http://localhost:${listener.port}`);
+      let socket = await promise;
+      ({ promise, resolve } = Promise.withResolvers());
+      if (at === "before") {
+        await Bun.sleep(16);
+        socket.end();
+      }
+      const fetchPromise = fetch(`http://localhost:${listener.port}`);
+      if (at === "after") {
+        await Bun.sleep(16);
+        socket.end();
+      }
+      socket = await promise;
+      socket.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+      socket.end();
+
+      const response = await fetchPromise;
+      expect(response.status).toBe(200);
+    });
+  }
 });
 
 it("--fetch-preconnect works", async () => {

--- a/test/js/web/fetch/fetch-preconnect.test.ts
+++ b/test/js/web/fetch/fetch-preconnect.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "bun:test";
+import "harness";
+it("fetch.preconnect works", async () => {
+  const { promise, resolve } = Promise.withResolvers();
+  const listener = Bun.listen({
+    port: 0,
+    hostname: "localhost",
+    socket: {
+      open(socket) {
+        resolve(socket);
+      },
+      data() {},
+      close() {},
+    },
+  });
+  fetch.preconnect(`http://localhost:${listener.port}`);
+  const socket = await promise;
+  const fetchPromise = fetch(`http://localhost:${listener.port}`);
+  await Bun.sleep(64);
+  socket.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+  socket.end();
+
+  const response = await fetchPromise;
+  expect(response.status).toBe(200);
+  listener.stop(true);
+});
+
+it("--fetch-preconnect works", async () => {
+  const { promise, resolve } = Promise.withResolvers();
+  const listener = Bun.listen({
+    port: 0,
+    hostname: "localhost",
+    socket: {
+      open(socket) {
+        socket.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+        socket.end();
+        resolve();
+      },
+      data() {},
+      close() {},
+    },
+  });
+
+  // Do --fetch-preconnect, but don't actually send a request.
+  expect([`--fetch-preconnect=http://localhost:${listener.port}`, "--eval", "Bun.sleep(64)"]).toRun();
+
+  await promise;
+  listener.stop(true);
+});
+
+it("fetch.preconnect validates the URL", async () => {
+  expect(() => fetch.preconnect("http://localhost:0")).toThrow();
+  expect(() => fetch.preconnect("")).toThrow();
+  expect(() => fetch.preconnect(" ")).toThrow();
+  expect(() => fetch.preconnect("unix:///tmp/foo")).toThrow();
+  expect(() => fetch.preconnect("http://:0")).toThrow();
+});

--- a/test/js/web/fetch/fetch-preconnect.test.ts
+++ b/test/js/web/fetch/fetch-preconnect.test.ts
@@ -1,93 +1,99 @@
 import { describe, it, expect } from "bun:test";
 import "harness";
-it("fetch.preconnect works", async () => {
-  const { promise, resolve } = Promise.withResolvers();
-  using listener = Bun.listen({
-    port: 0,
-    hostname: "localhost",
-    socket: {
-      open(socket) {
-        resolve(socket);
-      },
-      data() {},
-      close() {},
-    },
-  });
-  fetch.preconnect(`http://localhost:${listener.port}`);
-  const socket = await promise;
-  const fetchPromise = fetch(`http://localhost:${listener.port}`);
-  await Bun.sleep(64);
-  socket.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
-  socket.end();
+import { isWindows } from "harness";
 
-  const response = await fetchPromise;
-  expect(response.status).toBe(200);
-});
-
-describe("closing the connection doesn't break the request", () => {
-  for (let at of ["before", "after"]) {
-    it(at, async () => {
-      let { promise, resolve } = Promise.withResolvers();
-      using listener = Bun.listen({
-        port: 0,
-        hostname: "localhost",
-        socket: {
-          open(socket) {
-            resolve(socket);
-          },
-          data() {},
-          close() {},
+// TODO: on Windows, these tests fail.
+// This feature is mostly meant for serverless JS environments, so we can no-op it on Windows.
+describe.todoIf(isWindows)("fetch.preconnect", () => {
+  it("fetch.preconnect works", async () => {
+    const { promise, resolve } = Promise.withResolvers();
+    using listener = Bun.listen({
+      port: 0,
+      hostname: "localhost",
+      socket: {
+        open(socket) {
+          resolve(socket);
         },
-      });
-      fetch.preconnect(`http://localhost:${listener.port}`);
-      let socket = await promise;
-      ({ promise, resolve } = Promise.withResolvers());
-      if (at === "before") {
-        await Bun.sleep(16);
-        socket.end();
-      }
-      const fetchPromise = fetch(`http://localhost:${listener.port}`);
-      if (at === "after") {
-        await Bun.sleep(16);
-        socket.end();
-      }
-      socket = await promise;
-      socket.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
-      socket.end();
-
-      const response = await fetchPromise;
-      expect(response.status).toBe(200);
+        data() {},
+        close() {},
+      },
     });
-  }
-});
+    fetch.preconnect(`http://localhost:${listener.port}`);
+    const socket = await promise;
+    const fetchPromise = fetch(`http://localhost:${listener.port}`);
+    await Bun.sleep(64);
+    socket.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+    socket.end();
 
-it("--fetch-preconnect works", async () => {
-  const { promise, resolve } = Promise.withResolvers();
-  const listener = Bun.listen({
-    port: 0,
-    hostname: "localhost",
-    socket: {
-      open(socket) {
+    const response = await fetchPromise;
+    expect(response.status).toBe(200);
+  });
+
+  describe("closing the connection doesn't break the request", () => {
+    for (let at of ["before", "after"]) {
+      it(at, async () => {
+        let { promise, resolve } = Promise.withResolvers();
+        using listener = Bun.listen({
+          port: 0,
+          hostname: "localhost",
+          socket: {
+            open(socket) {
+              resolve(socket);
+            },
+            data() {},
+            close() {},
+          },
+        });
+        fetch.preconnect(`http://localhost:${listener.port}`);
+        let socket = await promise;
+        ({ promise, resolve } = Promise.withResolvers());
+        if (at === "before") {
+          await Bun.sleep(16);
+          socket.end();
+        }
+        const fetchPromise = fetch(`http://localhost:${listener.port}`);
+        if (at === "after") {
+          await Bun.sleep(16);
+          socket.end();
+        }
+        socket = await promise;
         socket.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
         socket.end();
-        resolve();
-      },
-      data() {},
-      close() {},
-    },
+
+        const response = await fetchPromise;
+        expect(response.status).toBe(200);
+      });
+    }
   });
 
-  // Do --fetch-preconnect, but don't actually send a request.
-  expect([`--fetch-preconnect=http://localhost:${listener.port}`, "--eval", "Bun.sleep(64)"]).toRun();
+  it("--fetch-preconnect works", async () => {
+    const { promise, resolve } = Promise.withResolvers();
+    const listener = Bun.listen({
+      port: 0,
+      hostname: "localhost",
+      socket: {
+        open(socket) {
+          socket.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+          socket.end();
+          resolve();
+        },
+        data() {},
+        close() {},
+      },
+    });
 
-  await promise;
-  listener.stop(true);
-});
+    // Do --fetch-preconnect, but don't actually send a request.
+    expect([`--fetch-preconnect=http://localhost:${listener.port}`, "--eval", "Bun.sleep(64)"]).toRun();
 
-it("fetch.preconnect validates the URL", async () => {
-  expect(() => fetch.preconnect("http://localhost:0")).toThrow();
-  expect(() => fetch.preconnect("")).toThrow();
-  expect(() => fetch.preconnect(" ")).toThrow();
-  expect(() => fetch.preconnect("unix:///tmp/foo")).toThrow();
-  expect(() => fetch.preconnect("http://:0")).toThrow();
+    await promise;
+    listener.stop(true);
+  });
+
+  it("fetch.preconnect validates the URL", async () => {
+    expect(() => fetch.preconnect("http://localhost:0")).toThrow();
+    expect(() => fetch.preconnect("")).toThrow();
+    expect(() => fetch.preconnect(" ")).toThrow();
+    expect(() => fetch.preconnect("unix:///tmp/foo")).toThrow();
+    expect(() => fetch.preconnect("http://:0")).toThrow();
+  });
 });

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/12701
+it("fetch() preserves body on redirect", async () => {
+  using server = Bun.serve({
+    port: 0,
+
+    async fetch(req) {
+      const { pathname } = new URL(req.url);
+      if (pathname === "/redirect") {
+        return new Response(null, {
+          status: 308,
+          headers: {
+            Location: "/redirect2",
+          },
+        });
+      }
+      if (pathname === "/redirect2") {
+        return new Response(req.body, { status: 200 });
+      }
+      return new Response("you shouldnt see this?", { status: 200 });
+    },
+  });
+
+  const res = await fetch(new URL("/redirect", server.url), {
+    method: "POST",
+    body: "hello",
+  });
+
+  expect(res.status).toBe(200);
+  expect(await res.text()).toBe("hello");
+});


### PR DESCRIPTION
### What does this PR do?

This adds a `--fetch-preconnect` CLI argument which lets you "warm up" a fetch request before any javascript code is loaded. It performs the DNS lookup, establishes a TCP connection, and runs TLS handshaking eagerly.

Also: fixes https://github.com/oven-sh/bun/issues/12701

This is useful for environments where you know your server or script will immediately make a request after it loads, but it takes some time for everything to load.

```ts
$ bun --fetch-preconnect=https://example.com ./hey.mjs
[8.37ms] fetch(https://example.com)
$ bun hey.mjs # Without preconnect
[51.92ms] fetch(https://example.com)
$ node hey.mjs
fetch(https://example.com): 68.417ms
```

```ts
   1   │ if (globalThis.Bun) {
   2   │   await Bun.sleep(1000);
   3   │ } else {
   4   │   await new Promise(resolve => setTimeout(resolve, 1000));
   5   │ }
   6   │
   7   │ console.time("fetch(https://example.com)");
   8   │ await fetch("https://example.com");
   9   │ console.timeEnd("fetch(https://example.com)");
```

This also adds a `fetch.preconnect(url: string): void` function, which does the same thing programmatically.

This is a lot like `<link rel="preconnect" href="<url>">` in HTML.

### How did you verify your code works?

There are tests. And docs.
