### PR TITLE
Added rounded borders for `bun outdated` table

### DIFF
--- a/src/cli/outdated_command.zig
+++ b/src/cli/outdated_command.zig
@@ -24,20 +24,20 @@ fn Table(
         column_inside_lengths: [num_columns]usize,
 
         pub fn topLeftSep(_: *const @This()) string {
-            return if (enable_ansi_colors) "┌" else "|";
+            return if (enable_ansi_colors) "╭" else "|";
         }
         pub fn topRightSep(_: *const @This()) string {
-            return if (enable_ansi_colors) "┐" else "|";
+            return if (enable_ansi_colors) "╮" else "|";
         }
         pub fn topColumnSep(_: *const @This()) string {
             return if (enable_ansi_colors) "┬" else "-";
         }
 
         pub fn bottomLeftSep(_: *const @This()) string {
-            return if (enable_ansi_colors) "└" else "|";
+            return if (enable_ansi_colors) "╰" else "|";
         }
         pub fn bottomRightSep(_: *const @This()) string {
-            return if (enable_ansi_colors) "┘" else "|";
+            return if (enable_ansi_colors) "╯" else "|";
         }
         pub fn bottomColumnSep(_: *const @This()) string {
             return if (enable_ansi_colors) "┴" else "-";


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

Makes rounded corners in the table

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### Description

In my opinion, the rounded corners are more pleasing to the eye and more modern

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
