### PR TITLE
13071 ensure unix path when running in windows

### DIFF
--- a/packages/bun-debug-adapter-protocol/package.json
+++ b/packages/bun-debug-adapter-protocol/package.json
@@ -4,5 +4,8 @@
   "dependencies": {
     "semver": "^7.5.4",
     "source-map-js": "^1.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.1.0"
   }
 }

--- a/packages/bun-debug-adapter-protocol/src/debugger/signal.ts
+++ b/packages/bun-debug-adapter-protocol/src/debugger/signal.ts
@@ -71,7 +71,7 @@ export class UnixSignal extends EventEmitter<UnixSignalEventMap> {
 }
 
 export function randomUnixPath(): string {
-  return join(tmpdir(), `${Math.random().toString(36).slice(2)}.sock`);
+  return join(tmpdir(), `${Math.random().toString(36).slice(2)}.sock`).replaceAll("\\","/");
 }
 
 function parseUnixPath(path: string | URL): string {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix for 
https://github.com/oven-sh/bun/issues/13071

method:
randomUnixPath()
found in 
packages\bun-debug-adapter-protocol\src\debugger\signal.ts

makes use of 
import { tmpdir } from "node:os";
which returns a temp path, since the method is called "randomUnixPath" it can create a Windows path, which causes issues in debugging

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
