### PR TITLE
fix(Server) handle `requestIP` after async call

### DIFF
--- a/src/bun.js/Weak.zig
+++ b/src/bun.js/Weak.zig
@@ -4,6 +4,8 @@ const JSC = bun.JSC;
 pub const WeakRefType = enum(u32) {
     None = 0,
     FetchResponse = 1,
+    PostgreSQLQueryClient = 2,
+    HTTPRequest = 3,
 };
 const WeakImpl = opaque {
     pub fn init(globalThis: *JSC.JSGlobalObject, value: JSC.JSValue, refType: WeakRefType, ctx: ?*anyopaque) *WeakImpl {

--- a/src/bun.js/Weak.zig
+++ b/src/bun.js/Weak.zig
@@ -5,7 +5,6 @@ pub const WeakRefType = enum(u32) {
     None = 0,
     FetchResponse = 1,
     PostgreSQLQueryClient = 2,
-    HTTPRequest = 3,
 };
 const WeakImpl = opaque {
     pub fn init(globalThis: *JSC.JSGlobalObject, value: JSC.JSValue, refType: WeakRefType, ctx: ?*anyopaque) *WeakImpl {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5830,11 +5830,9 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 return JSC.jsBoolean(false);
             }
 
-            if (upgrader.upgrade_context == null or @intFromPtr(upgrader.upgrade_context) == std.math.maxInt(usize) or upgrader.req == null) {
+            if (upgrader.upgrade_context == null or @intFromPtr(upgrader.upgrade_context) == std.math.maxInt(usize)) {
                 return JSC.jsBoolean(false);
             }
-
-            const req = upgrader.req.?;
 
             const resp = upgrader.resp.?;
             const ctx = upgrader.upgrade_context.?;
@@ -5851,22 +5849,23 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 sec_websocket_extensions = head.fastGet(.SecWebSocketExtensions) orelse ZigString.Empty;
             }
 
-            if (sec_websocket_key_str.len == 0) {
-                sec_websocket_key_str = ZigString.init(req.header("sec-websocket-key") orelse "");
+            if(upgrader.req) |req| {
+                if (sec_websocket_key_str.len == 0) {
+                    sec_websocket_key_str = ZigString.init(req.header("sec-websocket-key") orelse "");
+                }
+                if (sec_websocket_protocol.len == 0) {
+                    sec_websocket_protocol = ZigString.init(req.header("sec-websocket-protocol") orelse "");
+                }
+
+                if (sec_websocket_extensions.len == 0) {
+                    sec_websocket_extensions = ZigString.init(req.header("sec-websocket-extensions") orelse "");
+                }
             }
 
             if (sec_websocket_key_str.len == 0) {
                 return JSC.jsBoolean(false);
             }
-
-            if (sec_websocket_protocol.len == 0) {
-                sec_websocket_protocol = ZigString.init(req.header("sec-websocket-protocol") orelse "");
-            }
-
-            if (sec_websocket_extensions.len == 0) {
-                sec_websocket_extensions = ZigString.init(req.header("sec-websocket-extensions") orelse "");
-            }
-
+           
             if (sec_websocket_protocol.len > 0) {
                 sec_websocket_protocol.markUTF8();
             }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2002,7 +2002,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             this.endRequestStreamingAndDrain();
             // TODO: has_marked_complete is doing something?
             this.flags.has_marked_complete = true;
-            
+
             if (this.defer_deinit_until_callback_completes) |defer_deinit| {
                 defer_deinit.* = true;
                 ctxLog("deferred deinit <d> ({*})<r>", .{this});
@@ -2399,7 +2399,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 this.response_jsvalue = JSC.JSValue.zero;
             }
 
-            if(this.request_weakref.get()) |request| {
+            if (this.request_weakref.get()) |request| {
                 request.request_context = AnyRequestContext.Null;
                 this.request_weakref.deinit();
             }
@@ -3527,7 +3527,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 }
 
                 if (!this.flags.has_abort_handler) {
-                    if(this.req) |req | {
+                    if (this.req) |req| {
                         try writer.writeAll(req.url());
                         return;
                     }
@@ -5842,7 +5842,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 sec_websocket_extensions = head.fastGet(.SecWebSocketExtensions) orelse ZigString.Empty;
             }
 
-            if(upgrader.req) |req| {
+            if (upgrader.req) |req| {
                 if (sec_websocket_key_str.len == 0) {
                     sec_websocket_key_str = ZigString.init(req.header("sec-websocket-key") orelse "");
                 }
@@ -5858,7 +5858,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             if (sec_websocket_key_str.len == 0) {
                 return JSC.jsBoolean(false);
             }
-           
+
             if (sec_websocket_protocol.len > 0) {
                 sec_websocket_protocol.markUTF8();
             }
@@ -6740,7 +6740,6 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 .body = body.ref(),
             });
             ctx.request_weakref = Request.WeakRef.create(request_object);
-
 
             if (comptime debug_mode) {
                 ctx.flags.is_web_browser_navigation = brk: {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -6828,7 +6828,6 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             ctx.defer_deinit_until_callback_completes = original_state;
 
             if (should_deinit_context) {
-                request_object.request_context = JSC.API.AnyRequestContext.Null;
                 ctx.deinit();
                 return;
             }
@@ -6879,7 +6878,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             const response_value = this.config.onRequest.call(this.globalThis, this.thisObject, &args);
             defer {
                 // uWS request will not live longer than this function
-                request_object.request_context = JSC.API.AnyRequestContext.Null;
+                request_object.request_context.detachRequest();
             }
 
             const original_state = ctx.defer_deinit_until_callback_completes;
@@ -6895,7 +6894,6 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             ctx.defer_deinit_until_callback_completes = original_state;
 
             if (should_deinit_context) {
-                request_object.request_context = JSC.API.AnyRequestContext.Null;
                 ctx.deinit();
                 return;
             }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2782,11 +2782,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             }
 
             if (this.blob.needsToReadFile()) {
-                if(this.req) |req| {
-                    req.setYield(false);
-                    if (!this.flags.has_sendfile_ctx)
-                        this.doSendfile(this.blob.Blob);
-                }
+                if (!this.flags.has_sendfile_ctx)
+                    this.doSendfile(this.blob.Blob);
                 return;
             }
 
@@ -6743,7 +6740,6 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 .signal = signal.ref(),
                 .body = body.ref(),
             });
-
 
             if (comptime debug_mode) {
                 ctx.flags.is_web_browser_navigation = brk: {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1843,7 +1843,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         /// this prevents an extra pthread_getspecific() call which shows up in profiling
         allocator: std.mem.Allocator,
         req: ?*uws.Request,
-        request_weakref: JSC.Weak(RequestContext) = .{},
+        request_ref: JSC.Strong = .{},
         signal: ?*JSC.WebCore.AbortSignal = null,
         method: HTTP.Method,
 
@@ -2399,10 +2399,10 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 this.response_jsvalue = JSC.JSValue.zero;
             }
 
-            if(this.request_weakref.get()) |js_request| {
+            if(this.request_ref.get()) |js_request| {
                 if(js_request.as(Request)) |request|{
                     request.request_context = AnyRequestContext.Null;
-                    this.request_weakref.deinit();
+                    this.request_ref.deinit();
                 }
             }
 
@@ -5953,6 +5953,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             // after upgrading we should not use the response anymore
             upgrader.resp = null;
             request.request_context = AnyRequestContext.Null;
+            upgrader.request_ref.deinit();
 
             data_value.ensureStillAlive();
             const ws = ServerWebSocket.new(.{
@@ -6793,7 +6794,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             }
             const js_request = request_object.toJS(this.globalThis);
             js_request.ensureStillAlive();
-            ctx.request_weakref = JSC.Weak(RequestContext).create(js_request, this.globalThis, .HTTPRequest, ctx);
+            ctx.request_ref = JSC.Strong.create(js_request, this.globalThis);
 
             // We keep the Request object alive for the duration of the request so that we can remove the pointer to the UWS request object.
             var args = [_]JSC.JSValue{
@@ -6868,6 +6869,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             };
             const request_value = args[0];
             request_value.ensureStillAlive();
+            ctx.request_ref = JSC.Strong.create(request_value, this.globalThis);
             const response_value = this.config.onRequest.call(this.globalThis, this.thisObject, &args);
             defer {
                 // uWS request will not live longer than this function

--- a/src/bun.js/bindings/Weak.cpp
+++ b/src/bun.js/bindings/Weak.cpp
@@ -11,7 +11,6 @@ enum class WeakRefType : uint32_t {
     None = 0,
     FetchResponse = 1,
     PostgreSQLQueryClient = 2,
-    HTTPRequest = 3,
 };
 
 typedef void (*WeakRefFinalizeFn)(void* context);
@@ -19,8 +18,7 @@ typedef void (*WeakRefFinalizeFn)(void* context);
 // clang-format off
 #define FOR_EACH_WEAK_REF_TYPE(macro) \
     macro(FetchResponse) \
-    macro(PostgreSQLQueryClient) \
-    macro(HTTPRequest)
+    macro(PostgreSQLQueryClient)
 
 // clang-format on
 
@@ -41,8 +39,6 @@ public:
                 break;
             case WeakRefType::PostgreSQLQueryClient:
                 // Bun__PostgreSQLQueryClient_finalize(context);
-                break;
-            case WeakRefType::HTTPRequest:
                 break;
             default:
                 break;
@@ -66,9 +62,6 @@ static JSC::WeakHandleOwner* getWeakRefOwner(WeakRefType type)
     }
     case WeakRefType::PostgreSQLQueryClient: {
         return getWeakRefOwner<WeakRefType::PostgreSQLQueryClient>();
-    }
-    case WeakRefType::HTTPRequest: {
-        return getWeakRefOwner<WeakRefType::HTTPRequest>();
     }
     default: {
         RELEASE_ASSERT_NOT_REACHED();

--- a/src/bun.js/bindings/Weak.cpp
+++ b/src/bun.js/bindings/Weak.cpp
@@ -11,6 +11,7 @@ enum class WeakRefType : uint32_t {
     None = 0,
     FetchResponse = 1,
     PostgreSQLQueryClient = 2,
+    HTTPRequest = 3,
 };
 
 typedef void (*WeakRefFinalizeFn)(void* context);
@@ -18,7 +19,8 @@ typedef void (*WeakRefFinalizeFn)(void* context);
 // clang-format off
 #define FOR_EACH_WEAK_REF_TYPE(macro) \
     macro(FetchResponse) \
-    macro(PostgreSQLQueryClient)
+    macro(PostgreSQLQueryClient) \
+    macro(HTTPRequest)
 
 // clang-format on
 
@@ -39,6 +41,8 @@ public:
                 break;
             case WeakRefType::PostgreSQLQueryClient:
                 // Bun__PostgreSQLQueryClient_finalize(context);
+                break;
+            case WeakRefType::HTTPRequest:
                 break;
             default:
                 break;
@@ -62,6 +66,9 @@ static JSC::WeakHandleOwner* getWeakRefOwner(WeakRefType type)
     }
     case WeakRefType::PostgreSQLQueryClient: {
         return getWeakRefOwner<WeakRefType::PostgreSQLQueryClient>();
+    }
+    case WeakRefType::HTTPRequest: {
+        return getWeakRefOwner<WeakRefType::HTTPRequest>();
     }
     default: {
         RELEASE_ASSERT_NOT_REACHED();

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -79,9 +79,9 @@ pub const Request = struct {
     pub const getBlobWithoutCallFrame = RequestMixin.getBlobWithoutCallFrame;
     pub const WeakRef = struct {
         value: ?*Request = null,
-        pub fn create(this: *Request) WeakRef {
-            this.weak_refs += 1;
-            return .{ .value = this };
+        pub fn create(req: *Request) WeakRef {
+            req.weak_refs += 1;
+            return .{ .value = req };
         }
 
         pub fn deinit(this: *WeakRef) void {
@@ -95,8 +95,8 @@ pub const Request = struct {
             }
         }
 
-        pub fn get(self: *WeakRef) ?*Request {
-            return self.value;
+        pub fn get(this: *WeakRef) ?*Request {
+            return this.value;
         }
     };
 

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -85,19 +85,21 @@ pub const Request = struct {
         }
 
         pub fn deinit(this: *WeakRef) void {
-            if(this.value) |value| {
+            if (this.value) |value| {
                 const count = value.weak_refs;
                 this.value = null;
                 value.weak_refs -= 1;
-                if(value.finalized and count == 1) {
+                if (value.finalized and count == 1) {
                     value.destroy();
                 }
             }
         }
 
         pub fn get(this: *WeakRef) ?*Request {
-            if(this.value) |value| {
-                if(!value.finalized) return value;
+            if (this.value) |value| {
+                if (!value.finalized) {
+                    return value;
+                }
             }
             return null;
         }
@@ -128,7 +130,6 @@ pub const Request = struct {
             .method = method,
         };
     }
-    
 
     pub fn getContentType(
         this: *Request,
@@ -322,7 +323,7 @@ pub const Request = struct {
         this.finalized = true;
         this.finalizeWithoutDeinit();
         _ = this.body.unref();
-        if(this.weak_refs == 0) {
+        if (this.weak_refs == 0) {
             this.destroy();
         }
     }

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -80,6 +80,7 @@ pub const Request = struct {
     pub const WeakRef = struct {
         value: ?*Request = null,
         pub fn create(req: *Request) WeakRef {
+            bun.assert(!req.finalized);
             req.weak_refs += 1;
             return .{ .value = req };
         }

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -96,7 +96,10 @@ pub const Request = struct {
         }
 
         pub fn get(this: *WeakRef) ?*Request {
-            return this.value;
+            if(this.value) |value| {
+                if(!value.finalized) return value;
+            }
+            return null;
         }
     };
 

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -78,20 +78,23 @@ pub const Request = struct {
     pub const getFormData = RequestMixin.getFormData;
     pub const getBlobWithoutCallFrame = RequestMixin.getBlobWithoutCallFrame;
     pub const WeakRef = struct {
-        value: ?*Request,
+        value: ?*Request = null,
         pub fn create(this: *Request) WeakRef {
             this.weak_refs += 1;
             return .{ .value = this };
         }
+
         pub fn deinit(this: *WeakRef) void {
             if(this.value) |value| {
                 const count = value.weak_refs;
+                this.value = null;
                 value.weak_refs -= 1;
                 if(value.finalized and count == 1) {
-                    this.destroy();
+                    value.destroy();
                 }
             }
         }
+
         pub fn get(self: *WeakRef) ?*Request {
             return self.value;
         }

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -59,7 +59,6 @@ pub const Request = struct {
     method: Method = Method.GET,
     request_context: JSC.API.AnyRequestContext = JSC.API.AnyRequestContext.Null,
     https: bool = false,
-    upgrader: ?*anyopaque = null,
 
     // We must report a consistent value for this
     reported_estimated_size: usize = 0,

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -80,7 +80,6 @@ pub const Request = struct {
     pub const WeakRef = struct {
         value: ?*Request = null,
         pub fn create(req: *Request) WeakRef {
-            bun.assert(!req.finalized);
             req.weak_refs += 1;
             return .{ .value = req };
         }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3673,6 +3673,7 @@ pub const WeakPtrData = packed struct(u32) {
     finalized: bool = false,
 
     pub fn onFinalize(this: *WeakPtrData) bool {
+        bun.debugAssert(!this.finalized);
         this.finalized = true;
         return this.reference_count == 0;
     }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3699,8 +3699,9 @@ pub fn WeakPtr(comptime T: type, comptime weakable_field: std.meta.FieldEnum(T))
             const weak_data: *WeakPtrData = &@field(value, @tagName(weakable_field));
 
             this.value = null;
-            weak_data.reference_count -= 1;
-            if (weak_data.finalized and weak_data.reference_count == 1) {
+            const count = weak_data.reference_count - 1;
+            weak_data.reference_count = count;
+            if (weak_data.finalized and count == 0) {
                 value.destroy();
             }
         }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3667,3 +3667,59 @@ extern "C" fn Bun__ramSize() usize;
 pub fn getTotalMemorySize() usize {
     return Bun__ramSize();
 }
+
+pub const WeakPtrData = packed struct(u32) {
+    reference_count: u31 = 0,
+    finalized: bool = false,
+
+    pub fn onFinalize(this: *WeakPtrData) bool {
+        this.finalized = true;
+        return this.reference_count == 0;
+    }
+};
+
+pub fn WeakPtr(comptime T: type, comptime weakable_field: std.meta.FieldEnum(T)) type {
+    return struct {
+        const WeakRef = @This();
+
+        value: ?*T = null,
+        pub fn create(req: *T) WeakRef {
+            bun.debugAssert(!@field(req, @tagName(weakable_field)).finalized);
+            @field(req, @tagName(weakable_field)).reference_count += 1;
+            return .{ .value = req };
+        }
+
+        comptime {
+            if (@TypeOf(@field(@as(T, undefined), @tagName(weakable_field))) != WeakPtrData) {
+                @compileError("Expected " ++ @typeName(T) ++ " to have a " ++ @typeName(WeakPtrData) ++ " field named " ++ @tagName(weakable_field));
+            }
+        }
+
+        fn deinitInternal(this: *WeakRef, value: *T) void {
+            const weak_data: *WeakPtrData = &@field(value, @tagName(weakable_field));
+
+            this.value = null;
+            weak_data.reference_count -= 1;
+            if (weak_data.finalized and weak_data.reference_count == 1) {
+                value.destroy();
+            }
+        }
+
+        pub fn deinit(this: *WeakRef) void {
+            if (this.value) |value| {
+                this.deinitInternal(value);
+            }
+        }
+
+        pub fn get(this: *WeakRef) ?*T {
+            if (this.value) |value| {
+                if (!@field(value, @tagName(weakable_field)).finalized) {
+                    return value;
+                }
+
+                this.deinitInternal(value);
+            }
+            return null;
+        }
+    };
+}

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,11 +1,11 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { bunExe, bunEnv, tmpdirSync, isDebug } from "harness";
+import { bunExe, bunEnv, tmpdirSync, isDebug, isWindows } from "harness";
 import { cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync, copyFileSync } from "fs";
 import { join } from "path";
 
-const timeout = isDebug ? Infinity : 10_000;
-const longTimeout = isDebug ? Infinity : 30_000;
+const timeout = (isDebug ? Infinity : (isWindows ? 20_000 : 10_000));
+const longTimeout = (isDebug ? Infinity : (isWindows ? 30_000 : 10_000));
 
 let hotRunnerRoot: string = "",
   cwd = "";

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -4,8 +4,8 @@ import { bunExe, bunEnv, tmpdirSync, isDebug, isWindows } from "harness";
 import { cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync, copyFileSync } from "fs";
 import { join } from "path";
 
-const timeout = (isDebug ? Infinity : (isWindows ? 20_000 : 10_000));
-const longTimeout = (isDebug ? Infinity : (isWindows ? 30_000 : 10_000));
+const timeout = isDebug ? Infinity : 10_000;
+const longTimeout = isDebug ? Infinity : 30_000;
 
 let hotRunnerRoot: string = "",
   cwd = "";

--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -143,6 +143,6 @@ for (const test_info of [
       expect(report.leak).toBeLessThanOrEqual(maxMemoryGrowth);
       expect(report.end_memory).toBeLessThanOrEqual(512 * 1024 * 1024);
     },
-    isDebug ? 60_000 : 30_000,
+    isDebug ? 60_000 : 40_000,
   );
 }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1860,7 +1860,7 @@ it("we should always send date", async () => {
 it("should allow use of custom timeout", async () => {
   using server = Bun.serve({
     port: 0,
-    idleTimeout: 4, // uws precision is in seconds, and lower than 4 seconds is not reliable its timer is not that accurate
+    idleTimeout: 5, // uws precision is in seconds, and lower than 4 seconds is not reliable its timer is not that accurate
     async fetch(req) {
       const url = new URL(req.url);
       return new Response(
@@ -1868,7 +1868,7 @@ it("should allow use of custom timeout", async () => {
           async pull(controller) {
             controller.enqueue("Hello,");
             if (url.pathname === "/timeout") {
-              await Bun.sleep(5000);
+              await Bun.sleep(7000);
             } else {
               await Bun.sleep(10);
             }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1857,7 +1857,7 @@ it("we should always send date", async () => {
   }
 });
 
-it.only("should allow use of custom timeout", async () => {
+it("should allow use of custom timeout", async () => {
   using server = Bun.serve({
     port: 0,
     idleTimeout: 8, // uws precision is in seconds, and lower than 4 seconds is not reliable its timer is not that accurate

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1857,10 +1857,10 @@ it("we should always send date", async () => {
   }
 });
 
-it("should allow use of custom timeout", async () => {
+it.only("should allow use of custom timeout", async () => {
   using server = Bun.serve({
     port: 0,
-    idleTimeout: 5, // uws precision is in seconds, and lower than 4 seconds is not reliable its timer is not that accurate
+    idleTimeout: 8, // uws precision is in seconds, and lower than 4 seconds is not reliable its timer is not that accurate
     async fetch(req) {
       const url = new URL(req.url);
       return new Response(
@@ -1868,7 +1868,7 @@ it("should allow use of custom timeout", async () => {
           async pull(controller) {
             controller.enqueue("Hello,");
             if (url.pathname === "/timeout") {
-              await Bun.sleep(7000);
+              await Bun.sleep(10000);
             } else {
               await Bun.sleep(10);
             }
@@ -1891,7 +1891,7 @@ it("should allow use of custom timeout", async () => {
     }
   }
   await Promise.all([testTimeout("/ok", true), testTimeout("/timeout", false)]);
-}, 10_000);
+}, 15_000);
 
 it("should reset timeout after writes", async () => {
   // the default is 10s so we send 15

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1944,3 +1944,19 @@ it("should reset timeout after writes", async () => {
 
   expect(received).toBe(CHUNKS * payload.byteLength);
 }, 20_000);
+
+it("allow requestIP after async operation", async () => {
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req, server) {
+      await Bun.sleep(1);
+      return new Response(JSON.stringify(server.requestIP(req)));
+    },
+  });
+
+  const ip = await fetch(server.url).then(res => res.json());
+  expect(ip).not.toBeNull();
+  expect(ip.port).toBeInteger();
+  expect(ip.address).toBeString();
+  expect(ip.family).toBeString();
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -159,12 +159,23 @@ describe("node:http", () => {
     });
 
     it("should use the provided port", async () => {
-      const server = http.createServer(() => {});
-      const random_port = randomPort();
-      server.listen(random_port);
-      const { port } = server.address();
-      expect(port).toEqual(random_port);
-      server.close();
+      while (true) {
+        try {
+          const server = http.createServer(() => {});
+          const random_port = randomPort();
+          server.listen(random_port);
+          const { port } = server.address();
+          expect(port).toEqual(random_port);
+          server.close();
+          break;
+        } catch (err) {
+          // Address in use try another port
+          if (err.code === "EADDRINUSE") {
+            continue;
+          }
+          throw err;
+        }
+      }
     });
 
     it("should assign a random port when undefined", async () => {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -269,7 +269,9 @@ for (const timeout of [0, 1, 10, 20, 100, 300]) {
         return new Response("Hello World");
       },
     });
-    const time = Date.now();
+    const THRESHOLD = 50;
+
+    const time = performance.now();
     try {
       await fetch(server.url, {
         //@ts-ignore
@@ -280,9 +282,9 @@ for (const timeout of [0, 1, 10, 20, 100, 300]) {
     } catch (err) {
       expect((err as Error).name).toBe("TimeoutError");
     } finally {
-      const diff = Date.now() - time;
-      expect(diff).toBeLessThanOrEqual(timeout + 30);
-      expect(diff).toBeGreaterThanOrEqual(timeout - 30);
+      const diff = performance.now() - time;
+      expect(diff).toBeLessThanOrEqual(timeout + THRESHOLD);
+      expect(diff).toBeGreaterThanOrEqual(timeout - THRESHOLD);
     }
   });
 }

--- a/test/js/web/timers/performance.test.js
+++ b/test/js/web/timers/performance.test.js
@@ -8,21 +8,15 @@ it("performance.now() should be monotonic", () => {
   const fourth = performance.now();
   const fifth = performance.now();
   const sixth = performance.now();
+  expect(first).toBeLessThanOrEqual(second);
+  expect(second).toBeLessThanOrEqual(third);
+  expect(third).toBeLessThanOrEqual(fourth);
+  expect(fourth).toBeLessThanOrEqual(fifth);
+  expect(fifth).toBeLessThanOrEqual(sixth);
   if (isWindows) {
     // Timer precision is monotonic on Windows, but it is 100ns of precision
     // making it extremely easy to hit overlapping timer values here.
-    expect(first).toBeLessThanOrEqual(second);
-    expect(second).toBeLessThanOrEqual(third);
-    expect(third).toBeLessThanOrEqual(fourth);
-    expect(fourth).toBeLessThanOrEqual(fifth);
-    expect(fifth).toBeLessThanOrEqual(sixth);
     Bun.sleepSync(0.001);
-  } else {
-    expect(first).toBeLessThan(second);
-    expect(second).toBeLessThan(third);
-    expect(third).toBeLessThan(fourth);
-    expect(fourth).toBeLessThan(fifth);
-    expect(fifth).toBeLessThan(sixth);
   }
   expect(Bun.nanoseconds()).toBeGreaterThan(0);
   expect(Bun.nanoseconds()).toBeGreaterThan(sixth);


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/11756
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
Existing tests + new test
<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
