### PR TITLE
Support doubles in v8::Number

### DIFF
--- a/src/bun.js/bindings/v8/V8Data.h
+++ b/src/bun.js/bindings/v8/V8Data.h
@@ -55,8 +55,12 @@ public:
                 return JSC::jsBoolean(false);
             }
 
-            JSC::JSCell** v8_object = reinterpret_cast<JSC::JSCell**>(raw_ptr);
-            return JSC::JSValue(v8_object[1]);
+            ObjectLayout* v8_object = reinterpret_cast<ObjectLayout*>(raw_ptr);
+            if (v8_object->map.getPtr<Map>()->instance_type == InstanceType::HeapNumber) {
+                return JSC::jsNumber(*reinterpret_cast<double*>(&v8_object->ptr));
+            } else {
+                return JSC::JSValue(reinterpret_cast<JSC::JSCell*>(v8_object->ptr));
+            }
         }
     }
 

--- a/src/bun.js/bindings/v8/V8Data.h
+++ b/src/bun.js/bindings/v8/V8Data.h
@@ -57,7 +57,7 @@ public:
 
             ObjectLayout* v8_object = reinterpret_cast<ObjectLayout*>(raw_ptr);
             if (v8_object->map.getPtr<Map>()->instance_type == InstanceType::HeapNumber) {
-                return JSC::jsNumber(*reinterpret_cast<double*>(&v8_object->ptr));
+                return JSC::jsDoubleNumber(*reinterpret_cast<double*>(&v8_object->ptr));
             } else {
                 return JSC::JSValue(reinterpret_cast<JSC::JSCell*>(v8_object->ptr));
             }

--- a/src/bun.js/bindings/v8/V8Handle.h
+++ b/src/bun.js/bindings/v8/V8Handle.h
@@ -4,6 +4,12 @@
 
 namespace v8 {
 
+struct ObjectLayout {
+    // these two fields are laid out so that V8 can find the map
+    TaggedPointer map;
+    void* ptr;
+};
+
 // A handle stored in a HandleScope with layout suitable for V8's inlined functions:
 // - The first field is a V8 tagged pointer. If it's a SMI (int32), it holds the numeric value
 //   directly and the other fields don't matter.
@@ -19,9 +25,8 @@ namespace v8 {
 //   points to Map::object_map or Map::raw_ptr_map).
 struct Handle {
     Handle(const Map* map_, void* ptr_)
-        : to_v8_object(&this->map)
-        , map(const_cast<Map*>(map_))
-        , ptr(ptr_)
+        : to_v8_object(&this->object)
+        , object({ .map = const_cast<Map*>(map_), .ptr = ptr_ })
     {
     }
 
@@ -37,12 +42,12 @@ struct Handle {
 
     Handle& operator=(const Handle& that)
     {
-        map = that.map;
-        ptr = that.ptr;
+        object.map = that.object.map;
+        object.ptr = that.object.ptr;
         if (that.to_v8_object.type() == TaggedPointer::Type::Smi) {
             to_v8_object = that.to_v8_object;
         } else {
-            to_v8_object = &this->map;
+            to_v8_object = &this->object;
         }
         return *this;
     }
@@ -54,11 +59,12 @@ struct Handle {
         if (to_v8_object.type() == TaggedPointer::Type::Smi) {
             return false;
         }
-        const Map* map_ptr = map.getPtr<Map>();
+        const Map* map_ptr = object.map.getPtr<Map>();
+        // TODO(@190n) exhaustively switch on InstanceType
         if (map_ptr == &Map::object_map || map_ptr == &Map::string_map) {
             return true;
-        } else if (map_ptr == &Map::map_map || map_ptr == &Map::raw_ptr_map
-            || map_ptr == &Map::oddball_map || map_ptr == &Map::boolean_map) {
+        } else if (map_ptr == &Map::map_map || map_ptr == &Map::raw_ptr_map || map_ptr == &Map::oddball_map
+            || map_ptr == &Map::boolean_map || map_ptr == &Map::heap_number_map) {
             return false;
         } else {
             RELEASE_ASSERT_NOT_REACHED("unknown Map at %p with instance type %" PRIx16,
@@ -68,9 +74,7 @@ struct Handle {
 
     // if not SMI, holds &this->map so that V8 can see what kind of object this is
     TaggedPointer to_v8_object;
-    // these two fields are laid out so that V8 can find the map
-    TaggedPointer map;
-    void* ptr;
+    ObjectLayout object;
 };
 
 }

--- a/src/bun.js/bindings/v8/V8HandleScope.h
+++ b/src/bun.js/bindings/v8/V8HandleScope.h
@@ -24,6 +24,10 @@ public:
             return Local<T>(buffer->createHandle(value.asCell(), &Map::object_map));
         } else if (value.isInt32()) {
             return Local<T>(buffer->createSmiHandle(value.asInt32()));
+        } else if (value.isNumber()) {
+            double numeric_value = value.asNumber();
+            void* double_reinterpreted_to_pointer = *reinterpret_cast<void**>(&numeric_value);
+            return Local<T>(buffer->createHandle(double_reinterpreted_to_pointer, &Map::heap_number_map));
         } else if (value.isUndefined()) {
             return Local<T>(isolate->globalInternals()->undefinedSlot());
         } else if (value.isNull()) {

--- a/src/bun.js/bindings/v8/V8HandleScopeBuffer.cpp
+++ b/src/bun.js/bindings/v8/V8HandleScopeBuffer.cpp
@@ -30,7 +30,7 @@ void HandleScopeBuffer::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     for (int i = 0; i < thisObject->size; i++) {
         auto& handle = thisObject->storage[i];
         if (handle.isCell()) {
-            JSCell::visitChildren(reinterpret_cast<JSCell*>(handle.ptr), visitor);
+            JSCell::visitChildren(reinterpret_cast<JSCell*>(handle.object.ptr), visitor);
         }
     }
 }

--- a/src/bun.js/bindings/v8/V8Map.cpp
+++ b/src/bun.js/bindings/v8/V8Map.cpp
@@ -9,5 +9,6 @@ const Map Map::raw_ptr_map(InstanceType::Object);
 const Map Map::oddball_map(InstanceType::Oddball);
 const Map Map::boolean_map(InstanceType::Oddball);
 const Map Map::string_map(InstanceType::String);
+const Map Map::heap_number_map(InstanceType::HeapNumber);
 
 }

--- a/src/bun.js/bindings/v8/V8Map.h
+++ b/src/bun.js/bindings/v8/V8Map.h
@@ -15,6 +15,9 @@ enum class InstanceType : uint16_t {
     // because then V8 will try to access internal fields directly instead of calling
     // SlowGetInternalField
     Object = 0x80,
+    // a number that doesn't fit in int32_t and is stored on the heap (for us, in the
+    // HandleScopeBuffer)
+    HeapNumber = 0x82,
 };
 
 // V8's description of the structure of an object
@@ -41,6 +44,8 @@ struct Map {
     static const Map boolean_map;
     // the map used by strings
     static const Map string_map;
+    // the map used by heap numbers
+    static const Map heap_number_map;
 
     Map(InstanceType instance_type_)
         : meta_map(const_cast<Map*>(&map_map))

--- a/src/bun.js/bindings/v8/V8Number.cpp
+++ b/src/bun.js/bindings/v8/V8Number.cpp
@@ -1,16 +1,10 @@
 #include "V8Number.h"
 #include "V8HandleScope.h"
 
-#include <cmath>
-#include <cstdint>
-
 namespace v8 {
 
 Local<Number> Number::New(Isolate* isolate, double value)
 {
-    double int_part;
-    RELEASE_ASSERT_WITH_MESSAGE(std::modf(value, &int_part) == 0.0, "TODO handle doubles in Number::New");
-    RELEASE_ASSERT_WITH_MESSAGE(int_part >= INT32_MIN && int_part <= INT32_MAX, "TODO handle doubles in Number::New");
     return isolate->currentHandleScope()->createLocal<Number>(JSC::jsNumber(value));
 }
 

--- a/test/v8/v8.test.ts
+++ b/test/v8/v8.test.ts
@@ -119,10 +119,10 @@ describe("Number", () => {
     checkSameOutput("test_v8_number_int", []);
   });
   // non-i32 v8::Number is not implemented yet
-  it.skip("can create large integer", () => {
+  it("can create large integer", () => {
     checkSameOutput("test_v8_number_large_int", []);
   });
-  it.skip("can create fraction", () => {
+  it("can create fraction", () => {
     checkSameOutput("test_v8_number_fraction", []);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Supports all double-precision numbers in v8::Number, rather than only 32-bit signed ints

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests