### PR TITLE
Configure libcpp assert to avoid macOS 13.0 issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1001,13 +1001,17 @@ add_compile_definitions(
 
 if(NOT ASSERT_ENABLED)
     if(APPLE)
-        add_compile_definitions("LIBCXX_ENABLE_ASSERTIONS=1")
+        add_compile_definitions("_LIBCXX_ENABLE_ASSERTIONS=0")
+        add_compile_definitions("_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE")
     endif()
 
     add_compile_definitions("NDEBUG=1")
 else()
     if(APPLE)
-        add_compile_definitions("LIBCXX_ENABLE_ASSERTIONS=0")
+        add_compile_definitions("_LIBCXX_ENABLE_ASSERTIONS=1")
+        add_compile_definitions("_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        add_compile_definitions("_GLIBCXX_ASSERTIONS=1")
     endif()
 
     add_compile_definitions("ASSERT_ENABLED=1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1000,8 +1000,16 @@ add_compile_definitions(
 )
 
 if(NOT ASSERT_ENABLED)
+    if(APPLE)
+        add_compile_definitions("LIBCXX_ENABLE_ASSERTIONS=1")
+    endif()
+
     add_compile_definitions("NDEBUG=1")
 else()
+    if(APPLE)
+        add_compile_definitions("LIBCXX_ENABLE_ASSERTIONS=0")
+    endif()
+
     add_compile_definitions("ASSERT_ENABLED=1")
 endif()
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -76,9 +76,7 @@ fi
 # https://gitlab.kitware.com/cmake/cmake/-/issues/25755
 if [[ $(uname -s) == 'Darwin' && $LLVM_VERSION == '18' ]]; then
   export CFLAGS="$CFLAGS -fno-define-target-os-macros "
-  export CXXFLAGS="$CXXFLAGS -fno-define-target-os-macros "
-
-  CXXFLAGS += " -D_LIBCXX_ENABLE_ASSERTIONS=0 -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE "
+  export CXXFLAGS="$CXXFLAGS -fno-define-target-os-macros -D_LIBCXX_ENABLE_ASSERTIONS=0 -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE "
 fi
 
 # libarchive needs position-independent executables to compile successfully

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -77,6 +77,8 @@ fi
 if [[ $(uname -s) == 'Darwin' && $LLVM_VERSION == '18' ]]; then
   export CFLAGS="$CFLAGS -fno-define-target-os-macros "
   export CXXFLAGS="$CXXFLAGS -fno-define-target-os-macros "
+
+  CXXFLAGS += " -D_LIBCXX_ENABLE_ASSERTIONS=0 -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE "
 fi
 
 # libarchive needs position-independent executables to compile successfully
@@ -120,7 +122,6 @@ fi
 
 if [[ $(uname -s) == 'Darwin' ]]; then
   export CMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET:-13.0}
-
   CMAKE_FLAGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
   export CFLAGS="$CFLAGS -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET} -D__DARWIN_NON_CANCELABLE=1 "
   export CXXFLAGS="$CXXFLAGS -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET} -D__DARWIN_NON_CANCELABLE=1 "

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -756,7 +756,7 @@ extern "C" JSC__JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
 
     auto* globalObject = createGlobalObject();
     if (UNLIKELY(!globalObject)) {
-        PANIC("Failed to allocate JavaScript global object. Did your computer run out of memory?");
+        BUN_PANIC("Failed to allocate JavaScript global object. Did your computer run out of memory?");
     }
 
     globalObject->setConsole(console_client);

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -714,7 +714,6 @@ void Zig::GlobalObject::resetOnEachMicrotaskTick()
 
 extern "C" JSC__JSGlobalObject* Zig__GlobalObject__create(void* console_client, int32_t executionContextId, bool miniMode, bool evalMode, void* worker_ptr)
 {
-
     auto heapSize = miniMode ? JSC::HeapType::Small : JSC::HeapType::Large;
     JSC::VM& vm = JSC::VM::create(heapSize).leakRef();
     // This must happen before JSVMClientData::create

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -139,6 +139,9 @@ const ZigStackFrameCode ZigStackFrameCodeGlobal = 4;
 const ZigStackFrameCode ZigStackFrameCodeWasm = 5;
 const ZigStackFrameCode ZigStackFrameCodeConstructor = 6;
 
+extern "C" void __attribute((__noreturn__)) Bun__panic(const char* message, size_t length);
+#define BUN_PANIC(message) Bun__panic(message, sizeof(message) - 1)
+
 typedef struct ZigStackFramePosition {
     int32_t line_zero_based;
     int32_t column_zero_based;
@@ -273,10 +276,7 @@ extern "C" void Bun__WTFStringImpl__ref(WTF::StringImpl* impl);
 extern "C" bool BunString__fromJS(JSC::JSGlobalObject*, JSC::EncodedJSValue, BunString*);
 extern "C" JSC::EncodedJSValue BunString__toJS(JSC::JSGlobalObject*, const BunString*);
 extern "C" void BunString__toWTFString(BunString*);
-extern "C" void Bun__panic(const char* message, size_t length);
-#ifndef PANIC
-#define PANIC(message) Bun__panic(message, sizeof(message) - 1)
-#endif
+
 namespace Bun {
 JSC::JSValue toJS(JSC::JSGlobalObject*, BunString);
 BunString toString(JSC::JSGlobalObject* globalObject, JSC::JSValue value);

--- a/src/bun.js/bindings/workaround-missing-symbols.cpp
+++ b/src/bun.js/bindings/workaround-missing-symbols.cpp
@@ -1,4 +1,5 @@
 
+
 #if defined(WIN32)
 
 #include <cstdint>
@@ -266,8 +267,23 @@ extern "C" int __wrap_mknodat(int dirfd, const char* path, __mode_t mode, __dev_
 // macOS
 #if defined(__APPLE__)
 
+#include <version>
 #include <dlfcn.h>
 #include <cstdint>
+#include <cstdarg>
+#include <cstdio>
+#include "headers.h"
+
+void std::__libcpp_verbose_abort(char const* format, ...)
+{
+    va_list list;
+    va_start(list, format);
+    char buffer[1024];
+    size_t len = vsnprintf(buffer, sizeof(buffer), format, list);
+    va_end(list);
+
+    Bun__panic(buffer, len);
+}
 
 extern "C" int pthread_self_is_exiting_np()
 {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
