### PR TITLE
fix(bundler): fix part liveness calculation

### DIFF
--- a/src/ast/base.zig
+++ b/src/ast/base.zig
@@ -140,8 +140,8 @@ pub const Ref = packed struct(u64) {
             writer,
             "Ref[inner={d}, src={d}, .{s}]",
             .{
-                ref.sourceIndex(),
                 ref.innerIndex(),
+                ref.sourceIndex(),
                 @tagName(ref.tag),
             },
         );

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1469,6 +1469,97 @@ describe("bundler", () => {
       stdout: "side effect",
     },
   });
+  itBundled("edgecase/EsmSideEffectsFalseWithSideEffectsExportFromCodeSplitting", {
+    files: {
+      "/file1.js": `
+        import("./file2.js");
+        console.log('file1');
+      `,
+      "/file1b.js": `
+        import("./file2.js");
+        console.log('file2');
+      `,
+      "/file2.js": `
+        export { a } from './file3.js';
+      `,
+      "/file3.js": `
+        export function a(input) {
+          return 42;
+        }
+        console.log('side effect');
+      `,
+      "/package.json": `
+        {
+          "name": "my-package",
+          "sideEffects": false
+        }
+      `,
+    },
+    splitting: true,
+    outdir: "out",
+    entryPoints: ["./file1.js", "./file1b.js"],
+    run: [
+      {
+        file: "/out/file1.js",
+        stdout: "file1\nside effect",
+      },
+      {
+        file: "/out/file1b.js",
+        stdout: "file2\nside effect",
+      },
+    ],
+  });
+  itBundled("edgecase/RequireSideEffectsFalseWithSideEffectsExportFrom", {
+    files: {
+      "/file1.js": `
+        require("./file2.js");
+      `,
+      "/file2.js": `
+        export { a } from './file3.js';
+      `,
+      "/file3.js": `
+        export function a(input) {
+          return 42;
+        }
+        console.log('side effect');
+      `,
+      "/package.json": `
+        {
+          "name": "my-package",
+          "sideEffects": false
+        }
+      `,
+    },
+    run: {
+      stdout: "side effect",
+    },
+  });
+  itBundled("edgecase/SideEffectsFalseWithSideEffectsExportFrom", {
+    files: {
+      "/file1.js": `
+        import("./file2.js");
+      `,
+      "/file2.js": `
+        import * as foo from './file3.js';
+        export default foo;
+      `,
+      "/file3.js": `
+        export function a(input) {
+          return 42;
+        }
+        console.log('side effect');
+      `,
+      "/package.json": `
+        {
+          "name": "my-package",
+          "sideEffects": false
+        }
+      `,
+    },
+    run: {
+      stdout: "side effect",
+    },
+  });
   itBundled("edgecase/BuiltinWithTrailingSlash", {
     files: {
       "/entry.js": `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1443,6 +1443,32 @@ describe("bundler", () => {
       "/entry.ts": [`"Y" has already been declared`],
     },
   });
+  // This specifically only happens with 'export { ... } from ...' syntax
+  itBundled("edgecase/EsmSideEffectsFalseWithSideEffectsExportFrom", {
+    files: {
+      "/file1.js": `
+        import("./file2.js");
+      `,
+      "/file2.js": `
+        export { a } from './file3.js';
+      `,
+      "/file3.js": `
+        export function a(input) {
+          return 42;
+        }
+        console.log('side effect');
+      `,
+      "/package.json": `
+        {
+          "name": "my-package",
+          "sideEffects": false
+        }
+      `,
+    },
+    run: {
+      stdout: "side effect",
+    },
+  });
   itBundled("edgecase/BuiltinWithTrailingSlash", {
     files: {
       "/entry.js": `


### PR DESCRIPTION
### What does this PR do?

This fixes a very subtle mistake when determining which parts are live. See https://github.com/oven-sh/bun/issues/12571#issuecomment-2244067465, After fixing this first bug, there were three or four other fixes which are all very subtle but now Bun is now correct when it comes to this dependency calculation instead of just getting lucky.

Not marking #12571 as fixed because want to keepthe issue open as it shows sourcemaps are broken, **which this PR does not address**.

Fixes #9037 (different repro, same underlying bug)

---

Note that for the provided reproduction in 12571, it now errors with when sending the callback.html

![image](https://github.com/user-attachments/assets/ff078b95-ce74-4eaf-b0ce-070346dc04a7)

@davidgomes
For the file not found, I think that there is a bug with bun there, but this pattern works:

```
createReadStream(require.resolve("./callback.html")).pipe(response)
```
