### PR TITLE
test: add failing test for #13696

### DIFF
--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -135,6 +135,51 @@ describe("node:http", () => {
       }
     });
 
+    it("response body streaming is immediate (#13696)", async () => {
+      const totalChunks = 10;
+      const spacing = 50;
+      const acceptableDelay = 20;
+    
+      try {
+        var server = createServer(async (req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          for (let i = 0; i < totalChunks; i++) {
+            res.write(new Date().getTime().toString() + "\n");
+    
+            if (i + 1 < totalChunks) await Bun.sleep(spacing);
+          }
+          res.end();
+        });
+        const url = await listen(server);
+        const res = await fetch(url);
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+    
+        let receivedChunks = 0;
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+    
+          receivedChunks++;
+    
+          // Verify that chunks are not held up longer than necessary
+          // at the receiver. This is likely to be in the single digits.
+          //
+          // #13696: Bun would delay the initial chunks and then send multiple
+          // chunks before real-time streaming started working.
+          expect(
+            new Date().getTime() - parseInt(decoder.decode(value).trimEnd())
+          ).toBeLessThan(acceptableDelay);
+        }
+    
+        // Verify that the correct number of chunks were sent (in case server
+        // decides to send no chunks at all).
+        expect(receivedChunks).toEqual(totalChunks);
+      } finally {
+        server.close();
+      }
+    });
+
     it("listen should return server", async () => {
       const server = createServer();
       const listenResponse = server.listen(0);


### PR DESCRIPTION
### What does this PR do?

This is the start of a fix for #13696 - a failing test.

***I am not planning on providing a fix*** as there is a significant speed bump for me in learning Zig and setting up the code base locally first. I provide this code in the hopes that someone will make use of it to provide an actual fix.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

I ran tests using both Bun and node locally, proving the code works in one but not the other. See also #13696. I have not run the test as part of Bun's test suite.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

- [x] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
