### PR TITLE
Fix importing empty toml file at runtime

### DIFF
--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -1789,6 +1789,17 @@ pub const ModuleLoader = struct {
                 }
 
                 if (loader == .json or loader == .toml) {
+                    if (parse_result.empty) {
+                        return ResolvedSource{
+                            .allocator = null,
+                            .specifier = input_specifier,
+                            .source_url = input_specifier.createIfDifferent(path.text),
+                            .hash = 0,
+                            .jsvalue_for_export = JSC.JSValue.createEmptyObject(jsc_vm.global, 0),
+                            .tag = .exports_object,
+                        };
+                    }
+
                     return ResolvedSource{
                         .allocator = null,
                         .specifier = input_specifier,

--- a/test/js/bun/resolve/jsonc.test.ts
+++ b/test/js/bun/resolve/jsonc.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test";
+import { join } from "path";
+import { tempDirWithFiles } from "harness";
+test("empty jsonc - package.json", async () => {
+  const dir = tempDirWithFiles("jsonc", {
+    "package.json": ``,
+    "index.ts": `
+    import pkg from './package.json';
+    if (JSON.stringify(pkg) !== '{}') throw new Error('package.json should be empty');
+    `,
+  });
+  expect([join(dir, "index.ts")]).toRun();
+});
+
+test("empty jsonc - tsconfig.json", async () => {
+  const dir = tempDirWithFiles("jsonc", {
+    "tsconfig.json": ``,
+    "index.ts": `
+    import tsconfig from './tsconfig.json';
+    if (JSON.stringify(tsconfig) !== '{}') throw new Error('tsconfig.json should be empty');
+    `,
+  });
+  expect([join(dir, "index.ts")]).toRun();
+});

--- a/test/js/bun/resolve/toml/toml.test.js
+++ b/test/js/bun/resolve/toml/toml.test.js
@@ -1,5 +1,6 @@
 import { expect, it } from "bun:test";
 import tomlFromCustomTypeAttribute from "./toml-fixture.toml.txt" with { type: "toml" };
+import emptyToml from "./toml-empty.toml";
 
 function checkToml(toml) {
   expect(toml.framework).toBe("next");
@@ -34,4 +35,8 @@ it("via dynamic import with type attribute", async () => {
   delete require.cache[require.resolve("./toml-fixture.toml.txt")];
   const toml = (await import("./toml-fixture.toml.txt", { with: { type: "toml" } })).default;
   checkToml(toml);
+});
+
+it("empty via import statement", () => {
+  expect(emptyToml).toEqual({});
 });


### PR DESCRIPTION
### What does this PR do?

Fix importing empty toml file at runtime

Fixes https://github.com/oven-sh/bun/issues/13170

### How did you verify your code works?

There is a test