### PR TITLE
fix fast shutdown

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -588,8 +588,10 @@ restart:
       goto restart;
     }
   }
-  // trigger writable if we failed last write with want read
-  // but do not trigger writable if read wanna write (avoid recursive loop)
+  // Trigger writable if we failed last SSL_write with SSL_ERROR_WANT_READ 
+  // If we failed SSL_read because we need to write more data (SSL_ERROR_WANT_WRITE) we are not going to trigger on_writable, we will wait until the next on_data or on_writable event
+  // SSL_read will try to flush the write buffer and if fails with SSL_ERROR_WANT_WRITE means the socket is not in a writable state anymore and only makes sense to trigger on_writable if we can write more data
+  // Otherwise we possible would trigger on_writable -> on_data event in a recursive loop
   if (s->ssl_write_wants_read && !s->ssl_read_wants_write) {
     s->ssl_write_wants_read = 0;
 

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -589,7 +589,8 @@ restart:
     }
   }
   // trigger writable if we failed last write with want read
-  if (s->ssl_write_wants_read) {
+  // but do not trigger writable if read wanna write (avoid recursive loop)
+  if (s->ssl_write_wants_read && !s->ssl_read_wants_write) {
     s->ssl_write_wants_read = 0;
 
     // make sure to update context before we call (context can change if the

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -300,6 +300,7 @@ int us_internal_handle_shutdown(struct us_internal_ssl_socket_t *s, int force_fa
       // 1 - We abort the connection to fast and we did not even start the first handshake
       // 2 - SSL is in a broken state
       // 3 - SSL is not broken but is in a state that we cannot recover from
+      s->fatal_error = 1;
       return 1;
     }
     return ret == 1;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 // clang-format off
-#include <stdio.h>
 #if (defined(LIBUS_USE_OPENSSL) || defined(LIBUS_USE_WOLFSSL))
 
 

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -258,32 +258,6 @@ it("fetch timeout works on tls", async () => {
     expect(total).toBeLessThanOrEqual(TIMEOUT + THRESHOLD);
   }
 });
-for (const timeout of [0, 1, 10, 20, 100, 300]) {
-  it(`fetch should abort as soon as possible under tls using AbortSignal.timeout(${timeout})`, async () => {
-    using server = Bun.serve({
-      port: 0,
-      tls: CERT_LOCALHOST_IP,
-      async fetch() {
-        await Bun.sleep(1000);
-        return new Response("Hello World");
-      },
-    });
-    const time = Date.now();
-    try {
-      await fetch(server.url, {
-        //@ts-ignore
-        tls: { ca: CERT_LOCALHOST_IP.cert },
-        signal: AbortSignal.timeout(timeout),
-      }).then(res => res.text());
-    } catch (err) {
-      expect((err as Error).name).toBe("TimeoutError");
-    } finally {
-      const diff = Date.now() - time;
-      expect(diff).toBeLessThanOrEqual(timeout + 10);
-      expect(diff).toBeGreaterThanOrEqual(timeout);
-    }
-  });
-}
 
 it("fetch should use NODE_EXTRA_CA_CERTS", async () => {
   using server = Bun.serve({

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -310,3 +310,29 @@ it("fetch should ignore invalid NODE_EXTRA_CA_CERTS", async () => {
     expect(await Bun.readableStreamToText(proc.stderr)).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
   }
 });
+it("fetch should abort as soon as possible under tls", async () => {
+  using server = Bun.serve({
+    port: 0,
+    tls: CERT_LOCALHOST_IP,
+    async fetch() {
+      await Bun.sleep(1000);
+      return new Response("Hello World");
+    },
+  });
+  for (const timeout of [0, 1, 10, 20, 100, 300]) {
+    const time = Date.now();
+    try {
+      await fetch(server.url, {
+        //@ts-ignore
+        tls: { ca: CERT_LOCALHOST_IP.cert },
+        signal: AbortSignal.timeout(timeout),
+      }).then(res => res.text());
+    } catch (err) {
+      expect((err as Error).name).toBe("TimeoutError");
+    } finally {
+      const diff = Date.now() - time;
+      expect(diff).toBeLessThanOrEqual(timeout + 10);
+      expect(diff).toBeGreaterThanOrEqual(timeout);
+    }
+  }
+});

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -275,6 +275,7 @@ for (const timeout of [0, 1, 10, 20, 100, 300]) {
         tls: { ca: CERT_LOCALHOST_IP.cert },
         signal: AbortSignal.timeout(timeout),
       }).then(res => res.text());
+      expect.unreachable();
     } catch (err) {
       expect((err as Error).name).toBe("TimeoutError");
     } finally {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -250,6 +250,7 @@ it("fetch timeout works on tls", async () => {
       signal: AbortSignal.timeout(TIMEOUT),
       tls: { ca: cert1.cert },
     }).then(res => res.text());
+    expect.unreachable();
   } catch (e) {
     expect(e.name).toBe("TimeoutError");
   } finally {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -258,6 +258,32 @@ it("fetch timeout works on tls", async () => {
     expect(total).toBeLessThanOrEqual(TIMEOUT + THRESHOLD);
   }
 });
+for (const timeout of [0, 1, 10, 20, 100, 300]) {
+  it(`fetch should abort as soon as possible under tls using AbortSignal.timeout(${timeout})`, async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: CERT_LOCALHOST_IP,
+      async fetch() {
+        await Bun.sleep(1000);
+        return new Response("Hello World");
+      },
+    });
+    const time = Date.now();
+    try {
+      await fetch(server.url, {
+        //@ts-ignore
+        tls: { ca: CERT_LOCALHOST_IP.cert },
+        signal: AbortSignal.timeout(timeout),
+      }).then(res => res.text());
+    } catch (err) {
+      expect((err as Error).name).toBe("TimeoutError");
+    } finally {
+      const diff = Date.now() - time;
+      expect(diff).toBeLessThanOrEqual(timeout + 10);
+      expect(diff).toBeGreaterThanOrEqual(timeout);
+    }
+  });
+}
 
 it("fetch should use NODE_EXTRA_CA_CERTS", async () => {
   using server = Bun.serve({
@@ -308,31 +334,5 @@ it("fetch should ignore invalid NODE_EXTRA_CA_CERTS", async () => {
 
     expect(await proc.exited).toBe(1);
     expect(await Bun.readableStreamToText(proc.stderr)).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
-  }
-});
-it("fetch should abort as soon as possible under tls", async () => {
-  using server = Bun.serve({
-    port: 0,
-    tls: CERT_LOCALHOST_IP,
-    async fetch() {
-      await Bun.sleep(1000);
-      return new Response("Hello World");
-    },
-  });
-  for (const timeout of [0, 1, 10, 20, 100, 300]) {
-    const time = Date.now();
-    try {
-      await fetch(server.url, {
-        //@ts-ignore
-        tls: { ca: CERT_LOCALHOST_IP.cert },
-        signal: AbortSignal.timeout(timeout),
-      }).then(res => res.text());
-    } catch (err) {
-      expect((err as Error).name).toBe("TimeoutError");
-    } finally {
-      const diff = Date.now() - time;
-      expect(diff).toBeLessThanOrEqual(timeout + 10);
-      expect(diff).toBeGreaterThanOrEqual(timeout);
-    }
   }
 });

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -258,6 +258,32 @@ it("fetch timeout works on tls", async () => {
     expect(total).toBeLessThanOrEqual(TIMEOUT + THRESHOLD);
   }
 });
+for (const timeout of [0, 1, 10, 20, 100, 300]) {
+  it(`fetch should abort as soon as possible under tls using AbortSignal.timeout(${timeout})`, async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: CERT_LOCALHOST_IP,
+      async fetch() {
+        await Bun.sleep(1000);
+        return new Response("Hello World");
+      },
+    });
+    const time = Date.now();
+    try {
+      await fetch(server.url, {
+        //@ts-ignore
+        tls: { ca: CERT_LOCALHOST_IP.cert },
+        signal: AbortSignal.timeout(timeout),
+      }).then(res => res.text());
+    } catch (err) {
+      expect((err as Error).name).toBe("TimeoutError");
+    } finally {
+      const diff = Date.now() - time;
+      expect(diff).toBeLessThanOrEqual(timeout + 30);
+      expect(diff).toBeGreaterThanOrEqual(timeout - 30);
+    }
+  });
+}
 
 it("fetch should use NODE_EXTRA_CA_CERTS", async () => {
   using server = Bun.serve({


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
