### PR TITLE
fix(expect) fix behavior of .not.throw when receiving a string

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -2390,6 +2390,7 @@ pub const Expect = struct {
                     JSValue.fromCell(js_str)
                 else
                     .undefined) orelse .undefined;
+                if (globalThis.hasException()) return .zero;
 
                 // TODO: remove this allocation
                 // partial match
@@ -2415,6 +2416,8 @@ pub const Expect = struct {
                     JSValue.fromCell(js_str)
                 else
                     .undefined) orelse .undefined;
+
+                if (globalThis.hasException()) return .zero;
                 // TODO: REMOVE THIS GETTER! Expose a binding to call .test on the RegExp object directly.
                 if (expected_value.get(globalThis, "test")) |test_fn| {
                     const matches = test_fn.call(globalThis, expected_value, &.{received_message});
@@ -2435,6 +2438,8 @@ pub const Expect = struct {
                     JSValue.fromCell(js_str)
                 else
                     .undefined) orelse .undefined;
+                if (globalThis.hasException()) return .zero;
+
                 // no partial match for this case
                 if (!expected_message.isSameValue(received_message, globalThis)) return .undefined;
 

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -2396,7 +2396,7 @@ pub const Expect = struct {
                 {
                     const expected_slice = expected_value.toSliceOrNull(globalThis) orelse return .zero;
                     defer expected_slice.deinit();
-                    const received_slice = received_message.toSlice(globalThis) orelse return .zero;
+                    const received_slice = received_message.toSliceOrNull(globalThis) orelse return .zero;
                     defer received_slice.deinit();
                     if (!strings.contains(received_slice.slice(), expected_slice.slice())) return .undefined;
                 }

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -2384,14 +2384,19 @@ pub const Expect = struct {
             }
 
             if (expected_value.isString()) {
-                const received_message = result.fastGet(globalThis, .message) orelse .undefined;
+                const received_message: JSValue = (if (result.isObject())
+                    result.fastGet(globalThis, .message)
+                else if (result.toStringOrNull(globalThis)) |js_str|
+                    JSValue.fromCell(js_str)
+                else
+                    .undefined) orelse .undefined;
 
                 // TODO: remove this allocation
                 // partial match
                 {
                     const expected_slice = expected_value.toSliceOrNull(globalThis) orelse return .zero;
                     defer expected_slice.deinit();
-                    const received_slice = received_message.toSliceOrNull(globalThis) orelse return .zero;
+                    const received_slice = received_message.toSlice(globalThis) orelse return .zero;
                     defer received_slice.deinit();
                     if (!strings.contains(received_slice.slice(), expected_slice.slice())) return .undefined;
                 }
@@ -2404,8 +2409,12 @@ pub const Expect = struct {
             }
 
             if (expected_value.isRegExp()) {
-                const received_message = result.fastGet(globalThis, .message) orelse .undefined;
-
+                const received_message: JSValue = (if (result.isObject())
+                    result.fastGet(globalThis, .message)
+                else if (result.toStringOrNull(globalThis)) |js_str|
+                    JSValue.fromCell(js_str)
+                else
+                    .undefined) orelse .undefined;
                 // TODO: REMOVE THIS GETTER! Expose a binding to call .test on the RegExp object directly.
                 if (expected_value.get(globalThis, "test")) |test_fn| {
                     const matches = test_fn.call(globalThis, expected_value, &.{received_message});
@@ -2420,7 +2429,12 @@ pub const Expect = struct {
             }
 
             if (expected_value.fastGet(globalThis, .message)) |expected_message| {
-                const received_message = result.fastGet(globalThis, .message) orelse .undefined;
+                const received_message: JSValue = (if (result.isObject())
+                    result.fastGet(globalThis, .message)
+                else if (result.toStringOrNull(globalThis)) |js_str|
+                    JSValue.fromCell(js_str)
+                else
+                    .undefined) orelse .undefined;
                 // no partial match for this case
                 if (!expected_message.isSameValue(received_message, globalThis)) return .undefined;
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4671,6 +4671,25 @@ describe("expect()", () => {
   test(' " " to contain ""', () => {
     expect(" ").toContain("");
   });
+
+  test("should work #13267", () => {
+    try {
+      expect(() => {
+        throw "!";
+      }).not.toThrow(/ball/);
+    } catch (e) {
+      expect(e).toBeUndefined();
+    }
+    try {
+      expect(() => {
+        throw "ball";
+      }).not.toThrow(/ball/);
+    } catch (e) {
+      expect(e).toBeDefined();
+      expect(e.message).toContain("Received message: ");
+      expect(e.message).toContain('"ball"');
+    }
+  });
 });
 
 function tmpFile(exists) {


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/13267
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
