### PR TITLE
Fix crash when throwing an exception from napi

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -45,7 +45,6 @@
 #include <JavaScriptCore/JSArrayBuffer.h>
 #include "JSFFIFunction.h"
 #include <JavaScriptCore/JavaScript.h>
-#include <JavaScriptCore/JSWeakValue.h>
 #include "napi.h"
 #include <JavaScriptCore/GetterSetter.h>
 #include <JavaScriptCore/JSSourceCode.h>
@@ -64,6 +63,7 @@
 #include <JavaScriptCore/FunctionPrototype.h>
 #include "CommonJSModuleRecord.h"
 #include "wtf/text/ASCIIFastPath.h"
+#include "JavaScriptCore/WeakInlines.h"
 
 // #include <iostream>
 using namespace JSC;
@@ -148,13 +148,8 @@ void NapiRef::ref()
     ++refCount;
     if (refCount == 1 && !weakValueRef.isClear()) {
         auto& vm = globalObject.get()->vm();
-        if (weakValueRef.isString()) {
-            strongRef.set(vm, JSC::JSValue(weakValueRef.string()));
-        } else if (weakValueRef.isObject()) {
-            strongRef.set(vm, JSC::JSValue(weakValueRef.object()));
-        } else {
-            strongRef.set(vm, weakValueRef.primitive());
-        }
+        strongRef.set(vm, weakValueRef.get());
+
         // isSet() will return always true after being set once
         // We cannot rely on isSet() to check if the value is set we need to use isClear()
         // .setString/.setObject/.setPrimitive will assert fail if called more than once (even after clear())
@@ -218,6 +213,101 @@ static uint32_t getPropertyAttributes(napi_property_descriptor prop)
     // }
 
     return result;
+}
+
+NapiWeakValue::~NapiWeakValue()
+{
+    clear();
+}
+
+void NapiWeakValue::clear()
+{
+    switch (m_tag) {
+    case WeakTypeTag::Cell: {
+        m_value.cell.clear();
+        break;
+    }
+    case WeakTypeTag::String: {
+        m_value.string.clear();
+        break;
+    }
+    default: {
+        break;
+    }
+    }
+
+    m_tag = WeakTypeTag::NotSet;
+}
+
+bool NapiWeakValue::isClear() const
+{
+    return m_tag == WeakTypeTag::NotSet;
+}
+
+void NapiWeakValue::setPrimitive(JSValue value)
+{
+    switch (m_tag) {
+    case WeakTypeTag::Cell: {
+        m_value.cell.clear();
+        break;
+    }
+    case WeakTypeTag::String: {
+        m_value.string.clear();
+        break;
+    }
+    default: {
+        break;
+    }
+    }
+    m_tag = WeakTypeTag::Primitive;
+    m_value.primitive = value;
+}
+
+void NapiWeakValue::set(JSValue value, WeakHandleOwner& owner, void* context)
+{
+    if (value.isCell()) {
+        auto* cell = value.asCell();
+        if (cell->isString()) {
+            setString(jsCast<JSString*>(cell), owner, context);
+        } else {
+            setCell(cell, owner, context);
+        }
+    } else {
+        setPrimitive(value);
+    }
+}
+
+void NapiWeakValue::setCell(JSCell* cell, WeakHandleOwner& owner, void* context)
+{
+    switch (m_tag) {
+    case WeakTypeTag::Cell: {
+        m_value.cell = JSC::Weak<JSCell>(cell, &owner, context);
+        break;
+    }
+    case WeakTypeTag::String: {
+        m_value.string.clear();
+        break;
+    }
+    default: {
+        break;
+    }
+    }
+}
+
+void NapiWeakValue::setString(JSString* string, WeakHandleOwner& owner, void* context)
+{
+    switch (m_tag) {
+    case WeakTypeTag::Cell: {
+        m_value.cell.clear();
+        break;
+    }
+    default: {
+        break;
+    }
+    }
+
+    m_value.string = JSC::Weak<JSString>(string, &owner, context);
+    m_tag = WeakTypeTag::String;
 }
 
 class NAPICallFrame {
@@ -672,7 +762,7 @@ extern "C" napi_status napi_set_named_property(napi_env env, napi_value object,
         return napi_object_expected;
     }
 
-    if (UNLIKELY(utf8name == nullptr || !*utf8name)) {
+    if (UNLIKELY(utf8name == nullptr || !*utf8name || !value)) {
         return napi_invalid_arg;
     }
 
@@ -971,7 +1061,8 @@ extern "C" napi_status napi_wrap(napi_env env,
     }
 
     auto* ref = new NapiRef(globalObject, 0);
-    ref->weakValueRef.setObject(value.getObject(), weakValueHandleOwner(), ref);
+
+    ref->weakValueRef.set(value, weakValueHandleOwner(), ref);
 
     if (finalize_cb) {
         ref->finalizer.finalize_cb = finalize_cb;
@@ -1239,7 +1330,6 @@ static JSValue createErrorForNapi(napi_env env, napi_value code, napi_value msg,
         }
     }
 
-
     auto* error = constructor(globalObject, message);
 
     if (codeValue && error) {
@@ -1274,13 +1364,13 @@ extern "C" napi_status napi_create_reference(napi_env env, napi_value value,
 {
     NAPI_PREMABLE
 
-    if (UNLIKELY(!result)) {
+    if (UNLIKELY(!result || !env)) {
         return napi_invalid_arg;
     }
 
     JSC::JSValue val = toJS(value);
 
-    if (!val || !val.isObject()) {
+    if (!val || !val.isCell()) {
         return napi_object_expected;
     }
 
@@ -1290,14 +1380,7 @@ extern "C" napi_status napi_create_reference(napi_env env, napi_value value,
     if (initial_refcount > 0) {
         ref->strongRef.set(globalObject->vm(), val);
     }
-    // we dont have a finalizer but we can use the weak value to re-ref again or get the value until the GC is called
-    if (val.isString()) {
-        ref->weakValueRef.setString(val.toString(globalObject), weakValueHandleOwner(), ref);
-    } else if (val.isObject()) {
-        ref->weakValueRef.setObject(val.getObject(), weakValueHandleOwner(), ref);
-    } else {
-        ref->weakValueRef.setPrimitive(val);
-    }
+    ref->weakValueRef.set(val, weakValueHandleOwner(), ref);
 
     *result = toNapi(ref);
 
@@ -2528,8 +2611,7 @@ extern "C" napi_status napi_set_instance_data(napi_env env,
     NAPI_PREMABLE
 
     Zig::GlobalObject* globalObject = toJS(env);
-    if (data)
-        globalObject->napiInstanceData = data;
+    globalObject->napiInstanceData = data;
 
     globalObject->napiInstanceDataFinalizer = reinterpret_cast<void*>(finalize_cb);
     globalObject->napiInstanceDataFinalizerHint = finalize_hint;

--- a/src/bun.js/bindings/napi.h
+++ b/src/bun.js/bindings/napi.h
@@ -62,6 +62,11 @@ public:
 };
 
 
+// This is essentially JSC::JSWeakValue, except with a JSCell* instead of a
+// JSObject*. Sometimes, a napi embedder might want to store a JSC::Exception, a
+// JSC::HeapBigInt, JSC::Symbol, etc inside of a NapiRef. So we can't limit it
+// to just JSObject*. It has to be JSCell*. It's not clear that we benefit from
+// not simply making this JSC::Unknown.
 class NapiWeakValue {
 public:
     NapiWeakValue() = default;


### PR DESCRIPTION
### What does this PR do?

Fix crash when throwing an exception from napi

This fixes the crash in https://github.com/oven-sh/bun/issues/13622, but does not fix the underlying cause of the crash.

After this PR, it throws an exception like the below:
```js
17 | var uv = (process.versions.uv || '').split('.')[0]
18 | 
19 | module.exports = load
20 | 
21 | function load (dir) {
22 |   return runtimeRequire(load.resolve(dir))
               ^
TypeError: Underlying ArrayBuffer has been detached from the view or out-of-bounds
      at load (/Users/jarred/Desktop/node_modules/node-gyp-build/node-gyp-build.js:22:10)
      at /Users/jarred/Desktop/node_modules/ref-napi/lib/ref.js:8:18
      at require (1:11)
      at /Users/jarred/Desktop/ref.js:1:5
```

The next step here is to implement NapiHandleScope and wire it up to the various places where objects are created.

### How did you verify your code works?

Manual :(