### PR TITLE
fix(docs): typo in `bundler/index.md`

### DIFF
--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -758,7 +758,7 @@ $ bun build ./index.tsx --outdir ./out --external '*'
 
 ### `packages`
 
-Control whatever package dependencies are included to bundle or not. Possible values: `bundle` (default), `external`. Bun threats any import which path do not start with `.`, `..` or `/` as package.
+Control whatever package dependencies are included to bundle or not. Possible values: `bundle` (default), `external`. Bun treats any import which path do not start with `.`, `..` or `/` as package.
 
 {% codetabs group="a" %}
 


### PR DESCRIPTION
### What does this PR do?

Fix typo in `docs/bundler/index.md`

`Bun threats any import` -> `Bun treats any import`.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
