### PR TITLE
fix(tls/websocket) TLS shutdown and close frame improvements

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -15,18 +15,18 @@
  * limitations under the License.
  */
 
-#include "libusockets.h"
 #include "internal/internal.h"
+#include "libusockets.h"
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 
 #ifndef _WIN32
 #include <arpa/inet.h>
 #endif
 
 #define CONCURRENT_CONNECTIONS 2
-
+// clang-format off
 int default_is_low_prio_handler(struct us_socket_t *s) {
     return 0;
 }
@@ -72,7 +72,7 @@ void us_socket_context_close(int ssl, struct us_socket_context_t *context) {
     struct us_socket_t *s = context->head_sockets;
     while (s) {
         struct us_socket_t *nextS = s->next;
-        us_socket_close(ssl, s, 0, 0);
+        us_socket_close(ssl, s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, 0);
         s = nextS;
     }
 }

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -206,6 +206,8 @@ struct us_internal_ssl_socket_t *ssl_on_open(struct us_internal_ssl_socket_t *s,
     SSL_set_connect_state(s->ssl);
   } else {
     SSL_set_accept_state(s->ssl);
+    // we do not allow renegotiation on the server side (should be the default for BoringSSL, but we set to make openssl compatible)
+    SSL_set_renegotiate_mode(s->ssl, ssl_renegotiate_never);
   }
 
   struct us_internal_ssl_socket_t *result =

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -450,7 +450,6 @@ restart:
         } else if (err == SSL_ERROR_ZERO_RETURN) {
           // Remotely-Initiated Shutdown
           // See: https://www.openssl.org/docs/manmaster/man3/SSL_shutdown.html
-          us_internal_handle_shutdown(s, 0);
 
           if (read) {
             context =

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -997,7 +997,7 @@ long us_internal_verify_peer_certificate( // NOLINT(runtime/int)
 
 struct us_bun_verify_error_t
 us_internal_verify_error(struct us_internal_ssl_socket_t *s) {
-  if (us_socket_is_closed(0, &s->s) || us_internal_ssl_socket_is_shut_down(s)) {
+  if (!s->ssl || us_socket_is_closed(0, &s->s) || us_internal_ssl_socket_is_shut_down(s)) {
     return (struct us_bun_verify_error_t){
         .error = 0, .code = NULL, .reason = NULL};
   }

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -224,6 +224,12 @@ struct us_internal_ssl_socket_t *ssl_on_open(struct us_internal_ssl_socket_t *s,
 }
 
 void us_internal_fast_shutdown(struct us_internal_ssl_socket_t *s) {
+  if (SSL_in_init(s->ssl) || SSL_get_quiet_shutdown(s->ssl)) {
+    // when SSL_in_init or quiet shutdown in BoringSSL, we call shutdown
+    // directly
+    us_socket_shutdown(0, &s->s);
+    return;
+  }
   // we are closing the socket but did not sent a shutdown yet
   if(SSL_get_shutdown(s->ssl) & SSL_SENT_SHUTDOWN) {
     // Zero means that we should wait for the peer to close the connection

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -227,7 +227,7 @@ struct us_internal_ssl_socket_t *ssl_on_open(struct us_internal_ssl_socket_t *s,
 /// @param s 
 void us_internal_handle_shutdown(struct us_internal_ssl_socket_t *s) {
   // if we are already shutdown or in the middle of a handshake we dont need to do anything
-  if(us_socket_is_shut_down(0, &s->s) || !s->ssl) return;
+  if(!s->ssl && us_socket_is_shut_down(0, &s->s)) return;
   
   // we are closing the socket but did not sent a shutdown yet
   int state = SSL_get_shutdown(s->ssl) ;

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// clang-format off
 #pragma once
 #ifndef INTERNAL_H
 #define INTERNAL_H
@@ -149,6 +150,10 @@ void us_internal_socket_context_unlink_socket(
 
 void us_internal_socket_after_resolve(struct us_connecting_socket_t *s);
 void us_internal_socket_after_open(struct us_socket_t *s, int error);
+struct us_internal_ssl_socket_t *
+us_internal_ssl_socket_close(struct us_internal_ssl_socket_t *s, int code,
+                             void *reason);
+                             
 int us_internal_handle_dns_results(struct us_loop_t *loop);
 
 /* Sockets are polls */

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -49,6 +49,7 @@
 #define LIBUS_EXT_ALIGNMENT 16
 #define ALLOW_SERVER_RENEGOTIATION 0
 
+#define LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN 0
 #define LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET 1
 
 /* Define what a socket descriptor is based on platform */

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -411,7 +411,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
                         if (us_socket_is_shut_down(0, s)) {
                             /* We got FIN back after sending it */
                             /* Todo: We should give "CLEAN SHUTDOWN" as reason here */
-                            s = us_socket_close(0, s, 0, NULL);
+                            s = us_socket_close(0, s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, NULL);
                         } else {
                             /* We got FIN, so stop polling for readable */
                             us_poll_change(&s->p, us_socket_context(0, s)->loop, us_poll_events(&s->p) & LIBUS_SOCKET_WRITABLE);
@@ -419,7 +419,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
                         }
                     } else if (length == LIBUS_SOCKET_ERROR && !bsd_would_block()) {
                         /* Todo: decide also here what kind of reason we should give */
-                        s = us_socket_close(0, s, 0, NULL);
+                        s = us_socket_close(0, s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, NULL);
                         return;
                     }
 

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -157,6 +157,9 @@ void us_connecting_socket_close(int ssl, struct us_connecting_socket_t *c) {
 } 
 
 struct us_socket_t *us_socket_close(int ssl, struct us_socket_t *s, int code, void *reason) {
+    if(ssl) {
+        return (struct us_socket_t *)us_internal_ssl_socket_close((struct us_internal_ssl_socket_t *) s, code, reason);
+    }
     if (!us_socket_is_closed(0, s)) {
         if (s->low_prio_state == 1) {
             /* Unlink this socket from the low-priority queue */


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix: https://github.com/oven-sh/bun/issues/12644
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing tests
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
