### PR TITLE
enable more gRPC server memory per session

### DIFF
--- a/test/js/third_party/grpc-js/node-server.fixture.js
+++ b/test/js/third_party/grpc-js/node-server.fixture.js
@@ -54,9 +54,9 @@ const serviceImpl =
       };
 
 function main() {
-  let options = process.env.GRPC_TEST_OPTIONS || {};
+  let options = JSON.parse(process.env.GRPC_TEST_OPTIONS);
   options = { "grpc-node.max_session_memory": 1024, ...options };
-  const server = options ? new grpc.Server(JSON.parse(options)) : new grpc.Server();
+  const server = options ? new grpc.Server(options) : new grpc.Server();
 
   process.stdin.on("data", data => {
     if (data.toString() === "shutdown") {

--- a/test/js/third_party/grpc-js/node-server.fixture.js
+++ b/test/js/third_party/grpc-js/node-server.fixture.js
@@ -54,7 +54,8 @@ const serviceImpl =
       };
 
 function main() {
-  const options = process.env.GRPC_TEST_OPTIONS;
+  let options = process.env.GRPC_TEST_OPTIONS || {};
+  options = { "grpc-node.max_session_memory": 1024, ...options };
   const server = options ? new grpc.Server(JSON.parse(options)) : new grpc.Server();
 
   process.stdin.on("data", data => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
BuiltKit should not fail on gRPC
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
