### PR TITLE
Use more compatible screen clearing ANSI escape

### DIFF
--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -596,8 +596,7 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
       // It only makes sense to clear if _stdout is a TTY.
       // Otherwise, do nothing.
       if (this._stdout.isTTY && process.env.TERM !== "dumb") {
-        this._stdout.write("\x1b[2J");
-        this._stdout.write("\x1b[0f");
+        this._stdout.write("\x1B[2J\x1B[3J\x1B[H");
       }
     },
 

--- a/src/output.zig
+++ b/src/output.zig
@@ -387,17 +387,17 @@ pub fn resetTerminal() void {
     }
 
     if (enable_ansi_colors_stderr) {
-        _ = source.error_stream.write("\x1b[H\x1b[2J").unwrap() catch 0;
+        _ = source.error_stream.write("\x1B[2J\x1B[3J\x1B[H").unwrap() catch 0;
     } else {
-        _ = source.stream.write("\x1b[H\x1b[2J").unwrap() catch 0;
+        _ = source.stream.write("\x1B[2J\x1B[3J\x1B[H").unwrap() catch 0;
     }
 }
 
 pub fn resetTerminalAll() void {
     if (enable_ansi_colors_stderr)
-        _ = source.error_stream.write("\x1b[H\x1b[2J").unwrap() catch 0;
+        _ = source.error_stream.write("\x1B[2J\x1B[3J\x1B[H").unwrap() catch 0;
     if (enable_ansi_colors_stdout)
-        _ = source.stream.write("\x1b[H\x1b[2J").unwrap() catch 0;
+        _ = source.stream.write("\x1B[2J\x1B[3J\x1B[H").unwrap() catch 0;
 }
 
 /// Write buffered stdout & stderr to the terminal.


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->


This switches the screen clearing string to one that's more compatible with different OSs/terminals, mirroring https://github.com/microsoft/TypeScript/pull/57701 (which contains a lot of background and testing). This fixes the comment in https://github.com/oven-sh/bun/issues/3491#issuecomment-2280877926 (and my own experience) where the VS Code terminal does not actually fully clear.

- [x] ~Documentation or TypeScript types (it's okay to leave the rest blank in this case)~
- [x] Code changes

### How did you verify your code works?

I'm not sure how to write an automated test for this (TS doesn't either!), but I have done so with the debug build with `--watch` by hand and it starts working the way I expect.

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

