### PR TITLE
Clean up some stack trace printing logic

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -596,9 +596,16 @@ pub const ZigStackFrame = extern struct {
             }
 
             try writer.writeAll(source_slice);
+            if (source_slice.len > 0 and (this.position.line.isValid() or this.position.column.isValid())) {
+                if (this.enable_color) {
+                    try writer.writeAll(comptime Output.prettyFmt("<r><d>:", true));
+                } else {
+                    try writer.writeAll(":");
+                }
+            }
 
             if (this.enable_color) {
-                if (this.position.line.isValid()) {
+                if (this.position.line.isValid() or this.position.column.isValid()) {
                     try writer.writeAll(comptime Output.prettyFmt("<r>", true));
                 } else {
                     try writer.writeAll(comptime Output.prettyFmt("<r>", true));
@@ -610,11 +617,11 @@ pub const ZigStackFrame = extern struct {
                     if (this.enable_color) {
                         try std.fmt.format(
                             writer,
-                            comptime Output.prettyFmt("<d>:<r><yellow>{d}<r><d>:<yellow>{d}<r>", true),
+                            comptime Output.prettyFmt("<yellow>{d}<r><d>:<yellow>{d}<r>", true),
                             .{ this.position.line.oneBased(), this.position.column.oneBased() },
                         );
                     } else {
-                        try std.fmt.format(writer, ":{d}:{d}", .{
+                        try std.fmt.format(writer, "{d}:{d}", .{
                             this.position.line.oneBased(),
                             this.position.column.oneBased(),
                         });
@@ -623,13 +630,13 @@ pub const ZigStackFrame = extern struct {
                     if (this.enable_color) {
                         try std.fmt.format(
                             writer,
-                            comptime Output.prettyFmt("<d>:<r><yellow>{d}<r>", true),
+                            comptime Output.prettyFmt("<yellow>{d}<r>", true),
                             .{
                                 this.position.line.oneBased(),
                             },
                         );
                     } else {
-                        try std.fmt.format(writer, ":{d}", .{
+                        try std.fmt.format(writer, "{d}", .{
                             this.position.line.oneBased(),
                         });
                     }
@@ -670,7 +677,11 @@ pub const ZigStackFrame = extern struct {
                     }
                 },
                 .Wasm => {
-                    try std.fmt.format(writer, "WASM {}", .{name});
+                    if (!name.isEmpty()) {
+                        try std.fmt.format(writer, "{}", .{name});
+                    } else {
+                        try writer.writeAll("WASM");
+                    }
                 },
                 .Constructor => {
                     try std.fmt.format(writer, "new {}", .{name});

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -2934,7 +2934,7 @@ pub const VirtualMachine = struct {
 
                 const has_name = std.fmt.count("{}", .{frame.nameFormatter(false)}) > 0;
 
-                if (has_name) {
+                if (has_name and !frame.position.isInvalid()) {
                     try writer.print(
                         comptime Output.prettyFmt(
                             "<r>      <d>at <r>{}<d> (<r>{}<d>)<r>\n",
@@ -2952,10 +2952,37 @@ pub const VirtualMachine = struct {
                             ),
                         },
                     );
-                } else {
+                } else if (!frame.position.isInvalid()) {
                     try writer.print(
                         comptime Output.prettyFmt(
                             "<r>      <d>at <r>{}\n",
+                            allow_ansi_colors,
+                        ),
+                        .{
+                            frame.sourceURLFormatter(
+                                dir,
+                                origin,
+                                false,
+                                allow_ansi_colors,
+                            ),
+                        },
+                    );
+                } else if (has_name) {
+                    try writer.print(
+                        comptime Output.prettyFmt(
+                            "<r>      <d>at <r>{}<d>\n",
+                            allow_ansi_colors,
+                        ),
+                        .{
+                            frame.nameFormatter(
+                                allow_ansi_colors,
+                            ),
+                        },
+                    );
+                } else {
+                    try writer.print(
+                        comptime Output.prettyFmt(
+                            "<r>      <d>at <r>{}<d>\n",
                             allow_ansi_colors,
                         ),
                         .{

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2960,7 +2960,7 @@ pub inline fn destroy(ptr: anytype) void {
         logAlloc("destroy({s}) = {*}", .{ meta.typeName(T), ptr });
     }
 
-    if (heap_breakdown.enabled) {
+    if (comptime heap_breakdown.enabled) {
         heap_breakdown.getZone(T).destroy(T, ptr);
     } else {
         default_allocator.destroy(ptr);


### PR DESCRIPTION
### What does this PR do?

- Remove unnecessary leading `:` 
- If JSC has any kind of function name for WASM call frames, include it instead of printing `WASM`

![image](https://github.com/user-attachments/assets/29dfe186-229a-4dc2-932e-5456b5a7e38c)
![image](https://github.com/user-attachments/assets/95e83d6d-15e9-4a7e-81b2-db1eff3a2c87)


### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
