### PR TITLE
Support Unicode strings in V8 APIs

### DIFF
--- a/src/bun.js/bindings/v8/V8InternalFieldObject.h
+++ b/src/bun.js/bindings/v8/V8InternalFieldObject.h
@@ -10,32 +10,6 @@ public:
 
     DECLARE_INFO;
 
-    struct InternalField {
-        union {
-            JSC::JSValue js_value;
-            void* raw;
-        } data;
-        bool is_js_value;
-
-        InternalField(JSC::JSValue js_value)
-            : data({ .js_value = js_value })
-            , is_js_value(true)
-        {
-        }
-
-        InternalField(void* raw)
-            : data({ .raw = raw })
-            , is_js_value(false)
-        {
-        }
-
-        InternalField()
-            : data({ .js_value = JSC::jsUndefined() })
-            , is_js_value(true)
-        {
-        }
-    };
-
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {
@@ -49,7 +23,7 @@ public:
             [](auto& spaces, auto&& space) { spaces.m_subspaceForInternalFieldObject = std::forward<decltype(space)>(space); });
     }
 
-    using FieldContainer = WTF::Vector<InternalField, 2>;
+    using FieldContainer = WTF::Vector<JSC::JSValue, 2>;
 
     FieldContainer* internalFields() { return &fields; }
     static InternalFieldObject* create(JSC::VM& vm, JSC::Structure* structure, Local<ObjectTemplate> objectTemplate);

--- a/src/bun.js/bindings/v8/V8Object.cpp
+++ b/src/bun.js/bindings/v8/V8Object.cpp
@@ -62,10 +62,10 @@ Maybe<bool> Object::Set(Local<Context> context, Local<Value> key, Local<Value> v
 
 void Object::SetInternalField(int index, Local<Data> data)
 {
-    auto fields = getInternalFieldsContainer(this);
-    if (fields && index >= 0 && index < fields->size()) {
-        fields->at(index) = InternalFieldObject::InternalField(data->localToJSValue(Isolate::GetCurrent()->globalInternals()));
-    }
+    auto* fields = getInternalFieldsContainer(this);
+    RELEASE_ASSERT(fields, "object has no internal fields");
+    RELEASE_ASSERT(index >= 0 && index < fields->size(), "internal field index is out of bounds");
+    fields->at(index) = InternalFieldObject::InternalField(data->localToJSValue(Isolate::GetCurrent()->globalInternals()));
 }
 
 Local<Data> Object::GetInternalField(int index)
@@ -86,8 +86,7 @@ Local<Data> Object::SlowGetInternalField(int index)
             V8_UNIMPLEMENTED();
         }
     }
-    // TODO handle undefined/null the way v8 does
-    return Local<Data>();
+    return handleScope->createLocal<Data>(JSC::jsUndefined());
 }
 
 }

--- a/src/bun.js/bindings/v8/V8Object.cpp
+++ b/src/bun.js/bindings/v8/V8Object.cpp
@@ -65,7 +65,7 @@ void Object::SetInternalField(int index, Local<Data> data)
     auto* fields = getInternalFieldsContainer(this);
     RELEASE_ASSERT(fields, "object has no internal fields");
     RELEASE_ASSERT(index >= 0 && index < fields->size(), "internal field index is out of bounds");
-    fields->at(index) = InternalFieldObject::InternalField(data->localToJSValue(Isolate::GetCurrent()->globalInternals()));
+    fields->at(index) = data->localToJSValue(Isolate::GetCurrent()->globalInternals());
 }
 
 Local<Data> Object::GetInternalField(int index)
@@ -80,11 +80,7 @@ Local<Data> Object::SlowGetInternalField(int index)
     HandleScope* handleScope = Isolate::fromGlobalObject(JSC::jsDynamicCast<Zig::GlobalObject*>(js_object->globalObject()))->currentHandleScope();
     if (fields && index >= 0 && index < fields->size()) {
         auto& field = fields->at(index);
-        if (field.is_js_value) {
-            return handleScope->createLocal<Data>(field.data.js_value);
-        } else {
-            V8_UNIMPLEMENTED();
-        }
+        return handleScope->createLocal<Data>(field);
     }
     return handleScope->createLocal<Data>(JSC::jsUndefined());
 }

--- a/src/bun.js/bindings/v8/V8String.cpp
+++ b/src/bun.js/bindings/v8/V8String.cpp
@@ -3,7 +3,6 @@
 #include "V8HandleScope.h"
 
 using JSC::JSString;
-using JSC::JSValue;
 
 namespace v8 {
 
@@ -31,38 +30,40 @@ MaybeLocal<String> String::NewFromUtf8(Isolate* isolate, char const* data, NewSt
     return MaybeLocal<String>(isolate->globalInternals()->currentHandleScope()->createLocal<String>(jsString));
 }
 
+extern "C" size_t TextEncoder__encodeInto8(const LChar* stringPtr, size_t stringLen, void* ptr, size_t len);
+extern "C" size_t TextEncoder__encodeInto16(const UChar* stringPtr, size_t stringLen, void* ptr, size_t len);
+
 int String::WriteUtf8(Isolate* isolate, char* buffer, int length, int* nchars_ref, int options) const
 {
     RELEASE_ASSERT(options == 0);
     auto jsString = localToObjectPointer<JSString>();
     WTF::String string = jsString->getString(isolate->globalObject());
 
-    // TODO(@190n) handle 16 bit strings
-    if (!string.is8Bit()) {
-        V8_UNIMPLEMENTED();
-    }
-    auto span = string.span8();
+    size_t unsigned_length = length < 0 ? SIZE_MAX : length;
 
-    int to_copy = length;
-    bool terminate = true;
-    if (to_copy < 0) {
-        to_copy = span.size();
-    } else if (to_copy > span.size()) {
-        to_copy = span.size();
-    } else if (length < span.size()) {
-        to_copy = length;
-        terminate = false;
+    uint64_t result = string.is8Bit() ? TextEncoder__encodeInto8(string.span8().data(), string.span8().size(), buffer, unsigned_length)
+                                      : TextEncoder__encodeInto16(string.span16().data(), string.span16().size(), buffer, unsigned_length);
+    uint32_t read = static_cast<uint32_t>(result);
+    uint32_t written = static_cast<uint32_t>(result >> 32);
+
+    if (written < length && read == string.length()) {
+        buffer[written] = 0;
+        written++;
     }
-    // TODO(@190n) span.data() is latin1 not utf8, but this is okay as long as the only way to make
-    // a v8 string is NewFromUtf8. that's because NewFromUtf8 will use either all ASCII or all UTF-16.
-    memcpy(buffer, span.data(), to_copy);
-    if (terminate) {
-        buffer[to_copy] = 0;
+    if (read < string.length() && U16_IS_SURROGATE(string[read]) && written + 3 <= length) {
+        // encode unpaired surrogate
+        UChar surrogate = string[read];
+        buffer[written + 0] = 0xe0 | (surrogate >> 12);
+        buffer[written + 1] = 0x80 | ((surrogate >> 6) & 0x3f);
+        buffer[written + 2] = 0x80 | (surrogate & 0x3f);
+        written += 3;
+        read += 1;
     }
     if (nchars_ref) {
-        *nchars_ref = to_copy;
+        *nchars_ref = read;
     }
-    return terminate ? to_copy + 1 : to_copy;
+
+    return written;
 }
 
 int String::Length() const

--- a/src/bun.js/bindings/v8/V8String.h
+++ b/src/bun.js/bindings/v8/V8String.h
@@ -23,6 +23,13 @@ public:
     };
 
     BUN_EXPORT static MaybeLocal<String> NewFromUtf8(Isolate* isolate, char const* data, NewStringType type, int length = -1);
+
+    // length:     number of bytes in buffer (if negative, assume it is large enough)
+    // nchars_ref: store number of code units written here
+    // return:     number of bytes copied including null terminator
+    //
+    // if string ends in a surrogate pair, but buffer is one byte too small to store it, instead
+    // endcode the unpaired lead surrogate with WTF-8
     BUN_EXPORT int WriteUtf8(Isolate* isolate, char* buffer, int length = -1, int* nchars_ref = nullptr, int options = NO_OPTIONS) const;
     BUN_EXPORT int Length() const;
 

--- a/test/v8/v8-module/main.cpp
+++ b/test/v8/v8-module/main.cpp
@@ -295,6 +295,32 @@ void test_v8_string_invalid_utf8(const FunctionCallbackInfo<Value> &info) {
   perform_string_test(info, mixed_sequence, 9, 15, replaced_sequence);
 }
 
+void test_v8_string_write_utf8(const FunctionCallbackInfo<Value> &info) {
+  Isolate *isolate = info.GetIsolate();
+
+  const unsigned char utf8_data_unsigned[] = {
+      'h', 'i', 240, 159, 143, 179, 239, 184, 143,  226,  128, 141,
+      226, 154, 167, 239, 184, 143, 'h', 'i', 0xc3, 0xa9, 0};
+  const char *utf8_data = reinterpret_cast<const char *>(utf8_data_unsigned);
+
+  constexpr size_t buf_size = sizeof(utf8_data_unsigned) + 3;
+  char buf[buf_size] = {0};
+  Local<String> s = String::NewFromUtf8(isolate, utf8_data).ToLocalChecked();
+  for (int i = buf_size; i >= 0; i--) {
+    memset(buf, 0xaa, buf_size);
+    int nchars;
+    int retval = s->WriteUtf8(isolate, buf, i, &nchars);
+    printf("buffer size = %2d, nchars = %2d, returned = %2d, data =", i, nchars,
+           retval);
+    for (int j = 0; j < buf_size; j++) {
+      printf("%c%02x", j == i ? '|' : ' ',
+             reinterpret_cast<unsigned char *>(buf)[j]);
+    }
+    printf("\n");
+  }
+  return ok(info);
+}
+
 void test_v8_external(const FunctionCallbackInfo<Value> &info) {
   Isolate *isolate = info.GetIsolate();
   int x = 5;
@@ -446,6 +472,8 @@ void initialize(Local<Object> exports) {
   NODE_SET_METHOD(exports, "test_v8_string_utf8", test_v8_string_utf8);
   NODE_SET_METHOD(exports, "test_v8_string_invalid_utf8",
                   test_v8_string_invalid_utf8);
+  NODE_SET_METHOD(exports, "test_v8_string_write_utf8",
+                  test_v8_string_write_utf8);
   NODE_SET_METHOD(exports, "test_v8_external", test_v8_external);
   NODE_SET_METHOD(exports, "test_v8_object", test_v8_object);
   NODE_SET_METHOD(exports, "test_v8_array_new", test_v8_array_new);

--- a/test/v8/v8-module/main.cpp
+++ b/test/v8/v8-module/main.cpp
@@ -303,7 +303,7 @@ void test_v8_string_write_utf8(const FunctionCallbackInfo<Value> &info) {
       226, 154, 167, 239, 184, 143, 'h', 'i', 0xc3, 0xa9, 0};
   const char *utf8_data = reinterpret_cast<const char *>(utf8_data_unsigned);
 
-  constexpr size_t buf_size = sizeof(utf8_data_unsigned) + 3;
+  constexpr int buf_size = sizeof(utf8_data_unsigned) + 3;
   char buf[buf_size] = {0};
   Local<String> s = String::NewFromUtf8(isolate, utf8_data).ToLocalChecked();
   for (int i = buf_size; i >= 0; i--) {

--- a/test/v8/v8.test.ts
+++ b/test/v8/v8.test.ts
@@ -132,11 +132,16 @@ describe("String", () => {
     checkSameOutput("test_v8_string_ascii", []);
   });
   // non-ASCII strings are not implemented yet
-  it.skip("can create and read back strings with UTF-8 characters", () => {
+  it("can create and read back strings with UTF-8 characters", () => {
     checkSameOutput("test_v8_string_utf8", []);
   });
-  it.skip("handles replacement correctly in strings with invalid UTF-8 sequences", () => {
+  it("handles replacement correctly in strings with invalid UTF-8 sequences", () => {
     checkSameOutput("test_v8_string_invalid_utf8", []);
+  });
+  describe("WriteUtf8", () => {
+    it("truncates the string correctly", () => {
+      checkSameOutput("test_v8_string_write_utf8", []);
+    });
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

Adds support in v8::String::WriteUtf8 for converting UTF-16 strings into UTF-8.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests
