### PR TITLE
ci: set duration when subprocess.on(error)

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -318,6 +318,7 @@ async function spawnSafe(options) {
         timer = setTimeout(() => done(resolve), timeout);
       });
       subprocess.on("error", error => {
+        duration = Date.now() - timestamp;
         spawnError = error;
         done(resolve);
       });


### PR DESCRIPTION
this should make it so test files that timeout or fail dont show up in the logs as `0s`