### PR TITLE
Sort heapStats().objectTypeCounts

### DIFF
--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -42,6 +42,24 @@ using namespace JSC;
 using namespace Zig;
 using namespace WebCore;
 
+class ResolvedSourceCodeHolder {
+public:
+    ResolvedSourceCodeHolder(ErrorableResolvedSource* res_)
+        : res(res_)
+    {
+    }
+
+    ~ResolvedSourceCodeHolder()
+    {
+        if (res->success && res->result.value.source_code.tag == BunStringTag::WTFStringImpl && res->result.value.needsDeref) {
+            res->result.value.needsDeref = false;
+            res->result.value.source_code.impl.wtf->deref();
+        }
+    }
+
+    ErrorableResolvedSource* res;
+};
+
 extern "C" BunLoaderType Bun__getDefaultLoader(JSC::JSGlobalObject*, BunString* specifier);
 
 static JSC::JSInternalPromise* rejectedInternalPromise(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
@@ -289,13 +307,7 @@ static JSValue handleVirtualModuleResult(
     auto onLoadResult = handleOnLoadResult(globalObject, virtualModuleResult, specifier, wasModuleMock);
     JSC::VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    WTF::String sourceCodeStringForDeref;
-    const auto getSourceCodeStringForDeref = [&]() {
-        if (res->success && res->result.value.needsDeref && res->result.value.source_code.tag == BunStringTag::WTFStringImpl) {
-            res->result.value.needsDeref = false;
-            sourceCodeStringForDeref = String(res->result.value.source_code.impl.wtf);
-        }
-    };
+    ResolvedSourceCodeHolder sourceCodeHolder(res);
 
     const auto reject = [&](JSC::JSValue exception) -> JSValue {
         if constexpr (allowPromise) {
@@ -342,7 +354,6 @@ static JSValue handleVirtualModuleResult(
         if (!res->success) {
             return reject(JSValue::decode(reinterpret_cast<EncodedJSValue>(res->result.err.ptr)));
         }
-        getSourceCodeStringForDeref();
 
         auto provider = Zig::SourceProvider::create(globalObject, res->result.value);
         return resolve(JSC::JSSourceCode::create(vm, JSC::SourceCode(provider)));
@@ -396,13 +407,7 @@ extern "C" void Bun__onFulfillAsyncModule(
     BunString* specifier,
     BunString* referrer)
 {
-    WTF::String sourceCodeStringForDeref;
-    const auto getSourceCodeStringForDeref = [&]() {
-        if (res->result.value.needsDeref && res->result.value.source_code.tag == BunStringTag::WTFStringImpl) {
-            res->result.value.needsDeref = false;
-            sourceCodeStringForDeref = String(res->result.value.source_code.impl.wtf);
-        }
-    };
+    ResolvedSourceCodeHolder sourceCodeHolder(res);
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSInternalPromise* promise = jsCast<JSC::JSInternalPromise*>(JSC::JSValue::decode(encodedPromiseValue));
@@ -414,7 +419,6 @@ extern "C" void Bun__onFulfillAsyncModule(
         return promise->reject(globalObject, exception);
     }
 
-    getSourceCodeStringForDeref();
     auto specifierValue = Bun::toJS(globalObject, *specifier);
 
     if (auto entry = globalObject->esmRegistryMap()->get(globalObject, specifierValue)) {
@@ -467,13 +471,7 @@ JSValue fetchCommonJSModule(
     memset(&resValue, 0, sizeof(ErrorableResolvedSource));
 
     ErrorableResolvedSource* res = &resValue;
-    WTF::String sourceCodeStringForDeref;
-    const auto getSourceCodeStringForDeref = [&]() {
-        if (res->success && res->result.value.needsDeref && res->result.value.source_code.tag == BunStringTag::WTFStringImpl) {
-            res->result.value.needsDeref = false;
-            sourceCodeStringForDeref = String(res->result.value.source_code.impl.wtf);
-        }
-    };
+    ResolvedSourceCodeHolder sourceCodeHolder(res);
     auto& builtinNames = WebCore::clientData(vm)->builtinNames();
 
     bool wasModuleMock = false;
@@ -600,8 +598,6 @@ JSValue fetchCommonJSModule(
     }
 
     Bun__transpileFile(bunVM, globalObject, specifier, referrer, typeAttribute, res, false);
-    getSourceCodeStringForDeref();
-
     if (res->success && res->result.value.isCommonJSModule) {
         target->evaluate(globalObject, specifier->toWTFString(BunString::ZeroCopy), res->result.value);
         RETURN_IF_EXCEPTION(scope, {});
@@ -669,6 +665,7 @@ static JSValue fetchESMSourceCode(
     void* bunVM = globalObject->bunVM();
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
+    ResolvedSourceCodeHolder sourceCodeHolder(res);
 
     const auto reject = [&](JSC::JSValue exception) -> JSValue {
         if constexpr (allowPromise) {
@@ -755,23 +752,13 @@ static JSValue fetchESMSourceCode(
         }
     }
 
-    WTF::String sourceCodeStringForDeref;
-    const auto getSourceCodeStringForDeref = [&]() {
-        if (res->success && res->result.value.needsDeref && res->result.value.source_code.tag == BunStringTag::WTFStringImpl) {
-            res->result.value.needsDeref = false;
-            sourceCodeStringForDeref = String(res->result.value.source_code.impl.wtf);
-        }
-    };
-
     if constexpr (allowPromise) {
         auto* pendingCtx = Bun__transpileFile(bunVM, globalObject, specifier, referrer, typeAttribute, res, true);
-        getSourceCodeStringForDeref();
         if (pendingCtx) {
             return pendingCtx;
         }
     } else {
         Bun__transpileFile(bunVM, globalObject, specifier, referrer, typeAttribute, res, false);
-        getSourceCodeStringForDeref();
     }
 
     if (res->success && res->result.value.isCommonJSModule) {

--- a/src/bun.js/modules/BunJSCModule.h
+++ b/src/bun.js/modules/BunJSCModule.h
@@ -29,6 +29,8 @@
 #include <JavaScriptCore/SamplingProfiler.h>
 #include <JavaScriptCore/TestRunnerUtils.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
+#include <algorithm>
+#include <cstddef>
 #include <wtf/FileSystem.h>
 #include <wtf/MemoryFootprint.h>
 #include <wtf/text/WTFString.h>
@@ -210,29 +212,78 @@ JSC_DEFINE_HOST_FUNCTION(functionMemoryUsageStatistics,
 
   auto &vm = globalObject->vm();
 
-  // this is a C API function
-  auto *stats = toJS(JSGetMemoryUsageStatistics(toRef(globalObject)));
-
-  if (JSValue heapSizeValue =
-          stats->getDirect(vm, Identifier::fromString(vm, "heapSize"_s))) {
-    ASSERT(heapSizeValue.isNumber());
-    if (heapSizeValue.toInt32(globalObject) == 0) {
-      vm.heap.collectNow(Sync, CollectionScope::Full);
-      JSC::DisallowGC disallowGC;
-      stats = toJS(JSGetMemoryUsageStatistics(toRef(globalObject)));
-    }
+  if (vm.heap.size() == 0) {
+    vm.heap.collectNow(Sync, CollectionScope::Full);
+    JSC::DisallowGC disallowGC;
   }
 
-  // This is missing from the C API
-  JSC::JSObject *protectedCounts = constructEmptyObject(globalObject);
-  auto typeCounts = *vm.heap.protectedObjectTypeCounts();
-  for (auto &it : typeCounts)
-    protectedCounts->putDirect(vm, Identifier::fromLatin1(vm, it.key),
-                               jsNumber(it.value));
+  const auto createdSortedTypeCounts =
+      [&](JSC::TypeCountSet *typeCounts) -> JSC::JSValue {
+    WTF::Vector<std::pair<Identifier, unsigned>> counts;
+    counts.reserveInitialCapacity(typeCounts->size());
+    for (auto &it : *typeCounts) {
+      if (it.value > 0)
+        counts.append(
+            std::make_pair(Identifier::fromLatin1(vm, it.key), it.value));
+    }
 
-  stats->putDirect(vm,
-                   Identifier::fromLatin1(vm, "protectedObjectTypeCounts"_s),
-                   protectedCounts);
+    // Sort by count first, then by name.
+    std::sort(counts.begin(), counts.end(),
+              [](const std::pair<Identifier, unsigned> &a,
+                 const std::pair<Identifier, unsigned> &b) {
+                if (a.second == b.second) {
+                  WTF::StringView left = a.first.string();
+                  WTF::StringView right = b.first.string();
+                  unsigned originalLeftLength = left.length();
+                  unsigned originalRightLength = right.length();
+                  unsigned size = std::min(left.length(), right.length());
+                  left = left.substring(0, size);
+                  right = right.substring(0, size);
+                  int result = WTF::codePointCompare(right, left);
+                  if (result == 0) {
+                    return originalLeftLength > originalRightLength;
+                  }
+
+                  return result > 0;
+                }
+
+                return a.second > b.second;
+              });
+
+    auto *objectTypeCounts = constructEmptyObject(globalObject);
+    for (auto &it : counts) {
+      objectTypeCounts->putDirect(vm, it.first, jsNumber(it.second));
+    }
+    return objectTypeCounts;
+  };
+
+  JSValue objectTypeCounts =
+      createdSortedTypeCounts(vm.heap.objectTypeCounts().get());
+  JSValue protectedCounts =
+      createdSortedTypeCounts(vm.heap.protectedObjectTypeCounts().get());
+
+  JSObject *object = constructEmptyObject(globalObject);
+  object->putDirect(vm, Identifier::fromString(vm, "objectTypeCounts"_s),
+                    objectTypeCounts);
+
+  object->putDirect(vm,
+                    Identifier::fromLatin1(vm, "protectedObjectTypeCounts"_s),
+                    protectedCounts);
+  object->putDirect(vm, Identifier::fromString(vm, "heapSize"_s),
+                    jsNumber(vm.heap.size()));
+  object->putDirect(vm, Identifier::fromString(vm, "heapCapacity"_s),
+                    jsNumber(vm.heap.capacity()));
+  object->putDirect(vm, Identifier::fromString(vm, "extraMemorySize"_s),
+                    jsNumber(vm.heap.extraMemorySize()));
+  object->putDirect(vm, Identifier::fromString(vm, "objectCount"_s),
+                    jsNumber(vm.heap.objectCount()));
+  object->putDirect(vm, Identifier::fromString(vm, "protectedObjectCount"_s),
+                    jsNumber(vm.heap.protectedObjectCount()));
+  object->putDirect(vm, Identifier::fromString(vm, "globalObjectCount"_s),
+                    jsNumber(vm.heap.globalObjectCount()));
+  object->putDirect(vm,
+                    Identifier::fromString(vm, "protectedGlobalObjectCount"_s),
+                    jsNumber(vm.heap.protectedGlobalObjectCount()));
 
 #if IS_MALLOC_DEBUGGING_ENABLED
 #if OS(DARWIN)
@@ -247,25 +298,56 @@ JSC_DEFINE_HOST_FUNCTION(functionMemoryUsageStatistics,
     zone_stats.max_size_in_use = 0;
     zone_stats.size_allocated = 0;
 
-    JSObject *zonesObject = constructEmptyObject(globalObject);
-    stats->putDirect(vm, Identifier::fromString(vm, "zones"_s), zonesObject);
     malloc_zone_pressure_relief(nullptr, 0);
     malloc_get_all_zones(mach_task_self(), 0, &zones, &count);
+    Vector<std::pair<Identifier, size_t>> zoneSizes;
+    zoneSizes.reserveInitialCapacity(count);
     for (unsigned i = 0; i < count; i++) {
       auto zone = reinterpret_cast<malloc_zone_t *>(zones[i]);
       if (const char *name = malloc_get_zone_name(zone)) {
         malloc_zone_statistics(reinterpret_cast<malloc_zone_t *>(zones[i]),
                                &zone_stats);
-        zonesObject->putDirect(
-            vm, Identifier::fromString(vm, String::fromUTF8(name)),
-            jsDoubleNumber(zone_stats.size_in_use));
+        zoneSizes.append(
+            std::make_pair(Identifier::fromString(vm, String::fromUTF8(name)),
+                           zone_stats.size_in_use));
       }
     }
+
+    std::sort(zoneSizes.begin(), zoneSizes.end(),
+              [](const std::pair<Identifier, size_t> &a,
+                 const std::pair<Identifier, size_t> &b) {
+                // Sort by name if the sizes are the same.
+                if (a.second == b.second) {
+                  WTF::StringView left = a.first.string();
+                  WTF::StringView right = b.first.string();
+                  unsigned originalLeftLength = left.length();
+                  unsigned originalRightLength = right.length();
+                  unsigned size = std::min(left.length(), right.length());
+                  left = left.substring(0, size);
+                  right = right.substring(0, size);
+                  int result = WTF::codePointCompare(right, left);
+                  if (result == 0) {
+                    return originalLeftLength > originalRightLength;
+                  }
+
+                  return result > 0;
+                }
+
+                return a.second > b.second;
+              });
+
+    auto *zoneSizesObject = constructEmptyObject(globalObject);
+    for (auto &it : zoneSizes) {
+      zoneSizesObject->putDirect(vm, it.first, jsDoubleNumber(it.second));
+    }
+
+    object->putDirect(vm, Identifier::fromString(vm, "zones"_s),
+                      zoneSizesObject);
   }
 #endif
 #endif
 
-  return JSValue::encode(stats);
+  return JSValue::encode(object);
 }
 
 JSC_DECLARE_HOST_FUNCTION(functionCreateMemoryFootprint);

--- a/src/heap_breakdown.zig
+++ b/src/heap_breakdown.zig
@@ -11,14 +11,14 @@ fn heapLabel(comptime T: type) [:0]const u8 {
         T.heap_label
     else
         bun.meta.typeBaseName(@typeName(T));
-    return "Bun__" ++ base_name;
+    return base_name;
 }
 
 pub fn allocator(comptime T: type) std.mem.Allocator {
     return namedAllocator(comptime heapLabel(T));
 }
 pub fn namedAllocator(comptime name: [:0]const u8) std.mem.Allocator {
-    return getZone(name).allocator();
+    return getZone("Bun__" ++ name).allocator();
 }
 
 pub fn getZoneT(comptime T: type) *Zone {


### PR DESCRIPTION
### What does this PR do?

Sort heapStats():
- `objectTypeCounts`
- `protectedObjectTypeCounts`
- `zones`

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
