### PR TITLE
refactor(fetch) make handshake less confuse

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -541,9 +541,7 @@ fn NewHTTPContext(comptime ssl: bool) type {
                             return;
                         }
                         // if handshake_success it self is false, this means that the connection was rejected
-                        closeSocket(socket);
-                        if (client.state.stage != .done and client.state.stage != .fail)
-                            client.fail(error.ConnectionRefused);
+                        client.closeAndFail(error.ConnectionRefused);
                         return;
                     }
                 

--- a/src/http.zig
+++ b/src/http.zig
@@ -504,7 +504,7 @@ fn NewHTTPContext(comptime ssl: bool) type {
                 success: i32,
                 ssl_error: uws.us_bun_verify_error_t,
             ) void {
-                const authorized = if (success == 1) true else false;
+                var authorized = if (success == 1) true else false;
 
                 const handshake_error = HTTPCertError{
                     .error_no = ssl_error.error_no,
@@ -515,7 +515,8 @@ fn NewHTTPContext(comptime ssl: bool) type {
 
                 const active = getTagged(ptr);
                 if (active.get(HTTPClient)) |client| {
-                    if (handshake_error.error_no != 0 and (client.flags.reject_unauthorized or !authorized)) {
+                    authorized = authorized or !client.flags.reject_unauthorized;
+                    if (handshake_error.error_no != 0 and !authorized) {
                         client.closeAndFail(BoringSSL.getCertErrorFromNo(handshake_error.error_no), comptime ssl, socket);
                         return;
                     }

--- a/src/http.zig
+++ b/src/http.zig
@@ -535,8 +535,9 @@ fn NewHTTPContext(comptime ssl: bool) type {
 
                         return client.firstCall(comptime ssl, socket);
                     } else {
-                        // only throw the ssl error if reject_unauthorized, if not this is a connection rejection
-                        if(client.flags.reject_unauthorized and client.flags.did_have_handshaking_error) {
+                        // if we are here is because server rejected us, and the error_no is the cause of this
+                        // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
+                        if(client.flags.did_have_handshaking_error) {
                             client.closeAndFail(BoringSSL.getCertErrorFromNo(handshake_error.error_no), comptime ssl, socket);
                             return;
                         }

--- a/src/http.zig
+++ b/src/http.zig
@@ -780,7 +780,7 @@ pub const HTTPThread = struct {
     queued_tasks: Queue = Queue{},
 
     queued_shutdowns: std.ArrayListUnmanaged(ShutdownMessage) = std.ArrayListUnmanaged(ShutdownMessage){},
-    queued_shutdowns_lock: bun.Lock = bun.Lock.init(),
+    queued_shutdowns_lock: bun.Lock = .{},
 
     has_awoken: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     timer: std.time.Timer,
@@ -3321,6 +3321,18 @@ pub const HTTPClientResult = struct {
     /// If is not chunked encoded and Content-Length is not provided this will be unknown
     body_size: BodySize = .unknown,
     certificate_info: ?CertificateInfo = null,
+
+    pub fn abortReason(this: *const HTTPClientResult) ?JSC.CommonAbortReason {
+        if (this.isTimeout()) {
+            return .Timeout;
+        }
+
+        if (this.isAbort()) {
+            return .UserAbort;
+        }
+
+        return null;
+    }
 
     pub const BodySize = union(enum) {
         total_received: usize,

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -396,7 +396,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             if (this.outgoing_websocket) |ws| {
                 reject_unauthorized = ws.rejectUnauthorized();
             }
-            if (ssl_error.error_no != 0 and (reject_unauthorized or !authorized)) {
+            if (ssl_error.error_no != 0 and (reject_unauthorized and !authorized)) {
                 this.fail(ErrorCode.tls_handshake_failed);
                 return;
             }

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -396,13 +396,8 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             if (this.outgoing_websocket) |ws| {
                 reject_unauthorized = ws.rejectUnauthorized();
             }
-            if (ssl_error.error_no != 0 and (reject_unauthorized and !authorized)) {
-                this.fail(ErrorCode.tls_handshake_failed);
-                return;
-            }
-
-            if (authorized) {
-                if (reject_unauthorized) {
+            if (reject_unauthorized) {
+                if (authorized) {
                     const ssl_ptr = @as(*BoringSSL.SSL, @ptrCast(socket.getNativeHandle()));
                     if (BoringSSL.SSL_get_servername(ssl_ptr, 0)) |servername| {
                         const hostname = servername[0..bun.len(servername)];
@@ -410,6 +405,8 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                             this.fail(ErrorCode.tls_handshake_failed);
                         }
                     }
+                } else {
+                    this.fail(ErrorCode.tls_handshake_failed);
                 }
             }
         }

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -414,6 +414,8 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                     }
                 }
             } else {
+                // if we are here is because server rejected us, and the error_no is the cause of this
+                // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS    
                 this.fail(ErrorCode.tls_handshake_failed);
             }
             

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -391,13 +391,20 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
         pub fn handleHandshake(this: *HTTPClient, socket: Socket, success: i32, ssl_error: uws.us_bun_verify_error_t) void {
             log("onHandshake({d})", .{success});
 
-            const authorized = if (success == 1) true else false;
+            const handshake_success = if (success == 1) true else false;
             var reject_unauthorized = false;
             if (this.outgoing_websocket) |ws| {
                 reject_unauthorized = ws.rejectUnauthorized();
             }
-            if (reject_unauthorized) {
-                if (authorized) {
+
+            if (handshake_success) {
+                // handshake completed but we may have ssl errors
+                if(reject_unauthorized) {
+                   // only reject the connection if reject_unauthorized == true
+                    if(ssl_error.error_no != 0){
+                        this.fail(ErrorCode.tls_handshake_failed);
+                        return;
+                    }
                     const ssl_ptr = @as(*BoringSSL.SSL, @ptrCast(socket.getNativeHandle()));
                     if (BoringSSL.SSL_get_servername(ssl_ptr, 0)) |servername| {
                         const hostname = servername[0..bun.len(servername)];
@@ -405,10 +412,11 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                             this.fail(ErrorCode.tls_handshake_failed);
                         }
                     }
-                } else {
-                    this.fail(ErrorCode.tls_handshake_failed);
                 }
+            } else {
+                this.fail(ErrorCode.tls_handshake_failed);
             }
+            
         }
 
         pub fn handleOpen(this: *HTTPClient, socket: Socket) void {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Existing tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
