### PR TITLE
fix(brotli): protect buffer jsvalues

### DIFF
--- a/src/bun.js/api/js_brotli.zig
+++ b/src/bun.js/api/js_brotli.zig
@@ -297,7 +297,6 @@ pub const BrotliEncoder = struct {
             this.input_lock.lock();
             defer this.input_lock.unlock();
 
-            input_to_queue.protect();
             this.input.writeItem(input_to_queue) catch bun.outOfMemory();
         }
         task.run();
@@ -523,7 +522,6 @@ pub const BrotliDecoder = struct {
             this.input_lock.lock();
             defer this.input_lock.unlock();
 
-            input_to_queue.protect();
             this.input.writeItem(input_to_queue) catch bun.outOfMemory();
         }
         task.run();

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -269,6 +269,26 @@ pub const BlobOrStringOrBuffer = union(enum) {
         };
     }
 
+    pub fn protect(this: *const BlobOrStringOrBuffer) void {
+        switch (this.*) {
+            .string_or_buffer => |sob| {
+                sob.protect();
+            },
+            else => {},
+        }
+    }
+
+    pub fn deinitAndUnprotect(this: *const BlobOrStringOrBuffer) void {
+        switch (this.*) {
+            .string_or_buffer => |sob| {
+                sob.deinitAndUnprotect();
+            },
+            .blob => |blob| {
+                blob.deinit();
+            },
+        }
+    }
+
     pub fn fromJS(global: *JSC.JSGlobalObject, allocator: std.mem.Allocator, value: JSC.JSValue) ?BlobOrStringOrBuffer {
         if (value.as(JSC.WebCore.Blob)) |blob| {
             if (blob.store) |store| {
@@ -313,6 +333,15 @@ pub const StringOrBuffer = union(enum) {
             .threadsafe_string => {},
             .encoded_slice => {},
             .buffer => {},
+        }
+    }
+
+    pub fn protect(this: *const StringOrBuffer) void {
+        switch (this.*) {
+            .buffer => |buf| {
+                buf.buffer.value.protect();
+            },
+            else => {},
         }
     }
 

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -278,12 +278,12 @@ pub const BlobOrStringOrBuffer = union(enum) {
         }
     }
 
-    pub fn deinitAndUnprotect(this: *const BlobOrStringOrBuffer) void {
+    pub fn deinitAndUnprotect(this: *BlobOrStringOrBuffer) void {
         switch (this.*) {
             .string_or_buffer => |sob| {
                 sob.deinitAndUnprotect();
             },
-            .blob => |blob| {
+            .blob => |*blob| {
                 blob.deinit();
             },
         }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
TODO: add a test that doesn't take a minute to run
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
