### PR TITLE
Docs: Update bunx doc for running local executables

### DIFF
--- a/docs/cli/bunx.md
+++ b/docs/cli/bunx.md
@@ -32,6 +32,11 @@ These executables are commonly plain JavaScript files marked with a [shebang lin
 console.log("Hello world!");
 ```
 
+To run local executables, the package needs to be linked. This will put the executables into the global bun binaries path so that it can be executed from anywhere in the command line.
+```bash
+$ bun link
+```
+
 These executables can be run with `bunx`,
 
 ```bash


### PR DESCRIPTION
### What does this PR do?
Update doc & clarifies steps for `bunx` to get the example in the docs to run locally.

As mentioned in the docs
>As with npx, bunx will check for a locally installed package first, then fall back to auto-installing the package from npm. Installed packages will be stored in Bun's global cache for future use.


Running e.g. `bunx my-cli` without first running `bun link` for local executables doesn't work because bun can't resolve the path of the executable. 
 

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?
**Before**

https://github.com/user-attachments/assets/bba83aed-d286-4241-b2bc-3db1c7aff70d


**After**

https://github.com/user-attachments/assets/f3af2d61-a57e-41fd-8198-793d81010e34

