### PR TITLE
Support asymmetric matchers in expect().toThrow

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -174,9 +174,7 @@ var access = function access(path, mode, callback) {
     } else if (callback == undefined) {
       fs.close(fd).then(() => {});
     } else {
-      const err = new TypeError("Callback must be a function");
-      err.code = "ERR_INVALID_ARG_TYPE";
-      throw err;
+      callback = ensureCallback(callback);
     }
   },
   rm = function rm(path, options, callback) {
@@ -552,9 +550,7 @@ var access = function access(path, mode, callback) {
       position = null;
     }
 
-    if (!$isCallable(callback)) {
-      throw new TypeError("callback must be a function");
-    }
+    callback = ensureCallback(callback);
 
     fs.writev(fd, buffers, position).$then(bytesWritten => callback(null, bytesWritten, buffers), callback);
   },
@@ -565,9 +561,7 @@ var access = function access(path, mode, callback) {
       position = null;
     }
 
-    if (!$isCallable(callback)) {
-      throw new TypeError("callback must be a function");
-    }
+    callback = ensureCallback(callback);
 
     fs.readv(fd, buffers, position).$then(bytesRead => callback(null, bytesRead, buffers), callback);
   },

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -783,6 +783,33 @@ describe("expect()", () => {
     });
   });
 
+  test("toThrow asymmetric matchers", () => {
+    expect(() => {
+      const err = new Error("foo");
+      err.code = "ERR_BAR";
+      throw err;
+    }).toThrow(expect.objectContaining({ code: "ERR_BAR" }));
+
+    expect(() => {
+      const err = new TypeError("foo");
+      err.code = "ERR_BAZ";
+      throw err;
+    }).not.toThrow(expect.objectContaining({ code: "ERR_BAR", name: "TypeError" }));
+
+    expect(() => {
+      const err = new TypeError("foo");
+      err.code = "ERR_BAZ";
+      throw err;
+    }).toThrow(expect.objectContaining({ code: "ERR_BAZ", name: "TypeError" }));
+
+    expect(() => {
+      const err = new TypeError("foo");
+      err.code = "ERR_BAZ";
+      throw err;
+    }).toThrow(expect.objectContaining({ code: "ERR_BAZ", name: "TypeError" }));
+
+  });
+
   test("toThrow", () => {
     expect(() => {
       throw new Error("hello");


### PR DESCRIPTION
### What does this PR do?

Support asymmetric matchers in expect().toThrow.

jest & vitest supports this. I did not verify whether jest/vitest use toStrictEqual or toEqual internally for this.

### How did you verify your code works?

There is a test