### PR TITLE
Expose fewer details of the HTTP client outside the HTTP thread

### DIFF
--- a/misctools/http_bench.zig
+++ b/misctools/http_bench.zig
@@ -192,7 +192,7 @@ pub fn main() anyerror!void {
     try channel.buffer.ensureTotalCapacity(args.count);
 
     try NetworkThread.init();
-    if (args.concurrency > 0) HTTP.AsyncHTTP.max_simultaneous_requests.store(args.concurrency, .monotonic);
+    if (args.concurrency > 0) HTTP.max_simultaneous_requests.store(args.concurrency, .monotonic);
     const Group = struct {
         response_body: MutableString = undefined,
         context: HTTP.HTTPChannelContext = undefined,

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -28,7 +28,6 @@ const bundler = bun.bundler;
 const DotEnv = @import("env_loader.zig");
 const which = @import("which.zig").which;
 const JSC = bun.JSC;
-const AsyncHTTP = bun.http.AsyncHTTP;
 const Arena = @import("./mimalloc_arena.zig").Arena;
 
 const OpaqueWrap = JSC.OpaqueWrap;
@@ -112,7 +111,7 @@ pub const Run = struct {
             failWithBuildError(vm);
         };
 
-        AsyncHTTP.loadEnv(vm.allocator, vm.log, b.env);
+        bun.http.loadEnv(vm.allocator, vm.log, b.env);
 
         vm.loadExtraEnv();
         vm.is_main_thread = true;
@@ -146,7 +145,7 @@ pub const Run = struct {
                 Global.exit(1);
             }
 
-            AsyncHTTP.preconnect(url, false);
+            bun.http.preconnect(url, false);
         }
     }
 
@@ -255,7 +254,7 @@ pub const Run = struct {
             failWithBuildError(vm);
         };
 
-        AsyncHTTP.loadEnv(vm.allocator, vm.log, b.env);
+        bun.http.loadEnv(vm.allocator, vm.log, b.env);
 
         vm.loadExtraEnv();
         vm.is_main_thread = true;

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -138,6 +138,17 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
         socket: InternalSocket,
         const ThisSocket = @This();
 
+        pub fn isSSL() bool {
+            return is_ssl;
+        }
+
+        pub fn toAnySocket(this: ThisSocket) uws.AnySocket {
+            return switch (is_ssl) {
+                true => uws.AnySocket{ .SocketTLS = this },
+                false => uws.AnySocket{ .SocketTCP = this },
+            };
+        }
+
         pub fn verifyError(this: ThisSocket) us_bun_verify_error_t {
             const socket = this.socket.get() orelse return std.mem.zeroes(us_bun_verify_error_t);
             const ssl_error: us_bun_verify_error_t = uws.us_socket_verify_error(comptime ssl_int, socket);

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -40,7 +40,6 @@ const Fs = @import("../fs.zig");
 const FileSystem = Fs.FileSystem;
 const Lock = @import("../lock.zig").Lock;
 const URL = @import("../url.zig").URL;
-const AsyncHTTP = bun.http.AsyncHTTP;
 const HTTPChannel = bun.http.HTTPChannel;
 
 const Integrity = @import("./integrity.zig").Integrity;


### PR DESCRIPTION
### What does this PR do?

This is a WIP PR to make the HTTP client more reliable by exposing less of the implementation details to code using it.  Instead of exposing the `AsyncHTTP` struct we only expose a ref-counted `*PendingHTTPRequest` pointer 

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
