### PR TITLE
fix overriding `sshCommand` and `askpass` from gitconfig

### DIFF
--- a/src/install/repository.zig
+++ b/src/install/repository.zig
@@ -16,11 +16,118 @@ const string = @import("../string_types.zig").string;
 const strings = @import("../string_immutable.zig");
 const GitSHA = String;
 const Path = bun.path;
+const File = bun.sys.File;
 
 threadlocal var final_path_buf: bun.PathBuffer = undefined;
 threadlocal var ssh_path_buf: bun.PathBuffer = undefined;
 threadlocal var folder_name_buf: bun.PathBuffer = undefined;
 threadlocal var json_path_buf: bun.PathBuffer = undefined;
+
+const SloppyGlobalGitConfig = struct {
+    has_askpass: bool = false,
+    has_ssh_command: bool = false,
+
+    var holder: SloppyGlobalGitConfig = .{};
+    var load_and_parse_once = std.once(loadAndParse);
+
+    pub fn get() SloppyGlobalGitConfig {
+        load_and_parse_once.call();
+        return holder;
+    }
+
+    pub fn loadAndParse() void {
+        const home_dir_path = brk: {
+            if (comptime Environment.isWindows) {
+                if (bun.getenvZ("USERPROFILE")) |env|
+                    break :brk bun.asByteSlice(env);
+            } else {
+                if (bun.getenvZ("HOME")) |env|
+                    break :brk bun.asByteSlice(env);
+            }
+
+            // won't find anything
+            return;
+        };
+
+        var home_dir = std.fs.openDirAbsolute(home_dir_path, .{}) catch return;
+        defer home_dir.close();
+        const config_file = home_dir.openFileZ(".gitconfig", .{}) catch return;
+        defer config_file.close();
+
+        var original_input = File.from(config_file).readToEnd(bun.default_allocator).unwrap() catch return;
+        defer bun.default_allocator.free(original_input);
+
+        if (comptime Environment.isWindows) {
+            if (strings.BOM.detect(original_input)) |bom| {
+                original_input = bom.removeAndConvertToUTF8AndFree(bun.default_allocator, original_input) catch bun.outOfMemory();
+            }
+        }
+
+        var remaining = bun.strings.split(original_input, "\n");
+        var found_askpass = false;
+        var found_ssh_command = false;
+        var @"[core]" = false;
+        while (remaining.next()) |line_| {
+            if (found_askpass and found_ssh_command) break;
+
+            const line = strings.trim(line_, " \r");
+
+            if (line.len == 0) continue;
+
+            if (line[0] == '[') {
+                if (strings.indexOfChar(line, ']')) |end_bracket| {
+                    if (strings.eqlComptime(line[0 .. end_bracket + 1], "[core]")) {
+                        @"[core]" = true;
+                        continue;
+                    }
+                }
+                @"[core]" = false;
+                continue;
+            }
+
+            if (@"[core]") {
+                if (!found_askpass) {
+                    if (line.len > "askpass".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."askpass".len], "askpass") and switch (line["askpass".len]) {
+                        ' ', '\t', '=' => true,
+                        else => false,
+                    }) {
+                        found_askpass = true;
+                        continue;
+                    }
+                }
+
+                if (!found_ssh_command) {
+                    if (line.len > "sshCommand".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."sshCommand".len], "sshCommand") and switch (line["sshCommand".len]) {
+                        ' ', '\t', '=' => true,
+                        else => false,
+                    }) {
+                        found_ssh_command = true;
+                    }
+                }
+            } else {
+                if (line.len > "core.askpass".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."core.askpass".len], "core.askpass") and switch (line["sshCommand".len]) {
+                    ' ', '\t', '=' => true,
+                    else => false,
+                }) {
+                    found_askpass = true;
+                    continue;
+                }
+
+                if (line.len > "core.sshCommand".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."core.sshCommand".len], "core.sshCommand") and switch (line["sshCommand".len]) {
+                    ' ', '\t', '=' => true,
+                    else => false,
+                }) {
+                    found_ssh_command = true;
+                }
+            }
+        }
+
+        holder = .{
+            .has_askpass = found_askpass,
+            .has_ssh_command = found_ssh_command,
+        };
+    }
+};
 
 pub const Repository = extern struct {
     owner: String = .{},
@@ -41,22 +148,18 @@ pub const Repository = extern struct {
                 // below will cause no prompt and throw instead.
                 var cloned = other.map.cloneWithAllocator(allocator) catch bun.outOfMemory();
 
-                const askpass_entry = cloned.getOrPutWithoutValue("GIT_ASKPASS") catch bun.outOfMemory();
-                if (!askpass_entry.found_existing) {
-                    askpass_entry.key_ptr.* = allocator.dupe(u8, "GIT_ASKPASS") catch bun.outOfMemory();
-                    askpass_entry.value_ptr.* = .{
-                        .value = allocator.dupe(u8, "echo") catch bun.outOfMemory(),
-                        .conditional = false,
-                    };
+                if (cloned.get("GIT_ASKPASS") == null) {
+                    const config = SloppyGlobalGitConfig.get();
+                    if (!config.has_askpass) {
+                        cloned.put("GIT_ASKPASS", "echo") catch bun.outOfMemory();
+                    }
                 }
 
-                const git_ssh_command_entry = cloned.getOrPutWithoutValue("GIT_SSH_COMMAND") catch bun.outOfMemory();
-                if (!git_ssh_command_entry.found_existing) {
-                    git_ssh_command_entry.key_ptr.* = allocator.dupe(u8, "GIT_SSH_COMMAND") catch bun.outOfMemory();
-                    git_ssh_command_entry.value_ptr.* = .{
-                        .value = allocator.dupe(u8, "ssh -oStrictHostKeyChecking=accept-new") catch bun.outOfMemory(),
-                        .conditional = false,
-                    };
+                if (cloned.get("GIT_SSH_COMMAND") == null) {
+                    const config = SloppyGlobalGitConfig.get();
+                    if (!config.has_ssh_command) {
+                        cloned.put("GIT_SSH_COMMAND", "ssh -oStrictHostKeyChecking=accept-new") catch bun.outOfMemory();
+                    }
                 }
 
                 this.env = cloned;


### PR DESCRIPTION
### What does this PR do?
fixes #12172 
fixes #12257 

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
TODO: tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
