### PR TITLE
feat: Add bun create from GitHub branch/commit

### DIFF
--- a/docs/cli/bun-create.md
+++ b/docs/cli/bun-create.md
@@ -37,6 +37,13 @@ $ bun create <user>/<repo> mydir
 $ bun create github.com/<user>/<repo> mydir
 ```
 
+You can also specify a branch or commit. If no branch or commit is specified, the default branch will be used.
+
+```bash
+$ bun create <user>/<repo>@<branch>
+$ bun create <user>/<repo>@<commit>
+```
+
 Bun will perform the following steps:
 
 - Download the template


### PR DESCRIPTION
### What does this PR do?

Fixes: https://github.com/oven-sh/bun/issues/13521

Previously, `bun create` only fetched the default branch for a GitHub repository, which is fine for simple use-cases, but I thought it would be nice to have the option to choose a branch or commit. 

This PR extends the `bun create` command with an optional branch/commit parameter, using the following syntax:

```sh
bun create <user>/<repo>@branch
 ```

or

```sh
bun create <user>/<repo>@commit
 ```

Please keep in mind that I am a TypeScript dev and I have never used Zig before (or any other low-level programming language). I have no idea what I am doing :D 

### How did you verify your code works?

I tested it manually by running `bun create itsyoboieltr/bender-stack@dev`, and it downloaded the dev branch, instead of the default `main` branch. Running `bun create itsyoboieltr/bender-stack@e336875013be9aebafa188eda51c50f11b1bb3b1` downloaded the repository's state in the pinned commit. I did not add any tests, as I could not find any existing tests for `bun create`.