### PR TITLE
fix(node:util): use `Object.setPrototypeOf` in `inherits`

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -135,15 +135,19 @@ var log = function log() {
   console.log("%s - %s", timestamp(), format.$apply(cjs_exports, arguments));
 };
 var inherits = function inherits(ctor, superCtor) {
+  if (ctor === undefined || ctor === null) {
+    throw ERR_INVALID_ARG_TYPE("ctor", "Function", ctor);
+  }
+
+  if (superCtor === undefined || superCtor === null) {
+    throw ERR_INVALID_ARG_TYPE("superCtor", "Function", superCtor);
+  }
+
+  if (superCtor.prototype === undefined) {
+    throw ERR_INVALID_ARG_TYPE("superCtor.prototype", "Object", superCtor.prototype);
+  }
   ctor.super_ = superCtor;
-  ctor.prototype = Object.create(superCtor.prototype, {
-    constructor: {
-      value: ctor,
-      enumerable: false,
-      writable: true,
-      configurable: true,
-    },
-  });
+  Object.setPrototypeOf(ctor.prototype, superCtor.prototype);
 };
 var _extend = function (origin, add) {
   if (!add || !isObject(add)) return origin;

--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -4293,30 +4293,37 @@ var require_lib = __commonJS({
       if (!(this instanceof Deflate)) return new Deflate(opts);
       Zlib.$call(this, opts, binding.DEFLATE);
     }
+    Deflate.prototype = {};
     function Inflate(opts) {
       if (!(this instanceof Inflate)) return new Inflate(opts);
       Zlib.$call(this, opts, binding.INFLATE);
     }
+    Inflate.prototype = {};
     function Gzip(opts) {
       if (!(this instanceof Gzip)) return new Gzip(opts);
       Zlib.$call(this, opts, binding.GZIP);
     }
+    Gzip.prototype = {};
     function Gunzip(opts) {
       if (!(this instanceof Gunzip)) return new Gunzip(opts);
       Zlib.$call(this, opts, binding.GUNZIP);
     }
+    Gunzip.prototype = {};
     function DeflateRaw(opts) {
       if (!(this instanceof DeflateRaw)) return new DeflateRaw(opts);
       Zlib.$call(this, opts, binding.DEFLATERAW);
     }
+    DeflateRaw.prototype = {};
     function InflateRaw(opts) {
       if (!(this instanceof InflateRaw)) return new InflateRaw(opts);
       Zlib.$call(this, opts, binding.INFLATERAW);
     }
+    InflateRaw.prototype = {};
     function Unzip(opts) {
       if (!(this instanceof Unzip)) return new Unzip(opts);
       Zlib.$call(this, opts, binding.UNZIP);
     }
+    Unzip.prototype = {};
     function isValidFlushFlag(flag) {
       return (
         flag === binding.Z_NO_FLUSH ||
@@ -4411,6 +4418,7 @@ var require_lib = __commonJS({
         enumerable: true,
       });
     }
+    Zlib.prototype = {};
     util.inherits(Zlib, Transform);
     Zlib.prototype.params = function (level, strategy, callback) {
       if (level < exports.Z_MIN_LEVEL || level > exports.Z_MAX_LEVEL) {

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -54,6 +54,19 @@ describe("util", () => {
       expect(util.toUSVString(strings[i])).toBe(outputs[i]);
     }
   });
+  it.only("inherits", () => {
+    function Bar() {}
+    Bar.prototype.bar = function () {};
+
+    Wat.prototype.func = function () {
+      return 43;
+    };
+
+    function Wat() {}
+
+    expect(util.inherits(Wat, Bar)).toBeUndefined();
+    expect(Wat.prototype.func).toBeDefined();
+  });
   describe("isArray", () => {
     it("all cases", () => {
       strictEqual(util.isArray([]), true);

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -54,7 +54,7 @@ describe("util", () => {
       expect(util.toUSVString(strings[i])).toBe(outputs[i]);
     }
   });
-  it.only("inherits", () => {
+  it("inherits", () => {
     function Bar() {}
     Bar.prototype.bar = function () {};
 


### PR DESCRIPTION
### What does this PR do?
fixes #10044 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
