### PR TITLE
fix(sockets) fix connecting sockets not reporting close when context or the socket it self is closed manually

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -130,9 +130,9 @@ void us_internal_socket_context_unlink_connecting_socket(int ssl, struct us_sock
         context->head_connecting_sockets = 0;
     } else {
         if (c->prev_pending) {
-            c->prev_pending->next = c->next;
+            c->prev_pending->next_pending = c->next_pending;
         } else {
-            context->head_connecting_sockets = c->next;
+            context->head_connecting_sockets = c->next_pending;
         }
         if (c->next) {
             c->next->prev_pending = c->prev_pending;

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -134,8 +134,8 @@ void us_internal_socket_context_unlink_connecting_socket(int ssl, struct us_sock
         } else {
             context->head_connecting_sockets = c->next_pending;
         }
-        if (c->next) {
-            c->next->prev_pending = c->prev_pending;
+        if (c->next_pending) {
+            c->next_pending->prev_pending = c->prev_pending;
         }
     }
     us_socket_context_unref(ssl, context);

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -176,6 +176,7 @@ struct us_socket_t {
 struct us_connecting_socket_t {
     alignas(LIBUS_EXT_ALIGNMENT) struct addrinfo_request *addrinfo_req;
     struct us_socket_context_t *context;
+    // this is used to track all dns resolutions in this connection
     struct us_connecting_socket_t *next;
     struct us_socket_t *connecting_head;
     int options;
@@ -186,6 +187,9 @@ struct us_connecting_socket_t {
     uint16_t port;
     int error;
     struct addrinfo *addrinfo_head;
+    // this is used to track pending connecting sockets in the context
+    struct us_connecting_socket_t* next_pending;
+    struct us_connecting_socket_t* prev_pending;
 };
 
 struct us_wrapped_socket_context_t {
@@ -264,6 +268,7 @@ struct us_socket_context_t {
   unsigned char long_timestamp;
   struct us_socket_t *head_sockets;
   struct us_listen_socket_t *head_listen_sockets;
+  struct us_connecting_socket_t *head_connecting_sockets;
   struct us_socket_t *iterator;
   struct us_socket_context_t *prev, *next;
 
@@ -434,6 +439,9 @@ us_internal_ssl_socket_open(us_internal_ssl_socket_r s, int is_client,
                             char *ip, int ip_length);
 
 int us_raw_root_certs(struct us_cert_string_t **out);
+
+void us_internal_socket_context_unlink_connecting_socket(int ssl, struct us_socket_context_t *context, struct us_connecting_socket_t *c);
+void us_internal_socket_context_link_connecting_socket(int ssl, struct us_socket_context_t *context, struct us_connecting_socket_t *c);
 #endif
 
 #endif // INTERNAL_H


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
