### PR TITLE
Call cancel on ReadableStream when Bun.serve() response is aborted

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2351,7 +2351,10 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             // if signal is not aborted, abort the signal
             if (this.signal) |signal| {
                 this.signal = null;
-                defer signal.unref();
+                defer {
+                    signal.pendingActivityUnref();
+                    signal.unref();
+                }
                 if (!signal.aborted()) {
                     signal.signal(globalThis, .ConnectionClosed);
                     any_js_calls = true;
@@ -2416,7 +2419,10 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             // if signal is not aborted, abort the signal
             if (this.signal) |signal| {
                 this.signal = null;
-                defer signal.unref();
+                defer {
+                    signal.pendingActivityUnref();
+                    signal.unref();
+                }
                 if (this.flags.aborted and !signal.aborted()) {
                     signal.signal(globalThis, .ConnectionClosed);
                 }
@@ -6732,6 +6738,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             ctx.request_body = body;
             var signal = JSC.WebCore.AbortSignal.new(this.globalThis);
             ctx.signal = signal;
+            signal.pendingActivityRef();
 
             const request_object = Request.new(.{
                 .method = ctx.method,

--- a/src/bun.js/bindings/AsyncContextFrame.h
+++ b/src/bun.js/bindings/AsyncContextFrame.h
@@ -36,7 +36,7 @@ public:
     {
         if constexpr (mode == JSC::SubspaceAccess::Concurrently)
             return nullptr;
-        return WebCore::subspaceForImpl<AsyncContextFrame, Bun::UseCustomHeapCellType::No>(
+        return WebCore::subspaceForImpl<AsyncContextFrame, WebCore::UseCustomHeapCellType::No>(
             vm,
             [](auto& spaces) { return spaces.m_clientSubspaceForAsyncContextFrame.get(); },
             [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForAsyncContextFrame = std::forward<decltype(space)>(space); },

--- a/src/bun.js/bindings/NodeTimerObject.cpp
+++ b/src/bun.js/bindings/NodeTimerObject.cpp
@@ -27,10 +27,10 @@ extern "C" void Bun__JSTimeout__call(JSC::EncodedJSValue encodedTimeoutValue, JS
     WebCore::JSTimeout* timeout = jsCast<WebCore::JSTimeout*>(JSC::JSValue::decode(encodedTimeoutValue));
 
     JSCell* callbackCell = timeout->m_callback.get().asCell();
-    JSValue restoreAsyncContext{};
+    JSValue restoreAsyncContext {};
     JSC::InternalFieldTuple* asyncContextData = nullptr;
 
-    if (auto *wrapper = jsDynamicCast<AsyncContextFrame*>(callbackCell)) {
+    if (auto* wrapper = jsDynamicCast<AsyncContextFrame*>(callbackCell)) {
         callbackCell = wrapper->callback.get().asCell();
         asyncContextData = globalObject->m_asyncContextData.get();
         restoreAsyncContext = asyncContextData->getInternalField(0);
@@ -64,7 +64,7 @@ extern "C" void Bun__JSTimeout__call(JSC::EncodedJSValue encodedTimeoutValue, JS
             }
         }
 
-        JSC::profiledCall(globalObject, ProfilingReason::API, JSValue(callbackCell), JSC::getCallData(callbackCell),  timeout, ArgList(args));
+        JSC::profiledCall(globalObject, ProfilingReason::API, JSValue(callbackCell), JSC::getCallData(callbackCell), timeout, ArgList(args));
         break;
     }
     }

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5666,6 +5666,18 @@ extern "C" JSC__JSValue WebCore__AbortSignal__toJS(WebCore__AbortSignal* arg0, J
     return JSValue::encode(toJS<IDLInterface<WebCore__AbortSignal>>(*globalObject, *jsCast<JSDOMGlobalObject*>(globalObject), *abortSignal));
 }
 
+extern "C" void WebCore__AbortSignal__incrementPendingActivity(WebCore__AbortSignal* arg0)
+{
+    WebCore::AbortSignal* abortSignal = reinterpret_cast<WebCore::AbortSignal*>(arg0);
+    abortSignal->incrementPendingActivityCount();
+}
+
+extern "C" void WebCore__AbortSignal__decrementPendingActivity(WebCore__AbortSignal* arg0)
+{
+    WebCore::AbortSignal* abortSignal = reinterpret_cast<WebCore::AbortSignal*>(arg0);
+    abortSignal->decrementPendingActivityCount();
+}
+
 extern "C" WebCore__AbortSignal* WebCore__AbortSignal__signal(WebCore__AbortSignal* arg0, JSC::JSGlobalObject* globalObject, uint8_t reason)
 {
 

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -2071,6 +2071,17 @@ pub const AbortSignal = extern opaque {
         return WebCore__AbortSignal__signal(this, globalObject, reason);
     }
 
+    extern fn WebCore__AbortSignal__incrementPendingActivity(*AbortSignal) void;
+    extern fn WebCore__AbortSignal__decrementPendingActivity(*AbortSignal) void;
+
+    pub fn pendingActivityRef(this: *AbortSignal) void {
+        return WebCore__AbortSignal__incrementPendingActivity(this);
+    }
+
+    pub fn pendingActivityUnref(this: *AbortSignal) void {
+        return WebCore__AbortSignal__decrementPendingActivity(this);
+    }
+
     /// This function is not threadsafe. aborted is a boolean, not an atomic!
     pub fn aborted(this: *AbortSignal) bool {
         return cppFn("aborted", .{this});

--- a/src/bun.js/bindings/webcore/AbortSignal.h
+++ b/src/bun.js/bindings/webcore/AbortSignal.h
@@ -102,6 +102,11 @@ public:
     const AbortSignalSet& sourceSignals() const { return m_sourceSignals; }
     AbortSignalSet& sourceSignals() { return m_sourceSignals; }
 
+    // https://github.com/oven-sh/bun/issues/4517
+    void incrementPendingActivityCount() { ++pendingActivityCount; }
+    void decrementPendingActivityCount() { --pendingActivityCount; }
+    bool hasPendingActivity() const { return pendingActivityCount > 0; }
+
 private:
     enum class Aborted : bool {
         No,
@@ -130,11 +135,12 @@ private:
     JSValueInWrappedObject m_reason;
     CommonAbortReason m_commonReason { CommonAbortReason::None };
     Vector<NativeCallbackTuple, 2> m_native_callbacks;
+    std::atomic<uint32_t> pendingActivityCount { 0 };
     uint32_t m_algorithmIdentifier { 0 };
-    bool m_aborted { false };
-    bool m_hasActiveTimeoutTimer { false };
-    bool m_hasAbortEventListener { false };
-    bool m_isDependent { false };
+    bool m_aborted : 1 = false;
+    bool m_hasActiveTimeoutTimer : 1 = false;
+    bool m_hasAbortEventListener : 1 = false;
+    bool m_isDependent : 1 = false;
 };
 
 WebCoreOpaqueRoot root(AbortSignal*);

--- a/src/bun.js/bindings/webcore/JSAbortSignal.cpp
+++ b/src/bun.js/bindings/webcore/JSAbortSignal.cpp
@@ -361,7 +361,7 @@ void JSAbortSignal::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 DEFINE_VISIT_CHILDREN(JSAbortSignal);
 
 template<typename Visitor>
-void JSAbortSignal::visitOutputConstraints(JSCell* cell, Visitor& visitor)
+void JSAbortSignal::visitOutputConstraintsImpl(JSCell* cell, Visitor& visitor)
 {
     auto* thisObject = jsCast<JSAbortSignal*>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
@@ -369,8 +369,8 @@ void JSAbortSignal::visitOutputConstraints(JSCell* cell, Visitor& visitor)
     thisObject->visitAdditionalChildren(visitor);
 }
 
-template void JSAbortSignal::visitOutputConstraints(JSCell*, AbstractSlotVisitor&);
-template void JSAbortSignal::visitOutputConstraints(JSCell*, SlotVisitor&);
+DEFINE_VISIT_OUTPUT_CONSTRAINTS(JSAbortSignal);
+
 void JSAbortSignal::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
     auto* thisObject = jsCast<JSAbortSignal*>(cell);

--- a/src/bun.js/bindings/webcore/JSAbortSignal.h
+++ b/src/bun.js/bindings/webcore/JSAbortSignal.h
@@ -59,9 +59,8 @@ public:
     }
     static JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm);
     DECLARE_VISIT_CHILDREN;
+    DECLARE_VISIT_OUTPUT_CONSTRAINTS;
     template<typename Visitor> void visitAdditionalChildren(Visitor&);
-
-    template<typename Visitor> static void visitOutputConstraints(JSCell*, Visitor&);
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
     AbortSignal& wrapped() const
     {

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1315,7 +1315,10 @@ pub const Fetch = struct {
         fn clearAbortSignal(this: *FetchTasklet) void {
             const signal = this.signal orelse return;
             this.signal = null;
-            defer signal.unref();
+            defer {
+                signal.pendingActivityUnref();
+                signal.unref();
+            }
 
             signal.cleanNativeBindings(this);
         }
@@ -1707,6 +1710,7 @@ pub const Fetch = struct {
             }
 
             if (fetch_tasklet.signal) |signal| {
+                signal.pendingActivityRef();
                 fetch_tasklet.signal = signal.listen(FetchTasklet, fetch_tasklet, FetchTasklet.abortListener);
             }
             return fetch_tasklet;

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -896,13 +896,14 @@ extern "C" void ${name}__onReady(JSC__JSValue controllerValue, JSC__JSValue amt,
     if (!function)
         return;
     JSC::JSGlobalObject *globalObject = controller->globalObject();
-
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(controller);
     arguments.append(JSC::JSValue::decode(amt));
     arguments.append(JSC::JSValue::decode(offset));
 
     AsyncContextFrame::call(globalObject, function, JSC::jsUndefined(), arguments);
+    RELEASE_AND_RETURN(scope, void());
 }
 
 extern "C" void ${name}__onStart(JSC__JSValue controllerValue)
@@ -920,13 +921,14 @@ extern "C" void ${name}__onClose(JSC__JSValue controllerValue, JSC__JSValue reas
     // only call close once
     controller->m_onClose.clear();
     JSC::JSGlobalObject* globalObject = controller->globalObject();
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     JSC::MarkedArgumentBuffer arguments;
     auto readableStream = controller->m_weakReadableStream.get();
     arguments.append(readableStream ? readableStream : JSC::jsUndefined());
-
     arguments.append(JSC::JSValue::decode(reason));
     AsyncContextFrame::call(globalObject, function, JSC::jsUndefined(), arguments);
+    RELEASE_AND_RETURN(scope, void());
 }
 
 `;

--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -55,10 +55,11 @@ export function initializeReadableStream(
   // direct streams are always lazy
   const isUnderlyingSourceLazy = !!underlyingSource.$lazy;
   const isLazy = isDirect || isUnderlyingSourceLazy;
+  let pullFn;
 
   // FIXME: We should introduce https://streams.spec.whatwg.org/#create-readable-stream.
   // For now, we emulate this with underlyingSource with private properties.
-  if ($getByIdDirectPrivate(underlyingSource, "pull") !== undefined && !isLazy) {
+  if (!isLazy && (pullFn = $getByIdDirectPrivate(underlyingSource, "pull")) !== undefined) {
     const size = $getByIdDirectPrivate(strategy, "size");
     const highWaterMark = $getByIdDirectPrivate(strategy, "highWaterMark");
     $putByIdDirectPrivate(this, "highWaterMark", highWaterMark);
@@ -69,7 +70,7 @@ export function initializeReadableStream(
       size,
       highWaterMark !== undefined ? highWaterMark : 1,
       $getByIdDirectPrivate(underlyingSource, "start"),
-      $getByIdDirectPrivate(underlyingSource, "pull"),
+      pullFn,
       $getByIdDirectPrivate(underlyingSource, "cancel"),
     );
 

--- a/src/js/builtins/ReadableStreamDefaultController.ts
+++ b/src/js/builtins/ReadableStreamDefaultController.ts
@@ -41,7 +41,6 @@ export function enqueue(this, chunk) {
 
 export function error(this, err) {
   if (!$isReadableStreamDefaultController(this)) throw $makeThisTypeError("ReadableStreamDefaultController", "error");
-
   $readableStreamDefaultControllerError(this, err);
 }
 

--- a/test/js/web/fetch/abort-signal-leak.test.ts
+++ b/test/js/web/fetch/abort-signal-leak.test.ts
@@ -1,0 +1,24 @@
+import { afterAll, test } from "bun:test";
+import {
+  server,
+  testReqSignalGetter,
+  testReqSignalAbortEventNeverResolves,
+  testReqSignalAbortEvent,
+} from "./abortsignal-leak-fixture";
+
+afterAll(async () => {
+  server.stop(true);
+});
+
+test("req.signal getter should not cause AbortSignal to never be GCed", async () => {
+  await testReqSignalGetter();
+});
+
+// https://github.com/oven-sh/bun/issues/4517
+test("'abort' event on req.signal should not cause AbortSignal to never be GCed", async () => {
+  await testReqSignalAbortEvent();
+});
+
+test("'abort' event hadnler on req.signal that never is called should not prevent AbortSignal from being GCed", async () => {
+  await testReqSignalAbortEventNeverResolves();
+});

--- a/test/js/web/fetch/abortsignal-leak-fixture.ts
+++ b/test/js/web/fetch/abortsignal-leak-fixture.ts
@@ -1,0 +1,217 @@
+import { heapStats } from "bun:jsc";
+import { expect } from "bun:test";
+
+let abortEventCount = 0;
+let onAbortHandler = () => {};
+let onRequestContinuePromise = Promise.withResolvers();
+let onRequestContinueHandler = () => {};
+export const server = Bun.serve({
+  port: 0,
+  // Set it to a long number so this test will time out if it's actually the idleTimeout.
+  idleTimeout: 254,
+
+  async fetch(req) {
+    if (req.url.endsWith("/no-abort-event-just-req-signal")) {
+      const signal = req.signal;
+      signal.aborted;
+      onRequestContinueHandler();
+      await onRequestContinuePromise.promise;
+      return new Response();
+    }
+
+    if (req.url.endsWith("/req-signal-aborted")) {
+      const signal = req.signal;
+      signal.addEventListener("abort", () => {
+        abortEventCount++;
+        onAbortHandler();
+      });
+      onRequestContinueHandler();
+      await onRequestContinuePromise.promise;
+      return new Response();
+    }
+
+    return new Response();
+  },
+});
+
+function checkForLeaks(batchSize) {
+  // AbortSignal often doesn't get cleaned up until the next full GC.
+  Bun.gc(true);
+
+  const { objectTypeCounts } = heapStats();
+  console.log(objectTypeCounts);
+  expect(objectTypeCounts.AbortSignal || 0).toBeLessThan(batchSize * 2);
+}
+
+// This test checks that calling req.signal doesn't cause the AbortSignal to be leaked.
+export async function testReqSignalGetter() {
+  const url = `${server.url}/req-signal-aborted`;
+  const batchSize = 50;
+  const iterations = 50;
+
+  async function batch() {
+    onRequestContinuePromise = Promise.withResolvers();
+    const promises = new Array(batchSize);
+    const controllers = new Array(batchSize);
+    let onRequestContinueCallCount = 0;
+    onRequestContinueHandler = () => {
+      onRequestContinueCallCount++;
+      if (onRequestContinueCallCount === batchSize) {
+        onRequestContinuePromise.resolve();
+      }
+    };
+    for (let i = 0; i < batchSize; i++) {
+      const controller = new AbortController();
+      controllers[i] = controller;
+      promises[i] = fetch(url, { signal: controller.signal }).catch(() => {});
+    }
+    await onRequestContinuePromise.promise;
+
+    for (const controller of controllers) {
+      controller.abort();
+    }
+
+    Bun.gc();
+    await Promise.allSettled(promises);
+  }
+
+  await batch();
+
+  const { objectTypeCounts } = heapStats();
+  console.log(objectTypeCounts);
+  for (let i = 0; i < iterations; i++) {
+    await batch();
+  }
+
+  checkForLeaks(batchSize);
+}
+
+// This test checks that calling req.signal.addEventListener("abort", ...)
+// doesn't cause the AbortSignal to be leaked after the request is aborted.
+export async function testReqSignalAbortEvent() {
+  const url = `${server.url}/req-signal-aborted`;
+  const batchSize = 50;
+  const iterations = 50;
+
+  async function batch() {
+    onRequestContinuePromise = Promise.withResolvers();
+    const promises = new Array(batchSize);
+    const controllers = new Array(batchSize);
+    let onRequestContinueCallCount = 0;
+    let onAbortCallCount = 0;
+
+    let waitForRequests = Promise.withResolvers();
+    onRequestContinueHandler = () => {
+      onRequestContinueCallCount++;
+
+      if (onRequestContinueCallCount === batchSize) {
+        waitForRequests.resolve();
+      }
+    };
+    onAbortHandler = () => {
+      onAbortCallCount++;
+
+      if (onAbortCallCount === batchSize) {
+        onRequestContinuePromise.resolve();
+      }
+    };
+    for (let i = 0; i < batchSize; i++) {
+      const controller = new AbortController();
+      controllers[i] = controller;
+      promises[i] = fetch(url, { signal: controller.signal }).catch(() => {});
+    }
+
+    await waitForRequests.promise;
+    await Bun.sleep(1);
+
+    for (const controller of controllers) {
+      controller.abort();
+    }
+    controllers.length = 0;
+
+    await onRequestContinuePromise.promise;
+
+    Bun.gc();
+    await Promise.allSettled(promises);
+  }
+  await batch();
+
+  const { objectTypeCounts } = heapStats();
+  console.log(objectTypeCounts);
+  for (let i = 0; i < iterations; i++) {
+    await batch();
+  }
+
+  checkForLeaks(batchSize);
+}
+
+// This test checks that we decrement the pending activity count for the AbortSignal.
+export async function testReqSignalAbortEventNeverResolves() {
+  const url = `${server.url}/req-signal-aborted`;
+  const batchSize = 50;
+  const iterations = 50;
+
+  async function batch() {
+    onRequestContinuePromise = Promise.withResolvers();
+    const promises = new Array(batchSize);
+    let onRequestContinueCallCount = 0;
+
+    onAbortHandler = () => {
+      throw new Error("abort event should not be emitted");
+    };
+    onRequestContinueHandler = () => {
+      onRequestContinueCallCount++;
+      if (onRequestContinueCallCount === batchSize) {
+        onRequestContinuePromise.resolve();
+      }
+    };
+    for (let i = 0; i < batchSize; i++) {
+      promises[i] = fetch(url);
+    }
+
+    await onRequestContinuePromise.promise;
+    await Bun.sleep(1);
+    Bun.gc();
+    await Promise.allSettled(promises);
+  }
+
+  await batch();
+
+  for (let i = 0; i < iterations; i++) {
+    await batch();
+  }
+
+  checkForLeaks(batchSize);
+}
+
+export async function runAll() {
+  let initialRSS = (process.memoryUsage.rss() / 1024 / 1024) | 0;
+  console.time("testReqSignalGetter");
+  await testReqSignalGetter();
+  console.timeEnd("testReqSignalGetter");
+  let rssAfterReqSignalGetter = (process.memoryUsage.rss() / 1024 / 1024) | 0;
+  console.log(`RSS after testReqSignalGetter: ${rssAfterReqSignalGetter}`);
+  console.log(`RSS delta after testReqSignalGetter: ${rssAfterReqSignalGetter - initialRSS}`);
+
+  console.time("testReqSignalAbortEvent");
+  await testReqSignalAbortEvent();
+  console.timeEnd("testReqSignalAbortEvent");
+  let rssAfterReqSignalAbortEvent = (process.memoryUsage.rss() / 1024 / 1024) | 0;
+  console.log(`RSS after testReqSignalAbortEvent: ${rssAfterReqSignalAbortEvent}`);
+  console.log(`RSS delta after testReqSignalAbortEvent: ${rssAfterReqSignalAbortEvent - rssAfterReqSignalGetter}`);
+
+  console.time("testReqSignalAbortEventNeverResolves");
+  await testReqSignalAbortEventNeverResolves();
+  console.timeEnd("testReqSignalAbortEventNeverResolves");
+  let rssAfterReqSignalAbortEventNeverResolves = (process.memoryUsage.rss() / 1024 / 1024) | 0;
+  console.log(`RSS after testReqSignalAbortEventNeverResolves: ${rssAfterReqSignalAbortEventNeverResolves}`);
+  console.log(
+    `RSS delta after testReqSignalAbortEventNeverResolves: ${rssAfterReqSignalAbortEventNeverResolves - rssAfterReqSignalAbortEvent}`,
+  );
+
+  server.stop(true);
+}
+
+if (import.meta.main) {
+  await runAll();
+}


### PR DESCRIPTION


### What does this PR do?

Fixes #4517
Fixes #6758

There were several different bugs causing #4517 and #6758.
- AbortSignal was being GC'd too early. While the C++ reference-counted object was kept alive, the JavaScript wrapper object was not. This meant there were situations that caused the `"abort"` event to not be emitted
- When given a ReadableStream (or async iterator), we were only starting the response after ReadableStream's `pull` or `start` async function resolved. This means if the request was aborted before the callback was run, it would never call the `cancel` function on the ReadableStream.
- For the async iterator ReadableStream case, we were throwing an uncatchable exception on abort. 

For GC, we add a pending activity counter to `AbortSignal`. 

### How did you verify your code works?

For the AbortSignal changes, there are memory leak tests

For the ReadableStream changes, there are new tests in serve.test.ts

For the readable stream async iterator changes, previous tests were failing after we started calling cancel/close on the ReadableStream.