### PR TITLE
Use JSMapIterator and JSSetIterator for deep equal comparisons

### DIFF
--- a/bench/deepEqual/map.js
+++ b/bench/deepEqual/map.js
@@ -1,0 +1,27 @@
+import { bench, run } from "mitata";
+import { expect } from "bun:test";
+
+const MAP_SIZE = 10_000;
+
+function* genPairs(count) {
+  for (let i = 0; i < MAP_SIZE; i++) {
+    yield ["k" + i, "v" + i];
+  }
+}
+
+class CustomMap extends Map {
+  abc = 123;
+  constructor(iterable) {
+    super(iterable);
+  }
+}
+
+const a = new Map(genPairs());
+const b = new Map(genPairs());
+bench("deepEqual Map", () => expect(a).toEqual(b));
+
+const x = new CustomMap(genPairs());
+const y = new CustomMap(genPairs());
+bench("deepEqual CustomMap", () => expect(x).toEqual(y));
+
+await run();

--- a/bench/deepEqual/set.js
+++ b/bench/deepEqual/set.js
@@ -1,0 +1,27 @@
+import { bench, run } from "mitata";
+import { expect } from "bun:test";
+
+const SET_SIZE = 10_000;
+
+function* genValues(count) {
+  for (let i = 0; i < SET_SIZE; i++) {
+    yield "v" + i;
+  }
+}
+
+class CustomSet extends Set {
+  abc = 123;
+  constructor(iterable) {
+    super(iterable);
+  }
+}
+
+const a = new Set(genValues());
+const b = new Set(genValues());
+bench("deepEqual Set", () => expect(a).toEqual(b));
+
+const x = new CustomSet(genValues());
+const y = new CustomSet(genValues());
+bench("deepEqual CustomSet", () => expect(x).toEqual(y));
+
+await run();

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -41,12 +41,14 @@
 #include "JavaScriptCore/JSClassRef.h"
 #include "JavaScriptCore/JSInternalPromise.h"
 #include "JavaScriptCore/JSMap.h"
+#include "JavaScriptCore/JSMapIterator.h"
 #include "JavaScriptCore/JSModuleLoader.h"
 #include "JavaScriptCore/JSModuleRecord.h"
 #include "JavaScriptCore/JSNativeStdFunction.h"
 #include "JavaScriptCore/JSONObject.h"
 #include "JavaScriptCore/JSObject.h"
 #include "JavaScriptCore/JSSet.h"
+#include "JavaScriptCore/JSSetIterator.h"
 #include "JavaScriptCore/JSString.h"
 #include "JavaScriptCore/ProxyObject.h"
 #include "JavaScriptCore/Microtask.h"
@@ -736,97 +738,12 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             return false;
         }
 
-        // bool canPerformFastSet = JSSet::isAddFastAndNonObservable(set1->structure()) && JSSet::isAddFastAndNonObservable(set2->structure());
-
-        // // This code is loosely based on
-        // // https://github.com/oven-sh/WebKit/blob/657558d4d4c9c33f41b9670e72d96a5a39fe546e/Source/JavaScriptCore/runtime/HashMapImplInlines.h#L203-L211
-        // if (canPerformFastSet && set1->isIteratorProtocolFastAndNonObservable() && set2->isIteratorProtocolFastAndNonObservable()) {
-        //     auto* bucket = set1->head();
-        //     while (bucket) {
-        //         if (!bucket->deleted()) {
-        //             auto key = bucket->key();
-        //             RETURN_IF_EXCEPTION(*scope, false);
-        //             auto** bucket2ptr = set2->findBucket(globalObject, key);
-
-        //             if (bucket2ptr && (*bucket2ptr)->deleted()) {
-        //                 bucket2ptr = nullptr;
-        //             }
-
-        //             if (!bucket2ptr) {
-        //                 auto findDeepEqualKey = [&]() -> bool {
-        //                     auto* bucket = set2->head();
-        //                     while (bucket) {
-        //                         if (!bucket->deleted()) {
-        //                             auto key2 = bucket->key();
-        //                             if (Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, key, key2, gcBuffer, stack, scope, false)) {
-        //                                 return true;
-        //                             }
-        //                         }
-        //                         bucket = bucket->next();
-        //                     }
-
-        //                     return false;
-        //                 };
-
-        //                 if (!findDeepEqualKey()) {
-        //                     return false;
-        //                 }
-        //             }
-        //         }
-        //         bucket = bucket->next();
-        //     }
-
-        //     return true;
-        // }
-
-        // This code path can be triggered when it is a class that extends from Set.
-        //
-        //    class MySet extends Set {}
-        //
-        IterationRecord iterationRecord1 = iteratorForIterable(globalObject, v1);
-        bool isEqual = true;
-
-        // https://github.com/oven-sh/bun/issues/7736
-        DeferGC deferGC(vm);
-
-        while (true) {
-            JSValue next1 = iteratorStep(globalObject, iterationRecord1);
-            if (next1.isFalse()) {
-                break;
+        auto iter1 = JSSetIterator::create(globalObject, set1->structure(), set1, IterationKind::Keys);
+        JSValue key1;
+        while (iter1->next(globalObject, key1)) {
+            if (!set2->has(globalObject, key1)) {
+                return false;
             }
-
-            JSValue nextValue1 = iteratorValue(globalObject, next1);
-            RETURN_IF_EXCEPTION(*scope, false);
-
-            bool found = false;
-            IterationRecord iterationRecord2 = iteratorForIterable(globalObject, v2);
-            while (true) {
-                JSValue next2 = iteratorStep(globalObject, iterationRecord2);
-                if (UNLIKELY(next2.isFalse())) {
-                    break;
-                }
-
-                JSValue nextValue2 = iteratorValue(globalObject, next2);
-                RETURN_IF_EXCEPTION(*scope, false);
-
-                // set has unique values, no need to count
-                if (Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, nextValue1, nextValue2, gcBuffer, stack, scope, false)) {
-                    found = true;
-                    if (!nextValue1.isPrimitive()) {
-                        stack.append({ nextValue1, nextValue2 });
-                    }
-                    break;
-                }
-            }
-
-            if (!found) {
-                isEqual = false;
-                break;
-            }
-        }
-
-        if (!isEqual) {
-            return false;
         }
 
         return true;
@@ -844,127 +761,13 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             return false;
         }
 
-        // bool canPerformFastSet = JSMap::isSetFastAndNonObservable(map1->structure()) && JSMap::isSetFastAndNonObservable(map2->structure());
-
-        // // This code is loosely based on
-        // // https://github.com/oven-sh/WebKit/blob/657558d4d4c9c33f41b9670e72d96a5a39fe546e/Source/JavaScriptCore/runtime/HashMapImplInlines.h#L203-L211
-        // if (canPerformFastSet && map1->isIteratorProtocolFastAndNonObservable() && map2->isIteratorProtocolFastAndNonObservable()) {
-        //     auto* bucket = map1->head();
-        //     while (bucket) {
-        //         if (!bucket->deleted()) {
-        //             auto key = bucket->key();
-        //             auto value = bucket->value();
-        //             RETURN_IF_EXCEPTION(*scope, false);
-        //             auto** bucket2ptr = map2->findBucket(globalObject, key);
-        //             JSMap::BucketType* bucket2 = nullptr;
-
-        //             if (bucket2ptr) {
-        //                 bucket2 = *bucket2ptr;
-
-        //                 if (bucket2->deleted()) {
-        //                     bucket2 = nullptr;
-        //                 }
-        //             }
-
-        //             if (!bucket2) {
-        //                 auto findDeepEqualKey = [&]() -> JSMap::BucketType* {
-        //                     auto* bucket = map2->head();
-        //                     while (bucket) {
-        //                         if (!bucket->deleted()) {
-        //                             auto key2 = bucket->key();
-        //                             if (Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, key, key2, gcBuffer, stack, scope, false)) {
-        //                                 return bucket;
-        //                             }
-        //                         }
-        //                         bucket = bucket->next();
-        //                     }
-
-        //                     return nullptr;
-        //                 };
-
-        //                 bucket2 = findDeepEqualKey();
-        //             }
-
-        //             if (!bucket2 || !Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, value, bucket2->value(), gcBuffer, stack, scope, false)) {
-        //                 return false;
-        //             }
-        //         }
-        //         bucket = bucket->next();
-        //     }
-
-        //     return true;
-        // }
-
-        // This code path can be triggered when it is a class that extends from Map.
-        //
-        //    class MyMap extends Map {}
-        //
-        IterationRecord iterationRecord1 = iteratorForIterable(globalObject, v1);
-        bool isEqual = true;
-
-        // https://github.com/oven-sh/bun/issues/7736
-        DeferGC deferGC(vm);
-
-        while (true) {
-            JSValue next1 = iteratorStep(globalObject, iterationRecord1);
-            if (next1.isFalse()) {
-                break;
-            }
-
-            JSValue nextValue1 = iteratorValue(globalObject, next1);
-            RETURN_IF_EXCEPTION(*scope, false);
-
-            if (UNLIKELY(!nextValue1.isObject())) {
+        auto iter1 = JSMapIterator::create(globalObject, map1->structure(), map1, IterationKind::Entries);
+        JSValue key1, value1;
+        while (iter1->nextKeyValue(globalObject, key1, value1)) {
+            JSValue value2 = map2->get(globalObject, key1);
+            if (!Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, value1, value2, gcBuffer, stack, scope, false)) {
                 return false;
             }
-
-            JSObject* nextValueObject1 = asObject(nextValue1);
-
-            JSValue key1 = nextValueObject1->getIndex(globalObject, static_cast<unsigned>(0));
-            RETURN_IF_EXCEPTION(*scope, false);
-
-            bool found = false;
-
-            IterationRecord iterationRecord2 = iteratorForIterable(globalObject, v2);
-
-            while (true) {
-
-                JSValue next2 = iteratorStep(globalObject, iterationRecord2);
-                if (UNLIKELY(next2.isFalse())) {
-                    break;
-                }
-
-                JSValue nextValue2 = iteratorValue(globalObject, next2);
-                RETURN_IF_EXCEPTION(*scope, false);
-
-                if (UNLIKELY(!nextValue2.isObject())) {
-                    return false;
-                }
-
-                JSObject* nextValueObject2 = asObject(nextValue2);
-
-                JSValue key2 = nextValueObject2->getIndex(globalObject, static_cast<unsigned>(0));
-                RETURN_IF_EXCEPTION(*scope, false);
-
-                if (Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, key1, key2, gcBuffer, stack, scope, false)) {
-                    if (Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, nextValue1, nextValue2, gcBuffer, stack, scope, false)) {
-                        found = true;
-                        if (!nextValue1.isPrimitive()) {
-                            stack.append({ nextValue1, nextValue2 });
-                        }
-                        break;
-                    }
-                }
-            }
-
-            if (!found) {
-                isEqual = false;
-                break;
-            }
-        }
-
-        if (!isEqual) {
-            return false;
         }
 
         return true;


### PR DESCRIPTION
### What does this PR do?

This brings us back to parity in benchmarks for the fast path before commit e42dede. At the same time, we can now eliminate the slow path as the JSC iterators can work on classes that extend the native JSMap and JSSet types and achieve the same benchmarks in those cases.

I had the following results on an Apple M1 Pro:

This commit:

```
benchmark                time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------- -----------------------------
deepEqual Map           227 µs/iter       (218 µs … 281 µs)    232 µs    259 µs    270 µs
deepEqual CustomMap     228 µs/iter       (219 µs … 324 µs)    232 µs    264 µs    315 µs
```

```
benchmark                time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------- -----------------------------
deepEqual Set           155 µs/iter       (149 µs … 203 µs)    155 µs    186 µs    200 µs
deepEqual CustomSet     155 µs/iter       (149 µs … 347 µs)    151 µs    181 µs    191 µs
```

Before commit e42dede:

```
benchmark                time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------- -----------------------------
deepEqual Map           207 µs/iter       (200 µs … 324 µs)    204 µs    234 µs    293 µs
deepEqual CustomMap   2'316 ms/iter   (2'304 ms … 2'343 ms)  2'324 ms  2'343 ms  2'343 ms
```

```
benchmark                time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------- -----------------------------
deepEqual Set           130 µs/iter       (125 µs … 181 µs)    128 µs    158 µs    176 µs
deepEqual CustomSet   1'889 ms/iter   (1'885 ms … 1'899 ms)  1'895 ms  1'899 ms  1'899 ms
```

Fixes https://github.com/oven-sh/bun/issues/12498.

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)