### PR TITLE
fix memory lifetime of define expressions

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -1240,7 +1240,7 @@ pub fn definesFromTransformOptions(
         }
     }
 
-    const resolved_defines = try defines.DefineData.from_input(user_defines, log, allocator);
+    const resolved_defines = try defines.DefineData.fromInput(user_defines, log, allocator);
 
     return try defines.Define.init(
         allocator,


### PR DESCRIPTION
### What does this PR do?

Use `expr.data.deepClone` instead of the old manual approach, which was incorrect. 

This resolves existing test failures I've had on debug builds, which was almost certainly lucky behavior in release builds.