### PR TITLE
fix(bundler): handle assigning to `exports`

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3366,6 +3366,13 @@ pub fn assertWithLocation(value: bool, src: std.builtin.SourceLocation) callconv
 
 /// This has no effect on the real code but capturing 'a' and 'b' into parameters makes assertion failures much easier inspect in a debugger.
 pub inline fn assert_eql(a: anytype, b: anytype) void {
+    if (@inComptime()) {
+        if (a != b) {
+            @compileLog(a);
+            @compileLog(b);
+            @compileError("A != B");
+        }
+    }
     return assert(a == b);
 }
 

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -1686,8 +1686,23 @@ pub const E = struct {
         was_originally_identifier: bool = false,
     };
 
+    /// This is a dot expression on exports, such as `exports.<ref>`. It is given
+    /// it's own AST node to allow CommonJS unwrapping, in which this can just be
+    /// the identifier in the Ref
     pub const CommonJSExportIdentifier = struct {
         ref: Ref = Ref.None,
+        base: Base = .exports,
+
+        /// The original variant of the dot expression must be known so that in the case that we
+        /// - fail to convert this to ESM
+        /// - ALSO see an assignment to `module.exports` (commonjs_module_exports_assigned_deoptimized)
+        /// It must be known if `exports` or `module.exports` was written in source
+        /// code, as the distinction will alter behavior. The fixup happens in the printer when
+        /// printing this node.
+        pub const Base = enum {
+            exports,
+            module_dot_exports,
+        };
     };
 
     // This is similar to EIdentifier but it represents class-private fields and
@@ -2769,8 +2784,7 @@ pub const E = struct {
     pub const RequireResolveString = struct {
         import_record_index: u32 = 0,
 
-        /// TODO:
-        close_paren_loc: logger.Loc = logger.Loc.Empty,
+        // close_paren_loc: logger.Loc = logger.Loc.Empty,
     };
 
     pub const InlinedEnum = struct {
@@ -4263,6 +4277,7 @@ pub const Expr = struct {
                     .data = Data{
                         .e_commonjs_export_identifier = .{
                             .ref = st.ref,
+                            .base = st.base,
                         },
                     },
                 };
@@ -4459,6 +4474,7 @@ pub const Expr = struct {
         e_import_identifier,
         e_private_identifier,
         e_commonjs_export_identifier,
+        e_module_dot_exports,
         e_boolean,
         e_number,
         e_big_int,
@@ -5153,6 +5169,7 @@ pub const Expr = struct {
         e_import_identifier: E.ImportIdentifier,
         e_private_identifier: E.PrivateIdentifier,
         e_commonjs_export_identifier: E.CommonJSExportIdentifier,
+        e_module_dot_exports,
 
         e_boolean: E.Boolean,
         e_number: E.Number,
@@ -5171,11 +5188,16 @@ pub const Expr = struct {
         e_undefined: E.Undefined,
         e_new_target: E.NewTarget,
         e_import_meta: E.ImportMeta,
+
         e_import_meta_main: E.ImportMetaMain,
         e_require_main,
 
         e_inlined_enum: *E.InlinedEnum,
         e_utf8_string: *E.UTF8String,
+
+        comptime {
+            bun.assert_eql(@sizeOf(Data), 24); // Do not increase the size of Expr
+        }
 
         pub fn as(data: Data, comptime tag: Tag) ?std.meta.FieldType(Data, tag) {
             return if (data == tag) @field(data, @tagName(tag)) else null;

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -2377,6 +2377,21 @@ fn NewPrinter(
                         }
                     }
                 },
+                .e_module_dot_exports => {
+                    p.printSpaceBeforeIdentifier();
+                    p.addSourceMapping(expr.loc);
+
+                    if (p.options.commonjs_module_exports_assigned_deoptimized) {
+                        if (p.options.commonjs_module_ref.isValid()) {
+                            p.printSymbol(p.options.commonjs_module_ref);
+                        } else {
+                            p.print("module");
+                        }
+                        p.print(".exports");
+                    } else {
+                        p.printSymbol(p.options.commonjs_named_exports_ref);
+                    }
+                },
                 .e_commonjs_export_identifier => |id| {
                     p.printSpaceBeforeIdentifier();
                     p.addSourceMapping(expr.loc);
@@ -2385,6 +2400,7 @@ fn NewPrinter(
                         if (value.loc_ref.ref.?.eql(id.ref)) {
                             if (p.options.commonjs_named_exports_deoptimized or value.needs_decl) {
                                 if (p.options.commonjs_module_exports_assigned_deoptimized and
+                                    id.base == .module_dot_exports and
                                     p.options.commonjs_module_ref.isValid())
                                 {
                                     p.printSymbol(p.options.commonjs_module_ref);


### PR DESCRIPTION
### What does this PR do?

This is a correction for #13017, which does not handle all cases.

I did not want to add an ast node for this but I don't think it's possible any other way. `e_module_dot_exports` represents `module.exports`, which is either lowered into `exports` or `module.exporst`.

Consider

```
let w = () => [module.exports, module.exports.xyz];
let x = () => [exports, exports.xyz];
// exports = { xyz: 123 };
// module.exporst = { xyz: 456 };
let y = () => [module.exports, module.exports.xyz];
let z = () => [exports, exports.xyz];
```

if line 3 and 4 stay commented out, all module.exports rewrite into `exports`. but once we see an assignment to **either one** of these fields, we must retroactively fix all instances of it, as there are behavioral differences if we substitute module.exports.
