### PR TITLE
fix(bundler): tagged templates can never be moved

### DIFF
--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -5587,7 +5587,7 @@ pub const Expr = struct {
                 .e_utf8_string,
                 => true,
 
-                .e_template => |template| template.parts.len == 0,
+                .e_template => |template| template.tag == null and template.parts.len == 0,
 
                 .e_array => |array| array.was_originally_macro,
                 .e_object => |object| object.was_originally_macro,

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1818,6 +1818,19 @@ describe("bundler", () => {
     },
     run: { stdout: "1" },
   });
+  itBundled("edgecase/DoNotMoveTaggedTemplateLiterals", {
+    files: {
+      "/entry.ts": `
+        globalThis.z = () => console.log(2)
+        const y = await import('./second.ts');
+      `,
+      "/second.ts": `
+        console.log(1);
+        export const y = z\`zyx\`;
+      `,
+    },
+    run: { stdout: "1\n2" },
+  });
 
   // TODO(@paperdave): test every case of this. I had already tested it manually, but it may break later
   const requireTranspilationListESM = [


### PR DESCRIPTION
### What does this PR do?

https://github.com/Coachonko/bun-1.1.21-bundler-regression
