### PR TITLE
ci: disable BUN_ENABLE_CRASH_REPORTING

### DIFF
--- a/packages/bun-internal-test/src/runner.node.mjs
+++ b/packages/bun-internal-test/src/runner.node.mjs
@@ -239,7 +239,7 @@ Starting "${testFileName}"
           GITHUB_ACTIONS: process.env.GITHUB_ACTIONS ?? "true",
           BUN_DEBUG_QUIET_LOGS: "1",
           BUN_INSTALL_CACHE_DIR: join(TMPDIR, ".bun-install-cache"),
-          BUN_ENABLE_CRASH_REPORTING: "1",
+          BUN_ENABLE_CRASH_REPORTING: "0",
           [windows ? "TEMP" : "TMPDIR"]: TMPDIR,
         },
       });

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -436,7 +436,7 @@ async function spawnBun(execPath, { args, cwd, timeout, env, stdout, stderr }) {
     BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
     BUN_DEBUG_QUIET_LOGS: "1",
     BUN_GARBAGE_COLLECTOR_LEVEL: "1",
-    BUN_ENABLE_CRASH_REPORTING: "1",
+    BUN_ENABLE_CRASH_REPORTING: "0", // change this to '1' if https://github.com/oven-sh/bun/issues/13012 is implemented
     BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
     BUN_INSTALL_CACHE_DIR: tmpdirPath,
     SHELLOPTS: isWindows ? "igncr" : undefined, // ignore "\r" on Windows


### PR DESCRIPTION
bun.report crash urls in our CI as-is will never be valid in our own CI since they will be development versions that bun.report doesn't know about. set this flag to disable in the runner so that bun attempts to print a stack trace to stderr instead