### PR TITLE
`throw("Out of memory")` -> throwOutOfMemory()

### DIFF
--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -1056,7 +1056,7 @@ pub fn transform(
         if (code == .buffer) {
             code_arg.unprotect();
         }
-        globalThis.throw("Out of memory", .{});
+        globalThis.throwOutOfMemory();
         return .zero;
     };
     task.schedule();

--- a/src/bun.js/api/glob.zig
+++ b/src/bun.js/api/glob.zig
@@ -259,7 +259,7 @@ fn makeGlobWalker(
 
     if (cwd != null) {
         var globWalker = alloc.create(GlobWalker) catch {
-            globalThis.throw("Out of memory", .{});
+            globalThis.throwOutOfMemory();
             return null;
         };
 
@@ -275,7 +275,7 @@ fn makeGlobWalker(
             error_on_broken_symlinks,
             only_files,
         ) catch {
-            globalThis.throw("Out of memory", .{});
+            globalThis.throwOutOfMemory();
             return null;
         }) {
             .err => |err| {
@@ -287,7 +287,7 @@ fn makeGlobWalker(
         return globWalker;
     }
     var globWalker = alloc.create(GlobWalker) catch {
-        globalThis.throw("Out of memory", .{});
+        globalThis.throwOutOfMemory();
         return null;
     };
 
@@ -301,7 +301,7 @@ fn makeGlobWalker(
         error_on_broken_symlinks,
         only_files,
     ) catch {
-        globalThis.throw("Out of memory", .{});
+        globalThis.throwOutOfMemory();
         return null;
     }) {
         .err => |err| {
@@ -400,7 +400,7 @@ pub fn __scan(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.CallFram
     incrPendingActivityFlag(&this.has_pending_activity);
     var task = WalkTask.create(globalThis, alloc, globWalker, &this.has_pending_activity) catch {
         decrPendingActivityFlag(&this.has_pending_activity);
-        globalThis.throw("Out of memory", .{});
+        globalThis.throwOutOfMemory();
         return .undefined;
     };
     task.schedule();
@@ -423,7 +423,7 @@ pub fn __scanSync(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.Call
     defer globWalker.deinit(true);
 
     switch (globWalker.walk() catch {
-        globalThis.throw("Out of memory", .{});
+        globalThis.throwOutOfMemory();
         return .undefined;
     }) {
         .err => |err| {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -6380,7 +6380,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             JSC.markBinding(@src());
             this.pending_requests += 1;
             req.setYield(false);
-            var ctx = this.request_pool_allocator.tryGet() catch @panic("ran out of memory");
+            var ctx = this.request_pool_allocator.tryGet() catch bun.outOfMemory();
             ctx.create(this, req, resp);
             var body = this.vm.initRequestBodyValue(.{ .Null = {} }) catch unreachable;
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -1871,6 +1871,16 @@ extern "C" JSC__JSValue ZigString__toJSONObject(const ZigString* strPtr, JSC::JS
     return JSValue::encode(result);
 }
 
+// We used to just throw "Out of memory" as a regular Error with that string.
+//
+// But JSC has some different handling for out of memory errors. So we should
+// make it look like what JSC does.
+void JSGlobalObject__throwOutOfMemoryError(JSC::JSGlobalObject* globalObject)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    throwOutOfMemoryError(globalObject, scope);
+}
+
 JSC__JSValue SystemError__toErrorInstance(const SystemError* arg0,
     JSC__JSGlobalObject* globalObject)
 {

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -2778,8 +2778,9 @@ pub const JSGlobalObject = opaque {
         return this.bunVM().allocator;
     }
 
+    extern fn JSGlobalObject__throwOutOfMemoryError(this: *JSGlobalObject) void;
     pub fn throwOutOfMemory(this: *JSGlobalObject) void {
-        this.throwValue(this.createErrorInstance("Out of memory", .{}));
+        JSGlobalObject__throwOutOfMemoryError(this);
     }
 
     pub fn throwTODO(this: *JSGlobalObject, msg: []const u8) void {

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -570,7 +570,7 @@ pub const BundleV2 = struct {
         if (path.pretty.ptr == path.text.ptr) {
             // TODO: outbase
             const rel = bun.path.relativePlatform(this.bundler.fs.top_level_dir, path.text, .loose, false);
-            path.pretty = this.graph.allocator.dupe(u8, rel) catch @panic("Ran out of memory");
+            path.pretty = this.graph.allocator.dupe(u8, rel) catch bun.outOfMemory();
         }
         path.assertPrettyIsValid();
 
@@ -580,13 +580,13 @@ pub const BundleV2 = struct {
                 secondary != path and
                 !strings.eqlLong(secondary.text, path.text, true))
             {
-                secondary_path_to_copy = secondary.dupeAlloc(this.graph.allocator) catch @panic("Ran out of memory");
+                secondary_path_to_copy = secondary.dupeAlloc(this.graph.allocator) catch bun.outOfMemory();
             }
         }
 
-        const entry = this.graph.path_to_source_index_map.getOrPut(this.graph.allocator, path.hashKey()) catch @panic("Ran out of memory");
+        const entry = this.graph.path_to_source_index_map.getOrPut(this.graph.allocator, path.hashKey()) catch bun.outOfMemory();
         if (!entry.found_existing) {
-            path.* = path.dupeAllocFixPretty(this.graph.allocator) catch @panic("Ran out of memory");
+            path.* = path.dupeAllocFixPretty(this.graph.allocator) catch bun.outOfMemory();
 
             // We need to parse this
             const source_index = Index.init(@as(u32, @intCast(this.graph.ast.len)));
@@ -616,8 +616,8 @@ pub const BundleV2 = struct {
                     .text, .json, .toml, .file => _resolver.SideEffects.no_side_effects__pure_data,
                     else => _resolver.SideEffects.has_side_effects,
                 },
-            }) catch @panic("Ran out of memory");
-            var task = this.graph.allocator.create(ParseTask) catch @panic("Ran out of memory");
+            }) catch bun.outOfMemory();
+            var task = this.graph.allocator.create(ParseTask) catch bun.outOfMemory();
             task.* = ParseTask.init(&resolve_result, source_index, this);
             task.loader = loader;
             task.jsx = this.bundler.options.jsx;
@@ -671,7 +671,7 @@ pub const BundleV2 = struct {
         if (path.pretty.ptr == path.text.ptr) {
             // TODO: outbase
             const rel = bun.path.relativePlatform(this.bundler.fs.top_level_dir, path.text, .loose, false);
-            path.pretty = this.graph.allocator.dupe(u8, rel) catch @panic("Ran out of memory");
+            path.pretty = this.graph.allocator.dupe(u8, rel) catch bun.outOfMemory();
         }
         path.* = try path.dupeAllocFixPretty(this.graph.allocator);
         path.assertPrettyIsValid();
@@ -2017,7 +2017,7 @@ pub const BundleV2 = struct {
                 continue;
             }
 
-            const resolve_entry = resolve_queue.getOrPut(hash_key) catch @panic("Ran out of memory");
+            const resolve_entry = resolve_queue.getOrPut(hash_key) catch bun.outOfMemory();
             if (resolve_entry.found_existing) {
                 import_record.path = resolve_entry.value_ptr.*.path;
 
@@ -2029,7 +2029,7 @@ pub const BundleV2 = struct {
                 const rel = bun.path.relativePlatform(this.bundler.fs.top_level_dir, path.text, .loose, false);
                 path.pretty = this.graph.allocator.dupe(u8, rel) catch bun.outOfMemory();
             }
-            path.* = path.dupeAllocFixPretty(this.graph.allocator) catch @panic("Ran out of memory");
+            path.* = path.dupeAllocFixPretty(this.graph.allocator) catch bun.outOfMemory();
 
             var secondary_path_to_copy: ?Fs.Path = null;
             if (resolve_result.path_pair.secondary) |*secondary| {
@@ -2037,14 +2037,14 @@ pub const BundleV2 = struct {
                     secondary != path and
                     !strings.eqlLong(secondary.text, path.text, true))
                 {
-                    secondary_path_to_copy = secondary.dupeAlloc(this.graph.allocator) catch @panic("Ran out of memory");
+                    secondary_path_to_copy = secondary.dupeAlloc(this.graph.allocator) catch bun.outOfMemory();
                 }
             }
 
             import_record.path = path.*;
             debug("created ParseTask: {s}", .{path.text});
 
-            var resolve_task = bun.default_allocator.create(ParseTask) catch @panic("Ran out of memory");
+            var resolve_task = bun.default_allocator.create(ParseTask) catch bun.outOfMemory();
             resolve_task.* = ParseTask.init(&resolve_result, null, this);
 
             resolve_task.secondary_path_for_commonjs_interop = secondary_path_to_copy;


### PR DESCRIPTION
### What does this PR do?

- Use JSC::throwOutOfMemory instead of an ErrorInstance with the message "Out of memory"
- Use bun.outOfMemory() instead of a slightly different panic string for the same thing

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
