### PR TITLE
Micro-optimize `Module._resolveFilename`

### DIFF
--- a/src/bun.js/bindings/CommonJSModuleRecord.h
+++ b/src/bun.js/bindings/CommonJSModuleRecord.h
@@ -1,7 +1,8 @@
 #pragma once
+#include "root.h"
+
 #include "JavaScriptCore/JSGlobalObject.h"
 #include "JavaScriptCore/JSString.h"
-#include "root.h"
 #include "headers-handwritten.h"
 #include "wtf/NakedPtr.h"
 

--- a/src/bun.js/bindings/ImportMetaObject.cpp
+++ b/src/bun.js/bindings/ImportMetaObject.cpp
@@ -102,7 +102,7 @@ static JSC::EncodedJSValue functionRequireResolve(JSC::JSGlobalObject* globalObj
             // require.resolve also supports a paths array
             // we only support a single path
             if (!fromValue.isUndefinedOrNull() && fromValue.isObject()) {
-                if (auto pathsObject = fromValue.getObject()->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, "paths"_s))) {
+                if (auto pathsObject = fromValue.getObject()->getIfPropertyExists(globalObject, builtinNames(vm).pathsPublicName())) {
                     if (pathsObject.isCell() && pathsObject.asCell()->type() == JSC::JSType::ArrayType) {
                         auto pathsArray = JSC::jsCast<JSC::JSArray*>(pathsObject);
                         if (pathsArray->length() > 0) {
@@ -209,7 +209,7 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSync(JSC::JSGlobalObje
 
         if (!fromValue.isUndefinedOrNull() && fromValue.isObject()) {
 
-            if (auto pathsObject = fromValue.getObject()->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, "paths"_s))) {
+            if (auto pathsObject = fromValue.getObject()->getIfPropertyExists(globalObject, builtinNames(vm).pathsPublicName())) {
                 if (pathsObject.isCell() && pathsObject.asCell()->type() == JSC::JSType::ArrayType) {
                     auto pathsArray = JSC::jsCast<JSC::JSArray*>(pathsObject);
                     if (pathsArray->length() > 0) {
@@ -358,7 +358,7 @@ JSC_DEFINE_HOST_FUNCTION(functionImportMeta__resolve,
         JSValue fromValue = callFrame->uncheckedArgument(1);
 
         if (!fromValue.isUndefinedOrNull() && fromValue.isObject()) {
-            if (JSValue pathsObject = fromValue.getObject()->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, "paths"_s))) {
+            if (JSValue pathsObject = fromValue.getObject()->getIfPropertyExists(globalObject, builtinNames(vm).pathsPublicName())) {
                 if (pathsObject.isCell() && pathsObject.asCell()->type() == JSC::JSType::ArrayType) {
                     auto* pathsArray = JSC::jsCast<JSC::JSArray*>(pathsObject);
                     if (pathsArray->length() > 0) {

--- a/src/bun.js/bindings/NodeVM.cpp
+++ b/src/bun.js/bindings/NodeVM.cpp
@@ -1,7 +1,7 @@
-
 #include "root.h"
 #include "JavaScriptCore/ExecutableInfo.h"
 
+#include "BunClientData.h"
 #include "NodeVM.h"
 #include "JavaScriptCore/JSObjectInlines.h"
 #include "wtf/text/ExternalStringImpl.h"
@@ -55,7 +55,7 @@ public:
             }
             JSObject* options = asObject(optionsArg);
 
-            if (JSValue filenameOpt = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "filename"_s))) {
+            if (JSValue filenameOpt = options->getIfPropertyExists(globalObject, builtinNames(vm).filenamePublicName())) {
                 if (filenameOpt.isString()) {
                     opts.filename = filenameOpt.toWTFString(globalObject);
                     any = true;

--- a/src/bun.js/modules/NodeModuleModule.h
+++ b/src/bun.js/modules/NodeModuleModule.h
@@ -334,6 +334,8 @@ struct Parent {
 
 Parent getParent(VM&vm, JSGlobalObject* global, JSValue maybe_parent) {
   Parent value { nullptr, nullptr };
+
+  if (!maybe_parent) {
     return value;
   }
   

--- a/src/bun.js/modules/NodeModuleModule.h
+++ b/src/bun.js/modules/NodeModuleModule.h
@@ -267,7 +267,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName, (JSC::JSGlobalObject * globa
         // weird thing.
         (fromValue.isObject()) {
 
-      if (auto idValue = fromValue.getObject()->getIfPropertyExists(globalObject, Identifier::fromString(vm, "filename"_s))) {
+      if (auto idValue = fromValue.getObject()->getIfPropertyExists(globalObject, builtinNames(vm).filenamePublicName())) {
         if (idValue.isString()) {
           fromValue = idValue;
         }
@@ -337,18 +337,21 @@ Parent getParent(VM&vm, JSGlobalObject* global, JSValue maybe_parent) {
   if (!maybe_parent.isCell()) {
     return value;
   }
-  if (!maybe_parent.isObject()) {
+  
+  auto parent = maybe_parent.getObject();
+  if (!parent) {
     return value;
   }
-  auto parent = maybe_parent.getObject();
+
   auto scope = DECLARE_THROW_SCOPE(vm);
-  JSValue paths = parent->get(global, Identifier::fromString(vm, "paths"_s));
+  const auto& builtinNames = Bun::builtinNames(vm);
+  JSValue paths = parent->get(global, builtinNames.pathsPublicName());
   RETURN_IF_EXCEPTION(scope, value);
   if (paths.isCell()) {
     value.paths = jsDynamicCast<JSArray*>(paths);
   }
 
-  JSValue filename = parent->get(global, Identifier::fromString(vm, "filename"_s));
+  JSValue filename = parent->get(global, builtinNames.filenamePublicName());
   RETURN_IF_EXCEPTION(scope, value);
   if (filename.isString()) {
     value.filename = filename.toString(global);
@@ -517,7 +520,7 @@ DEFINE_NATIVE_MODULE(NodeModule) {
   putNativeFn(Identifier::fromString(vm, "_resolveLookupPaths"_s), jsFunctionResolveLookupPaths);
 
   putNativeFn(Identifier::fromString(vm, "createRequire"_s), jsFunctionNodeModuleCreateRequire);
-  putNativeFn(Identifier::fromString(vm, "paths"_s), Resolver__nodeModulePathsForJS);
+  putNativeFn(builtinNames(vm).pathsPublicName(), Resolver__nodeModulePathsForJS);
   putNativeFn(Identifier::fromString(vm, "findSourceMap"_s), jsFunctionFindSourceMap);
   putNativeFn(Identifier::fromString(vm, "syncBuiltinExports"_s), jsFunctionSyncBuiltinExports);
   putNativeFn(Identifier::fromString(vm, "SourceMap"_s), jsFunctionSourceMap);

--- a/src/bun.js/modules/NodeModuleModule.h
+++ b/src/bun.js/modules/NodeModuleModule.h
@@ -334,7 +334,6 @@ struct Parent {
 
 Parent getParent(VM&vm, JSGlobalObject* global, JSValue maybe_parent) {
   Parent value { nullptr, nullptr };
-  if (!maybe_parent.isCell()) {
     return value;
   }
   

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -94,7 +94,7 @@ using namespace JSC;
     macro(fetch) \
     macro(fetchRequest) \
     macro(file) \
-    macro(filePath) \
+    macro(filename) \
     macro(fillFromJS) \
     macro(finishConsumingStream) \
     macro(flush) \
@@ -152,6 +152,7 @@ using namespace JSC;
     macro(password) \
     macro(patch) \
     macro(path) \
+    macro(paths) \
     macro(pathname) \
     macro(pause) \
     macro(pendingAbortRequest) \


### PR DESCRIPTION
### What does this PR do?

Add `"paths"` and `"filename"` to builtin identifiers to avoid a call to Identifier::fromString in a hot code path.

This is frequently used by Next.js.

### How did you verify your code works?

There should be no behavior changes