### PR TITLE
fix (worker-eval): fail worker with source when eval = false

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -216,9 +216,15 @@ class Worker extends EventEmitter {
 
     const builtinsGeneratorHatesEval = "ev" + "a" + "l"[0];
     if (options && builtinsGeneratorHatesEval in options) {
+      if (options[builtinsGeneratorHatesEval]) {
+        const blob = new Blob([filename], { type: "" });
+        this.#urlToRevoke = filename = URL.createObjectURL(blob);
+      } else {
+        // if options.eval = false, allow the constructor below to fail, if
+        // we convert the code to a blob, it will succeed.
+        this.#urlToRevoke = filename;
+      }
       delete options[builtinsGeneratorHatesEval];
-      const blob = new Blob([filename], { type: "" });
-      this.#urlToRevoke = filename = URL.createObjectURL(blob);
     }
     try {
       this.#worker = new WebWorker(filename, options);


### PR DESCRIPTION
### What does this PR do?

ensures that creating a Worker with source code and options.eval = false fails with expected error.

Fixes: #13034
Fixes: #11801 (Need to Confirm)

This issue seems to have been introduced [here](https://github.com/oven-sh/bun/pull/11537) and was released in [1.1.13](https://github.com/oven-sh/bun/releases/tag/bun-v1.1.13), which tallies with the original report of the issue in #11801.

### How did you verify your code works?

All tests which were introduced in the [Blob URL PR](https://github.com/oven-sh/bun/pull/11537) are passing, and new tests have been added to verify this change works as expected. 