### PR TITLE
ZigString.static() doesnt need to make an explicit global variable

### DIFF
--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -607,12 +607,8 @@ pub const ZigString = extern struct {
         return out;
     }
 
-    pub fn static(comptime slice_: []const u8) *const ZigString {
-        const Holder = struct {
-            pub const value = &ZigString{ ._unsafe_ptr_do_not_use = slice_.ptr, .len = slice_.len };
-        };
-
-        return Holder.value;
+    pub inline fn static(comptime slice_: []const u8) *const ZigString {
+        return comptime &ZigString{ ._unsafe_ptr_do_not_use = slice_.ptr, .len = slice_.len };
     }
 
     pub const GithubActionFormatter = struct {


### PR DESCRIPTION
split off from https://github.com/oven-sh/bun/pull/11492 to merge independently