### PR TITLE
Fix UDP socket tests on macOS 13.

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -42,8 +42,8 @@
 #include <mstcpip.h>
 #endif
 
-#if defined(__APPLE__) && defined(__aarch64__)
-#define HAS_MSGX
+#if defined(__APPLE__)
+extern int Bun__doesMacOSVersionSupportSendRecvMsgX();
 #endif
 
 
@@ -77,32 +77,30 @@ int bsd_sendmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_sendbuf* sendbuf, int fl
     }
     return sendbuf->num;
 #elif defined(__APPLE__)
-    // TODO figure out why sendmsg_x fails when one of the messages is empty
-    // so that we can get rid of this code.
-    // One of the weird things is that once a non-empty message has been sent on the socket,
-    // empty messages start working as well. Bizzare.
-#ifdef HAS_MSGX
-    if (sendbuf->has_empty) {
-#endif
-        for (int i = 0; i < sendbuf->num; i++) {
-            while (1) {
-                ssize_t ret = sendmsg(fd, &sendbuf->msgvec[i].msg_hdr, flags);
-                if (ret < 0) {
-                    if (errno == EINTR) continue;
-                    if (errno == EAGAIN || errno == EWOULDBLOCK) return i;
-                    return ret;
-                }
-                break;
-            }
+    // sendmsg_x does not support addresses.
+    if (!sendbuf->has_empty && !sendbuf->has_addresses) {
+        while (1) {
+            int ret = sendmsg_x(fd, sendbuf->msgvec, sendbuf->num, flags);
+            if (ret >= 0) return ret;
+            // If we receive EMMSGSIZE, we should use the fallback code.
+            if (errno == EMSGSIZE) break;
+            if (errno != EINTR) return ret;
         }
-        return sendbuf->num;
-#ifdef HAS_MSGX
     }
-    while (1) {
-        int ret = sendmsg_x(fd, sendbuf->msgvec, sendbuf->num, flags);
-        if (ret >= 0 || errno != EINTR) return ret;
+
+    for (size_t i = 0, count = sendbuf->num; i < count; i++) {
+        while (1) {
+            ssize_t ret = sendmsg(fd, &sendbuf->msgvec[i].msg_hdr, flags);
+            if (ret < 0) {
+                if (errno == EINTR) continue;
+                if (errno == EAGAIN || errno == EWOULDBLOCK) return i;
+                return ret;
+            }
+            break;
+        }
     }
-#endif
+
+    return sendbuf->num;
 #else
     while (1) {
         int ret = sendmmsg(fd, sendbuf->msgvec, sendbuf->num, flags | MSG_NOSIGNAL);
@@ -124,12 +122,13 @@ int bsd_recvmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_recvbuf *recvbuf, int fl
         return 1;
     }
 #elif defined(__APPLE__)
-#ifdef HAS_MSGX
-    while (1) {
-        int ret = recvmsg_x(fd, recvbuf->msgvec, LIBUS_UDP_RECV_COUNT, flags);
-        if (ret >= 0 || errno != EINTR) return ret;
+    if (Bun__doesMacOSVersionSupportSendRecvMsgX()) {
+        while (1) {
+            int ret = recvmsg_x(fd, recvbuf->msgvec, LIBUS_UDP_RECV_COUNT, flags);
+            if (ret >= 0 || errno != EINTR) return ret;
+        }
     }
-#else
+
     for (int i = 0; i < LIBUS_UDP_RECV_COUNT; ++i) {
         while (1) {
             ssize_t ret = recvmsg(fd, &recvbuf->msgvec[i].msg_hdr, flags);
@@ -143,7 +142,6 @@ int bsd_recvmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_recvbuf *recvbuf, int fl
         }
     }
     return LIBUS_UDP_RECV_COUNT;
-#endif
 #else
     while (1) {
         int ret = recvmmsg(fd, (struct mmsghdr *)&recvbuf->msgvec, LIBUS_UDP_RECV_COUNT, flags, 0);
@@ -158,19 +156,20 @@ void bsd_udp_setup_recvbuf(struct udp_recvbuf *recvbuf, void *databuf, size_t da
     recvbuf->buflen = databuflen;
 #else
     // assert(databuflen > LIBUS_UDP_MAX_SIZE * LIBUS_UDP_RECV_COUNT);
-
-    for (int i = 0; i < LIBUS_UDP_RECV_COUNT; i++) {
+    memset(recvbuf, 0, sizeof(struct udp_recvbuf));
+    for (size_t i = 0; i < LIBUS_UDP_RECV_COUNT; i++) {
         recvbuf->iov[i].iov_base = (char*)databuf + i * LIBUS_UDP_MAX_SIZE;
         recvbuf->iov[i].iov_len = LIBUS_UDP_MAX_SIZE;
 
-        recvbuf->msgvec[i].msg_hdr.msg_name = &recvbuf->addr[i];
-        recvbuf->msgvec[i].msg_hdr.msg_namelen = sizeof(struct sockaddr_storage);
-
-        recvbuf->msgvec[i].msg_hdr.msg_iov = &recvbuf->iov[i];
-        recvbuf->msgvec[i].msg_hdr.msg_iovlen = 1;
-
-        recvbuf->msgvec[i].msg_hdr.msg_control = recvbuf->control[i];
-        recvbuf->msgvec[i].msg_hdr.msg_controllen = 256;
+        struct msghdr mh = {};
+        memset(&mh, 0, sizeof(struct msghdr));
+        mh.msg_name = &recvbuf->addr[i];
+        mh.msg_namelen = sizeof(struct sockaddr_storage);
+        mh.msg_iov = &recvbuf->iov[i];
+        mh.msg_iovlen = 1;
+        mh.msg_control = recvbuf->control[i];
+        mh.msg_controllen = sizeof(recvbuf->control[i]);
+        recvbuf->msgvec[i].msg_hdr = mh;
     }
 #endif
 }
@@ -183,7 +182,12 @@ int bsd_udp_setup_sendbuf(struct udp_sendbuf *buf, size_t bufsize, void** payloa
     buf->num = num;
     return num;
 #else
+    // TODO: can we skip empty messages altogether? Do we really need to send 0-length messages?
     buf->has_empty = 0;
+
+    // sendmsg_x docs states it does not support addresses.
+    buf->has_addresses = 0;
+
     struct mmsghdr *msgvec = buf->msgvec;
     // todo check this math
     size_t count = (bufsize - sizeof(struct udp_sendbuf)) / (sizeof(struct mmsghdr) + sizeof(struct iovec));
@@ -198,6 +202,9 @@ int bsd_udp_setup_sendbuf(struct udp_sendbuf *buf, size_t bufsize, void** payloa
             addr_len = addr->sa_family == AF_INET ? sizeof(struct sockaddr_in) 
                      : addr->sa_family == AF_INET6 ? sizeof(struct sockaddr_in6) 
                      : 0;
+            if (addr_len > 0) {
+                buf->has_addresses = 1;
+            }
         }
         iov[i].iov_base = payloads[i];
         iov[i].iov_len = lengths[i];
@@ -209,6 +216,7 @@ int bsd_udp_setup_sendbuf(struct udp_sendbuf *buf, size_t bufsize, void** payloa
         msgvec[i].msg_hdr.msg_iovlen = 1;
         msgvec[i].msg_hdr.msg_flags = 0;
         msgvec[i].msg_len = 0;
+
 
         if (lengths[i] == 0) {
             buf->has_empty = 1;

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -78,7 +78,7 @@ int bsd_sendmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_sendbuf* sendbuf, int fl
     return sendbuf->num;
 #elif defined(__APPLE__)
     // sendmsg_x does not support addresses.
-    if (!sendbuf->has_empty && !sendbuf->has_addresses) {
+    if (!sendbuf->has_empty && !sendbuf->has_addresses && Bun__doesMacOSVersionSupportSendRecvMsgX()) {
         while (1) {
             int ret = sendmsg_x(fd, sendbuf->msgvec, sendbuf->num, flags);
             if (ret >= 0) return ret;

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -65,14 +65,76 @@ struct bsd_addr_t {
 #endif
 
 #ifdef __APPLE__
-// a.k.a msghdr_x
-struct mmsghdr { 
+/*
+ * Extended version for sendmsg_x() and recvmsg_x() calls
+ */
+struct mmsghdr {
     struct msghdr msg_hdr;
     size_t msg_len;	/* byte length of buffer in msg_iov */
 };
+/*
+ * recvmsg_x() is a system call similar to recvmsg(2) to receive
+ * several datagrams at once in the array of message headers "msgp".
+ *
+ * recvmsg_x() can be used only with protocols handlers that have been specially
+ * modified to support sending and receiving several datagrams at once.
+ *
+ * The size of the array "msgp" is given by the argument "cnt".
+ *
+ * The "flags" arguments supports only the value MSG_DONTWAIT.
+ *
+ * Each member of "msgp" array is of type "struct msghdr_x".
+ *
+ * The "msg_iov" and "msg_iovlen" are input parameters that describe where to
+ * store a datagram in a scatter gather locations of buffers -- see recvmsg(2).
+ * On output the field "msg_datalen" gives the length of the received datagram.
+ *
+ * The field "msg_flags" must be set to zero on input. On output, "msg_flags"
+ * may have MSG_TRUNC set to indicate the trailing portion of the datagram was
+ * discarded because the datagram was larger than the buffer supplied.
+ * recvmsg_x() returns as soon as a datagram is truncated.
+ *
+ * recvmsg_x() may return with less than "cnt" datagrams received based on
+ * the low water mark and the amount of data pending in the socket buffer.
+ *
+ * recvmsg_x() returns the number of datagrams that have been received,
+ * or -1 if an error occurred.
+ *
+ * NOTE: This a private system call, the API is subject to change.
+ */
+ssize_t recvmsg_x(int s, const struct mmsghdr *msgp, u_int cnt, int flags);
 
-ssize_t sendmsg_x(int s, struct mmsghdr *msgp, u_int cnt, int flags);
-ssize_t recvmsg_x(int s, struct mmsghdr *msgp, u_int cnt, int flags);
+/*
+ * sendmsg_x() is a system call similar to send(2) to send
+ * several datagrams at once in the array of message headers "msgp".
+ *
+ * sendmsg_x() can be used only with protocols handlers that have been specially
+ * modified to support sending and receiving several datagrams at once.
+ *
+ * The size of the array "msgp" is given by the argument "cnt".
+ *
+ * The "flags" arguments supports only the value MSG_DONTWAIT.
+ *
+ * Each member of "msgp" array is of type "struct msghdr_x".
+ *
+ * The "msg_iov" and "msg_iovlen" are input parameters that specify the
+ * data to be sent in a scatter gather locations of buffers -- see sendmsg(2).
+ *
+ * sendmsg_x() fails with EMSGSIZE if the sum of the length of the datagrams
+ * is greater than the high water mark.
+ *
+ * Address and ancillary data are not supported so the following fields
+ * must be set to zero on input:
+ *   "msg_name", "msg_namelen", "msg_control" and "msg_controllen".
+ *
+ * The field "msg_flags" and "msg_datalen" must be set to zero on input.
+ *
+ * sendmsg_x() returns the number of datagrams that have been sent,
+ * or -1 if an error occurred.
+ *
+ * NOTE: This a private system call, the API is subject to change.
+ */
+ssize_t sendmsg_x(int s, const struct mmsghdr *msgp, u_int cnt, int flags);
 #endif
 
 struct udp_recvbuf {
@@ -96,8 +158,9 @@ struct udp_sendbuf {
     void **addresses;
     int num;
 #else
-    int num;
-    char has_empty;
+    unsigned int has_empty : 1;
+    unsigned int has_addresses : 1;
+    unsigned int num;
     struct mmsghdr msgvec[];
 #endif
 };

--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -304,6 +304,28 @@ pub const GenerateHeader = struct {
             return platform_;
         }
 
+        var use_msgx_on_macos_14_or_later: bool = false;
+        var detectUseMsgXOnMacOS14OrLater_once = std.once(detectUseMsgXOnMacOS14OrLater);
+        fn detectUseMsgXOnMacOS14OrLater() void {
+            const version = Semver.Version.parseUTF8(forOS().version);
+            if (version.version.max().major >= 14) {
+                use_msgx_on_macos_14_or_later = true;
+            }
+        }
+
+        pub export fn Bun__doesMacOSVersionSupportSendRecvMsgX() i32 {
+            if (comptime !Environment.isMac) {
+                // this should not be used on non-mac platforms.
+                return 0;
+            }
+
+            detectUseMsgXOnMacOS14OrLater_once.call();
+
+            // Make this a no-op for CI.
+            return 1;
+            // return @intFromBool(use_msgx_on_macos_14_or_later);
+        }
+
         pub fn kernelVersion() Semver.Version {
             if (comptime !Environment.isLinux) {
                 @compileError("This function is only implemented on Linux");

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -609,6 +609,10 @@ pub const Version = extern struct {
         return this.patch == 0 and this.minor == 0 and this.major == 0;
     }
 
+    pub fn parseUTF8(slice: []const u8) ParseResult {
+        return parse(.{ .buf = slice, .slice = slice });
+    }
+
     pub fn cloneInto(this: Version, slice: []const u8, buf: *[]u8) Version {
         return .{
             .major = this.major,


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
