### PR TITLE
faster `TextEncoderStream` part 2

### DIFF
--- a/bench/snippets/text-encoder-stream.mjs
+++ b/bench/snippets/text-encoder-stream.mjs
@@ -2,12 +2,19 @@ import { bench, run } from "./runner.mjs";
 
 const latin1 = `hello hello hello!!!! `.repeat(10240);
 
-function create(src) {
-  function split(str, chunkSize) {
+const astralCharacter = "\u{1F499}"; // BLUE HEART
+const leading = astralCharacter[0];
+const trailing = astralCharacter[1];
+
+async function create(src, testPendingSurrogate) {
+  function split(str, chunkSize, pendingLeadSurrogate) {
     let chunkedHTML = [];
     let html = str;
     while (html.length > 0) {
-      chunkedHTML.push(html.slice(0, chunkSize));
+      pendingLeadSurrogate
+        ? chunkedHTML.push(html.slice(0, chunkSize) + leading)
+        : chunkedHTML.push(html.slice(0, chunkSize));
+
       html = html.slice(chunkSize);
     }
     return chunkedHTML;
@@ -29,21 +36,30 @@ function create(src) {
   // if (new TextDecoder().decode(await runBench(oneKB)) !== src) {
   //   throw new Error("Benchmark failed");
   // }
+
+  const pendingSurrogateTests = [false];
+  if (testPendingSurrogate) {
+    pendingSurrogateTests.push(true);
+  }
+
   const sizes = [1024, 16 * 1024, 64 * 1024, 256 * 1024];
   for (const chunkSize of sizes) {
-    const text = split(src, chunkSize);
-    bench(
-      `${Math.round(src.length / 1024)} KB of text in ${Math.round(chunkSize / 1024) > 0 ? Math.round(chunkSize / 1024) : (chunkSize / 1024).toFixed(2)} KB chunks`,
-      async () => {
-        await runBench(text);
-      },
-    );
+    for (const pendingLeadSurrogate of pendingSurrogateTests) {
+      const text = split(src, chunkSize, testPendingSurrogate && pendingLeadSurrogate);
+      bench(
+        `${Math.round(src.length / 1024)} KB, ${Math.round(chunkSize / 1024) > 0 ? Math.round(chunkSize / 1024) : (chunkSize / 1024).toFixed(2)} KB chunks, ${pendingLeadSurrogate ? "pending surrogate" : ""}`,
+        async () => {
+          await runBench(text);
+        },
+      );
+    }
   }
 }
-create(latin1);
+create(latin1, false);
 create(
   // bun's old readme was extremely long
   await fetch("https://web.archive.org/web/20230119110956/https://github.com/oven-sh/bun").then(res => res.text()),
+  true,
 );
 
 await run();

--- a/src/bun.js/bindings/bun-simdutf.zig
+++ b/src/bun.js/bindings/bun-simdutf.zig
@@ -56,6 +56,7 @@ pub extern fn simdutf__convert_utf8_to_utf16le(buf: [*]const u8, len: usize, utf
 pub extern fn simdutf__convert_utf8_to_utf16be(buf: [*]const u8, len: usize, utf16_output: [*]u16) usize;
 pub extern fn simdutf__convert_utf8_to_utf16le_with_errors(buf: [*]const u8, len: usize, utf16_output: [*]u16) SIMDUTFResult;
 pub extern fn simdutf__convert_utf8_to_utf16be_with_errors(buf: [*]const u8, len: usize, utf16_output: [*]u16) SIMDUTFResult;
+pub extern fn simdutf__convert_valid_utf8_to_utf16le(buf: [*]const u8, len: usize, utf16_buffer: [*]u16) usize;
 pub extern fn simdutf__convert_valid_utf8_to_utf16be(buf: [*]const u8, len: usize, utf16_buffer: [*]u16) usize;
 pub extern fn simdutf__convert_utf8_to_utf32(buf: [*]const u8, len: usize, utf32_output: [*]u32) usize;
 pub extern fn simdutf__convert_utf8_to_utf32_with_errors(buf: [*]const u8, len: usize, utf32_output: [*]u32) SIMDUTFResult;
@@ -167,11 +168,58 @@ pub const convert = struct {
                 };
 
                 pub fn le(input: []const u8, output: []u32) usize {
-                    return simdutf__convert_valid_utf8_to_utf32(input.ptr, input.len, output.ptr);
+                    return simdutf__convert_utf8_to_utf32(input.ptr, input.len, output.ptr);
                 }
                 pub fn be(input: []const u8, output: []u32) usize {
+                    return simdutf__convert_utf8_to_utf32(input.ptr, input.len, output.ptr);
+                }
+            };
+        };
+    };
+
+    pub const valid = struct {
+        pub const utf16 = struct {
+            pub const to = struct {
+                pub const utf8 = struct {
+                    pub fn le(input: []const u16, output: []u8) usize {
+                        return simdutf__convert_valid_utf16le_to_utf8(input.ptr, input.len, output.ptr);
+                    }
+                    pub fn be(input: []const u16, output: []u8) usize {
+                        return simdutf__convert_valid_utf16be_to_utf8(input.ptr, input.len, output.ptr);
+                    }
+                };
+            };
+        };
+
+        pub const utf8 = struct {
+            pub const to = struct {
+                pub const utf16 = struct {
+                    pub fn le(input: []const u8, output: []u16) usize {
+                        return simdutf__convert_valid_utf8_to_utf16le(input.ptr, input.len, output.ptr);
+                    }
+                    pub fn be(input: []const u8, output: []u16) usize {
+                        return simdutf__convert_valid_utf8_to_utf16be(input.ptr, input.len, output.ptr);
+                    }
+                };
+                pub fn utf32(input: []const u8, output: []u32) usize {
                     return simdutf__convert_valid_utf8_to_utf32(input.ptr, input.len, output.ptr);
                 }
+            };
+        };
+
+        pub const utf32 = struct {
+            pub const to = struct {
+                pub fn utf8(input: []const u32, output: []u8) usize {
+                    return simdutf__convert_valid_utf32_to_utf8(input.ptr, input.len, output.ptr);
+                }
+                pub const utf16 = struct {
+                    pub fn le(input: []const u32, output: []u16) usize {
+                        return simdutf__convert_valid_utf32_to_utf16le(input.ptr, input.len, output.ptr);
+                    }
+                    pub fn be(input: []const u32, output: []u16) usize {
+                        return simdutf__convert_valid_utf32_to_utf16be(input.ptr, input.len, output.ptr);
+                    }
+                };
             };
         };
     };
@@ -189,10 +237,10 @@ pub const convert = struct {
                 };
 
                 pub fn le(input: []const u16, output: []u8) usize {
-                    return simdutf__convert_valid_utf16le_to_utf8(input.ptr, input.len, output.ptr);
+                    return simdutf__convert_utf16le_to_utf8(input.ptr, input.len, output.ptr);
                 }
                 pub fn be(input: []const u16, output: []u8) usize {
-                    return simdutf__convert_valid_utf16be_to_utf8(input.ptr, input.len, output.ptr);
+                    return simdutf__convert_utf16be_to_utf8(input.ptr, input.len, output.ptr);
                 }
             };
 
@@ -207,10 +255,10 @@ pub const convert = struct {
                 };
 
                 pub fn le(input: []const u16, output: []u32) usize {
-                    return simdutf__convert_valid_utf16le_to_utf32(input.ptr, input.len, output.ptr);
+                    return simdutf__convert_utf16le_to_utf32(input.ptr, input.len, output.ptr);
                 }
                 pub fn be(input: []const u16, output: []u32) usize {
-                    return simdutf__convert_valid_utf16be_to_utf32(input.ptr, input.len, output.ptr);
+                    return simdutf__convert_utf16be_to_utf32(input.ptr, input.len, output.ptr);
                 }
             };
         };
@@ -229,10 +277,10 @@ pub const convert = struct {
                 };
 
                 pub fn le(input: []const u32, output: []u8) usize {
-                    return simdutf__convert_valid_utf32_to_utf8(input.ptr, input.len, output.ptr);
+                    return simdutf__convert_utf32_to_utf8(input.ptr, input.len, output.ptr);
                 }
                 pub fn be(input: []const u32, output: []u8) usize {
-                    return simdutf__convert_valid_utf32_to_utf8(input.ptr, input.len, output.ptr);
+                    return simdutf__convert_utf32_to_utf8(input.ptr, input.len, output.ptr);
                 }
             };
 
@@ -247,10 +295,10 @@ pub const convert = struct {
                 };
 
                 pub fn le(input: []const u32, output: []u16) usize {
-                    return simdutf__convert_valid_utf32_to_utf16le(input.ptr, input.len, output.ptr);
+                    return simdutf__convert_utf32_to_utf16le(input.ptr, input.len, output.ptr);
                 }
                 pub fn be(input: []const u32, output: []u16) usize {
-                    return simdutf__convert_valid_utf32_to_utf16be(input.ptr, input.len, output.ptr);
+                    return simdutf__convert_utf32_to_utf16be(input.ptr, input.len, output.ptr);
                 }
             };
         };

--- a/src/bun.js/rare_data.zig
+++ b/src/bun.js/rare_data.zig
@@ -49,12 +49,23 @@ listening_sockets_for_watch_mode_lock: bun.Lock = .{},
 
 temp_pipe_read_buffer: ?*PipeReadBuffer = null,
 
+text_encoder_stream_buffer: ?*TextEncoderStreamBuffer = undefined,
+
+pub const TextEncoderStreamBuffer = [256 * 1024]u8;
+
 const PipeReadBuffer = [256 * 1024]u8;
 
 pub fn pipeReadBuffer(this: *RareData) *PipeReadBuffer {
     return this.temp_pipe_read_buffer orelse {
         this.temp_pipe_read_buffer = default_allocator.create(PipeReadBuffer) catch bun.outOfMemory();
         return this.temp_pipe_read_buffer.?;
+    };
+}
+
+pub fn textEncoderStreamBuffer(this: *RareData) *PipeReadBuffer {
+    return this.text_encoder_stream_buffer orelse {
+        this.text_encoder_stream_buffer = default_allocator.create(TextEncoderStreamBuffer) catch bun.outOfMemory();
+        return this.text_encoder_stream_buffer.?;
     };
 }
 

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -577,7 +577,7 @@ pub const TextEncoderStreamEncoder = struct {
 
         bun.debugAssert(remain.len != 0);
 
-        const max_length = (remain.len * 3) + prepend.len;
+        const max_length = ((remain.len + 1) * 3) + prepend.len;
 
         const buf = bun.default_allocator.alloc(u8, max_length) catch {
             globalObject.throwOutOfMemory();

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -539,7 +539,7 @@ pub const TextEncoderStreamEncoder = struct {
 
                     remain = remain[1..];
                     if (remain.len == 0) {
-                        return ArrayBuffer.createBuffer(
+                        return ArrayBuffer.createUint8Array(
                             globalObject,
                             sequence[0..converted.utf8Width()],
                         );
@@ -568,7 +568,7 @@ pub const TextEncoderStreamEncoder = struct {
                     return .undefined;
                 }
 
-                return ArrayBuffer.createBuffer(
+                return ArrayBuffer.createUint8Array(
                     globalObject,
                     prepend.bytes[0..prepend.len],
                 );
@@ -654,7 +654,7 @@ pub const TextEncoderStreamEncoder = struct {
         return if (this.pending_lead_surrogate == null)
             .undefined
         else
-            JSC.ArrayBuffer.createBuffer(globalObject, &.{ 0xef, 0xbf, 0xbd });
+            JSC.ArrayBuffer.createUint8Array(globalObject, &.{ 0xef, 0xbf, 0xbd });
     }
 };
 

--- a/src/glob.zig
+++ b/src/glob.zig
@@ -1039,7 +1039,7 @@ pub fn GlobWalker_(
         }
 
         pub fn convertUtf8ToCodepoints(codepoints: []u32, pattern: []const u8) void {
-            _ = bun.simdutf.convert.utf8.to.utf32.le(pattern, codepoints);
+            _ = bun.simdutf.convert.valid.utf8.to.utf32(pattern, codepoints);
         }
 
         pub fn debugPatternComopnents(this: *GlobWalker) void {


### PR DESCRIPTION
### What does this PR do?
- Excludes pending surrogates from simdutf conversion, avoiding errors with valid input
- Does not get the length. First over allocates, then resizes
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Existing tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
