### PR TITLE
fix(napi): unref threadsafe functions on finalize

### DIFF
--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1544,6 +1544,8 @@ pub const ThreadSafeFunction = struct {
 
     pub fn finalize(opaq: *anyopaque) void {
         var this = bun.cast(*ThreadSafeFunction, opaq);
+        this.unref();
+
         if (this.finalizer.fun) |fun| {
             fun(this.event_loop.global, this.finalizer.data, this.ctx);
         }

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -69,6 +69,33 @@ static napi_value test_issue_11949(const Napi::CallbackInfo &info) {
   return result;
 }
 
+static void callback_1(napi_env env, napi_value js_callback, void *context,
+                       void *data) {}
+
+napi_value test_napi_threadsafe_function_does_not_hang_after_finalize(
+    const Napi::CallbackInfo &info) {
+
+  Napi::Env env = info.Env();
+  napi_status status;
+
+  napi_value resource_name;
+  status = napi_create_string_utf8(env, "simple", 6, &resource_name);
+  assert(status == napi_ok);
+
+  napi_threadsafe_function cb;
+  status = napi_create_threadsafe_function(env, nullptr, nullptr, resource_name,
+                                           0, 1, nullptr, nullptr, nullptr,
+                                           &callback_1, &cb);
+  assert(status == napi_ok);
+
+  status = napi_release_threadsafe_function(cb, napi_tsfn_release);
+  assert(status == napi_ok);
+
+  printf("success!");
+
+  return ok(env);
+}
+
 napi_value
 test_napi_get_value_string_utf8_with_buffer(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
@@ -123,10 +150,8 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports1) {
 
   Napi::Object exports = Init2(env, exports1);
 
-  node::AddEnvironmentCleanupHook(
-      isolate, [](void *) {}, isolate);
-  node::RemoveEnvironmentCleanupHook(
-      isolate, [](void *) {}, isolate);
+  node::AddEnvironmentCleanupHook(isolate, [](void *) {}, isolate);
+  node::RemoveEnvironmentCleanupHook(isolate, [](void *) {}, isolate);
 
   exports.Set("test_issue_7685", Napi::Function::New(env, test_issue_7685));
   exports.Set("test_issue_11949", Napi::Function::New(env, test_issue_11949));
@@ -134,6 +159,12 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports1) {
   exports.Set(
       "test_napi_get_value_string_utf8_with_buffer",
       Napi::Function::New(env, test_napi_get_value_string_utf8_with_buffer));
+
+  exports.Set(
+      "test_napi_threadsafe_function_does_not_hang_after_finalize",
+      Napi::Function::New(
+          env, test_napi_threadsafe_function_does_not_hang_after_finalize));
+
   return exports;
 }
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -59,6 +59,11 @@ describe("napi", () => {
     });
   });
 
+  it("threadsafe function does not hang on finalize", () => {
+    const result = checkSameOutput("test_napi_threadsafe_function_does_not_hang_after_finalize", []);
+    expect(result).toBe("success!");
+  });
+
   it("#1288", async () => {
     const result = checkSameOutput("self", []);
     expect(result).toBe("hello world!");


### PR DESCRIPTION
### What does this PR do?
fixes process hanging with Prisma.

Similar behavior is seen in node with:
`Finalize() -> EmptyQueueAndDelete() -> delete this -> ~ThreadSafeFunction() -> env->Unref()`
https://github.com/nodejs/node/blob/c112b4bc1d1ac511797c4f674d43f614c594d02b/src/node_api.cc#L432
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a simple test with `napi_release_threadsafe_function`
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
