### PR TITLE
experiment: disable jit on windows

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -418,6 +418,15 @@ async function spawnSafe(options) {
   };
 }
 
+const windowsOnlyEnv = isWindows
+  ? {
+      SHELLOPTS: "igncr",
+
+      // experiment:
+      BUN_JSC_useJIT: "0",
+    }
+  : {};
+
 /**
  * @param {string} execPath
  * @param {SpawnOptions} options
@@ -429,6 +438,7 @@ async function spawnBun(execPath, { args, cwd, timeout, env, stdout, stderr }) {
   const { username } = userInfo();
   const bunEnv = {
     ...process.env,
+    ...windowsOnlyEnv,
     PATH: path,
     TMPDIR: tmpdirPath,
     USER: username,
@@ -440,7 +450,6 @@ async function spawnBun(execPath, { args, cwd, timeout, env, stdout, stderr }) {
     BUN_ENABLE_CRASH_REPORTING: "0", // change this to '1' if https://github.com/oven-sh/bun/issues/13012 is implemented
     BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
     BUN_INSTALL_CACHE_DIR: tmpdirPath,
-    SHELLOPTS: isWindows ? "igncr" : undefined, // ignore "\r" on Windows
     // Used in Node.js tests.
     TEST_TMPDIR: tmpdirPath,
   };


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
