### PR TITLE
ci: put file link next to name separately

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1418,10 +1418,9 @@ function formatTestToMarkdown(result, concise) {
       markdown += "<details><summary>";
     }
 
+    markdown += `<code>${testTitle}</code>`;
     if (testUrl) {
-      markdown += `<a href="${testUrl}"><code>${testTitle}</code></a>`;
-    } else {
-      markdown += `<a><code>${testTitle}</code></a>`;
+      markdown += ` <a href="${testUrl}">[link]</a>`;
     }
     if (error) {
       markdown += ` - ${error}`;

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1410,7 +1410,6 @@ function formatTestToMarkdown(result, concise) {
     }
 
     const testTitle = testPath.replace(/\\/g, "/");
-    const testUrl = getFileUrl(testPath, errorLine);
 
     if (concise) {
       markdown += "<li>";
@@ -1419,9 +1418,9 @@ function formatTestToMarkdown(result, concise) {
     }
 
     markdown += `<code>${testTitle}</code>`;
-    if (testUrl) {
-      markdown += ` <a href="${testUrl}">[link]</a>`;
-    }
+    markdown += ` <a href="${process.env["BUILDKITE_BUILD_URL"]}#annotation-${testTitle}">[logs]</a>`;
+    markdown += ` <a href="${getFileUrl(testPath, errorLine)}">[source]</a>`;
+
     if (error) {
       markdown += ` - ${error}`;
     }


### PR DESCRIPTION
before

- [`test/cli/hot/watch.test.ts`](https://github.com/oven-sh/bun/blob/b5922338ea4979849c66c5db5f77aa71275a0a65/test/cli/hot/watch.test.ts) - 1 failing on [🪟 x64](https://buildkite.com/bun/bun/builds/1602#019135ad-73f8-4183-aa58-4b38b8710859)

after

- `test/cli/hot/watch.test.ts` [[link]](https://github.com/oven-sh/bun/blob/b5922338ea4979849c66c5db5f77aa71275a0a65/test/cli/hot/watch.test.ts) - 1 failing on [🪟 x64](https://buildkite.com/bun/bun/builds/1602#019135ad-73f8-4183-aa58-4b38b8710859)

after

- `test/cli/hot/watch.test.ts` [[logs]](https://buildkite.com/bun/bun/builds/1602#annotation-test/cli/hot/watch.test.ts) [[source]](https://github.com/oven-sh/bun/blob/b5922338ea4979849c66c5db5f77aa71275a0a65/test/cli/hot/watch.test.ts) - 1 failing on [🪟 x64](https://buildkite.com/bun/bun/builds/1602#019135ad-73f8-4183-aa58-4b38b8710859)

--- 

im regularly trying to copy-paste the file paths so that i can open them up in my editor but the text being link-ified makes that harder. this patch keeps it around but moves it to its own button instead

edit: the logs link doesnt work as good as i was expecting because the annotations arent there on page-load. this is still an improvement over status quo though imo and will passively work without change on our end if buildkite fixes that issue