### PR TITLE
fix(Bun.serve) ensure timeout reset when we write data

### DIFF
--- a/.buildkite/scripts/build-bun.sh
+++ b/.buildkite/scripts/build-bun.sh
@@ -52,9 +52,11 @@ for name in bun bun-profile; do
   run_command mv "$name" "$dir/$name"
   run_command zip -r "$dir.zip" "$dir"
   source "$cwd/.buildkite/scripts/upload-artifact.sh" "$dir.zip"
-  if [ "$name" == "bun-profile" ]; then
-    export BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING="1"
-    run_command "./$name" -e "require('fs').writeFileSync('./features.json', JSON.stringify(require('bun:internal-for-testing').crash_handler.getFeatureData()))"
-    source "$cwd/.buildkite/scripts/upload-artifact.sh" "features.json"
-  fi
+  # temporary disable this so CI can run
+  # this is failing because $name is now in $dir/$name and if changed to $dir/$name we get ENOENT reading "bun:internal-for-testing"
+  # if [ "$name" == "bun-profile" ]; then
+  #   export BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING="1"
+  #   run_command "./$name" -e "require('fs').writeFileSync('./features.json', JSON.stringify(require('bun:internal-for-testing').crash_handler.getFeatureData()))"
+  #   source "$cwd/.buildkite/scripts/upload-artifact.sh" "features.json"
+  # fi
 done

--- a/.buildkite/scripts/build-bun.sh
+++ b/.buildkite/scripts/build-bun.sh
@@ -52,11 +52,9 @@ for name in bun bun-profile; do
   run_command mv "$name" "$dir/$name"
   run_command zip -r "$dir.zip" "$dir"
   source "$cwd/.buildkite/scripts/upload-artifact.sh" "$dir.zip"
-  # temporary disable this so CI can run
-  # this is failing because $name is now in $dir/$name and if changed to $dir/$name we get ENOENT reading "bun:internal-for-testing"
-  # if [ "$name" == "bun-profile" ]; then
-  #   export BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING="1"
-  #   run_command "./$name" -e "require('fs').writeFileSync('./features.json', JSON.stringify(require('bun:internal-for-testing').crash_handler.getFeatureData()))"
-  #   source "$cwd/.buildkite/scripts/upload-artifact.sh" "features.json"
-  # fi
+  if [ "$name" == "bun-profile" ]; then
+    export BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING="1"
+    run_command "./$name" -e "require('fs').writeFileSync('./features.json', JSON.stringify(require('bun:internal-for-testing').crash_handler.getFeatureData()))"
+    source "$cwd/.buildkite/scripts/upload-artifact.sh" "features.json"
+  fi
 done

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -305,7 +305,7 @@ private:
 
                 /* Timeout on uncork failure */
                 auto [written, failed] = ((AsyncSocket<SSL> *) returnedSocket)->uncork();
-                if (failed) {
+                if (written > 0 || failed) {
                     /* All Http sockets timeout by this, and this behavior match the one in HttpResponse::cork */
                     ((HttpResponse<SSL> *) s)->resetTimeout();
                 }

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -479,9 +479,8 @@ public:
         Super::write("\r\n", 2);
 
         auto [written, failed] = Super::write(data.data(), (int) data.length());
-        if (written > 0 || failed) {
-            this->resetTimeout();
-        }
+        /* Reset timeout on each sended chunk */
+        this->resetTimeout();
 
         /* If we did not fail the write, accept more */
         return !failed;

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -188,11 +188,8 @@ public:
 
             /* Success is when we wrote the entire thing without any failures */
             bool success = written == data.length() && !failed;
-
-            /* If we are now at the end, start a timeout. Also start a timeout if we failed. */
-            if (!success || httpResponseData->offset == totalSize) {
-                this->resetTimeout();
-            }
+            /* Reset the timeout on each tryEnd */
+            this->resetTimeout();
 
             /* Remove onAborted function if we reach the end */
             if (httpResponseData->offset == totalSize) {
@@ -482,7 +479,7 @@ public:
         Super::write("\r\n", 2);
 
         auto [written, failed] = Super::write(data.data(), (int) data.length());
-        if (failed) {
+        if (written > 0 || failed) {
             this->resetTimeout();
         }
 
@@ -539,7 +536,7 @@ public:
                 return static_cast<HttpResponse *>(newCorkedSocket);
             }
 
-            if (failed) {
+            if (written > 0 || failed) {
                 /* For now we only have one single timeout so let's use it */
                 /* This behavior should equal the behavior in HttpContext when uncorking fails */
                 this->resetTimeout();

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -2522,6 +2522,8 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
         }
 
         fn registerAutoFlusher(this: *@This()) void {
+            // if we enqueue data we should reset the timeout
+            this.res.resetTimeout();
             if (!this.auto_flusher.registered)
                 AutoFlusher.registerDeferredMicrotaskWithTypeUnchecked(@This(), this, this.globalThis.bunVM());
         }

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1161,7 +1161,15 @@ extern "C"
       uwsRes->resetTimeout();
     }
   }
-
+  void uws_res_reset_timeout(int ssl, uws_res_r res) {
+    if (ssl) {
+      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      uwsRes->resetTimeout();
+    } else {
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+      uwsRes->resetTimeout();
+    }
+  }
   void uws_res_timeout(int ssl, uws_res_r res, uint8_t seconds) {
     if (ssl) {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -2270,6 +2270,9 @@ pub fn NewApp(comptime ssl: bool) type {
             pub fn timeout(res: *Response, seconds: u8) void {
                 uws_res_timeout(ssl_flag, res.downcast(), seconds);
             }
+            pub fn resetTimeout(res: *Response) void {
+                uws_res_reset_timeout(ssl_flag, res.downcast());
+            }
             pub fn write(res: *Response, data: []const u8) bool {
                 return uws_res_write(ssl_flag, res.downcast(), data.ptr, data.len);
             }
@@ -2683,7 +2686,7 @@ extern fn uws_res_write_header_int(ssl: i32, res: *uws_res, key: [*c]const u8, k
 extern fn uws_res_end_without_body(ssl: i32, res: *uws_res, close_connection: bool) void;
 extern fn uws_res_end_sendfile(ssl: i32, res: *uws_res, write_offset: u64, close_connection: bool) void;
 extern fn uws_res_timeout(ssl: i32, res: *uws_res, timeout: u8) void;
-
+extern fn uws_res_reset_timeout(ssl: i32, res: *uws_res) void;
 extern fn uws_res_write(ssl: i32, res: *uws_res, data: [*c]const u8, length: usize) bool;
 extern fn uws_res_get_write_offset(ssl: i32, res: *uws_res) u64;
 extern fn uws_res_override_write_offset(ssl: i32, res: *uws_res, u64) void;

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1941,5 +1941,5 @@ it("should reset timeout after writes", async () => {
     expect(err?.code).toBe("ConnectionClosed");
   }
 
-  expect(received).toBeGreaterThanOrEqual(CHUNKS);
+  expect(received).toBe(CHUNKS);
 }, 22_000);

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1893,7 +1893,7 @@ it("should allow use of custom timeout", async () => {
   await Promise.all([testTimeout("/ok", true), testTimeout("/timeout", false)]);
 }, 10_000);
 
-it.only("should reset timeout after writes", async () => {
+it("should reset timeout after writes", async () => {
   // the default is 10s so we send 15
   // this test should take 20s at most
   const CHUNKS = 15;


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/13515
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Test added
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
