### PR TITLE
Fix AES-GCM encryption of empty messages

### DIFF
--- a/test/regression/issue/01466.test.ts
+++ b/test/regression/issue/01466.test.ts
@@ -1,0 +1,18 @@
+async function doTest(additionalData) {
+  const name = "AES-GCM";
+  const key = await crypto.subtle.generateKey({ name, length: 128 }, false, ["encrypt", "decrypt"]);
+  const plaintext = new Uint8Array();
+  const iv = crypto.getRandomValues(new Uint8Array(16));
+  const algorithm = { name, iv, tagLength: 128, additionalData };
+  const ciphertext = await crypto.subtle.encrypt(algorithm, key, plaintext);
+  const decrypted = await crypto.subtle.decrypt(algorithm, key, ciphertext);
+  expect(new TextDecoder().decode(decrypted)).toBe("");
+}
+
+it("crypto.subtle.encrypt AES-GCM empty data", async () => {
+  doTest(undefined);
+});
+
+it("crypto.subtle.encrypt AES-GCM empty data with additional associated data", async () => {
+  doTest(crypto.getRandomValues(new Uint8Array(16)));
+});


### PR DESCRIPTION
### What does this PR do?

AES-GCM is not block based, unlike AES-CBC, so we're not required to pad the ciphertext. Instead, a tag is written at the end to authenticate the plaintext after decryption. `EVP_EncryptFinal_Ex` within this context is used as a way to signal that we've concluded writing our data and should proceed to compute the authentication tag. In the case of a zero message, this logic would essentially get triggered via the earlier call to `EVP_EncryptUpdate`, resulting in an error when `EVP_EncryptFinal_Ex` is then called because it is not idempotent. To fix, we simply check that we have some plaintext to write before writing it.

Fixes https://github.com/oven-sh/bun/issues/1466.

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)