### PR TITLE
fix crash in populateStackTrace()

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4311,7 +4311,7 @@ static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& 
 
     while (frame_i < frame_count && stack_frame_i < total_frame_count) {
         // Skip native frames
-        while (stack_frame_i < total_frame_count && !(&frames.at(stack_frame_i))->codeBlock() && !(&frames.at(stack_frame_i))->isWasmFrame()) {
+        while (stack_frame_i < total_frame_count && !(&frames.at(stack_frame_i))->hasLineAndColumnInfo() && !(&frames.at(stack_frame_i))->isWasmFrame()) {
             stack_frame_i++;
         }
         if (stack_frame_i >= total_frame_count)


### PR DESCRIPTION
fixes a crash because codeBlock() asserts m_codeBlock is valid so it never made it to the boolean operator overload. whereas hasLineAndColumnInfo() actually checks if it is there which is what we intended to do.

split off from https://github.com/oven-sh/bun/pull/11492 to merge independently

test results should be identical to baseline
