### PR TITLE
fix freeing semver ranges

### DIFF
--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -825,17 +825,9 @@ pub fn parseWithTag(
                 input,
                 sliced.sub(input),
             ) catch |err| {
-                if (log_) |log| log.addErrorFmt(
-                    null,
-                    logger.Loc.Empty,
-                    allocator,
-                    "{s} parsing version \"{s}\"",
-                    .{
-                        @errorName(err),
-                        dependency,
-                    },
-                ) catch unreachable;
-                return null;
+                switch (err) {
+                    error.OutOfMemory => bun.outOfMemory(),
+                }
             };
 
             const result = Version{

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -1868,18 +1868,18 @@ pub const Query = struct {
             try std.json.encodeJsonString(temp, .{}, writer);
         }
 
-        pub fn deinit(this: *Group) void {
+        pub fn deinit(this: *const Group) void {
             var list = this.head;
             var allocator = this.allocator;
 
             while (list.next) |next| {
                 var query = list.head;
                 while (query.next) |next_query| {
-                    allocator.destroy(next_query);
                     query = next_query.*;
+                    allocator.destroy(next_query);
                 }
-                allocator.destroy(next);
                 list = next.*;
+                allocator.destroy(next);
             }
         }
 
@@ -2245,11 +2245,13 @@ pub const Query = struct {
         };
     };
 
+    const ParseError = error{OutOfMemory};
+
     pub fn parse(
         allocator: Allocator,
         input: string,
         sliced: SlicedString,
-    ) !Group {
+    ) ParseError!Group {
         var i: usize = 0;
         var list = Group{
             .allocator = allocator,
@@ -2590,7 +2592,15 @@ pub const SemverObject = struct {
             allocator,
             right.slice(),
             SlicedString.init(right.slice(), right.slice()),
-        ) catch return .false;
+        ) catch |err| {
+            switch (err) {
+                error.OutOfMemory => {
+                    globalThis.throwOutOfMemory();
+                    return .zero;
+                },
+            }
+        };
+        defer right_group.deinit();
 
         const right_version = right_group.getExactVersion();
 


### PR DESCRIPTION
### What does this PR do?
- Frees list and query pointers after copying contents
- Fixes an unlikely memory leak in `Bun.semver.satisfies`. Unlikely because a 512 byte stack fallback allocator is used
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Manually. I could add a test for the memory leak
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
