### PR TITLE
launch.json: remove BUN_DEBUG_ALL=1 from 'bun run'

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -152,7 +152,6 @@
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_EventLoop": "1",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "2",
-        "BUN_DEBUG_ALL": "1",
       },
       "console": "internalConsole",
     },


### PR DESCRIPTION
found during working on https://github.com/oven-sh/bun/pull/11492

appears to have been added by accident