### PR TITLE
feat(Bun.serve idleTimeout) allow custom timeouts

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2343,6 +2343,14 @@ declare module "bun" {
     unix?: never;
 
     /**
+     * Sets the the number of seconds to wait before timing out a connection
+     * due to inactivity.
+     *
+     * Default is `10` seconds.
+     */
+    idleTimeout?: number;
+
+    /**
      * Handle HTTP requests
      *
      * Respond to {@link Request} objects with a {@link Response} object.

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -36,6 +36,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     using OnWritableCallback = bool (*)(uWS::HttpResponse<SSL>*, uint64_t, void*);
     using OnAbortedCallback = void (*)(uWS::HttpResponse<SSL>*, void*);
     using OnDataCallback = void (*)(uWS::HttpResponse<SSL>* response, const char* chunk, size_t chunk_length, bool, void*);
+    uint8_t idleTimeout = 10; // default HTTP_TIMEOUT 10 seconds
 
     /* When we are done with a response we mark it like so */
     void markDone() {

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1149,7 +1149,7 @@ extern "C"
       data->offset = offset;
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
       data->markDone();
-      us_socket_timeout(true, (us_socket_t *)uwsRes, uWS::HTTP_TIMEOUT_S);
+      uwsRes->resetTimeout();
     }
     else
     {
@@ -1158,9 +1158,20 @@ extern "C"
       data->offset = offset;
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
       data->markDone();
-      us_socket_timeout(0, (us_socket_t *)uwsRes, uWS::HTTP_TIMEOUT_S);
+      uwsRes->resetTimeout();
     }
   }
+
+  void uws_res_timeout(int ssl, uws_res_r res, uint8_t seconds) {
+    if (ssl) {
+      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      uwsRes->setTimeout(seconds);
+    } else {
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+      uwsRes->setTimeout(seconds);
+    }
+  }
+
   void uws_res_end_without_body(int ssl, uws_res_r res, bool close_connection)
   {
     if (ssl)
@@ -1181,7 +1192,7 @@ extern "C"
       }
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
       data->markDone();
-      us_socket_timeout(true, (us_socket_t *)uwsRes, uWS::HTTP_TIMEOUT_S);
+      uwsRes->resetTimeout();
     }
     else
     {
@@ -1203,7 +1214,7 @@ extern "C"
       }
       data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
       data->markDone();
-      us_socket_timeout(false, (us_socket_t *)uwsRes, uWS::HTTP_TIMEOUT_S);
+      uwsRes->resetTimeout();
     }
   }
 

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -86,7 +86,7 @@ pub const InternalSocket = union(enum) {
     detached: void,
     pub fn isDetached(this: InternalSocket) bool {
         return this == .detached;
-    }  
+    }
     pub fn detach(this: *InternalSocket) void {
         this.* = .detached;
     }
@@ -222,7 +222,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
 
         pub fn ssl(this: ThisSocket) ?*BoringSSL.SSL {
             if (comptime is_ssl) {
-                if(this.getNativeHandle()) |handle| {
+                if (this.getNativeHandle()) |handle| {
                     return @as(*BoringSSL.SSL, @ptrCast(handle));
                 }
                 return null;
@@ -674,7 +674,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
         ) ?ThisSocket {
             const socket_ = ThisSocket{ .socket = .{ .done = us_socket_from_fd(ctx, @sizeOf(*anyopaque), bun.socketcast(handle)) orelse return null } };
 
-            if(socket_.ext(*anyopaque)) |holder| {
+            if (socket_.ext(*anyopaque)) |holder| {
                 holder.* = this;
             }
 
@@ -712,7 +712,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 return error.FailedToOpenSocket;
 
             const socket_ = ThisSocket{ .socket = .{ .done = socket } };
-            if(socket_.ext(*anyopaque)) |holder| {
+            if (socket_.ext(*anyopaque)) |holder| {
                 holder.* = ctx;
             }
             return socket_;
@@ -755,7 +755,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 ThisSocket{
                     .socket = .{ .connecting = @ptrCast(socket_ptr) },
                 };
-            if(socket.ext(*anyopaque)) |holder| {
+            if (socket.ext(*anyopaque)) |holder| {
                 holder.* = ptr;
             }
             return socket;
@@ -1067,7 +1067,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             const new_socket = us_socket_context_adopt_socket(comptime ssl_int, socket_ctx, socket, -1) orelse return false;
             bun.assert(new_socket == socket);
             var adopted = ThisSocket.from(new_socket);
-            if(adopted.ext(*anyopaque)) |holder| {
+            if (adopted.ext(*anyopaque)) |holder| {
                 holder.* = ctx;
             }
             @field(ctx, socket_field_name) = adopted;
@@ -2267,6 +2267,9 @@ pub fn NewApp(comptime ssl: bool) type {
             pub fn endSendFile(res: *Response, write_offset: u64, close_connection: bool) void {
                 uws_res_end_sendfile(ssl_flag, res.downcast(), write_offset, close_connection);
             }
+            pub fn timeout(res: *Response, seconds: u8) void {
+                uws_res_timeout(ssl_flag, res.downcast(), seconds);
+            }
             pub fn write(res: *Response, data: []const u8) bool {
                 return uws_res_write(ssl_flag, res.downcast(), data.ptr, data.len);
             }
@@ -2679,6 +2682,8 @@ extern fn uws_res_write_header(ssl: i32, res: *uws_res, key: [*c]const u8, key_l
 extern fn uws_res_write_header_int(ssl: i32, res: *uws_res, key: [*c]const u8, key_length: usize, value: u64) void;
 extern fn uws_res_end_without_body(ssl: i32, res: *uws_res, close_connection: bool) void;
 extern fn uws_res_end_sendfile(ssl: i32, res: *uws_res, write_offset: u64, close_connection: bool) void;
+extern fn uws_res_timeout(ssl: i32, res: *uws_res, timeout: u8) void;
+
 extern fn uws_res_write(ssl: i32, res: *uws_res, data: [*c]const u8, length: usize) bool;
 extern fn uws_res_get_write_offset(ssl: i32, res: *uws_res) u64;
 extern fn uws_res_override_write_offset(ssl: i32, res: *uws_res, u64) void;

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1856,3 +1856,36 @@ it("we should always send date", async () => {
     expect(res.headers.has("Date")).toBeTrue();
   }
 });
+
+it("should allow use of custom timeout", async () => {
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 4, // uws precision is in seconds, and lower than 4 seconds is not reliable its timer is not that accurate
+    async fetch(req) {
+      const url = new URL(req.url);
+      return new Response(
+        new ReadableStream({
+          async pull(controller) {
+            controller.enqueue("Hello,");
+            if (url.pathname === "/timeout") {
+              await Bun.sleep(5000);
+            } else {
+              await Bun.sleep(10);
+            }
+            controller.enqueue(" World!");
+
+            controller.close();
+          },
+        }),
+        { headers: { "Content-Type": "text/plain" } },
+      );
+    },
+  });
+  const res = await fetch(new URL("/timeout", server.url.origin));
+  expect(res.status).toBe(200);
+  expect(res.text()).rejects.toThrow(/The socket connection was closed unexpectedly./);
+
+  const res2 = await fetch(new URL("/ok", server.url.origin));
+  expect(res2.status).toBe(200);
+  expect(res2.text()).resolves.toBe("Hello, World!");
+}, 10_000);

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1881,11 +1881,14 @@ it("should allow use of custom timeout", async () => {
       );
     },
   });
-  const res = await fetch(new URL("/timeout", server.url.origin));
-  expect(res.status).toBe(200);
-  expect(res.text()).rejects.toThrow(/The socket connection was closed unexpectedly./);
-
-  const res2 = await fetch(new URL("/ok", server.url.origin));
-  expect(res2.status).toBe(200);
-  expect(res2.text()).resolves.toBe("Hello, World!");
+  async function testTimeout(pathname: string, success: boolean) {
+    const res = await fetch(new URL(pathname, server.url.origin));
+    expect(res.status).toBe(200);
+    if (success) {
+      expect(res.text()).resolves.toBe("Hello, World!");
+    } else {
+      expect(res.text()).rejects.toThrow(/The socket connection was closed unexpectedly./);
+    }
+  }
+  await Promise.all([testTimeout("/ok", true), testTimeout("/timeout", false)]);
 }, 10_000);


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/13392
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
Added a test
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
