### PR TITLE
fix(node:http): use a unique FakeSocket per socketId. only fire conne…

### DIFF
--- a/src/bun.js/api/server.classes.ts
+++ b/src/bun.js/api/server.classes.ts
@@ -32,6 +32,10 @@ function generate(name) {
         fn: "doRequestIP",
         length: 1,
       },
+      requestSocketId: {
+        fn: "doRequestSocketId",
+        length: 1,
+      },
       port: {
         getter: "getPort",
       },


### PR DESCRIPTION
### What does this PR do?

- Partially Fixes https://github.com/oven-sh/bun/issues/13088

### Notes/Investigation

https://gist.github.com/billywhizz/ff5382889152d8f9d357a6de0c10fae1

### Description

- This PR, instead of creating a ```FakeSocket``` for every request, will surface the socketIdentifier to node:http module which will now only create a new ```FakeSocket``` for each socketIdentifier that doesn't exist in it's ```Map``` of active sockets. 
- The overhead is minimal for a local release build against current Bun release - ~1.5% on macos. this overhead may go away with a CI build?

### Questions/Issues

- we seem to have always created a new ```FakeSocket``` instance for **every** request. was this by design - for a particular reason - or just something we did to get over an issue? it obv. adds unnecessary overhead but also, in case of this memory leak, it is a big problem when the middleware is using each socket instance as the key into it's Map. apart from the memory leak, it means all their counts for requests per socket will be 1 maximum. 

```JavaScript
server.on('connection', (socket) => {
    console.log(`server.onconnection`);
    this.requestCountPerSocket.set(socket, 0);
    console.log(socket.constructor.name)
    socket.once('close', () => {
        console.log('socket.once.close')
        this.requestCountPerSocket.delete(socket)
    });
});
server.on('request', (req, res) => {
    this.requestCountPerSocket.set(req.socket, (this.requestCountPerSocket.get(req.socket) ?? 0) + 1);
    res.once('finish', () => {
        const pending = (this.requestCountPerSocket.get(req.socket) ?? 0) - 1;
        console.log(`response.onfinish ${pending}`)
        this.requestCountPerSocket.set(req.socket, pending);
        if (this.stopped && pending === 0) {
            console.log(`req.socket.end`)
            req.socket.end();
        }
    });
});
```

- In my PR i am creating a single ```FakeSocket``` per socketidentifier, which i have surfaced to JS, but i don't know if that will cause problems elsewhere - needs further testing.
- I am not sure how best to surface the close event for underlying sockets to the node:http module. any advice appreciated.

### TODO

- run existing tests
- add specific tests for this issue to ensure memleak is not happening
- handle and test with other kinds of sockets where ```FakeSocket``` is used
- handle the misidentification of the connection as a ```secureConnection```
- Surface/handle the socket close event in node:http module and fire the 'close' event to any listeners when it is received. without this, the middleware in question will keep existing sockets in it's internal map after they are closed, which is a memory leak, but obv. one that will happen at a much slower rate than currently given we don't now create a ```FakeSocket``` on every request.

### Other Notes

- after this change, we don't see the explosive memory growth and memory usage on macos is ~150MB compared to ~230 MB for node.js. RPS is ~68k RPS versus 23k RPS for node.js.
