### PR TITLE
Support Worker, relative file paths in standalone executables, and partially directories

### DIFF
--- a/docs/bundler/executables.md
+++ b/docs/bundler/executables.md
@@ -249,7 +249,7 @@ The list of embedded files excludes bundled source code like `.ts` and `.js` fil
 
 #### Content hash
 
-By default, embedded files have a content hash appended to their name. This is useful for situations where you want to serve the file from a URL or CDN and ensure it is unique. But sometimes, this is unexpected and you might want the original name instead:
+By default, embedded files have a content hash appended to their name. This is useful for situations where you want to serve the file from a URL or CDN and have fewer cache invalidation issues. But sometimes, this is unexpected and you might want the original name instead:
 
 To disable the content hash, pass `--asset-naming` to `bun build --compile` like this:
 

--- a/docs/bundler/executables.md
+++ b/docs/bundler/executables.md
@@ -228,6 +228,35 @@ export default {
 
 This is honestly a workaround, and we expect to improve this in the future with a more direct API.
 
+### Listing embedded files
+
+To get a list of all embedded files, use `Bun.embeddedFiles`:
+
+```js
+import "./icon.png" with { type: "file" };
+import { embeddedFiles } from "bun";
+
+console.log(embeddedFiles[0].name); // `icon-${hash}.png`
+```
+
+`Bun.embeddedFiles` returns an array of `Blob` objects which you can use to get the size, contents, and other properties of the files.
+
+```ts
+embeddedFiles: Blob[]
+```
+
+The list of embedded files excludes bundled source code like `.ts` and `.js` files.
+
+#### Content hash
+
+By default, embedded files have a content hash appended to their name. This is useful for situations where you want to serve the file from a URL or CDN and ensure it is unique. But sometimes, this is unexpected and you might want the original name instead:
+
+To disable the content hash, pass `--asset-naming` to `bun build --compile` like this:
+
+```sh
+$ bun build --compile --asset-naming="[name].[ext]" ./index.ts
+```
+
 ## Minification
 
 To trim down the size of the executable a little, pass `--minify` to `bun build --compile`. This uses Bun's minifier to reduce the code size. Overall though, Bun's binary is still way too big and we need to make it smaller.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2861,6 +2861,13 @@ declare module "bun" {
   function file(path: string | URL, options?: BlobPropertyBag): BunFile;
 
   /**
+   * A list of files embedded into the standalone executable. Lexigraphically sorted by name.
+   *
+   * If the process is not a standalone executable, this returns an empty array.
+   */
+  const embeddedFiles: ReadonlyArray<Blob>;
+
+  /**
    * `Blob` that leverages the fastest system calls available to operate on files.
    *
    * This Blob is lazy. It won't do any work until you read from it. Errors propagate as promise rejections.

--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -35,6 +35,8 @@ pub const StandaloneModuleGraph = struct {
 
     pub const base_public_path = targetBasePublicPath(Environment.os, "");
 
+    pub const base_public_path_with_default_suffix = targetBasePublicPath(Environment.os, "root/");
+
     pub fn targetBasePublicPath(target: Environment.OperatingSystem, comptime suffix: [:0]const u8) [:0]const u8 {
         return switch (target) {
             .windows => "B:/~BUN/" ++ suffix,
@@ -56,6 +58,11 @@ pub const StandaloneModuleGraph = struct {
         if (!isBunStandaloneFilePath(base_path)) {
             return null;
         }
+
+        return this.findAssumeStandalonePath(name);
+    }
+
+    pub fn findAssumeStandalonePath(this: *const StandaloneModuleGraph, name: []const u8) ?*File {
         if (Environment.isWindows) {
             var normalized_buf: bun.PathBuffer = undefined;
             const normalized = bun.path.platformToPosixBuf(u8, name, &normalized_buf);

--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -97,6 +97,12 @@ pub const StandaloneModuleGraph = struct {
         encoding: Encoding = .binary,
         wtf_string: bun.String = bun.String.empty,
 
+        pub fn lessThanByIndex(ctx: []const File, lhs_i: u32, rhs_i: u32) bool {
+            const lhs = ctx[lhs_i];
+            const rhs = ctx[rhs_i];
+            return bun.strings.cmpStringsAsc({}, lhs.name, rhs.name);
+        }
+
         pub fn toWTFString(this: *File) bun.String {
             if (this.wtf_string.isEmpty()) {
                 switch (this.encoding) {
@@ -129,7 +135,15 @@ pub const StandaloneModuleGraph = struct {
                     b.content_type_allocated = false;
                 }
 
+                // The real name goes here:
                 store.data.bytes.stored_name = bun.PathString.init(this.name);
+
+                // The pretty name goes here:
+                if (strings.hasPrefixComptime(this.name, base_public_path_with_default_suffix)) {
+                    b.name = bun.String.createUTF8(this.name[base_public_path_with_default_suffix.len..]);
+                } else if (this.name.len > 0) {
+                    b.name = bun.String.createUTF8(this.name);
+                }
 
                 this.cached_blob = b;
             }

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -72,6 +72,7 @@ pub const BunObject = struct {
     pub const stdout = toJSGetter(Bun.getStdout);
     pub const unsafe = toJSGetter(Bun.getUnsafe);
     pub const semver = toJSGetter(Bun.getSemver);
+    pub const embeddedFiles = toJSGetter(Bun.getEmbeddedFiles);
     // --- Getters ---
 
     fn getterName(comptime baseName: anytype) [:0]const u8 {
@@ -131,6 +132,7 @@ pub const BunObject = struct {
         @export(BunObject.stdout, .{ .name = getterName("stdout") });
         @export(BunObject.unsafe, .{ .name = getterName("unsafe") });
         @export(BunObject.semver, .{ .name = getterName("semver") });
+        @export(BunObject.embeddedFiles, .{ .name = getterName("embeddedFiles") });
         // --- Getters --
 
         // -- Callbacks --
@@ -3786,6 +3788,42 @@ pub fn getGlobConstructor(
     _: *JSC.JSObject,
 ) JSC.JSValue {
     return JSC.API.Glob.getConstructor(globalThis);
+}
+
+pub fn getEmbeddedFiles(
+    globalThis: *JSC.JSGlobalObject,
+    _: *JSC.JSObject,
+) JSC.JSValue {
+    const vm = globalThis.bunVM();
+    const graph = vm.standalone_module_graph orelse return JSC.JSValue.createEmptyArray(globalThis, 0);
+
+    const unsorted_files = graph.files.values();
+    var sort_indices = std.ArrayList(u32).initCapacity(bun.default_allocator, unsorted_files.len) catch bun.outOfMemory();
+    defer sort_indices.deinit();
+    for (0..unsorted_files.len) |index| {
+        // Some % of people using `bun build --compile` want to obscure the source code
+        // We don't really do that right now, but exposing the output source
+        // code here as an easily accessible Blob is even worse for them.
+        // So let's omit any source code files from the list.
+        if (unsorted_files[index].loader.isJavaScriptLike()) continue;
+        sort_indices.appendAssumeCapacity(@intCast(index));
+    }
+
+    var i: u32 = 0;
+    var array = JSC.JSValue.createEmptyArray(globalThis, sort_indices.items.len);
+    std.mem.sort(u32, sort_indices.items, unsorted_files, bun.StandaloneModuleGraph.File.lessThanByIndex);
+    for (sort_indices.items) |index| {
+        const file = &unsorted_files[index];
+        // We call .dupe() on this to ensure that we don't return a blob that might get freed later.
+        const input_blob = file.blob(globalThis);
+        const blob = JSC.WebCore.Blob.new(input_blob.dupeWithContentType(true));
+        blob.allocator = bun.default_allocator;
+        blob.name = input_blob.name.dupeRef();
+        array.putIndex(globalThis, i, blob.toJS(globalThis));
+        i += 1;
+    }
+
+    return array;
 }
 
 pub fn getSemver(

--- a/src/bun.js/bindings/BunObject+exports.h
+++ b/src/bun.js/bindings/BunObject+exports.h
@@ -30,6 +30,7 @@
     macro(stdout) \
     macro(unsafe) \
     macro(semver) \
+    macro(embeddedFiles) \
 
 // --- Callbacks ---
 #define FOR_EACH_CALLBACK(macro) \

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -553,6 +553,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     SHA512_256                                     BunObject_getter_wrap_SHA512_256                                    DontDelete|PropertyCallback
     TOML                                           BunObject_getter_wrap_TOML                                          DontDelete|PropertyCallback
     Transpiler                                     BunObject_getter_wrap_Transpiler                                    DontDelete|PropertyCallback
+    embeddedFiles                                  BunObject_getter_wrap_embeddedFiles                                 DontDelete|PropertyCallback
     allocUnsafe                                    BunObject_callback_allocUnsafe                                      DontDelete|Function 1
     argv                                           BunObject_getter_wrap_argv                                          DontDelete|PropertyCallback
     build                                          BunObject_callback_build                                            DontDelete|Function 1

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1861,8 +1861,14 @@ pub const VirtualMachine = struct {
             .handler = ModuleLoader.AsyncModule.Queue.onWakeHandler,
             .onDependencyError = JSC.ModuleLoader.AsyncModule.Queue.onDependencyError,
         };
+        vm.bundler.resolver.standalone_module_graph = opts.graph;
 
-        vm.bundler.configureLinker();
+        if (opts.graph == null) {
+            vm.bundler.configureLinker();
+        } else {
+            vm.bundler.configureLinkerWithAutoJSX(false);
+        }
+
         try vm.bundler.configureFramework(false);
         vm.smol = opts.smol;
         vm.bundler.macro_context = js_ast.Macro.MacroContext.init(&vm.bundler);

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -130,12 +130,6 @@ pub const BuildCommand = struct {
                 return;
             }
 
-            if (this_bundler.options.entry_points.len > 1) {
-                Output.prettyErrorln("<r><red>error<r><d>:<r> multiple entry points are not supported with --compile", .{});
-                Global.exit(1);
-                return;
-            }
-
             if (ctx.bundler_options.outdir.len > 0) {
                 Output.prettyErrorln("<r><red>error<r><d>:<r> cannot use --compile with --outdir", .{});
                 Global.exit(1);
@@ -177,7 +171,7 @@ pub const BuildCommand = struct {
             }
         }
 
-        if (ctx.bundler_options.outdir.len == 0) {
+        if (ctx.bundler_options.outdir.len == 0 and !ctx.bundler_options.compile) {
             if (this_bundler.options.entry_points.len > 1) {
                 Output.prettyErrorln("<r><red>error<r><d>:<r> Must use <b>--outdir<r> when specifying more than one entry point.", .{});
                 Global.exit(1);

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -75,6 +75,7 @@ describe("bundler", () => {
     files: {
       "/entry.ts": /* js */ `
       import {rmSync} from 'fs';
+      import {createRequire} from 'module';
         import './foo.file';
         import './1.embed';
         import './2.embed';
@@ -95,6 +96,9 @@ describe("bundler", () => {
         }
 
         if (Bun.embeddedFiles.length !== 3) throw "fail";
+        if ((await Bun.file(createRequire(import.meta.url).resolve('./1.embed')).text()).trim() !== "abcd") throw "fail";
+        if ((await Bun.file(createRequire(import.meta.url).resolve('./2.embed')).text()).trim() !== "abcd") throw "fail";
+        if ((await Bun.file(createRequire(import.meta.url).resolve('./foo.file')).text()).trim() !== "abcd") throw "fail";
         if ((await Bun.file(import.meta.require.resolve('./1.embed')).text()).trim() !== "abcd") throw "fail";
         if ((await Bun.file(import.meta.require.resolve('./2.embed')).text()).trim() !== "abcd") throw "fail";
         if ((await Bun.file(import.meta.require.resolve('./foo.file')).text()).trim() !== "abcd") throw "fail";
@@ -111,7 +115,7 @@ describe("bundler", () => {
     `.trim(),
     },
     outfile: "dist/out",
-    run: { stdout: "Hello, world!" },
+    run: { stdout: "Hello, world!", setCwd: true },
   });
   itBundled("compile/ResolveEmbeddedFileOutfile", {
     compile: true,


### PR DESCRIPTION
### What does this PR do?

This implements support for using `Worker` in `bun build --compile`'d executables, along with relative file paths in the embedded executable. This also unblocks #6653. 

Fixes https://github.com/oven-sh/bun/issues/13405
Fixes https://github.com/oven-sh/bun/issues/12649
Fixes https://github.com/oven-sh/bun/issues/7901
Fixes https://github.com/oven-sh/bun/issues/7534

Also adds `Bun.embeddedFiles` which returns `Blob[]` of embedded non-code files in the executable.

For workers, one still needs to manually append entry points

### How did you verify your code works?

There are tests