### PR TITLE
fix fs.test.ts

### DIFF
--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2381,11 +2381,11 @@ describe("fs/promises", () => {
     const full = resolve(import.meta.dir, "../");
 
     const doIt = async () => {
+      const maxFD = getMaxFD();
       for (let i = 0; i < warmup; i++) {
         await promises.readdir(full, { withFileTypes });
       }
 
-      const maxFD = getMaxFD();
       const pending = new Array(iterCount);
       for (let i = 0; i < iterCount; i++) {
         pending[i] = promises.readdir(full, { recursive: true, withFileTypes });


### PR DESCRIPTION
```
2410 |       expect(maxFD).toBe(newMaxFD); // assert we do not leak file descriptors
                           ^
error: expect(received).toBe(expected)
 
Expected: 695
Received: 696
 
      at /var/lib/buildkite-agent/builds/ip-172-31-25-245-yjkoZT/bun/bun/test/js/node/fs/fs.test.ts:2410:21
✗ fs/promises > readdir(path, {recursive: true} should work x 100 [785.72ms]
```

~~this error was reproducible locally and this fixes it testing locally as well. previously we were measuring the fd count after the warmup instead of at the beginning of the test. due to this some of the warmup objects may not have cleaned themself up yet and introducec flakyness depending on gc aggressiveness~~

that diagnosis was wrong