### PR TITLE
fix(bundler): ignore external rules for entrypoint

### DIFF
--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1347,7 +1347,7 @@ describe("bundler", () => {
       `,
     },
   });
-  itBundled("edgecase/EntrypointWithoutPrefixSlashOrDotIsNotConsideredExternal", {
+  itBundled("edgecase/EntrypointWithoutPrefixSlashOrDotIsNotConsideredExternal#12734", {
     files: {
       "/src/entry.ts": /* ts */ `
         import { helloWorld } from "./second.ts";

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1347,6 +1347,27 @@ describe("bundler", () => {
       `,
     },
   });
+  itBundled("edgecase/EntrypointWithoutPrefixSlashOrDotIsNotConsideredExternal", {
+    files: {
+      "/src/entry.ts": /* ts */ `
+        import { helloWorld } from "./second.ts";
+        console.log(helloWorld);
+      `,
+      "/src/second.ts": /* ts */ `
+        export const helloWorld = "Hello World";
+      `,
+    },
+    root: "/src",
+    entryPointsRaw: ["src/entry.ts"],
+    packages: "external",
+    target: "bun",
+    run: {
+      file: "/src/entry.ts",
+      stdout: `
+        Hello World
+      `,
+    },
+  });
   itBundled("edgecase/IntegerUnderflow#12547", {
     files: {
       "/entry.js": `


### PR DESCRIPTION
### What does this PR do?

This PR fixes issue where bundler with packages=external do not resolve local imports where entrypoint is not starting with '.', '/'. I also added a test which passes on this PR and fails on main.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->



- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

Closes #12734 
