### PR TITLE
fix(IPC) make IPC on windows compatible with node.js

### DIFF
--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1286,7 +1286,7 @@ pub fn spawnProcessPosix(
             .inherit => {
                 try actions.inherit(fileno);
             },
-            .ignore => {
+            .ipc, .ignore => {
                 try actions.openZ(fileno, "/dev/null", flag | bun.O.CREAT, 0o664);
             },
             .path => |path| {
@@ -1405,7 +1405,7 @@ pub fn spawnProcessPosix(
             .path => |path| {
                 try actions.open(fileno, path, bun.O.RDWR | bun.O.CREAT, 0o664);
             },
-            .buffer => {
+            .ipc, .buffer => {
                 const fds: [2]bun.FileDescriptor = brk: {
                     var fds_: [2]std.c.fd_t = undefined;
                     const rc = std.c.socketpair(std.posix.AF.UNIX, std.posix.SOCK.STREAM, 0, &fds_);

--- a/src/bun.js/api/bun/spawn/stdio.zig
+++ b/src/bun.js/api/bun/spawn/stdio.zig
@@ -27,6 +27,7 @@ pub const Stdio = union(enum) {
     array_buffer: JSC.ArrayBuffer.Strong,
     memfd: bun.FileDescriptor,
     pipe: void,
+    ipc: void,
 
     const log = bun.sys.syslog;
 
@@ -197,6 +198,7 @@ pub const Stdio = union(enum) {
                 },
                 .dup2 => .{ .dup2 = .{ .out = stdio.dup2.out, .to = stdio.dup2.to } },
                 .capture, .pipe, .array_buffer => .{ .buffer = {} },
+                .ipc => .{ .ipc = {} },
                 .fd => |fd| .{ .pipe = fd },
                 .memfd => |fd| .{ .pipe = fd },
                 .path => |pathlike| .{ .path = pathlike.slice() },
@@ -248,6 +250,7 @@ pub const Stdio = union(enum) {
 
                     break :brk .{ .buffer = bun.default_allocator.create(uv.Pipe) catch bun.outOfMemory() };
                 },
+                .ipc => .{ .ipc = bun.default_allocator.create(uv.Pipe) catch bun.outOfMemory() },
                 .capture, .pipe, .array_buffer => .{ .buffer = bun.default_allocator.create(uv.Pipe) catch bun.outOfMemory() },
                 .fd => |fd| .{ .pipe = fd },
                 .dup2 => .{ .dup2 = .{ .out = stdio.dup2.out, .to = stdio.dup2.to } },
@@ -282,6 +285,7 @@ pub const Stdio = union(enum) {
     pub fn isPiped(self: Stdio) bool {
         return switch (self) {
             .capture, .array_buffer, .blob, .pipe => true,
+            .ipc => Environment.isWindows,
             else => false,
         };
     }
@@ -312,7 +316,7 @@ pub const Stdio = union(enum) {
             } else if (str.eqlComptime("pipe") or str.eqlComptime("overlapped")) {
                 out_stdio.* = Stdio{ .pipe = {} };
             } else if (str.eqlComptime("ipc")) {
-                out_stdio.* = Stdio{ .pipe = {} }; // TODO:
+                out_stdio.* = Stdio{ .ipc = {} };
             } else {
                 globalThis.throwInvalidArguments("stdio must be an array of 'inherit', 'pipe', 'ignore', Bun.file(pathOrFd), number, or null", .{});
                 return false;

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -2155,6 +2155,7 @@ pub const Subprocess = struct {
                     return .zero;
                 }
             }
+            ipc_data.writeVersionPacket();
         }
 
         if (subprocess.stdin == .pipe) {

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -433,11 +433,9 @@ pub const Subprocess = struct {
             if (Environment.isWindows) {
                 return switch (stdio) {
                     .inherit => Readable{ .inherit = {} },
-                    .ignore => Readable{ .ignore = {} },
-                    .path => Readable{ .ignore = {} },
+                    .ignore, .ipc, .path, .memfd => Readable{ .ignore = {} },
                     .fd => |fd| Readable{ .fd = fd },
                     .dup2 => |dup2| Readable{ .fd = dup2.out.toFd() },
-                    .memfd => Readable{ .ignore = {} },
                     .pipe => Readable{ .pipe = PipeReader.create(event_loop, process, result) },
                     .array_buffer, .blob => Output.panic("TODO: implement ArrayBuffer & Blob support in Stdio readable", .{}),
                     .capture => Output.panic("TODO: implement capture support in Stdio readable", .{}),
@@ -452,8 +450,7 @@ pub const Subprocess = struct {
 
             return switch (stdio) {
                 .inherit => Readable{ .inherit = {} },
-                .ignore => Readable{ .ignore = {} },
-                .path => Readable{ .ignore = {} },
+                .ignore, .ipc, .path => Readable{ .ignore = {} },
                 .fd => Readable{ .fd = result.? },
                 .memfd => Readable{ .memfd = stdio.memfd },
                 .pipe => Readable{ .pipe = PipeReader.create(event_loop, process, result) },
@@ -1264,7 +1261,7 @@ pub const Subprocess = struct {
                     .memfd, .path, .ignore => {
                         return Writable{ .ignore = {} };
                     },
-                    .capture => {
+                    .ipc, .capture => {
                         return Writable{ .ignore = {} };
                     },
                 }
@@ -1323,7 +1320,7 @@ pub const Subprocess = struct {
                 .path, .ignore => {
                     return Writable{ .ignore = {} };
                 },
-                .capture => {
+                .ipc, .capture => {
                     return Writable{ .ignore = {} };
                 },
             }
@@ -1667,6 +1664,7 @@ pub const Subprocess = struct {
         var ipc_callback: JSValue = .zero;
         var extra_fds = std.ArrayList(bun.spawn.SpawnOptions.Stdio).init(bun.default_allocator);
         var argv0: ?[*:0]const u8 = null;
+        var ipc_channel: i32 = -1;
 
         var windows_hide: bool = false;
         var windows_verbatim_arguments: bool = false;
@@ -1799,13 +1797,6 @@ pub const Subprocess = struct {
                             };
 
                             ipc_callback = val.withAsyncContextIfNeeded(globalThis);
-
-                            if (Environment.isPosix) {
-                                extra_fds.append(.{ .buffer = {} }) catch {
-                                    globalThis.throwOutOfMemory();
-                                    return .zero;
-                                };
-                            }
                         }
                     }
                 }
@@ -1848,7 +1839,6 @@ pub const Subprocess = struct {
                     };
                     env_array = envp_managed.moveToUnmanaged();
                 }
-
                 if (args.get(globalThis, "stdio")) |stdio_val| {
                     if (!stdio_val.isEmptyOrUndefinedOrNull()) {
                         if (stdio_val.jsType().isArray()) {
@@ -1874,6 +1864,9 @@ pub const Subprocess = struct {
                                         return e.throwJS(globalThis);
                                     },
                                 };
+                                if (opt == .ipc) {
+                                    ipc_channel = @intCast(extra_fds.items.len);
+                                }
                                 extra_fds.append(opt) catch {
                                     globalThis.throwOutOfMemory();
                                     return .zero;
@@ -1954,8 +1947,8 @@ pub const Subprocess = struct {
                 }
             }
         }
-
-        var windows_ipc_env_buf: if (Environment.isWindows) ["NODE_CHANNEL_FD=\\\\.\\pipe\\BUN_IPC_00000000-0000-0000-0000-000000000000\x00".len]u8 else void = undefined;
+        //"NODE_CHANNEL_FD=" is 16 bytes long, 15 bytes for the number, and 1 byte for the null terminator should be enough/safe
+        var ipc_env_buf: [32]u8 = undefined;
         if (!is_sync) if (maybe_ipc_mode) |ipc_mode| {
             // IPC is currently implemented in a very limited way.
             //
@@ -1964,25 +1957,42 @@ pub const Subprocess = struct {
             //
             // Bun currently only supports three fds: stdin, stdout, and stderr, which are all unidirectional
             //
-            // And then fd 3 is assigned specifically and only for IPC. This is quite lame, because Node.js allows
-            // the ipc fd to be any number and it just works. But most people only care about the default `.fork()`
-            // behavior, where this workaround suffices.
+            // And then one fd is assigned specifically and only for IPC. If the user dont specify it, we add one (default: 3).
             //
             // When Bun.spawn() is given an `.ipc` callback, it enables IPC as follows:
             env_array.ensureUnusedCapacity(allocator, 3) catch |err| return globalThis.handleError(err, "in Bun.spawn");
-            if (Environment.isPosix) {
-                env_array.appendAssumeCapacity("NODE_CHANNEL_FD=3");
-            } else {
-                const uuid = globalThis.bunVM().rareData().nextUUID();
-                const pipe_env = std.fmt.bufPrintZ(
-                    &windows_ipc_env_buf,
-                    "NODE_CHANNEL_FD=\\\\.\\pipe\\BUN_IPC_{s}",
-                    .{uuid},
-                ) catch |err| switch (err) {
-                    error.NoSpaceLeft => unreachable, // upper bound for this string is known
-                };
-                env_array.appendAssumeCapacity(pipe_env);
-            }
+            const ipc_fd: u32 = brk: {
+                if (ipc_channel == -1) {
+                    // If the user didn't specify an IPC channel, we need to add one
+                    ipc_channel = @intCast(extra_fds.items.len);
+                    var ipc_extra_fd_default = Stdio{ .ipc = {} };
+                    const fd: u32 = @intCast(ipc_channel + 3);
+                    switch (ipc_extra_fd_default.asSpawnOption(fd)) {
+                        .result => |opt| {
+                            extra_fds.append(opt) catch {
+                                globalThis.throwOutOfMemory();
+                                return .zero;
+                            };
+                        },
+                        .err => |e| {
+                            return e.throwJS(globalThis);
+                        },
+                    }
+                    break :brk fd;
+                } else {
+                    break :brk @intCast(ipc_channel + 3);
+                }
+            };
+
+            const pipe_env = std.fmt.bufPrintZ(
+                &ipc_env_buf,
+                "NODE_CHANNEL_FD={d}",
+                .{ipc_fd},
+            ) catch {
+                globalThis.throwOutOfMemory();
+                return .zero;
+            };
+            env_array.appendAssumeCapacity(pipe_env);
 
             env_array.appendAssumeCapacity(switch (ipc_mode) {
                 inline else => |t| "NODE_CHANNEL_SERIALIZATION_MODE=" ++ @tagName(t),
@@ -2063,7 +2073,7 @@ pub const Subprocess = struct {
                     uws.us_socket_from_fd(
                         jsc_vm.rareData().spawnIPCContext(jsc_vm),
                         @sizeOf(*Subprocess),
-                        spawned.extra_pipes.items[0].cast(),
+                        spawned.extra_pipes.items[@intCast(ipc_channel)].cast(),
                     ) orelse {
                         process_allocator.destroy(subprocess);
                         spawn_options.deinit();
@@ -2138,14 +2148,13 @@ pub const Subprocess = struct {
                 if (ipc_data.configureServer(
                     Subprocess,
                     subprocess,
-                    windows_ipc_env_buf["NODE_CHANNEL_FD=".len..],
+                    subprocess.stdio_pipes.items[@intCast(ipc_channel)].buffer,
                 ).asErr()) |err| {
                     process_allocator.destroy(subprocess);
                     globalThis.throwValue(err.toJSC(globalThis));
                     return .zero;
                 }
             }
-            ipc_data.writeVersionPacket();
         }
 
         if (subprocess.stdin == .pipe) {

--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -392,43 +392,54 @@ const NamedPipeIPCData = struct {
         }
     }
 
-    pub fn configureServer(this: *NamedPipeIPCData, comptime Context: type, instance: *Context, named_pipe: []const u8) JSC.Maybe(void) {
+    pub fn configureServer(this: *NamedPipeIPCData, comptime Context: type, instance: *Context, ipc_pipe: *uv.Pipe) JSC.Maybe(void) {
         log("configureServer", .{});
-        const ipc_pipe = bun.default_allocator.create(uv.Pipe) catch bun.outOfMemory();
         this.server = ipc_pipe;
-        ipc_pipe.data = this;
-        if (ipc_pipe.init(uv.Loop.get(), false).asErr()) |err| {
-            bun.default_allocator.destroy(ipc_pipe);
-            this.server = null;
-            return .{ .err = err };
-        }
         ipc_pipe.data = @ptrCast(instance);
         this.onClose = .{
             .callback = @ptrCast(&NewNamedPipeIPCHandler(Context).onClose),
             .context = @ptrCast(instance),
         };
-        if (ipc_pipe.listenNamedPipe(named_pipe, 0, instance, NewNamedPipeIPCHandler(Context).onNewClientConnect).asErr()) |err| {
-            bun.default_allocator.destroy(ipc_pipe);
-            this.server = null;
-            return .{ .err = err };
-        }
-
+        this.connected = true;
         ipc_pipe.setPendingInstancesCount(1);
-
         ipc_pipe.unref();
 
+        const startPipeResult = this.writer.startWithPipe(ipc_pipe);
+        if (startPipeResult == .err) {
+            this.close();
+            return startPipeResult;
+        }
+
+        const stream = this.writer.getStream() orelse {
+            this.close();
+            return JSC.Maybe(void).errno(bun.C.E.PIPE, .pipe);
+        };
+
+        const readStartResult = stream.readStart(instance, NewNamedPipeIPCHandler(Context).onReadAlloc, NewNamedPipeIPCHandler(Context).onReadError, NewNamedPipeIPCHandler(Context).onRead);
+        if (readStartResult == .err) {
+            this.close();
+            return readStartResult;
+        }
+        this.writeVersionPacket();
+        _ = this.writer.flush();
         return .{ .result = {} };
     }
 
-    pub fn configureClient(this: *NamedPipeIPCData, comptime Context: type, instance: *Context, named_pipe: []const u8) !void {
+    pub fn configureClient(this: *NamedPipeIPCData, comptime Context: type, instance: *Context, pipe_fd: bun.FileDescriptor) !void {
         log("configureClient", .{});
         const ipc_pipe = bun.default_allocator.create(uv.Pipe) catch bun.outOfMemory();
         ipc_pipe.init(uv.Loop.get(), true).unwrap() catch |err| {
             bun.default_allocator.destroy(ipc_pipe);
             return err;
         };
-        this.writer.startWithPipe(ipc_pipe).unwrap() catch |err| {
+        ipc_pipe.open(pipe_fd).unwrap() catch |err| {
             bun.default_allocator.destroy(ipc_pipe);
+            return err;
+        };
+        this.connected = true;
+
+        this.writer.startWithPipe(ipc_pipe).unwrap() catch |err| {
+            this.close();
             return err;
         };
         this.connect_req.data = @ptrCast(instance);
@@ -436,7 +447,19 @@ const NamedPipeIPCData = struct {
             .callback = @ptrCast(&NewNamedPipeIPCHandler(Context).onClose),
             .context = @ptrCast(instance),
         };
-        try ipc_pipe.connect(&this.connect_req, named_pipe, instance, NewNamedPipeIPCHandler(Context).onConnect).unwrap();
+
+        const stream = this.writer.getStream() orelse {
+            this.close();
+            return error.FailedToConnectIPC;
+        };
+
+        stream.readStart(instance, NewNamedPipeIPCHandler(Context).onReadAlloc, NewNamedPipeIPCHandler(Context).onReadError, NewNamedPipeIPCHandler(Context).onRead).unwrap() catch |err| {
+            this.close();
+            return err;
+        };
+        this.writeVersionPacket();
+
+        _ = this.writer.flush();
     }
 
     fn deinit(this: *NamedPipeIPCData) void {
@@ -719,30 +742,6 @@ fn NewNamedPipeIPCHandler(comptime Context: type) type {
 
         pub fn onClose(this: *Context) void {
             this.handleIPCClose();
-        }
-
-        fn onConnect(this: *Context, status: uv.ReturnCode) void {
-            const ipc = this.ipc();
-
-            log("onConnect {d}", .{status.int()});
-            ipc.connected = true;
-
-            if (status.errEnum()) |_| {
-                Output.printErrorln("Failed to connect IPC pipe", .{});
-                return;
-            }
-            const stream = ipc.writer.getStream() orelse {
-                ipc.close();
-                Output.printErrorln("Failed to connect IPC pipe", .{});
-                return;
-            };
-
-            stream.readStart(this, onReadAlloc, onReadError, onRead).unwrap() catch {
-                ipc.close();
-                Output.printErrorln("Failed to connect IPC pipe", .{});
-                return;
-            };
-            _ = ipc.writer.flush();
         }
     };
 }

--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -401,7 +401,6 @@ const NamedPipeIPCData = struct {
             .context = @ptrCast(instance),
         };
         this.connected = true;
-        ipc_pipe.setPendingInstancesCount(1);
         ipc_pipe.unref();
 
         const startPipeResult = this.writer.startWithPipe(ipc_pipe);
@@ -420,8 +419,6 @@ const NamedPipeIPCData = struct {
             this.close();
             return readStartResult;
         }
-        this.writeVersionPacket();
-        _ = this.writer.flush();
         return .{ .result = {} };
     }
 
@@ -436,6 +433,7 @@ const NamedPipeIPCData = struct {
             bun.default_allocator.destroy(ipc_pipe);
             return err;
         };
+        ipc_pipe.unref();
         this.connected = true;
 
         this.writer.startWithPipe(ipc_pipe).unwrap() catch |err| {
@@ -457,9 +455,6 @@ const NamedPipeIPCData = struct {
             this.close();
             return err;
         };
-        this.writeVersionPacket();
-
-        _ = this.writer.flush();
     }
 
     fn deinit(this: *NamedPipeIPCData) void {

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -1304,8 +1304,9 @@ pub const Pipe = extern struct {
         return .{ .result = {} };
     }
 
-    pub fn open(this: *Pipe, file: uv_file) Maybe(void) {
-        if (uv_pipe_open(this, file).toError(.open)) |err| return .{ .err = err };
+    pub fn open(this: *Pipe, file: bun.FileDescriptor) Maybe(void) {
+        const uv_fd = bun.uvfdcast(file);
+        if (uv_pipe_open(this, uv_fd).toError(.open)) |err| return .{ .err = err };
 
         return .{ .result = {} };
     }

--- a/src/io/source.zig
+++ b/src/io/source.zig
@@ -113,9 +113,7 @@ pub const Source = union(enum) {
             else => {},
         }
 
-        const file_fd = bun.uvfdcast(fd);
-
-        return switch (pipe.open(file_fd)) {
+        return switch (pipe.open(fd)) {
             .err => |err| .{
                 .err = err,
             },

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -202,7 +202,7 @@ pub const ShellSubprocess = struct {
                     .memfd, .path, .ignore => {
                         return Writable{ .ignore = {} };
                     },
-                    .capture => {
+                    .ipc, .capture => {
                         return Writable{ .ignore = {} };
                     },
                 }
@@ -240,7 +240,7 @@ pub const ShellSubprocess = struct {
                 .path, .ignore => {
                     return Writable{ .ignore = {} };
                 },
-                .capture => {
+                .ipc, .capture => {
                     return Writable{ .ignore = {} };
                 },
             }
@@ -375,7 +375,7 @@ pub const ShellSubprocess = struct {
             if (Environment.isWindows) {
                 return switch (stdio) {
                     .inherit => Readable{ .inherit = {} },
-                    .dup2, .ignore => Readable{ .ignore = {} },
+                    .ipc, .dup2, .ignore => Readable{ .ignore = {} },
                     .path => Readable{ .ignore = {} },
                     .fd => |fd| Readable{ .fd = fd },
                     // blobs are immutable, so we should only ever get the case
@@ -396,7 +396,7 @@ pub const ShellSubprocess = struct {
 
             return switch (stdio) {
                 .inherit => Readable{ .inherit = {} },
-                .dup2, .ignore => Readable{ .ignore = {} },
+                .ipc, .dup2, .ignore => Readable{ .ignore = {} },
                 .path => Readable{ .ignore = {} },
                 .fd => Readable{ .fd = result.? },
                 // blobs are immutable, so we should only ever get the case


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Existing tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
