### PR TITLE
bindings: make ZigGlobalObject drainMicrotasks a method

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3438,7 +3438,7 @@ void GlobalObject::drainMicrotasks()
     vm.drainMicrotasks();
 }
 
-extern "C" void JSC__JSGlobalObject__drainMicrotasks(Zig::GlobalObject* globalObject)
+extern "C" void Zig__GlobalObject__drainMicrotasks(Zig::GlobalObject* globalObject)
 {
     globalObject->drainMicrotasks();
 }

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -55,6 +55,10 @@ pub const ZigGlobalObject = extern struct {
         return shim.cppFn("getModuleRegistryMap", .{global});
     }
 
+    pub fn drainMicrotasks(global: *ZigGlobalObject) void {
+        return shim.cppFn("drainMicrotasks", .{global});
+    }
+
     pub fn resetModuleRegistryMap(global: *JSGlobalObject, map: *anyopaque) bool {
         return shim.cppFn("resetModuleRegistryMap", .{ global, map });
     }

--- a/src/bun.js/bindings/headers.zig
+++ b/src/bun.js/bindings/headers.zig
@@ -356,6 +356,7 @@ pub extern fn Reader__intptr__put(arg0: *bindings.JSGlobalObject, JSValue1: JSC_
 pub extern fn Zig__GlobalObject__create(arg0: ?*anyopaque, arg1: i32, arg2: bool, arg3: bool, arg4: ?*anyopaque) *bindings.JSGlobalObject;
 pub extern fn Zig__GlobalObject__getModuleRegistryMap(arg0: *bindings.JSGlobalObject) ?*anyopaque;
 pub extern fn Zig__GlobalObject__resetModuleRegistryMap(arg0: *bindings.JSGlobalObject, arg1: ?*anyopaque) bool;
+pub extern fn Zig__GlobalObject__drainMicrotasks(arg0: *bindings.ZigGlobalObject) void;
 pub extern fn ArrayBufferSink__assignToStream(arg0: *bindings.JSGlobalObject, JSValue1: JSC__JSValue, arg2: ?*anyopaque, arg3: [*c]*anyopaque) JSC__JSValue;
 pub extern fn ArrayBufferSink__createObject(arg0: *bindings.JSGlobalObject, arg1: ?*anyopaque, onDestroyPtrTag: usize) JSC__JSValue;
 pub extern fn ArrayBufferSink__detachPtr(JSValue0: JSC__JSValue) void;

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -841,12 +841,12 @@ pub const EventLoop = struct {
         }
     }
 
-    extern fn JSC__JSGlobalObject__drainMicrotasks(*JSC.JSGlobalObject) void;
     pub fn drainMicrotasksWithGlobal(this: *EventLoop, globalObject: *JSC.JSGlobalObject, jsc_vm: *JSC.VM) void {
         JSC.markBinding(@src());
 
+        const global: *JSC.ZigGlobalObject = @ptrCast(globalObject);
         jsc_vm.releaseWeakRefs();
-        JSC__JSGlobalObject__drainMicrotasks(globalObject);
+        global.drainMicrotasks();
         this.deferred_tasks.run();
 
         if (comptime bun.Environment.isDebug) {


### PR DESCRIPTION
split off from https://github.com/oven-sh/bun/pull/11492 to merge independently