### PR TITLE
fix(randomInt) allow negatives and improve args validation

### DIFF
--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -2912,6 +2912,15 @@ pub const JSGlobalObject = opaque {
         this.ERR_INVALID_ARG_TYPE("The \"{s}\" argument must be of type {s}. Received {}", .{ argname, typename, bun.fmt.quote(ty_str.slice()) }).throw();
         return .zero;
     }
+    pub fn throwInvalidArgumentRangeValue(
+        this: *JSGlobalObject,
+        argname: []const u8,
+        typename: []const u8,
+        value: i64,
+    ) JSValue {
+        this.ERR_OUT_OF_RANGE("The \"{s}\" is out of range. {s}. Received {}", .{ argname, typename, value }).throw();
+        return .zero;
+    }
 
     pub fn createNotEnoughArguments(
         this: *JSGlobalObject,
@@ -4422,7 +4431,7 @@ pub const JSValue = enum(JSValueReprInt) {
     }
 
     pub fn jsNumberFromInt64(i: i64) JSValue {
-        if (i <= std.math.maxInt(i32)) {
+        if (i <= std.math.maxInt(i32) and i >= std.math.minInt(i32)) {
             return jsNumberFromInt32(@as(i32, @intCast(i)));
         }
 

--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -11,20 +11,32 @@ const assert = bun.assert;
 const EVP = Crypto.EVP;
 const PBKDF2 = EVP.PBKDF2;
 const JSValue = JSC.JSValue;
-
+const validators = @import("./util/validators.zig");
 fn randomInt(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) JSC.JSValue {
     const arguments = callframe.arguments(2).slice();
 
-    var at_least: u52 = 0;
-    var at_most: u52 = std.math.maxInt(u52);
 
     //min, max
     if (!arguments[0].isNumber()) return globalThis.throwInvalidArgumentTypeValue("min", "safe integer", arguments[0]);
     if (!arguments[1].isNumber()) return globalThis.throwInvalidArgumentTypeValue("max", "safe integer", arguments[1]);
-    at_least = arguments[0].to(u52);
-    at_most = arguments[1].to(u52);
+    const min = arguments[0].to(i64);
+    const max = arguments[1].to(i64);
+    
+    if(min > validators.NUMBER__MAX_SAFE_INTEGER or min < validators.NUMBER__MIN_SAFE_INTEGER) {
+      return globalThis.throwInvalidArgumentRangeValue("min", "It must be a safe integer type number", min);
+    }
+    if(max > validators.NUMBER__MAX_SAFE_INTEGER) {
+      return globalThis.throwInvalidArgumentRangeValue("max", "It must be a safe integer type number", max);
+    }
+    if(min >= max) {
+      return globalThis.throwInvalidArgumentRangeValue("max", "should be greater than min", max);
+    }
+    const diff = max - min;
+    if(diff > 281474976710655) {
+      return globalThis.throwInvalidArgumentRangeValue("max - min", "It must be <= 281474976710655", diff);
+    }
 
-    return JSC.JSValue.jsNumberFromUint64(std.crypto.random.intRangeLessThan(u52, at_least, at_most));
+    return JSC.JSValue.jsNumberFromInt64(std.crypto.random.intRangeLessThan(i64, min, max));
 }
 
 fn pbkdf2(

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -1,14 +1,31 @@
-import { it, expect } from "bun:test";
+import { it, expect, describe } from "bun:test";
 import { randomInt } from "crypto";
 
-it("randomInt args validation", async () => {
-  expect(() => randomInt(-1)).toThrow(RangeError);
-  expect(() => randomInt(0)).toThrow(RangeError);
-  expect(() => randomInt(1, 0)).toThrow(RangeError);
-  expect(() => randomInt(10, 5)).toThrow(RangeError);
-  expect(() => randomInt(-2, -1)).not.toThrow(RangeError);
-  expect(() => randomInt(-2, Number.MAX_SAFE_INTEGER)).toThrow(RangeError);
-  expect(() => randomInt(Number.MAX_SAFE_INTEGER + 1)).toThrow(RangeError);
-  expect(() => randomInt(-Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)).toThrow(RangeError);
-  expect(() => randomInt(-Number.MAX_SAFE_INTEGER, -Number.MAX_SAFE_INTEGER + 1)).not.toThrow(RangeError);
+describe("randomInt args validation", async () => {
+  it("default min is 0 so max should be greater than 0", () => {
+    expect(() => randomInt(-1)).toThrow(RangeError);
+    expect(() => randomInt(0)).toThrow(RangeError);
+  });
+  it("max should be >= min", () => {
+    expect(() => randomInt(1, 0)).toThrow(RangeError);
+    expect(() => randomInt(10, 5)).toThrow(RangeError);
+  });
+
+  it("we allow negative numbers", () => {
+    expect(() => randomInt(-2, -1)).not.toThrow(RangeError);
+  });
+
+  it("max/min should not be greater than Number.MAX_SAFE_INTEGER or less than Number.MIN_SAFE_INTEGER", () => {
+    expect(() => randomInt(Number.MAX_SAFE_INTEGER + 1)).toThrow(RangeError);
+    expect(() => randomInt(-Number.MAX_SAFE_INTEGER - 1, -Number.MAX_SAFE_INTEGER + 1)).toThrow(RangeError);
+  });
+
+  it("max - min should be <= 281474976710655", () => {
+    expect(() => randomInt(-2, Number.MAX_SAFE_INTEGER)).toThrow(RangeError);
+    expect(() => randomInt(-Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)).toThrow(RangeError);
+  });
+
+  it("accept large negative numbers", () => {
+    expect(() => randomInt(-Number.MAX_SAFE_INTEGER, -Number.MAX_SAFE_INTEGER + 1)).not.toThrow(RangeError);
+  });
 });

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -1,0 +1,14 @@
+import { it, expect } from "bun:test";
+import { randomInt } from "crypto";
+
+it("randomInt args validation", async () => {
+  expect(() => randomInt(-1)).toThrow(RangeError);
+  expect(() => randomInt(0)).toThrow(RangeError);
+  expect(() => randomInt(1, 0)).toThrow(RangeError);
+  expect(() => randomInt(10, 5)).toThrow(RangeError);
+  expect(() => randomInt(-2, -1)).not.toThrow(RangeError);
+  expect(() => randomInt(-2, Number.MAX_SAFE_INTEGER)).toThrow(RangeError);
+  expect(() => randomInt(Number.MAX_SAFE_INTEGER + 1)).toThrow(RangeError);
+  expect(() => randomInt(-Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)).toThrow(RangeError);
+  expect(() => randomInt(-Number.MAX_SAFE_INTEGER, -Number.MAX_SAFE_INTEGER + 1)).not.toThrow(RangeError);
+});


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/13524
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Test added
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
