### PR TITLE
windows: fix fs-promises-writeFile-async-iterator.test.ts

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -586,22 +586,17 @@ async function writeFileAsyncIteratorInner(fd, iterable, encoding) {
   const mustRencode = !(encoding === "utf8" || encoding === "utf-8" || encoding === "binary" || encoding === "buffer");
   let totalBytesWritten = 0;
 
-  try {
-    for await (let chunk of iterable) {
-      if (mustRencode && typeof chunk === "string") {
-        $debug("Re-encoding chunk to", encoding);
-        chunk = Buffer.from(chunk, encoding);
-      }
-
-      const prom = writer.write(chunk);
-      if (prom && $isPromise(prom)) {
-        totalBytesWritten += await prom;
-      } else {
-        totalBytesWritten += prom;
-      }
+  for await (let chunk of iterable) {
+    if (mustRencode && typeof chunk === "string") {
+      $debug("Re-encoding chunk to", encoding);
+      chunk = Buffer.from(chunk, encoding);
     }
-  } finally {
-    await writer.end();
+    totalBytesWritten += chunk.length;
+
+    const prom = writer.write(chunk);
+    if (prom && $isPromise(prom)) {
+      await prom;
+    }
   }
 
   return totalBytesWritten;

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, mock } from "bun:test";
 import { writeFile } from "fs/promises";
 import { tempDirWithFiles } from "harness";
+
 test("fs.promises.writeFile async iterator", async () => {
   const dir = tempDirWithFiles("fs-promises-writeFile-async-iterator", {
     "file1.txt": "0 Hello, world!",


### PR DESCRIPTION
fixes the mentioned test for windows. was failing when it was introduced in https://github.com/oven-sh/bun/pull/13044. manually tested on windows and macos that `fs-promises-writeFile-async-iterator.test.ts` and `fs.test.ts` still worked after this patch.
