### PR TITLE
doc: minor typo fixes and cleanup

### DIFF
--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -156,7 +156,7 @@ Like the Bun runtime, the bundler supports an array of file types out of the box
 ---
 
 - `.js` `.jsx`, `.cjs` `.mjs` `.mts` `.cts` `.ts` `.tsx`
-- Uses Bun's built-in transpiler to parse the file and transpile TypeScript/JSX syntax to vanilla JavaScript. The bundler executes a set of default transforms including dead code elimination and tree shaking. At the moment Bun does not attempt to down-convert syntax; if you use recently ECMAScript syntax, that will be reflected in the bundled code.
+- Uses Bun's built-in transpiler to parse the file and transpile TypeScript/JSX syntax to vanilla JavaScript. The bundler executes a set of default transforms including dead code elimination and tree shaking. At the moment Bun does not attempt to down-convert syntax; if you use recent ECMAScript syntax, that will be reflected in the bundled code.
 
 ---
 
@@ -608,6 +608,8 @@ Generated bundles contain a [debug id](https://sentry.engineering/blog/the-case-
 //# debugId=<DEBUG ID>
 ```
 
+{% /callout %}
+
 ---
 
 - `"inline"`
@@ -620,8 +622,6 @@ Generated bundles contain a [debug id](https://sentry.engineering/blog/the-case-
   ```
 
   The associated `*.js.map` sourcemap will be a JSON file containing an equivalent `debugId` property.
-
-{% /callout %}
 
 ### `minify`
 

--- a/docs/bundler/vs-esbuild.md
+++ b/docs/bundler/vs-esbuild.md
@@ -78,13 +78,11 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 - `--minify`
 - `--minify`
-- No differences
 
 ---
 
 - `--outdir`
 - `--outdir`
-- No differences
 
 ---
 
@@ -95,7 +93,6 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 - `--packages`
 - `--packages`
-- No differences
 
 ---
 
@@ -113,25 +110,22 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 - `--sourcemap`
 - `--sourcemap`
-- No differences
 
 ---
 
 - `--splitting`
 - `--splitting`
-- No differences
 
 ---
 
 - `--target`
 - n/a
-- No supported. Bun's bundler performs no syntactic down-leveling at this time.
+- Not supported. Bun's bundler performs no syntactic down-leveling at this time.
 
 ---
 
 - `--watch`
 - `--watch`
-- No differences
 
 ---
 
@@ -392,7 +386,6 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 - `--sourcemap`
 - `--sourcemap`
-- No differences
 
 ---
 
@@ -552,7 +545,6 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 - `external`
 - `external`
-- No differences
 
 ---
 
@@ -750,13 +742,11 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 - `outdir`
 - `outdir`
-- No differences
 
 ---
 
 - `outfile`
 - `outfile`
-- No differences
 
 ---
 
@@ -786,7 +776,6 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 - `publicPath`
 - `publicPath`
-- No differences
 
 ---
 
@@ -828,7 +817,6 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 - `splitting`
 - `splitting`
-- No differences
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

- Fixes in `docs/bundler/index.md`:
  - Typo fix: "if you use recently ECMAScript syntax" -> "if you use recent ECMAScript syntax"
  - Moved a `{% /callout %}` to only contain content that should be inside the callout
- Fixes in `docs/bundler/vs-esbuild.md`:
  - Removed "No differences" to be consistent with other options that don't list any notes. This looks cleaner than putting "No differences" everywhere.
  - Typo fix: "No supported." -> "Not supported."

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

No code changes were made.
