### PR TITLE
Implement `aborted()` in node:util and getEventListeners in node:events

### DIFF
--- a/src/bun.js/bindings/webcore/JSEventTargetNode.cpp
+++ b/src/bun.js/bindings/webcore/JSEventTargetNode.cpp
@@ -1,0 +1,47 @@
+
+
+#include "root.h"
+
+#include "JavaScriptCore/JSGlobalObject.h"
+#include "JavaScriptCore/ArgList.h"
+#include "JavaScriptCore/JSGlobalObjectInlines.h"
+#include "JSEventTarget.h"
+#include "JavaScriptCore/JSArray.h"
+#include "wtf/text/MakeString.h"
+
+namespace Bun {
+
+using namespace JSC;
+using namespace WebCore;
+JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeEventsGetEventListeners, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    JSC::VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    if (callFrame->argumentCount() < 2) {
+        throwTypeError(globalObject, throwScope, "getEventListeners needs 2 arguments"_s);
+        return JSValue::encode(jsUndefined());
+    }
+
+    JSValue thisValue = callFrame->argument(0);
+    auto* thisObject = jsDynamicCast<JSEventTarget*>(thisValue);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    auto eventType = callFrame->argument(1).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
+
+    if (UNLIKELY(!thisObject))
+        return JSValue::encode(constructEmptyArray(globalObject, nullptr, 0));
+
+    MarkedArgumentBuffer values;
+    auto& listeners = thisObject->wrapped().eventListeners(WTF::makeAtomString(eventType));
+    for (auto& listener : listeners) {
+        auto* function = listener->callback().jsFunction();
+        if (function) {
+            values.append(function);
+        }
+    }
+
+    return JSValue::encode(constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), values));
+}
+
+}

--- a/src/bun.js/bindings/webcore/JSEventTargetNode.h
+++ b/src/bun.js/bindings/webcore/JSEventTargetNode.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace Bun {
+
+JSC_DECLARE_HOST_FUNCTION(jsFunctionNodeEventsGetEventListeners);
+
+}

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -424,12 +424,18 @@ function on(emitter, event, options = {}) {
   return iterator();
 }
 
-const toStringTag = Symbol.toStringTag;
+const getEventListenersForEventTarget = $newCppFunction(
+  "JSEventTargetNode.cpp",
+  "jsFunctionNodeEventsGetEventListeners",
+  1,
+);
+
 function getEventListeners(emitter, type) {
-  if (emitter?.[toStringTag] === "EventTarget") {
-    throwNotImplemented("getEventListeners with an EventTarget", 2678);
+  if ($isCallable(emitter?.listeners)) {
+    return emitter.listeners(type);
   }
-  return emitter.listeners(type);
+
+  return getEventListenersForEventTarget(emitter, type);
 }
 
 function setMaxListeners(n, ...eventTargets) {

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -70,6 +70,9 @@ describe("node:events", () => {
 describe("EventEmitter", () => {
   test("getEventListeners", () => {
     expect(getEventListeners(new EventEmitter(), "hey").length).toBe(0);
+    const emitter = new EventEmitter();
+    emitter.on("hey", () => {});
+    expect(getEventListeners(emitter, "hey").length).toBe(1);
   });
 
   test("constructor", () => {
@@ -848,4 +851,13 @@ test("getMaxListeners", () => {
   expect(emitter.getMaxListeners()).toBe(10);
   emitter.setMaxListeners(20);
   expect(emitter.getMaxListeners()).toBe(20);
+});
+
+test("getEventListeners", () => {
+  const target = new EventTarget();
+  expect(getEventListeners(target, "hey").length).toBe(0);
+  target.addEventListener("hey", () => {}, { once: true });
+  expect(getEventListeners(target, "hey").length).toBe(1);
+  target.dispatchEvent(new Event("hey"));
+  expect(getEventListeners(target, "hey").length).toBe(0);
 });

--- a/test/js/node/util/test-aborted.test.ts
+++ b/test/js/node/util/test-aborted.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { getEventListeners } from "events";
+import { aborted } from "util";
+
+test("aborted works when provided a resource that was already aborted", () => {
+  const ac = new AbortController();
+  const abortedPromise = aborted(ac.signal, {});
+  ac.abort();
+
+  expect(ac.signal.aborted).toBe(true);
+  expect(getEventListeners(ac.signal, "abort").length).toBe(0);
+  return expect(abortedPromise).resolves.toBeUndefined();
+});
+
+test("aborted works when provided a resource that was not already aborted", async () => {
+  const ac = new AbortController();
+  var strong = {};
+  globalThis.strong = strong;
+  const abortedPromise = aborted(ac.signal, strong);
+  expect(getEventListeners(ac.signal, "abort").length).toBe(1);
+  const sleepy = Bun.sleep(10).then(() => {
+    ac.abort();
+  });
+  await 42;
+  expect(ac.signal.aborted).toBe(false);
+  expect(Bun.peek.status(abortedPromise)).toBe("pending");
+  await sleepy;
+  await abortedPromise;
+  expect(ac.signal.aborted).toBe(true);
+  expect(getEventListeners(ac.signal, "abort").length).toBe(0);
+  return expect(abortedPromise).resolves.toBeUndefined();
+});
+
+test("aborted with gc cleanup", async () => {
+  const ac = new AbortController();
+  const abortedPromise = aborted(ac.signal, {});
+
+  await new Promise(resolve => setImmediate(resolve));
+  Bun.gc(true);
+  ac.abort();
+
+  expect(ac.signal.aborted).toBe(true);
+  expect(getEventListeners(ac.signal, "abort").length).toBe(0);
+  return expect(await abortedPromise).toBeUndefined();
+});
+
+test("fails with error if not provided abort signal", async () => {
+  const invalidSignals = [{}, null, undefined, Symbol(), [], 1, 0, 1n, true, false, "a", () => {}];
+
+  for (const sig of invalidSignals) {
+    await expect(() => aborted(sig, {})).toThrow();
+  }
+});
+
+test("fails if not provided a resource", async () => {
+  const ac = new AbortController();
+  const invalidResources = [null, undefined, 0, 1, 0n, 1n, Symbol(), "", "a"];
+
+  for (const resource of invalidResources) {
+    await expect(() => aborted(ac.signal, resource)).toThrow();
+  }
+});

--- a/test/js/node/util/test-aborted.test.ts
+++ b/test/js/node/util/test-aborted.test.ts
@@ -1,3 +1,6 @@
+// Most of this test was copied from
+// https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/test/parallel/test-aborted-util.js#L1-L60
+// and then translated to bun:test using Claude.
 import { expect, test } from "bun:test";
 import { getEventListeners } from "events";
 import { aborted } from "util";
@@ -28,6 +31,7 @@ test("aborted works when provided a resource that was not already aborted", asyn
   await abortedPromise;
   expect(ac.signal.aborted).toBe(true);
   expect(getEventListeners(ac.signal, "abort").length).toBe(0);
+  delete globalThis.strong;
   return expect(abortedPromise).resolves.toBeUndefined();
 });
 


### PR DESCRIPTION
### What does this PR do?

Implement `aborted()` in node:util and getEventListeners in node:events

Fixes https://github.com/oven-sh/bun/issues/11716



### How did you verify your code works?

Tests, mostly copied from Node and then translated with Claude