### PR TITLE
fixes relationship between process.kill and process._kill

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -2773,6 +2773,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionKill,
     auto global = jsCast<Zig::GlobalObject*>(globalObject);
     auto& vm = global->vm();
     JSValue _killFn = global->processObject()->get(globalObject, Identifier::fromString(vm, "_kill"_s));
+    RETURN_IF_EXCEPTION(scope, {});
     if (!_killFn.isCallable()) {
         throwTypeError(globalObject, scope, "process._kill is not a function"_s);
         return JSValue::encode({});


### PR DESCRIPTION
- kill should call _kill
- throw should happen in kill not _kill
- on success kill should return true
- _kill should not throw unless there's not enough arguments
- _kill should behave the same on both posix and windows

for most this change will be invisible but it allows kill to be overridden in the way that the node apis expect
i should add a test before merge

split off from https://github.com/oven-sh/bun/pull/11492 to merge independently

test results should be identical to baseline
