### PR TITLE
node:v8: expose DefaultDeserializer and DefaultSerializer exports

### DIFF
--- a/src/js/node/v8.ts
+++ b/src/js/node/v8.ts
@@ -160,4 +160,6 @@ hideFromStack(
   DefaultDeserializer,
   DefaultSerializer,
   GCProfiler,
+  DefaultDeserializer,
+  DefaultSerializer,
 );


### PR DESCRIPTION
split off from https://github.com/oven-sh/bun/pull/11492 to merge independently

these classes will throw not implemented errors but that will be a better experience than them being undefined