### PR TITLE
Handle values for optional long options properly

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -238,7 +238,7 @@ pub const Arguments = struct {
         clap.parseParam("--no-clear-screen                Disable clearing the terminal screen on reload when --watch is enabled") catch unreachable,
         clap.parseParam("--target <STR>                   The intended execution environment for the bundle. \"browser\", \"bun\" or \"node\"") catch unreachable,
         clap.parseParam("--outdir <STR>                   Default to \"dist\" if multiple files") catch unreachable,
-        clap.parseParam("--outfile <STR>                   Write to a file") catch unreachable,
+        clap.parseParam("--outfile <STR>                  Write to a file") catch unreachable,
         clap.parseParam("--sourcemap <STR>?               Build with sourcemaps - 'inline', 'external', or 'none'") catch unreachable,
         clap.parseParam("--format <STR>                   Specifies the module format to build to. Only \"esm\" is supported.") catch unreachable,
         clap.parseParam("--root <STR>                     Root directory used for multiple entry points") catch unreachable,

--- a/src/deps/zig-clap/clap/args.zig
+++ b/src/deps/zig-clap/clap/args.zig
@@ -80,6 +80,14 @@ pub const OsIterator = struct {
 
         return null;
     }
+
+    pub fn peek(iter: *OsIterator) ?[:0]const u8 {
+        if (iter.remain.len > 0) {
+            return iter.remain[0];
+        }
+
+        return null;
+    }
 };
 
 /// An argument iterator that takes a string and parses it into arguments, simulating

--- a/src/deps/zig-clap/clap/streaming.zig
+++ b/src/deps/zig-clap/clap/streaming.zig
@@ -85,7 +85,14 @@ pub fn StreamingClap(comptime Id: type, comptime ArgIterator: type) type {
                                 return parser.err(arg, .{ .long = name }, error.DoesntTakeValue);
                             }
 
-                            return ArgType{ .param = param, .value = maybe_value };
+                            if (parser.iter.peek()) |value| {
+                                if (!mem.startsWith(u8, value, "--") and !mem.startsWith(u8, value, "-")) {
+                                    _ = parser.iter.next();
+                                    return ArgType{ .param = param, .value = value };
+                                }
+                            }
+
+                            return ArgType{ .param = param, .value = null };
                         }
 
                         const value = blk: {


### PR DESCRIPTION
### What does this PR do?
This fixes: https://github.com/oven-sh/bun/issues/12779

This PR improves argument parsing for long options in the CLI by:

- Adding a `peek()` function to `OsIterator`
- Modifying `StreamingClap` to better handle optional long options
- Enhance detection of option values provided as separate arguments

- [x] Code changes

### How did you verify your code works?
Manually
