### PR TITLE
Include "name" and lastModified when console.log'ing Blob or File

### DIFF
--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -85,7 +85,7 @@ pub const Body = struct {
             try formatter.printComma(Writer, writer, enable_ansi_colors);
             try writer.writeAll("\n");
             try formatter.writeIndent(Writer, writer);
-            try Blob.writeFormatForSize(this.value.size(), writer, enable_ansi_colors);
+            try Blob.writeFormatForSize(false, this.value.size(), writer, enable_ansi_colors);
         } else if (this.value == .Locked) {
             if (this.value.Locked.readable.get()) |stream| {
                 try formatter.printComma(Writer, writer, enable_ansi_colors);

--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -69,7 +69,7 @@ pub const Body = struct {
         };
     }
 
-    pub fn writeFormat(this: *const Body, comptime Formatter: type, formatter: *Formatter, writer: anytype, comptime enable_ansi_colors: bool) !void {
+    pub fn writeFormat(this: *Body, comptime Formatter: type, formatter: *Formatter, writer: anytype, comptime enable_ansi_colors: bool) !void {
         const Writer = @TypeOf(writer);
 
         try formatter.writeIndent(Writer, writer);

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -182,7 +182,8 @@ pub const Request = struct {
                 try formatter.writeIndent(Writer, writer);
                 const size = this.body.value.size();
                 if (size == 0) {
-                    try Blob.initEmpty(undefined).writeFormat(Formatter, formatter, writer, enable_ansi_colors);
+                    var empty = Blob.initEmpty(undefined);
+                    try empty.writeFormat(Formatter, formatter, writer, enable_ansi_colors);
                 } else {
                     try Blob.writeFormatForSize(size, writer, enable_ansi_colors);
                 }

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -185,7 +185,7 @@ pub const Request = struct {
                     var empty = Blob.initEmpty(undefined);
                     try empty.writeFormat(Formatter, formatter, writer, enable_ansi_colors);
                 } else {
-                    try Blob.writeFormatForSize(size, writer, enable_ansi_colors);
+                    try Blob.writeFormatForSize(false, size, writer, enable_ansi_colors);
                 }
             } else if (this.body.value == .Locked) {
                 if (this.body.value.Locked.readable.get()) |stream| {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -541,3 +541,19 @@ describe("console.logging function displays async and generator names", async ()
     });
   }
 });
+
+it("console.log on a Blob shows name", () => {
+  const blob = new Blob(["foo"], { type: "text/plain" });
+  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  type: "text/plain;charset=utf-8"\n}');
+  blob.name = "bar";
+  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "bar"\n  type: "text/plain;charset=utf-8"\n}');
+  blob.name = "foobar";
+  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "foobar"\n  type: "text/plain;charset=utf-8"\n}');
+
+  const file = new File(["foo"], "bar.txt", { type: "text/plain" });
+  expect(Bun.inspect(file)).toBe('Blob (3 bytes) {\n  name: "bar.txt"\n  type: "text/plain;charset=utf-8"\n}');
+  file.name = "foobar";
+  expect(Bun.inspect(file)).toBe('Blob (3 bytes) {\n  name: "foobar"\n  type: "text/plain;charset=utf-8"\n}');
+  file.name = "";
+  expect(Bun.inspect(file)).toBe('Blob (3 bytes) {\n  name: ""\n  type: "text/plain;charset=utf-8"\n}');
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -546,14 +546,20 @@ it("console.log on a Blob shows name", () => {
   const blob = new Blob(["foo"], { type: "text/plain" });
   expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  type: "text/plain;charset=utf-8"\n}');
   blob.name = "bar";
-  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "bar"\n  type: "text/plain;charset=utf-8"\n}');
+  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "bar",\n  type: "text/plain;charset=utf-8"\n}');
   blob.name = "foobar";
-  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "foobar"\n  type: "text/plain;charset=utf-8"\n}');
+  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "foobar",\n  type: "text/plain;charset=utf-8"\n}');
 
   const file = new File(["foo"], "bar.txt", { type: "text/plain" });
-  expect(Bun.inspect(file)).toBe('Blob (3 bytes) {\n  name: "bar.txt"\n  type: "text/plain;charset=utf-8"\n}');
+  expect(Bun.inspect(file)).toBe(
+    `File (3 bytes) {\n  name: "bar.txt",\n  type: "text/plain;charset=utf-8",\n lastModified: ${file.lastModified}\n}`,
+  );
   file.name = "foobar";
-  expect(Bun.inspect(file)).toBe('Blob (3 bytes) {\n  name: "foobar"\n  type: "text/plain;charset=utf-8"\n}');
+  expect(Bun.inspect(file)).toBe(
+    `File (3 bytes) {\n  name: "foobar",\n  type: "text/plain;charset=utf-8",\n lastModified: ${file.lastModified}\n}`,
+  );
   file.name = "";
-  expect(Bun.inspect(file)).toBe('Blob (3 bytes) {\n  name: ""\n  type: "text/plain;charset=utf-8"\n}');
+  expect(Bun.inspect(file)).toBe(
+    `File (3 bytes) {\n  name: "",\n  type: "text/plain;charset=utf-8",\n lastModified: ${file.lastModified}\n}`,
+  );
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -552,14 +552,14 @@ it("console.log on a Blob shows name", () => {
 
   const file = new File(["foo"], "bar.txt", { type: "text/plain" });
   expect(Bun.inspect(file)).toBe(
-    `File (3 bytes) {\n  name: "bar.txt",\n  type: "text/plain;charset=utf-8",\n lastModified: ${file.lastModified}\n}`,
+    `File (3 bytes) {\n  name: "bar.txt",\n  type: "text/plain;charset=utf-8",\n  lastModified: ${file.lastModified}\n}`,
   );
   file.name = "foobar";
   expect(Bun.inspect(file)).toBe(
-    `File (3 bytes) {\n  name: "foobar",\n  type: "text/plain;charset=utf-8",\n lastModified: ${file.lastModified}\n}`,
+    `File (3 bytes) {\n  name: "foobar",\n  type: "text/plain;charset=utf-8",\n  lastModified: ${file.lastModified}\n}`,
   );
   file.name = "";
   expect(Bun.inspect(file)).toBe(
-    `File (3 bytes) {\n  name: "",\n  type: "text/plain;charset=utf-8",\n lastModified: ${file.lastModified}\n}`,
+    `File (3 bytes) {\n  name: "",\n  type: "text/plain;charset=utf-8",\n  lastModified: ${file.lastModified}\n}`,
   );
 });


### PR DESCRIPTION
### What does this PR do?

Include "name" when console.log'ing Blob

Before:
```js
❯ bun name.js
Blob (4 bytes) {
  type: "application/json;charset=utf-8"
}
Blob (4 bytes) {
  type: "application/json;charset=utf-8"
}
```

After:
```js
❯ bun name.js
Blob (4 bytes) {
  name: "name.json",
  type: "application/json;charset=utf-8"
}
File (4 bytes) {
  name: "hey.json",
  type: "application/json;charset=utf-8",
  lastModified: 1724197005270
}
```

### How did you verify your code works?

There is a test