### PR TITLE
docs: remove extra assignment

### DIFF
--- a/docs/guides/http/cluster.md
+++ b/docs/guides/http/cluster.md
@@ -10,7 +10,7 @@ This automatically load balances incoming requests across multiple instances of 
 ```ts#server.ts
 import { serve } from "bun";
 
-const id = = Math.random().toString(36).slice(2);
+const id = Math.random().toString(36).slice(2);
 
 serve({
   port: process.env.PORT || 8080,


### PR DESCRIPTION
### What does this PR do?

This pull request fixes a typo in the `node:cluster` example code by removing an extra assignment operator

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes