### PR TITLE
use .undefined literal instead of jsUndefined() call

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -327,7 +327,7 @@ pub fn shell(
     var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
     const string_args = arguments.nextEat() orelse {
         globalThis.throw("shell: expected 2 arguments, got 0", .{});
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     };
 
     const template_args_js = arguments.nextEat() orelse {
@@ -459,7 +459,7 @@ pub fn braces(
 
     const brace_str_js = arguments.nextEat() orelse {
         globalThis.throw("braces: expected at least 1 argument, got 0", .{});
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     };
     const brace_str = brace_str_js.toBunString(globalThis);
     defer brace_str.deref();
@@ -566,7 +566,7 @@ pub fn which(
     defer arguments.deinit();
     const path_arg = arguments.nextEat() orelse {
         globalThis.throw("which: expected 1 argument, got 0", .{});
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     };
 
     var path_str: ZigString.Slice = ZigString.Slice.empty;
@@ -589,7 +589,7 @@ pub fn which(
 
     if (bin_str.len >= bun.MAX_PATH_BYTES) {
         globalThis.throw("bin path is too long", .{});
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     if (bin_str.len == 0) {
@@ -980,7 +980,7 @@ pub fn openInEditor(
         return .zero;
     };
 
-    return JSC.JSValue.jsUndefined();
+    return .undefined;
 }
 
 pub fn getPublicPath(to: string, origin: URL, comptime Writer: type, writer: Writer) void {
@@ -3445,7 +3445,7 @@ pub export fn Bun__escapeHTML16(globalObject: *JSC.JSGlobalObject, input_value: 
     const input_slice = ptr[0..len];
     const escaped = strings.escapeHTMLForUTF16Input(globalObject.bunVM().allocator, input_slice) catch {
         globalObject.vm().throwError(globalObject, ZigString.init("Out of memory").toJS(globalObject));
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     };
 
     switch (escaped) {
@@ -3491,7 +3491,7 @@ pub export fn Bun__escapeHTML8(globalObject: *JSC.JSGlobalObject, input_value: J
 
     const escaped = strings.escapeHTMLForLatin1Input(allocator, input_slice) catch {
         globalObject.vm().throwError(globalObject, ZigString.init("Out of memory").toJS(globalObject));
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     };
 
     switch (escaped) {
@@ -4557,8 +4557,8 @@ pub const FFIObject = struct {
 
 fn stringWidth(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) JSC.JSValue {
     const arguments = callframe.arguments(2).slice();
-    const value = if (arguments.len > 0) arguments[0] else JSC.JSValue.jsUndefined();
-    const options_object = if (arguments.len > 1) arguments[1] else JSC.JSValue.jsUndefined();
+    const value = if (arguments.len > 0) arguments[0] else .undefined;
+    const options_object = if (arguments.len > 1) arguments[1] else .undefined;
 
     if (!value.isString()) {
         return JSC.jsNumber(0);
@@ -4671,7 +4671,7 @@ pub const JSZlib = struct {
     // This has to be `inline` due to the callframe.
     inline fn getOptions(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) ?struct { JSC.Node.StringOrBuffer, ?JSValue } {
         const arguments = callframe.arguments(2).slice();
-        const buffer_value = if (arguments.len > 0) arguments[0] else JSC.JSValue.jsUndefined();
+        const buffer_value = if (arguments.len > 0) arguments[0] else .undefined;
         const options_val: ?JSValue =
             if (arguments.len > 1 and arguments[1].isObject())
             arguments[1]

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -548,12 +548,12 @@ pub const JSBundler = struct {
     ) JSC.JSValue {
         if (arguments.len == 0 or !arguments[0].isObject()) {
             globalThis.throwInvalidArguments("Expected a config object to be passed to Bun.build", .{});
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         var plugins: ?*Plugin = null;
         const config = Config.fromJS(globalThis, arguments[0], &plugins, globalThis.allocator()) catch {
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         };
 
         return bun.BundleV2.generateFromJavaScript(
@@ -563,7 +563,7 @@ pub const JSBundler = struct {
             globalThis.bunVM().eventLoop(),
             bun.default_allocator,
         ) catch {
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         };
     }
 

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -716,7 +716,7 @@ pub const H2FrameParser = struct {
 
         stream.state = .CLOSED;
         if (rstCode == .NO_ERROR) {
-            this.dispatchWithExtra(.onStreamEnd, JSC.JSValue.jsNumber(stream.id), JSC.JSValue.jsUndefined());
+            this.dispatchWithExtra(.onStreamEnd, JSC.JSValue.jsNumber(stream.id), .undefined);
         } else {
             this.dispatchWithExtra(.onStreamError, JSC.JSValue.jsNumber(stream.id), JSC.JSValue.jsNumber(@intFromEnum(rstCode)));
         }
@@ -1428,7 +1428,7 @@ pub const H2FrameParser = struct {
             return .zero;
         };
 
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn loadSettingsFromJSValue(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, options: JSC.JSValue) bool {
@@ -1544,7 +1544,7 @@ pub const H2FrameParser = struct {
 
         if (this.loadSettingsFromJSValue(globalObject, options)) {
             this.setSettings(this.localSettings);
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         return .zero;
@@ -1608,14 +1608,14 @@ pub const H2FrameParser = struct {
                     if (opaque_data_arg.asArrayBuffer(globalObject)) |array_buffer| {
                         const slice = array_buffer.byteSlice();
                         this.sendGoAway(0, @enumFromInt(errorCode), slice, lastStreamID);
-                        return JSC.JSValue.jsUndefined();
+                        return .undefined;
                     }
                 }
             }
         }
 
         this.sendGoAway(0, @enumFromInt(errorCode), "", lastStreamID);
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn ping(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) JSValue {
@@ -1629,7 +1629,7 @@ pub const H2FrameParser = struct {
         if (args_list.ptr[0].asArrayBuffer(globalObject)) |array_buffer| {
             const slice = array_buffer.slice();
             this.sendPing(false, slice);
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         globalObject.throw("Expected payload to be a Buffer", .{});
@@ -2038,7 +2038,7 @@ pub const H2FrameParser = struct {
                         stream.state = .CLOSED;
                         stream.rstCode = @intFromEnum(ErrorCode.COMPRESSION_ERROR);
                         this.dispatchWithExtra(.onStreamError, JSC.JSValue.jsNumber(stream_id), JSC.JSValue.jsNumber(stream.rstCode));
-                        return JSC.JSValue.jsUndefined();
+                        return .undefined;
                     };
                 }
             } else {
@@ -2058,7 +2058,7 @@ pub const H2FrameParser = struct {
                     stream.state = .CLOSED;
                     stream.rstCode = @intFromEnum(ErrorCode.COMPRESSION_ERROR);
                     this.dispatchWithExtra(.onStreamError, JSC.JSValue.jsNumber(stream_id), JSC.JSValue.jsNumber(stream.rstCode));
-                    return JSC.JSValue.jsUndefined();
+                    return .undefined;
                 };
             }
         }
@@ -2075,7 +2075,7 @@ pub const H2FrameParser = struct {
         frame.write(@TypeOf(writer), writer);
         _ = writer.write(buffer[0..encoded_size]) catch 0;
 
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
     pub fn writeStream(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) JSValue {
         JSC.markBinding(@src());
@@ -2250,7 +2250,7 @@ pub const H2FrameParser = struct {
                             stream.state = .CLOSED;
                             stream.rstCode = @intFromEnum(ErrorCode.COMPRESSION_ERROR);
                             this.dispatchWithExtra(.onStreamError, JSC.JSValue.jsNumber(stream_id), JSC.JSValue.jsNumber(stream.rstCode));
-                            return JSC.JSValue.jsUndefined();
+                            return .undefined;
                         };
                     }
                 } else {
@@ -2439,7 +2439,7 @@ pub const H2FrameParser = struct {
                 const result = this.readBytes(bytes);
                 bytes = bytes[result..];
             }
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
         globalObject.throw("Expected data to be a Buffer or ArrayBuffer", .{});
         return .zero;

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -696,12 +696,12 @@ pub const Subprocess = struct {
 
     pub fn doRef(this: *Subprocess, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) JSValue {
         this.ref();
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn doUnref(this: *Subprocess, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) JSValue {
         this.unref();
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn onStdinDestroyed(this: *Subprocess) void {
@@ -737,7 +737,7 @@ pub const Subprocess = struct {
         const success = ipc_data.serializeAndSend(global, value);
         if (!success) return .zero;
 
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn disconnect(this: *Subprocess) void {
@@ -1471,9 +1471,9 @@ pub const Subprocess = struct {
                     if (status == .err)
                     status.err.toJSC(globalThis)
                 else
-                    JSC.JSValue.jsUndefined();
+                    .undefined;
 
-                const this_value = if (this_jsvalue.isEmptyOrUndefinedOrNull()) JSC.JSValue.jsUndefined() else this_jsvalue;
+                const this_value = if (this_jsvalue.isEmptyOrUndefinedOrNull()) .undefined else this_jsvalue;
                 this_value.ensureStillAlive();
 
                 const args = [_]JSValue{
@@ -1856,7 +1856,7 @@ pub const Subprocess = struct {
                             var i: u32 = 0;
                             while (stdio_iter.next()) |value| : (i += 1) {
                                 if (!stdio[i].extract(globalThis, i, value))
-                                    return JSC.JSValue.jsUndefined();
+                                    return .undefined;
                                 if (i == 2)
                                     break;
                             }
@@ -1865,7 +1865,7 @@ pub const Subprocess = struct {
                             while (stdio_iter.next()) |value| : (i += 1) {
                                 var new_item: Stdio = undefined;
                                 if (!new_item.extract(globalThis, i, value)) {
-                                    return JSC.JSValue.jsUndefined();
+                                    return .undefined;
                                 }
 
                                 const opt = switch (new_item.asSpawnOption(i)) {

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -145,7 +145,7 @@ pub const FFI = struct {
     ) callconv(.C) JSValue {
         JSC.markBinding(@src());
         if (this.closed) {
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
         this.closed = true;
         if (this.dylib) |*dylib| {
@@ -160,7 +160,7 @@ pub const FFI = struct {
         }
         this.functions.deinit(allocator);
 
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn printCallback(global: *JSGlobalObject, object: JSC.JSValue) JSValue {

--- a/src/bun.js/api/glob.zig
+++ b/src/bun.js/api/glob.zig
@@ -448,12 +448,12 @@ pub fn match(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.CallFrame
     defer arguments.deinit();
     const str_arg = arguments.nextEat() orelse {
         globalThis.throw("Glob.matchString: expected 1 arguments, got 0", .{});
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     };
 
     if (!str_arg.isString()) {
         globalThis.throw("Glob.matchString: first argument is not a string", .{});
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     var str = str_arg.toSlice(globalThis, arena.allocator());

--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -1040,7 +1040,7 @@ pub const TextChunk = struct {
 
     fn contentHandler(this: *TextChunk, comptime Callback: (fn (*LOLHTML.TextChunk, []const u8, bool) LOLHTML.Error!void), thisObject: JSValue, globalObject: *JSGlobalObject, content: ZigString, contentOptions: ?ContentOptions) JSValue {
         if (this.text_chunk == null)
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         var content_slice = content.toSlice(bun.default_allocator);
         defer content_slice.deinit();
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1616,7 +1616,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
             defer ctx.deref();
 
-            handleReject(ctx, if (!err.isEmptyOrUndefinedOrNull()) err else JSC.JSValue.jsUndefined());
+            handleReject(ctx, if (!err.isEmptyOrUndefinedOrNull()) err else .undefined);
             return JSValue.jsUndefined();
         }
 
@@ -5723,21 +5723,21 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 };
 
                 JSC.C.JSValueUnprotect(this.globalThis, this.thisObject.asObjectRef());
-                this.thisObject = JSC.JSValue.jsUndefined();
+                this.thisObject = .undefined;
                 this.stop(abrupt);
             }
 
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         pub fn disposeFromJS(this: *ThisServer) JSC.JSValue {
             if (this.listener != null) {
                 JSC.C.JSValueUnprotect(this.globalThis, this.thisObject.asObjectRef());
-                this.thisObject = JSC.JSValue.jsUndefined();
+                this.thisObject = .undefined;
                 this.stop(true);
             }
 
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         pub fn getPort(

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -487,7 +487,7 @@ pub export fn Bun__reportUnhandledError(globalObject: *JSGlobalObject, value: JS
     // See the crash in https://github.com/oven-sh/bun/issues/9778
     const jsc_vm = JSC.VirtualMachine.get();
     _ = jsc_vm.uncaughtException(globalObject, value, false);
-    return JSC.JSValue.jsUndefined();
+    return .undefined;
 }
 
 /// This function is called on another thread
@@ -2928,7 +2928,7 @@ pub const VirtualMachine = struct {
     pub fn reportUncaughtException(globalObject: *JSGlobalObject, exception: *JSC.Exception) JSValue {
         var jsc_vm = globalObject.bunVM();
         _ = jsc_vm.uncaughtException(globalObject, exception.value(), false);
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn printStackTrace(comptime Writer: type, writer: Writer, trace: ZigStackTrace, comptime allow_ansi_colors: bool) !void {

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -305,7 +305,7 @@ pub const StatWatcher = struct {
             if (obj.js_this != .zero) {
                 return obj.js_this;
             }
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
     };
 
@@ -314,7 +314,7 @@ pub const StatWatcher = struct {
             this.persistent = true;
             this.poll_ref.ref(this.ctx);
         }
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn doUnref(this: *StatWatcher, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) JSC.JSValue {
@@ -322,7 +322,7 @@ pub const StatWatcher = struct {
             this.persistent = false;
             this.poll_ref.unref(this.ctx);
         }
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn hasPendingActivity(this: *StatWatcher) bool {
@@ -345,7 +345,7 @@ pub const StatWatcher = struct {
 
     pub fn doClose(this: *StatWatcher, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) JSC.JSValue {
         this.close();
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     /// If the scheduler is not using this, free instantly, otherwise mark for being freed.

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -579,7 +579,7 @@ pub const FSWatcher = struct {
         if (js_this == .zero) return;
         const listener = FSWatcher.listenerGetCached(js_this) orelse return;
         const globalObject = this.globalThis;
-        var filename: JSC.JSValue = JSC.JSValue.jsUndefined();
+        var filename: JSC.JSValue = .undefined;
         if (file_name.len > 0) {
             if (this.encoding == .buffer)
                 filename = JSC.ArrayBuffer.createBuffer(globalObject, file_name)
@@ -615,7 +615,7 @@ pub const FSWatcher = struct {
             this.persistent = true;
             this.poll_ref.ref(this.ctx);
         }
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn doUnref(this: *FSWatcher, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) JSC.JSValue {
@@ -623,7 +623,7 @@ pub const FSWatcher = struct {
             this.persistent = false;
             this.poll_ref.unref(this.ctx);
         }
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn hasRef(this: *FSWatcher, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) JSC.JSValue {
@@ -698,7 +698,7 @@ pub const FSWatcher = struct {
 
     pub fn doClose(this: *FSWatcher, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) JSC.JSValue {
         this.close();
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn finalize(this: *FSWatcher) void {

--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -66,7 +66,7 @@ pub const OS = struct {
             };
 
             globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         };
     }
 
@@ -320,7 +320,7 @@ pub const OS = struct {
                 globalThis,
             );
             globalThis.vm().throwError(globalThis, err);
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         const pid = if (arguments.len > 0) arguments[0].asInt32() else 0;
@@ -342,7 +342,7 @@ pub const OS = struct {
             };
 
             globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         return JSC.JSValue.jsNumberFromInt32(priority);
@@ -425,7 +425,7 @@ pub const OS = struct {
             };
 
             globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
         defer C.freeifaddrs(interface_start);
 
@@ -736,7 +736,7 @@ pub const OS = struct {
                 globalThis,
             );
             globalThis.vm().throwError(globalThis, err);
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         const pid = if (arguments.len == 2) arguments[0].coerce(i32, globalThis) else 0;
@@ -750,7 +750,7 @@ pub const OS = struct {
                 globalThis,
             );
             globalThis.vm().throwError(globalThis, err);
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         const errcode = C.setProcessPriority(pid, priority);
@@ -765,7 +765,7 @@ pub const OS = struct {
                 };
 
                 globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             },
             .ACCES => {
                 const err = JSC.SystemError{
@@ -777,12 +777,12 @@ pub const OS = struct {
                 };
 
                 globalThis.vm().throwError(globalThis, err.toErrorInstance(globalThis));
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             },
             else => {},
         }
 
-        return JSC.JSValue.jsUndefined();
+        return .undefined;
     }
 
     pub fn totalmem(_: *JSC.JSGlobalObject, _: *JSC.CallFrame) JSC.JSValue {

--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -463,7 +463,7 @@ pub fn basename(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*
         };
     }
 
-    const path_ptr = if (args_len > 0) args_ptr[0] else JSC.JSValue.jsUndefined();
+    const path_ptr = if (args_len > 0) args_ptr[0] else .undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         return .zero;
@@ -658,7 +658,7 @@ pub inline fn dirnameJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, i
 }
 
 pub fn dirname(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const path_ptr = if (args_len > 0) args_ptr[0] else JSC.JSValue.jsUndefined();
+    const path_ptr = if (args_len > 0) args_ptr[0] else .undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -857,7 +857,7 @@ pub inline fn extnameJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, i
 }
 
 pub fn extname(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const path_ptr = if (args_len > 0) args_ptr[0] else JSC.JSValue.jsUndefined();
+    const path_ptr = if (args_len > 0) args_ptr[0] else .undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -971,7 +971,7 @@ pub fn formatJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, allocator
 }
 
 pub fn format(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const pathObject_ptr = if (args_len > 0) args_ptr[0] else JSC.JSValue.jsUndefined();
+    const pathObject_ptr = if (args_len > 0) args_ptr[0] else .undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateObject(globalObject, pathObject_ptr, "pathObject", .{}, .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -1045,7 +1045,7 @@ pub fn isAbsoluteWindowsZigString(pathZStr: JSC.ZigString) bool {
 }
 
 pub fn isAbsolute(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const path_ptr = if (args_len > 0) args_ptr[0] else JSC.JSValue.jsUndefined();
+    const path_ptr = if (args_len > 0) args_ptr[0] else .undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -1658,7 +1658,7 @@ pub fn normalizeJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, alloca
 }
 
 pub fn normalize(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const path_ptr = if (args_len > 0) args_ptr[0] else JSC.JSValue.jsUndefined();
+    const path_ptr = if (args_len > 0) args_ptr[0] else .undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -1981,7 +1981,7 @@ pub inline fn parseJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, isW
 }
 
 pub fn parse(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const path_ptr = if (args_len > 0) args_ptr[0] else JSC.JSValue.jsUndefined();
+    const path_ptr = if (args_len > 0) args_ptr[0] else .undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -2340,13 +2340,13 @@ pub fn relativeJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, allocat
 }
 
 pub fn relative(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const from_ptr = if (args_len > 0) args_ptr[0] else JSC.JSValue.jsUndefined();
+    const from_ptr = if (args_len > 0) args_ptr[0] else .undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, from_ptr, "from", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
         return .zero;
     };
-    const to_ptr = if (args_len > 1) args_ptr[1] else JSC.JSValue.jsUndefined();
+    const to_ptr = if (args_len > 1) args_ptr[1] else .undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, to_ptr, "to", .{}) catch {
         return .zero;
@@ -2906,7 +2906,7 @@ pub fn toNamespacedPathJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject,
 }
 
 pub fn toNamespacedPath(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    if (args_len == 0) return JSC.JSValue.jsUndefined();
+    if (args_len == 0) return .undefined;
     var path_ptr = args_ptr[0];
 
     // Based on Node v21.6.1 path.win32.toNamespacedPath and path.posix.toNamespacedPath:

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -2101,7 +2101,7 @@ pub const Process = struct {
                 fs.top_level_dir_buf[len + 1] = 0;
                 fs.top_level_dir = fs.top_level_dir_buf[0 .. len + 1];
 
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             },
             .err => |e| return e.toJSC(globalObject),
         }

--- a/src/bun.js/webcore.zig
+++ b/src/bun.js/webcore.zig
@@ -512,7 +512,7 @@ pub const Crypto = struct {
             // i don't think its a real scenario, but just in case
             buf = globalThis.allocator().alloc(u8, keylen) catch {
                 globalThis.throw("Failed to allocate memory", .{});
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             };
             needs_deinit = true;
         } else {
@@ -570,25 +570,25 @@ pub const Crypto = struct {
 
         if (arguments.len < 2) {
             globalThis.throwInvalidArguments("Expected 2 typed arrays but got nothing", .{});
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         const array_buffer_a = arguments[0].asArrayBuffer(globalThis) orelse {
             globalThis.throwInvalidArguments("Expected typed array but got {s}", .{@tagName(arguments[0].jsType())});
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         };
         const a = array_buffer_a.byteSlice();
 
         const array_buffer_b = arguments[1].asArrayBuffer(globalThis) orelse {
             globalThis.throwInvalidArguments("Expected typed array but got {s}", .{@tagName(arguments[1].jsType())});
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         };
         const b = array_buffer_b.byteSlice();
 
         const len = a.len;
         if (b.len != len) {
             globalThis.throw("Input buffers must have the same byte length", .{});
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
         return JSC.jsBoolean(len == 0 or bun.BoringSSL.CRYPTO_memcmp(a.ptr, b.ptr, len) == 0);
     }
@@ -619,12 +619,12 @@ pub const Crypto = struct {
         const arguments = callframe.arguments(1).slice();
         if (arguments.len == 0) {
             globalThis.throwInvalidArguments("Expected typed array but got nothing", .{});
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         var array_buffer = arguments[0].asArrayBuffer(globalThis) orelse {
             globalThis.throwInvalidArguments("Expected typed array but got {s}", .{@tagName(arguments[0].jsType())});
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         };
         const slice = array_buffer.byteSlice();
 

--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -220,7 +220,7 @@ pub const Body = struct {
 
                                 break :brk globalThis.readableStreamToFormData(readable.value, switch (form_data.?.encoding) {
                                     .Multipart => |multipart| bun.String.init(multipart).toJS(globalThis),
-                                    .URLEncoded => JSC.JSValue.jsUndefined(),
+                                    .URLEncoded => .undefined,
                                 });
                             },
                             else => unreachable,

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -198,7 +198,7 @@ pub const TextEncoder = struct {
         array.ensureStillAlive();
 
         if (encoder.any_non_ascii) {
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         if (array.isEmpty()) {

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1220,7 +1220,7 @@ pub const Fetch = struct {
                         const js_hostname = hostname.toJS(globalObject);
                         js_hostname.ensureStillAlive();
                         js_cert.ensureStillAlive();
-                        const check_result = check_server_identity.call(globalObject, JSC.JSValue.jsUndefined(), &[_]JSC.JSValue{ js_hostname, js_cert });
+                        const check_result = check_server_identity.call(globalObject, .undefined, &[_]JSC.JSValue{ js_hostname, js_cert });
                         // if check failed abort the request
                         if (check_result.isAnyError()) {
                             // mark to wait until deinit
@@ -2059,7 +2059,7 @@ pub const Fetch = struct {
                                     hostname = null;
                                 }
                                 // an error was thrown
-                                return JSC.JSValue.jsUndefined();
+                                return .undefined;
                             }
                         } else {
                             body = request.body.value.useAsAnyBlob();
@@ -2372,7 +2372,7 @@ pub const Fetch = struct {
                                     hostname = null;
                                 }
                                 // an error was thrown
-                                return JSC.JSValue.jsUndefined();
+                                return .undefined;
                             }
                         }
 

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -481,14 +481,14 @@ pub const StreamStart = union(Tag) {
     pub fn toJS(this: StreamStart, globalThis: *JSGlobalObject) JSC.JSValue {
         switch (this) {
             .empty, .ready => {
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             },
             .chunk_size => |chunk| {
                 return JSC.JSValue.jsNumber(@as(Blob.SizeType, @intCast(chunk)));
             },
             .err => |err| {
                 globalThis.vm().throwError(globalThis, err.toJSC(globalThis));
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             },
             .owned_and_done => |list| {
                 return JSC.ArrayBuffer.fromBytes(list.slice(), .Uint8Array).toJS(globalThis, null);
@@ -497,7 +497,7 @@ pub const StreamStart = union(Tag) {
                 return JSC.ArrayBuffer.create(globalThis, list.slice(), .Uint8Array);
             },
             else => {
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             },
         }
     }
@@ -1633,7 +1633,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
                     .code = bun.String.static(@as(string, @tagName(JSC.Node.ErrorCode.ERR_ILLEGAL_CONSTRUCTOR))),
                 };
                 globalThis.throwValue(err.toErrorInstance(globalThis));
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             }
 
             var allocator = globalThis.bunVM().allocator;
@@ -1641,7 +1641,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
                 globalThis.vm().throwError(globalThis, Syscall.Error.oom.toJSC(
                     globalThis,
                 ));
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             };
             this.sink.construct(allocator);
             return createObject(globalThis, this, 0);
@@ -1685,7 +1685,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
         fn invalidThis(globalThis: *JSGlobalObject) JSValue {
             const err = JSC.toTypeError(JSC.Node.ErrorCode.ERR_INVALID_THIS, "Expected Sink", .{}, globalThis);
             globalThis.vm().throwError(globalThis, err);
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         pub fn unprotect(this: *@This()) void {
@@ -1700,7 +1700,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
             if (comptime @hasDecl(SinkType, "getPendingError")) {
                 if (this.sink.getPendingError()) |err| {
                     globalThis.vm().throwError(globalThis, err);
-                    return JSC.JSValue.jsUndefined();
+                    return .undefined;
                 }
             }
 
@@ -1714,7 +1714,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
                     .{},
                     globalThis,
                 ));
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             }
 
             const arg = args[0];
@@ -1728,7 +1728,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
                     .{},
                     globalThis,
                 ));
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             }
 
             if (arg.asArrayBuffer(globalThis)) |buffer| {
@@ -1747,7 +1747,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
                     .{},
                     globalThis,
                 ));
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             }
 
             const str = arg.getZigString(globalThis);
@@ -1770,7 +1770,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
             if (comptime @hasDecl(SinkType, "getPendingError")) {
                 if (this.sink.getPendingError()) |err| {
                     globalThis.vm().throwError(globalThis, err);
-                    return JSC.JSValue.jsUndefined();
+                    return .undefined;
                 }
             }
 
@@ -1784,7 +1784,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
                     globalThis,
                 );
                 globalThis.vm().throwError(globalThis, err);
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             }
 
             const arg = args[0];
@@ -1808,7 +1808,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
             if (comptime @hasDecl(SinkType, "getPendingError")) {
                 if (this.sink.getPendingError()) |err| {
                     globalThis.vm().throwError(globalThis, err);
-                    return JSC.JSValue.jsUndefined();
+                    return .undefined;
                 }
             }
 
@@ -1823,7 +1823,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
             if (comptime @hasDecl(SinkType, "getPendingError")) {
                 if (this.sink.getPendingError()) |err| {
                     globalThis.vm().throwError(globalThis, err);
-                    return JSC.JSValue.jsUndefined();
+                    return .undefined;
                 }
             }
 
@@ -1842,7 +1842,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
                     .result => |value| value,
                     .err => |err| blk: {
                         globalThis.vm().throwError(globalThis, err.toJSC(globalThis));
-                        break :blk JSC.JSValue.jsUndefined();
+                        break :blk .undefined;
                     },
                 };
             }
@@ -1858,7 +1858,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
             if (comptime @hasDecl(SinkType, "getPendingError")) {
                 if (this.sink.getPendingError()) |err| {
                     globalThis.vm().throwError(globalThis, err);
-                    return JSC.JSValue.jsUndefined();
+                    return .undefined;
                 }
             }
 
@@ -1891,7 +1891,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
             if (comptime @hasDecl(SinkType, "getPendingError")) {
                 if (this.sink.getPendingError()) |err| {
                     globalThis.vm().throwError(globalThis, err);
-                    return JSC.JSValue.jsUndefined();
+                    return .undefined;
                 }
             }
 
@@ -1914,7 +1914,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
             if (comptime @hasDecl(SinkType, "getPendingError")) {
                 if (this.sink.getPendingError()) |err| {
                     globalThis.vm().throwError(globalThis, err);
-                    return JSC.JSValue.jsUndefined();
+                    return .undefined;
                 }
             }
 
@@ -1969,7 +1969,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
 //             var this = @ptrCast(*ThisSocket, @alignCast( fromJS(globalThis, callframe.this()) orelse {
 //                 const err = JSC.toTypeError(JSC.Node.ErrorCode.ERR_INVALID_THIS, "Expected Socket", .{}, globalThis);
 //                 globalThis.vm().throwError(globalThis, err);
-//                 return JSC.JSValue.jsUndefined();
+//                 return .undefined;
 //             }));
 //         }
 //     };
@@ -2765,7 +2765,7 @@ pub fn ReadableStreamSource(
                 const view = arguments.ptr[0];
                 view.ensureStillAlive();
                 this.this_jsvalue = this_jsvalue;
-                var buffer = view.asArrayBuffer(globalThis) orelse return JSC.JSValue.jsUndefined();
+                var buffer = view.asArrayBuffer(globalThis) orelse return .undefined;
                 return processResult(
                     this_jsvalue,
                     globalThis,
@@ -2784,7 +2784,7 @@ pub fn ReadableStreamSource(
                     .chunk_size => |size| return JSValue.jsNumber(size),
                     .err => |err| {
                         globalThis.vm().throwError(globalThis, err.toJSC(globalThis));
-                        return JSC.JSValue.jsUndefined();
+                        return .undefined;
                     },
                     else => |rc| {
                         return rc.toJS(globalThis);
@@ -2828,7 +2828,7 @@ pub fn ReadableStreamSource(
                 JSC.markBinding(@src());
                 this.this_jsvalue = callFrame.this();
                 this.cancel();
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             }
 
             pub fn setOnCloseFromJS(this: *ReadableStreamSourceType, globalObject: *JSC.JSGlobalObject, value: JSC.JSValue) bool {
@@ -2894,7 +2894,7 @@ pub fn ReadableStreamSource(
                 const ref_or_unref = callFrame.argument(0).toBooleanSlow(globalObject);
                 this.setRef(ref_or_unref);
 
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             }
 
             fn onClose(ptr: ?*anyopaque) void {
@@ -3248,7 +3248,7 @@ pub const FileSink = struct {
         }
 
         if (this.done) {
-            return .{ .result = JSC.JSValue.jsUndefined() };
+            return .{ .result = .undefined };
         }
 
         const rc = this.writer.flush();

--- a/src/deps/c_ares.zig
+++ b/src/deps/c_ares.zig
@@ -315,7 +315,7 @@ pub const struct_nameinfo = extern struct {
             const node_slice = this.node[0..node_len];
             array.putIndex(globalThis, 0, JSC.ZigString.fromUTF8(node_slice).toJS(globalThis));
         } else {
-            array.putIndex(globalThis, 0, JSC.JSValue.jsUndefined());
+            array.putIndex(globalThis, 0, .undefined);
         }
 
         if (this.service != null) {
@@ -323,7 +323,7 @@ pub const struct_nameinfo = extern struct {
             const service_slice = this.service[0..service_len];
             array.putIndex(globalThis, 1, JSC.ZigString.fromUTF8(service_slice).toJS(globalThis));
         } else {
-            array.putIndex(globalThis, 1, JSC.JSValue.jsUndefined());
+            array.putIndex(globalThis, 1, .undefined);
         }
 
         return array;
@@ -1579,7 +1579,7 @@ pub export fn Bun__canonicalizeIP(
         const addr_slice = addr.toSlice(bun.default_allocator);
         const addr_str = addr_slice.slice();
         if (addr_str.len >= INET6_ADDRSTRLEN) {
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
 
         var ip_std_text: [INET6_ADDRSTRLEN + 1]u8 = undefined;
@@ -1593,12 +1593,12 @@ pub export fn Bun__canonicalizeIP(
         if (ares_inet_pton(af, &ip_addr, &ip_std_text) != 1) {
             af = AF.INET6;
             if (ares_inet_pton(af, &ip_addr, &ip_std_text) != 1) {
-                return JSC.JSValue.jsUndefined();
+                return .undefined;
             }
         }
         // ip_addr will contain the null-terminated string of the cannonicalized IP
         if (ares_inet_ntop(af, &ip_std_text, &ip_addr, @sizeOf(@TypeOf(ip_addr))) == null) {
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         }
         // use the null-terminated size to return the string
         const size = bun.len(bun.cast([*:0]u8, &ip_addr));

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -717,7 +717,7 @@ pub const Log = struct {
 
         const count = @as(u16, @intCast(@min(msgs.len, errors_stack.len)));
         switch (count) {
-            0 => return JSC.JSValue.jsUndefined(),
+            0 => return .undefined,
             1 => {
                 const msg = msgs[0];
                 return switch (msg.metadata) {

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -725,7 +725,7 @@ pub export fn napi_make_callback(env: napi_env, _: *anyopaque, recv: napi_value,
         if (recv != .zero)
             recv
         else
-            JSC.JSValue.jsUndefined(),
+            .undefined,
         if (arg_count > 0 and args != null)
             @as([*]const JSC.JSValue, @ptrCast(args.?))[0..arg_count]
         else
@@ -1608,10 +1608,10 @@ pub export fn napi_create_threadsafe_function(
         .callback = if (call_js_cb) |c| .{
             .c = .{
                 .napi_threadsafe_function_call_js = c,
-                .js = if (func == .zero) JSC.JSValue.jsUndefined() else func.withAsyncContextIfNeeded(env),
+                .js = if (func == .zero) .undefined else func.withAsyncContextIfNeeded(env),
             },
         } else .{
-            .js = if (func == .zero) JSC.JSValue.jsUndefined() else func.withAsyncContextIfNeeded(env),
+            .js = if (func == .zero) .undefined else func.withAsyncContextIfNeeded(env),
         },
         .ctx = context,
         .channel = ThreadSafeFunction.Queue.init(max_queue_size, bun.default_allocator),

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -4362,7 +4362,7 @@ pub const TestingAPIs = struct {
         var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
         const string = arguments.nextEat() orelse {
             globalThis.throw("shellInternals.disabledOnPosix: expected 1 arguments, got 0", .{});
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         };
 
         const bunstr = string.toBunString(globalThis);
@@ -4386,7 +4386,7 @@ pub const TestingAPIs = struct {
         var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
         const string_args = arguments.nextEat() orelse {
             globalThis.throw("shell_parse: expected 2 arguments, got 0", .{});
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         };
 
         var arena = std.heap.ArenaAllocator.init(bun.default_allocator);
@@ -4476,7 +4476,7 @@ pub const TestingAPIs = struct {
         var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
         const string_args = arguments.nextEat() orelse {
             globalThis.throw("shell_parse: expected 2 arguments, got 0", .{});
-            return JSC.JSValue.jsUndefined();
+            return .undefined;
         };
 
         var arena = bun.ArenaAllocator.init(bun.default_allocator);


### PR DESCRIPTION
function call is `inline` so behavior should be the same but this is more clear and should marginally improve compile time

split off from https://github.com/oven-sh/bun/pull/11492 to merge independently

