### PR TITLE
fix(net) make sure to always end the connection when destroy is called

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -76,14 +76,11 @@ const bunTLSConnectOptions = Symbol.for("::buntlsconnectoptions::");
 
 const kRealListen = Symbol("kRealListen");
 
-function closeNT(self) {
-  self.emit("close");
-}
 function endNT(socket, callback, err) {
   socket.end();
   callback(err);
 }
-function closeNT(callback, err) {
+function closeNT(self, callback, err) {
   callback(err);
 }
 
@@ -642,6 +639,11 @@ const Socket = (function (InternalSocket) {
     }
 
     _destroy(err, callback) {
+      const socket = this[bunSocketInternal];
+      if (socket) {
+        this[bunSocketInternal] = null;
+        socket.end();
+      }
       process.nextTick(closeNT, callback, err);
     }
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -642,8 +642,11 @@ const Socket = (function (InternalSocket) {
       const socket = this[bunSocketInternal];
       if (socket) {
         this[bunSocketInternal] = null;
-        socket.end();
+        // we still have a socket, call end before destroy
+        process.nextTick(endNT, socket, callback, err);
+        return;
       }
+      // no socket, just destroy
       process.nextTick(closeNT, callback, err);
     }
 
@@ -657,6 +660,7 @@ const Socket = (function (InternalSocket) {
         this.#final_callback = callback;
       } else {
         // emit FIN not allowing half open
+        this[bunSocketInternal] = null;
         process.nextTick(endNT, socket, callback);
       }
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -80,7 +80,7 @@ function endNT(socket, callback, err) {
   socket.end();
   callback(err);
 }
-function closeNT(self, callback, err) {
+function closeNT(callback, err) {
   callback(err);
 }
 

--- a/test/js/node/net/node-destroy-fixture.js
+++ b/test/js/node/net/node-destroy-fixture.js
@@ -2,7 +2,7 @@ const net = require("node:net");
 const { promise, resolve } = Promise.withResolvers();
 const client = net.createConnection(process.env.PORT, "localhost");
 client.on("connect", () => {
-  client.destroy(); // it worked normally before this PR
+  client.destroy();
   resolve(0);
 });
 

--- a/test/js/node/net/node-destroy-fixture.js
+++ b/test/js/node/net/node-destroy-fixture.js
@@ -1,0 +1,14 @@
+const net = require("node:net");
+const { promise, resolve } = Promise.withResolvers();
+const client = net.createConnection(process.env.PORT, "localhost");
+client.on("connect", () => {
+  client.destroy(); // it worked normally before this PR
+  resolve(0);
+});
+
+client.on("error", err => {
+  console.error("error", err);
+  resolve(1);
+});
+
+await promise;


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/13411
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Test added
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
