### PR TITLE
docs: update `oven-sh/setup-bun@v2`

### DIFF
--- a/docs/guides/install/cicd.md
+++ b/docs/guides/install/cicd.md
@@ -13,7 +13,7 @@ jobs:
     steps:
       # ...
       - uses: actions/checkout@v4
-+     - uses: oven-sh/setup-bun@v1
++     - uses: oven-sh/setup-bun@v2
 
       # run any `bun` or `bunx` command
 +     - run: bun install
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # ...
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
 +       with:
 +         version: 0.7.0 # or "canary"
 ```


### PR DESCRIPTION
It has been stated in the marketplace that use  `@v2`  https://github.com/marketplace/actions/setup-bun#usage

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

https://github.com/marketplace/actions/setup-bun#usage
![image](https://github.com/user-attachments/assets/6f2efc24-d660-455e-aa54-1fbeee0fb028)


<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
