### PR TITLE
Fix alignment calculation in Zone.create function

### DIFF
--- a/src/heap_breakdown.zig
+++ b/src/heap_breakdown.zig
@@ -97,8 +97,10 @@ pub const Zone = opaque {
 
     /// Create a single-item pointer with initialized data.
     pub inline fn create(zone: *Zone, comptime T: type, data: T) *T {
+        const align_of_t: usize = @alignOf(T);
+        const log2_align_of_t = @ctz(align_of_t);
         const ptr: *T = @alignCast(@ptrCast(
-            rawAlloc(zone, @sizeOf(T), @alignOf(T), @returnAddress()) orelse bun.outOfMemory(),
+            rawAlloc(zone, @sizeOf(T), log2_align_of_t, @returnAddress()) orelse bun.outOfMemory(),
         ));
         ptr.* = data;
         return ptr;


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue in the `Zone.create` function where the alignment value was incorrectly passed to `rawAlloc`. The changes include:

- Adding explicit calculation of alignment as a usize
- Calculating log2 of alignment using `@ctz`
- Passing log2 of alignment to rawAlloc instead of raw alignment value

- [x] Code changes