### PR TITLE
Change contributing docs to use llvm 18 on macos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Bun requires LLVM 16 (`clang` is part of LLVM). This version requirement is to m
 {% codetabs %}
 
 ```bash#macOS (Homebrew)
-$ brew install llvm@16
+$ brew install llvm@18
 ```
 
 ```bash#Ubuntu/Debian


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
`bun setup` requires llvm 18. this pr changes the llvm version in contributing docs from 16 to 18 (for macos).
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes