### PR TITLE
Fix memory leak when requiring or importing modules that get GC'd later

### DIFF
--- a/src/bun.js/bindings/CommonJSModuleRecord.cpp
+++ b/src/bun.js/bindings/CommonJSModuleRecord.cpp
@@ -30,6 +30,8 @@
  */
 
 #include "headers.h"
+
+#include "JavaScriptCore/Synchronousness.h"
 #include "JavaScriptCore/JSCast.h"
 #include <JavaScriptCore/JSMapInlines.h>
 #include "root.h"
@@ -72,6 +74,7 @@
 #include "PathInlines.h"
 #include "wtf/NakedPtr.h"
 #include "wtf/URL.h"
+#include "wtf/text/StringImpl.h"
 
 extern "C" bool Bun__isBunMain(JSC::JSGlobalObject* global, const BunString*);
 
@@ -152,7 +155,6 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
     JSValue fnValue = JSC::evaluate(globalObject, code, jsUndefined(), exception);
 
     if (UNLIKELY(exception.get() || fnValue.isEmpty())) {
-
         return false;
     }
 
@@ -171,6 +173,13 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
         args.append(Zig::ImportMetaObject::create(globalObject, filename));
     }
 
+    // Clear the source code as early as possible.
+    code = {};
+
+    // Call the CommonJS module wrapper function.
+    //
+    //    fn(exports, require, module, __filename, __dirname) { /* code */ }(exports, require, module, __filename, __dirname)
+    //
     JSC::call(globalObject, fn, callData, moduleObject, args, exception);
 
     return exception.get() == nullptr;
@@ -352,9 +361,15 @@ JSC_DEFINE_CUSTOM_GETTER(getterParent, (JSC::JSGlobalObject * globalObject, JSC:
     if (UNLIKELY(!thisObject)) {
         return JSValue::encode(jsUndefined());
     }
-    auto v = thisObject->m_parent.get();
-    if (v)
-        return JSValue::encode(thisObject->m_parent.get());
+
+    if (thisObject->m_overridenParent) {
+        return JSValue::encode(thisObject->m_overridenParent.get());
+    }
+
+    if (thisObject->m_parent) {
+        auto* parent = thisObject->m_parent.get();
+        return JSValue::encode(parent);
+    }
 
     // initialize parent by checking if it is the main module. we do this lazily because most people
     // dont need `module.parent` and creating commonjs module records is done a ton.
@@ -363,12 +378,11 @@ JSC_DEFINE_CUSTOM_GETTER(getterParent, (JSC::JSGlobalObject * globalObject, JSC:
         auto id = idValue->value(globalObject);
         auto idStr = Bun::toString(id);
         if (Bun__isBunMain(globalObject, &idStr)) {
-            thisObject->m_parent.set(globalObject->vm(), thisObject, jsNull());
+            thisObject->m_overridenParent.set(globalObject->vm(), thisObject, jsNull());
             return JSValue::encode(jsNull());
         }
     }
 
-    thisObject->m_parent.set(globalObject->vm(), thisObject, jsUndefined());
     return JSValue::encode(jsUndefined());
 }
 
@@ -454,7 +468,15 @@ JSC_DEFINE_CUSTOM_SETTER(setterParent,
     if (!thisObject)
         return false;
 
-    thisObject->m_parent.set(globalObject->vm(), thisObject, JSValue::decode(value));
+    JSValue decodedValue = JSValue::decode(value);
+
+    if (auto* parent = jsDynamicCast<JSCommonJSModule*>(decodedValue)) {
+        thisObject->m_parent = parent;
+        thisObject->m_overridenParent.clear();
+    } else {
+        thisObject->m_parent = {};
+        thisObject->m_overridenParent.set(globalObject->vm(), thisObject, JSValue::decode(value));
+    }
 
     return true;
 }
@@ -640,7 +662,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionCreateCommonJSModule, (JSGlobalObject * globa
 {
     RELEASE_ASSERT(callframe->argumentCount() == 4);
 
-    auto id = callframe->uncheckedArgument(0).toWTFString(globalObject);
+    auto id = callframe->uncheckedArgument(0).toString(globalObject);
     JSValue object = callframe->uncheckedArgument(1);
     JSValue hasEvaluated = callframe->uncheckedArgument(2);
     ASSERT(hasEvaluated.isBoolean());
@@ -651,15 +673,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionCreateCommonJSModule, (JSGlobalObject * globa
 
 JSCommonJSModule* JSCommonJSModule::create(
     Zig::GlobalObject* globalObject,
-    const WTF::String& key,
+    JSC::JSString* requireMapKey,
     JSValue exportsObject,
     bool hasEvaluated,
     JSValue parent)
 {
     auto& vm = globalObject->vm();
-    JSString* requireMapKey = JSC::jsStringWithCache(vm, key);
-
-    auto index = key.reverseFind(PLATFORM_SEP, key.length());
+    auto key = requireMapKey->value(globalObject);
+    auto index = key->reverseFind(PLATFORM_SEP, key->length());
 
     JSString* dirname;
     if (index != WTF::notFound) {
@@ -679,9 +700,29 @@ JSCommonJSModule* JSCommonJSModule::create(
         exportsObject,
         0);
     out->hasEvaluated = hasEvaluated;
-    out->m_parent.set(vm, out, parent);
+    if (parent && parent.isCell()) {
+        if (auto* parentModule = jsDynamicCast<JSCommonJSModule*>(parent)) {
+            out->m_parent = JSC::Weak<JSCommonJSModule>(parentModule);
+        } else {
+            out->m_overridenParent.set(vm, out, parent);
+        }
+    } else if (parent) {
+        out->m_overridenParent.set(vm, out, parent);
+    }
 
     return out;
+}
+
+JSCommonJSModule* JSCommonJSModule::create(
+    Zig::GlobalObject* globalObject,
+    const WTF::String& key,
+    JSValue exportsObject,
+    bool hasEvaluated,
+    JSValue parent)
+{
+    auto& vm = globalObject->vm();
+    auto* requireMapKey = JSC::jsStringWithCache(vm, key);
+    return JSCommonJSModule::create(globalObject, requireMapKey, exportsObject, hasEvaluated, parent);
 }
 
 void JSCommonJSModule::destroy(JSC::JSCell* cell)
@@ -908,6 +949,7 @@ void JSCommonJSModule::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_filename);
     visitor.append(thisObject->m_dirname);
     visitor.append(thisObject->m_paths);
+    visitor.append(thisObject->m_overridenParent);
 }
 
 DEFINE_VISIT_CHILDREN(JSCommonJSModule);
@@ -1014,7 +1056,6 @@ bool JSCommonJSModule::evaluate(
     this->sourceCode = JSC::SourceCode(WTFMove(sourceProvider));
 
     WTF::NakedPtr<JSC::Exception> exception;
-
     evaluateCommonJSModuleOnce(vm, globalObject, this, this->m_dirname.get(), this->m_filename.get(), exception);
 
     if (exception.get()) {

--- a/src/bun.js/bindings/CommonJSModuleRecord.h
+++ b/src/bun.js/bindings/CommonJSModuleRecord.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "JavaScriptCore/JSGlobalObject.h"
+#include "JavaScriptCore/JSString.h"
 #include "root.h"
 #include "headers-handwritten.h"
 #include "wtf/NakedPtr.h"
@@ -35,7 +36,19 @@ public:
     mutable JSC::WriteBarrier<Unknown> m_filename;
     mutable JSC::WriteBarrier<JSString> m_dirname;
     mutable JSC::WriteBarrier<Unknown> m_paths;
-    mutable JSC::WriteBarrier<Unknown> m_parent;
+
+    // Visited by the GC. When the module is assigned a non-JSCommonJSModule
+    // parent, it is assigned to this field.
+    //
+    //    module.parent = parent;
+    //
+    mutable JSC::WriteBarrier<Unknown> m_overridenParent;
+
+    // Not visited by the GC.
+    // When the module is assigned a JSCommonJSModule parent, it is assigned to this field.
+    // This is the normal state.
+    JSC::Weak<JSCommonJSModule> m_parent {};
+
     bool ignoreESModuleAnnotation { false };
     JSC::SourceCode sourceCode = JSC::SourceCode();
 
@@ -68,6 +81,11 @@ public:
     static JSCommonJSModule* create(
         Zig::GlobalObject* globalObject,
         const WTF::String& key,
+        JSValue exportsObject, bool hasEvaluated, JSValue parent);
+
+    static JSCommonJSModule* create(
+        Zig::GlobalObject* globalObject,
+        JSC::JSString* key,
         JSValue exportsObject, bool hasEvaluated, JSValue parent);
 
     static JSCommonJSModule* create(

--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -42,6 +42,24 @@ using namespace JSC;
 using namespace Zig;
 using namespace WebCore;
 
+class ResolvedSourceCodeHolder {
+public:
+    ResolvedSourceCodeHolder(ErrorableResolvedSource* res_)
+        : res(res_)
+    {
+    }
+
+    ~ResolvedSourceCodeHolder()
+    {
+        if (res->success && res->result.value.source_code.tag == BunStringTag::WTFStringImpl && res->result.value.needsDeref) {
+            res->result.value.needsDeref = false;
+            res->result.value.source_code.impl.wtf->deref();
+        }
+    }
+
+    ErrorableResolvedSource* res;
+};
+
 extern "C" BunLoaderType Bun__getDefaultLoader(JSC::JSGlobalObject*, BunString* specifier);
 
 static JSC::JSInternalPromise* rejectedInternalPromise(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
@@ -289,13 +307,7 @@ static JSValue handleVirtualModuleResult(
     auto onLoadResult = handleOnLoadResult(globalObject, virtualModuleResult, specifier, wasModuleMock);
     JSC::VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    WTF::String sourceCodeStringForDeref;
-    const auto getSourceCodeStringForDeref = [&]() {
-        if (res->success && res->result.value.needsDeref && res->result.value.source_code.tag == BunStringTag::WTFStringImpl) {
-            res->result.value.needsDeref = false;
-            sourceCodeStringForDeref = String(res->result.value.source_code.impl.wtf);
-        }
-    };
+    ResolvedSourceCodeHolder sourceCodeHolder(res);
 
     const auto reject = [&](JSC::JSValue exception) -> JSValue {
         if constexpr (allowPromise) {
@@ -342,7 +354,6 @@ static JSValue handleVirtualModuleResult(
         if (!res->success) {
             return reject(JSValue::decode(reinterpret_cast<EncodedJSValue>(res->result.err.ptr)));
         }
-        getSourceCodeStringForDeref();
 
         auto provider = Zig::SourceProvider::create(globalObject, res->result.value);
         return resolve(JSC::JSSourceCode::create(vm, JSC::SourceCode(provider)));
@@ -396,13 +407,7 @@ extern "C" void Bun__onFulfillAsyncModule(
     BunString* specifier,
     BunString* referrer)
 {
-    WTF::String sourceCodeStringForDeref;
-    const auto getSourceCodeStringForDeref = [&]() {
-        if (res->result.value.needsDeref && res->result.value.source_code.tag == BunStringTag::WTFStringImpl) {
-            res->result.value.needsDeref = false;
-            sourceCodeStringForDeref = String(res->result.value.source_code.impl.wtf);
-        }
-    };
+    ResolvedSourceCodeHolder sourceCodeHolder(res);
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSInternalPromise* promise = jsCast<JSC::JSInternalPromise*>(JSC::JSValue::decode(encodedPromiseValue));
@@ -414,7 +419,6 @@ extern "C" void Bun__onFulfillAsyncModule(
         return promise->reject(globalObject, exception);
     }
 
-    getSourceCodeStringForDeref();
     auto specifierValue = Bun::toJS(globalObject, *specifier);
 
     if (auto entry = globalObject->esmRegistryMap()->get(globalObject, specifierValue)) {
@@ -467,13 +471,7 @@ JSValue fetchCommonJSModule(
     memset(&resValue, 0, sizeof(ErrorableResolvedSource));
 
     ErrorableResolvedSource* res = &resValue;
-    WTF::String sourceCodeStringForDeref;
-    const auto getSourceCodeStringForDeref = [&]() {
-        if (res->success && res->result.value.needsDeref && res->result.value.source_code.tag == BunStringTag::WTFStringImpl) {
-            res->result.value.needsDeref = false;
-            sourceCodeStringForDeref = String(res->result.value.source_code.impl.wtf);
-        }
-    };
+    ResolvedSourceCodeHolder sourceCodeHolder(res);
     auto& builtinNames = WebCore::clientData(vm)->builtinNames();
 
     bool wasModuleMock = false;
@@ -600,8 +598,6 @@ JSValue fetchCommonJSModule(
     }
 
     Bun__transpileFile(bunVM, globalObject, specifier, referrer, typeAttribute, res, false);
-    getSourceCodeStringForDeref();
-
     if (res->success && res->result.value.isCommonJSModule) {
         target->evaluate(globalObject, specifier->toWTFString(BunString::ZeroCopy), res->result.value);
         RETURN_IF_EXCEPTION(scope, {});
@@ -669,6 +665,7 @@ static JSValue fetchESMSourceCode(
     void* bunVM = globalObject->bunVM();
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
+    ResolvedSourceCodeHolder sourceCodeHolder(res);
 
     const auto reject = [&](JSC::JSValue exception) -> JSValue {
         if constexpr (allowPromise) {
@@ -755,23 +752,13 @@ static JSValue fetchESMSourceCode(
         }
     }
 
-    WTF::String sourceCodeStringForDeref;
-    const auto getSourceCodeStringForDeref = [&]() {
-        if (res->success && res->result.value.needsDeref && res->result.value.source_code.tag == BunStringTag::WTFStringImpl) {
-            res->result.value.needsDeref = false;
-            sourceCodeStringForDeref = String(res->result.value.source_code.impl.wtf);
-        }
-    };
-
     if constexpr (allowPromise) {
         auto* pendingCtx = Bun__transpileFile(bunVM, globalObject, specifier, referrer, typeAttribute, res, true);
-        getSourceCodeStringForDeref();
         if (pendingCtx) {
             return pendingCtx;
         }
     } else {
         Bun__transpileFile(bunVM, globalObject, specifier, referrer, typeAttribute, res, false);
-        getSourceCodeStringForDeref();
     }
 
     if (res->success && res->result.value.isCommonJSModule) {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -978,8 +978,16 @@ pub const VirtualMachine = struct {
         };
     }
 
-    pub fn loadExtraEnv(this: *VirtualMachine) void {
+    pub fn loadExtraEnvAndSourceCodePrinter(this: *VirtualMachine) void {
         var map = this.bundler.env.map;
+
+        if (source_code_printer == null) {
+            const allocator = if (bun.heap_breakdown.enabled) bun.heap_breakdown.namedAllocator("SourceCode") else this.allocator;
+            const writer = try js_printer.BufferWriter.init(allocator);
+            source_code_printer = allocator.create(js_printer.BufferPrinter) catch unreachable;
+            source_code_printer.?.* = js_printer.BufferPrinter.init(writer);
+            source_code_printer.?.ctx.append_null_byte = false;
+        }
 
         if (map.get("BUN_SHOW_BUN_STACKFRAMES") != null) {
             this.hide_bun_stackframes = false;
@@ -1563,13 +1571,6 @@ pub const VirtualMachine = struct {
         vm.regular_event_loop.virtual_machine = vm;
         vm.jsc = vm.global.vm();
 
-        if (source_code_printer == null) {
-            const writer = try js_printer.BufferWriter.init(allocator);
-            source_code_printer = allocator.create(js_printer.BufferPrinter) catch unreachable;
-            source_code_printer.?.* = js_printer.BufferPrinter.init(writer);
-            source_code_printer.?.ctx.append_null_byte = false;
-        }
-
         vm.configureDebugger(opts.debugger);
         vm.body_value_hive_allocator = BodyValueHiveAllocator.init(bun.typedAllocator(JSC.WebCore.Body.Value));
 
@@ -1682,13 +1683,6 @@ pub const VirtualMachine = struct {
 
         if (opts.smol)
             is_smol_mode = opts.smol;
-
-        if (source_code_printer == null) {
-            const writer = try js_printer.BufferWriter.init(allocator);
-            source_code_printer = allocator.create(js_printer.BufferPrinter) catch unreachable;
-            source_code_printer.?.* = js_printer.BufferPrinter.init(writer);
-            source_code_printer.?.ctx.append_null_byte = false;
-        }
 
         vm.configureDebugger(opts.debugger);
         vm.body_value_hive_allocator = BodyValueHiveAllocator.init(bun.typedAllocator(JSC.WebCore.Body.Value));
@@ -1828,12 +1822,6 @@ pub const VirtualMachine = struct {
         vm.regular_event_loop.virtual_machine = vm;
         vm.jsc = vm.global.vm();
         vm.bundler.setAllocator(allocator);
-        if (source_code_printer == null) {
-            const writer = try js_printer.BufferWriter.init(allocator);
-            source_code_printer = allocator.create(js_printer.BufferPrinter) catch unreachable;
-            source_code_printer.?.* = js_printer.BufferPrinter.init(writer);
-            source_code_printer.?.ctx.append_null_byte = false;
-        }
         vm.body_value_hive_allocator = BodyValueHiveAllocator.init(bun.typedAllocator(JSC.WebCore.Body.Value));
 
         return vm;
@@ -2433,6 +2421,10 @@ pub const VirtualMachine = struct {
 
     // TODO:
     pub fn deinit(this: *VirtualMachine) void {
+        if (source_code_printer) |print| {
+            print.getMutableBuffer().deinit();
+            print.ctx.written = &.{};
+        }
         this.source_mappings.deinit();
         if (this.rare_data) |rare_data| {
             rare_data.deinit();

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -978,9 +978,7 @@ pub const VirtualMachine = struct {
         };
     }
 
-    pub fn loadExtraEnvAndSourceCodePrinter(this: *VirtualMachine) void {
-        var map = this.bundler.env.map;
-
+    fn ensureSourceCodePrinter(this: *VirtualMachine) void {
         if (source_code_printer == null) {
             const allocator = if (bun.heap_breakdown.enabled) bun.heap_breakdown.namedAllocator("SourceCode") else this.allocator;
             const writer = try js_printer.BufferWriter.init(allocator);
@@ -988,6 +986,12 @@ pub const VirtualMachine = struct {
             source_code_printer.?.* = js_printer.BufferPrinter.init(writer);
             source_code_printer.?.ctx.append_null_byte = false;
         }
+    }
+
+    pub fn loadExtraEnvAndSourceCodePrinter(this: *VirtualMachine) void {
+        var map = this.bundler.env.map;
+
+        ensureSourceCodePrinter(this);
 
         if (map.get("BUN_SHOW_BUN_STACKFRAMES") != null) {
             this.hide_bun_stackframes = false;
@@ -1447,6 +1451,7 @@ pub const VirtualMachine = struct {
             this.macro_event_loop.global = this.global;
             this.macro_event_loop.virtual_machine = this;
             this.macro_event_loop.concurrent_tasks = .{};
+            ensureSourceCodePrinter(this);
         }
 
         this.bundler.options.target = .bun_macro;

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -1905,10 +1905,10 @@ pub const ModuleLoader = struct {
 
                 var printer = source_code_printer.*;
                 printer.ctx.reset();
-
+                defer source_code_printer.* = printer;
                 _ = brk: {
                     var mapper = jsc_vm.sourceMapHandler(&printer);
-                    defer source_code_printer.* = printer;
+
                     break :brk try jsc_vm.bundler.printWithSourceMap(
                         parse_result,
                         @TypeOf(&printer),
@@ -1961,7 +1961,6 @@ pub const ModuleLoader = struct {
 
                         if (written.len > 1024 * 1024 * 2 or jsc_vm.smol) {
                             printer.ctx.buffer.deinit();
-                            source_code_printer.* = printer;
                         }
 
                         break :brk result;

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -217,7 +217,7 @@ pub const WebWorker = struct {
 
         vm.bundler.env = loader;
 
-        vm.loadExtraEnv();
+        vm.loadExtraEnvAndSourceCodePrinter();
         vm.is_main_thread = false;
         JSC.VirtualMachine.is_main_thread_vm = false;
         vm.onUnhandledRejection = onUnhandledRejection;

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -114,7 +114,7 @@ pub const Run = struct {
 
         AsyncHTTP.loadEnv(vm.allocator, vm.log, b.env);
 
-        vm.loadExtraEnv();
+        vm.loadExtraEnvAndSourceCodePrinter();
         vm.is_main_thread = true;
         JSC.VirtualMachine.is_main_thread_vm = true;
 
@@ -257,7 +257,7 @@ pub const Run = struct {
 
         AsyncHTTP.loadEnv(vm.allocator, vm.log, b.env);
 
-        vm.loadExtraEnv();
+        vm.loadExtraEnvAndSourceCodePrinter();
         vm.is_main_thread = true;
         JSC.VirtualMachine.is_main_thread_vm = true;
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -816,7 +816,7 @@ pub const TestCommand = struct {
 
         try vm.bundler.configureDefines();
 
-        vm.loadExtraEnv();
+        vm.loadExtraEnvAndSourceCodePrinter();
         vm.is_main_thread = true;
         JSC.VirtualMachine.is_main_thread_vm = true;
 

--- a/src/heap_breakdown.zig
+++ b/src/heap_breakdown.zig
@@ -11,14 +11,14 @@ fn heapLabel(comptime T: type) [:0]const u8 {
         T.heap_label
     else
         bun.meta.typeBaseName(@typeName(T));
-    return "Bun__" ++ base_name;
+    return base_name;
 }
 
 pub fn allocator(comptime T: type) std.mem.Allocator {
     return namedAllocator(comptime heapLabel(T));
 }
 pub fn namedAllocator(comptime name: [:0]const u8) std.mem.Allocator {
-    return getZone(name).allocator();
+    return getZone("Bun__" ++ name).allocator();
 }
 
 pub fn getZoneT(comptime T: type) *Zone {

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -5924,6 +5924,7 @@ pub const BufferWriter = struct {
     pub fn reset(ctx: *BufferWriter) void {
         ctx.buffer.reset();
         ctx.approximate_newline_count = 0;
+        ctx.written = &.{};
     }
 
     pub fn writtenWithoutTrailingZero(ctx: *const BufferWriter) []u8 {

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 // This also tests __dirname and __filename
@@ -24,6 +24,227 @@ test("require.cache does not include unevaluated modules", () => {
 
   expect(stdout.toString().trim()).toEndWith("--pass--");
   expect(exitCode).toBe(0);
+});
+
+describe("files transpiled and loaded don't leak the output source code", () => {
+  test("via require() with a lot of long export names", () => {
+    let text = "";
+    for (let i = 0; i < 10000; i++) {
+      text += `exports.superDuperExtraCrazyLongNameWowSuchNameLongYouveNeverSeenANameThisLongForACommonJSModuleExport${i} = 1;\n`;
+    }
+
+    console.log("Text length:", text.length);
+
+    const dir = tempDirWithFiles("require-cache-bug-leak-1", {
+      "index.js": text,
+      "require-cache-bug-leak-fixture.js": `
+        const path = require.resolve("./index.js");
+        const gc = global.gc || globalThis?.Bun?.gc || (() => {});
+        function bust() {
+          const mod = require.cache[path];
+          if (mod) {
+            mod.parent = null;
+            mod.children = [];
+            delete require.cache[path];
+          }
+        }
+
+        for (let i = 0; i < 50; i++) {
+          require(path);
+          bust();
+        }
+        gc(true);
+        const baseline = process.memoryUsage.rss();
+        for (let i = 0; i < 500; i++) {
+          require(path);
+          bust(path);
+          console.log("RSS", (process.memoryUsage.rss() / 1024 / 1024) | 0, "MB");
+        }
+        gc(true);
+        const rss = process.memoryUsage.rss();
+        const diff = rss - baseline;
+        console.log("RSS diff", (diff / 1024 / 1024) | 0, "MB");
+        console.log("RSS", (diff / 1024 / 1024) | 0, "MB");
+        if (diff > 100 * 1024 * 1024) {
+          // Bun v1.1.21 reported 844 MB here on macoS arm64.
+          throw new Error("Memory leak detected");
+        }
+
+        exports.abc = 123;
+      `,
+    });
+    console.log({ dir });
+    const { exitCode, resourceUsage } = Bun.spawnSync({
+      cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
+      env: bunEnv,
+      stdio: ["inherit", "inherit", "inherit"],
+    });
+
+    console.log(resourceUsage);
+    expect(exitCode).toBe(0);
+  }, 60000);
+
+  test("via await import() with a lot of function calls", () => {
+    let text = "function i() { return 1; }\n";
+    for (let i = 0; i < 20000; i++) {
+      text += `i();\n`;
+    }
+    text += "exports.forceCommonJS = true;\n";
+
+    console.log("Text length:", text.length);
+
+    const dir = tempDirWithFiles("require-cache-bug-leak-3", {
+      "index.js": text,
+      "require-cache-bug-leak-fixture.js": `
+        const path = require.resolve("./index.js");
+        const gc = global.gc || globalThis?.Bun?.gc || (() => {});
+        function bust() {
+          delete require.cache[path];
+        }
+
+        for (let i = 0; i < 100; i++) {
+          await import(path);
+          bust();
+        }
+        gc(true);
+        const baseline = process.memoryUsage.rss();
+        for (let i = 0; i < 400; i++) {
+          await import(path);
+          bust(path);
+          console.log("RSS", (process.memoryUsage.rss() / 1024 / 1024) | 0, "MB");
+        }
+        gc(true);
+        const rss = process.memoryUsage.rss();
+        const diff = rss - baseline;
+        console.log("RSS diff", (diff / 1024 / 1024) | 0, "MB");
+        console.log("RSS", (diff / 1024 / 1024) | 0, "MB");
+        if (diff > 64 * 1024 * 1024) {
+          // Bun v1.1.22 reported 1 MB here on macoS arm64.
+          // Bun v1.1.21 reported 257 MB here on macoS arm64.
+          throw new Error("Memory leak detected");
+        }
+
+        export default 123;
+      `,
+    });
+    const { exitCode, resourceUsage } = Bun.spawnSync({
+      cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
+      env: bunEnv,
+      stdio: ["inherit", "inherit", "inherit"],
+    });
+
+    console.log(resourceUsage);
+    expect(exitCode).toBe(0);
+  }, 60000); // takes 4s on an M1 in release build
+
+  test("via import() with a lot of long export names", () => {
+    let text = "";
+    for (let i = 0; i < 10000; i++) {
+      text += `export const superDuperExtraCrazyLongNameWowSuchNameLongYouveNeverSeenANameThisLongForACommonJSModuleExport${i} = 1;\n`;
+    }
+
+    const dir = tempDirWithFiles("require-cache-bug-leak-4", {
+      "index.js": text,
+      "require-cache-bug-leak-fixture.js": `
+        const path = require.resolve("./index.js");
+        const gc = global.gc || globalThis?.Bun?.gc || (() => {});
+        function bust() {
+          delete require.cache[path];
+        }
+
+        for (let i = 0; i < 50; i++) {
+          await import(path);
+          bust();
+        }
+        gc(true);
+        const baseline = process.memoryUsage.rss();
+        for (let i = 0; i < 250; i++) {
+          await import(path);
+          bust(path);
+          console.log("RSS", (process.memoryUsage.rss() / 1024 / 1024) | 0, "MB");
+        }
+        gc(true);
+        const rss = process.memoryUsage.rss();
+        const diff = rss - baseline;
+        console.log("RSS diff", (diff / 1024 / 1024) | 0, "MB");
+        console.log("RSS", (diff / 1024 / 1024) | 0, "MB");
+        if (diff > 64 * 1024 * 1024) {
+          // Bun v1.1.21 reported 423 MB here on macoS arm64.
+          // Bun v1.1.22 reported 4 MB here on macoS arm64.
+          throw new Error("Memory leak detected");
+        }
+
+        export default 124;
+      `,
+    });
+    console.log({ dir });
+    const { exitCode, resourceUsage } = Bun.spawnSync({
+      cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
+      env: bunEnv,
+      stdio: ["inherit", "inherit", "inherit"],
+    });
+
+    console.log(resourceUsage);
+    expect(exitCode).toBe(0);
+  }, 60000);
+
+  test("via require() with a lot of function calls", () => {
+    let text = "function i() { return 1; }\n";
+    for (let i = 0; i < 20000; i++) {
+      text += `i();\n`;
+    }
+    text += "exports.forceCommonJS = true;\n";
+
+    console.log("Text length:", text.length);
+
+    const dir = tempDirWithFiles("require-cache-bug-leak-2", {
+      "index.js": text,
+      "require-cache-bug-leak-fixture.js": `
+        const path = require.resolve("./index.js");
+        const gc = global.gc || globalThis?.Bun?.gc || (() => {});
+        function bust() {
+          const mod = require.cache[path];
+          if (mod) {
+            mod.parent = null;
+            mod.children = [];
+            delete require.cache[path];
+          }
+        }
+
+        for (let i = 0; i < 100; i++) {
+          require(path);
+          bust();
+        }
+        gc(true);
+        const baseline = process.memoryUsage.rss();
+        for (let i = 0; i < 400; i++) {
+          require(path);
+          bust(path);
+          console.log("RSS", (process.memoryUsage.rss() / 1024 / 1024) | 0, "MB");
+        }
+        gc(true);
+        const rss = process.memoryUsage.rss();
+        const diff = rss - baseline;
+        console.log("RSS diff", (diff / 1024 / 1024) | 0, "MB");
+        console.log("RSS", (diff / 1024 / 1024) | 0, "MB");
+        if (diff > 64 * 1024 * 1024) {
+          // Bun v1.1.22 reported 4 MB here on macoS arm64.
+          // Bun v1.1.21 reported 248 MB here on macoS arm64.
+          throw new Error("Memory leak detected");
+        }
+
+        exports.abc = 123;
+      `,
+    });
+    const { exitCode, resourceUsage } = Bun.spawnSync({
+      cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
+      env: bunEnv,
+      stdio: ["inherit", "inherit", "inherit"],
+    });
+
+    console.log(resourceUsage);
+    expect(exitCode).toBe(0);
+  }, 60000); // takes 4s on an M1 in release build
 });
 
 describe("files transpiled and loaded don't leak the AST", () => {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -48,6 +48,12 @@ for (let key in bunEnv) {
 
 delete bunEnv.NODE_ENV;
 
+if (isDebug) {
+  // This makes debug build memory leak tests more reliable.
+  // The code for dumping out the debug build transpiled source code has leaks.
+  bunEnv.BUN_DEBUG_NO_DUMP = "1";
+}
+
 export function bunExe() {
   if (isWindows) return process.execPath.replaceAll("\\", "/");
   return process.execPath;

--- a/test/regression/issue/03830.test.ts
+++ b/test/regression/issue/03830.test.ts
@@ -24,6 +24,6 @@ it("macros should not lead to seg faults under any given input", async () => {
     stderr: "pipe",
   });
 
-  expect(stderr.toString().trim().replaceAll(testDir, "[dir]")).toMatchSnapshot();
+  expect(stderr.toString().trim().replaceAll(testDir, "[dir]").replaceAll("\\", "/")).toMatchSnapshot();
   expect(exitCode).toBe(1);
 });

--- a/test/regression/issue/__snapshots__/03830.test.ts.snap
+++ b/test/regression/issue/__snapshots__/03830.test.ts.snap
@@ -27,3 +27,17 @@ exports[`macros should not lead to seg faults under any given input 1`] = `
 error: "Cannot convert argument type to JS" error in macro
     at [dir]/index.ts:2:1"
 `;
+
+exports[`macros should not lead to seg faults under any given input 1`] = `
+"2 | fn(\`©${''}\`);
+    ^
+error: "Cannot convert argument type to JS" error in macro
+    at [dir]/index.ts:2:1"
+`;
+
+exports[`macros should not lead to seg faults under any given input 1`] = `
+"2 | fn(\`©${''}\`);
+    ^
+error: "Cannot convert argument type to JS" error in macro
+    at [dir]/index.ts:2:1"
+`;


### PR DESCRIPTION
### What does this PR do?

This properly decrements the reference count for output source code.

Requiring `@mui/icons-material` 30 times uses about 30% less memory

<img width="740" alt="image" src="https://github.com/user-attachments/assets/37cbbd2e-fd70-48f7-ac21-8cf4bedf0866">


### How did you verify your code works?

There are tests