### PR TITLE
fix node/fs.promises.FileHandle.read() not behaving like NodeJS

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -362,6 +362,9 @@ export default exports;
     }
 
     async read(buffer, offset, length, position) {
+      if (length === 0) {
+        return { buffer, bytesRead: 0 };
+      }
       const fd = this[kFd];
       throwEBADFIfNecessary(read, fd);
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -124,6 +124,12 @@ describe("FileHandle", () => {
     expect(await fd.read(buf, 0, 10, 0)).toEqual({ bytesRead: 10, buffer: buf });
   });
 
+  if("FileHandle#read handles 0 length reads", async () => {
+    await using fd = await fs.promises.open(__filename);
+    const buf = Buffer.alloc(1);
+    expect(await fd.read(buf, 0, 0)).toEqual({ bytesRead: 0, buffer: buf });
+  });
+
   it("FileHandle#readv returns object", async () => {
     await using fd = await fs.promises.open(__filename);
     const buffers = [Buffer.alloc(10), Buffer.alloc(10)];


### PR DESCRIPTION
### What does this PR do?

fix `fs.promises.filehandle.read()` throws when bytes to read (`args.length`) equals 0 (fix #13146)

[NodeJS doesn't check if args.length equals 0](https://github.com/nodejs/node/blob/a4f609faf5a7fd42a3886e1273fe2af6ad5cb84d/src/node_file.cc#L2595-L2597) and handles it gracefully

I have chosen to fix it on the js side because I think calling the bindings is redundant in this case - and also I'm not sure if there is a reason for the Zig check since [`Syscall.read`](https://github.com/oven-sh/bun/blob/9f7c6e34cb9eab2b634fff284088b27db36b6857/src/bun.js/node/node_fs.zig#L4894C24-L4894C36) should handle 0 length reads ([Windows _read](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/read) and [Linux read(2)](https://man7.org/linux/man-pages/man2/read.2.html) both are ok with it?)

<!-- - [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case) -->
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

- [x] I included a test for the new code, or existing tests cover it
<!--  - [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`) -->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

> [!NOTE]  
> This check is kinda redundant now, but i guess can be kept just to be sure?
> https://github.com/oven-sh/bun/blob/9f7c6e34cb9eab2b634fff284088b27db36b6857/src/bun.js/node/node_fs.zig#L2916-L2919