### PR TITLE
ci: debug node-http.test.ts windows segfault not having a stack trace

### DIFF
--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -884,10 +884,12 @@ pub fn printMetadata(writer: anytype) !void {
             &peak_commit,
             &page_faults,
         );
-        try writer.print("Elapsed: {d}ms | User: {d}ms | Sys: {d}ms\nRSS: {:<3.2} | Peak: {:<3.2} | Commit: {:<3.2} | Faults: {d}\n", .{
+        try writer.print("Elapsed: {d}ms | User: {d}ms | Sys: {d}ms\n", .{
             elapsed_msecs,
             user_msecs,
             system_msecs,
+        });
+        try writer.print("RSS: {:<3.2} | Peak: {:<3.2} | Commit: {:<3.2} | Faults: {d}\n", .{
             std.fmt.fmtIntSizeDec(current_rss),
             std.fmt.fmtIntSizeDec(peak_rss),
             std.fmt.fmtIntSizeDec(current_commit),

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -895,6 +895,9 @@ pub fn printMetadata(writer: anytype) !void {
             std.fmt.fmtIntSizeDec(current_commit),
             page_faults,
         });
+        try writer.print("Env: BUN_CRASH_REPORT_URL = {?s}\n", .{bun.getenvZ("BUN_CRASH_REPORT_URL")});
+        try writer.print("Env: BUN_ENABLE_CRASH_REPORTING = {?s}\n", .{bun.getenvZ("BUN_ENABLE_CRASH_REPORTING")});
+        try writer.print("isReportingEnabled: {}\n", .{isReportingEnabled()});
     }
 
     if (Output.enable_ansi_colors) {


### PR DESCRIPTION
https://github.com/oven-sh/bun/pull/13013 should have fixed this, so add some more metadata to shine a light on its decision making