### PR TITLE
Free more data on worker destruction

### DIFF
--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -331,6 +331,16 @@ pub const All = struct {
         return JSValue.jsUndefined();
     }
 
+    pub fn deinit(this: *All) void {
+        if (Environment.isWindows) {
+            this.uv_timer.stop();
+        }
+
+        this.maps.setImmediate.clearAndFree(bun.default_allocator);
+        this.maps.setTimeout.clearAndFree(bun.default_allocator);
+        this.maps.setInterval.clearAndFree(bun.default_allocator);
+    }
+
     const Shimmer = @import("../bindings/shimmer.zig").Shimmer;
 
     pub const shim = Shimmer("Bun", "Timer", @This());

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3293,8 +3293,11 @@ JSValue GlobalObject_getGlobalThis(VM& vm, JSObject* globalObject)
     return jsCast<Zig::GlobalObject*>(globalObject)->globalThis();
 }
 
-// This is like `putDirectBuiltinFunction` but for the global static list.
-#define globalBuiltinFunction(vm, globalObject, identifier, function, attributes) JSC::JSGlobalObject::GlobalPropertyInfo(identifier, JSFunction::create(vm, function, globalObject), attributes)
+JSC_DEFINE_CUSTOM_GETTER(getProcessBindingsConstants, (JSGlobalObject * globalObject, EncodedJSValue, PropertyName))
+{
+
+    return JSValue::encode(jsCast<Zig::GlobalObject*>(globalObject)->processBindingConstants());
+}
 
 void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 {
@@ -3329,7 +3332,6 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
         GlobalPropertyInfo(vm.propertyNames->builtinNames().ArrayBufferPrivateName(), arrayBufferConstructor(), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.LoaderPrivateName(), this->moduleLoader(), PropertyAttribute::DontDelete | 0),
         GlobalPropertyInfo(builtinNames.internalModuleRegistryPrivateName(), this->internalModuleRegistry(), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
-        GlobalPropertyInfo(builtinNames.processBindingConstantsPrivateName(), this->processBindingConstants(), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.requireMapPrivateName(), this->requireMap(), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | 0),
     };
     addStaticGlobals(staticGlobals, std::size(staticGlobals));
@@ -3347,6 +3349,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     putDirectBuiltinFunction(vm, this, builtinNames.requireNativeModulePrivateName(), moduleRequireNativeModuleCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 
     putDirectBuiltinFunction(vm, this, builtinNames.overridableRequirePrivateName(), moduleOverridableRequireCodeGenerator(vm), 0);
+    putDirectCustomAccessor(vm, builtinNames.processBindingConstantsPrivateName(), JSC::CustomGetterSetter::create(vm, getProcessBindingsConstants, nullptr), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 
     putDirectNativeFunction(vm, this, builtinNames.createUninitializedArrayBufferPrivateName(), 1, functionCreateUninitializedArrayBuffer, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.resolveSyncPrivateName(), 1, functionImportMeta__resolveSyncPrivate, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -2433,6 +2433,7 @@ pub const VirtualMachine = struct {
 
     // TODO:
     pub fn deinit(this: *VirtualMachine) void {
+        this.timer.deinit();
         this.source_mappings.deinit();
         if (this.rare_data) |rare_data| {
             rare_data.deinit();

--- a/src/bun.js/rare_data.zig
+++ b/src/bun.js/rare_data.zig
@@ -402,4 +402,24 @@ pub fn deinit(this: *RareData) void {
     if (this.boring_ssl_engine) |engine| {
         _ = bun.BoringSSL.ENGINE_free(engine);
     }
+
+    if (this.stderr_store) |store| {
+        this.stderr_store = null;
+        store.deref();
+    }
+
+    if (this.stdout_store) |store| {
+        this.stdout_store = null;
+        store.deref();
+    }
+
+    if (this.stdin_store) |store| {
+        this.stdin_store = null;
+        store.deref();
+    }
+
+    if (this.entropy_cache) |cache| {
+        this.entropy_cache = null;
+        bun.default_allocator.destroy(cache);
+    }
 }


### PR DESCRIPTION
### What does this PR do?

Free more data when a Worker terminates

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
