### PR TITLE
Preserve `"use strict";` directive in CommonJS modules at top of file

### DIFF
--- a/src/bun.js/RuntimeTranspilerCache.zig
+++ b/src/bun.js/RuntimeTranspilerCache.zig
@@ -2,7 +2,8 @@
 /// Version 3: "Infinity" becomes "1/0".
 /// Version 4: TypeScript enums are properly handled + more constant folding
 /// Version 5: `require.main === module` no longer marks a module as CJS
-const expected_version = 5;
+/// Version 6: `use strict` is preserved in CommonJS modules when at the top of the file
+const expected_version = 6;
 
 const bun = @import("root").bun;
 const std = @import("std");

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -259,9 +259,9 @@ function Agent(options = kEmptyObject) {
   if (options.noDelay === undefined) options.noDelay = true;
 
   // Don't confuse net and make it think that we're connecting to a pipe
-  this.requests = kEmptyObject;
-  this.sockets = kEmptyObject;
-  this.freeSockets = kEmptyObject;
+  this.requests = Object.create(null);
+  this.sockets = Object.create(null);
+  this.freeSockets = Object.create(null);
 
   this.keepAliveMsecs = options.keepAliveMsecs || 1000;
   this.keepAlive = options.keepAlive || false;

--- a/test/bundler/transpiler/preserve-use-strict-cjs.test.ts
+++ b/test/bundler/transpiler/preserve-use-strict-cjs.test.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "bun:test";
+import path from "path";
+
+test(`"use strict'; preserves strict mode in CJS`, async () => {
+  expect([path.join(import.meta.dir, "strict-mode-fixture.ts")]).toRun();
+});
+
+test(`sloppy mode by default in CJS`, async () => {
+  expect([path.join(import.meta.dir, "sloppy-mode-fixture.ts")]).toRun();
+});

--- a/test/bundler/transpiler/sloppy-mode-fixture.ts
+++ b/test/bundler/transpiler/sloppy-mode-fixture.ts
@@ -1,0 +1,11 @@
+function checkThis() {
+  if (this !== globalThis) {
+    throw new Error("this is not globalThis");
+  }
+}
+
+checkThis();
+
+module.exports = {
+  FORCE_COMMON_JS: true,
+};

--- a/test/bundler/transpiler/strict-mode-fixture.ts
+++ b/test/bundler/transpiler/strict-mode-fixture.ts
@@ -1,0 +1,13 @@
+"use strict";
+
+function checkThis() {
+  if (this !== undefined) {
+    throw new Error("this is not undefined");
+  }
+}
+
+checkThis();
+
+module.exports = {
+  FORCE_COMMON_JS: true,
+};


### PR DESCRIPTION
### What does this PR do?

The following code would be evaluated in sloppy mode at runtime:
```js
"use strict";

function hey() {
  console.log(this);
}

hey();

exports.abc = 123;
```

This is incorrect. There are a few issues related to this need to search through

### How did you verify your code works?

There is a test