### PR TITLE
fix(bundler): use visited enum value

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -18095,6 +18095,8 @@ fn NewParser_(
                     return p.classCanBeRemovedIfUnused(ex);
                 },
                 .e_identifier => |ex| {
+                    bun.assert(!ex.ref.isSourceContentsSlice()); // was not visited
+
                     if (ex.must_keep_due_to_with_stmt) {
                         return false;
                     }
@@ -20308,11 +20310,11 @@ fn NewParser_(
                                     ) catch bun.outOfMemory();
                                 },
                                 else => {
-                                    if (enum_value.knownPrimitive() == .string) {
+                                    if (visited.knownPrimitive() == .string) {
                                         has_string_value = true;
                                     }
 
-                                    if (!p.exprCanBeRemovedIfUnused(&enum_value)) {
+                                    if (!p.exprCanBeRemovedIfUnused(&visited)) {
                                         all_values_are_pure = false;
                                     }
                                 },

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1809,16 +1809,14 @@ describe("bundler", () => {
   itBundled("edgecase/IdentifierInEnum#13081", {
     files: {
       "/entry.ts": `
-        export const B1 = "bbbbbbbbbbbbbbbb";
-
-        export enum AccountType {
-          A = A1_AAAAAAAAAAAAAAAAAAA,
-          B = B1,
+        let ZZZZZZZZZ = 1;
+        enum B {
+          C = ZZZZZZZZZ,
         }
-
-        console.log(AccountType);
+        console.log(B.C);
       `,
     },
+    run: { stdout: "1" },
   });
 
   // TODO(@paperdave): test every case of this. I had already tested it manually, but it may break later

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1798,12 +1798,26 @@ describe("bundler", () => {
         export const other = [capture(require.main === module), capture(import.meta.main)];
       `,
     },
-    target: 'node',
+    target: "node",
     capture: ["false", "false", "__require.main == __require.module", "__require.main == __require.module"],
     onAfterBundle(api) {
       // This should not be marked as a CommonJS module
       api.expectFile("/out.js").not.toMatch(/\brequire\b/); // __require is ok
       api.expectFile("/out.js").not.toMatch(/[^\.:]module/); // `.module` and `node:module` are ok.
+    },
+  });
+  itBundled("edgecase/IdentifierInEnum#13081", {
+    files: {
+      "/entry.ts": `
+        export const B1 = "bbbbbbbbbbbbbbbb";
+
+        export enum AccountType {
+          A = A1_AAAAAAAAAAAAAAAAAAA,
+          B = B1,
+        }
+
+        console.log(AccountType);
+      `,
     },
   });
 


### PR DESCRIPTION
### What does this PR do?

Fixes #13081

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
