### PR TITLE
fix(build): use specific version of lld for link on unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1223,7 +1223,7 @@ endif()
 
 if(UNIX AND NOT APPLE)
     target_link_options(${bun} PUBLIC
-        -fuse-ld=lld
+        -fuse-ld=lld-${LLVM_VERSION}
         -fno-pic
         -static-libstdc++
         -static-libgcc


### PR DESCRIPTION
### What does this PR do?

ensures the correct version of lld is used to link the binary. if an older version of llvm is installed by default, it will currently use that rather than llvm-16 for linking.

### How did you verify your code works?

it builds successfully for both lto and non-lto builds on linux/ubunt 22.04 with llvm-14 (default) and llvm-16 installed. without this change, the lto build failed.