### PR TITLE
test: toRun matcher should check output if optionalStdout is empty string

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -371,7 +371,7 @@ expect.extend({
       };
     }
 
-    if (optionalStdout) {
+    if (optionalStdout != null) {
       return {
         pass: result.stdout.toString("utf-8") === optionalStdout,
         message: () =>


### PR DESCRIPTION
split off from https://github.com/oven-sh/bun/pull/11492 to merge independently

test results should be identical to baseline

just discovered this when writing some new tests. running on CI on its own to see if it catches anything