### PR TITLE
implement NODE_EXTRA_CA_CERTS

### DIFF
--- a/packages/bun-usockets/src/crypto/root_certs.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs.cpp
@@ -5,7 +5,7 @@
 #include <atomic>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
-
+#include <string.h>
 static const int root_certs_size = sizeof(root_certs) / sizeof(root_certs[0]);
 static X509 *root_cert_instances[sizeof(root_certs) / sizeof(root_certs[0])] = {
     NULL};

--- a/packages/bun-usockets/src/crypto/root_certs.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs.cpp
@@ -1,13 +1,16 @@
 // MSVC doesn't support C11 stdatomic.h propertly yet.
 // so we use C++ std::atomic instead.
-#include "./internal/internal.h"
 #include "./root_certs.h"
-#include <openssl/x509.h>
-#include <openssl/pem.h>
+#include "./internal/internal.h"
 #include <atomic>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
 
 static const int root_certs_size = sizeof(root_certs) / sizeof(root_certs[0]);
-static X509* root_cert_instances[sizeof(root_certs) / sizeof(root_certs[0])]  = {NULL};
+static X509 *root_cert_instances[sizeof(root_certs) / sizeof(root_certs[0])] = {
+    NULL};
+static X509 *root_extra_cert_instances = {NULL};
+
 static std::atomic_flag root_cert_instances_lock = ATOMIC_FLAG_INIT;
 static std::atomic_bool root_cert_instances_initialized = 0;
 
@@ -16,15 +19,16 @@ static std::atomic_bool root_cert_instances_initialized = 0;
 // for the OpenSSL CLI, but works poorly for this case because it involves
 // synchronous interaction with the controlling terminal, something we never
 // want, and use this function to avoid it.
-int us_no_password_callback(char* buf, int size, int rwflag, void* u) {
+int us_no_password_callback(char *buf, int size, int rwflag, void *u) {
   return 0;
 }
 
-static X509 * us_ssl_ctx_get_X509_without_callback_from(struct us_cert_string_t content) {
+static X509 *
+us_ssl_ctx_get_X509_without_callback_from(struct us_cert_string_t content) {
   X509 *x = NULL;
   BIO *in;
 
-  ERR_clear_error();  // clear error stack for SSL_CTX_use_certificate()
+  ERR_clear_error(); // clear error stack for SSL_CTX_use_certificate()
 
   in = BIO_new_mem_buf(content.str, content.len);
   if (in == NULL) {
@@ -37,9 +41,37 @@ static X509 * us_ssl_ctx_get_X509_without_callback_from(struct us_cert_string_t 
     OPENSSL_PUT_ERROR(SSL, ERR_R_PEM_LIB);
     goto end;
   }
-
   return x;
+end:
+  X509_free(x);
+  BIO_free(in);
+  return NULL;
+}
 
+static X509 *
+us_ssl_ctx_get_X509_without_callback_from_file(const char *filename) {
+  X509 *x = NULL;
+  BIO *in;
+
+  ERR_clear_error(); // clear error stack for SSL_CTX_use_certificate()
+
+  in = BIO_new(BIO_s_file());
+  if (in == NULL) {
+    OPENSSL_PUT_ERROR(SSL, ERR_R_BUF_LIB);
+    goto end;
+  }
+
+  if (BIO_read_filename(in, filename) <= 0) {
+    OPENSSL_PUT_ERROR(SSL, ERR_R_SYS_LIB);
+    goto end;
+  }
+
+  x = PEM_read_bio_X509(in, NULL, us_no_password_callback, NULL);
+  if (x == NULL) {
+    OPENSSL_PUT_ERROR(SSL, ERR_R_PEM_LIB);
+    goto end;
+  }
+  return x;
 end:
   X509_free(x);
   BIO_free(in);
@@ -47,44 +79,65 @@ end:
 }
 
 static void us_internal_init_root_certs() {
-    if(std::atomic_load(&root_cert_instances_initialized) == 1) return;
+  if (std::atomic_load(&root_cert_instances_initialized) == 1)
+    return;
 
-    while(atomic_flag_test_and_set_explicit(&root_cert_instances_lock, std::memory_order_acquire));
+  while (atomic_flag_test_and_set_explicit(&root_cert_instances_lock,
+                                           std::memory_order_acquire))
+    ;
 
-    if(!atomic_exchange(&root_cert_instances_initialized, 1)) {
-        for (size_t i = 0; i < root_certs_size; i++) {
-            root_cert_instances[i] = us_ssl_ctx_get_X509_without_callback_from(root_certs[i]);
-        }        
-    }
-
-    atomic_flag_clear_explicit(&root_cert_instances_lock, std::memory_order_release);
-}
-
-extern "C" int us_internal_raw_root_certs(struct us_cert_string_t** out) {
-    *out = root_certs;
-    return root_certs_size;
-}
-
-extern "C" X509_STORE* us_get_default_ca_store() {
-    X509_STORE *store = X509_STORE_new();
-    if (store == NULL) {
-        return NULL;
-    }
-    
-    if (!X509_STORE_set_default_paths(store)) {
-        X509_STORE_free(store);
-        return NULL;
-    }
-    
-    us_internal_init_root_certs();
-
-    // load all root_cert_instances on the default ca store
+  if (!atomic_exchange(&root_cert_instances_initialized, 1)) {
     for (size_t i = 0; i < root_certs_size; i++) {
-        X509* cert = root_cert_instances[i];
-        if(cert == NULL) continue;
-        X509_up_ref(cert);
-        X509_STORE_add_cert(store, cert);       
+      root_cert_instances[i] =
+          us_ssl_ctx_get_X509_without_callback_from(root_certs[i]);
     }
-    
-    return store;
+
+    // get extra cert option from environment variable
+    const char *extra_cert = getenv("NODE_EXTRA_CA_CERTS");
+    if (extra_cert) {
+      size_t length = strlen(extra_cert);
+      if (length > 0) {
+        root_extra_cert_instances =
+            us_ssl_ctx_get_X509_without_callback_from_file(extra_cert);
+      }
+    }
+  }
+
+  atomic_flag_clear_explicit(&root_cert_instances_lock,
+                             std::memory_order_release);
+}
+
+extern "C" int us_internal_raw_root_certs(struct us_cert_string_t **out) {
+  *out = root_certs;
+  return root_certs_size;
+}
+
+extern "C" X509_STORE *us_get_default_ca_store() {
+  X509_STORE *store = X509_STORE_new();
+  if (store == NULL) {
+    return NULL;
+  }
+
+  if (!X509_STORE_set_default_paths(store)) {
+    X509_STORE_free(store);
+    return NULL;
+  }
+
+  us_internal_init_root_certs();
+
+  // load all root_cert_instances on the default ca store
+  for (size_t i = 0; i < root_certs_size; i++) {
+    X509 *cert = root_cert_instances[i];
+    if (cert == NULL)
+      continue;
+    X509_up_ref(cert);
+    X509_STORE_add_cert(store, cert);
+  }
+
+  if (root_extra_cert_instances) {
+    X509_up_ref(root_extra_cert_instances);
+    X509_STORE_add_cert(store, root_extra_cert_instances);
+  }
+
+  return store;
 }

--- a/test/js/web/fetch/fetch.tls.extra-cert.fixture.js
+++ b/test/js/web/fetch/fetch.tls.extra-cert.fixture.js
@@ -1,0 +1,11 @@
+try {
+  const response = await fetch(process.env.SERVER, {
+    tls: {
+      rejectUnauthorized: true,
+    },
+  }).then(res => res.text());
+  process.exit(response === "OK" ? 0 : 1);
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -260,7 +260,7 @@ it("fetch timeout works on tls", async () => {
 });
 
 it("fetch should use NODE_EXTRA_CA_CERTS", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     tls: cert1,
     fetch() {
@@ -286,7 +286,7 @@ it("fetch should use NODE_EXTRA_CA_CERTS", async () => {
 });
 
 it("fetch should ignore invalid NODE_EXTRA_CA_CERTS", async () => {
-  const server = Bun.serve({
+  using server = Bun.serve({
     port: 0,
     tls: cert1,
     fetch() {


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/7124
Fix: https://github.com/oven-sh/bun/issues/8686
Fix: https://github.com/oven-sh/bun/issues/7200

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
Added tests
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
