### PR TITLE
fix: Fix bun build for programs that depend on global require

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -6923,6 +6923,11 @@ pub const LinkerContext = struct {
                 j.pushStatic("// @bun\n");
                 line_offset.advance("// @bun\n");
             }
+
+            // Inject `require` definition to support the common use case of
+            // modules expecting it to be defined in the global scope.
+            j.pushStatic("var { require } = import.meta;\n");
+            line_offset.advance("var { require } = import.meta;\n");
         }
 
         // TODO: banner


### PR DESCRIPTION
### What does this PR do?

This fixes #5809 by adding `var {require} = import.meta;` to the beginning of the generated js file as suggested in the thread, immediately after any hashbang and `// @bun` if applicable.

- [X] Code changes

### How did you verify your code works?

Verified that
1. Existing codebase that worked with `bun run` failed to run (pre PR changes) after `bun build`, both with and without `--compile`.
2. Same codebase ran correctly after the change and `bun build`, both with and without `--compile`.
3. Output js when built without `--compile` is identical to before the changes except for added line at top.

TODO: Update existing tests

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->