### PR TITLE
Update documentation about .stringMatching

### DIFF
--- a/docs/test/writing.md
+++ b/docs/test/writing.md
@@ -394,7 +394,7 @@ Bun implements the following matchers. Full Jest compatibility is on the roadmap
 
 ---
 
-- ✅
+- ❌
 - [`.stringMatching()`](https://jestjs.io/docs/expect#expectstringmatchingstring--regexp)
 
 ---


### PR DESCRIPTION


### What does this PR do?

This will update the documentation of expect().stringMatching  

`.stringMatching` was documented to be supported, but bun v1.1.24 gives the message `.stringMatching is not a function`. 

(I recommend using the supported `.toMatch` instead.)

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

