### PR TITLE
Fix "bun exec" examples

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2389,8 +2389,8 @@ pub const Command = struct {
                         \\<b><red>Note<r>: If executing this from a shell, make sure to escape the string!
                         \\
                         \\<b>Examples<d>:<r>
-                        \\  <b>bunx exec "echo hi"<r>
-                        \\  <b>bunx exec "echo \"hey friends\"!"<r>
+                        \\  <b>bun exec "echo hi"<r>
+                        \\  <b>bun exec "echo \"hey friends\"!"<r>
                         \\
                     , .{});
                     Output.flush();

--- a/test/js/bun/shell/exec.test.ts
+++ b/test/js/bun/shell/exec.test.ts
@@ -19,7 +19,7 @@ describe("bun exec", () => {
   TestBuilder.command`${BUN} exec`
     .env(bunEnv)
     .stdout(
-      'Usage: bun exec <script>\n\nExecute a shell script directly from Bun.\n\nNote: If executing this from a shell, make sure to escape the string!\n\nExamples:\n  bunx exec "echo hi"\n  bunx exec "echo \\"hey friends\\"!"\n',
+      'Usage: bun exec <script>\n\nExecute a shell script directly from Bun.\n\nNote: If executing this from a shell, make sure to escape the string!\n\nExamples:\n  bun exec "echo hi"\n  bun exec "echo \\"hey friends\\"!"\n',
     )
     .runAsTest("no args prints help text");
 


### PR DESCRIPTION
### What does this PR do?

Not much, just fixed examples in `bun exec` output when run without args.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes