### PR TITLE
Enable concurrent transpiler on Windows

### DIFF
--- a/src/feature_flags.zig
+++ b/src/feature_flags.zig
@@ -155,8 +155,7 @@ pub const export_star_redirect = false;
 
 pub const streaming_file_uploads_for_http_client = true;
 
-// TODO: fix concurrent transpiler on Windows
-pub const concurrent_transpiler = !env.isWindows;
+pub const concurrent_transpiler = true;
 
 // https://github.com/oven-sh/bun/issues/5426#issuecomment-1813865316
 pub const disable_auto_js_to_ts_in_node_modules = true;


### PR DESCRIPTION
### What does this PR do?

Enable concurrent transpiler on Windows

The Windows tests on #12911 fail because the concurrent transpiler is not enabledand the error is thrown synchronously but hidden behind the import, when it shouldn't. This isn't a great fix for that test failure, but it is still better than status quo.

### How did you verify your code works?

