### PR TITLE
feature: add debugger info endpoint (/json) for external tool discovery...

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -1,5 +1,4 @@
 import type { Server as WebSocketServer, WebSocketHandler, ServerWebSocket, SocketHandler, Socket } from "bun";
-
 export default function (
   executionContextId: string,
   url: string,
@@ -129,7 +128,7 @@ class Debugger {
         return Response.json(versionInfo());
       case "/json":
       case "/json/list":
-      // TODO?
+        return Response.json(debuggerInfo(this));
     }
 
     if (!this.#url.protocol.includes("unix") && this.#url.pathname !== pathname) {
@@ -213,6 +212,24 @@ function versionInfo(): unknown {
     "Bun-Version": Bun.version,
     "Bun-Revision": Bun.revision,
   };
+}
+
+function debuggerInfo(d: Debugger): unknown {
+    const ws = `${d.url}`.replace(/wss?:\/\//, '')
+
+    return [
+        {
+            "description": `Bun instance (version: ${Bun.version}, revision: ${Bun.revision})`,
+            "devtoolsFrontendUrl": `devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=${ws}`,
+            "devtoolsFrontendUrlCompat": `devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=${ws}`,
+            "faviconUrl": "https://bun.sh/logo_avatar.svg",
+            "id": `${ws}`.split('/').pop(),
+            "title": Bun.main,
+            "type": "bun",
+            "url": Bun.pathToFileURL(Bun.main),
+            "webSocketDebuggerUrl": d.url
+        }
+    ]
 }
 
 function webSocketWriter(ws: ServerWebSocket<unknown>): Writer {

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -216,14 +216,14 @@ function versionInfo(): unknown {
 
 function debuggerInfo(d: Debugger): unknown {
     const ws = `${d.url}`.replace(/wss?:\/\//, '')
+    const id = `${ws}`.split('/').pop()
 
     return [
         {
             "description": `Bun instance (version: ${Bun.version}, revision: ${Bun.revision})`,
-            "devtoolsFrontendUrl": `devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=${ws}`,
-            "devtoolsFrontendUrlCompat": `devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=${ws}`,
+            "devtoolsFrontendUrl": `https://debug.bun.sh/#${ws}`,
             "faviconUrl": "https://bun.sh/logo_avatar.svg",
-            "id": `${ws}`.split('/').pop(),
+            id,
             "title": Bun.main,
             "type": "bun",
             "url": Bun.pathToFileURL(Bun.main),


### PR DESCRIPTION
including browser DevTools similar to Node.js

### What does this PR do?

Fixes this issue https://github.com/oven-sh/bun/issues/9609 by adding a /json endpoint which lists the debugger metadata similar to Node.js

![image](https://github.com/user-attachments/assets/1911cd46-0dc4-4dd7-866d-4913b223eef9)

This is useful to allow Bun to be debugged with browser DevTools (i.e. Chrome, Edge, etc) in addition to the Bun web debugger.