### PR TITLE
ci: format: switch to mlugg/setup-zig

### DIFF
--- a/.github/workflows/run-format.yml
+++ b/.github/workflows/run-format.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           bun-version: "1.1.20"
       - name: Setup Zig
-        uses: goto-bus-stop/setup-zig@c7b6cdd3adba8f8b96984640ff172c37c93f73ee
+        uses: mlugg/setup-zig@v1
         with:
           version: ${{ inputs.zig-version }}
       - name: Install Dependencies


### PR DESCRIPTION
found during working on https://github.com/oven-sh/bun/pull/11492

goto-bus-stop/setup-zig is deprecated by the maintainer and no longer recommended. mlugg/setup-zig is now preferred and has multiple improvements.

this will additionally fix a warning thats raised in actions during runs

> The following actions uses Node.js version which is deprecated and will be forced to run on node20: goto-bus-stop/setup-zig@c7b6cdd3adba8f8b96984640ff172c37c93f73ee. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
