### PR TITLE
Fix memory leak when printing any error's source code.

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -1,6 +1,3 @@
-#include "JSFFIFunction.h"
-#include "ZigSourceProvider.h"
-#include "headers-handwritten.h"
 #include "root.h"
 #include "JavaScriptCore/JSCast.h"
 #include "JavaScriptCore/JSType.h"
@@ -10,6 +7,7 @@
 #include "JavaScriptCore/JSPromiseConstructor.h"
 #include "JavaScriptCore/DeleteAllCodeEffort.h"
 #include "JavaScriptCore/BooleanObject.h"
+#include "JSFFIFunction.h"
 #include "headers.h"
 
 #include "BunClientData.h"

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -223,6 +223,13 @@ pub const ResolvedSource = extern struct {
     pub const Tag = @import("ResolvedSourceTag").ResolvedSourceTag;
 };
 
+pub const SourceProvider = opaque {
+    extern fn JSC__SourceProvider__deref(*SourceProvider) void;
+    pub fn deref(provider: *SourceProvider) void {
+        JSC__SourceProvider__deref(provider);
+    }
+};
+
 const Mimalloc = @import("../../allocators/mimalloc.zig");
 
 export fn ZigString__free(raw: [*]const u8, len: usize, allocator_: ?*anyopaque) void {
@@ -425,6 +432,10 @@ pub const ZigStackTrace = extern struct {
 
     frames_ptr: [*]ZigStackFrame,
     frames_len: u8,
+
+    /// Non-null if `source_lines_*` points into data owned by a JSC::SourceProvider.
+    /// If so, then .deref must be called on it to release the memory.
+    referenced_source_provider: ?*JSC.SourceProvider = null,
 
     pub fn toAPI(
         this: *const ZigStackTrace,
@@ -786,6 +797,10 @@ pub const ZigException = extern struct {
         for (this.stack.frames_ptr[0..this.stack.frames_len]) |*frame| {
             frame.deinit();
         }
+
+        if (this.stack.referenced_source_provider) |source| {
+            source.deref();
+        }
     }
 
     pub const shim = Shimmer("Zig", "Exception", @This());
@@ -828,7 +843,9 @@ pub const ZigException = extern struct {
         }
 
         pub fn deinit(this: *Holder, vm: *JSC.VirtualMachine) void {
-            this.zigException().deinit();
+            if (this.loaded) {
+                this.zig_exception.deinit();
+            }
             if (this.need_to_clear_parser_arena_on_deinit) {
                 vm.module_loader.resetArena(vm);
             }

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -169,6 +169,7 @@ typedef struct ZigStackTrace {
     uint8_t source_lines_to_collect;
     ZigStackFrame* frames_ptr;
     uint8_t frames_len;
+    JSC::SourceProvider* referenced_source_provider;
 } ZigStackTrace;
 
 typedef struct ZigException {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -3246,6 +3246,9 @@ pub const VirtualMachine = struct {
         var exception = exception_holder.zigException();
         defer exception_holder.deinit(this);
 
+        // The ZigException structure stores substrings of the source code, in
+        // which we need the lifetime of this data to outlive the inner call to
+        // remapZigException, but still get freed.
         var source_code_slice: ?ZigString.Slice = null;
         defer if (source_code_slice) |slice| slice.deinit();
 

--- a/src/string.zig
+++ b/src/string.zig
@@ -277,7 +277,7 @@ pub const Tag = enum(u8) {
     /// into a WTF::String.
     /// Can be in either `utf8` or `utf16le` encodings.
     ZigString = 2,
-    /// Static memory that is guarenteed to never be freed. When converted to WTF::String,
+    /// Static memory that is guaranteed to never be freed. When converted to WTF::String,
     /// the memory is not cloned, but instead referenced with WTF::ExternalStringImpl.
     /// Can be in either `utf8` or `utf16le` encodings.
     StaticZigString = 3,

--- a/test/js/bun/util/inspect-error-leak.test.js
+++ b/test/js/bun/util/inspect-error-leak.test.js
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test";
+
+test("Printing errors does not leak", () => {
+  function batch() {
+    for (let i = 0; i < 1000; i++) {
+      Bun.inspect(new Error("leak"));
+    }
+    Bun.gc(true);
+  }
+
+  batch();
+  const baseline = Math.floor(process.memoryUsage.rss() / 1024);
+  for (let i = 0; i < 20; i++) {
+    batch();
+    const after = Math.floor(process.memoryUsage.rss() / 1024);
+    const diff = after - baseline;
+    expect(diff, `after ${i} iterations`).toBeLessThan(5000);
+  }
+}, 10_000);


### PR DESCRIPTION
Fixes memory leak when printing any error with an associated JSC::SourceProvider. This affects basically every error print. We were leaking copied string views used for the source preview.

Test case:

```ts
function batch() {
  for (let i = 0; i < 10000; i++) {
    Bun.inspect(new Error("leak"));
  }
  Bun.gc(true);
}

batch();
const baseline = (process.memoryUsage.rss() / 1024 / 1024) | 0;
for (let i = 0; i < 100; i++) {
  batch();
}
const after = (process.memoryUsage.rss() / 1024 / 1024) | 0;
const diff = after - baseline;
console.log(require("bun:jsc").heapStats());

console.log(`Baseline: ${baseline} MB`);
console.log(`After: ${after} MB`);
console.log(`Diff: ${diff | 0} MB`);
```

---

Going forward, i don't think it is a good idea to use this pattern:

```c++
Bun::toStringRef(stringView.toStringWithoutCopying());
```

The first call `stringView.toStringWithoutCopying` indeed does not copy, but subsequent uses in either `Bun::toStringRef` or wherever after will end up just cloning the string. In fact, when dealing with `WTF::StringView`, any conversion to bun string outside of `Bun::toStringView` is a copy, since string views are non-owning (nothing to add a ref to).

`Bun::toStringView`, on the other hand, will create a true string view, but we must manually manage the lifetime of it. There isn't a 1:1 migration path for this pattern, since it depends on the lifetime of the StringView.

For this case, the solution is to hold a ref on the provider until source mapping is done.
```
// It is key to not clone this data because source code strings are large.
// Usage of toStringView (non-owning) is safe as we ref the provider.
provider->ref();
ASSERT(*referenced_source_provider == nullptr);
*referenced_source_provider = provider;
```
Then when the rest of the exception is freed (in Zig) this source provider may be deref'd

```zig
    if (this.stack.referenced_source_provider) |source| {
        source.deref();
    }
```