### PR TITLE
fix(bun:test): make sure `test.each` doesn't return `.zero`

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1674,7 +1674,7 @@ inline fn createScope(
         Jest.runner.?.setOnly();
         tag_to_use = .only;
     } else if (is_test and Jest.runner.?.only and parent.tag != .only) {
-        return .zero;
+        return .undefined;
     }
 
     var is_skip = tag == .skip or
@@ -1781,9 +1781,9 @@ fn consumeArg(
     if (should_write) {
         const owned_slice = arg.toSliceOrNull(globalThis) orelse return error.Failed;
         defer owned_slice.deinit();
-        try array_list.appendSlice(allocator, owned_slice.slice());
+        array_list.appendSlice(allocator, owned_slice.slice()) catch bun.outOfMemory();
     } else {
-        try array_list.appendSlice(allocator, fallback);
+        array_list.appendSlice(allocator, fallback) catch bun.outOfMemory();
     }
     str_idx.* += 1;
     args_idx.* += 1;
@@ -1794,7 +1794,7 @@ fn formatLabel(globalThis: *JSGlobalObject, label: string, function_args: []JSVa
     const allocator = getAllocator(globalThis);
     var idx: usize = 0;
     var args_idx: usize = 0;
-    var list = try std.ArrayListUnmanaged(u8).initCapacity(allocator, label.len);
+    var list = std.ArrayListUnmanaged(u8).initCapacity(allocator, label.len) catch bun.outOfMemory();
 
     while (idx < label.len) {
         const char = label[idx];
@@ -1818,9 +1818,9 @@ fn formatLabel(globalThis: *JSGlobalObject, label: string, function_args: []JSVa
                     var str = bun.String.empty;
                     defer str.deref();
                     current_arg.jsonStringify(globalThis, 0, &str);
-                    const owned_slice = try str.toOwnedSlice(allocator);
+                    const owned_slice = str.toOwnedSlice(allocator) catch bun.outOfMemory();
                     defer allocator.free(owned_slice);
-                    try list.appendSlice(allocator, owned_slice);
+                    list.appendSlice(allocator, owned_slice) catch bun.outOfMemory();
                     idx += 1;
                     args_idx += 1;
                 },
@@ -1830,27 +1830,27 @@ fn formatLabel(globalThis: *JSGlobalObject, label: string, function_args: []JSVa
                         .quote_strings = true,
                     };
                     const value_fmt = current_arg.toFmt(&formatter);
-                    const test_index_str = try std.fmt.allocPrint(allocator, "{any}", .{value_fmt});
+                    const test_index_str = std.fmt.allocPrint(allocator, "{any}", .{value_fmt}) catch bun.outOfMemory();
                     defer allocator.free(test_index_str);
-                    try list.appendSlice(allocator, test_index_str);
+                    list.appendSlice(allocator, test_index_str) catch bun.outOfMemory();
                     idx += 1;
                     args_idx += 1;
                 },
                 '#' => {
-                    const test_index_str = try std.fmt.allocPrint(allocator, "{d}", .{test_idx});
+                    const test_index_str = std.fmt.allocPrint(allocator, "{d}", .{test_idx}) catch bun.outOfMemory();
                     defer allocator.free(test_index_str);
-                    try list.appendSlice(allocator, test_index_str);
+                    list.appendSlice(allocator, test_index_str) catch bun.outOfMemory();
                     idx += 1;
                 },
                 '%' => {
-                    try list.append(allocator, '%');
+                    list.append(allocator, '%') catch bun.outOfMemory();
                     idx += 1;
                 },
                 else => {
                     // ignore unrecognized fmt
                 },
             }
-        } else try list.append(allocator, char);
+        } else list.append(allocator, char) catch bun.outOfMemory();
         idx += 1;
     }
 
@@ -1918,14 +1918,14 @@ fn eachBind(
         const allocator = getAllocator(globalThis);
         const each_data = bun.cast(*EachData, data);
         JSC.setFunctionData(callee, null);
-        const array = each_data.*.strong.get() orelse return .zero;
+        const array = each_data.*.strong.get() orelse return .undefined;
         defer {
             each_data.*.strong.deinit();
             allocator.destroy(each_data);
         }
 
         if (array.isUndefinedOrNull() or !array.jsType().isArray()) {
-            return .zero;
+            return .undefined;
         }
 
         var iter = array.arrayIterator(globalThis);
@@ -1996,7 +1996,7 @@ fn eachBind(
                 function.unprotect();
             } else if (each_data.is_test) {
                 if (Jest.runner.?.only and tag != .only) {
-                    return .zero;
+                    return .undefined;
                 } else {
                     function.protect();
                     parent.tests.append(allocator, TestScope{
@@ -2026,7 +2026,7 @@ fn eachBind(
         }
     }
 
-    return .zero;
+    return .undefined;
 }
 
 inline fn createEach(

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -53,3 +53,7 @@ describe.each(["some", "cool", "strings"])("works with describe: %s", s => {
     done();
   });
 });
+
+describe("does not return zero", () => {
+  expect(it.each([1, 2])("wat", () => {})).toBeUndefined();
+});


### PR DESCRIPTION
### What does this PR do?
unless there's an exception
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
