### PR TITLE
Make bun install faster in China

### DIFF
--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -45,13 +45,13 @@ pub const Loader = struct {
     did_load_process: bool = false,
     reject_unauthorized: ?bool = null,
 
-    is_user_probably_in_china: ?bool = null,
+    is_user_probably_in_mainland_china: ?bool = null,
 
     pub fn iterator(this: *const Loader) Map.HashTable.Iterator {
         return this.map.iterator();
     }
 
-    fn isUserProbablyInChinaImpl(this: *Loader) bool {
+    fn isUserProbablyInMainlandChinaImpl(this: *Loader) bool {
         if (this.get("LANG") orelse this.get("LC_ALL") orelse this.get("LC_CTYPE")) |lang| {
             // LANG=zh_CN
             // LANG=zh-CN
@@ -72,10 +72,10 @@ pub const Loader = struct {
         return false;
     }
 
-    pub fn isUserProbablyInChina(this: *Loader) bool {
-        return this.is_user_probably_in_china orelse {
-            this.is_user_probably_in_china = this.isUserProbablyInChinaImpl();
-            return this.is_user_probably_in_china.?;
+    pub fn isUserProbablyInMainlandChina(this: *Loader) bool {
+        return this.is_user_probably_in_mainland_china orelse {
+            this.is_user_probably_in_mainland_china = this.isUserProbablyInMainlandChinaImpl();
+            return this.is_user_probably_in_mainland_china.?;
         };
     }
 

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -64,6 +64,7 @@ pub const Loader = struct {
                         after = after[0..separator];
                     }
 
+                    // We specifically want mainland china.
                     return strings.eqlComptime(after, "CN") or strings.eqlComptime(after, "cn");
                 }
             }

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -1049,7 +1049,7 @@ pub fn loadNpmrc(
             if (install.default_registry) |dr|
                 break :brk bun.URL.parse(dr.url);
 
-            if (env.isUserProbablyInChina()) {
+            if (env.isUserProbablyInMainlandChina()) {
                 break :brk bun.URL.parse(Registry.default_china_url);
             }
 

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -1049,6 +1049,10 @@ pub fn loadNpmrc(
             if (install.default_registry) |dr|
                 break :brk bun.URL.parse(dr.url);
 
+            if (env.isUserProbablyInChina()) {
+                break :brk bun.URL.parse(Registry.default_china_url);
+            }
+
             break :brk bun.URL.parse(Registry.default_url);
         };
 
@@ -1128,7 +1132,7 @@ pub fn loadNpmrc(
                             .password = "",
                             .token = "",
                             .username = "",
-                            .url = Registry.default_url,
+                            .url = default_registry_url.href,
                         };
                         break :brk &install.default_registry.?;
                     };

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -11492,7 +11492,7 @@ pub const PackageManager = struct {
         } else {
             Output.prettyErrorln("<r><b>bun {s} <r><d>v" ++ Global.package_json_version_with_sha ++ " 大陸<r>\n", .{name});
 
-            if (Options.log_message_for_verbose_install_that_using_base_url_for_china) {
+            if (verbose_install and Options.log_message_for_verbose_install_that_using_base_url_for_china) {
                 Output.prettyErrorln("检测到中文区域。默认使用 'registry.npmmirror.com' npm 注册表。", .{});
             }
         }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -7009,7 +7009,7 @@ pub const PackageManager = struct {
 
             return error.@"Missing global bin directory: try setting $BUN_INSTALL";
         }
-        pub var log_message_for_verbose_install_that_using_base_url_for_china = false;
+        pub var is_using_mainland_china_mirror_source = false;
 
         pub fn load(
             this: *Options,
@@ -7034,7 +7034,7 @@ pub const PackageManager = struct {
             if (base.url.len == 0) {
                 if (env.isUserProbablyInMainlandChina()) {
                     base.url = Npm.Registry.default_china_url;
-                    log_message_for_verbose_install_that_using_base_url_for_china = true;
+                    is_using_mainland_china_mirror_source = true;
                 } else {
                     base.url = Npm.Registry.default_url;
                 }
@@ -8771,7 +8771,7 @@ pub const PackageManager = struct {
         };
 
         if (manager.options.shouldPrintCommandName()) {
-            printCommandName(manager.env, "link");
+            printCommandName("link");
             Output.flush();
         }
 
@@ -8953,7 +8953,7 @@ pub const PackageManager = struct {
         };
 
         if (manager.options.shouldPrintCommandName()) {
-            printCommandName(manager.env, "unlink");
+            printCommandName("unlink");
             Output.flush();
         }
 
@@ -9754,7 +9754,7 @@ pub const PackageManager = struct {
         };
 
         if (manager.options.shouldPrintCommandName()) {
-            printCommandName(manager.env, @tagName(subcommand));
+            printCommandName(@tagName(subcommand));
             Output.flush();
         }
 
@@ -11486,15 +11486,11 @@ pub const PackageManager = struct {
     var package_json_cwd_buf: bun.PathBuffer = undefined;
     pub var package_json_cwd: string = "";
 
-    fn printCommandName(env: *DotEnv.Loader, name: []const u8) void {
-        if (!env.isUserProbablyInMainlandChina()) {
-            Output.prettyErrorln("<r><b>bun {s} <r><d>v" ++ Global.package_json_version_with_sha ++ "<r>\n", .{name});
+    fn printCommandName(name: []const u8) void {
+        if (Options.is_using_mainland_china_mirror_source) {
+            Output.prettyErrorln("<r><b>bun {s} <r><d>v" ++ Global.package_json_version_with_sha ++ " (using registry.npmmirror.com)<r>\n", .{name});
         } else {
-            Output.prettyErrorln("<r><b>bun {s} <r><d>v" ++ Global.package_json_version_with_sha ++ " 大陸<r>\n", .{name});
-
-            if (verbose_install and Options.log_message_for_verbose_install_that_using_base_url_for_china) {
-                Output.prettyErrorln("检测到中文区域。默认使用 'registry.npmmirror.com' npm 注册表。", .{});
-            }
+            Output.prettyErrorln("<r><b>bun {s} <r><d>v" ++ Global.package_json_version_with_sha ++ "<r>\n", .{name});
         }
     }
 
@@ -11505,7 +11501,7 @@ pub const PackageManager = struct {
         // switch to `bun add <package>`
         if (manager.options.positionals.len > 1) {
             if (manager.options.shouldPrintCommandName()) {
-                printCommandName(manager.env, "add");
+                printCommandName("add");
 
                 Output.flush();
             }
@@ -11517,7 +11513,7 @@ pub const PackageManager = struct {
         }
 
         if (manager.options.shouldPrintCommandName()) {
-            printCommandName(manager.env, "install");
+            printCommandName("install");
             Output.flush();
         }
 

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -37,6 +37,13 @@ const Npm = @This();
 pub const Registry = struct {
     pub const default_url = "https://registry.npmjs.org/";
     pub const default_url_hash = bun.Wyhash11.hash(0, strings.withoutTrailingSlash(default_url));
+
+    // Users have reported bun install being slow in China.
+    // https://npmmirror.com/
+    // https://cnpmjs.org
+    pub const default_china_url = "https://registry.npmmirror.com/";
+    pub const default_china_url_hash = bun.Wyhash11.hash(0, strings.withoutTrailingSlash(default_china_url));
+
     pub const BodyPool = ObjectPool(MutableString, MutableString.init2048, true, 8);
 
     pub const Scope = struct {
@@ -879,6 +886,7 @@ pub const PackageManifest = struct {
 
         fn manifestFileName(buf: []u8, file_id: u64, scope: *const Registry.Scope) ![:0]const u8 {
             const file_id_hex_fmt = bun.fmt.hexIntLower(file_id);
+            // For compatibility & complexity reasons, we prefix even if the default registry is the china mirror.
             return if (scope.url_hash == Registry.default_url_hash)
                 try std.fmt.bufPrintZ(buf, "{any}.npm", .{file_id_hex_fmt})
             else


### PR DESCRIPTION
## This PR will not be merged

See **[this comment](https://github.com/oven-sh/bun/pull/12936#issuecomment-2265147603)**

----

Original PR:

### What does this PR do?

![image](https://github.com/user-attachments/assets/fcc5cbe7-c008-4c02-ba9b-cac6c49baa37)


When the locale is the country code `CN` or `cn`:
- Default to registry.npmmirror.com

Default these environment variables for lifecycle scripts:
```bash
npm_config_disturl="https://npmmirror.com/dist"
npm_config_sharp_binary_host="https://npmmirror.com/mirrors/sharp/"
npm_config_sharp_libvips_binary_host="https://npmmirror.com/mirrors/sharp-libvips"
npm_config_profiler_binary_host_mirror="https://npmmirror.com/mirrors/node-inspector/"
npm_config_fse_binary_host_mirror="https://npmmirror.com/mirrors/fsevents"
npm_config_node_sqlite3_binary_host_mirror="https://npmmirror.com/mirrors"
npm_config_sqlite3_binary_host_mirror="https://npmmirror.com/mirrors"
npm_config_sqlite3_binary_site="https://npmmirror.com/mirrors/sqlite3"
npm_config_electron_mirror="https://npmmirror.com/mirrors/electron/v"
PUPPETEER_DOWNLOAD_BASE_URL="https://npmmirror.com/mirrors"
npm_config_chromedriver_cdnurl="https://npmmirror.com/mirrors/chromedriver"
npm_config_operadriver_cdnurl="https://npmmirror.com/mirrors/operadriver"
npm_config_phantomjs_cdnurl="https://npmmirror.com/mirrors/phantomjs"
npm_config_python_mirror="https://npmmirror.com/mirrors/python"
npm_config_sass_binary_site="https://npmmirror.com/mirrors/node-sass"
```

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
