### PR TITLE
fix(ws) fix handling of messages

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -747,10 +747,14 @@ class BunWebSocketMocked extends EventEmitter {
     if (this.#state === 1) {
       const compress = opts?.compress;
       data = normalizeData(data, opts);
+      // send returns:
+      // 1+ - The number of bytes sent is always the length of the data never less
+      // 0 - dropped due to backpressure (not sent)
+      // -1 - enqueue the data internaly
+      // we dont need to do anything with the return value here
       const written = this.#ws.send(data, compress);
-
-      if (written == -1) {
-        // backpressure
+      if (written === 0) {
+        // dropped
         this.#enquedMessages.push([data, compress, cb]);
         this.#bufferedAmount += data.length;
         return;

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -748,7 +748,7 @@ class BunWebSocketMocked extends EventEmitter {
       const compress = opts?.compress;
       data = normalizeData(data, opts);
       // send returns:
-      // 1+ - The number of bytes sent is always the length of the data never less
+      // 1+ - The number of bytes sent is always the byte length of the data never less
       // 0 - dropped due to backpressure (not sent)
       // -1 - enqueue the data internaly
       // we dont need to do anything with the return value here

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -454,3 +454,49 @@ async function listen(): Promise<URL> {
   }
   throw new Error("No URL found?");
 }
+it("WebSocketServer should handle backpressure", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const PAYLOAD_SIZE = 64 * 1024;
+  const ITERATIONS = 10;
+  const payload = Buffer.alloc(PAYLOAD_SIZE, "a");
+  let received = 0;
+
+  const wss = new WebSocketServer({ port: 0 });
+
+  wss.on("connection", function connection(ws) {
+    ws.onerror = reject;
+
+    let i = 0;
+
+    async function commit(err?: Error) {
+      if (err) {
+        reject(err);
+        return;
+      }
+      await Bun.sleep(10);
+
+      if (i < ITERATIONS) {
+        i++;
+        ws.send(payload, commit);
+      } else {
+        ws.close();
+      }
+    }
+
+    commit(undefined);
+  });
+
+  try {
+    const ws = new WebSocket("ws://localhost:" + wss.address().port);
+    ws.onmessage = event => {
+      received += event.data.byteLength;
+    };
+    ws.onclose = resolve;
+    ws.onerror = reject;
+    await promise;
+
+    expect(received).toBe(PAYLOAD_SIZE * ITERATIONS);
+  } finally {
+    wss.close();
+  }
+});


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/9368
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
