### PR TITLE
Support async iterators in fs.promises.writeFile

### DIFF
--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "bun:test";
+import { writeFile } from "fs/promises";
+import { tempDirWithFiles } from "harness";
+test("fs.promises.writeFile async iterator", async () => {
+  const dir = tempDirWithFiles("fs-promises-writeFile-async-iterator", {
+    "file1.txt": "0 Hello, world!",
+  });
+  const path = dir + "/file2.txt";
+
+  const stream = async function* () {
+    yield "1 ";
+    yield "Hello, ";
+    yield "world!";
+  };
+
+  await writeFile(path, stream());
+  expect(await Bun.file(path).text()).toBe("1 Hello, world!");
+
+  const bufStream = async function* () {
+    yield Buffer.from("2 ");
+    yield Buffer.from("Hello, ");
+    yield Buffer.from("world!");
+  };
+
+  await writeFile(path, bufStream());
+
+  expect(await Bun.file(path).text()).toBe("2 Hello, world!");
+});
+
+test("fs.promises.writeFile async iterator throws on invalid input", async () => {
+  const dir = tempDirWithFiles("fs-promises-writeFile-async-iterator", {
+    "file1.txt": "0 Hello, world!",
+  });
+  const symbolStream = async function* () {
+    yield Symbol("lolwhat");
+  };
+
+  expect(() => writeFile(dir + "/file2.txt", symbolStream())).toThrow();
+  expect(() =>
+    writeFile(
+      require("os").devNull,
+      (async function* () {
+        yield "once";
+        throw new Error("good");
+      })(),
+    ),
+  ).toThrow("good");
+});

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { test, expect, mock } from "bun:test";
 import { writeFile } from "fs/promises";
 import { tempDirWithFiles } from "harness";
 test("fs.promises.writeFile async iterator", async () => {
@@ -38,11 +38,16 @@ test("fs.promises.writeFile async iterator throws on invalid input", async () =>
   expect(() => writeFile(dir + "/file2.txt", symbolStream())).toThrow();
   expect(() =>
     writeFile(
-      require("os").devNull,
+      dir + "/file3.txt",
       (async function* () {
         yield "once";
         throw new Error("good");
       })(),
     ),
   ).toThrow("good");
+  const fn = {
+    [Symbol.asyncIterator]: mock(() => {}),
+  };
+  expect(() => writeFile(dir, fn)).toThrow();
+  expect(fn[Symbol.asyncIterator]).not.toBeCalled();
 });


### PR DESCRIPTION

### What does this PR do?

This is an undocumented feature of `fs.promises.writeFile`. Source: https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/fs/promises.js#L481-L493

Fixes https://github.com/oven-sh/bun/issues/11633

### How did you verify your code works?

There are a couple tests