### PR TITLE
fix(bundler): printing e_commonjs_export_identifier when it got deoptimized.

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -9034,6 +9034,7 @@ pub const LinkerContext = struct {
             .indent = .{},
             .commonjs_named_exports = ast.commonjs_named_exports,
             .commonjs_named_exports_ref = ast.exports_ref,
+            .commonjs_module_ref = if (ast.flags.uses_module_ref) ast.module_ref else Ref.None,
             .commonjs_named_exports_deoptimized = flags.wrap == .cjs,
             // .const_values = c.graph.const_values,
             .ts_enums = c.graph.ts_enums,

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -9036,6 +9036,7 @@ pub const LinkerContext = struct {
             .commonjs_named_exports_ref = ast.exports_ref,
             .commonjs_module_ref = if (ast.flags.uses_module_ref) ast.module_ref else Ref.None,
             .commonjs_named_exports_deoptimized = flags.wrap == .cjs,
+            .commonjs_module_exports_assigned_deoptimized = ast.flags.commonjs_module_exports_assigned_deoptimized,
             // .const_values = c.graph.const_values,
             .ts_enums = c.graph.ts_enums,
 

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -6610,6 +6610,7 @@ pub const Ast = struct {
     uses_exports_ref: bool = false,
     uses_module_ref: bool = false,
     uses_require_ref: bool = false,
+    commonjs_module_exports_assigned_deoptimized: bool = false,
 
     force_cjs_to_esm: bool = false,
     exports_kind: ExportsKind = ExportsKind.none,
@@ -6769,19 +6770,20 @@ pub const BundledAst = struct {
     pub const CommonJSNamedExports = Ast.CommonJSNamedExports;
     pub const ConstValuesMap = Ast.ConstValuesMap;
 
-    pub const Flags = packed struct {
+    pub const Flags = packed struct(u8) {
         // This is a list of CommonJS features. When a file uses CommonJS features,
         // it's not a candidate for "flat bundling" and must be wrapped in its own
         // closure.
         uses_exports_ref: bool = false,
         uses_module_ref: bool = false,
         // uses_require_ref: bool = false,
-
         uses_export_keyword: bool = false,
-
         has_char_freq: bool = false,
         force_cjs_to_esm: bool = false,
         has_lazy_export: bool = false,
+        commonjs_module_exports_assigned_deoptimized: bool = false,
+
+        _: u1 = 0,
     };
 
     pub const empty = BundledAst.init(Ast.empty);
@@ -6792,9 +6794,6 @@ pub const BundledAst = struct {
     pub inline fn uses_module_ref(this: *const BundledAst) bool {
         return this.flags.uses_module_ref;
     }
-    // pub inline fn uses_require_ref(this: *const BundledAst) bool {
-    //     return this.flags.uses_require_ref;
-    // }
 
     pub fn toAST(this: *const BundledAst) Ast {
         return .{
@@ -6844,6 +6843,7 @@ pub const BundledAst = struct {
             .export_keyword = .{ .len = if (this.flags.uses_export_keyword) 1 else 0, .loc = .{} },
             .force_cjs_to_esm = this.flags.force_cjs_to_esm,
             .has_lazy_export = this.flags.has_lazy_export,
+            .commonjs_module_exports_assigned_deoptimized = this.flags.commonjs_module_exports_assigned_deoptimized,
         };
     }
 
@@ -6897,6 +6897,7 @@ pub const BundledAst = struct {
                 .has_char_freq = ast.char_freq != null,
                 .force_cjs_to_esm = ast.force_cjs_to_esm,
                 .has_lazy_export = ast.has_lazy_export,
+                .commonjs_module_exports_assigned_deoptimized = ast.commonjs_module_exports_assigned_deoptimized,
             },
         };
     }

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -5029,6 +5029,7 @@ fn NewParser_(
 
         commonjs_named_exports: js_ast.Ast.CommonJSNamedExports = .{},
         commonjs_named_exports_deoptimized: bool = false,
+        commonjs_module_exports_assigned_deoptimized: bool = false,
         commonjs_named_exports_needs_conversion: u32 = std.math.maxInt(u32),
         had_commonjs_named_exports_this_visit: bool = false,
         commonjs_replacement_stmts: StmtNodeList = &.{},
@@ -18709,6 +18710,9 @@ fn NewParser_(
                             p.ignoreUsage(p.module_ref);
                             return p.valueForRequire(name_loc);
                         } else if (!p.commonjs_named_exports_deoptimized and strings.eqlComptime(name, "exports")) {
+                            if (identifier_opts.assign_target != .none) {
+                                p.commonjs_module_exports_assigned_deoptimized = true;
+                            }
 
                             // Detect if we are doing
                             //
@@ -23951,6 +23955,7 @@ fn NewParser_(
                 .uses_exports_ref = p.symbols.items[p.exports_ref.inner_index].use_count_estimate > 0,
                 .uses_require_ref = p.runtime_imports.__require != null and
                     p.symbols.items[p.runtime_imports.__require.?.ref.inner_index].use_count_estimate > 0,
+                .commonjs_module_exports_assigned_deoptimized = p.commonjs_module_exports_assigned_deoptimized,
                 // .top_Level_await_keyword = p.top_level_await_keyword,
                 .commonjs_named_exports = p.commonjs_named_exports,
                 .has_commonjs_export_names = p.has_commonjs_export_names,

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -532,6 +532,7 @@ pub const Options = struct {
 
     commonjs_named_exports: js_ast.Ast.CommonJSNamedExports = .{},
     commonjs_named_exports_deoptimized: bool = false,
+    commonjs_module_exports_assigned_deoptimized: bool = false,
     commonjs_named_exports_ref: Ref = Ref.None,
     commonjs_module_ref: Ref = Ref.None,
 
@@ -2383,7 +2384,7 @@ fn NewPrinter(
                     for (p.options.commonjs_named_exports.keys(), p.options.commonjs_named_exports.values()) |key, value| {
                         if (value.loc_ref.ref.?.eql(id.ref)) {
                             if (p.options.commonjs_named_exports_deoptimized or value.needs_decl) {
-                                if (p.options.commonjs_named_exports_deoptimized and
+                                if (p.options.commonjs_module_exports_assigned_deoptimized and
                                     p.options.commonjs_module_ref.isValid())
                                 {
                                     p.printSymbol(p.options.commonjs_module_ref);

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -2383,7 +2383,15 @@ fn NewPrinter(
                     for (p.options.commonjs_named_exports.keys(), p.options.commonjs_named_exports.values()) |key, value| {
                         if (value.loc_ref.ref.?.eql(id.ref)) {
                             if (p.options.commonjs_named_exports_deoptimized or value.needs_decl) {
-                                p.printSymbol(p.options.commonjs_named_exports_ref);
+                                if (p.options.commonjs_named_exports_deoptimized and
+                                    p.options.commonjs_module_ref.isValid())
+                                {
+                                    p.printSymbol(p.options.commonjs_module_ref);
+                                    p.print(".exports");
+                                } else {
+                                    p.printSymbol(p.options.commonjs_named_exports_ref);
+                                }
+
                                 if (p.canPrintIdentifier(key)) {
                                     p.print(".");
                                     p.print(key);

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -347,4 +347,30 @@ describe("bundler", () => {
     minifyIdentifiers: true,
     target: "bun",
   });
+  itBundled("cjs2esm/ModuleExportsRenaming1", {
+    files: {
+      "/entry.js": /* js */ `
+        let y = () => module.exports.xyz;
+        exports = { xyz: 123 };
+        let z = () => module.exports.xyz;
+        console.log(y(), z());
+      `,
+    },
+    run: {
+      stdout: "undefined undefined",
+    },
+  });
+  itBundled("cjs2esm/ModuleExportsRenaming2", {
+    files: {
+      "/entry.js": /* js */ `
+        let y = () => module.exports.xyz;
+        module.exports = { xyz: 123 };
+        let z = () => module.exports.xyz;
+        console.log(y(), z());
+      `,
+    },
+    run: {
+      stdout: "123 123",
+    },
+  });
 });

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -347,20 +347,7 @@ describe("bundler", () => {
     minifyIdentifiers: true,
     target: "bun",
   });
-  itBundled("cjs2esm/ModuleExportsRenaming1", {
-    files: {
-      "/entry.js": /* js */ `
-        let y = () => module.exports.xyz;
-        exports = { xyz: 123 };
-        let z = () => module.exports.xyz;
-        console.log(y(), z());
-      `,
-    },
-    run: {
-      stdout: "undefined undefined",
-    },
-  });
-  itBundled("cjs2esm/ModuleExportsRenaming2", {
+  itBundled("cjs2esm/ModuleExportsRenaming", {
     files: {
       "/entry.js": /* js */ `
         let y = () => module.exports.xyz;


### PR DESCRIPTION
### What does this PR do?

Fixes #13006

Consider this code snippet

```ts
let y = () => module.exports.xyz; // A
module.exports = { xyz: 123 }; // B
let z = () => module.exports.xyz; // C
console.log(y(), z());
```

- A visits and converts `module.exports` to `exports` and creates a CJS Export Identifier. this node is for `<export id>.xyz` in one node, for when this module gets converted CJS->ESM
- reassigning `module.exports` says 
- C visits and does not perform conversion since we are de-optimized

see the issue, we never update A, so we have to handle printing it back as `module.exports`, since the `exports` variable was not updated.

```diff
 var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);

 // index.ts
 var require_index = __commonJS((exports, module) => {
-  var y = () => exports.xyz;
+  var y = () => module.exports.xyz;
   module.exports = { xyz: 123 };
   var z = () => module.exports.xyz;
   console.log(y(), z());
 });
 export default require_index();
```

EDIT: the approach taken was slightly altered as just changing the printer would cause react to get a bit larger. the new approach does some parser changes to ensure this change is only applied when it is needed