### PR TITLE
doc: fix incorrect documentation relating to the --define flag

### DIFF
--- a/docs/guides/runtime/define-constant.md
+++ b/docs/guides/runtime/define-constant.md
@@ -5,8 +5,8 @@ name: Define and replace static globals & constants
 The `--define` flag lets you declare statically-analyzable constants and globals. It replace all usages of an identifier or property in a JavaScript or TypeScript file with a constant value. This feature is supported at runtime and also in `bun build`. This is sort of similar to `#define` in C/C++, except for JavaScript.
 
 ```ts
-bun --define:process.env.NODE_ENV="'production'" src/index.ts # Runtime
-bun build --define:process.env.NODE_ENV="'production'" src/index.ts # Build
+bun --define process.env.NODE_ENV="'production'" src/index.ts # Runtime
+bun build --define process.env.NODE_ENV="'production'" src/index.ts # Build
 ```
 
 ---
@@ -95,7 +95,7 @@ To replace all usages of `AWS` with the JSON object `{"ACCESS_KEY":"abc","SECRET
 
 ```sh
 # JSON
-bun --define:AWS='{"ACCESS_KEY":"abc","SECRET_KEY":"def"}' src/index.ts
+bun --define AWS='{"ACCESS_KEY":"abc","SECRET_KEY":"def"}' src/index.ts
 ```
 
 Those will be transformed into the equivalent JavaScript code.
@@ -119,7 +119,7 @@ You can also pass properties to the `--define` flag.
 For example, to replace all usages of `console.write` with `console.log`, you can use the following command (requires Bun v1.1.5 or later)
 
 ```sh
-bun --define:console.write=console.log src/index.ts
+bun --define console.write=console.log src/index.ts
 ```
 
 That transforms the following input:


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

This fixes the examples for the `--define` flag. Correct usage of it:
```
bun --define VAR="'value'" ...
```
However, some parts of the documentation use the following example, which results in no replacement but no error either:
```
bun --define:VAR="'value'" ...
```

This was discussed in the Bun server [here](https://discord.com/channels/876711213126520882/876711213126520885/1268026468781395988).

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
