### PR TITLE
change Body.Value.Error to not always allocate JSValues

### DIFF
--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -493,7 +493,7 @@ pub const HTMLRewriter = struct {
             return response_js_value;
         }
 
-        pub fn onFinishedBuffering(ctx: *anyopaque, bytes: []const u8, js_err: ?JSC.JSValue, is_async: bool) void {
+        pub fn onFinishedBuffering(ctx: *anyopaque, bytes: []const u8, js_err: ?JSC.WebCore.Body.Value.ValueError, is_async: bool) void {
             const sink = bun.cast(*BufferOutputSink, ctx);
             if (js_err) |err| {
                 if (sink.response.body.value == .Locked and @intFromPtr(sink.response.body.value.Locked.task) == @intFromPtr(sink) and
@@ -510,7 +510,7 @@ pub const HTMLRewriter = struct {
                     sink.response.body.value.Locked.task = null;
                 }
                 if (is_async) {
-                    sink.response.body.value.toErrorInstance(err, sink.global);
+                    sink.response.body.value.toErrorInstance(err.ref(sink.global), sink.global);
                 } else {
                     var ret_err = throwLOLHTMLError(sink.global);
                     ret_err.ensureStillAlive();
@@ -544,7 +544,7 @@ pub const HTMLRewriter = struct {
                 sink.deinit();
 
                 if (is_async) {
-                    response.body.value.toErrorInstance(throwLOLHTMLError(global), global);
+                    response.body.value.toErrorInstance(.{ .Message = throwLOLHTMLStringError() }, global);
 
                     return null;
                 } else {
@@ -558,7 +558,7 @@ pub const HTMLRewriter = struct {
                 sink.deinit();
 
                 if (is_async) {
-                    response.body.value.toErrorInstance(throwLOLHTMLError(global), global);
+                    response.body.value.toErrorInstance(.{ .Message = throwLOLHTMLStringError() }, global);
                     return null;
                 } else {
                     return throwLOLHTMLError(global);
@@ -1027,6 +1027,11 @@ fn throwLOLHTMLError(global: *JSGlobalObject) JSValue {
     const err = LOLHTML.HTMLString.lastError();
     defer err.deinit();
     return ZigString.fromUTF8(err.slice()).toErrorInstance(global);
+}
+fn throwLOLHTMLStringError() bun.String {
+    const err = LOLHTML.HTMLString.lastError();
+    defer err.deinit();
+    return bun.String.fromUTF8(err.slice());
 }
 
 fn htmlStringValue(input: LOLHTML.HTMLString, globalObject: *JSGlobalObject) JSValue {

--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -510,7 +510,7 @@ pub const HTMLRewriter = struct {
                     sink.response.body.value.Locked.task = null;
                 }
                 if (is_async) {
-                    sink.response.body.value.toErrorInstance(err.ref(sink.global), sink.global);
+                    sink.response.body.value.toErrorInstance(err.dupe(sink.global), sink.global);
                 } else {
                     var ret_err = throwLOLHTMLError(sink.global);
                     ret_err.ensureStillAlive();

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1933,7 +1933,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     // User called .blob(), .json(), text(), or .arrayBuffer() on the Request object
                     // but we received nothing or the connection was aborted
                     if (body.value == .Locked) {
-                        body.value.toErrorInstance(JSC.toTypeError(.ABORT_ERR, "Request aborted", .{}, this.server.globalThis), this.server.globalThis);
+                        body.value.toErrorInstance(.{ .Aborted = {} }, this.server.globalThis);
                         any_js_calls = true;
                     }
                 }
@@ -1994,7 +1994,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 // Case 3:
                 // Stream was not consumed and the connection was aborted or ended
                 if (body.value == .Locked) {
-                    body.value.toErrorInstance(JSC.toTypeError(.ABORT_ERR, "Request aborted", .{}, this.server.globalThis), this.server.globalThis);
+                    body.value.toErrorInstance(.{ .Aborted = {} }, this.server.globalThis);
                 }
             }
 
@@ -2894,14 +2894,13 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             value.toBlobIfPossible();
 
             switch (value.*) {
-                .Error => {
-                    const err = value.Error;
+                .Error => |*err_ref| {
                     _ = value.use();
                     if (this.isAbortedOrEnded()) {
                         this.deref();
                         return;
                     }
-                    this.runErrorHandler(err);
+                    this.runErrorHandler(err_ref.toJS(this.server.globalThis));
                     return;
                 },
                 // .InlineBlob,

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1109,12 +1109,10 @@ pub const Blob = struct {
                     => {
                         break :brk response.body.use();
                     },
-                    .Error => {
+                    .Error => |*err_ref| {
                         destination_blob.detach();
-                        const err = response.body.value.Error;
-                        err.unprotect();
                         _ = response.body.value.use();
-                        return JSC.JSPromise.rejectedPromiseValue(globalThis, err);
+                        return JSC.JSPromise.rejectedPromiseValue(globalThis, err_ref.toJS(globalThis));
                     },
                     .Locked => {
                         var task = bun.new(WriteFileWaitFromLockedValueTask, .{
@@ -1142,12 +1140,10 @@ pub const Blob = struct {
                     => {
                         break :brk request.body.value.use();
                     },
-                    .Error => {
+                    .Error => |*err_ref| {
                         destination_blob.detach();
-                        const err = request.body.value.Error;
-                        err.unprotect();
                         _ = request.body.value.use();
-                        return JSC.JSPromise.rejectedPromiseValue(globalThis, err);
+                        return JSC.JSPromise.rejectedPromiseValue(globalThis, err_ref.toJS(globalThis));
                     },
                     .Locked => {
                         var task = bun.new(WriteFileWaitFromLockedValueTask, .{

--- a/src/bun.js/webcore/blob/WriteFile.zig
+++ b/src/bun.js/webcore/blob/WriteFile.zig
@@ -687,12 +687,12 @@ pub const WriteFileWaitFromLockedValueTask = struct {
         var globalThis = this.globalThis;
         var file_blob = this.file_blob;
         switch (value.*) {
-            .Error => |err| {
+            .Error => |*err_ref| {
                 file_blob.detach();
                 _ = value.use();
                 this.promise.strong.deinit();
                 bun.destroy(this);
-                promise.reject(globalThis, err);
+                promise.reject(globalThis, err_ref.toJS(globalThis));
             },
             .Used => {
                 file_blob.detach();

--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -949,11 +949,10 @@ pub const Body = struct {
         }
 
         pub fn toError(this: *Value, err: anyerror, global: *JSGlobalObject) void {
-            return this.toErrorInstance(.{ .Message = bun.String.init(std.fmt.allocPrint(
-                bun.default_allocator,
+            return this.toErrorInstance(.{ .Message = bun.String.createFormat(
                 "Error reading file {s}",
                 .{@errorName(err)},
-            ) catch bun.outOfMemory()) }, global);
+            ) catch bun.outOfMemory() }, global);
         }
 
         pub fn deinit(this: *Value) void {

--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -334,7 +334,7 @@ pub const Body = struct {
                 return js_value;
             }
 
-            pub fn ref(this: *const @This(), globalObject: *JSC.JSGlobalObject) @This() {
+            pub fn dupe(this: *const @This(), globalObject: *JSC.JSGlobalObject) @This() {
                 var value = this.*;
                 switch (this.*) {
                     .SystemError => value.SystemError.ref(),
@@ -935,8 +935,9 @@ pub const Body = struct {
                             },
                             bun.default_allocator,
                         );
+                    } else {
+                        readable.abort(global);
                     }
-                    readable.abort(global);
                 }
 
                 if (locked.onReceiveValue) |onReceiveValue| {

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -931,14 +931,15 @@ pub const Fetch = struct {
             }
 
             if (!success) {
-                const err = this.onReject();
-                err.ensureStillAlive();
+                var err = this.onReject();
+                var need_deinit = true;
+                defer if (need_deinit) err.deinit();
                 // if we are streaming update with error
                 if (this.readable_stream_ref.get()) |readable| {
                     if (readable.ptr == .Bytes) {
                         readable.ptr.Bytes.onData(
                             .{
-                                .err = .{ .JSValue = err },
+                                .err = .{ .JSValue = err.toJS(globalThis) },
                             },
                             bun.default_allocator,
                         );
@@ -946,14 +947,15 @@ pub const Fetch = struct {
                 }
                 // if we are buffering resolve the promise
                 if (this.getCurrentResponse()) |response| {
+                    response.body.value.toErrorInstance(err, globalThis);
+                    need_deinit = false; // body value now owns the error
                     const body = response.body;
                     if (body.value == .Locked) {
                         if (body.value.Locked.promise) |promise_| {
                             const promise = promise_.asAnyPromise().?;
-                            promise.reject(globalThis, err);
+                            promise.reject(globalThis, response.body.value.Error.toJS(globalThis));
                         }
                     }
-                    response.body.value.toErrorInstance(err, globalThis);
                 }
                 return;
             }
@@ -1110,12 +1112,12 @@ pub const Fetch = struct {
                     // we need to abort the request
                     const promise = promise_value.asAnyPromise().?;
                     const tracker = this.tracker;
-                    const result = this.onReject();
+                    var result = this.onReject();
+                    defer result.deinit();
 
-                    result.ensureStillAlive();
                     promise_value.ensureStillAlive();
 
-                    promise.reject(globalThis, result);
+                    promise.reject(globalThis, result.toJS(globalThis));
 
                     tracker.didDispatch(globalThis);
                     this.promise.deinit();
@@ -1152,10 +1154,14 @@ pub const Fetch = struct {
             const success = this.result.isSuccess();
 
             const result = switch (success) {
-                true => this.onResolve(),
-                false => this.onReject(),
+                true => JSC.Strong.create(this.onResolve(), globalThis),
+                false => brk: {
+                    // in this case we wanna a JSC.Strong so we just convert it
+                    var value = this.onReject();
+                    _ = value.toJS(globalThis);
+                    break :brk value.JSValue;
+                },
             };
-            result.ensureStillAlive();
 
             promise_value.ensureStillAlive();
             const Holder = struct {
@@ -1190,7 +1196,7 @@ pub const Fetch = struct {
             };
             var holder = bun.default_allocator.create(Holder) catch bun.outOfMemory();
             holder.* = .{
-                .held = JSC.Strong.create(result, globalThis),
+                .held = result,
                 // we need the promise to be alive until the task is done
                 .promise = this.promise.strong,
                 .globalObject = globalThis,
@@ -1265,22 +1271,22 @@ pub const Fetch = struct {
             return null;
         }
 
-        pub fn onReject(this: *FetchTasklet) JSValue {
+        pub fn onReject(this: *FetchTasklet) Body.Value.ValueError {
             bun.assert(this.result.fail != null);
             log("onReject", .{});
 
             if (this.getAbortError()) |err| {
-                return err;
+                return .{ .JSValue = JSC.Strong.create(err, this.global_this) };
             }
 
             if (this.result.isTimeout()) {
                 // Timeout without reason
-                return JSC.WebCore.AbortSignal.createTimeoutError(JSC.ZigString.static("The operation timed out"), &JSC.ZigString.Empty, this.global_this);
+                return .{ .Timeout = {} };
             }
 
             if (this.result.isAbort()) {
                 // Abort without reason
-                return JSC.WebCore.AbortSignal.createAbortError(JSC.ZigString.static("The user aborted a request"), &JSC.ZigString.Empty, this.global_this);
+                return .{ .Aborted = {} };
             }
 
             // some times we don't have metadata so we also check http.url
@@ -1375,7 +1381,7 @@ pub const Fetch = struct {
                 .path = path,
             };
 
-            return fetch_error.toErrorInstance(this.global_this);
+            return .{ .SystemError = fetch_error };
         }
 
         pub fn onReadableStreamAvailable(ctx: *anyopaque, readable: JSC.WebCore.ReadableStream) void {
@@ -1433,7 +1439,11 @@ pub const Fetch = struct {
 
         fn toBodyValue(this: *FetchTasklet) Body.Value {
             if (this.getAbortError()) |err| {
-                return .{ .Error = err };
+                return .{
+                    .Error = .{
+                        .JSValue = JSC.Strong.create(err, this.global_this),
+                    },
+                };
             }
             if (this.is_waiting_body) {
                 const response = Body.Value{

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -4504,7 +4504,7 @@ pub const ByteStream = struct {
             this.pending_buffer = &.{};
             this.pending.result.deinit();
             this.pending.result = .{ .done = {} };
-            this.pending.abort();
+            this.pending.run();
         }
 
         this.parent().destroy();

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2008,12 +2008,16 @@ export function readableStreamDefineLazyIterators(prototype) {
       reader.releaseLock();
 
       if (!preventCancel && !$isReadableStreamLocked(stream)) {
-        stream.cancel(deferredError);
+        const promise = stream.cancel(deferredError);
+        if (Bun.peek.status(promise) === "rejected") {
+          $markPromiseAsHandled(promise);
+        }
       }
 
       if (deferredError) {
         throw deferredError;
       }
+
     }
   };
   var createAsyncIterator = function asyncIterator() {

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -544,8 +544,9 @@ test("should be able to async upgrade using custom protocol", async () => {
   expect(await promise).toBe(true);
 });
 
-test("should be able to abrubtly close a upload request", async () => {
+test.only("should be able to abrubtly close a upload request", async () => {
   const { promise, resolve } = Promise.withResolvers();
+  const { promise: promise2, resolve: resolve2 } = Promise.withResolvers();
   using server = Bun.serve({
     port: 0,
     hostname: "localhost",
@@ -562,8 +563,10 @@ test("should be able to abrubtly close a upload request", async () => {
         }
       } catch (e) {
         expect((e as Error)?.name).toBe("AbortError");
-      } 
-     
+      } finally {
+        resolve2();
+      }
+            
       return new Response("Received " + total_size);
     },
   });
@@ -623,6 +626,6 @@ test("should be able to abrubtly close a upload request", async () => {
       data(socket, data) {},
     },
   });
-  await promise;
+  await Promise.all([promise, promise2]);
   expect().pass();
 });

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -544,7 +544,7 @@ test("should be able to async upgrade using custom protocol", async () => {
   expect(await promise).toBe(true);
 });
 
-test.only("should be able to abrubtly close a upload request", async () => {
+test("should be able to abrubtly close a upload request", async () => {
   const { promise, resolve } = Promise.withResolvers();
   const { promise: promise2, resolve: resolve2 } = Promise.withResolvers();
   using server = Bun.serve({

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -553,14 +553,17 @@ test("should be able to abrubtly close a upload request", async () => {
     async fetch(req) {
       let total_size = 0;
       req.signal.addEventListener("abort", resolve);
-
-      for await (const chunk of req.body as ReadableStream) {
-        total_size += chunk.length;
-        if (total_size > 1024 * 1024 * 1024) {
-          return new Response("too big", { status: 413 });
+      try{
+        for await (const chunk of req.body as ReadableStream) {
+          total_size += chunk.length;
+          if (total_size > 1024 * 1024 * 1024) {
+            return new Response("too big", { status: 413 });
+          }
         }
-      }
-
+      } catch (e) {
+        expect((e as Error)?.name).toBe("AbortError");
+      } 
+     
       return new Response("Received " + total_size);
     },
   });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1562,7 +1562,7 @@ it("should resolve pending promise if requested ended with pending read", async 
     {
       fetch(req) {
         // @ts-ignore
-        req.body?.getReader().read().catch(shouldError).then(shouldMarkDone);
+        req.body?.getReader().read().then(shouldMarkDone).catch(shouldError)
         return new Response("OK");
       },
     },
@@ -1573,8 +1573,9 @@ it("should resolve pending promise if requested ended with pending read", async 
       });
       const text = await response.text();
       expect(text).toContain("OK");
-      expect(is_done).toBe(true);
-      expect(error).toBeUndefined();
+      expect(is_done).toBe(false);
+      expect(error).toBeDefined();
+      expect(error.name).toContain("AbortError");
     },
   );
 });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1652,6 +1652,7 @@ it("should be able to abrupt stop the server", async () => {
 });
 
 it("should not instanciate error instances in each request", async () => {
+  const startErrorCount = heapStats().objectTypeCounts.Error || 0;
   using server = Bun.serve({
     port: 0,
     async fetch(req, server) {
@@ -1669,5 +1670,5 @@ it("should not instanciate error instances in each request", async () => {
       await Promise.all(batch);
     }
   }
-  expect(heapStats().objectTypeCounts.Error || 0).toBe(0);
+  expect(heapStats().objectTypeCounts.Error || 0).toBeLessThanOrEqual(startErrorCount);
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
Existing tests + test changes + new test
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
