### PR TITLE
Expose `maxLifetime` from uWebSockets for controlling maximum number of minutes a ws connection stays open

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2215,6 +2215,17 @@ declare module "bun" {
     idleTimeout?: number;
 
     /**
+     * Total minutes of activity before a client is automatically disconnected.
+     *
+     * `0` disables this feature.
+     * Must be a number between 0 and 240.
+     *
+     * @default 0
+     * @since Bun v1.1.26
+     */
+    maxLifetime?: number;
+
+    /**
      * Should `ws.publish()` also send a message to `ws` (itself), if it is subscribed?
      *
      * Default is `false`.


### PR DESCRIPTION
### What does this PR do?

This lets you always disconnect a ServerWebSocket connection after some amount of time without needing to roll your own `setTimeout` code on each websocket connection to do this



### How did you verify your code works?

Needs some kind of a test before we can merge this