### PR TITLE
fix(tls/fetch) Better SSLWrapper for http proxy and start of Duplex support on tls

### DIFF
--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -39,7 +39,7 @@ pub fn SSLWrapper(T: type) type {
             is_client: bool = false,
             authorized: bool = false,
         };
-        pub const HandshakeState = enum(u8) {
+        pub const HandshakeState = enum(u2) {
             HANDSHAKE_PENDING = 0,
             HANDSHAKE_COMPLETED = 1,
             HANDSHAKE_RENEGOTIATION_PENDING = 2,

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -310,7 +310,6 @@ pub fn SSLWrapper(T: type) type {
                         } else if (err == BoringSSL.SSL_ERROR_ZERO_RETURN) {
                             // Remotely-Initiated Shutdown
                             // See: https://www.openssl.org/docs/manmaster/man3/SSL_shutdown.html
-                            // zero return can be EOF/FIN, if we have data just signal on_data and close
                             this.flags.received_ssl_shutdown = true;
                             // 2-step shutdown
                             _ = this.shutdown(false);

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -295,7 +295,6 @@ pub fn SSLWrapper(T: type) type {
                     if (err != BoringSSL.SSL_ERROR_WANT_READ and err != BoringSSL.SSL_ERROR_WANT_WRITE) {
                         if (err == BoringSSL.SSL_ERROR_WANT_RENEGOTIATE) {
                             this.flags.handshake_state = HandshakeState.HANDSHAKE_RENEGOTIATION_PENDING;
-                            this.flags.handshake_state = HandshakeState.HANDSHAKE_RENEGOTIATION_PENDING;
                             if (!BoringSSL.SSL_renegotiate(this.ssl)) {
                                 this.flags.handshake_state = HandshakeState.HANDSHAKE_COMPLETED;
                                 // we failed to renegotiate

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -55,11 +55,11 @@ pub fn SSLWrapper(T: type) type {
         pub fn init(ssl_options: JSC.API.ServerConfig.SSLConfig, is_client: bool, handlers: Handlers) ?This {
             BoringSSL.load();
 
-           const ctx_opts: uws.us_bun_socket_context_options_t = JSC.API.ServerConfig.SSLConfig.asUSockets(ssl_options);
-           // Create SSL context using uSockets to match behavior of node.js
-           const ctx = uws.create_ssl_context_from_bun_options(ctx_opts) orelse return null; // invalid options
-           const ssl = BoringSSL.SSL_new(ctx) orelse bun.outOfMemory();
-           if (is_client) {
+            const ctx_opts: uws.us_bun_socket_context_options_t = JSC.API.ServerConfig.SSLConfig.asUSockets(ssl_options);
+            // Create SSL context using uSockets to match behavior of node.js
+            const ctx = uws.create_ssl_context_from_bun_options(ctx_opts) orelse return null; // invalid options
+            const ssl = BoringSSL.SSL_new(ctx) orelse bun.outOfMemory();
+            if (is_client) {
                 BoringSSL.SSL_set_renegotiate_mode(ssl, BoringSSL.ssl_renegotiate_freely);
                 BoringSSL.SSL_set_connect_state(ssl);
             } else {

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -120,7 +120,7 @@ pub fn SSLWrapper(T: type) type {
 
         /// Shutdown the write direction of the SSL and returns if we are completed closed or not
         /// We cannot assume that the read part will remain open after we sent a shutdown, the other side will probably complete the 2-step shutdown ASAP.
-        /// Caution: never reuse a socket if fast_shutdown = true, this will also fully close both read and write directions 
+        /// Caution: never reuse a socket if fast_shutdown = true, this will also fully close both read and write directions
         pub fn shutdown(this: *This, fast_shutdown: bool) bool {
             // we already sent the ssl shutdown
             if (this.flags.sent_ssl_shutdown) return this.received_ssl_shutdown;

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -51,7 +51,7 @@ pub fn SSLWrapper(T: type) type {
             onClose: fn (T) void,
         };
 
-        /// Initialize the SSLWrapper with a SSL_CTX* specific SSL_CTX remember to call SSL_CTX_up_ref if you want to keep the SSL_CTX alive after the SSLWrapper is deinitialized
+        /// Initialize the SSLWrapper with a specific SSL_CTX*, remember to call SSL_CTX_up_ref if you want to keep the SSL_CTX alive after the SSLWrapper is deinitialized
         pub initWithCTX(ctx: *BoringSSL.SSL_CTX, is_client: bool, handlers: Handlers) !This {
             BoringSSL.load();
 

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -53,6 +53,8 @@ pub fn SSLWrapper(T: type) type {
 
         /// Initialize the SSLWrapper with a SSL_CTX* specific SSL_CTX remember to call SSL_CTX_up_ref if you want to keep the SSL_CTX alive after the SSLWrapper is deinitialized
         pub initWithCTX(ctx: *BoringSSL.SSL_CTX, is_client: bool, handlers: Handlers) !This {
+            BoringSSL.load();
+
             const ssl = BoringSSL.SSL_new(ctx) orelse return error.OutOfMemory;
             errdefer BoringSSL.SSL_free(ssl);
             

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -317,9 +317,9 @@ pub fn SSLWrapper(T: type) type {
 
         pub fn deinit(this: *This) void {
             // SSL_free will also free the input and output BIOs
-            _ = BoringSSL.SSL_free(this.ssl); 
+            _ = BoringSSL.SSL_free(this.ssl);
             // SSL_CTX_free will free the SSL context and all the certificates
-            _ = BoringSSL.SSL_CTX_free(this.ctx); 
+            _ = BoringSSL.SSL_CTX_free(this.ctx);
         }
     };
 }

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -1,0 +1,314 @@
+const bun = @import("root").bun;
+
+const BoringSSL = bun.BoringSSL;
+const X509 = @import("./x509.zig");
+const JSC = bun.JSC;
+const uws = bun.uws;
+
+/// Mimics the behavior of openssl.c in uSockets, wrapping data that can be received from any where (network, DuplexStream, etc)
+pub fn SSLWrapper(T: type) type {
+    // receiveData() is called when we receive data from the network (encrypted data that will be decrypted by SSLWrapper)
+    // writeData() is called when we want to send data to the network (unencrypted data that will be encrypted by SSLWrapper)
+
+    // after init we need to call start() to start the SSL handshake
+    // this will trigger the onOpen callback before the handshake starts and the onHandshake callback after the handshake completes
+    // onRead and onWrite callbacks are triggered when we have data to read or write respectively
+    // onRead will pass the decrypted data that we received from the network
+    // onWrite will pass the encrypted data that we want to send to the network
+    // onClose callback is triggered when we wanna the network connection to be closed (remember to flush the data before closing the connection)
+
+    // Notes:
+    // SSL_read() read unencrypted data which is stored in the input BIO.
+    // SSL_write() write unencrypted data into the output BIO.
+    // BIO_write() write encrypted data into the input BIO.
+    // BIO_read() read encrypted data from the output BIO.
+
+    return struct {
+        const This = @This();
+
+        handlers: Handlers,
+        ssl: *BoringSSL.SSL,
+        input: *BoringSSL.BIO,
+        output: *BoringSSL.BIO,
+        ctx: *BoringSSL.SSL_CTX,
+
+        flags: Flags = .{},
+
+        pub const Flags = packed struct {
+            handshake_state: HandshakeState = HandshakeState.HANDSHAKE_PENDING,
+            received_ssl_shutdown: bool = false,
+            is_client: bool = false,
+        };
+        pub const HandshakeState = enum(u8) {
+            HANDSHAKE_PENDING = 0,
+            HANDSHAKE_COMPLETED = 1,
+            HANDSHAKE_RENEGOTIATION_PENDING = 2,
+        };
+        pub const Handlers = struct {
+            ctx: T,
+            onOpen: fn (T, *This) void,
+            onHandshake: fn (T, *This, bool, uws.us_bun_verify_error_t) void,
+            onWrite: fn (T, *This, []const u8) void,
+            onRead: fn (T, *This, []const u8) void,
+            onClose: fn (T) void,
+        };
+        pub fn init(ssl_options: JSC.API.ServerConfig.SSLConfig, is_client: bool, handlers: Handlers) This {
+            BoringSSL.load();
+
+           const ctx_opts: uws.us_bun_socket_context_options_t = JSC.API.ServerConfig.SSLConfig.asUSockets(ssl_options);
+           // Create SSL context using uSockets to match behavior of node.js
+           const ctx = uws.create_ssl_context_from_bun_options(ctx_opts) orelse bun.outOfMemory();
+           const ssl = BoringSSL.SSL_new(ctx) orelse bun.outOfMemory();
+           if (is_client) {
+                BoringSSL.SSL_set_renegotiate_mode(ssl, BoringSSL.ssl_renegotiate_freely);
+                BoringSSL.SSL_set_connect_state(ssl);
+            } else {
+                BoringSSL.SSL_set_accept_state(ssl);
+            }
+            const input = BoringSSL.BIO_new(BoringSSL.BIO_s_mem()) orelse bun.outOfMemory();
+            const output = BoringSSL.BIO_new(BoringSSL.BIO_s_mem()) orelse bun.outOfMemory();
+            
+            BoringSSL.BIO_set_mem_eof_return(input, -1);
+            BoringSSL.BIO_set_mem_eof_return(output, -1);
+
+            BoringSSL.SSL_set_bio(ssl, input, output);
+
+           return .{
+                .handlers = handlers,
+                .flags = . { .is_client },
+                .ctx = ctx,
+                .ssl = ssl,
+                .input = input,
+                .output = output,
+           };
+        }   
+
+        pub fn start(this: *This) void {
+            // trigger the onOpen callback so the user can configure the SSL connection before first handshake
+            this.handlers.onOpen(this.handlers.ctx, this);
+            // start the handshake
+            this.handleTraffic();
+        }
+        
+        fn triggerHandshakeCallback(this: *This, success: bool, result: uws.us_bun_verify_error_t) void {
+            // trigger the handshake callback
+            this.handlers.onHandshake(this.handlers.ctx, this, success, result);
+        }
+
+        fn triggerWannaWriteCallback(this: *This, data: []const u8) void {
+            // trigger the onWrite callback
+            this.handlers.onWrite(this.handlers.ctx, this, data);
+        }
+
+        fn triggerReadCallback(this: *This, data: []const u8) void {
+            // trigger the onRead callback
+            this.handlers.onRead(this.handlers.ctx, this, data);
+        }
+
+        fn triggerCloseCallback(this: *This) void {
+            // trigger the onClose callback
+            this.handlers.onClose(this.handlers.ctx);
+        }
+
+        fn getVerifyError(this: *This) uws.us_bun_verify_error_t {
+            if(this.flags.received_ssl_shutdown == true) {
+                return .{};
+            }
+            return uws.us_bun_verify_error_t(this.ssl);
+        }
+        /// Update the handshake state
+        /// Returns true if we can call handleReading
+        fn updateHandshakeState(this: *This) bool {
+            if(BoringSSL.SSL_is_init_finished(this.ssl)) {
+                // handshake already completed nothing to do here
+                if (BoringSSL.SSL_get_shutdown(this.ssl) & BoringSSL.SSL_RECEIVED_SHUTDOWN) {
+                    // we received a shutdown
+                    this.flags.received_ssl_shutdown = true;
+                    this.triggerCloseCallback();
+                }
+                return false;
+            }
+
+            const result = BoringSSL.SSL_do_handshake(this.ssl);
+
+            if (BoringSSL.SSL_get_shutdown(this.ssl) & BoringSSL.SSL_RECEIVED_SHUTDOWN) {
+                this.flags.received_ssl_shutdown = true;
+                this.flags.handshake_state = HandshakeState.HANDSHAKE_COMPLETED;
+                this.triggerHandshakeCallback(false, this.getVerifyError());
+                this.triggerCloseCallback();
+                return false;
+            }
+
+            if (result <= 0) {
+
+                const err = BoringSSL.SSL_get_error(this.ssl, result);
+                // as far as I know these are the only errors we want to handle
+                if (err != BoringSSL.SSL_ERROR_WANT_READ and err != BoringSSL.SSL_ERROR_WANT_WRITE) {
+                    this.flags.handshake_state = HandshakeState.HANDSHAKE_COMPLETED;
+
+                    this.flags.handshake_state = HandshakeState.HANDSHAKE_COMPLETED;
+                    this.triggerHandshakeCallback(true, this.getVerifyError());
+
+                    // clear per thread error queue if it may contain something
+                    if (err == BoringSSL.SSL_ERROR_SSL or err == BoringSSL.SSL_ERROR_SYSCALL) {
+                        BoringSSL.ERR_clear_error();
+                    }
+                    return true;
+                }
+                this.flags.handshake_state = HandshakeState.HANDSHAKE_PENDING;
+                // ensure that we'll cycle through internal openssl's state
+                this.writeData("");
+                return true;
+            }
+
+            // handshake completed
+            this.flags.handshake_state = HandshakeState.HANDSHAKE_COMPLETED;
+            this.triggerHandshakeCallback(true, this.getVerifyError());
+
+            // ensure that we'll cycle through internal openssl's state
+            this.writeData("");
+
+            return true;
+        }
+
+        fn handleEndOfRenegociation(this: *This) void {
+            if (this.flags.handshake_state == HandshakeState.HANDSHAKE_RENEGOTIATION_PENDING) {
+              // renegotiation ended successfully call on_handshake
+              this.flags.handshake_state = HandshakeState.HANDSHAKE_COMPLETED;
+              this.triggerHandshakeCallback(true, this.getVerifyError());
+            }
+        }
+        /// Handle reading data
+        /// Returns true if we can call handleWriting
+        fn handleReading(this: *This) bool {
+            // handle reading
+            var buffer: [16384]u8 = undefined;
+            var read: usize = 0;
+            // read data from the input BIO
+            while(BoringSSL.BIO_ctrl_pending(this.input) > 0) {
+                const available = buffer[read..];
+                const just_read = BoringSSL.SSL_read(this.ssl, available.ptr, available.len);
+
+                if(just_read <= 0) {
+                    const err = BoringSSL.SSL_get_error(this.ssl, just_read);
+                    if (err != BoringSSL.SSL_ERROR_WANT_READ and err != BoringSSL.SSL_ERROR_WANT_WRITE) {
+                        if(err == BoringSSL.SSL_ERROR_WANT_RENEGOTIATE) {
+                            this.flags.handshake_state = HandshakeState.HANDSHAKE_RENEGOTIATION_PENDING;
+                            this.flags.handshake_state = HandshakeState.HANDSHAKE_RENEGOTIATION_PENDING;
+                            if (!BoringSSL.SSL_renegotiate(this.ssl)) {
+                                this.flags.handshake_state = HandshakeState.HANDSHAKE_COMPLETED;
+                                // we failed to renegotiate
+                                this.triggerHandshakeCallback(false, this.getVerifyError());
+                                this.triggerCloseCallback();
+                                return false;
+                            }
+                            // ok, we are done here, we need to call SSL_read again
+                            // this dont mean that we are done with the handshake renegotiation
+                            // we need to call SSL_read again
+                            continue;
+                        } else if (err == BoringSSL.SSL_ERROR_ZERO_RETURN) {
+                            // zero return can be EOF/FIN, if we have data just signal on_data and close
+                            this.flags.received_ssl_shutdown = true;
+                            this.handleEndOfRenegociation();
+                        }
+
+                        // flush the reading
+                        if (read > 0) {
+                            this.triggerReadCallback(buffer[0..read]);
+                        }
+                        BoringSSL.ERR_clear_error();
+                        this.triggerCloseCallback();
+                        return false;
+                    } else {
+                        // we wanna read/write just break
+                        break;
+                    }
+                }
+
+                this.handleEndOfRenegociation();
+
+                read += just_read;
+                if(read == buffer.len) {
+                    // we filled the buffer
+                    this.triggerReadCallback(buffer[0..read]);
+                    read = 0;
+                }
+            }
+            // we finished reading
+            if (read > 0) {
+                this.triggerReadCallback(buffer[0..read]);
+            }
+            return true;
+        }
+
+        fn handleWriting(this: *This) void {
+            var buffer: [16384]u8 = undefined;
+            while(true) {
+                // read data from the output BIO
+                const pending = BoringSSL.BIO_ctrl_pending(this.output);
+                if (pending <= 0) {
+                    // no data to write
+                    break;
+                }
+                // limit the read to the buffer size
+                const len = @min(pending, buffer.len);
+                const pending_buffer = buffer[0..len];
+                const read = BoringSSL.BIO_read(this.output, pending_buffer.ptr, len);
+                if (read > 0) {
+                    this.triggerWannaWriteCallback(buffer[0..read]);
+                }
+            }
+        }
+
+        fn handleTraffic(this: *This) void {
+            if(this.updateHandshakeState()) {
+                if(this.handleReading()) {
+                    // we may have data to write
+                    this.handleWriting();
+                }
+            }
+        }
+
+        // Receive data from the network (encrypted data)
+        pub fn receiveData(this: *This, data: []const u8) void {
+            const written = BoringSSL.BIO_write(this.input, data.ptr, @as(c_int, @intCast(data.len)));
+            if (written > -1) {
+                this.handleTraffic();
+            }
+        }
+
+        // Send data to the network (unencrypted data)    
+        pub fn writeData(this: *This, data: []const u8) usize {
+            if(data.len == 0) {
+                // just cycle through internal openssl's state
+                _ = BoringSSL.SSL_write(this.ssl, data.ptr, @as(c_int, @intCast(data.len)));
+                this.handleTraffic();
+                return 0;
+            }
+            const written = BoringSSL.SSL_write(this.ssl, data.ptr, @as(c_int, @intCast(data.len)));
+            if(written <= 0) {
+                const err = BoringSSL.SSL_get_error(this.ssl, written);
+                if (err == BoringSSL.SSL_ERROR_WANT_READ or err == BoringSSL.SSL_ERROR_WANT_WRITE) {
+                    // we wanna read/write
+                    this.handleTraffic();
+                    return 0;
+                } 
+                // some bad error happened here we must close
+                BoringSSL.ERR_clear_error();
+                this.triggerCloseCallback();
+                return 0;
+            }
+            this.handleTraffic();
+            return @intCast(written);
+        }
+
+        pub fn deinit(this: *This) void {
+            // Free everything
+            _ = BoringSSL.SSL_free(this.ssl);
+            _ = BoringSSL.BIO_free(this.input);
+            _ = BoringSSL.BIO_free(this.output);
+            _ = BoringSSL.SSL_CTX_free(this.ctx);
+        }
+    };
+    
+}

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -55,15 +55,15 @@ pub fn SSLWrapper(T: type) type {
         pub fn init(ssl_options: JSC.API.ServerConfig.SSLConfig, is_client: bool, handlers: Handlers) ?This {
             BoringSSL.load();
 
-           const ctx_opts: uws.us_bun_socket_context_options_t = JSC.API.ServerConfig.SSLConfig.asUSockets(ssl_options);
-           // Create SSL context using uSockets to match behavior of node.js
-           const ctx = uws.create_ssl_context_from_bun_options(ctx_opts) orelse return null; // invalid options
-           const ssl = BoringSSL.SSL_new(ctx) orelse bun.outOfMemory();
+            const ctx_opts: uws.us_bun_socket_context_options_t = JSC.API.ServerConfig.SSLConfig.asUSockets(ssl_options);
+            // Create SSL context using uSockets to match behavior of node.js
+            const ctx = uws.create_ssl_context_from_bun_options(ctx_opts) orelse return null; // invalid options
+            const ssl = BoringSSL.SSL_new(ctx) orelse bun.outOfMemory();
 
-           // OpenSSL enables TLS renegotiation by default and accepts renegotiation requests from the peer transparently. Renegotiation is an extremely problematic protocol feature, so BoringSSL rejects peer renegotiations by default.
-           // We explicitly set the SSL_set_renegotiate_mode so if we switch to OpenSSL we keep the same behavior
-           // See: https://boringssl.googlesource.com/boringssl/+/HEAD/PORTING.md#TLS-renegotiation
-           if (is_client) {
+            // OpenSSL enables TLS renegotiation by default and accepts renegotiation requests from the peer transparently. Renegotiation is an extremely problematic protocol feature, so BoringSSL rejects peer renegotiations by default.
+            // We explicitly set the SSL_set_renegotiate_mode so if we switch to OpenSSL we keep the same behavior
+            // See: https://boringssl.googlesource.com/boringssl/+/HEAD/PORTING.md#TLS-renegotiation
+            if (is_client) {
                 // Set the renegotiation mode to explicit so that we can renegotiate on the client side if needed (better performance than ssl_renegotiate_freely)
                 // BoringSSL: Renegotiation is only supported as a client in TLS and the HelloRequest must be received at a quiet point in the application protocol. This is sufficient to support the common use of requesting a new client certificate between an HTTP request and response in (unpipelined) HTTP/1.1.
                 BoringSSL.SSL_set_renegotiate_mode(ssl, BoringSSL.ssl_renegotiate_explicit);

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -130,7 +130,7 @@ pub fn SSLWrapper(T: type) type {
             // The peer might continue sending data for some period of time before handling the local application's shutdown indication.
             // This will start a full shutdown process if fast_shutdown = false, we can assume that the other side will complete the 2-step shutdown ASAP.
             const ret = BoringSSL.SSL_shutdown(this.ssl);
-            if (fast_shutdown and ret == 0) {                
+            if (fast_shutdown and ret == 0) {
                 // This allows for a more rapid shutdown process if the application does not wish to wait for the peer.
                 // This alternative "fast shutdown" approach should only be done if it is known that the peer will not send more data, otherwise there is a risk of an application exposing itself to a truncation attack.
                 // The full SSL_shutdown() process, in which both parties send close_notify alerts and SSL_shutdown() returns 1, provides a cryptographically authenticated indication of the end of a connection.
@@ -161,7 +161,7 @@ pub fn SSLWrapper(T: type) type {
             return 0;
         }
 
-        // Return if we have pending data to be read or write 
+        // Return if we have pending data to be read or write
         pub fn hasPendingData(this: *This) bool {
             return BoringSSL.BIO_ctrl_pending(BoringSSL.SSL_get_wbio(this.ssl)) > 0 or BoringSSL.BIO_ctrl_pending(BoringSSL.SSL_get_rbio(this.ssl)) > 0;
         }

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -108,7 +108,6 @@ pub fn SSLWrapper(T: type) type {
             this.handleTraffic();
         }
 
-
         /// Shutdown the read direction of the SSL (fake it just for convenience)
         pub fn shutdownRead(this: *This) void {
             // We cannot shutdown read in SSL, the read direction is closed by the peer.
@@ -250,7 +249,7 @@ pub fn SSLWrapper(T: type) type {
             }
             return uws.us_ssl_socket_verify_error_from_ssl(this.ssl);
         }
-        
+
         /// Update the handshake state
         /// Returns true if we can call handleReading
         fn updateHandshakeState(this: *This) bool {

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -238,6 +238,13 @@ pub fn SSLWrapper(T: type) type {
                 // The fast shutdown approach can only be used if there is no intention to reuse the underlying connection (e.g. a TCP connection) for further communication; in this case, the full shutdown process must be performed to ensure synchronisation.
                 _ = BoringSSL.SSL_shutdown(this.ssl);
                 this.received_ssl_shutdown = true;
+                // Reset pending handshake because we are closed for sure now
+                if (this.flags.handshake_state != HandshakeState.HANDSHAKE_COMPLETED) {
+                    this.flags.handshake_state = HandshakeState.HANDSHAKE_COMPLETED;
+                    this.triggerHandshakeCallback(false, this.getVerifyError());
+                }
+                // we need to trigger close because we are not receiving a SSL_shutdown
+                this.triggerCloseCallback();
             }
 
             // we sent the shutdown

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -130,7 +130,7 @@ pub fn SSLWrapper(T: type) type {
             // The peer might continue sending data for some period of time before handling the local application's shutdown indication.
             // This will start a full shutdown process if fast_shutdown = false, we can assume that the other side will complete the 2-step shutdown ASAP.
             const ret = BoringSSL.SSL_shutdown(this.ssl);
-            if (fast_shutdown and ret == 0) {
+            if (fast_shutdown and ret == 0) {                
                 // This allows for a more rapid shutdown process if the application does not wish to wait for the peer.
                 // This alternative "fast shutdown" approach should only be done if it is known that the peer will not send more data, otherwise there is a risk of an application exposing itself to a truncation attack.
                 // The full SSL_shutdown() process, in which both parties send close_notify alerts and SSL_shutdown() returns 1, provides a cryptographically authenticated indication of the end of a connection.
@@ -159,6 +159,11 @@ pub fn SSLWrapper(T: type) type {
             const pending = BoringSSL.BIO_ctrl_pending(BoringSSL.SSL_get_wbio(this.ssl));
             if (pending > 0) return @intCast(pending);
             return 0;
+        }
+
+        // Return if we have pending data to be read or write 
+        pub fn hasPendingData(this: *This) bool {
+            return BoringSSL.BIO_ctrl_pending(BoringSSL.SSL_get_wbio(this.ssl)) > 0 or BoringSSL.BIO_ctrl_pending(BoringSSL.SSL_get_rbio(this.ssl)) > 0;
         }
 
         // We sent or received a shutdown (closing or closed)

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -128,6 +128,7 @@ pub fn SSLWrapper(T: type) type {
             // Calling SSL_shutdown() only closes the write direction of the connection; the read direction is closed by the peer.
             // Once SSL_shutdown() is called, SSL_write(3) can no longer be used, but SSL_read(3) may still be used until the peer decides to close the connection in turn.
             // The peer might continue sending data for some period of time before handling the local application's shutdown indication.
+            // This will start a full shutdown process, we can assume that the other side will complete the 2-step shutdown like we do.
             const ret = BoringSSL.SSL_shutdown(this.ssl);
             if (fast_shutdown and ret == 0) {
                 // This allows for a more rapid shutdown process if the application does not wish to wait for the peer.

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -55,11 +55,11 @@ pub fn SSLWrapper(T: type) type {
         pub fn init(ssl_options: JSC.API.ServerConfig.SSLConfig, is_client: bool, handlers: Handlers) ?This {
             BoringSSL.load();
 
-           const ctx_opts: uws.us_bun_socket_context_options_t = JSC.API.ServerConfig.SSLConfig.asUSockets(ssl_options);
-           // Create SSL context using uSockets to match behavior of node.js
-           const ctx = uws.create_ssl_context_from_bun_options(ctx_opts) orelse return null; // invalid options
-           const ssl = BoringSSL.SSL_new(ctx) orelse bun.outOfMemory();
-           if (is_client) {
+            const ctx_opts: uws.us_bun_socket_context_options_t = JSC.API.ServerConfig.SSLConfig.asUSockets(ssl_options);
+            // Create SSL context using uSockets to match behavior of node.js
+            const ctx = uws.create_ssl_context_from_bun_options(ctx_opts) orelse return null; // invalid options
+            const ssl = BoringSSL.SSL_new(ctx) orelse bun.outOfMemory();
+            if (is_client) {
                 // Set the renegotiation mode to explicit so that we can renegotiate on the client side if needed (better performance than ssl_renegotiate_freely)
                 BoringSSL.SSL_set_renegotiate_mode(ssl, BoringSSL.ssl_renegotiate_explicit);
                 BoringSSL.SSL_set_connect_state(ssl);

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -224,7 +224,7 @@ pub fn SSLWrapper(T: type) type {
         /// Caution: never reuse a socket if fast_shutdown = true
         fn shutdown(this: *This, fast_shutdown: bool) bool {
             // we already sent the ssl shutdown
-            if(this.flags.sent_ssl_shutdown) return this.received_ssl_shutdown;
+            if (this.flags.sent_ssl_shutdown) return this.received_ssl_shutdown;
 
             // Calling SSL_shutdown() only closes the write direction of the connection; the read direction is closed by the peer.
             // Once SSL_shutdown() is called, SSL_write(3) can no longer be used, but SSL_read(3) may still be used until the peer decides to close the connection in turn.
@@ -276,7 +276,6 @@ pub fn SSLWrapper(T: type) type {
         /// Handle reading data
         /// Returns true if we can call handleWriting
         fn handleReading(this: *This, buffer: []u8) bool {
-            
             var read: usize = 0;
             const input = BoringSSL.SSL_get_rbio(this.ssl) orelse return;
             // read data from the input BIO

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -316,11 +316,10 @@ pub fn SSLWrapper(T: type) type {
         }
 
         pub fn deinit(this: *This) void {
-            // Free everything
-            _ = BoringSSL.SSL_free(this.ssl);
-            _ = BoringSSL.BIO_free(this.input);
-            _ = BoringSSL.BIO_free(this.output);
-            _ = BoringSSL.SSL_CTX_free(this.ctx);
+            // SSL_free will also free the input and output BIOs
+            _ = BoringSSL.SSL_free(this.ssl); 
+            // SSL_CTX_free will free the SSL context and all the certificates
+            _ = BoringSSL.SSL_CTX_free(this.ctx); 
         }
     };
 }

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -133,7 +133,7 @@ pub fn SSLWrapper(T: type) type {
             if (this.isShutdown()) {
                 return .{};
             }
-            return uws.us_bun_verify_error_t(this.ssl);
+            return uws.us_ssl_socket_verify_error_from_ssl(this.ssl);
         }
         /// Update the handshake state
         /// Returns true if we can call handleReading

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -55,16 +55,16 @@ pub fn SSLWrapper(T: type) type {
         pub fn init(ssl_options: JSC.API.ServerConfig.SSLConfig, is_client: bool, handlers: Handlers) !This {
             BoringSSL.load();
 
-           const ctx_opts: uws.us_bun_socket_context_options_t = JSC.API.ServerConfig.SSLConfig.asUSockets(ssl_options);
-           // Create SSL context using uSockets to match behavior of node.js
-           const ctx = uws.create_ssl_context_from_bun_options(ctx_opts) orelse return error.InvalidOptions; // invalid options
-           errdefer BoringSSL.SSL_CTX_free(ctx);
-           const ssl = BoringSSL.SSL_new(ctx) orelse return error.OutOfMemory;
-           errdefer BoringSSL.SSL_free(ssl);
-           // OpenSSL enables TLS renegotiation by default and accepts renegotiation requests from the peer transparently. Renegotiation is an extremely problematic protocol feature, so BoringSSL rejects peer renegotiations by default.
-           // We explicitly set the SSL_set_renegotiate_mode so if we switch to OpenSSL we keep the same behavior
-           // See: https://boringssl.googlesource.com/boringssl/+/HEAD/PORTING.md#TLS-renegotiation
-           if (is_client) {
+            const ctx_opts: uws.us_bun_socket_context_options_t = JSC.API.ServerConfig.SSLConfig.asUSockets(ssl_options);
+            // Create SSL context using uSockets to match behavior of node.js
+            const ctx = uws.create_ssl_context_from_bun_options(ctx_opts) orelse return error.InvalidOptions; // invalid options
+            errdefer BoringSSL.SSL_CTX_free(ctx);
+            const ssl = BoringSSL.SSL_new(ctx) orelse return error.OutOfMemory;
+            errdefer BoringSSL.SSL_free(ssl);
+            // OpenSSL enables TLS renegotiation by default and accepts renegotiation requests from the peer transparently. Renegotiation is an extremely problematic protocol feature, so BoringSSL rejects peer renegotiations by default.
+            // We explicitly set the SSL_set_renegotiate_mode so if we switch to OpenSSL we keep the same behavior
+            // See: https://boringssl.googlesource.com/boringssl/+/HEAD/PORTING.md#TLS-renegotiation
+            if (is_client) {
                 // Set the renegotiation mode to explicit so that we can renegotiate on the client side if needed (better performance than ssl_renegotiate_freely)
                 // BoringSSL: Renegotiation is only supported as a client in TLS and the HelloRequest must be received at a quiet point in the application protocol. This is sufficient to support the common use of requesting a new client certificate between an HTTP request and response in (unpipelined) HTTP/1.1.
                 BoringSSL.SSL_set_renegotiate_mode(ssl, BoringSSL.ssl_renegotiate_explicit);

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -209,7 +209,6 @@ pub fn SSLWrapper(T: type) type {
 
             if (data.len == 0) {
                 // just cycle through internal openssl's state
-                _ = BoringSSL.SSL_write(this.ssl, data.ptr, @as(c_int, @intCast(data.len)));
                 this.handleTraffic();
                 return 0;
             }
@@ -320,17 +319,12 @@ pub fn SSLWrapper(T: type) type {
                     return true;
                 }
                 this.flags.handshake_state = HandshakeState.HANDSHAKE_PENDING;
-                // ensure that we'll cycle through internal openssl's state
-                this.writeData("");
                 return true;
             }
 
             // handshake completed
             this.flags.handshake_state = HandshakeState.HANDSHAKE_COMPLETED;
             this.triggerHandshakeCallback(true, this.getVerifyError());
-
-            // ensure that we'll cycle through internal openssl's state
-            this.writeData("");
 
             return true;
         }

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -158,7 +158,7 @@ pub fn SSLWrapper(T: type) type {
                     this.flags.fatal_error = true;
                     this.triggerCloseCallback();
                 }
-            }
+            };
             return ret == 1; // truly closed
         }
 
@@ -308,11 +308,11 @@ pub fn SSLWrapper(T: type) type {
                 if (err != BoringSSL.SSL_ERROR_WANT_READ and err != BoringSSL.SSL_ERROR_WANT_WRITE) {
                     // clear per thread error queue if it may contain something
                     this.flags.fatal_error = err == BoringSSL.SSL_ERROR_SSL or err == BoringSSL.SSL_ERROR_SYSCALL;
-                    
+
                     this.flags.handshake_state = HandshakeState.HANDSHAKE_COMPLETED;
                     this.triggerHandshakeCallback(false, this.getVerifyError());
-                    
-                    if(this.flags.fatal_error) {
+
+                    if (this.flags.fatal_error) {
                         this.triggerCloseCallback();
                         return false;
                     }
@@ -381,7 +381,7 @@ pub fn SSLWrapper(T: type) type {
                         if (read > 0) {
                             this.triggerDataCallback(buffer[0..read]);
                         }
-                       
+
                         this.triggerCloseCallback();
                         return false;
                     } else {

--- a/src/deps/boringssl.translated.zig
+++ b/src/deps/boringssl.translated.zig
@@ -18737,7 +18737,7 @@ pub extern fn RAND_bytes(buf: [*]u8, len: usize) c_int;
 /// Hence, this function should never be called by libraries.
 pub extern fn RAND_enable_fork_unsafe_buffering(c_int) void;
 
-pub extern fn SSL_new(ctx: ?*SSL_CTX) *SSL;
+pub extern fn SSL_new(ctx: ?*SSL_CTX) ?*SSL;
 
 pub extern fn EVP_md4() *const EVP_MD;
 pub extern fn EVP_md5() *const EVP_MD;

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1411,7 +1411,6 @@ pub const us_bun_socket_context_options_t = extern struct {
 };
 pub extern fn create_ssl_context_from_bun_options(options: us_bun_socket_context_options_t) ?*BoringSSL.SSL_CTX;
 
-
 pub const us_bun_verify_error_t = extern struct {
     error_no: i32 = 0,
     code: [*c]const u8 = null,

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1409,12 +1409,15 @@ pub const us_bun_socket_context_options_t = extern struct {
     client_renegotiation_limit: u32 = 3,
     client_renegotiation_window: u32 = 600,
 };
+pub extern fn create_ssl_context_from_bun_options(options: us_bun_socket_context_options_t) ?*BoringSSL.SSL_CTX;
+
 
 pub const us_bun_verify_error_t = extern struct {
     error_no: i32 = 0,
     code: [*c]const u8 = null,
     reason: [*c]const u8 = null,
 };
+pub extern fn us_ssl_socket_verify_error_from_ssl(ssl: *BoringSSL.SSL) us_bun_verify_error_t;
 
 pub const us_socket_events_t = extern struct {
     on_open: ?*const fn (*Socket, i32, [*c]u8, i32) callconv(.C) ?*Socket = null,

--- a/src/http.zig
+++ b/src/http.zig
@@ -1063,7 +1063,7 @@ pub const HTTPThread = struct {
                 client.flags.disable_keepalive = true;
                 if (client.http_proxy) |url| {
                     // https://github.com/oven-sh/bun/issues/11343
-                    if (strings.eqlComptime(url.protocol, "https") or strings.eqlComptime(url.protocol, "http")) {
+                    if (url.protocol.len == 0 or strings.eqlComptime(url.protocol, "https") or strings.eqlComptime(url.protocol, "http")) {
                         return try this.context(is_ssl).connect(client, url.hostname, url.getPortAuto());
                     }
                     return error.UnsupportedProxyProtocol;
@@ -1073,7 +1073,7 @@ pub const HTTPThread = struct {
         }
         if (client.http_proxy) |url| {
             // https://github.com/oven-sh/bun/issues/11343
-            if (strings.eqlComptime(url.protocol, "https") or strings.eqlComptime(url.protocol, "http")) {
+            if (url.protocol.len == 0 or strings.eqlComptime(url.protocol, "https") or strings.eqlComptime(url.protocol, "http")) {
                 return try this.context(is_ssl).connect(client, url.hostname, url.getPortAuto());
             }
             return error.UnsupportedProxyProtocol;

--- a/src/http.zig
+++ b/src/http.zig
@@ -1205,11 +1205,11 @@ pub fn checkServerIdentity(
     comptime is_ssl: bool,
     socket: NewHTTPContext(is_ssl).HTTPSocket,
     certError: HTTPCertError,
-    ssl_ptr: *BoringSSL.SSL,
-    allow_proxy_url: bool,
+    sslPtr: *BoringSSL.SSL,
+    allowProxyUrl: bool,
 ) bool {
     if (client.flags.reject_unauthorized) {
-        if (BoringSSL.SSL_get_peer_cert_chain(ssl_ptr)) |cert_chain| {
+        if (BoringSSL.SSL_get_peer_cert_chain(sslPtr)) |cert_chain| {
             if (BoringSSL.sk_X509_value(cert_chain, 0)) |x509| {
 
                 // check if we need to report the error (probably to `checkServerIdentity` was informed from JS side)
@@ -1223,7 +1223,7 @@ pub fn checkServerIdentity(
                     assert(result_size == cert_size);
 
                     var hostname = client.hostname orelse client.url.hostname;
-                    if (allow_proxy_url) {
+                    if (allowProxyUrl) {
                         if (client.http_proxy) |proxy| {
                             hostname = proxy.hostname;
                         }
@@ -1248,7 +1248,7 @@ pub fn checkServerIdentity(
                     // fast path
 
                     var hostname = client.hostname orelse client.url.hostname;
-                    if (allow_proxy_url) {
+                    if (allowProxyUrl) {
                         if (client.http_proxy) |proxy| {
                             hostname = proxy.hostname;
                         }

--- a/src/http.zig
+++ b/src/http.zig
@@ -33,6 +33,7 @@ const BoringSSL = bun.BoringSSL;
 const Progress = bun.Progress;
 const X509 = @import("./bun.js/api/bun/x509.zig");
 const SSLConfig = @import("./bun.js/api/server.zig").ServerConfig.SSLConfig;
+const SSLWrapper = @import("./bun.js/api/bun/ssl_wrapper.zig").SSLWrapper;
 
 const URLBufferPool = ObjectPool([8192]u8, null, false, 10);
 const uws = bun.uws;
@@ -199,132 +200,290 @@ pub const Sendfile = struct {
     };
 };
 
-const ProxySSLData = struct {
-    buffer: std.ArrayList(u8),
-    partial: bool,
-    temporary_slice: ?[]const u8,
-    pub fn init() !ProxySSLData {
-        const buffer = try std.ArrayList(u8).initCapacity(bun.default_allocator, 16 * 1024);
-
-        return ProxySSLData{ .buffer = buffer, .partial = false, .temporary_slice = null };
-    }
-
-    pub fn slice(this: *@This()) []const u8 {
-        if (this.temporary_slice) |data| {
-            return data;
-        }
-        const data = this.buffer.toOwnedSliceSentinel(0) catch unreachable;
-        this.temporary_slice = data;
-        return data;
-    }
-
-    pub fn deinit(this: @This()) void {
-        this.buffer.deinit();
-        if (this.temporary_slice) |data| {
-            bun.default_allocator.free(data);
-        }
-    }
-};
-
 const ProxyTunnel = struct {
-    ssl_ctx: *BoringSSL.SSL_CTX,
-    ssl: *BoringSSL.SSL,
-    out_bio: *BoringSSL.BIO,
-    in_bio: *BoringSSL.BIO,
-    partial_data: ?ProxySSLData,
-    read_buffer: []u8,
+    wrapper: ?ProxyTunnelWrapper = null,
+    shutdown_err: anyerror = error.ConnectionClosed,
+    // active socket is the socket that is currently being used
+    socket: union(enum) {
+        tcp: NewHTTPContext(false).HTTPSocket,
+        ssl: NewHTTPContext(true).HTTPSocket,
+        none: void,
+    } = .{ .none = {} },
+    write_buffer: bun.io.StreamBuffer = .{},
 
-    pub fn init(comptime is_ssl: bool, client: *HTTPClient, socket: NewHTTPContext(is_ssl).HTTPSocket) ProxyTunnel {
-        BoringSSL.load();
-        const context = BoringSSL.SSL_CTX.init();
+    const ProxyTunnelWrapper = SSLWrapper(*HTTPClient);
 
-        if (context) |ssl_context| {
-            const ssl_ctx = ssl_context;
-            var ssl = BoringSSL.SSL.init(ssl_context);
-            ssl.setIsClient(true);
-            var out_bio: *BoringSSL.BIO = undefined;
-            if (comptime is_ssl) {
-                //TLS -> TLS
-                const proxy_ssl: *BoringSSL.SSL = @as(*BoringSSL.SSL, @ptrCast(socket.getNativeHandle()));
-                //create new SSL BIO
-                out_bio = BoringSSL.BIO_new(BoringSSL.BIO_f_ssl()) orelse unreachable;
-                //chain SSL bio with proxy BIO
-                const proxy_bio = BoringSSL.SSL_get_wbio(proxy_ssl);
-                _ = BoringSSL.BIO_push(out_bio, proxy_bio);
-            } else {
-                // socket output bio for non-TLS -> TLS
-                const fd = @as(c_int, @intCast(@intFromPtr(socket.getNativeHandle())));
-                out_bio = BoringSSL.BIO_new_fd(fd, BoringSSL.BIO_NOCLOSE);
-            }
+    fn onOpen(this: *HTTPClient) void {
+        this.state.response_stage = .proxy_handshake;
+        this.state.request_stage = .proxy_handshake;
+        if (this.proxy_tunnel) |*proxy| {
+            if (proxy.wrapper) |*wrapper| {
+                var ssl_ptr = wrapper.ssl orelse return;
+                const _hostname = this.hostname orelse this.url.hostname;
 
-            // in memory bio to control input flow from onData handler
-            const in_bio = BoringSSL.BIO.init() catch {
-                unreachable;
-            };
-            _ = BoringSSL.BIO_set_mem_eof_return(in_bio, -1);
-            ssl.setBIO(in_bio, out_bio);
-
-            const hostname = bun.default_allocator.dupeZ(u8, client.hostname orelse client.url.hostname) catch unreachable;
-            defer bun.default_allocator.free(hostname);
-
-            ssl.configureHTTPClient(hostname);
-            BoringSSL.SSL_CTX_set_verify(ssl_ctx, BoringSSL.SSL_VERIFY_NONE, null);
-            BoringSSL.SSL_set_verify(ssl, BoringSSL.SSL_VERIFY_NONE, null);
-            // TODO: change this to ssl_renegotiate_explicit for optimization
-            // if we allow renegotiation, we need to set the mode here
-            // https://github.com/oven-sh/bun/issues/6197
-            // https://github.com/oven-sh/bun/issues/5363
-            // renegotiation is only valid for <= TLS1_2_VERSION
-            BoringSSL.SSL_set_renegotiate_mode(ssl, BoringSSL.ssl_renegotiate_freely);
-            return ProxyTunnel{ .ssl = ssl, .ssl_ctx = ssl_ctx, .in_bio = in_bio, .out_bio = out_bio, .read_buffer = bun.default_allocator.alloc(u8, 16 * 1024) catch unreachable, .partial_data = null };
-        }
-        unreachable;
-    }
-
-    pub fn getSSLData(this: *@This(), incoming_data: ?[]const u8) !ProxySSLData {
-        if (incoming_data) |data| {
-            _ = this.in_bio.write(data) catch {
-                return error.OutOfMemory;
-            };
-        }
-
-        var data: ProxySSLData = undefined;
-        if (this.partial_data) |partial| {
-            data = partial;
-            data.partial = false;
-        } else {
-            data = try ProxySSLData.init();
-        }
-
-        var writer = data.buffer.writer();
-        while (true) {
-            const read_size = this.ssl.read(this.read_buffer) catch |err| {
-                // handshake needed
-                if (err == error.WantWrite) {
-                    //needs handshake
-                    data.partial = true;
-                    this.partial_data = data;
-                    return data;
+                var hostname: [:0]const u8 = "";
+                var hostname_needs_free = false;
+                if (!strings.isIPAddress(_hostname)) {
+                    if (_hostname.len < temp_hostname.len) {
+                        @memcpy(temp_hostname[0.._hostname.len], _hostname);
+                        temp_hostname[_hostname.len] = 0;
+                        hostname = temp_hostname[0.._hostname.len :0];
+                    } else {
+                        hostname = bun.default_allocator.dupeZ(u8, _hostname) catch unreachable;
+                        hostname_needs_free = true;
+                    }
                 }
 
-                break;
-            };
-            // no more data
-            if (read_size == 0) {
-                break;
+                defer if (hostname_needs_free) bun.default_allocator.free(hostname);
+                ssl_ptr.configureHTTPClient(hostname);
             }
-            _ = writer.write(this.read_buffer[0..read_size]) catch 0;
         }
-        return data;
     }
-    pub fn deinit(this: @This()) void {
-        this.ssl.deinit();
-        this.ssl_ctx.deinit();
-        if (this.partial_data) |ssl_data| {
-            ssl_data.deinit();
+
+    fn onData(this: *HTTPClient, decoded_data: []const u8) void {
+        if (decoded_data.len == 0) return;
+        log("onData decoded {}", .{decoded_data.len});
+
+        if (this.proxy_tunnel) |*proxy| {
+            switch (this.state.response_stage) {
+                .body => {
+                    if (decoded_data.len == 0) return;
+                    const report_progress = this.handleResponseBody(decoded_data, false) catch |err| {
+                        proxy.close(err);
+                        return;
+                    };
+
+                    if (report_progress) {
+                        switch (proxy.socket) {
+                            .ssl => |socket| {
+                                this.progressUpdate(true, &http_thread.https_context, socket);
+                            },
+                            .tcp => |socket| {
+                                this.progressUpdate(false, &http_thread.http_context, socket);
+                            },
+                            .none => {},
+                        }
+                        return;
+                    }
+                },
+                .body_chunk => {
+                    if (decoded_data.len == 0) return;
+                    const report_progress = this.handleResponseBodyChunkedEncoding(decoded_data) catch |err| {
+                        proxy.close(err);
+                        return;
+                    };
+
+                    if (report_progress) {
+                        switch (proxy.socket) {
+                            .ssl => |socket| {
+                                this.progressUpdate(true, &http_thread.https_context, socket);
+                            },
+                            .tcp => |socket| {
+                                this.progressUpdate(false, &http_thread.http_context, socket);
+                            },
+                            .none => {},
+                        }
+                        return;
+                    }
+                },
+                .proxy_decoded_headers, .proxy_headers => {
+                    this.flags.proxy_tunneling = false;
+                    this.state.response_stage = .proxy_decoded_headers;
+
+                    switch (proxy.socket) {
+                        .ssl => |socket| {
+                            this.onData(true, decoded_data, &http_thread.https_context, socket);
+                        },
+                        .tcp => |socket| {
+                            this.onData(false, decoded_data, &http_thread.http_context, socket);
+                        },
+                        .none => {},
+                    }
+                },
+                else => {
+                    this.state.pending_response = null;
+                    proxy.close(error.UnexpectedData);
+                },
+            }
         }
-        bun.default_allocator.free(this.read_buffer);
-        // no need to call BIO_free because of ssl.setBIO
+    }
+
+    fn onHandshake(this: *HTTPClient, handshake_success: bool, ssl_error: uws.us_bun_verify_error_t) void {
+        if (this.proxy_tunnel) |*proxy| {
+            this.state.response_stage = .proxy_headers;
+            this.state.request_stage = .proxy_headers;
+            this.state.request_sent_len = 0;
+            const handshake_error = HTTPCertError{
+                .error_no = ssl_error.error_no,
+                .code = if (ssl_error.code == null) "" else ssl_error.code[0..bun.len(ssl_error.code) :0],
+                .reason = if (ssl_error.code == null) "" else ssl_error.reason[0..bun.len(ssl_error.reason) :0],
+            };
+            if (handshake_success) {
+                // handshake completed but we may have ssl errors
+                this.flags.did_have_handshaking_error = handshake_error.error_no != 0;
+                if (this.flags.reject_unauthorized) {
+                    // only reject the connection if reject_unauthorized == true
+                    if (this.flags.did_have_handshaking_error) {
+                        proxy.close(BoringSSL.getCertErrorFromNo(handshake_error.error_no));
+                        return;
+                    }
+
+                    // if checkServerIdentity returns false, we dont call open this means that the connection was rejected
+                    bun.assert(proxy.wrapper != null);
+                    const ssl_ptr = proxy.wrapper.?.ssl orelse return;
+
+                    switch (proxy.socket) {
+                        .ssl => |socket| {
+                            if (!this.checkServerIdentity(true, socket, handshake_error, ssl_ptr)) {
+                                this.flags.did_have_handshaking_error = true;
+                                this.unregisterAbortTracker();
+                                return;
+                            }
+                        },
+                        .tcp => |socket| {
+                            if (!this.checkServerIdentity(false, socket, handshake_error, ssl_ptr)) {
+                                this.flags.did_have_handshaking_error = true;
+                                this.unregisterAbortTracker();
+                                return;
+                            }
+                        },
+                        .none => {},
+                    }
+                }
+
+                switch (proxy.socket) {
+                    .ssl => |socket| {
+                        this.onWritable(true, true, socket);
+                    },
+                    .tcp => |socket| {
+                        this.onWritable(true, false, socket);
+                    },
+                    .none => {},
+                }
+            } else {
+                // if we are here is because server rejected us, and the error_no is the cause of this
+                // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
+                if (this.flags.did_have_handshaking_error) {
+                    proxy.close(BoringSSL.getCertErrorFromNo(handshake_error.error_no));
+                    return;
+                }
+                // if handshake_success it self is false, this means that the connection was rejected
+                proxy.close(error.ConnectionRefused);
+                return;
+            }
+        }
+    }
+
+    pub fn write(this: *HTTPClient, encoded_data: []const u8) void {
+        if (this.proxy_tunnel) |*proxy| {
+            const written = switch (proxy.socket) {
+                .ssl => |socket| socket.write(encoded_data, true),
+                .tcp => |socket| socket.write(encoded_data, true),
+                .none => 0,
+            };
+            const pending = encoded_data[@intCast(written)..];
+            if (pending.len > 0) {
+                // lets flush when we are trully writable
+                proxy.write_buffer.write(pending) catch bun.outOfMemory();
+            }
+        }
+    }
+
+    fn onClose(this: *HTTPClient) void {
+        if (this.proxy_tunnel) |*proxy| {
+            const err = proxy.shutdown_err;
+            switch (proxy.socket) {
+                .ssl => |socket| {
+                    this.closeAndFail(err, true, socket);
+                },
+                .tcp => |socket| {
+                    this.closeAndFail(err, false, socket);
+                },
+                .none => {},
+            }
+        }
+    }
+
+    fn start(ctx: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket, ssl_options: JSC.API.ServerConfig.SSLConfig) void {
+        ctx.proxy_tunnel = .{};
+        if (ctx.proxy_tunnel) |*this| {
+            if (is_ssl) {
+                this.socket = .{ .ssl = socket };
+            } else {
+                this.socket = .{ .tcp = socket };
+            }
+            var custom_options = ssl_options;
+            // we always request the cert so we can verify it and also we manually abort the connection if the hostname doesn't match
+            custom_options.reject_unauthorized = 0;
+            custom_options.request_cert = 1;
+            this.wrapper = SSLWrapper(*HTTPClient).init(custom_options, true, .{
+                .onOpen = ProxyTunnel.onOpen,
+                .onData = ProxyTunnel.onData,
+                .onHandshake = ProxyTunnel.onHandshake,
+                .onClose = ProxyTunnel.onClose,
+                .write = ProxyTunnel.write,
+                .ctx = ctx,
+            }) catch |err| {
+                if (err == error.OutOfMemory) {
+                    bun.outOfMemory();
+                }
+
+                // invalid TLS Options
+                this.socket = .{ .none = {} };
+                this.wrapper = null;
+                ctx.closeAndFail(error.ConnectionRefused, is_ssl, socket);
+                return;
+            };
+            this.wrapper.?.start();
+        }
+    }
+
+    pub fn close(this: *ProxyTunnel, err: anyerror) void {
+        this.shutdown_err = err;
+        if (this.wrapper) |*wrapper| {
+            // fast shutdown the connection
+            _ = wrapper.shutdown(true);
+        }
+    }
+
+    pub fn onWritable(this: *ProxyTunnel, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
+        const encoded_data = this.write_buffer.slice();
+        if (encoded_data.len == 0) {
+            return;
+        }
+        const written = socket.write(encoded_data, true);
+        if (written == encoded_data.len) {
+            this.write_buffer.reset();
+            return;
+        }
+
+        this.write_buffer.cursor += @intCast(written);
+        if (this.wrapper) |*wrapper| {
+            // Cycle to through the SSL state machine
+            _ = wrapper.flush();
+        }
+    }
+
+    pub fn receiveData(this: *ProxyTunnel, buf: []const u8) void {
+        if (this.wrapper) |*wrapper| {
+            wrapper.receiveData(buf);
+        }
+    }
+
+    pub fn writeData(this: *ProxyTunnel, buf: []const u8) !usize {
+        if (this.wrapper) |*wrapper| {
+            return try wrapper.writeData(buf);
+        }
+        return 0;
+    }
+
+    pub fn deinit(this: *ProxyTunnel) void {
+        this.socket = .{ .none = {} };
+        if (this.wrapper) |*wrapper| {
+            wrapper.deinit();
+            this.wrapper = null;
+        }
+        this.write_buffer.deinit();
     }
 };
 
@@ -534,7 +693,8 @@ fn NewHTTPContext(comptime ssl: bool) type {
                             }
 
                             // if checkServerIdentity returns false, we dont call open this means that the connection was rejected
-                            if (!client.checkServerIdentity(comptime ssl, socket, handshake_error)) {
+                            const ssl_ptr = @as(*BoringSSL.SSL, @ptrCast(socket.getNativeHandle()));
+                            if (!client.checkServerIdentity(comptime ssl, socket, handshake_error, ssl_ptr)) {
                                 client.flags.did_have_handshaking_error = true;
                                 client.unregisterAbortTracker();
                                 if (!socket.isClosed()) terminateSocket(socket);
@@ -882,7 +1042,11 @@ pub const HTTPThread = struct {
                         requested_config.deinit();
                         bun.default_allocator.destroy(requested_config);
                         client.tls_props = other_config;
-                        return try custom_ssl_context_map.get(other_config).?.connect(client, client.url.hostname, client.url.getPortAuto());
+                        if (client.http_proxy) |url| {
+                            return try custom_ssl_context_map.get(other_config).?.connect(client, url.hostname, url.getPortAuto());
+                        } else {
+                            return try custom_ssl_context_map.get(other_config).?.connect(client, client.url.hostname, client.url.getPortAuto());
+                        }
                     }
                 }
                 // we need the config so dont free it
@@ -897,6 +1061,9 @@ pub const HTTPThread = struct {
                 // We might deinit the socket context, so we disable keepalive to make sure we don't
                 // free it while in use.
                 client.flags.disable_keepalive = true;
+                if (client.http_proxy) |url| {
+                    return try this.context(is_ssl).connect(client, url.hostname, url.getPortAuto());
+                }
                 return try custom_context.connect(client, client.url.hostname, client.url.getPortAuto());
             }
         }
@@ -1030,12 +1197,9 @@ pub fn checkServerIdentity(
     comptime is_ssl: bool,
     socket: NewHTTPContext(is_ssl).HTTPSocket,
     certError: HTTPCertError,
+    ssl_ptr: *BoringSSL.SSL,
 ) bool {
-    if (comptime is_ssl == false) {
-        @panic("checkServerIdentity called on non-ssl socket");
-    }
     if (client.flags.reject_unauthorized) {
-        const ssl_ptr = @as(*BoringSSL.SSL, @ptrCast(socket.getNativeHandle()));
         if (BoringSSL.SSL_get_peer_cert_chain(ssl_ptr)) |cert_chain| {
             if (BoringSSL.sk_X509_value(cert_chain, 0)) |x509| {
 
@@ -1065,7 +1229,7 @@ pub fn checkServerIdentity(
                     };
 
                     // we inform the user that the cert is invalid
-                    client.progressUpdate(true, &http_thread.https_context, socket);
+                    client.progressUpdate(is_ssl, if (is_ssl) &http_thread.https_context else &http_thread.http_context, socket);
                     // continue until we are aborted or not
                     return true;
                 } else {
@@ -1231,7 +1395,6 @@ pub fn onTimeout(
     if (client.flags.disable_timeout) return;
     log("Timeout  {s}\n", .{client.url.href});
     defer NewHTTPContext(is_ssl).terminateSocket(socket);
-
     client.fail(error.Timeout);
 }
 pub fn onConnectError(
@@ -1747,9 +1910,10 @@ pub fn deinit(this: *HTTPClient) void {
         this.allocator.free(auth);
         this.proxy_authorization = null;
     }
-    if (this.proxy_tunnel) |tunnel| {
-        tunnel.deinit();
+    if (this.proxy_tunnel != null) {
+        var tunnel = this.proxy_tunnel.?;
         this.proxy_tunnel = null;
+        tunnel.deinit();
     }
     this.unix_socket_path.deinit();
     this.unix_socket_path = JSC.ZigString.Slice.empty;
@@ -2479,8 +2643,8 @@ pub fn doRedirect(
     this.flags.proxy_tunneling = false;
     if (this.proxy_tunnel != null) {
         var tunnel = this.proxy_tunnel.?;
-        tunnel.deinit();
         this.proxy_tunnel = null;
+        tunnel.deinit();
     }
 
     return this.start(.{ .bytes = request_body }, body_out_str);
@@ -2605,6 +2769,10 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
         }
     }
 
+    if (this.proxy_tunnel) |*proxy| {
+        proxy.onWritable(is_ssl, socket);
+    }
+
     switch (this.state.request_stage) {
         .pending, .headers => {
             var stack_fallback = std.heap.stackFallback(16384, default_allocator);
@@ -2698,7 +2866,11 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
                 false;
 
             if (has_sent_headers and has_sent_body) {
-                this.state.request_stage = .done;
+                if (this.flags.proxy_tunneling) {
+                    this.state.request_stage = .proxy_handshake;
+                } else {
+                    this.state.request_stage = .body;
+                }
                 return;
             }
 
@@ -2767,119 +2939,92 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
             if (this.state.original_request_body != .bytes) {
                 @panic("sendfile is only supported without SSL. This code should never have been reached!");
             }
-            var proxy = this.proxy_tunnel orelse return;
+            if (this.proxy_tunnel) |*proxy| {
+                this.setTimeout(socket, 5);
 
-            this.setTimeout(socket, 5);
+                const to_send = this.state.request_body;
+                const amount = proxy.writeData(to_send) catch return; // just wait and retry when onWritable! if closed internally will call proxy.onClose
 
-            const to_send = this.state.request_body;
-            const amount = proxy.ssl.write(to_send) catch |err| {
-                if (err == error.WantWrite) //just wait and retry when onWritable!
+                this.state.request_sent_len += @as(usize, @intCast(amount));
+                this.state.request_body = this.state.request_body[@as(usize, @intCast(amount))..];
+
+                if (this.state.request_body.len == 0) {
+                    this.state.request_stage = .done;
                     return;
-
-                this.closeAndFail(error.WriteFailed, is_ssl, socket);
-                return;
-            };
-
-            this.state.request_sent_len += @as(usize, @intCast(amount));
-            this.state.request_body = this.state.request_body[@as(usize, @intCast(amount))..];
-
-            if (this.state.request_body.len == 0) {
-                this.state.request_stage = .done;
-                return;
+                }
             }
         },
         .proxy_headers => {
-            const proxy = this.proxy_tunnel orelse return;
+            if (this.proxy_tunnel) |*proxy| {
+                this.setTimeout(socket, 5);
+                var stack_fallback = std.heap.stackFallback(16384, default_allocator);
+                const allocator = stack_fallback.get();
+                var list = std.ArrayList(u8).initCapacity(allocator, stack_fallback.buffer.len) catch unreachable;
+                defer if (list.capacity > stack_fallback.buffer.len) list.deinit();
+                const writer = &list.writer();
 
-            this.setTimeout(socket, 5);
-            var stack_fallback = std.heap.stackFallback(16384, default_allocator);
-            const allocator = stack_fallback.get();
-            var list = std.ArrayList(u8).initCapacity(allocator, stack_fallback.buffer.len) catch unreachable;
-            defer if (list.capacity > stack_fallback.buffer.len) list.deinit();
-            const writer = &list.writer();
-
-            const request = this.buildRequest(this.state.request_body.len);
-            writeRequest(
-                @TypeOf(writer),
-                writer,
-                request,
-            ) catch {
-                this.closeAndFail(error.OutOfMemory, is_ssl, socket);
-                return;
-            };
-
-            const headers_len = list.items.len;
-            assert(list.items.len == writer.context.items.len);
-            if (this.state.request_body.len > 0 and list.capacity - list.items.len > 0) {
-                var remain = list.items.ptr[list.items.len..list.capacity];
-                const wrote = @min(remain.len, this.state.request_body.len);
-                assert(wrote > 0);
-                @memcpy(remain[0..wrote], this.state.request_body[0..wrote]);
-                list.items.len += wrote;
-            }
-
-            const to_send = list.items[this.state.request_sent_len..];
-            if (comptime Environment.allow_assert) {
-                assert(!socket.isShutdown());
-                assert(!socket.isClosed());
-            }
-
-            const amount = proxy.ssl.write(to_send) catch |err| {
-                if (err == error.WantWrite) //just wait and retry when onWritable!
+                const request = this.buildRequest(this.state.request_body.len);
+                writeRequest(
+                    @TypeOf(writer),
+                    writer,
+                    request,
+                ) catch {
+                    this.closeAndFail(error.OutOfMemory, is_ssl, socket);
                     return;
+                };
 
-                this.closeAndFail(error.WriteFailed, is_ssl, socket);
-                return;
-            };
+                const headers_len = list.items.len;
+                assert(list.items.len == writer.context.items.len);
+                if (this.state.request_body.len > 0 and list.capacity - list.items.len > 0) {
+                    var remain = list.items.ptr[list.items.len..list.capacity];
+                    const wrote = @min(remain.len, this.state.request_body.len);
+                    assert(wrote > 0);
+                    @memcpy(remain[0..wrote], this.state.request_body[0..wrote]);
+                    list.items.len += wrote;
+                }
 
-            if (comptime is_first_call) {
-                if (amount == 0) {
-                    // don't worry about it
+                const to_send = list.items[this.state.request_sent_len..];
+                if (comptime Environment.allow_assert) {
+                    assert(!socket.isShutdown());
+                    assert(!socket.isClosed());
+                }
+                const amount = proxy.writeData(to_send) catch return; // just wait and retry when onWritable! if closed internally will call proxy.onClose
+
+                if (comptime is_first_call) {
+                    if (amount == 0) {
+                        // don't worry about it
+                        return;
+                    }
+                }
+
+                this.state.request_sent_len += @as(usize, @intCast(amount));
+                const has_sent_headers = this.state.request_sent_len >= headers_len;
+
+                if (has_sent_headers and this.state.request_body.len > 0) {
+                    this.state.request_body = this.state.request_body[this.state.request_sent_len - headers_len ..];
+                }
+
+                const has_sent_body = this.state.request_body.len == 0;
+
+                if (has_sent_headers and has_sent_body) {
+                    this.state.request_stage = .done;
                     return;
                 }
-            }
 
-            this.state.request_sent_len += @as(usize, @intCast(amount));
-            const has_sent_headers = this.state.request_sent_len >= headers_len;
+                if (has_sent_headers) {
+                    this.state.request_stage = .proxy_body;
+                    assert(this.state.request_body.len > 0);
 
-            if (has_sent_headers and this.state.request_body.len > 0) {
-                this.state.request_body = this.state.request_body[this.state.request_sent_len - headers_len ..];
-            }
-
-            const has_sent_body = this.state.request_body.len == 0;
-
-            if (has_sent_headers and has_sent_body) {
-                this.state.request_stage = .done;
-                return;
-            }
-
-            if (has_sent_headers) {
-                this.state.request_stage = .proxy_body;
-                assert(this.state.request_body.len > 0);
-
-                // we sent everything, but there's some body leftover
-                if (amount == @as(c_int, @intCast(to_send.len))) {
-                    this.onWritable(false, is_ssl, socket);
+                    // we sent everything, but there's some body leftover
+                    if (amount == @as(c_int, @intCast(to_send.len))) {
+                        this.onWritable(false, is_ssl, socket);
+                    }
+                } else {
+                    this.state.request_stage = .proxy_headers;
                 }
-            } else {
-                this.state.request_stage = .proxy_headers;
             }
         },
-        else => {
-            //Just check if need to call SSL_read if requested to be writable
-            var proxy = this.proxy_tunnel orelse return;
-            this.setTimeout(socket, 5);
-            var data = proxy.getSSLData(null) catch |err| {
-                this.closeAndFail(err, is_ssl, socket);
-                return;
-            };
-            if (data.partial) return;
-            //only deinit if is not partial
-            defer data.deinit();
-            const decoded_data = data.slice();
-            if (decoded_data.len == 0) return;
-            this.onData(is_ssl, decoded_data, if (comptime is_ssl) &http_thread.https_context else &http_thread.http_context, socket);
-        },
+        else => {},
     }
 }
 
@@ -2891,53 +3036,10 @@ pub fn closeAndFail(this: *HTTPClient, err: anyerror, comptime is_ssl: bool, soc
     this.fail(err);
 }
 
-fn startProxySendHeaders(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
-    this.state.response_stage = .proxy_headers;
-    this.state.request_stage = .proxy_headers;
-    this.state.request_sent_len = 0;
-    this.onWritable(true, is_ssl, socket);
-}
-
-fn retryProxyHandshake(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
-    const proxy = this.proxy_tunnel orelse return;
-    if (proxy.ssl.isInitFinished()) {
-        this.startProxySendHeaders(is_ssl, socket);
-        return;
-    }
-    proxy.ssl.handshake() catch |err| {
-        switch (err) {
-            error.WantWrite, error.WantRead => {
-                return;
-            },
-            else => {
-                log("Error performing SSL handshake with host through proxy {any}\n", .{err});
-                this.closeAndFail(err, is_ssl, socket);
-                return;
-            },
-        }
-    };
-    this.startProxySendHeaders(is_ssl, socket);
-}
 fn startProxyHandshake(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
-    this.state.response_stage = .proxy_handshake;
-    this.state.request_stage = .proxy_handshake;
-    const proxy = ProxyTunnel.init(is_ssl, this, socket);
-    this.proxy_tunnel = proxy;
-
-    proxy.ssl.handshake() catch |err| {
-        switch (err) {
-            error.WantWrite, error.WantRead => {
-                //Wait and Pull
-                return;
-            },
-            else => {
-                log("Error performing SSL handshake with host through proxy {any}\n", .{err});
-                this.closeAndFail(err, is_ssl, socket);
-                return;
-            },
-        }
-    };
-    this.startProxySendHeaders(is_ssl, socket);
+    // if we have options we pass them (ca, reject_unauthorized, etc) otherwise use the default
+    const ssl_options = if (this.tls_props != null) this.tls_props.?.* else JSC.API.ServerConfig.SSLConfig.zero;
+    ProxyTunnel.start(this, is_ssl, socket, ssl_options);
 }
 
 inline fn handleShortRead(
@@ -2958,7 +3060,13 @@ inline fn handleShortRead(
 
     this.setTimeout(socket, 5);
 }
-pub fn onData(this: *HTTPClient, comptime is_ssl: bool, incoming_data: []const u8, ctx: *NewHTTPContext(is_ssl), socket: NewHTTPContext(is_ssl).HTTPSocket) void {
+pub fn onData(
+    this: *HTTPClient,
+    comptime is_ssl: bool,
+    incoming_data: []const u8,
+    ctx: *NewHTTPContext(is_ssl),
+    socket: NewHTTPContext(is_ssl).HTTPSocket,
+) void {
     log("onData {}", .{incoming_data.len});
     if (this.signals.get(.aborted)) {
         this.closeAndAbort(is_ssl, socket);
@@ -3102,25 +3210,8 @@ pub fn onData(this: *HTTPClient, comptime is_ssl: bool, incoming_data: []const u
         .body => {
             this.setTimeout(socket, 5);
 
-            if (this.proxy_tunnel != null) {
-                var proxy = this.proxy_tunnel.?;
-                var data = proxy.getSSLData(incoming_data) catch |err| {
-                    this.closeAndFail(err, is_ssl, socket);
-                    return;
-                };
-                if (data.partial) return;
-                defer data.deinit();
-                const decoded_data = data.slice();
-                if (decoded_data.len == 0) return;
-                const report_progress = this.handleResponseBody(decoded_data, false) catch |err| {
-                    this.closeAndFail(err, is_ssl, socket);
-                    return;
-                };
-
-                if (report_progress) {
-                    this.progressUpdate(is_ssl, ctx, socket);
-                    return;
-                }
+            if (this.proxy_tunnel) |*proxy| {
+                proxy.receiveData(incoming_data);
             } else {
                 const report_progress = this.handleResponseBody(incoming_data, false) catch |err| {
                     this.closeAndFail(err, is_ssl, socket);
@@ -3137,26 +3228,8 @@ pub fn onData(this: *HTTPClient, comptime is_ssl: bool, incoming_data: []const u
         .body_chunk => {
             this.setTimeout(socket, 5);
 
-            if (this.proxy_tunnel != null) {
-                var proxy = this.proxy_tunnel.?;
-                var data = proxy.getSSLData(incoming_data) catch |err| {
-                    this.closeAndFail(err, is_ssl, socket);
-                    return;
-                };
-                if (data.partial) return;
-                defer data.deinit();
-                const decoded_data = data.slice();
-                if (decoded_data.len == 0) return;
-
-                const report_progress = this.handleResponseBodyChunkedEncoding(decoded_data) catch |err| {
-                    this.closeAndFail(err, is_ssl, socket);
-                    return;
-                };
-
-                if (report_progress) {
-                    this.progressUpdate(is_ssl, ctx, socket);
-                    return;
-                }
+            if (this.proxy_tunnel) |*proxy| {
+                proxy.receiveData(incoming_data);
             } else {
                 const report_progress = this.handleResponseBodyChunkedEncoding(incoming_data) catch |err| {
                     this.closeAndFail(err, is_ssl, socket);
@@ -3171,32 +3244,11 @@ pub fn onData(this: *HTTPClient, comptime is_ssl: bool, incoming_data: []const u
         },
 
         .fail => {},
-        .proxy_headers => {
+        .proxy_headers, .proxy_handshake => {
             this.setTimeout(socket, 5);
-            var proxy = this.proxy_tunnel orelse return;
-            var data = proxy.getSSLData(incoming_data) catch |err| {
-                this.closeAndFail(err, is_ssl, socket);
-                return;
-            };
-            if (data.partial) return;
-            //only deinit if is not partial
-            defer data.deinit();
-            const decoded_data = data.slice();
-            if (decoded_data.len == 0) return;
-            this.flags.proxy_tunneling = false;
-            this.state.response_stage = .proxy_decoded_headers;
-            //actual do the header parsing!
-            this.onData(is_ssl, decoded_data, ctx, socket);
-        },
-        .proxy_handshake => {
-            this.setTimeout(socket, 5);
-
-            // put more data into SSL
-            const proxy = this.proxy_tunnel orelse return;
-            _ = proxy.in_bio.write(incoming_data) catch 0;
-
-            //retry again!
-            this.retryProxyHandshake(is_ssl, socket);
+            if (this.proxy_tunnel) |*proxy| {
+                proxy.receiveData(incoming_data);
+            }
             return;
         },
         else => {
@@ -3213,6 +3265,11 @@ pub fn closeAndAbort(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPCo
 
 fn fail(this: *HTTPClient, err: anyerror) void {
     this.unregisterAbortTracker();
+    if (this.proxy_tunnel != null) {
+        var tunnel = this.proxy_tunnel.?;
+        this.proxy_tunnel = null;
+        tunnel.deinit();
+    }
     if (this.state.stage != .done and this.state.stage != .fail) {
         this.state.request_stage = .fail;
         this.state.response_stage = .fail;

--- a/src/http.zig
+++ b/src/http.zig
@@ -1248,8 +1248,10 @@ pub fn checkServerIdentity(
                     // fast path
 
                     var hostname = client.hostname orelse client.url.hostname;
-                    if (client.http_proxy) |proxy| {
-                        hostname = proxy.hostname;
+                    if (allow_proxy_url) {
+                        if (client.http_proxy) |proxy| {
+                            hostname = proxy.hostname;
+                        }
                     }
 
                     if (BoringSSL.checkX509ServerIdentity(x509, hostname)) {

--- a/src/http.zig
+++ b/src/http.zig
@@ -1062,13 +1062,21 @@ pub const HTTPThread = struct {
                 // free it while in use.
                 client.flags.disable_keepalive = true;
                 if (client.http_proxy) |url| {
-                    return try this.context(is_ssl).connect(client, url.hostname, url.getPortAuto());
+                    // https://github.com/oven-sh/bun/issues/11343
+                    if (strings.eqlComptime(url.protocol, "https") or strings.eqlComptime(url.protocol, "http")) {
+                        return try this.context(is_ssl).connect(client, url.hostname, url.getPortAuto());
+                    }
+                    return error.UnsupportedProxyProtocol;
                 }
                 return try custom_context.connect(client, client.url.hostname, client.url.getPortAuto());
             }
         }
         if (client.http_proxy) |url| {
-            return try this.context(is_ssl).connect(client, url.hostname, url.getPortAuto());
+            // https://github.com/oven-sh/bun/issues/11343
+            if (strings.eqlComptime(url.protocol, "https") or strings.eqlComptime(url.protocol, "http")) {
+                return try this.context(is_ssl).connect(client, url.hostname, url.getPortAuto());
+            }
+            return error.UnsupportedProxyProtocol;
         }
         return try this.context(is_ssl).connect(client, client.url.hostname, client.url.getPortAuto());
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -849,6 +849,15 @@ class Server extends EventEmitter {
     return this;
   }
 
+  [Symbol.asyncDispose]() {
+    const { resolve, reject, promise } = Promise.withResolvers();
+    this.close(function (err, ...args) {
+      if (err) reject(err);
+      else resolve(...args);
+    });
+    return promise;
+  }
+
   _emitCloseIfDrained() {
     if (this[bunSocketInternal] || this[bunSocketServerConnections] > 0) {
       return;

--- a/test/js/bun/http/proxy.test.js
+++ b/test/js/bun/http/proxy.test.js
@@ -6,7 +6,6 @@ import path from "path";
 import { bunExe } from "harness";
 
 let proxy, auth_proxy, server;
-
 beforeAll(() => {
   proxy = Bun.serve({
     port: 0,

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { once } from "node:events";
+import tls from "node:tls";
+import net from "node:net";
+import { tls as tlsCert } from "harness";
+import type { Server } from "bun";
+async function createProxyServer(is_tls: boolean) {
+  const serverArgs = [];
+  if (is_tls) {
+    serverArgs.push({
+      ...tlsCert,
+      rejectUnauthorized: false,
+    });
+  }
+  serverArgs.push((clientSocket: net.Socket | tls.TLSSocket) => {
+    clientSocket.once("data", data => {
+      const request = data.toString();
+      const [method, path] = request.split(" ");
+      let host: string;
+      let port: number | string = 0;
+      let request_path: string;
+      if (path.indexOf("http") !== -1) {
+        const url = new URL(path);
+        host = url.hostname;
+        port = url.port;
+        request_path = url.pathname + (url.search || "");
+      } else {
+        // Extract the host and port from the CONNECT request
+        [host, port] = path.split(":");
+      }
+      const destinationPort = Number.parseInt((port || (method === "CONNECT" ? "443" : "80")).toString(), 10);
+      const destinationHost = host || "";
+      // Establish a connection to the destination server
+      const serverSocket = net.connect(destinationPort, destinationHost, () => {
+        if (method === "CONNECT") {
+          // 220 OK with host so the client knows the connection was successful
+          clientSocket.write("HTTP/1.1 200 OK\r\nHost: localhost\r\n\r\n");
+
+          // Pipe data between client and server
+          clientSocket.pipe(serverSocket);
+          serverSocket.pipe(clientSocket);
+        } else {
+          serverSocket.write(`${method} ${request_path} HTTP/1.1\r\n`);
+          // Send the request to the destination server
+          serverSocket.write(data.slice(request.indexOf("\r\n") + 2));
+          serverSocket.pipe(clientSocket);
+        }
+      });
+
+      serverSocket.on("error", err => {
+        clientSocket.end();
+      });
+    });
+  });
+  // Create a server to listen for incoming HTTPS connections
+  //@ts-ignore
+  const server = (is_tls ? tls : net).createServer(...serverArgs);
+
+  server.listen(0);
+  await once(server, "listening");
+  const port = server.address().port;
+  const url = `http${is_tls ? "s" : ""}://localhost:${port}`;
+  return { server, url };
+}
+
+let httpServer: Server;
+let httpsServer: Server;
+let httpProxyServer: { server: net.Server; url: string };
+let httpsProxyServer: { server: net.Server; url: string };
+
+beforeAll(async () => {
+  httpServer = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      if (req.method === "POST") {
+        const text = await req.text();
+        return new Response(text, { status: 200 });
+      }
+      return new Response("", { status: 200 });
+    },
+  });
+
+  httpsServer = Bun.serve({
+    port: 0,
+    tls: tlsCert,
+    async fetch(req) {
+      if (req.method === "POST") {
+        const text = await req.text();
+        return new Response(text, { status: 200 });
+      }
+      return new Response("", { status: 200 });
+    },
+  });
+
+  httpProxyServer = await createProxyServer(false);
+  httpsProxyServer = await createProxyServer(true);
+});
+
+afterAll(() => {
+  httpServer.stop();
+  httpsServer.stop();
+  httpProxyServer.server.close();
+  httpsProxyServer.server.close();
+});
+
+for (const proxy_tls of [false, true]) {
+  for (const target_tls of [false, true]) {
+    for (const body of [undefined, "Hello, World"]) {
+      test(`${body === undefined ? "GET" : "POST"} ${proxy_tls ? "TLS" : "non-TLS"} proxy -> ${target_tls ? "TLS" : "non-TLS"} body type ${typeof body}`, async () => {
+        const response = await fetch(target_tls ? httpsServer.url : httpServer.url, {
+          method: body === undefined ? "GET" : "POST",
+          proxy: proxy_tls ? httpsProxyServer.url : httpProxyServer.url,
+          headers: {
+            "Content-Type": "plain/text",
+          },
+          keepalive: false,
+          body: body,
+          tls: {
+            ca: tlsCert.cert,
+            rejectUnauthorized: false,
+          },
+        });
+        expect(response.ok).toBe(true);
+        expect(response.status).toBe(200);
+        expect(response.statusText).toBe("OK");
+        const result = await response.text();
+
+        expect(result).toBe(body || "");
+      });
+    }
+  }
+}
+
+test("unsupported protocol", async () => {
+  expect(
+    fetch("https://httpbin.org/get", {
+      proxy: "ftp://asdf.com",
+    }),
+  ).rejects.toThrowError(
+    expect.objectContaining({
+      code: "UnsupportedProxyProtocol",
+    }),
+  );
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

Fix: https://github.com/oven-sh/bun/issues/13238
Fix: https://github.com/oven-sh/bun/issues/12007
Fix: https://github.com/oven-sh/bun/issues/12665
Fix: https://github.com/oven-sh/bun/issues/12751
Fix: https://github.com/oven-sh/bun/issues/12846
Fix: https://github.com/oven-sh/bun/issues/11343 (check for protocol type)
Fix: https://github.com/oven-sh/bun/issues/11298
Fix: https://github.com/oven-sh/bun/issues/11111
Fix: https://github.com/oven-sh/bun/issues/10616
Fix: https://github.com/oven-sh/bun/issues/10244
Fix: https://github.com/oven-sh/bun/issues/9586
Fix: https://github.com/oven-sh/bun/issues/9827
### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
